### PR TITLE
feat(gRPC): preserve gRPC client error information

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/client/common.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/common.rs
@@ -91,9 +91,9 @@ pub fn assert_grpc_not_found<T: std::fmt::Debug>(result: Result<T, Error>) {
     }
 }
 
-/// Check if error is a Server error containing "not found".
+/// Check if error is a Server error with NOT_FOUND status code.
 pub fn is_server_not_found(err: &Error) -> bool {
-    matches!(err, Error::Server(msg) if msg.to_lowercase().contains("not found"))
+    matches!(err, Error::Server(status) if tonic::Code::from_i32(status.code) == tonic::Code::NotFound)
 }
 
 /// Assert that a result is a Server "not found" error.

--- a/crates/iota-grpc-client/src/api/common.rs
+++ b/crates/iota-grpc-client/src/api/common.rs
@@ -10,6 +10,7 @@ use iota_grpc_types::v0::{
 };
 pub use iota_grpc_types::{
     field::{FieldMask, FieldMaskUtil},
+    google::rpc::Status as RpcStatus,
     proto::TryFromProtoError,
 };
 use iota_sdk_types::Digest;
@@ -22,9 +23,14 @@ pub enum Error {
     #[error("proto conversion error: {0}")]
     ProtoConversion(#[from] TryFromProtoError),
 
-    /// Error from the gRPC server.
-    #[error("server error: {0}")]
-    Server(String),
+    /// Per-item error returned by the server (preserves code, message,
+    /// details).
+    #[error("server error (code {code}): {msg}", code = .0.code, msg = .0.message)]
+    Server(RpcStatus),
+
+    /// Client-side protocol error (e.g. checkpoint stream reassembly).
+    #[error("protocol error: {0}")]
+    Protocol(String),
 
     /// Error converting signatures.
     #[error("signature conversion error: {0}")]
@@ -39,20 +45,14 @@ pub enum Error {
     Grpc(#[from] tonic::Status),
 }
 
-impl Error {
-    /// Create a new server error.
-    pub fn server<T: AsRef<str>>(msg: T) -> Self {
-        Error::Server(msg.as_ref().to_string())
-    }
-}
-
 impl From<Error> for tonic::Status {
     fn from(err: Error) -> Self {
         match err {
             Error::ProtoConversion(e) => {
                 tonic::Status::internal(format!("proto conversion error: {e}"))
             }
-            Error::Server(msg) => tonic::Status::internal(format!("server error: {msg}")),
+            Error::Server(status) => status.to_tonic_status(),
+            Error::Protocol(msg) => tonic::Status::internal(format!("protocol error: {msg}")),
             Error::Signature(msg) => {
                 tonic::Status::internal(format!("signature conversion error: {msg}"))
             }
@@ -141,9 +141,9 @@ impl ProtoResult for ObjectResult {
     fn into_result(self) -> Result<Self::Value> {
         match self.result {
             Some(object_result::Result::Object(obj)) => Ok(obj),
-            Some(object_result::Result::Error(e)) => Err(Error::Server(e.message)),
+            Some(object_result::Result::Error(e)) => Err(Error::Server(e)),
             None => Err(TryFromProtoError::missing("result").into()),
-            Some(_) => Err(Error::server("Unknown object result type")),
+            Some(_) => Err(Error::Protocol("Unknown object result type".into())),
         }
     }
 }
@@ -154,9 +154,9 @@ impl ProtoResult for TransactionResult {
     fn into_result(self) -> Result<Self::Value> {
         match self.result {
             Some(transaction_result::Result::Transaction(tx)) => Ok(tx),
-            Some(transaction_result::Result::Error(e)) => Err(Error::Server(e.message)),
+            Some(transaction_result::Result::Error(e)) => Err(Error::Server(e)),
             None => Err(TryFromProtoError::missing("result").into()),
-            Some(_) => Err(Error::server("Unknown transaction result type")),
+            Some(_) => Err(Error::Protocol("Unknown transaction result type".into())),
         }
     }
 }

--- a/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
@@ -169,7 +169,7 @@ impl Client {
                 GetCheckpointDataRequest::default().with_digest(val)
             }
             _ => {
-                return Err(Error::server("Invalid checkpoint ID type"));
+                return Err(Error::Protocol("Invalid checkpoint ID type".into()));
             }
         }
         .with_read_mask(field_mask_with_default(read_mask, CHECKPOINT_READ_MASK));
@@ -305,7 +305,7 @@ impl Client {
 
                         // Start of new checkpoint - throw error if previous checkpoint was incomplete
                         if current_sequence_number.is_some() {
-                            Err(Error::server("Received new chunked checkpoint header before completing previous checkpoint"))?;
+                            Err(Error::Protocol("Received new chunked checkpoint header before completing previous checkpoint".into()))?;
                         }
                         current_sequence_number = checkpoint.sequence_number;
 
@@ -326,7 +326,7 @@ impl Client {
 
                     Some(checkpoint_data::Payload::Transactions(txs)) => {
                         if current_sequence_number.is_none() {
-                            Err(Error::server("Received new chunked checkpoint transactions before receiving checkpoint header"))?;
+                            Err(Error::Protocol("Received new chunked checkpoint transactions before receiving checkpoint header".into()))?;
                         }
 
                         // Accumulate proto transactions (no deserialization)
@@ -335,7 +335,7 @@ impl Client {
 
                     Some(checkpoint_data::Payload::Events(events)) => {
                         if current_sequence_number.is_none() {
-                            Err(Error::server("Received new chunked checkpoint events before receiving checkpoint header"))?;
+                            Err(Error::Protocol("Received new chunked checkpoint events before receiving checkpoint header".into()))?;
                         }
 
                         // Accumulate proto events (no deserialization)
@@ -346,13 +346,13 @@ impl Client {
                         // End of current checkpoint - assemble the result and yield it
                          let sequence_number = current_sequence_number
                         .take()
-                        .ok_or_else(|| -> Error { Error::server("Received checkpoint end marker before receiving checkpoint header") })?;
+                        .ok_or_else(|| -> Error { Error::Protocol("Received checkpoint end marker before receiving checkpoint header".into()) })?;
 
                         let marker_sequence_number = marker.sequence_number
                         .ok_or_else(|| -> Error { TryFromProtoError::missing("end_marker.sequence_number").into() })?;
 
                         if marker_sequence_number != sequence_number {
-                            Err(Error::server(format!(
+                            Err(Error::Protocol(format!(
                                 "EndMarker sequence_number {marker_sequence_number} does not match current checkpoint sequence_number {sequence_number:?}",
                             )))?;
                         }
@@ -376,14 +376,14 @@ impl Client {
 
                     Some(_) => {
                         // Unknown payload type
-                        Err(Error::server("Received unknown checkpoint data payload type"))?;
+                        Err(Error::Protocol("Received unknown checkpoint data payload type".into()))?;
                     }
                 }
             }
 
             // Check if stream ended with incomplete checkpoint data
             if let Some(sequence_number) = current_sequence_number {
-                Err(Error::server(format!(
+                Err(Error::Protocol(format!(
                     "Stream ended with incomplete checkpoint data for sequence number {sequence_number}"
                 )))?;
             }

--- a/crates/iota-grpc-client/src/api/mod.rs
+++ b/crates/iota-grpc-client/src/api/mod.rs
@@ -15,7 +15,7 @@ pub mod ledger;
 
 pub use common::{
     CHECKPOINT_READ_MASK, EPOCH_READ_MASK, EXECUTION_READ_MASK, Error, OBJECTS_READ_MASK, Result,
-    SERVICE_INFO_READ_MASK, TRANSACTIONS_READ_MASK,
+    RpcStatus, SERVICE_INFO_READ_MASK, TRANSACTIONS_READ_MASK,
 };
 pub(crate) use common::{
     ProtoResult, TryFromProtoError, build_proto_transaction, field_mask_with_default,

--- a/crates/iota-grpc-client/src/lib.rs
+++ b/crates/iota-grpc-client/src/lib.rs
@@ -38,7 +38,7 @@ pub mod api;
 // Re-export types for convenience
 pub use api::{
     CHECKPOINT_READ_MASK, CheckpointResponse, EPOCH_READ_MASK, EXECUTION_READ_MASK, Error,
-    OBJECTS_READ_MASK, Result, SERVICE_INFO_READ_MASK, TRANSACTIONS_READ_MASK,
+    OBJECTS_READ_MASK, Result, RpcStatus, SERVICE_INFO_READ_MASK, TRANSACTIONS_READ_MASK,
 };
 
 mod client;

--- a/crates/iota-grpc-types/src/proto/google.rs
+++ b/crates/iota-grpc-types/src/proto/google.rs
@@ -17,6 +17,21 @@ pub mod rpc {
         }
     }
 
+    impl Status {
+        /// Convert to a [`tonic::Status`], preserving code, message, and
+        /// details.
+        ///
+        /// The details are encoded as the binary `google.rpc.Status` message,
+        /// matching the `grpc-status-details-bin` trailer convention.
+        pub fn to_tonic_status(&self) -> tonic::Status {
+            use prost::Message;
+
+            let code = tonic::Code::from_i32(self.code);
+            let details_bytes = self.encode_to_vec();
+            tonic::Status::with_details(code, &self.message, details_bytes.into())
+        }
+    }
+
     impl ::prost::Name for ErrorInfo {
         const NAME: &'static str = "ErrorInfo";
         const PACKAGE: &'static str = "google.rpc";


### PR DESCRIPTION
# Description of change

- Preserve the full `google.rpc.Status` (code, message, details) in per-item server errors instead of flattening to a string, so consumers can match on status codes like `NOT_FOUND` vs `INTERNAL`.
- Split the old `Error::Server(String)` into `Error::Server(RpcStatus)` for actual server errors and `Error::Protocol(String)` for client-side protocol errors that were incorrectly sharing the same variant.

## Links to any relevant issues

fixes #10429

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation