### PR TITLE
feat(gRPC): do not return all entries of maps if parent wildcard was passed

### DIFF
--- a/crates/iota-grpc-client/src/api/ledger/epochs.rs
+++ b/crates/iota-grpc-client/src/api/ledger/epochs.rs
@@ -34,7 +34,24 @@ impl Client {
     /// - `start` - Epoch start timestamp
     /// - `end` - Epoch end timestamp
     /// - `reference_gas_price` - Reference gas price in NANOS
-    /// - `protocol_config` - Protocol configuration for this epoch
+    /// - `protocol_config` - Protocol configuration for this epoch. The
+    ///   sub-fields use a two-level path because each map is wrapped in its own
+    ///   message:
+    ///   - `protocol_config.protocol_version` - the protocol version number
+    ///   - `protocol_config.feature_flags.flags` - all feature flags
+    ///     (`map<string, bool>`)
+    ///   - `protocol_config.feature_flags.flags.<name>` - a single named flag
+    ///   - `protocol_config.attributes.attributes` - all numeric attributes
+    ///     (`map<string, string>`)
+    ///   - `protocol_config.attributes.attributes.<name>` - a single named
+    ///     attribute
+    ///
+    ///   > **Note:** Requesting just `protocol_config.feature_flags` (without
+    ///   > `.flags`) or just `protocol_config.attributes` (without
+    ///   > `.attributes`) results in the respective wrapper field being `None`
+    ///   > in the response. This lets clients distinguish "field not requested"
+    ///   > from "empty map". Always include the inner field name to receive
+    ///   > data.
     ///
     /// # Example
     ///
@@ -50,6 +67,28 @@ impl Client {
     /// // Get specific epoch with custom fields
     /// let epoch = client
     ///     .get_epoch(Some(0), Some("epoch,reference_gas_price,first_checkpoint"))
+    ///     .await?;
+    ///
+    /// // Get all feature flags for the current epoch
+    /// let epoch = client
+    ///     .get_epoch(None, Some("protocol_config.feature_flags.flags"))
+    ///     .await?;
+    /// let flags = epoch.protocol_config.unwrap().feature_flags.unwrap().flags;
+    ///
+    /// // Get a single named feature flag
+    /// let epoch = client
+    ///     .get_epoch(
+    ///         None,
+    ///         Some("protocol_config.feature_flags.flags.zklogin_auth"),
+    ///     )
+    ///     .await?;
+    ///
+    /// // Get a single named attribute
+    /// let epoch = client
+    ///     .get_epoch(
+    ///         None,
+    ///         Some("protocol_config.attributes.attributes.max_tx_gas"),
+    ///     )
     ///     .await?;
     /// # Ok(())
     /// # }

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -64,6 +64,7 @@ impl CheckpointDataResponse {
         json_name: "checkpoint",
         number: 1i32,
         is_optional: true,
+        is_map: false,
         message_fields: Some(Checkpoint::FIELDS),
     };
 
@@ -72,6 +73,7 @@ impl CheckpointDataResponse {
         json_name: "transactions",
         number: 2i32,
         is_optional: true,
+        is_map: false,
         message_fields: Some(ExecutedTransaction::FIELDS),
     };
 
@@ -80,6 +82,7 @@ impl CheckpointDataResponse {
         json_name: "events",
         number: 3i32,
         is_optional: true,
+        is_map: false,
         message_fields: Some(Event::FIELDS),
     };
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use iota_grpc_types::{
     field::{FieldMaskTree, FieldMaskUtil},
     proto::timestamp_ms_to_proto,
@@ -11,12 +13,12 @@ use iota_grpc_types::{
         ledger_service::{GetEpochRequest, GetEpochResponse},
     },
 };
-use iota_protocol_config::ProtocolConfig as IotaProtocolConfig;
+use iota_protocol_config::{Chain, ProtocolConfig as IotaProtocolConfig};
 use iota_types::committee::EpochId;
 use prost_types::FieldMask;
 use tonic::Status;
 
-use crate::{ledger_service::LedgerGrpcService, merge::Merge};
+use crate::{ledger_service::LedgerGrpcService, merge::Merge, types::GrpcReader};
 
 pub const READ_MASK_DEFAULT: &str = crate::field_mask!(
     "epoch",
@@ -27,6 +29,113 @@ pub const READ_MASK_DEFAULT: &str = crate::field_mask!(
     "reference_gas_price",
     "protocol_config.protocol_version"
 );
+
+/// Source for building `Epoch` using the `Merge` trait.
+pub struct EpochReadSource {
+    pub reader: Arc<GrpcReader>,
+    pub chain: Chain,
+    pub epoch: u64,
+    pub current_epoch: u64,
+}
+
+impl Merge<&EpochReadSource> for Epoch {
+    fn merge(
+        &mut self,
+        source: &EpochReadSource,
+        mask: &FieldMaskTree,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if mask.contains(Self::EPOCH_FIELD.name) {
+            self.epoch = Some(source.epoch);
+        }
+
+        // Fetch epoch_info once for all fields that depend on it.
+        let needs_epoch_info = mask.contains(Self::FIRST_CHECKPOINT_FIELD.name)
+            || mask.contains(Self::LAST_CHECKPOINT_FIELD.name)
+            || mask.contains(Self::START_FIELD.name)
+            || mask.contains(Self::END_FIELD.name)
+            || mask.contains(Self::REFERENCE_GAS_PRICE_FIELD.name)
+            || mask.subtree(Self::PROTOCOL_CONFIG_FIELD.name).is_some()
+            || (mask.contains(Self::BCS_SYSTEM_STATE_FIELD.name)
+                && source.epoch != source.current_epoch);
+
+        let epoch_info = if needs_epoch_info {
+            source
+                .reader
+                .get_epoch_info(source.epoch)
+                .map_err(|e| format!("Failed to get epoch info: {e}"))?
+        } else {
+            None
+        };
+
+        if let Some(ref epoch_info) = epoch_info {
+            if mask.contains(Self::FIRST_CHECKPOINT_FIELD.name) {
+                self.first_checkpoint = Some(epoch_info.start_checkpoint);
+            }
+
+            if mask.contains(Self::LAST_CHECKPOINT_FIELD.name) {
+                if let Some(end_checkpoint) = epoch_info.end_checkpoint {
+                    self.last_checkpoint = Some(end_checkpoint);
+                }
+            }
+
+            if mask.contains(Self::START_FIELD.name) {
+                self.start = Some(timestamp_ms_to_proto(epoch_info.start_timestamp_ms));
+            }
+
+            if mask.contains(Self::END_FIELD.name) {
+                if let Some(end_timestamp_ms) = epoch_info.end_timestamp_ms {
+                    self.end = Some(timestamp_ms_to_proto(end_timestamp_ms));
+                }
+            }
+
+            if mask.contains(Self::REFERENCE_GAS_PRICE_FIELD.name) {
+                self.reference_gas_price = Some(epoch_info.reference_gas_price);
+            }
+
+            if let Some(submask) = mask.subtree(Self::PROTOCOL_CONFIG_FIELD.name) {
+                let iota_config = IotaProtocolConfig::get_for_version_if_supported(
+                    epoch_info.protocol_version.into(),
+                    source.chain,
+                )
+                .ok_or_else(|| ProtocolVersionNotFoundError::new(epoch_info.protocol_version))?;
+                self.protocol_config = Some(ProtocolConfig::merge_from(&iota_config, &submask)?);
+            }
+        }
+
+        if mask.contains(Self::BCS_SYSTEM_STATE_FIELD.name) {
+            // For the current epoch use the live system state; for historical
+            // epochs use the snapshot stored at the start of the epoch.
+            let system_state = if source.epoch == source.current_epoch {
+                source
+                    .reader
+                    .get_system_state()
+                    .map_err(|e| format!("Failed to get system state: {e}"))?
+            } else if let Some(ref info) = epoch_info {
+                info.system_state.clone()
+            } else {
+                return Err(format!(
+                    "Cannot get system state for historical epoch {}: epoch info not available",
+                    source.epoch
+                )
+                .into());
+            };
+            self.bcs_system_state = Some(BcsData::serialize(&system_state)?);
+        }
+
+        if mask.contains(Self::COMMITTEE_FIELD.name) {
+            let committee = source
+                .reader
+                .get_committee(source.epoch)
+                .map_err(|e| format!("Failed to get committee: {e}"))?
+                .ok_or_else(|| CommitteeNotFoundError::new(source.epoch))?;
+            let sdk_committee: iota_sdk_types::ValidatorCommittee =
+                committee.as_ref().clone().into();
+            self.committee = Some(sdk_committee.into());
+        }
+
+        Ok(())
+    }
+}
 
 #[tracing::instrument(skip(service))]
 pub fn get_epoch(
@@ -43,8 +152,6 @@ pub fn get_epoch(
         FieldMaskTree::from(read_mask)
     };
 
-    let mut message = Epoch::default();
-
     let current_epoch = service
         .reader
         .get_latest_checkpoint()
@@ -52,89 +159,15 @@ pub fn get_epoch(
         .epoch();
     let epoch = request.epoch.unwrap_or(current_epoch);
 
-    let mut system_state =
-        if epoch == current_epoch && read_mask.contains(Epoch::BCS_SYSTEM_STATE_FIELD.name) {
-            Some(
-                service
-                    .reader
-                    .get_system_state()
-                    .map_err(|e| Status::internal(format!("Failed to get system state: {e}")))?,
-            )
-        } else {
-            None
-        };
+    let source = EpochReadSource {
+        reader: service.reader.clone(),
+        chain: service.chain,
+        epoch,
+        current_epoch,
+    };
 
-    if read_mask.contains(Epoch::EPOCH_FIELD.name) {
-        message = message.with_epoch(epoch);
-    }
-
-    if let Some(epoch_info) = service
-        .reader
-        .get_epoch_info(epoch)
-        .map_err(|e| Status::internal(format!("Failed to get epoch info: {e}")))?
-    {
-        if read_mask.contains(Epoch::FIRST_CHECKPOINT_FIELD.name) {
-            message = message.with_first_checkpoint(epoch_info.start_checkpoint);
-        }
-
-        if read_mask.contains(Epoch::LAST_CHECKPOINT_FIELD.name) {
-            if let Some(end_checkpoint) = epoch_info.end_checkpoint {
-                message = message.with_last_checkpoint(end_checkpoint);
-            }
-        }
-
-        if read_mask.contains(Epoch::START_FIELD.name) {
-            message = message.with_start(timestamp_ms_to_proto(epoch_info.start_timestamp_ms));
-        }
-
-        if read_mask.contains(Epoch::END_FIELD.name) {
-            if let Some(end_timestamp_ms) = epoch_info.end_timestamp_ms {
-                message = message.with_end(timestamp_ms_to_proto(end_timestamp_ms));
-            }
-        }
-
-        if read_mask.contains(Epoch::REFERENCE_GAS_PRICE_FIELD.name) {
-            message = message.with_reference_gas_price(epoch_info.reference_gas_price);
-        }
-
-        if let Some(submask) = read_mask.subtree(Epoch::PROTOCOL_CONFIG_FIELD.name) {
-            let iota_config = IotaProtocolConfig::get_for_version_if_supported(
-                epoch_info.protocol_version.into(),
-                service.chain,
-            )
-            .ok_or_else(|| ProtocolVersionNotFoundError::new(epoch_info.protocol_version))?;
-            message = message.with_protocol_config(
-                ProtocolConfig::merge_from(&iota_config, &submask).map_err(|e| {
-                    Status::internal(format!("Failed to merge protocol config: {e}"))
-                })?,
-            );
-        }
-
-        // If we're not loading the current epoch then grab the indexed snapshot of the
-        // system state at the start of the epoch.
-        if system_state.is_none() {
-            system_state = Some(epoch_info.system_state);
-        }
-    }
-
-    if let Some(system_state) = system_state {
-        if read_mask.contains(Epoch::BCS_SYSTEM_STATE_FIELD.name) {
-            message =
-                message.with_bcs_system_state(BcsData::serialize(&system_state).map_err(|e| {
-                    Status::internal(format!("Failed to serialize system state: {e}"))
-                })?);
-        }
-    }
-
-    if read_mask.contains(Epoch::COMMITTEE_FIELD.name) {
-        let committee = service
-            .reader
-            .get_committee(epoch)
-            .map_err(|e| Status::internal(format!("Failed to get committee: {e}")))?
-            .ok_or_else(|| CommitteeNotFoundError::new(epoch))?;
-        let sdk_committee: iota_sdk_types::ValidatorCommittee = committee.as_ref().clone().into();
-        message = message.with_committee(sdk_committee);
-    }
+    let message = Epoch::merge_from(&source, &read_mask)
+        .map_err(|e| Status::internal(format!("Failed to build epoch response: {e}")))?;
 
     Ok(GetEpochResponse::default().with_epoch(message))
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -100,7 +100,7 @@ pub fn get_epoch(
         if let Some(submask) = read_mask.subtree(Epoch::PROTOCOL_CONFIG_FIELD.name) {
             message = message.with_protocol_config(
                 ProtocolConfig::merge_from(
-                    get_protocol_config(epoch_info.protocol_version, service.chain)?,
+                    &get_protocol_config(epoch_info.protocol_version, service.chain)?,
                     &submask,
                 )
                 .map_err(|e| Status::internal(format!("Failed to merge protocol config: {e}")))?,

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -11,7 +11,7 @@ use iota_grpc_types::{
         ledger_service::{GetEpochRequest, GetEpochResponse},
     },
 };
-use iota_protocol_config::{Chain, ProtocolConfig as IotaProtocolConfig, ProtocolConfigValue};
+use iota_protocol_config::ProtocolConfig as IotaProtocolConfig;
 use iota_types::committee::EpochId;
 use prost_types::FieldMask;
 use tonic::Status;
@@ -98,12 +98,15 @@ pub fn get_epoch(
         }
 
         if let Some(submask) = read_mask.subtree(Epoch::PROTOCOL_CONFIG_FIELD.name) {
+            let iota_config = IotaProtocolConfig::get_for_version_if_supported(
+                epoch_info.protocol_version.into(),
+                service.chain,
+            )
+            .ok_or_else(|| ProtocolVersionNotFoundError::new(epoch_info.protocol_version))?;
             message = message.with_protocol_config(
-                ProtocolConfig::merge_from(
-                    &get_protocol_config(epoch_info.protocol_version, service.chain)?,
-                    &submask,
-                )
-                .map_err(|e| Status::internal(format!("Failed to merge protocol config: {e}")))?,
+                ProtocolConfig::merge_from(&iota_config, &submask).map_err(|e| {
+                    Status::internal(format!("Failed to merge protocol config: {e}"))
+                })?,
             );
         }
 
@@ -184,41 +187,4 @@ impl From<ProtocolVersionNotFoundError> for Status {
     fn from(value: ProtocolVersionNotFoundError) -> Self {
         Status::not_found(value.to_string())
     }
-}
-
-fn get_protocol_config(
-    version: u64,
-    chain: Chain,
-) -> std::result::Result<ProtocolConfig, ProtocolVersionNotFoundError> {
-    let config = IotaProtocolConfig::get_for_version_if_supported(version.into(), chain)
-        .ok_or_else(|| ProtocolVersionNotFoundError::new(version))?;
-    Ok(protocol_config_to_proto(config))
-}
-
-pub fn protocol_config_to_proto(config: IotaProtocolConfig) -> ProtocolConfig {
-    let protocol_version = config.version.as_u64();
-    let attributes = config
-        .attr_map()
-        .into_iter()
-        .filter_map(|(k, maybe_v)| {
-            maybe_v.map(move |v| {
-                let v = match v {
-                    ProtocolConfigValue::u16(x) => x.to_string(),
-                    ProtocolConfigValue::u32(y) => y.to_string(),
-                    ProtocolConfigValue::u64(z) => z.to_string(),
-                    ProtocolConfigValue::bool(b) => b.to_string(),
-                };
-                (k, v)
-            })
-        })
-        .collect();
-    ProtocolConfig::default()
-        .with_protocol_version(protocol_version)
-        .with_feature_flags(
-            iota_grpc_types::v0::epoch::ProtocolFeatureFlags::default()
-                .with_flags(config.feature_map().into_iter().collect()),
-        )
-        .with_attributes(
-            iota_grpc_types::v0::epoch::ProtocolAttributes::default().with_attributes(attributes),
-        )
 }

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -45,44 +45,52 @@ impl Merge<&IotaProtocolConfig> for ProtocolConfig {
         }
 
         if let Some(submask) = mask.subtree(Self::FEATURE_FLAGS_FIELD.name) {
-            let flags = match submask.map_field_filter(ProtocolFeatureFlags::FLAGS_FIELD.name) {
-                // If the inner field is not requested at all, don't include any entries
-                None => Default::default(),
-                // wildcard: if the inner field is requested without specific keys (e.g.
-                // `feature_flags.flags`), include all entries
-                Some(None) => source.feature_map().into_iter().collect(),
-                // If specific keys are requested (e.g. `feature_flags.flags.flag_a`), include
-                // only those entries
-                Some(Some(keys)) => source
-                    .feature_map()
-                    .into_iter()
-                    .filter(|(k, _)| keys.contains(k.as_str()))
-                    .collect(),
-            };
-            self.feature_flags = Some(ProtocolFeatureFlags::default().with_flags(flags));
+            if let Some(filter) = submask.map_field_filter(ProtocolFeatureFlags::FLAGS_FIELD.name) {
+                let flags = match filter {
+                    // wildcard: if the inner field is requested without specific keys (e.g.
+                    // `feature_flags.flags`), include all entries
+                    None => source.feature_map().into_iter().collect(),
+                    // If specific keys are requested (e.g. `feature_flags.flags.flag_a`), include
+                    // only those entries
+                    Some(keys) => source
+                        .feature_map()
+                        .into_iter()
+                        .filter(|(k, _)| keys.contains(k.as_str()))
+                        .collect(),
+                };
+                self.feature_flags = Some(ProtocolFeatureFlags::default().with_flags(flags));
+            }
+            // If the inner flags field was not requested (bare `feature_flags`
+            // in mask), leave feature_flags as None so the client
+            // knows no data was returned.
         }
 
         if let Some(submask) = mask.subtree(Self::ATTRIBUTES_FIELD.name) {
-            let attrs = match submask.map_field_filter(ProtocolAttributes::ATTRIBUTES_FIELD.name) {
-                // If the inner field is not requested at all, don't include any entries
-                None => Default::default(),
-                // wildcard: if the inner field is requested without specific keys (e.g.
-                // `attributes.attributes`), include all entries
-                Some(None) => source
-                    .attr_map()
-                    .into_iter()
-                    .filter_map(|(k, v)| v.map(|v| (k, protocol_config_value_to_string(v))))
-                    .collect(),
-                // If specific keys are requested (e.g. `attributes.attributes.key_a`), include
-                // only those entries
-                Some(Some(keys)) => source
-                    .attr_map()
-                    .into_iter()
-                    .filter(|(k, _)| keys.contains(k.as_str()))
-                    .filter_map(|(k, v)| v.map(|v| (k, protocol_config_value_to_string(v))))
-                    .collect(),
-            };
-            self.attributes = Some(ProtocolAttributes::default().with_attributes(attrs));
+            if let Some(filter) =
+                submask.map_field_filter(ProtocolAttributes::ATTRIBUTES_FIELD.name)
+            {
+                let attrs = match filter {
+                    // wildcard: if the inner field is requested without specific keys (e.g.
+                    // `attributes.attributes`), include all entries
+                    None => source
+                        .attr_map()
+                        .into_iter()
+                        .filter_map(|(k, v)| v.map(|v| (k, protocol_config_value_to_string(v))))
+                        .collect(),
+                    // If specific keys are requested (e.g. `attributes.attributes.key_a`), include
+                    // only those entries
+                    Some(keys) => source
+                        .attr_map()
+                        .into_iter()
+                        .filter(|(k, _)| keys.contains(k.as_str()))
+                        .filter_map(|(k, v)| v.map(|v| (k, protocol_config_value_to_string(v))))
+                        .collect(),
+                };
+                self.attributes = Some(ProtocolAttributes::default().with_attributes(attrs));
+            }
+            // If the inner attributes field was not requested (bare
+            // `attributes` in mask), leave attributes as None so
+            // the client knows no data was returned.
         }
 
         Ok(())
@@ -815,12 +823,12 @@ mod tests {
     // ── attributes ──────────────────────────────────────────────────────────
 
     #[test]
-    fn test_protocol_config_merge_wrapper_only_gives_empty_attributes() {
-        // "attributes" (bare wrapper) → ProtocolAttributes present but map is empty
+    fn test_protocol_config_merge_wrapper_only_gives_none_attributes() {
+        // "attributes" (bare wrapper, no inner field) → attributes is None
         let source = make_iota_protocol_config();
         let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["attributes"]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
-        assert!(result.attributes.unwrap().attributes.is_empty());
+        assert!(result.attributes.is_none());
     }
 
     #[test]
@@ -885,13 +893,12 @@ mod tests {
     // ── feature_flags ────────────────────────────────────────────────────────
 
     #[test]
-    fn test_protocol_config_merge_wrapper_only_gives_empty_flags() {
-        // "feature_flags" (bare wrapper) → ProtocolFeatureFlags present but map is
-        // empty
+    fn test_protocol_config_merge_wrapper_only_gives_none_flags() {
+        // "feature_flags" (bare wrapper, no inner field) → feature_flags is None
         let source = make_iota_protocol_config();
         let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["feature_flags"]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
-        assert!(result.feature_flags.unwrap().flags.is_empty());
+        assert!(result.feature_flags.is_none());
     }
 
     #[test]

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -9,7 +9,7 @@ use iota_grpc_types::{
     v0::{
         bcs::BcsData,
         checkpoint::{Checkpoint, CheckpointContents, CheckpointSummary},
-        epoch::{Epoch, ProtocolConfig},
+        epoch::{Epoch, ProtocolAttributes, ProtocolConfig, ProtocolFeatureFlags},
         event::{Event, Events},
         object::{Object, Objects},
         signatures::{UserSignature, UserSignatures},
@@ -113,41 +113,56 @@ impl Merge<&ProtocolConfig> for ProtocolConfig {
             self.protocol_version = *protocol_version;
         }
 
-        if mask.contains(Self::FEATURE_FLAGS_FIELD.name) {
-            self.feature_flags = feature_flags.to_owned();
+        if let Some(submask) = mask.subtree(Self::FEATURE_FLAGS_FIELD.name) {
+            let flags = match submask.map_field_filter(ProtocolFeatureFlags::FLAGS_FIELD.name) {
+                // If the inner field is not requested at all, don't include any entries
+                None => Default::default(),
+                // wildcard: if the inner field is requested without specific keys (e.g.
+                // `feature_flags.flags`), include all entries
+                Some(None) => feature_flags
+                    .as_ref()
+                    .map(|ff| ff.flags.clone())
+                    .unwrap_or_default(),
+                // If specific keys are requested (e.g. `feature_flags.flags.flag_a`), include only
+                // those entries
+                Some(Some(keys)) => feature_flags
+                    .as_ref()
+                    .map(|ff| {
+                        ff.flags
+                            .iter()
+                            .filter(|(k, _)| keys.contains(*k))
+                            .map(|(k, v)| (k.clone(), *v))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            };
+            self.feature_flags = Some(ProtocolFeatureFlags::default().with_flags(flags));
         }
 
-        if mask.contains(Self::ATTRIBUTES_FIELD.name) {
-            self.attributes = attributes.to_owned();
-        }
-
-        Ok(())
-    }
-}
-
-impl Merge<ProtocolConfig> for ProtocolConfig {
-    fn merge(
-        &mut self,
-        source: ProtocolConfig,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let ProtocolConfig {
-            protocol_version,
-            feature_flags,
-            attributes,
-            ..
-        } = source;
-
-        if mask.contains(Self::PROTOCOL_VERSION_FIELD.name) {
-            self.protocol_version = protocol_version;
-        }
-
-        if mask.contains(Self::FEATURE_FLAGS_FIELD.name) {
-            self.feature_flags = feature_flags;
-        }
-
-        if mask.contains(Self::ATTRIBUTES_FIELD.name) {
-            self.attributes = attributes;
+        if let Some(submask) = mask.subtree(Self::ATTRIBUTES_FIELD.name) {
+            let attrs = match submask.map_field_filter(ProtocolAttributes::ATTRIBUTES_FIELD.name) {
+                // If the inner field is not requested at all, don't include any entries
+                None => Default::default(),
+                // wildcard: if the inner field is requested without specific keys (e.g.
+                // `attributes.attributes`), include all entries
+                Some(None) => attributes
+                    .as_ref()
+                    .map(|a| a.attributes.clone())
+                    .unwrap_or_default(),
+                // If specific keys are requested (e.g. `attributes.attributes.key_a`), include only
+                // those entries
+                Some(Some(keys)) => attributes
+                    .as_ref()
+                    .map(|a| {
+                        a.attributes
+                            .iter()
+                            .filter(|(k, _)| keys.contains(*k))
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            };
+            self.attributes = Some(ProtocolAttributes::default().with_attributes(attrs));
         }
 
         Ok(())
@@ -853,5 +868,166 @@ impl Merge<&Transaction> for Transaction {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use iota_grpc_types::{
+        field::FieldMaskUtil,
+        v0::epoch::{Epoch, ProtocolAttributes, ProtocolConfig, ProtocolFeatureFlags},
+    };
+    use prost_types::FieldMask;
+
+    use super::*;
+
+    fn make_protocol_config() -> ProtocolConfig {
+        let mut flags = BTreeMap::new();
+        flags.insert("flag_a".to_string(), true);
+        flags.insert("flag_b".to_string(), false);
+        flags.insert("flag_c".to_string(), true);
+
+        let mut attrs = BTreeMap::new();
+        attrs.insert("max_tx_gas".to_string(), "1000".to_string());
+        attrs.insert("max_num_events".to_string(), "256".to_string());
+        attrs.insert("other_attr".to_string(), "42".to_string());
+
+        ProtocolConfig::default()
+            .with_protocol_version(42)
+            .with_feature_flags(ProtocolFeatureFlags::default().with_flags(flags))
+            .with_attributes(ProtocolAttributes::default().with_attributes(attrs))
+    }
+
+    // ── attributes ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_protocol_config_merge_wrapper_only_gives_empty_attributes() {
+        // "attributes" (no inner field) → ProtocolAttributes present but map is empty
+        let source = make_protocol_config();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["attributes"]));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        assert!(result.attributes.unwrap().attributes.is_empty());
+    }
+
+    #[test]
+    fn test_protocol_config_merge_attributes_field_returns_all() {
+        // "attributes.attributes" → all entries
+        let source = make_protocol_config();
+        let mask =
+            FieldMaskTree::from_field_mask(&FieldMask::from_paths(["attributes.attributes"]));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        let attrs = result.attributes.unwrap();
+        assert_eq!(attrs.attributes.len(), 3);
+        assert_eq!(attrs.attributes["max_tx_gas"], "1000");
+        assert_eq!(attrs.attributes["max_num_events"], "256");
+        assert_eq!(attrs.attributes["other_attr"], "42");
+    }
+
+    #[test]
+    fn test_protocol_config_merge_explicit_attribute_keys() {
+        // "attributes.attributes.key" → only that key
+        let source = make_protocol_config();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([
+            "protocol_version",
+            "attributes.attributes.max_tx_gas",
+        ]));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        assert_eq!(result.protocol_version, Some(42));
+        let attrs = result.attributes.unwrap();
+        assert_eq!(attrs.attributes.len(), 1);
+        assert_eq!(attrs.attributes["max_tx_gas"], "1000");
+    }
+
+    #[test]
+    fn test_protocol_config_merge_multiple_attribute_keys() {
+        // Multiple "attributes.attributes.keyN" → only those keys
+        let source = make_protocol_config();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([
+            "attributes.attributes.max_tx_gas",
+            "attributes.attributes.max_num_events",
+        ]));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        let attrs = result.attributes.unwrap();
+        assert_eq!(attrs.attributes.len(), 2);
+        assert!(attrs.attributes.contains_key("max_tx_gas"));
+        assert!(attrs.attributes.contains_key("max_num_events"));
+        assert!(!attrs.attributes.contains_key("other_attr"));
+    }
+
+    // ── feature_flags ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_protocol_config_merge_wrapper_only_gives_empty_flags() {
+        // "feature_flags" (no inner field) → ProtocolFeatureFlags present but map is
+        // empty
+        let source = make_protocol_config();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["feature_flags"]));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        assert!(result.feature_flags.unwrap().flags.is_empty());
+    }
+
+    #[test]
+    fn test_protocol_config_merge_flags_field_returns_all() {
+        // "feature_flags.flags" → all flags
+        let source = make_protocol_config();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["feature_flags.flags"]));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        let flags = result.feature_flags.unwrap();
+        assert_eq!(flags.flags.len(), 3);
+        assert!(flags.flags["flag_a"]);
+        assert!(!flags.flags["flag_b"]);
+        assert!(flags.flags["flag_c"]);
+    }
+
+    #[test]
+    fn test_protocol_config_merge_explicit_flag_keys() {
+        // "feature_flags.flags.keyN" → only those flags
+        let source = make_protocol_config();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([
+            "feature_flags.flags.flag_a",
+            "feature_flags.flags.flag_c",
+        ]));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        let flags = result.feature_flags.unwrap();
+        assert_eq!(flags.flags.len(), 2);
+        assert!(flags.flags["flag_a"]);
+        assert!(flags.flags["flag_c"]);
+        assert!(!flags.flags.contains_key("flag_b"));
+    }
+
+    // ── misc ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_protocol_config_merge_no_map_fields_when_not_requested() {
+        let source = make_protocol_config();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["protocol_version"]));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        assert_eq!(result.protocol_version, Some(42));
+        assert!(result.feature_flags.is_none());
+        assert!(result.attributes.is_none());
+    }
+
+    #[test]
+    fn test_epoch_merge_protocol_config_with_key_filter() {
+        let mut epoch = Epoch::default();
+        epoch.epoch = Some(1);
+        epoch.protocol_config = Some(make_protocol_config());
+
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([
+            "epoch",
+            "protocol_config.protocol_version",
+            "protocol_config.attributes.attributes.max_tx_gas",
+        ]));
+
+        let result = Epoch::merge_from(&epoch, &mask).unwrap();
+
+        assert_eq!(result.epoch, Some(1));
+        let pc = result.protocol_config.unwrap();
+        assert_eq!(pc.protocol_version, Some(42));
+        let attrs = pc.attributes.unwrap();
+        assert_eq!(attrs.attributes.len(), 1);
+        assert_eq!(attrs.attributes["max_tx_gas"], "1000");
     }
 }

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -9,7 +9,7 @@ use iota_grpc_types::{
     v0::{
         bcs::BcsData,
         checkpoint::{Checkpoint, CheckpointContents, CheckpointSummary},
-        epoch::{Epoch, ProtocolAttributes, ProtocolConfig, ProtocolFeatureFlags},
+        epoch::{ProtocolAttributes, ProtocolConfig, ProtocolFeatureFlags},
         event::{Event, Events},
         object::{Object, Objects},
         signatures::{UserSignature, UserSignatures},
@@ -18,6 +18,7 @@ use iota_grpc_types::{
         versioned::{VersionedCheckpointSummary, VersionedEvent, VersionedObject},
     },
 };
+use iota_protocol_config::{ProtocolConfig as IotaProtocolConfig, ProtocolConfigValue};
 use iota_types::iota_sdk_types_conversions::SdkTypeConversionError;
 
 pub trait Merge<T> {
@@ -33,84 +34,14 @@ pub trait Merge<T> {
     }
 }
 
-// Epoch implementations
-impl Merge<&Epoch> for Epoch {
+impl Merge<&IotaProtocolConfig> for ProtocolConfig {
     fn merge(
         &mut self,
-        source: &Epoch,
+        source: &IotaProtocolConfig,
         mask: &FieldMaskTree,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let Epoch {
-            epoch,
-            committee,
-            bcs_system_state,
-            first_checkpoint,
-            last_checkpoint,
-            start,
-            end,
-            reference_gas_price,
-            protocol_config,
-            ..
-        } = source;
-
-        if mask.contains(Self::EPOCH_FIELD.name) {
-            self.epoch = *epoch;
-        }
-
-        if mask.contains(Self::COMMITTEE_FIELD.name) {
-            self.committee = committee.to_owned();
-        }
-
-        if mask.contains(Self::BCS_SYSTEM_STATE_FIELD.name) {
-            self.bcs_system_state = bcs_system_state.to_owned();
-        }
-
-        if mask.contains(Self::FIRST_CHECKPOINT_FIELD.name) {
-            self.first_checkpoint = first_checkpoint.to_owned();
-        }
-
-        if mask.contains(Self::LAST_CHECKPOINT_FIELD.name) {
-            self.last_checkpoint = last_checkpoint.to_owned();
-        }
-
-        if mask.contains(Self::START_FIELD.name) {
-            self.start = start.to_owned();
-        }
-
-        if mask.contains(Self::END_FIELD.name) {
-            self.end = end.to_owned();
-        }
-
-        if mask.contains(Self::REFERENCE_GAS_PRICE_FIELD.name) {
-            self.reference_gas_price = reference_gas_price.to_owned();
-        }
-
-        if let Some(submask) = mask.subtree(Self::PROTOCOL_CONFIG_FIELD.name) {
-            self.protocol_config = protocol_config
-                .as_ref()
-                .map(|config| ProtocolConfig::merge_from(config, &submask))
-                .transpose()?;
-        }
-
-        Ok(())
-    }
-}
-
-impl Merge<&ProtocolConfig> for ProtocolConfig {
-    fn merge(
-        &mut self,
-        source: &ProtocolConfig,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let ProtocolConfig {
-            protocol_version,
-            feature_flags,
-            attributes,
-            ..
-        } = source;
-
         if mask.contains(Self::PROTOCOL_VERSION_FIELD.name) {
-            self.protocol_version = *protocol_version;
+            self.protocol_version = Some(source.version.as_u64());
         }
 
         if let Some(submask) = mask.subtree(Self::FEATURE_FLAGS_FIELD.name) {
@@ -119,22 +50,14 @@ impl Merge<&ProtocolConfig> for ProtocolConfig {
                 None => Default::default(),
                 // wildcard: if the inner field is requested without specific keys (e.g.
                 // `feature_flags.flags`), include all entries
-                Some(None) => feature_flags
-                    .as_ref()
-                    .map(|ff| ff.flags.clone())
-                    .unwrap_or_default(),
-                // If specific keys are requested (e.g. `feature_flags.flags.flag_a`), include only
-                // those entries
-                Some(Some(keys)) => feature_flags
-                    .as_ref()
-                    .map(|ff| {
-                        ff.flags
-                            .iter()
-                            .filter(|(k, _)| keys.contains(*k))
-                            .map(|(k, v)| (k.clone(), *v))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                Some(None) => source.feature_map().into_iter().collect(),
+                // If specific keys are requested (e.g. `feature_flags.flags.flag_a`), include
+                // only those entries
+                Some(Some(keys)) => source
+                    .feature_map()
+                    .into_iter()
+                    .filter(|(k, _)| keys.contains(k.as_str()))
+                    .collect(),
             };
             self.feature_flags = Some(ProtocolFeatureFlags::default().with_flags(flags));
         }
@@ -145,27 +68,33 @@ impl Merge<&ProtocolConfig> for ProtocolConfig {
                 None => Default::default(),
                 // wildcard: if the inner field is requested without specific keys (e.g.
                 // `attributes.attributes`), include all entries
-                Some(None) => attributes
-                    .as_ref()
-                    .map(|a| a.attributes.clone())
-                    .unwrap_or_default(),
-                // If specific keys are requested (e.g. `attributes.attributes.key_a`), include only
-                // those entries
-                Some(Some(keys)) => attributes
-                    .as_ref()
-                    .map(|a| {
-                        a.attributes
-                            .iter()
-                            .filter(|(k, _)| keys.contains(*k))
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                Some(None) => source
+                    .attr_map()
+                    .into_iter()
+                    .filter_map(|(k, v)| v.map(|v| (k, protocol_config_value_to_string(v))))
+                    .collect(),
+                // If specific keys are requested (e.g. `attributes.attributes.key_a`), include
+                // only those entries
+                Some(Some(keys)) => source
+                    .attr_map()
+                    .into_iter()
+                    .filter(|(k, _)| keys.contains(k.as_str()))
+                    .filter_map(|(k, v)| v.map(|v| (k, protocol_config_value_to_string(v))))
+                    .collect(),
             };
             self.attributes = Some(ProtocolAttributes::default().with_attributes(attrs));
         }
 
         Ok(())
+    }
+}
+
+fn protocol_config_value_to_string(v: ProtocolConfigValue) -> String {
+    match v {
+        ProtocolConfigValue::u16(x) => x.to_string(),
+        ProtocolConfigValue::u32(x) => x.to_string(),
+        ProtocolConfigValue::u64(x) => x.to_string(),
+        ProtocolConfigValue::bool(x) => x.to_string(),
     }
 }
 
@@ -873,39 +802,22 @@ impl Merge<&Transaction> for Transaction {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use iota_grpc_types::{
-        field::FieldMaskUtil,
-        v0::epoch::{Epoch, ProtocolAttributes, ProtocolConfig, ProtocolFeatureFlags},
-    };
+    use iota_grpc_types::{field::FieldMaskUtil, v0::epoch::ProtocolConfig};
+    use iota_protocol_config::{Chain, ProtocolConfig as IotaProtocolConfig};
     use prost_types::FieldMask;
 
     use super::*;
 
-    fn make_protocol_config() -> ProtocolConfig {
-        let mut flags = BTreeMap::new();
-        flags.insert("flag_a".to_string(), true);
-        flags.insert("flag_b".to_string(), false);
-        flags.insert("flag_c".to_string(), true);
-
-        let mut attrs = BTreeMap::new();
-        attrs.insert("max_tx_gas".to_string(), "1000".to_string());
-        attrs.insert("max_num_events".to_string(), "256".to_string());
-        attrs.insert("other_attr".to_string(), "42".to_string());
-
-        ProtocolConfig::default()
-            .with_protocol_version(42)
-            .with_feature_flags(ProtocolFeatureFlags::default().with_flags(flags))
-            .with_attributes(ProtocolAttributes::default().with_attributes(attrs))
+    fn make_iota_protocol_config() -> IotaProtocolConfig {
+        IotaProtocolConfig::get_for_version(1.into(), Chain::Testnet)
     }
 
     // ── attributes ──────────────────────────────────────────────────────────
 
     #[test]
     fn test_protocol_config_merge_wrapper_only_gives_empty_attributes() {
-        // "attributes" (no inner field) → ProtocolAttributes present but map is empty
-        let source = make_protocol_config();
+        // "attributes" (bare wrapper) → ProtocolAttributes present but map is empty
+        let source = make_iota_protocol_config();
         let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["attributes"]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
         assert!(result.attributes.unwrap().attributes.is_empty());
@@ -913,56 +825,70 @@ mod tests {
 
     #[test]
     fn test_protocol_config_merge_attributes_field_returns_all() {
-        // "attributes.attributes" → all entries
-        let source = make_protocol_config();
+        // "attributes.attributes" → all non-None entries from attr_map()
+        let source = make_iota_protocol_config();
+        let expected_count = source
+            .attr_map()
+            .into_values()
+            .filter(Option::is_some)
+            .count();
         let mask =
             FieldMaskTree::from_field_mask(&FieldMask::from_paths(["attributes.attributes"]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
-        let attrs = result.attributes.unwrap();
-        assert_eq!(attrs.attributes.len(), 3);
-        assert_eq!(attrs.attributes["max_tx_gas"], "1000");
-        assert_eq!(attrs.attributes["max_num_events"], "256");
-        assert_eq!(attrs.attributes["other_attr"], "42");
+        assert_eq!(result.attributes.unwrap().attributes.len(), expected_count);
     }
 
     #[test]
-    fn test_protocol_config_merge_explicit_attribute_keys() {
-        // "attributes.attributes.key" → only that key
-        let source = make_protocol_config();
-        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([
-            "protocol_version",
-            "attributes.attributes.max_tx_gas",
-        ]));
+    fn test_protocol_config_merge_explicit_attribute_key() {
+        // "attributes.attributes.<key>" → only that one attribute
+        let source = make_iota_protocol_config();
+        let key = source
+            .attr_map()
+            .into_iter()
+            .find(|(_, v)| v.is_some())
+            .map(|(k, _)| k)
+            .unwrap();
+        let path = format!("attributes.attributes.{key}");
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([&path]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
-        assert_eq!(result.protocol_version, Some(42));
-        let attrs = result.attributes.unwrap();
-        assert_eq!(attrs.attributes.len(), 1);
-        assert_eq!(attrs.attributes["max_tx_gas"], "1000");
+        let attrs = result.attributes.unwrap().attributes;
+        assert_eq!(attrs.len(), 1);
+        assert!(attrs.contains_key(&key));
     }
 
     #[test]
     fn test_protocol_config_merge_multiple_attribute_keys() {
-        // Multiple "attributes.attributes.keyN" → only those keys
-        let source = make_protocol_config();
-        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([
-            "attributes.attributes.max_tx_gas",
-            "attributes.attributes.max_num_events",
-        ]));
+        // Multiple "attributes.attributes.<key>" → only those keys
+        let source = make_iota_protocol_config();
+        let keys: Vec<String> = source
+            .attr_map()
+            .into_iter()
+            .filter(|(_, v)| v.is_some())
+            .map(|(k, _)| k)
+            .take(2)
+            .collect();
+        assert_eq!(keys.len(), 2, "expected at least 2 non-None attributes");
+        let paths: Vec<String> = keys
+            .iter()
+            .map(|k| format!("attributes.attributes.{k}"))
+            .collect();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(
+            paths.iter().map(String::as_str),
+        ));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
-        let attrs = result.attributes.unwrap();
-        assert_eq!(attrs.attributes.len(), 2);
-        assert!(attrs.attributes.contains_key("max_tx_gas"));
-        assert!(attrs.attributes.contains_key("max_num_events"));
-        assert!(!attrs.attributes.contains_key("other_attr"));
+        let attrs = result.attributes.unwrap().attributes;
+        assert_eq!(attrs.len(), 2);
+        assert!(attrs.contains_key(&keys[0]));
+        assert!(attrs.contains_key(&keys[1]));
     }
 
     // ── feature_flags ────────────────────────────────────────────────────────
 
     #[test]
     fn test_protocol_config_merge_wrapper_only_gives_empty_flags() {
-        // "feature_flags" (no inner field) → ProtocolFeatureFlags present but map is
+        // "feature_flags" (bare wrapper) → ProtocolFeatureFlags present but map is
         // empty
-        let source = make_protocol_config();
+        let source = make_iota_protocol_config();
         let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["feature_flags"]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
         assert!(result.feature_flags.unwrap().flags.is_empty());
@@ -970,64 +896,58 @@ mod tests {
 
     #[test]
     fn test_protocol_config_merge_flags_field_returns_all() {
-        // "feature_flags.flags" → all flags
-        let source = make_protocol_config();
+        // "feature_flags.flags" → all entries from feature_map()
+        let source = make_iota_protocol_config();
+        let expected_count = source.feature_map().len();
         let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["feature_flags.flags"]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
-        let flags = result.feature_flags.unwrap();
-        assert_eq!(flags.flags.len(), 3);
-        assert!(flags.flags["flag_a"]);
-        assert!(!flags.flags["flag_b"]);
-        assert!(flags.flags["flag_c"]);
+        assert_eq!(result.feature_flags.unwrap().flags.len(), expected_count);
     }
 
     #[test]
-    fn test_protocol_config_merge_explicit_flag_keys() {
-        // "feature_flags.flags.keyN" → only those flags
-        let source = make_protocol_config();
-        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([
-            "feature_flags.flags.flag_a",
-            "feature_flags.flags.flag_c",
-        ]));
+    fn test_protocol_config_merge_explicit_flag_key() {
+        // "feature_flags.flags.<key>" → only that one flag
+        let source = make_iota_protocol_config();
+        let key = source.feature_map().into_keys().next().unwrap();
+        let path = format!("feature_flags.flags.{key}");
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([&path]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
-        let flags = result.feature_flags.unwrap();
-        assert_eq!(flags.flags.len(), 2);
-        assert!(flags.flags["flag_a"]);
-        assert!(flags.flags["flag_c"]);
-        assert!(!flags.flags.contains_key("flag_b"));
+        let flags = result.feature_flags.unwrap().flags;
+        assert_eq!(flags.len(), 1);
+        assert!(flags.contains_key(&key));
+    }
+
+    #[test]
+    fn test_protocol_config_merge_multiple_flag_keys() {
+        // Multiple "feature_flags.flags.<key>" → only those keys
+        let source = make_iota_protocol_config();
+        let keys: Vec<String> = source.feature_map().into_keys().take(2).collect();
+        assert_eq!(keys.len(), 2, "expected at least 2 feature flags");
+        let paths: Vec<String> = keys
+            .iter()
+            .map(|k| format!("feature_flags.flags.{k}"))
+            .collect();
+        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(
+            paths.iter().map(String::as_str),
+        ));
+        let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
+        let flags = result.feature_flags.unwrap().flags;
+        assert_eq!(flags.len(), 2);
+        assert!(flags.contains_key(&keys[0]));
+        assert!(flags.contains_key(&keys[1]));
     }
 
     // ── misc ─────────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_protocol_config_merge_no_map_fields_when_not_requested() {
-        let source = make_protocol_config();
+    fn test_protocol_config_merge_version_only() {
+        // "protocol_version" → version set, no map fields populated
+        let source = make_iota_protocol_config();
+        let expected_version = source.version.as_u64();
         let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths(["protocol_version"]));
         let result = ProtocolConfig::merge_from(&source, &mask).unwrap();
-        assert_eq!(result.protocol_version, Some(42));
+        assert_eq!(result.protocol_version, Some(expected_version));
         assert!(result.feature_flags.is_none());
         assert!(result.attributes.is_none());
-    }
-
-    #[test]
-    fn test_epoch_merge_protocol_config_with_key_filter() {
-        let mut epoch = Epoch::default();
-        epoch.epoch = Some(1);
-        epoch.protocol_config = Some(make_protocol_config());
-
-        let mask = FieldMaskTree::from_field_mask(&FieldMask::from_paths([
-            "epoch",
-            "protocol_config.protocol_version",
-            "protocol_config.attributes.attributes.max_tx_gas",
-        ]));
-
-        let result = Epoch::merge_from(&epoch, &mask).unwrap();
-
-        assert_eq!(result.epoch, Some(1));
-        let pc = result.protocol_config.unwrap();
-        assert_eq!(pc.protocol_version, Some(42));
-        let attrs = pc.attributes.unwrap();
-        assert_eq!(attrs.attributes.len(), 1);
-        assert_eq!(attrs.attributes["max_tx_gas"], "1000");
     }
 }

--- a/crates/iota-grpc-types/src/field/field_mask_tree.rs
+++ b/crates/iota-grpc-types/src/field/field_mask_tree.rs
@@ -144,6 +144,55 @@ impl FieldMaskTree {
         true
     }
 
+    /// Returns the explicit map keys requested in this subtree, or `None` if
+    /// this tree is a wildcard (no explicit key filter).
+    ///
+    /// When a user specifies explicit map keys via a field mask (e.g.
+    /// `attributes.max_tx_gas`), this method returns an iterator over those
+    /// key names. When the tree is a wildcard, `None` is returned to indicate
+    /// "no filter — return all (or none, per policy)".
+    pub fn map_keys(&self) -> Option<impl Iterator<Item = &str>> {
+        if self.wildcard {
+            None
+        } else {
+            Some(self.root.children.keys().map(String::as_str))
+        }
+    }
+
+    /// Determines which entries of an inner map field should be included.
+    ///
+    /// Call this on the subtree rooted at a **map-wrapper message field**
+    /// (e.g. the subtree at `feature_flags` or `attributes` inside
+    /// `ProtocolConfig`) and pass the name of the **inner map field** (e.g.
+    /// `"flags"` or `"attributes"`).  The return value tells the caller what
+    /// to put in the resulting map:
+    ///
+    /// - `None` — the wrapper itself was a wildcard *or* the inner field was
+    ///   not explicitly requested → include an **empty map**.
+    /// - `Some(None)` — the inner field was requested without specific keys
+    ///   (e.g. `feature_flags.flags`) → include **all entries**.
+    /// - `Some(Some(keys))` — only these specific keys were requested (e.g.
+    ///   `feature_flags.flags.flag_a`) → include **only those entries**.
+    pub fn map_field_filter(
+        &self,
+        inner_field_name: &str,
+    ) -> Option<Option<std::collections::HashSet<String>>> {
+        match self.map_keys() {
+            // Wildcard at the wrapper level (e.g. bare "feature_flags") → empty
+            None => None,
+            Some(_) => match self.subtree(inner_field_name) {
+                // Inner field not among the requested children → empty
+                None => None,
+                Some(inner) => match inner.map_keys() {
+                    // Inner field requested without specific keys → all entries
+                    None => Some(None),
+                    // Specific keys requested
+                    Some(keys) => Some(Some(keys.map(String::from).collect())),
+                },
+            },
+        }
+    }
+
     pub fn subtree<P: AsRef<str>>(&self, path: P) -> Option<Self> {
         let path = path.as_ref();
 
@@ -254,5 +303,75 @@ mod tests {
         assert!(tree.contains("foo.bar"));
         assert!(!tree.contains("foo.baz"));
         assert!(!tree.contains("foobar"));
+    }
+
+    #[test]
+    fn test_map_keys() {
+        // Empty tree → no wildcard, no keys
+        let tree = FieldMaskTree::default();
+        let keys: Option<Vec<&str>> = tree.map_keys().map(|it| it.collect());
+        assert_eq!(keys, Some(vec![]));
+
+        // Wildcard tree → None
+        let tree = FieldMaskTree::new_wildcard();
+        assert!(tree.map_keys().is_none());
+
+        // Tree with specific keys
+        let mut tree = FieldMaskTree::default();
+        tree.add_field_path("key_a");
+        tree.add_field_path("key_b");
+        let mut keys: Vec<&str> = tree.map_keys().unwrap().collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["key_a", "key_b"]);
+
+        // Subtree map_keys: after subtree(), map_keys on the result
+        let mut tree = FieldMaskTree::default();
+        tree.add_field_path("attributes.max_tx_gas");
+        tree.add_field_path("attributes.max_num_events");
+
+        // The subtree at "attributes" should have the two keys
+        let subtree = tree.subtree("attributes").unwrap();
+        let mut keys: Vec<&str> = subtree.map_keys().unwrap().collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["max_num_events", "max_tx_gas"]);
+
+        // Subtree when "attributes" is a leaf (wildcard-like subtree) → None
+        let mut tree = FieldMaskTree::default();
+        tree.add_field_path("attributes");
+        let subtree = tree.subtree("attributes").unwrap();
+        assert!(subtree.map_keys().is_none());
+    }
+
+    #[test]
+    fn test_map_field_filter() {
+        // Simulates: wrapper "feature_flags" contains inner map field "flags"
+
+        // Case 1: bare wrapper (wildcard) → None (empty map)
+        let mut tree = FieldMaskTree::default();
+        tree.add_field_path("feature_flags");
+        let subtree = tree.subtree("feature_flags").unwrap();
+        assert!(subtree.map_field_filter("flags").is_none());
+
+        // Case 2: inner map field requested without keys → Some(None) (all entries)
+        let mut tree = FieldMaskTree::default();
+        tree.add_field_path("feature_flags.flags");
+        let subtree = tree.subtree("feature_flags").unwrap();
+        assert!(matches!(subtree.map_field_filter("flags"), Some(None)));
+
+        // Case 3: specific keys → Some(Some(keys))
+        let mut tree = FieldMaskTree::default();
+        tree.add_field_path("feature_flags.flags.flag_a");
+        tree.add_field_path("feature_flags.flags.flag_c");
+        let subtree = tree.subtree("feature_flags").unwrap();
+        let filter = subtree.map_field_filter("flags");
+        let mut keys: Vec<String> = filter.unwrap().unwrap().into_iter().collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["flag_a", "flag_c"]);
+
+        // Case 4: inner field name not in the tree → None (empty map)
+        let mut tree = FieldMaskTree::default();
+        tree.add_field_path("feature_flags.other_field");
+        let subtree = tree.subtree("feature_flags").unwrap();
+        assert!(subtree.map_field_filter("flags").is_none());
     }
 }

--- a/crates/iota-grpc-types/src/field/field_mask_tree.rs
+++ b/crates/iota-grpc-types/src/field/field_mask_tree.rs
@@ -168,7 +168,9 @@ impl FieldMaskTree {
     /// to put in the resulting map:
     ///
     /// - `None` — the wrapper itself was a wildcard *or* the inner field was
-    ///   not explicitly requested → include an **empty map**.
+    ///   not explicitly requested → **omit the wrapper field entirely** (leave
+    ///   it as `None` in the response so clients can distinguish "not
+    ///   requested" from "empty").
     /// - `Some(None)` — the inner field was requested without specific keys
     ///   (e.g. `feature_flags.flags`) → include **all entries**.
     /// - `Some(Some(keys))` — only these specific keys were requested (e.g.

--- a/crates/iota-grpc-types/src/field/field_mask_util.rs
+++ b/crates/iota-grpc-types/src/field/field_mask_util.rs
@@ -65,6 +65,8 @@ impl FieldMaskUtil for FieldMask {
                 if let Some(field) = fields.iter().find(|field| field.name == field_name) {
                     match (field.message_fields, remainder) {
                         (None, None) | (Some(_), None) => return true,
+                        // If the matched field is a map, any key name after it is valid
+                        (None, Some(_)) if field.is_map => return true,
                         (None, Some(_)) => return false,
                         (Some(sub_message_fields), Some(remainder)) => {
                             fields = sub_message_fields;
@@ -186,6 +188,7 @@ mod tests {
                     json_name: "a",
                     number: 1,
                     is_optional: false,
+                    is_map: false,
                     message_fields: None,
                 },
                 &MessageField {
@@ -193,6 +196,7 @@ mod tests {
                     json_name: "b",
                     number: 2,
                     is_optional: false,
+                    is_map: false,
                     message_fields: None,
                 },
             ];
@@ -214,5 +218,58 @@ mod tests {
         assert_eq!(mask.validate::<Foo>(), Err("baz.a"));
         let mask = FieldMask::from_str("foobar");
         assert_eq!(mask.validate::<Foo>(), Err("foobar"));
+    }
+
+    #[test]
+    fn test_validate_map_key() {
+        // Simulates ProtocolConfig-like structure:
+        //   Outer.map_wrapper (message) -> MapWrapper.entries (map<string, string>)
+        struct Outer;
+        struct MapWrapper;
+
+        // MapWrapper has a single map field
+        const MAP_FIELD: &MessageField = &MessageField {
+            name: "entries",
+            json_name: "entries",
+            number: 1,
+            is_optional: false,
+            is_map: true,
+            message_fields: None,
+        };
+
+        impl MessageFields for MapWrapper {
+            const FIELDS: &'static [&'static MessageField] = &[MAP_FIELD];
+        }
+
+        impl MessageFields for Outer {
+            const FIELDS: &'static [&'static MessageField] = &[
+                &MessageField::new("scalar"),
+                &MessageField::new("map_wrapper").with_message_fields(MapWrapper::FIELDS),
+            ];
+        }
+
+        // Exact field name is valid
+        let mask = FieldMask::from_str("map_wrapper");
+        assert_eq!(mask.validate::<Outer>(), Ok(()));
+
+        // Exact map field name is valid
+        let mask = FieldMask::from_str("map_wrapper.entries");
+        assert_eq!(mask.validate::<Outer>(), Ok(()));
+
+        // Any key after the map field is valid
+        let mask = FieldMask::from_str("map_wrapper.entries.my_key");
+        assert_eq!(mask.validate::<Outer>(), Ok(()));
+
+        // Multiple keys
+        let mask = FieldMask::from_str("map_wrapper.entries.key1,map_wrapper.entries.key2");
+        assert_eq!(mask.validate::<Outer>(), Ok(()));
+
+        // Non-map scalar field still rejects sub-paths
+        let mask = FieldMask::from_str("scalar.bad");
+        assert_eq!(mask.validate::<Outer>(), Err("scalar.bad"));
+
+        // Non-existent top-level field is rejected
+        let mask = FieldMask::from_str("no_such_field");
+        assert_eq!(mask.validate::<Outer>(), Err("no_such_field"));
     }
 }

--- a/crates/iota-grpc-types/src/field/mod.rs
+++ b/crates/iota-grpc-types/src/field/mod.rs
@@ -62,6 +62,7 @@ pub struct MessageField {
     pub json_name: &'static str,
     pub number: i32,
     pub is_optional: bool,
+    pub is_map: bool,
     pub message_fields: Option<&'static [&'static MessageField]>,
 }
 
@@ -100,6 +101,7 @@ impl MessageField {
             json_name: "",
             number: 0,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         }
     }
@@ -114,6 +116,11 @@ impl MessageField {
 
     pub const fn with_optional(mut self, is_optional: bool) -> Self {
         self.is_optional = is_optional;
+        self
+    }
+
+    pub const fn with_is_map(mut self, is_map: bool) -> Self {
+        self.is_map = is_map;
         self
     }
 }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.bcs.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.bcs.field_info.rs
@@ -13,6 +13,7 @@ mod _field_impls {
             json_name: "data",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.checkpoint.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.checkpoint.field_info.rs
@@ -25,6 +25,7 @@ mod _field_impls {
             json_name: "digest",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
@@ -32,6 +33,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -76,6 +78,7 @@ mod _field_impls {
             json_name: "digest",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
@@ -83,6 +86,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -127,6 +131,7 @@ mod _field_impls {
             json_name: "sequenceNumber",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const SUMMARY_FIELD: &'static MessageField = &MessageField {
@@ -134,6 +139,7 @@ mod _field_impls {
             json_name: "summary",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(CheckpointSummary::FIELDS),
         };
         pub const CONTENTS_FIELD: &'static MessageField = &MessageField {
@@ -141,6 +147,7 @@ mod _field_impls {
             json_name: "contents",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(CheckpointContents::FIELDS),
         };
         pub const SIGNATURE_FIELD: &'static MessageField = &MessageField {
@@ -148,6 +155,7 @@ mod _field_impls {
             json_name: "signature",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ValidatorAggregatedSignature::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.command.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.command.field_info.rs
@@ -81,6 +81,7 @@ mod _field_impls {
                 json_name: "index",
                 number: 1i32,
                 is_optional: true,
+                is_map: false,
                 message_fields: None,
             };
         }
@@ -118,6 +119,7 @@ mod _field_impls {
                 json_name: "index",
                 number: 1i32,
                 is_optional: true,
+                is_map: false,
                 message_fields: None,
             };
             pub const NESTED_RESULT_INDEX_FIELD: &'static MessageField = &MessageField {
@@ -125,6 +127,7 @@ mod _field_impls {
                 json_name: "nestedResultIndex",
                 number: 2i32,
                 is_optional: true,
+                is_map: false,
                 message_fields: None,
             };
         }
@@ -170,6 +173,7 @@ mod _field_impls {
             json_name: "unknown",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Unknown::FIELDS),
         };
         pub const GAS_COIN_FIELD: &'static MessageField = &MessageField {
@@ -177,6 +181,7 @@ mod _field_impls {
             json_name: "gasCoin",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(GasCoin::FIELDS),
         };
         pub const INPUT_FIELD: &'static MessageField = &MessageField {
@@ -184,6 +189,7 @@ mod _field_impls {
             json_name: "input",
             number: 3i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Input::FIELDS),
         };
         pub const RESULT_FIELD: &'static MessageField = &MessageField {
@@ -191,6 +197,7 @@ mod _field_impls {
             json_name: "result",
             number: 4i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Result::FIELDS),
         };
     }
@@ -245,6 +252,7 @@ mod _field_impls {
             json_name: "argument",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Argument::FIELDS),
         };
         pub const TYPE_TAG_FIELD: &'static MessageField = &MessageField {
@@ -252,6 +260,7 @@ mod _field_impls {
             json_name: "typeTag",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(TypeTag::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
@@ -259,6 +268,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
         pub const JSON_FIELD: &'static MessageField = &MessageField {
@@ -266,6 +276,7 @@ mod _field_impls {
             json_name: "json",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -320,6 +331,7 @@ mod _field_impls {
             json_name: "outputs",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(CommandOutput::FIELDS),
         };
     }
@@ -357,6 +369,7 @@ mod _field_impls {
             json_name: "mutatedByRef",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(CommandOutputs::FIELDS),
         };
         pub const RETURN_VALUES_FIELD: &'static MessageField = &MessageField {
@@ -364,6 +377,7 @@ mod _field_impls {
             json_name: "returnValues",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(CommandOutputs::FIELDS),
         };
     }
@@ -408,6 +422,7 @@ mod _field_impls {
             json_name: "results",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(CommandResult::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.epoch.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.epoch.field_info.rs
@@ -17,6 +17,7 @@ mod _field_impls {
             json_name: "publicKey",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const WEIGHT_FIELD: &'static MessageField = &MessageField {
@@ -24,6 +25,7 @@ mod _field_impls {
             json_name: "weight",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -68,6 +70,7 @@ mod _field_impls {
             json_name: "members",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(ValidatorCommitteeMember::FIELDS),
         };
     }
@@ -105,6 +108,7 @@ mod _field_impls {
             json_name: "epoch",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const MEMBERS_FIELD: &'static MessageField = &MessageField {
@@ -112,6 +116,7 @@ mod _field_impls {
             json_name: "members",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ValidatorCommitteeMembers::FIELDS),
         };
     }
@@ -156,6 +161,7 @@ mod _field_impls {
             json_name: "flags",
             number: 1i32,
             is_optional: false,
+            is_map: true,
             message_fields: None,
         };
     }
@@ -193,6 +199,7 @@ mod _field_impls {
             json_name: "attributes",
             number: 1i32,
             is_optional: false,
+            is_map: true,
             message_fields: None,
         };
     }
@@ -230,6 +237,7 @@ mod _field_impls {
             json_name: "protocolVersion",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const FEATURE_FLAGS_FIELD: &'static MessageField = &MessageField {
@@ -237,6 +245,7 @@ mod _field_impls {
             json_name: "featureFlags",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ProtocolFeatureFlags::FIELDS),
         };
         pub const ATTRIBUTES_FIELD: &'static MessageField = &MessageField {
@@ -244,6 +253,7 @@ mod _field_impls {
             json_name: "attributes",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ProtocolAttributes::FIELDS),
         };
     }
@@ -293,6 +303,7 @@ mod _field_impls {
             json_name: "epoch",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const COMMITTEE_FIELD: &'static MessageField = &MessageField {
@@ -300,6 +311,7 @@ mod _field_impls {
             json_name: "committee",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ValidatorCommittee::FIELDS),
         };
         pub const BCS_SYSTEM_STATE_FIELD: &'static MessageField = &MessageField {
@@ -307,6 +319,7 @@ mod _field_impls {
             json_name: "bcsSystemState",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
         pub const FIRST_CHECKPOINT_FIELD: &'static MessageField = &MessageField {
@@ -314,6 +327,7 @@ mod _field_impls {
             json_name: "firstCheckpoint",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const LAST_CHECKPOINT_FIELD: &'static MessageField = &MessageField {
@@ -321,6 +335,7 @@ mod _field_impls {
             json_name: "lastCheckpoint",
             number: 5i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const START_FIELD: &'static MessageField = &MessageField {
@@ -328,6 +343,7 @@ mod _field_impls {
             json_name: "start",
             number: 6i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const END_FIELD: &'static MessageField = &MessageField {
@@ -335,6 +351,7 @@ mod _field_impls {
             json_name: "end",
             number: 7i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const REFERENCE_GAS_PRICE_FIELD: &'static MessageField = &MessageField {
@@ -342,6 +359,7 @@ mod _field_impls {
             json_name: "referenceGasPrice",
             number: 8i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const PROTOCOL_CONFIG_FIELD: &'static MessageField = &MessageField {
@@ -349,6 +367,7 @@ mod _field_impls {
             json_name: "protocolConfig",
             number: 9i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ProtocolConfig::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.event.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.event.field_info.rs
@@ -21,6 +21,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
         pub const PACKAGE_ID_FIELD: &'static MessageField = &MessageField {
@@ -28,6 +29,7 @@ mod _field_impls {
             json_name: "packageId",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Address::FIELDS),
         };
         pub const MODULE_FIELD: &'static MessageField = &MessageField {
@@ -35,6 +37,7 @@ mod _field_impls {
             json_name: "module",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const SENDER_FIELD: &'static MessageField = &MessageField {
@@ -42,6 +45,7 @@ mod _field_impls {
             json_name: "sender",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Address::FIELDS),
         };
         pub const EVENT_TYPE_FIELD: &'static MessageField = &MessageField {
@@ -49,6 +53,7 @@ mod _field_impls {
             json_name: "eventType",
             number: 5i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const BCS_CONTENTS_FIELD: &'static MessageField = &MessageField {
@@ -56,6 +61,7 @@ mod _field_impls {
             json_name: "bcsContents",
             number: 6i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
         pub const JSON_CONTENTS_FIELD: &'static MessageField = &MessageField {
@@ -63,6 +69,7 @@ mod _field_impls {
             json_name: "jsonContents",
             number: 7i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -132,6 +139,7 @@ mod _field_impls {
             json_name: "events",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Event::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.field_info.rs
@@ -21,6 +21,7 @@ mod _field_impls {
             json_name: "filters",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -58,6 +59,7 @@ mod _field_impls {
             json_name: "filters",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -95,6 +97,7 @@ mod _field_impls {
             json_name: "filter",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -132,6 +135,7 @@ mod _field_impls {
             json_name: "address",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Address::FIELDS),
         };
     }
@@ -169,6 +173,7 @@ mod _field_impls {
             json_name: "packageId",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Address::FIELDS),
         };
         pub const MODULE_FIELD: &'static MessageField = &MessageField {
@@ -176,6 +181,7 @@ mod _field_impls {
             json_name: "module",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -220,6 +226,7 @@ mod _field_impls {
             json_name: "structTag",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -257,6 +264,7 @@ mod _field_impls {
             json_name: "all",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(AllEventFilter::FIELDS),
         };
         pub const ANY_FIELD: &'static MessageField = &MessageField {
@@ -264,6 +272,7 @@ mod _field_impls {
             json_name: "any",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(AnyEventFilter::FIELDS),
         };
         pub const NEGATION_FIELD: &'static MessageField = &MessageField {
@@ -271,6 +280,7 @@ mod _field_impls {
             json_name: "negation",
             number: 3i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(NotEventFilter::FIELDS),
         };
         pub const SENDER_FIELD: &'static MessageField = &MessageField {
@@ -278,6 +288,7 @@ mod _field_impls {
             json_name: "sender",
             number: 4i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(AddressFilter::FIELDS),
         };
         pub const MOVE_PACKAGE_AND_MODULE_FIELD: &'static MessageField = &MessageField {
@@ -285,6 +296,7 @@ mod _field_impls {
             json_name: "movePackageAndModule",
             number: 5i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(MovePackageAndModuleFilter::FIELDS),
         };
         pub const MOVE_EVENT_PACKAGE_AND_MODULE_FIELD: &'static MessageField = &MessageField {
@@ -292,6 +304,7 @@ mod _field_impls {
             json_name: "moveEventPackageAndModule",
             number: 6i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(MovePackageAndModuleFilter::FIELDS),
         };
         pub const MOVE_EVENT_TYPE_FIELD: &'static MessageField = &MessageField {
@@ -299,6 +312,7 @@ mod _field_impls {
             json_name: "moveEventType",
             number: 7i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(MoveEventTypeFilter::FIELDS),
         };
     }
@@ -372,6 +386,7 @@ mod _field_impls {
             json_name: "filters",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -409,6 +424,7 @@ mod _field_impls {
             json_name: "filters",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -446,6 +462,7 @@ mod _field_impls {
             json_name: "filter",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -483,6 +500,7 @@ mod _field_impls {
             json_name: "kinds",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -520,6 +538,7 @@ mod _field_impls {
             json_name: "objectRef",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(ObjectReference::FIELDS),
         };
     }
@@ -557,6 +576,7 @@ mod _field_impls {
             json_name: "packageId",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Address::FIELDS),
         };
         pub const MODULE_FIELD: &'static MessageField = &MessageField {
@@ -564,6 +584,7 @@ mod _field_impls {
             json_name: "module",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const FUNCTION_FIELD: &'static MessageField = &MessageField {
@@ -571,6 +592,7 @@ mod _field_impls {
             json_name: "function",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -620,6 +642,7 @@ mod _field_impls {
             json_name: "all",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(AllTransactionFilter::FIELDS),
         };
         pub const ANY_FIELD: &'static MessageField = &MessageField {
@@ -627,6 +650,7 @@ mod _field_impls {
             json_name: "any",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(AnyTransactionFilter::FIELDS),
         };
         pub const NEGATION_FIELD: &'static MessageField = &MessageField {
@@ -634,6 +658,7 @@ mod _field_impls {
             json_name: "negation",
             number: 3i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(NotTransactionFilter::FIELDS),
         };
         pub const TRANSACTION_KINDS_FIELD: &'static MessageField = &MessageField {
@@ -641,6 +666,7 @@ mod _field_impls {
             json_name: "transactionKinds",
             number: 4i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(TransactionKindsFilter::FIELDS),
         };
         pub const SENDER_FIELD: &'static MessageField = &MessageField {
@@ -648,6 +674,7 @@ mod _field_impls {
             json_name: "sender",
             number: 5i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(AddressFilter::FIELDS),
         };
         pub const RECEIVER_FIELD: &'static MessageField = &MessageField {
@@ -655,6 +682,7 @@ mod _field_impls {
             json_name: "receiver",
             number: 6i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(AddressFilter::FIELDS),
         };
         pub const AFFECTED_OBJECT_FIELD: &'static MessageField = &MessageField {
@@ -662,6 +690,7 @@ mod _field_impls {
             json_name: "affectedObject",
             number: 7i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(ObjectIdFilter::FIELDS),
         };
         pub const MOVE_CALL_FIELD: &'static MessageField = &MessageField {
@@ -669,6 +698,7 @@ mod _field_impls {
             json_name: "moveCall",
             number: 8i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(MoveCallFilter::FIELDS),
         };
         pub const EVENT_FIELD: &'static MessageField = &MessageField {
@@ -676,6 +706,7 @@ mod _field_impls {
             json_name: "event",
             number: 9i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(EventFilter::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.field_info.rs
@@ -57,6 +57,7 @@ mod _field_impls {
                 json_name: "sequenceNumber",
                 number: 1i32,
                 is_optional: true,
+                is_map: false,
                 message_fields: None,
             };
         }
@@ -97,6 +98,7 @@ mod _field_impls {
             json_name: "readMask",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -134,6 +136,7 @@ mod _field_impls {
             json_name: "chainId",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
         pub const CHAIN_FIELD: &'static MessageField = &MessageField {
@@ -141,6 +144,7 @@ mod _field_impls {
             json_name: "chain",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const EPOCH_FIELD: &'static MessageField = &MessageField {
@@ -148,6 +152,7 @@ mod _field_impls {
             json_name: "epoch",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const EXECUTED_CHECKPOINT_HEIGHT_FIELD: &'static MessageField = &MessageField {
@@ -155,6 +160,7 @@ mod _field_impls {
             json_name: "executedCheckpointHeight",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const EXECUTED_CHECKPOINT_TIMESTAMP_FIELD: &'static MessageField = &MessageField {
@@ -162,6 +168,7 @@ mod _field_impls {
             json_name: "executedCheckpointTimestamp",
             number: 5i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const LOWEST_AVAILABLE_CHECKPOINT_FIELD: &'static MessageField = &MessageField {
@@ -169,6 +176,7 @@ mod _field_impls {
             json_name: "lowestAvailableCheckpoint",
             number: 6i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const LOWEST_AVAILABLE_CHECKPOINT_OBJECTS_FIELD: &'static MessageField = &MessageField {
@@ -176,6 +184,7 @@ mod _field_impls {
             json_name: "lowestAvailableCheckpointObjects",
             number: 7i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const SERVER_FIELD: &'static MessageField = &MessageField {
@@ -183,6 +192,7 @@ mod _field_impls {
             json_name: "server",
             number: 8i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -264,6 +274,7 @@ mod _field_impls {
             json_name: "objectRef",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ObjectReference::FIELDS),
         };
     }
@@ -301,6 +312,7 @@ mod _field_impls {
             json_name: "requests",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(ObjectRequest::FIELDS),
         };
     }
@@ -338,6 +350,7 @@ mod _field_impls {
             json_name: "requests",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ObjectRequests::FIELDS),
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
@@ -345,6 +358,7 @@ mod _field_impls {
             json_name: "readMask",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
@@ -352,6 +366,7 @@ mod _field_impls {
             json_name: "maxMessageSizeBytes",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -401,6 +416,7 @@ mod _field_impls {
             json_name: "object",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Object::FIELDS),
         };
         pub const ERROR_FIELD: &'static MessageField = &MessageField {
@@ -408,6 +424,7 @@ mod _field_impls {
             json_name: "error",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -452,6 +469,7 @@ mod _field_impls {
             json_name: "objects",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(ObjectResult::FIELDS),
         };
         pub const HAS_NEXT_FIELD: &'static MessageField = &MessageField {
@@ -459,6 +477,7 @@ mod _field_impls {
             json_name: "hasNext",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -503,6 +522,7 @@ mod _field_impls {
             json_name: "digest",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
     }
@@ -540,6 +560,7 @@ mod _field_impls {
             json_name: "requests",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(TransactionRequest::FIELDS),
         };
     }
@@ -577,6 +598,7 @@ mod _field_impls {
             json_name: "requests",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(TransactionRequests::FIELDS),
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
@@ -584,6 +606,7 @@ mod _field_impls {
             json_name: "readMask",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
@@ -591,6 +614,7 @@ mod _field_impls {
             json_name: "maxMessageSizeBytes",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -640,6 +664,7 @@ mod _field_impls {
             json_name: "transaction",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
         pub const ERROR_FIELD: &'static MessageField = &MessageField {
@@ -647,6 +672,7 @@ mod _field_impls {
             json_name: "error",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -691,6 +717,7 @@ mod _field_impls {
             json_name: "transactions",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(TransactionResult::FIELDS),
         };
         pub const HAS_NEXT_FIELD: &'static MessageField = &MessageField {
@@ -698,6 +725,7 @@ mod _field_impls {
             json_name: "hasNext",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -742,6 +770,7 @@ mod _field_impls {
             json_name: "latest",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const SEQUENCE_NUMBER_FIELD: &'static MessageField = &MessageField {
@@ -749,6 +778,7 @@ mod _field_impls {
             json_name: "sequenceNumber",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const DIGEST_FIELD: &'static MessageField = &MessageField {
@@ -756,6 +786,7 @@ mod _field_impls {
             json_name: "digest",
             number: 3i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
@@ -763,6 +794,7 @@ mod _field_impls {
             json_name: "readMask",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const TRANSACTIONS_FILTER_FIELD: &'static MessageField = &MessageField {
@@ -770,6 +802,7 @@ mod _field_impls {
             json_name: "transactionsFilter",
             number: 5i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(TransactionFilter::FIELDS),
         };
         pub const EVENTS_FILTER_FIELD: &'static MessageField = &MessageField {
@@ -777,6 +810,7 @@ mod _field_impls {
             json_name: "eventsFilter",
             number: 6i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(EventFilter::FIELDS),
         };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
@@ -784,6 +818,7 @@ mod _field_impls {
             json_name: "maxMessageSizeBytes",
             number: 7i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -853,6 +888,7 @@ mod _field_impls {
             json_name: "startSequenceNumber",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const END_SEQUENCE_NUMBER_FIELD: &'static MessageField = &MessageField {
@@ -860,6 +896,7 @@ mod _field_impls {
             json_name: "endSequenceNumber",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
@@ -867,6 +904,7 @@ mod _field_impls {
             json_name: "readMask",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const TRANSACTIONS_FILTER_FIELD: &'static MessageField = &MessageField {
@@ -874,6 +912,7 @@ mod _field_impls {
             json_name: "transactionsFilter",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(TransactionFilter::FIELDS),
         };
         pub const EVENTS_FILTER_FIELD: &'static MessageField = &MessageField {
@@ -881,6 +920,7 @@ mod _field_impls {
             json_name: "eventsFilter",
             number: 5i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(EventFilter::FIELDS),
         };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
@@ -888,6 +928,7 @@ mod _field_impls {
             json_name: "maxMessageSizeBytes",
             number: 6i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -954,6 +995,7 @@ mod _field_impls {
             json_name: "checkpoint",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Checkpoint::FIELDS),
         };
         pub const TRANSACTIONS_FIELD: &'static MessageField = &MessageField {
@@ -961,6 +1003,7 @@ mod _field_impls {
             json_name: "transactions",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(ExecutedTransactions::FIELDS),
         };
         pub const EVENTS_FIELD: &'static MessageField = &MessageField {
@@ -968,6 +1011,7 @@ mod _field_impls {
             json_name: "events",
             number: 3i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Events::FIELDS),
         };
         pub const END_MARKER_FIELD: &'static MessageField = &MessageField {
@@ -975,6 +1019,7 @@ mod _field_impls {
             json_name: "endMarker",
             number: 4i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(EndMarker::FIELDS),
         };
     }
@@ -1029,6 +1074,7 @@ mod _field_impls {
             json_name: "epoch",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
@@ -1036,6 +1082,7 @@ mod _field_impls {
             json_name: "readMask",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -1080,6 +1127,7 @@ mod _field_impls {
             json_name: "epoch",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Epoch::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.object.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.object.field_info.rs
@@ -21,6 +21,7 @@ mod _field_impls {
             json_name: "reference",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ObjectReference::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
@@ -28,6 +29,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -72,6 +74,7 @@ mod _field_impls {
             json_name: "objects",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(Object::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.signatures.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.signatures.field_info.rs
@@ -17,6 +17,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -54,6 +55,7 @@ mod _field_impls {
             json_name: "signatures",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(UserSignature::FIELDS),
         };
     }
@@ -91,6 +93,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.transaction.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.transaction.field_info.rs
@@ -33,6 +33,7 @@ mod _field_impls {
             json_name: "digest",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
@@ -40,6 +41,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -84,6 +86,7 @@ mod _field_impls {
             json_name: "digest",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
         pub const BCS_FIELD: &'static MessageField = &MessageField {
@@ -91,6 +94,7 @@ mod _field_impls {
             json_name: "bcs",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(BcsData::FIELDS),
         };
     }
@@ -135,6 +139,7 @@ mod _field_impls {
             json_name: "digest",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
         pub const EVENTS_FIELD: &'static MessageField = &MessageField {
@@ -142,6 +147,7 @@ mod _field_impls {
             json_name: "events",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Events::FIELDS),
         };
     }
@@ -186,6 +192,7 @@ mod _field_impls {
             json_name: "transaction",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Transaction::FIELDS),
         };
         pub const SIGNATURES_FIELD: &'static MessageField = &MessageField {
@@ -193,6 +200,7 @@ mod _field_impls {
             json_name: "signatures",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(UserSignatures::FIELDS),
         };
         pub const EFFECTS_FIELD: &'static MessageField = &MessageField {
@@ -200,6 +208,7 @@ mod _field_impls {
             json_name: "effects",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(TransactionEffects::FIELDS),
         };
         pub const EVENTS_FIELD: &'static MessageField = &MessageField {
@@ -207,6 +216,7 @@ mod _field_impls {
             json_name: "events",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(TransactionEvents::FIELDS),
         };
         pub const CHECKPOINT_FIELD: &'static MessageField = &MessageField {
@@ -214,6 +224,7 @@ mod _field_impls {
             json_name: "checkpoint",
             number: 5i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const TIMESTAMP_FIELD: &'static MessageField = &MessageField {
@@ -221,6 +232,7 @@ mod _field_impls {
             json_name: "timestamp",
             number: 6i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const INPUT_OBJECTS_FIELD: &'static MessageField = &MessageField {
@@ -228,6 +240,7 @@ mod _field_impls {
             json_name: "inputObjects",
             number: 7i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Objects::FIELDS),
         };
         pub const OUTPUT_OBJECTS_FIELD: &'static MessageField = &MessageField {
@@ -235,6 +248,7 @@ mod _field_impls {
             json_name: "outputObjects",
             number: 8i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Objects::FIELDS),
         };
     }
@@ -309,6 +323,7 @@ mod _field_impls {
             json_name: "transactions",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.transaction_execution_service.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.transaction_execution_service.field_info.rs
@@ -29,6 +29,7 @@ mod _field_impls {
             json_name: "transaction",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Transaction::FIELDS),
         };
         pub const SIGNATURES_FIELD: &'static MessageField = &MessageField {
@@ -36,6 +37,7 @@ mod _field_impls {
             json_name: "signatures",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(UserSignatures::FIELDS),
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
@@ -43,6 +45,7 @@ mod _field_impls {
             json_name: "readMask",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -92,6 +95,7 @@ mod _field_impls {
             json_name: "transaction",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
     }
@@ -129,6 +133,7 @@ mod _field_impls {
             json_name: "transaction",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Transaction::FIELDS),
         };
         pub const TX_CHECKS_FIELD: &'static MessageField = &MessageField {
@@ -136,6 +141,7 @@ mod _field_impls {
             json_name: "txChecks",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const ESTIMATE_GAS_BUDGET_FIELD: &'static MessageField = &MessageField {
@@ -143,6 +149,7 @@ mod _field_impls {
             json_name: "estimateGasBudget",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const READ_MASK_FIELD: &'static MessageField = &MessageField {
@@ -150,6 +157,7 @@ mod _field_impls {
             json_name: "readMask",
             number: 4i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -204,6 +212,7 @@ mod _field_impls {
             json_name: "transaction",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(ExecutedTransaction::FIELDS),
         };
         pub const COMMAND_RESULTS_FIELD: &'static MessageField = &MessageField {
@@ -211,6 +220,7 @@ mod _field_impls {
             json_name: "commandResults",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(CommandResults::FIELDS),
         };
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.types.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.types.field_info.rs
@@ -13,6 +13,7 @@ mod _field_impls {
             json_name: "address",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -50,6 +51,7 @@ mod _field_impls {
             json_name: "digest",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -87,6 +89,7 @@ mod _field_impls {
             json_name: "objectId",
             number: 1i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const VERSION_FIELD: &'static MessageField = &MessageField {
@@ -94,6 +97,7 @@ mod _field_impls {
             json_name: "version",
             number: 2i32,
             is_optional: true,
+            is_map: false,
             message_fields: None,
         };
         pub const DIGEST_FIELD: &'static MessageField = &MessageField {
@@ -101,6 +105,7 @@ mod _field_impls {
             json_name: "digest",
             number: 3i32,
             is_optional: true,
+            is_map: false,
             message_fields: Some(Digest::FIELDS),
         };
     }
@@ -150,6 +155,7 @@ mod _field_impls {
             json_name: "innerType",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -187,6 +193,7 @@ mod _field_impls {
             json_name: "structTag",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
     }
@@ -224,6 +231,7 @@ mod _field_impls {
             json_name: "boolTag",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const U8_TAG_FIELD: &'static MessageField = &MessageField {
@@ -231,6 +239,7 @@ mod _field_impls {
             json_name: "u8Tag",
             number: 2i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const U16_TAG_FIELD: &'static MessageField = &MessageField {
@@ -238,6 +247,7 @@ mod _field_impls {
             json_name: "u16Tag",
             number: 3i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const U32_TAG_FIELD: &'static MessageField = &MessageField {
@@ -245,6 +255,7 @@ mod _field_impls {
             json_name: "u32Tag",
             number: 4i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const U64_TAG_FIELD: &'static MessageField = &MessageField {
@@ -252,6 +263,7 @@ mod _field_impls {
             json_name: "u64Tag",
             number: 5i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const U128_TAG_FIELD: &'static MessageField = &MessageField {
@@ -259,6 +271,7 @@ mod _field_impls {
             json_name: "u128Tag",
             number: 6i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const U256_TAG_FIELD: &'static MessageField = &MessageField {
@@ -266,6 +279,7 @@ mod _field_impls {
             json_name: "u256Tag",
             number: 7i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const ADDRESS_TAG_FIELD: &'static MessageField = &MessageField {
@@ -273,6 +287,7 @@ mod _field_impls {
             json_name: "addressTag",
             number: 8i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const SIGNER_TAG_FIELD: &'static MessageField = &MessageField {
@@ -280,6 +295,7 @@ mod _field_impls {
             json_name: "signerTag",
             number: 9i32,
             is_optional: false,
+            is_map: false,
             message_fields: None,
         };
         pub const VECTOR_TAG_FIELD: &'static MessageField = &MessageField {
@@ -287,6 +303,7 @@ mod _field_impls {
             json_name: "vectorTag",
             number: 10i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(TypeTagVector::FIELDS),
         };
         pub const STRUCT_TAG_FIELD: &'static MessageField = &MessageField {
@@ -294,6 +311,7 @@ mod _field_impls {
             json_name: "structTag",
             number: 11i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(TypeTagStruct::FIELDS),
         };
     }
@@ -383,6 +401,7 @@ mod _field_impls {
             json_name: "typeTags",
             number: 1i32,
             is_optional: false,
+            is_map: false,
             message_fields: Some(TypeTag::FIELDS),
         };
     }

--- a/crates/iota-proto-build/src/generate_fields.rs
+++ b/crates/iota-proto-build/src/generate_fields.rs
@@ -447,7 +447,7 @@ fn generate_field_constant(
     // Check if the field is optional in the proto definition
     let is_proto3_optional = field.proto3_optional.unwrap_or(false);
 
-    let message_fields =
+    let (is_map, message_fields) =
         if matches!(field.r#type(), Type::Message) && !field.type_name().contains("google") {
             let field_message_name = field.type_name().split('.').next_back().unwrap();
 
@@ -468,17 +468,16 @@ fn generate_field_constant(
             let is_circular_reference = is_boxed
                 && dependency_graph.has_circular_dependency(message_name, field_message_name);
 
-            if field_message_name == message_name
-                || map_types.contains(field_message_name)
-                || is_circular_reference
-            {
-                quote! { None }
+            if field_message_name == message_name || is_circular_reference {
+                (quote! { false }, quote! { None })
+            } else if map_types.contains(field_message_name) {
+                (quote! { true }, quote! { None })
             } else {
                 let field_message = quote::format_ident!("{field_message_name}");
-                quote! { Some(#field_message::FIELDS) }
+                (quote! { false }, quote! { Some(#field_message::FIELDS) })
             }
         } else {
-            quote! { None }
+            (quote! { false }, quote! { None })
         };
 
     quote! {
@@ -487,6 +486,7 @@ fn generate_field_constant(
             json_name: #json_name,
             number: #number,
             is_optional: #is_proto3_optional,
+            is_map: #is_map,
             message_fields: #message_fields,
         };
     }


### PR DESCRIPTION
# Description of change

Right now if a wildcard field mask is passed to `get_epoch`, all possible values for the protocol attributes and protocol flags are returned. This would create huge responses, even if those fields are mostly not relevant for clients. With the changed logic, they can either specify keys inside the map directly, or still get all values when mentioning the inner field inside the wrapper as a wildcard for the map.

```rust
// Get all feature flags for the current epoch
let epoch = client
    .get_epoch(None, Some("protocol_config.feature_flags.flags"))
    .await?;
let flags = epoch.protocol_config.unwrap().feature_flags.unwrap().flags;

// Get a single named feature flag
let epoch = client
    .get_epoch(
        None,
        Some("protocol_config.feature_flags.flags.zklogin_auth"),
    )
    .await?;

// Get a single named attribute
let epoch = client
    .get_epoch(
        None,
        Some("protocol_config.attributes.attributes.max_tx_gas"),
    )
    .await?;
```

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes