### PR TITLE
fix(iota-e2e-test): Re-enable `test_traffic_sketch_with_slow_blocks`

### DIFF
--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -637,8 +637,9 @@ async fn test_traffic_sketch_no_blocks() {
     let policy = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 1,
-        spam_policy_type: PolicyType::NoOp,
-        error_policy_type: PolicyType::FreqThreshold(sketch_config),
+        spam_policy_type: PolicyType::FreqThreshold(sketch_config),
+        error_policy_type: PolicyType::NoOp,
+        spam_sample_rate: Weight::one(),
         // keeping channel capacity small results in less errors in test metrics,
         // in case of congestion (due to running on slower hardware) requests are dropped
         // and do not influence the rate and do not make the spam rate inconsistent
@@ -667,7 +668,6 @@ async fn test_traffic_sketch_no_blocks() {
     assert!(metrics.total_time_blocked < Duration::from_secs(10));
 }
 
-#[ignore]
 #[sim_test]
 async fn test_traffic_sketch_with_slow_blocks() {
     telemetry_subscribers::init_for_testing();
@@ -681,9 +681,10 @@ async fn test_traffic_sketch_with_slow_blocks() {
     let policy = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 1,
-        spam_policy_type: PolicyType::NoOp,
-        error_policy_type: PolicyType::FreqThreshold(sketch_config),
-        channel_capacity: 100,
+        spam_policy_type: PolicyType::FreqThreshold(sketch_config),
+        error_policy_type: PolicyType::NoOp,
+        spam_sample_rate: Weight::one(),
+        channel_capacity: 10,
         dry_run: false,
         ..Default::default()
     };
@@ -699,9 +700,10 @@ async fn test_traffic_sketch_with_slow_blocks() {
     let expected_requests = 10_000 * 10 * 20;
     assert!(metrics.num_requests > expected_requests - 1_000);
     assert!(metrics.num_requests < expected_requests + 200);
-    // due to averaging, we will take 4 seconds to start blocking, then
-    // will be in blocklist for 1 second (roughly)
-    assert!(metrics.num_blocked as f64 > (expected_requests as f64 / 4.0) * 0.90);
+    // Due to averaging, we will take 4 seconds to start blocking, then
+    // will be in blocklist for 1 second (roughly). The cycle is 4s unblocked
+    // + 1s blocked = 5s, giving ~20% of requests blocked.
+    assert!(metrics.num_blocked as f64 > (expected_requests as f64 / 5.0) * 0.90);
     // 10 clients, blocked at least every 5 seconds, over 20 seconds
     assert!(metrics.num_blocklist_adds >= 40);
     assert!(metrics.abs_time_to_first_block.unwrap() < Duration::from_secs(5));


### PR DESCRIPTION
# Description of change

- Fix test_traffic_sketch_with_slow_blocks which has been `#[ignore]` since it was inherited from upstream https://github.com/MystenLabs/sui/pull/17408 when we rebased
- The test had three compounding bugs:
  - `FreqThresholdConfig` was on error_policy_type instead of `spam_policy_type`: `TrafficSim` only generates spam tallies (no error_info), so the policy was never triggered
  - Missing `spam_sample_rate: Weight::one()`: the default 20% sampling starves the sketch below the threshold
Blocking assertion used / 4.0 (25%) instead of / 5.0 (20%), but the actual cycle is 4s unblocked + 1s blocked = 5s
- Apply the same policy fix to `test_traffic_sketch_no_blocks` which had the same latent bug (though it can already pass)
- Test passed by `cargo simtest --package iota-e2e-tests --test traffic_control_tests -- test_traffic_sketch_with_slow_blocks` locally.

## Links to any relevant issues

fixes #4450 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Nodes (Validators and Full nodes): Fix bugs and re-enable `test_traffic_sketch_with_slow_blocks` 