### PR TITLE
fix(ts-sdk): update auto generated types for MoveAuthenticator after versioning

### DIFF
--- a/.changeset/silent-beds-complain.md
+++ b/.changeset/silent-beds-complain.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': minor
+---
+
+Support MoveAuthenticator versioning.

--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -105,14 +105,15 @@ export function Signatures({ transaction }: SignaturesProps) {
 
             if (parsed.signatureScheme === 'MoveAuthenticator') {
                 const authenticatedObjectId =
-                    parsed.moveAuthenticator.objectToAuthenticate.Object?.$kind ===
+                    parsed.moveAuthenticator.V1.objectToAuthenticate.Object?.$kind ===
                     'ImmOrOwnedObject'
-                        ? parsed.moveAuthenticator.objectToAuthenticate.Object.ImmOrOwnedObject
+                        ? parsed.moveAuthenticator.V1.objectToAuthenticate.Object.ImmOrOwnedObject
                               .objectId
-                        : parsed.moveAuthenticator.objectToAuthenticate.Object?.$kind ===
+                        : parsed.moveAuthenticator.V1.objectToAuthenticate.Object?.$kind ===
                             'Receiving'
-                          ? parsed.moveAuthenticator.objectToAuthenticate.Object.Receiving.objectId
-                          : parsed.moveAuthenticator.objectToAuthenticate.Object?.SharedObject
+                          ? parsed.moveAuthenticator.V1.objectToAuthenticate.Object.Receiving
+                                .objectId
+                          : parsed.moveAuthenticator.V1.objectToAuthenticate.Object?.SharedObject
                                 ?.objectId;
                 return {
                     ...parsed,

--- a/sdk/typescript/src/bcs/bcs.ts
+++ b/sdk/typescript/src/bcs/bcs.ts
@@ -320,12 +320,18 @@ export const PasskeyAuthenticator = bcs.struct('PasskeyAuthenticator', {
     userSignature: bcs.vector(bcs.u8()),
 });
 
-/**
- * MoveAuthenticator allows authenticating transactions via a Move function call
- * as part of Account Abstraction.
- */
-export const MoveAuthenticator = bcs.struct('MoveAuthenticator', {
+const MoveAuthenticatorV1 = bcs.struct('MoveAuthenticatorV1', {
     callArgs: bcs.vector(CallArg),
     typeArgs: bcs.vector(TypeTag),
     objectToAuthenticate: CallArg,
+});
+
+/**
+ * MoveAuthenticator allows authenticating transactions via a Move function call
+ * as part of Account Abstraction.
+ * The enum wrapper matches the Rust `MoveAuthenticatorInner` enum, which adds a
+ * one-byte variant prefix to the BCS representation.
+ */
+export const MoveAuthenticator = bcs.enum('MoveAuthenticator', {
+    V1: MoveAuthenticatorV1,
 });

--- a/sdk/typescript/src/client/types/generated.ts
+++ b/sdk/typescript/src/client/types/generated.ts
@@ -1098,7 +1098,11 @@ export interface IotaValidatorSummary {
  * Move code. This function represents the data received by the Move authenticate function during the
  * Account Abstraction authentication flow.
  */
-export interface MoveAuthenticator {
+export type MoveAuthenticator = {
+    V1: MoveAuthenticatorV1;
+};
+/** MoveAuthenticatorV1 is the first version of MoveAuthenticator. */
+export interface MoveAuthenticatorV1 {
     /** Input objects or primitive values */
     call_args: CallArg[];
     /** The object that is authenticated. Represents the account being the sender of the transaction. */

--- a/sdk/typescript/src/keypairs/move-authenticator/builder.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/builder.ts
@@ -251,6 +251,7 @@ export class MoveAuthenticatorBuilder {
         }
 
         return {
+            version: 'V1' as const,
             callArgs: resolvedCallArgs,
             typeArgs: this.typeArgs,
             objectToAuthenticate,

--- a/sdk/typescript/src/keypairs/move-authenticator/signer.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/signer.ts
@@ -55,8 +55,12 @@ export class MoveSigner extends Signer {
      * based on the object ID.
      */
     getPublicKey(): PublicKey {
-        const objectId = getObjectIdFromCallArg(this.data.objectToAuthenticate);
-        return new MoveAuthenticatorPublicKey(objectId);
+        if (this.data.version === 'V1') {
+            return new MoveAuthenticatorPublicKey(
+                getObjectIdFromCallArg(this.data.objectToAuthenticate),
+            );
+        }
+        throw new Error(`Unsupported MoveAuthenticator version: ${this.data.version}`);
     }
 
     /**
@@ -66,13 +70,18 @@ export class MoveSigner extends Signer {
      * @returns The BCS-serialized MoveAuthenticator bytes
      */
     async sign(): Promise<Uint8Array> {
-        return bcs.MoveAuthenticator.serialize({
-            callArgs: this.data.callArgs,
-            typeArgs: this.data.typeArgs,
-            objectToAuthenticate: {
-                Object: this.data.objectToAuthenticate,
-            },
-        }).toBytes();
+        if (this.data.version === 'V1') {
+            return bcs.MoveAuthenticator.serialize({
+                V1: {
+                    callArgs: this.data.callArgs,
+                    typeArgs: this.data.typeArgs,
+                    objectToAuthenticate: {
+                        Object: this.data.objectToAuthenticate,
+                    },
+                },
+            }).toBytes();
+        }
+        throw new Error(`Unsupported MoveAuthenticator version: ${this.data.version}`);
     }
 
     /**

--- a/sdk/typescript/src/keypairs/move-authenticator/types.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/types.ts
@@ -17,10 +17,13 @@ export type MoveAuthenticatorCallArg =
     | { Pure: Uint8Array };
 
 /**
- * The resolved MoveAuthenticator data structure.
- * Fields match the Rust MoveAuthenticator struct.
+ * The resolved MoveAuthenticator data structure, versioned as a discriminated
+ * union. Add new variants here when new versions are introduced on the Rust side.
  */
-export interface MoveAuthenticatorData {
+export type MoveAuthenticatorData = MoveAuthenticatorDataV1; // future: | MoveAuthenticatorDataV2;
+
+export interface MoveAuthenticatorDataV1 {
+    version: 'V1';
     callArgs: CallArg[];
     typeArgs: string[];
     objectToAuthenticate: ObjectArg;

--- a/sdk/typescript/src/verify/verify.ts
+++ b/sdk/typescript/src/verify/verify.ts
@@ -91,16 +91,21 @@ function parseSignature(signature: string) {
     }
 
     if (parsedSignature.signatureScheme === 'MoveAuthenticator') {
-        const authenticatedObjectId =
-            parsedSignature.moveAuthenticator.objectToAuthenticate.Object?.$kind ===
-            'ImmOrOwnedObject'
-                ? parsedSignature.moveAuthenticator.objectToAuthenticate.Object.ImmOrOwnedObject
-                      .objectId
-                : parsedSignature.moveAuthenticator.objectToAuthenticate.Object?.$kind ===
-                    'Receiving'
-                  ? parsedSignature.moveAuthenticator.objectToAuthenticate.Object.Receiving.objectId
-                  : parsedSignature.moveAuthenticator.objectToAuthenticate.Object?.SharedObject
-                        ?.objectId;
+        const moveAuth = parsedSignature.moveAuthenticator;
+        let authenticatedObjectId: string | undefined;
+
+        if (moveAuth.$kind === 'V1') {
+            const { objectToAuthenticate } = moveAuth.V1;
+            authenticatedObjectId =
+                objectToAuthenticate.Object?.$kind === 'ImmOrOwnedObject'
+                    ? objectToAuthenticate.Object.ImmOrOwnedObject.objectId
+                    : objectToAuthenticate.Object?.$kind === 'Receiving'
+                      ? objectToAuthenticate.Object.Receiving.objectId
+                      : objectToAuthenticate.Object?.SharedObject?.objectId;
+        } else {
+            throw new Error(`Unsupported MoveAuthenticator version: ${moveAuth.$kind}`);
+        }
+
         return {
             ...parsedSignature,
             publicKey: new MoveAuthenticatorPublicKey(authenticatedObjectId!),


### PR DESCRIPTION
# Description of change

Given the (breaking) changes in #10349, this PR updates the generated MoveAuthenticator type and updates the handling of such signature. 

Coming from the rust side is a hierarchization of the `MoveAuthenticator` and a following creation of a `MoveAuthenticatorV1`. This should make it easier to create `V2`, `V3` and so on, in the future.
