### PR TITLE
fix(aws): Add aws-orchestrator improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "iota-sdk-types",
  "rand 0.8.5",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -14328,6 +14329,7 @@ dependencies = [
  "rand 0.8.5",
  "rs_merkle",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6057,6 +6057,8 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.64",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/consensus/config/Cargo.toml
+++ b/consensus/config/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 rand.workspace = true
 serde.workspace = true
+tracing.workspace = true
 
 # internal dependencies
 iota-network-stack.workspace = true

--- a/consensus/config/src/crypto.rs
+++ b/consensus/config/src/crypto.rs
@@ -22,6 +22,7 @@ use fastcrypto::{
 };
 use iota_sdk_types::crypto::INTENT_PREFIX_LENGTH;
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 
 /// Network key is used for TLS and as the network identity of the authority.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -88,6 +89,7 @@ impl ProtocolPublicKey {
         Self(key)
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn verify(
         &self,
         message: &[u8],
@@ -114,6 +116,7 @@ impl ProtocolKeyPair {
         ProtocolPublicKey(self.0.public().clone())
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn sign(&self, message: &[u8]) -> ProtocolKeySignature {
         ProtocolKeySignature(self.0.sign(message))
     }

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -18,6 +18,7 @@ use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 
 use crate::{
     commit::CommitVote,
@@ -353,6 +354,7 @@ impl SignedBlock {
 
     /// This method only verifies this block's signature. Verification of the
     /// full block should be done via BlockVerifier.
+    #[instrument(level = "trace", skip_all)]
     pub(crate) fn verify_signature(&self, context: &Context) -> ConsensusResult<()> {
         let block = &self.inner;
         let committee = &context.committee;
@@ -403,6 +405,7 @@ fn to_consensus_block_intent(digest: InnerBlockDigest) -> IntentMessage<InnerBlo
 /// 1. Compute the digest of `Block`.
 /// 2. Wrap the digest in `IntentMessage`.
 /// 3. Sign the serialized `IntentMessage`, or verify signature against it.
+#[instrument(level = "trace", skip_all)]
 fn compute_block_signature(
     block: &Block,
     protocol_keypair: &ProtocolKeyPair,
@@ -412,6 +415,7 @@ fn compute_block_signature(
         .map_err(ConsensusError::SerializationFailure)?;
     Ok(protocol_keypair.sign(&message))
 }
+#[instrument(level = "trace", skip_all)]
 fn verify_block_signature(
     block: &Block,
     signature: &[u8],

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -4,6 +4,8 @@
 
 use std::{collections::BTreeSet, sync::Arc};
 
+use tracing::instrument;
+
 use crate::{
     Round,
     block::{
@@ -101,6 +103,7 @@ impl SignedBlockVerifier {
 
 // All block verification logic are implemented below.
 impl BlockVerifier for SignedBlockVerifier {
+    #[instrument(level = "trace", skip_all)]
     fn verify(&self, block: &SignedBlock) -> ConsensusResult<()> {
         let committee = &self.context.committee;
         // The block must belong to the current epoch and have valid authority index,

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -48,7 +48,7 @@ use tokio::{
     task::{JoinHandle, JoinSet},
     time::{MissedTickBehavior, sleep},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info, instrument, warn};
 
 use crate::{
     CommitConsumerMonitor, CommitIndex,
@@ -784,6 +784,7 @@ impl<C: NetworkClient> Inner<C> {
     /// Verifies the commits and also certifies them using the provided vote
     /// blocks for the last commit. The method returns the trusted commits
     /// and the votes as verified blocks.
+    #[instrument(level = "trace", skip_all)]
     fn verify_commits(
         &self,
         peer: AuthorityIndex,

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -12,7 +12,7 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, timeout},
 };
-use tracing::{debug, error, info};
+use tracing::{Instrument, debug, error, info, trace_span};
 
 use crate::{
     Round,
@@ -229,6 +229,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             .inc();
                         let result = authority_service
                             .handle_send_block(peer, block.clone())
+                            .instrument(trace_span!("handle_send_block"))
                             .await;
                         if let Err(e) = result {
                             context

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -30,7 +30,7 @@ use tokio::{
     task::{JoinError, JoinSet},
     time::{Instant, sleep, sleep_until, timeout},
 };
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::{
     BlockAPI, CommitIndex, Round,
@@ -751,6 +751,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             .collect::<Vec<_>>()
     }
 
+    #[instrument(level = "trace", skip_all)]
     fn verify_blocks(
         serialized_blocks: Vec<Bytes>,
         block_verifier: Arc<V>,

--- a/crates/iota-aws-orchestrator/Cargo.toml
+++ b/crates/iota-aws-orchestrator/Cargo.toml
@@ -37,6 +37,8 @@ iota-config.workspace = true
 iota-metrics.workspace = true
 iota-swarm-config.workspace = true
 iota-types.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/iota-aws-orchestrator/Cargo.toml
+++ b/crates/iota-aws-orchestrator/Cargo.toml
@@ -29,6 +29,8 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 # internal dependencies
 iota-benchmark.workspace = true
@@ -37,8 +39,6 @@ iota-config.workspace = true
 iota-metrics.workspace = true
 iota-swarm-config.workspace = true
 iota-types.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/iota-aws-orchestrator/assets/plot.py
+++ b/crates/iota-aws-orchestrator/assets/plot.py
@@ -8,6 +8,9 @@ import glob
 import json
 import math
 import os
+# Set the backend before importing pyplot to avoid macOS icon issues
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.ticker as tick
 from glob import glob
@@ -23,58 +26,98 @@ def gen_data(measurement):
             yield data
 
 def aggregate_tps(measurement, i=-1):
-    max_duration = 0
-    for data in gen_data(measurement):
-        duration = float(data[i]['timestamp']['secs'])
-        max_duration = max(duration, max_duration)
-
+    # Calculate TPS for each scraper based on its own timestamp, then sum
+    # This matches: sum of (count / timestamp) for each measurement
     tps = []
     for data in gen_data(measurement):
-        count = float(data[i]['count'])
-        tps += [(count / max_duration) if max_duration != 0 else 0]
+        last = data[i]
+        count = float(last['count'])
+        duration = float(last['timestamp']['secs'])
+        tps += [(count / duration) if duration != 0 else 0]
     return sum(tps)
 
 
 def aggregate_average_latency(measurement, i=-1):
-    latency = []
+    # Calculate weighted average: (sum of all latency_sum) / (sum of all counts)
+    total_sum = 0
+    total_count = 0
     for data in gen_data(measurement):
         last = data[i]
-        count = float(last['count'])
-        total = float(last['sum']['secs'])
-        latency += [total / count if count != 0 else 0]
-    return sum(latency) / len(latency) if latency else 0
+        total_sum += float(last['sum']['secs'])
+        total_count += float(last['count'])
+    return total_sum / total_count if total_count != 0 else 0
 
 
 def aggregate_stdev_latency(measurement, i=-1):
-    stdev = []
+    # Calculate pooled standard deviation using combined squared_sum, sum, and count
+    # Formula: sqrt((Σsquared_sum / Σcount) - (Σsum / Σcount)^2)
+    total_sum = 0
+    total_squared_sum = 0
+    total_count = 0
+    
     for data in gen_data(measurement):
         last = data[i]
-        count = float(last['count'])
-        if count == 0:
-            stdev += [0]
-        else:
-            first_term = float(last['squared_sum']['secs']) / count
-            second_term = (float(last['sum']['secs']) / count)**2
-            # Ensure we don't take square root of a negative number due to floating-point precision
-            variance = max(0, first_term - second_term)
-            stdev += [math.sqrt(variance)]
-    return max(stdev)
+        total_sum += float(last['sum']['secs'])
+        total_squared_sum += float(last['squared_sum']['secs'])
+        total_count += float(last['count'])
+    
+    if total_count == 0:
+        return 0
+    
+    first_term = total_squared_sum / total_count
+    avg = total_sum / total_count
+    variance = max(0, first_term - avg**2)
+    return math.sqrt(variance)
 
 
 def aggregate_p_latency(measurement, p=50, i=-1):
-    latency = []
+    # Aggregate all histogram buckets, then calculate quantile with linear interpolation
+    # This matches Prometheus's histogram_quantile behavior
+    combined_buckets = {}
+    total_count = 0
+    
     for data in gen_data(measurement):
         last = data[i]
-        count = float(last['count'])
-        buckets = [(float(l), c) for l, c in last['buckets'].items()]
-        buckets.sort(key=lambda x: x[0])
-
-        for l, c in buckets:
-            if c >= count * p / 100:
-                latency += [l]
-                break
-
-    return sum(latency) / len(latency) if latency else 0
+        total_count += float(last['count'])
+        for bucket_id, bucket_count in last['buckets'].items():
+            combined_buckets[bucket_id] = combined_buckets.get(bucket_id, 0) + bucket_count
+    
+    if total_count == 0:
+        return 0
+    
+    # Parse and sort buckets
+    buckets = []
+    for bucket_id, count in combined_buckets.items():
+        if bucket_id == 'inf':
+            bound = float('inf')
+        else:
+            bound = float(bucket_id)
+        buckets.append((bound, count))
+    buckets.sort(key=lambda x: x[0])
+    
+    # Calculate the rank for the desired quantile
+    rank = (p / 100.0) * total_count
+    
+    # Find the bucket containing the quantile using linear interpolation
+    prev_count = 0.0
+    prev_bound = 0.0
+    
+    for bound, count in buckets:
+        if count >= rank:
+            # If this is the first bucket or all observations are in this bucket
+            if prev_count == 0.0 or count == prev_count:
+                return bound
+            
+            # Linear interpolation between prev_bound and bound
+            fraction = (rank - prev_count) / (count - prev_count)
+            interpolated = prev_bound + (bound - prev_bound) * fraction
+            return interpolated
+        
+        prev_count = count
+        prev_bound = bound
+    
+    # Fallback
+    return prev_bound
 
 
 class PlotType(Enum):

--- a/crates/iota-aws-orchestrator/src/logger.rs
+++ b/crates/iota-aws-orchestrator/src/logger.rs
@@ -33,6 +33,12 @@ pub struct SwappableWriter {
     inner: Arc<Mutex<Box<dyn Write + Send>>>,
 }
 
+impl Default for SwappableWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SwappableWriter {
     pub fn new() -> Self {
         Self {

--- a/crates/iota-aws-orchestrator/src/logger.rs
+++ b/crates/iota-aws-orchestrator/src/logger.rs
@@ -2,32 +2,135 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    fs::{File, OpenOptions},
+    fs::OpenOptions,
     io::Write,
     path::Path,
-    sync::Mutex,
+    sync::{Arc, Mutex},
 };
 
-/// Global logger instance for writing to both stdout and file
-static LOGGER: Mutex<Option<File>> = Mutex::new(None);
+use tracing::info;
+use tracing_subscriber::{
+    Registry,
+    filter::{LevelFilter, filter_fn},
+    fmt::{self, MakeWriter},
+    prelude::*,
+};
+
+// These act as our "Context" to route logs to the right file.
+tokio::task_local! {
+    pub static IS_OP: bool;
+    pub static IS_LOOP: bool;
+}
+
+// Helper to check flags
+fn is_op() -> bool {
+    IS_OP.try_with(|v| *v).unwrap_or(false)
+}
+fn is_loop() -> bool {
+    IS_LOOP.try_with(|v| *v).unwrap_or(false)
+}
+
+// Shared writer for the loop layer that can be swapped
+// This is used in `run_benchmark` to redirect logs to different set of parameters benchmarks
+pub struct SwappableWriter {
+    inner: Arc<Mutex<Box<dyn Write + Send>>>,
+}
+
+impl SwappableWriter {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Box::new(std::io::sink()))),
+        }
+    }
+
+    pub fn swap(&self, new_writer: Box<dyn Write + Send>) -> std::io::Result<()> {
+        let mut writer = self.inner.lock().unwrap();
+        // Flush the old writer before swapping to ensure buffered data is written
+        writer.flush()?;
+        *writer = new_writer;
+        Ok(())
+    }
+}
+
+impl Clone for SwappableWriter {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl Write for SwappableWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.lock().unwrap().flush()
+    }
+}
+
+impl<'a> MakeWriter<'a> for SwappableWriter {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
 
 /// Initialize the logger with a file path
-pub fn init_logger<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
-    let file = OpenOptions::new().create(true).append(true).open(path)?;
+pub fn init_logger<P: AsRef<Path>>(
+    benchmark_dir: P,
+    operation: &str,
+) -> std::io::Result<SwappableWriter> {
+    // Main logs: Accept everything that is NOT in the Op function
+    let main_filter = filter_fn(|_| !is_op());
 
-    LOGGER.lock().unwrap().replace(file);
-    Ok(())
+    // Op logs: Accept things inside Op, but NOT inside the Loop
+    let op_filter = filter_fn(|_| is_op() && !is_loop());
+
+    // Loop logs: Accept ONLY things inside the Loop
+    let loop_filter = filter_fn(|_| is_loop());
+
+    // Layer 1: Main.log
+    let main_path = benchmark_dir.as_ref().join("main.log");
+    let main_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(main_path)?;
+    let main_layer = fmt::Layer::default()
+        .with_ansi(false)
+        .with_writer(Arc::new(main_file))
+        .with_filter(main_filter)
+        .with_filter(LevelFilter::INFO);
+
+    // Layer 2: Op Layer
+    let op_path = benchmark_dir.as_ref().join(format!("{operation}.log"));
+    let op_file = OpenOptions::new().create(true).append(true).open(op_path)?;
+    let op_layer = fmt::Layer::default()
+        .with_ansi(false)
+        .with_writer(Arc::new(op_file))
+        .with_filter(op_filter)
+        .with_filter(LevelFilter::INFO);
+
+    // Layer 3: Loop Layer - using swappable writer
+    let loop_writer = SwappableWriter::new();
+    let loop_layer = fmt::Layer::default()
+        .with_ansi(false)
+        .with_writer(loop_writer.clone())
+        .with_filter(loop_filter)
+        .with_filter(LevelFilter::INFO);
+
+    Registry::default()
+        .with(main_layer)
+        .with(op_layer)
+        .with(loop_layer)
+        .init();
+
+    Ok(loop_writer)
 }
 
 /// Log a message to the file (if initialized)
 pub fn log(message: &str) {
-    if let Some(mut file) = LOGGER.lock().unwrap().as_ref() {
-        let _ = write!(file, "{}", message);
-        let _ = file.flush();
-    }
-}
-
-/// Close the logger
-pub fn close_logger() {
-    LOGGER.lock().unwrap().take();
+    info!("{}", message);
 }

--- a/crates/iota-aws-orchestrator/src/logger.rs
+++ b/crates/iota-aws-orchestrator/src/logger.rs
@@ -18,20 +18,17 @@ use tracing_subscriber::{
 
 // These act as our "Context" to route logs to the right file.
 tokio::task_local! {
-    pub static IS_OP: bool;
     pub static IS_LOOP: bool;
 }
 
 // Helper to check flags
-fn is_op() -> bool {
-    IS_OP.try_with(|v| *v).unwrap_or(false)
-}
 fn is_loop() -> bool {
     IS_LOOP.try_with(|v| *v).unwrap_or(false)
 }
 
 // Shared writer for the loop layer that can be swapped
-// This is used in `run_benchmark` to redirect logs to different set of parameters benchmarks
+// This is used in `run_benchmark` to redirect logs to different set of
+// parameters benchmarks
 pub struct SwappableWriter {
     inner: Arc<Mutex<Box<dyn Write + Send>>>,
 }
@@ -79,15 +76,9 @@ impl<'a> MakeWriter<'a> for SwappableWriter {
 }
 
 /// Initialize the logger with a file path
-pub fn init_logger<P: AsRef<Path>>(
-    benchmark_dir: P,
-    operation: &str,
-) -> std::io::Result<SwappableWriter> {
+pub fn init_logger<P: AsRef<Path>>(benchmark_dir: P) -> std::io::Result<SwappableWriter> {
     // Main logs: Accept everything that is NOT in the Op function
-    let main_filter = filter_fn(|_| !is_op());
-
-    // Op logs: Accept things inside Op, but NOT inside the Loop
-    let op_filter = filter_fn(|_| is_op() && !is_loop());
+    let main_filter = filter_fn(|_| !is_loop());
 
     // Loop logs: Accept ONLY things inside the Loop
     let loop_filter = filter_fn(|_| is_loop());
@@ -104,16 +95,7 @@ pub fn init_logger<P: AsRef<Path>>(
         .with_filter(main_filter)
         .with_filter(LevelFilter::INFO);
 
-    // Layer 2: Op Layer
-    let op_path = benchmark_dir.as_ref().join(format!("{operation}.log"));
-    let op_file = OpenOptions::new().create(true).append(true).open(op_path)?;
-    let op_layer = fmt::Layer::default()
-        .with_ansi(false)
-        .with_writer(Arc::new(op_file))
-        .with_filter(op_filter)
-        .with_filter(LevelFilter::INFO);
-
-    // Layer 3: Loop Layer - using swappable writer
+    // Layer 2: Loop Layer - using swappable writer
     let loop_writer = SwappableWriter::new();
     let loop_layer = fmt::Layer::default()
         .with_ansi(false)
@@ -121,11 +103,7 @@ pub fn init_logger<P: AsRef<Path>>(
         .with_filter(loop_filter)
         .with_filter(LevelFilter::INFO);
 
-    Registry::default()
-        .with(main_layer)
-        .with(op_layer)
-        .with(loop_layer)
-        .init();
+    Registry::default().with(main_layer).with(loop_layer).init();
 
     Ok(loop_writer)
 }

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -408,7 +408,7 @@ fn init_benchmark_logger(
     let commit = settings.repository.commit.replace("/", "_");
 
     let mut timestamp = chrono::Local::now().format("%y%m%d_%H%M%S").to_string();
-    timestamp.push_str("_");
+    timestamp.push('_');
     timestamp.push_str(operation);
 
     let benchmark_dir = settings.results_dir.join(&commit).join(&timestamp);

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{str::FromStr, time::Duration};
+use std::{fs, str::FromStr, time::Duration};
 
 use benchmark::{BenchmarkParametersGenerator, LoadType};
 use clap::{Parser, ValueEnum};
@@ -399,6 +399,26 @@ async fn main() -> Result<()> {
     }
 }
 
+// Create benchmark_dir and initialize logger
+// Then benchmark_dir would be like results/<commit>/<timestamp>_<operation>
+fn init_benchmark_logger(
+    settings: &Settings,
+    operation: &str,
+) -> std::io::Result<(std::path::PathBuf, crate::logger::SwappableWriter)> {
+    let commit = settings.repository.commit.replace("/", "_");
+
+    let mut timestamp = chrono::Local::now().format("%y%m%d_%H%M%S").to_string();
+    timestamp.push_str("_");
+    timestamp.push_str(operation);
+
+    let benchmark_dir = settings.results_dir.join(&commit).join(&timestamp);
+    fs::create_dir_all(&benchmark_dir)?;
+
+    let swappable_writer = crate::logger::init_logger(&benchmark_dir, operation)?;
+
+    Ok((benchmark_dir, swappable_writer))
+}
+
 async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts) -> Result<()> {
     // Create a new testbed.
     let mut testbed = Testbed::new(settings.clone(), client)
@@ -417,16 +437,20 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 skip_monitoring,
                 use_spot_instances,
                 id,
-            } => testbed
-                .deploy(
-                    instances,
-                    skip_monitoring,
-                    dedicated_clients,
-                    use_spot_instances,
-                    id,
-                )
-                .await
-                .wrap_err("Failed to deploy testbed")?,
+            } => {
+                let (_benchmark_dir, _writer) = init_benchmark_logger(&settings, "deploy")?;
+
+                testbed
+                    .deploy(
+                        instances,
+                        skip_monitoring,
+                        dedicated_clients,
+                        use_spot_instances,
+                        id,
+                    )
+                    .await
+                    .wrap_err("Failed to deploy testbed")?
+            }
 
             // Start the specified number of instances on an existing testbed.
             TestbedAction::Start {
@@ -565,6 +589,8 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
                 None => None,
             };
 
+            let (benchmark_dir, writer) = init_benchmark_logger(&settings, "benchmark_run")?;
+
             let mut generator = BenchmarkParametersGenerator::new(
                 committee,
                 dedicated_clients,
@@ -614,6 +640,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             .with_log_processing(log_processing)
             .with_dedicated_clients(dedicated_clients)
             .skip_monitoring(skip_monitoring)
+            .with_benchmark_dir_and_writer(benchmark_dir, writer)
             .run_benchmarks(generator)
             .await
             .wrap_err("Failed to run benchmarks")?;

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -414,7 +414,7 @@ fn init_benchmark_logger(
     let benchmark_dir = settings.results_dir.join(&commit).join(&timestamp);
     fs::create_dir_all(&benchmark_dir)?;
 
-    let swappable_writer = crate::logger::init_logger(&benchmark_dir, operation)?;
+    let swappable_writer = crate::logger::init_logger(&benchmark_dir)?;
 
     Ok((benchmark_dir, swappable_writer))
 }

--- a/crates/iota-aws-orchestrator/src/measurement.rs
+++ b/crates/iota-aws-orchestrator/src/measurement.rs
@@ -277,7 +277,6 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
         // Collect all last measurements
         let last_measurements: Vec<_> = self.last_measurements_iter().collect();
 
-
         // Calculate and sum TPS for each measurement
         last_measurements.iter().map(|x| x.tps(&x.timestamp)).sum()
     }

--- a/crates/iota-aws-orchestrator/src/measurement.rs
+++ b/crates/iota-aws-orchestrator/src/measurement.rs
@@ -260,18 +260,12 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
         // Collect all last measurements
         let last_measurements: Vec<_> = self.last_measurements_iter().collect();
 
-        // Get the maximum timestamp
-        let duration = last_measurements
-            .iter()
-            .map(|x| x.timestamp)
-            .max()
-            .unwrap_or_default();
-
         last_measurements
             .into_iter()
             // Sum TPS for each workload across all scrapers
             .fold(HashMap::new(), |mut acc, measurement| {
-                *acc.entry(measurement.workload.clone()).or_insert(0) += measurement.tps(&duration);
+                *acc.entry(measurement.workload.clone()).or_insert(0) +=
+                    measurement.tps(&measurement.timestamp);
                 acc
             })
     }
@@ -283,15 +277,9 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
         // Collect all last measurements
         let last_measurements: Vec<_> = self.last_measurements_iter().collect();
 
-        // Get the maximum timestamp
-        let duration = last_measurements
-            .iter()
-            .map(|x| x.timestamp)
-            .max()
-            .unwrap_or_default();
 
         // Calculate and sum TPS for each measurement
-        last_measurements.iter().map(|x| x.tps(&duration)).sum()
+        last_measurements.iter().map(|x| x.tps(&x.timestamp)).sum()
     }
 
     pub fn workload_average_latency(&self) -> HashMap<String, Duration> {

--- a/crates/iota-aws-orchestrator/src/measurement.rs
+++ b/crates/iota-aws-orchestrator/src/measurement.rs
@@ -282,52 +282,112 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
     }
 
     pub fn workload_average_latency(&self) -> HashMap<String, Duration> {
-        self.last_measurements_iter()
-            // get the maximum latency of each workload across all scrapers
-            .fold(HashMap::new(), |mut acc, measurement| {
-                let latency = measurement.average_latency();
-                acc.entry(measurement.workload.clone())
-                    .and_modify(|max_latency| {
-                        if latency > *max_latency {
-                            *max_latency = latency;
-                        }
-                    })
-                    .or_insert(latency);
-                acc
+        // Collect sum and count for each workload across all scrapers
+        let mut workload_data: HashMap<String, (Duration, usize)> = HashMap::new();
+
+        for measurement in self.last_measurements_iter() {
+            workload_data
+                .entry(measurement.workload.clone())
+                .and_modify(|(sum, count)| {
+                    *sum += measurement.sum;
+                    *count += measurement.count;
+                })
+                .or_insert((measurement.sum, measurement.count));
+        }
+
+        // Calculate average for each workload
+        workload_data
+            .into_iter()
+            .map(|(workload, (sum, count))| {
+                let avg = if count == 0 {
+                    Duration::default()
+                } else {
+                    sum.checked_div(count as u32).unwrap_or_default()
+                };
+                (workload, avg)
             })
+            .collect()
     }
 
     /// Aggregate the average latency of multiple data points by taking the
-    /// average.
+    /// weighted average based on transaction counts.
+    /// This computes: (sum of all latency_sum) / (sum of all counts)
     pub fn aggregate_average_latency(&self) -> Duration {
         let last_measurements: Vec<_> = self.last_measurements_iter().collect();
 
-        last_measurements
-            .iter()
-            .map(|x| x.average_latency())
-            .sum::<Duration>()
-            .checked_div(last_measurements.len() as u32)
+        let total_sum: Duration = last_measurements.iter().map(|x| x.sum).sum();
+        let total_count: usize = last_measurements.iter().map(|x| x.count).sum();
+
+        if total_count == 0 {
+            return Duration::default();
+        }
+
+        total_sum
+            .checked_div(total_count as u32)
             .unwrap_or_default()
     }
 
     pub fn workload_stdev_latency(&self) -> HashMap<String, Duration> {
-        self.last_measurements_iter()
-            // get the maximum stdev latency of each workload across all scrapers
-            .fold(HashMap::new(), |mut acc, measurement| {
-                let stdev = measurement.stdev_latency();
-                acc.entry(measurement.workload.clone())
-                    .and_modify(|max_stdev| {
-                        if stdev > *max_stdev {
-                            *max_stdev = stdev;
-                        }
-                    })
-                    .or_insert(stdev);
-                acc
+        // Collect sum, squared_sum, and count for each workload across all scrapers
+        let mut workload_data: HashMap<String, (Duration, Duration, usize)> = HashMap::new();
+
+        for measurement in self.last_measurements_iter() {
+            workload_data
+                .entry(measurement.workload.clone())
+                .and_modify(|(sum, squared_sum, count)| {
+                    *sum += measurement.sum;
+                    *squared_sum += measurement.squared_sum;
+                    *count += measurement.count;
+                })
+                .or_insert((measurement.sum, measurement.squared_sum, measurement.count));
+        }
+
+        // Calculate stdev for each workload from aggregated data
+        workload_data
+            .into_iter()
+            .map(|(workload, (sum, squared_sum, count))| {
+                let stdev = if count == 0 {
+                    Duration::default()
+                } else {
+                    let first_term = squared_sum.as_secs_f64() / count as f64;
+                    let avg = sum.as_secs_f64() / count as f64;
+                    let variance = if avg.powf(2.0) > first_term {
+                        0.0
+                    } else {
+                        first_term - avg.powf(2.0)
+                    };
+                    Duration::from_secs_f64(variance.sqrt())
+                };
+                (workload, stdev)
             })
+            .collect()
     }
 
-    /// Aggregate the stdev latency of multiple data points by taking the max.
+    /// Aggregate the stdev latency by combining all squared sums, sums, and
+    /// counts. Uses the pooled variance formula: sqrt((Σsquared_sum /
+    /// Σcount) - (Σsum / Σcount)^2)
     pub fn aggregate_stdev_latency(&self) -> Duration {
+        let last_measurements: Vec<_> = self.last_measurements_iter().collect();
+
+        let total_sum: Duration = last_measurements.iter().map(|x| x.sum).sum();
+        let total_squared_sum: Duration = last_measurements.iter().map(|x| x.squared_sum).sum();
+        let total_count: usize = last_measurements.iter().map(|x| x.count).sum();
+
+        if total_count == 0 {
+            return Duration::default();
+        }
+
+        let first_term = total_squared_sum.as_secs_f64() / total_count as f64;
+        let avg = total_sum.as_secs_f64() / total_count as f64;
+        let variance = if avg.powf(2.0) > first_term {
+            0.0
+        } else {
+            first_term - avg.powf(2.0)
+        };
+
+        Duration::from_secs_f64(variance.sqrt())
+    }
+
     pub fn workload_p50_latency(&self) -> HashMap<String, Duration> {
         // Aggregate buckets and counts for each workload across all scrapers
         let mut workload_data: HashMap<String, (HashMap<BucketId, usize>, usize)> = HashMap::new();
@@ -823,6 +883,49 @@ mod test {
         let p50 = super::p50_latency(&data.buckets, data.count);
         // Should be around 636-637ms
         assert!(p50.as_millis() >= 636 && p50.as_millis() <= 637);
+    }
+
+    #[test]
+    fn aggregate_average_latency_weighted() {
+        // Test that aggregate average is properly weighted
+        let settings = Settings::new_for_test();
+        let mut aggregator = MeasurementsCollection::<TestBenchmarkType>::new(
+            &settings,
+            BenchmarkParameters::default(),
+        );
+
+        // Scraper 1: 100 transactions with 2s total = 20ms avg
+        let measurement1 = HashMap::from([(
+            "test".to_string(),
+            Measurement {
+                workload: "test".into(),
+                timestamp: Duration::from_secs(10),
+                buckets: HashMap::new(),
+                sum: Duration::from_secs(2),
+                count: 100,
+                squared_sum: Duration::from_secs(0),
+            },
+        )]);
+
+        // Scraper 2: 200 transactions with 10s total = 50ms avg
+        let measurement2 = HashMap::from([(
+            "test".to_string(),
+            Measurement {
+                workload: "test".into(),
+                timestamp: Duration::from_secs(10),
+                buckets: HashMap::new(),
+                sum: Duration::from_secs(10),
+                count: 200,
+                squared_sum: Duration::from_secs(0),
+            },
+        )]);
+
+        aggregator.add(1, measurement1);
+        aggregator.add(2, measurement2);
+
+        // Weighted average should be (2 + 10) / (100 + 200) = 12 / 300 = 0.04s = 40ms
+        let avg = aggregator.aggregate_average_latency();
+        assert_eq!(avg.as_millis(), 40);
     }
 
     #[test]

--- a/crates/iota-aws-orchestrator/src/measurement.rs
+++ b/crates/iota-aws-orchestrator/src/measurement.rs
@@ -328,10 +328,97 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
 
     /// Aggregate the stdev latency of multiple data points by taking the max.
     pub fn aggregate_stdev_latency(&self) -> Duration {
-        self.last_measurements_iter()
-            .map(|x| x.stdev_latency())
-            .max()
-            .unwrap_or_default()
+    pub fn workload_p50_latency(&self) -> HashMap<String, Duration> {
+        // Aggregate buckets and counts for each workload across all scrapers
+        let mut workload_data: HashMap<String, (HashMap<BucketId, usize>, usize)> = HashMap::new();
+
+        for measurement in self.last_measurements_iter() {
+            workload_data
+                .entry(measurement.workload.clone())
+                .and_modify(|(buckets, count)| {
+                    // Sum bucket counts
+                    for (bucket_id, bucket_count) in &measurement.buckets {
+                        *buckets.entry(bucket_id.clone()).or_insert(0) += bucket_count;
+                    }
+                    *count += measurement.count;
+                })
+                .or_insert((measurement.buckets.clone(), measurement.count));
+        }
+
+        // Calculate P50 for each workload from aggregated buckets
+        workload_data
+            .into_iter()
+            .map(|(workload, (buckets, count))| {
+                let p50 = p50_latency(&buckets, count);
+                (workload, p50)
+            })
+            .collect()
+    }
+
+    /// Aggregate the P50 latency by combining all histogram buckets and
+    /// calculating P50 from the combined histogram.
+    pub fn aggregate_p50_latency(&self) -> Duration {
+        let last_measurements: Vec<_> = self.last_measurements_iter().collect();
+
+        // Aggregate all buckets across all workloads and scrapers
+        let mut combined_buckets: HashMap<BucketId, usize> = HashMap::new();
+        let mut total_count = 0;
+
+        for measurement in &last_measurements {
+            for (bucket_id, bucket_count) in &measurement.buckets {
+                *combined_buckets.entry(bucket_id.clone()).or_insert(0) += bucket_count;
+            }
+            total_count += measurement.count;
+        }
+
+        // Calculate P50 from combined histogram
+        p50_latency(&combined_buckets, total_count)
+    }
+
+    pub fn workload_p99_latency(&self) -> HashMap<String, Duration> {
+        // Aggregate buckets and counts for each workload across all scrapers
+        let mut workload_data: HashMap<String, (HashMap<BucketId, usize>, usize)> = HashMap::new();
+
+        for measurement in self.last_measurements_iter() {
+            workload_data
+                .entry(measurement.workload.clone())
+                .and_modify(|(buckets, count)| {
+                    // Sum bucket counts
+                    for (bucket_id, bucket_count) in &measurement.buckets {
+                        *buckets.entry(bucket_id.clone()).or_insert(0) += bucket_count;
+                    }
+                    *count += measurement.count;
+                })
+                .or_insert((measurement.buckets.clone(), measurement.count));
+        }
+
+        // Calculate P99 for each workload from aggregated buckets
+        workload_data
+            .into_iter()
+            .map(|(workload, (buckets, count))| {
+                let p99 = p99_latency(&buckets, count);
+                (workload, p99)
+            })
+            .collect()
+    }
+
+    /// Aggregate the P99 latency by combining all histogram buckets and
+    /// calculating P99 from the combined histogram.
+    pub fn aggregate_p99_latency(&self) -> Duration {
+        let last_measurements: Vec<_> = self.last_measurements_iter().collect();
+
+        // Aggregate all buckets across all workloads and scrapers
+        let mut combined_buckets: HashMap<BucketId, usize> = HashMap::new();
+        let mut total_count = 0;
+
+        for measurement in &last_measurements {
+            for (bucket_id, bucket_count) in &measurement.buckets {
+                *combined_buckets.entry(bucket_id.clone()).or_insert(0) += bucket_count;
+            }
+            total_count += measurement.count;
+        }
+
+        p99_latency(&combined_buckets, total_count)
     }
 
     /// Save the collection of measurements as a json file.
@@ -435,6 +522,10 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
         let average_latency = self.aggregate_average_latency();
         let workload_stdev_latency = self.workload_stdev_latency();
         let stdev_latency = self.aggregate_stdev_latency();
+        let workload_p50_latency = self.workload_p50_latency();
+        let p50_latency = self.aggregate_p50_latency();
+        let workload_p99_latency = self.workload_p99_latency();
+        let p99_latency = self.aggregate_p99_latency();
 
         let target = self.parameters.load as f64;
         let achieved = total_tps as f64;
@@ -513,7 +604,24 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
             );
         }
         table.add_row(row![bH2->""]);
-        table.add_row(row![bH2->"Per-workload stdev latency"]);
+
+        table.add_row(row![b->"Latency (p50):", format!("{} ms", p50_latency.as_millis())]);
+        for (workload, latency) in &workload_p50_latency {
+            table.add_row(
+                row![b->format!("  {workload} p50 Latency:"), format!("{} ms", latency.as_millis())],
+            );
+        }
+        table.add_row(row![bH2->""]);
+
+        table.add_row(row![b->"Latency (p99):", format!("{} ms", p99_latency.as_millis())]);
+        for (workload, latency) in &workload_p99_latency {
+            table.add_row(
+                row![b->format!("  {workload} p99 Latency:"), format!("{} ms", latency.as_millis())],
+            );
+        }
+        table.add_row(row![bH2->""]);
+
+        table.add_row(row![b->"Latency (stdev):", format!("{} ms", stdev_latency.as_millis())]);
         for (workload, latency) in &workload_stdev_latency {
             table.add_row(
                 row![b->format!("  {workload} stdev:"), format!("{} ms", latency.as_millis())],
@@ -538,6 +646,98 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
             .flat_map(|workload_map| workload_map.values())
             .filter_map(|measurements| measurements.last())
     }
+}
+
+/// Compute the P50 (median) latency from histogram buckets.
+fn p50_latency(buckets: &HashMap<BucketId, usize>, count: usize) -> Duration {
+    histogram_quantile(&buckets, count, 0.5)
+}
+
+/// Compute the P99 latency from histogram buckets using.
+fn p99_latency(buckets: &HashMap<BucketId, usize>, count: usize) -> Duration {
+    histogram_quantile(&buckets, count, 0.99)
+}
+
+/// Calculate a quantile from histogram buckets using linear interpolation,
+/// matching Prometheus's histogram_quantile behavior.
+fn histogram_quantile(buckets: &HashMap<BucketId, usize>, count: usize, quantile: f64) -> Duration {
+    if count == 0 || quantile < 0.0 || quantile > 1.0 {
+        return Duration::default();
+    }
+
+    // Parse and sort buckets by boundary
+    let mut buckets: Vec<(f64, usize)> = buckets
+        .iter()
+        .filter_map(|(bucket, count)| {
+            let bound = if bucket == "inf" {
+                f64::INFINITY
+            } else {
+                bucket.parse::<f64>().ok()?
+            };
+            Some((bound, *count))
+        })
+        .collect();
+
+    if buckets.is_empty() {
+        return Duration::default();
+    }
+
+    buckets.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    // The rank we're looking for (0.5 for P50 means the middle observation)
+    let rank = quantile * count as f64;
+
+    // Handle edge cases
+    if rank < 0.0 {
+        return Duration::default();
+    }
+
+    // Find the two buckets between which the quantile falls
+    //
+    // Example: Calculate P50 (median) with 1000 total observations
+    // Buckets: [(0.5s, 400), (1.0s, 800), (2.0s, 1000)]
+    // This means: 400 observations ≤ 0.5s, 800 observations ≤ 1.0s, 1000 observations ≤ 2.0s
+    //
+    // rank = 0.5 * 1000 = 500 (we want the 500th observation)
+    //
+    // Iteration 1: bound=0.5s, count=400
+    //   - 400 < 500, so P50 is not in this bucket, continue
+    //   - prev_count=400, prev_bound=0.5
+    //
+    // Iteration 2: bound=1.0s, count=800
+    //   - 800 >= 500, so P50 is in this bucket (between observations 400-800)
+    //   - Linear interpolation:
+    //     fraction = (500 - 400) / (800 - 400) = 100 / 400 = 0.25
+    //     interpolated = 0.5 + (1.0 - 0.5) * 0.25 = 0.5 + 0.125 = 0.625s
+    //   - The 500th observation is estimated at 0.625s
+    let mut prev_count = 0.0;
+    let mut prev_bound = 0.0;
+
+    for (bound, count) in buckets {
+        let count_f64 = count as f64;
+
+        // If this bucket contains our quantile
+        if count_f64 >= rank {
+            // If this is the first bucket or all observations are in this bucket
+            if prev_count == 0.0 || count_f64 == prev_count {
+                return Duration::from_secs_f64(bound);
+            }
+
+            // Linear interpolation between prev_bound and bound
+            // Formula: prev_bound + (bound - prev_bound) * ((rank - prev_count) / (count -
+            // prev_count))
+            let fraction = (rank - prev_count) / (count_f64 - prev_count);
+            let interpolated = prev_bound + (bound - prev_bound) * fraction;
+
+            return Duration::from_secs_f64(interpolated);
+        }
+
+        prev_count = count_f64;
+        prev_bound = bound;
+    }
+
+    // If we get here, return the last finite bucket boundary
+    Duration::from_secs_f64(prev_bound)
 }
 
 #[cfg(test)]
@@ -586,6 +786,43 @@ mod test {
         // sqrt( squared_sum / count - avg^2 )
         let stdev = data.stdev_latency();
         assert_eq!((stdev.as_secs_f64() * 10.0).round(), 7.0);
+    }
+
+    #[test]
+    fn p50_latency() {
+        // Test with the example histogram from prometheus_parse test
+        // Total count: 1860, P50 should be at observation 930
+        // Buckets show: 506 at 0.5s, 1282 at 0.75s
+        // So P50 falls between 0.5s and 0.75s buckets
+        // Linear interpolation: 0.5 + (0.75 - 0.5) * ((930 - 506) / (1282 - 506))
+        //                     = 0.5 + 0.25 * (424 / 776)
+        //                     = 0.5 + 0.25 * 0.5464
+        //                     = 0.5 + 0.1366
+        //                     = 0.6366s ≈ 637ms
+        let data = Measurement {
+            workload: "transfer_object".into(),
+            timestamp: Duration::from_secs(30),
+            buckets: [
+                ("0.1".into(), 0),
+                ("0.25".into(), 0),
+                ("0.5".into(), 506),
+                ("0.75".into(), 1282),
+                ("1".into(), 1693),
+                ("1.25".into(), 1816),
+                ("1.5".into(), 1860),
+                ("inf".into(), 1860),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            sum: Duration::from_secs(1265),
+            count: 1860,
+            squared_sum: Duration::from_secs(952),
+        };
+
+        let p50 = super::p50_latency(&data.buckets, data.count);
+        // Should be around 636-637ms
+        assert!(p50.as_millis() >= 636 && p50.as_millis() <= 637);
     }
 
     #[test]

--- a/crates/iota-aws-orchestrator/src/measurement.rs
+++ b/crates/iota-aws-orchestrator/src/measurement.rs
@@ -710,18 +710,18 @@ impl<T: BenchmarkType> MeasurementsCollection<T> {
 
 /// Compute the P50 (median) latency from histogram buckets.
 fn p50_latency(buckets: &HashMap<BucketId, usize>, count: usize) -> Duration {
-    histogram_quantile(&buckets, count, 0.5)
+    histogram_quantile(buckets, count, 0.5)
 }
 
 /// Compute the P99 latency from histogram buckets using.
 fn p99_latency(buckets: &HashMap<BucketId, usize>, count: usize) -> Duration {
-    histogram_quantile(&buckets, count, 0.99)
+    histogram_quantile(buckets, count, 0.99)
 }
 
 /// Calculate a quantile from histogram buckets using linear interpolation,
 /// matching Prometheus's histogram_quantile behavior.
 fn histogram_quantile(buckets: &HashMap<BucketId, usize>, count: usize, quantile: f64) -> Duration {
-    if count == 0 || quantile < 0.0 || quantile > 1.0 {
+    if count == 0 || !(0.0..=1.0).contains(&quantile) {
         return Duration::default();
     }
 
@@ -756,7 +756,8 @@ fn histogram_quantile(buckets: &HashMap<BucketId, usize>, count: usize, quantile
     //
     // Example: Calculate P50 (median) with 1000 total observations
     // Buckets: [(0.5s, 400), (1.0s, 800), (2.0s, 1000)]
-    // This means: 400 observations ≤ 0.5s, 800 observations ≤ 1.0s, 1000 observations ≤ 2.0s
+    // This means: 400 observations ≤ 0.5s, 800 observations ≤ 1.0s, 1000
+    // observations ≤ 2.0s
     //
     // rank = 0.5 * 1000 = 500 (we want the 500th observation)
     //
@@ -766,9 +767,8 @@ fn histogram_quantile(buckets: &HashMap<BucketId, usize>, count: usize, quantile
     //
     // Iteration 2: bound=1.0s, count=800
     //   - 800 >= 500, so P50 is in this bucket (between observations 400-800)
-    //   - Linear interpolation:
-    //     fraction = (500 - 400) / (800 - 400) = 100 / 400 = 0.25
-    //     interpolated = 0.5 + (1.0 - 0.5) * 0.25 = 0.5 + 0.125 = 0.625s
+    //   - Linear interpolation: fraction = (500 - 400) / (800 - 400) = 100 / 400 =
+    //     0.25 interpolated = 0.5 + (1.0 - 0.5) * 0.25 = 0.5 + 0.125 = 0.625s
     //   - The 500th observation is estimated at 0.625s
     let mut prev_count = 0.0;
     let mut prev_bound = 0.0;

--- a/crates/iota-aws-orchestrator/src/monitor.rs
+++ b/crates/iota-aws-orchestrator/src/monitor.rs
@@ -48,6 +48,7 @@ impl Monitor {
         &self,
         protocol_commands: &P,
         use_internal_ip_address: bool,
+        use_fullnode_for_execution: bool,
         snapshot_dir: Option<&str>,
     ) -> MonitorResult<()> {
         let instance = std::iter::once(self.instance.clone());
@@ -56,6 +57,7 @@ impl Monitor {
             self.nodes.clone(),
             protocol_commands,
             use_internal_ip_address,
+            use_fullnode_for_execution,
             snapshot_dir,
         );
         self.ssh_manager
@@ -118,6 +120,7 @@ impl Prometheus {
         nodes: I,
         protocol: &P,
         use_internal_ip_address: bool,
+        use_fullnode_for_execution: bool,
         snapshot_dir: Option<&str>,
     ) -> String
     where
@@ -133,9 +136,18 @@ impl Prometheus {
         for (i, (_, clients_metrics_path)) in clients_metrics_path.into_iter().enumerate() {
             let id = format!("client-{i}");
             let client_ip = clients_metrics_path.split(":").next().unwrap().to_string();
-            client_ips.push(client_ip);
+            client_ips.push(client_ip.clone());
             let scrape_config = Self::scrape_configuration(&id, &clients_metrics_path);
             config.push(scrape_config);
+
+            // When using fullnode for execution, also scrape fullnode metrics on port 9184
+            if use_fullnode_for_execution {
+                let fullnode_metrics_path = format!("{client_ip}:9184/metrics");
+                let fullnode_id = format!("fullnode-{i}");
+                let fullnode_scrape_config =
+                    Self::scrape_configuration(&fullnode_id, &fullnode_metrics_path);
+                config.push(fullnode_scrape_config);
+            }
         }
         // Add configurations to scrape the nodes.
         let mut node_ips = vec![];

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -1266,8 +1266,7 @@ done"#
 
                     // Download the log files.
                     if self.log_processing {
-                        let error_counter =
-                            self.download_logs(&parameters.benchmark_dir).await?;
+                        let error_counter = self.download_logs(&parameters.benchmark_dir).await?;
                         error_counter.print_summary();
                     }
 

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -1198,7 +1198,7 @@ done"#
                         .expect("Failed to create benchmark directory");
 
                     // Swap the loop logger to write to this benchmark's log file
-                    let log_file_path = parameters.benchmark_dir.join("logs.txt");
+                    let log_file_path = parameters.benchmark_dir.join("logs.log");
                     let new_file = OpenOptions::new()
                         .create(true)
                         .append(true)

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -4,8 +4,9 @@
 
 use std::{
     collections::HashSet,
-    fs::{self},
+    fs::{self, OpenOptions},
     future::Future,
+    io::Write,
     marker::PhantomData,
     path::Path,
     time::Duration,
@@ -14,6 +15,7 @@ use std::{
 use chrono;
 use futures;
 use tokio::time::{self, Instant};
+use tracing::info;
 
 use crate::{
     benchmark::{BenchmarkParameters, BenchmarkParametersGenerator, BenchmarkType, RunInterval},
@@ -22,6 +24,7 @@ use crate::{
     display,
     error::{TestbedError, TestbedResult},
     faults::CrashRecoverySchedule,
+    logger::{IS_LOOP, IS_OP, SwappableWriter},
     logs::LogsAnalyzer,
     measurement::MeasurementsCollection,
     monitor::{Monitor, Prometheus},
@@ -67,6 +70,10 @@ pub struct Orchestrator<P, T> {
     /// Whether to forgo a grafana and prometheus instance and leave the testbed
     /// unmonitored.
     skip_monitoring: bool,
+    /// Directory to store benchmark results.
+    benchmark_dir: std::path::PathBuf,
+    /// Writer for benchmark logs.
+    benchmark_writer: crate::logger::SwappableWriter,
 }
 
 impl<P, T> Orchestrator<P, T> {
@@ -101,6 +108,8 @@ impl<P, T> Orchestrator<P, T> {
             log_processing: false,
             dedicated_clients: 0,
             skip_monitoring: false,
+            benchmark_dir: Path::new("benchmark_results").to_path_buf(),
+            benchmark_writer: SwappableWriter::new(),
         }
     }
 
@@ -137,6 +146,16 @@ impl<P, T> Orchestrator<P, T> {
     /// Set the number of instances running exclusively load generators.
     pub fn with_dedicated_clients(mut self, dedicated_clients: usize) -> Self {
         self.dedicated_clients = dedicated_clients;
+        self
+    }
+
+    pub fn with_benchmark_dir_and_writer<F: AsRef<Path>>(
+        mut self,
+        benchmark_dir: F,
+        writer: crate::logger::SwappableWriter,
+    ) -> Self {
+        self.benchmark_dir = benchmark_dir.as_ref().to_path_buf();
+        self.benchmark_writer = writer;
         self
     }
 
@@ -507,6 +526,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             .execute(self.instances_without_metrics(), command, context)
             .await?;
 
+        display::action("Configuration of all instances completed");
         display::done();
         Ok(())
     }
@@ -530,6 +550,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         let context = CommandContext::default();
         self.ssh_manager.execute(active, command, context).await?;
 
+        display::action("Cleanup of all instances completed");
         display::done();
         Ok(())
     }
@@ -542,12 +563,14 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
         self.boot_nodes(self.node_instances.clone(), parameters)
             .await?;
 
+        display::action("Deployment of validators completed");
         display::done();
         Ok(())
     }
 
     /// Deploy the load generators.
     pub async fn run_clients(&self, parameters: &BenchmarkParameters<T>) -> TestbedResult<()> {
+        display::action("Starting deployment of load generators");
         if self.settings.use_fullnode_for_execution {
             display::action("Setting up full nodes");
 
@@ -611,6 +634,8 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
             .execute_per_instance(metrics_script.clone(), metrics_context)
             .await?;
 
+        display::action("Background metrics collection service started");
+        display::action("Deployment of load generators completed");
         display::done();
         Ok(())
     }
@@ -740,6 +765,7 @@ done"#
             }
         }
 
+        display::action("Benchmark run completed");
         display::done();
         Ok(())
     }
@@ -1082,45 +1108,46 @@ done"#
         &mut self,
         mut generator: BenchmarkParametersGenerator<T>,
     ) -> TestbedResult<()> {
-        display::header("Preparing testbed");
-        display::config("Commit", format!("'{}'", &self.settings.repository.commit));
-        display::newline();
+        info!("Starting benchmarks execution");
 
-        // Cleanup the testbed (in case the previous run was not completed).
-        self.cleanup(true).await?;
+        let result = IS_OP
+            .scope(true, async {
+                display::header("Preparing testbed");
+                display::config("Commit", format!("'{}'", &self.settings.repository.commit));
+                display::newline();
 
-        let commit = self.settings.repository.commit.replace("/", "_");
-        let timestamp = chrono::Local::now().format("%y%m%d_%H%M%S").to_string();
-        let benchmark_dir = self.settings.results_dir.join(&commit).join(&timestamp);
+                // Cleanup the testbed (in case the previous run was not completed).
+                self.cleanup(true).await?;
+                let timestamp = chrono::Local::now().format("%y%m%d_%H%M%S").to_string();
 
-        display::config("dedicated_clients", self.dedicated_clients);
-        display::config("nodes", self.node_instances.len());
-        display::config("clients", self.client_instances.len());
-        display::config("metrics", self.metrics_instance.is_some());
+                display::config("dedicated_clients", self.dedicated_clients);
+                display::config("nodes", self.node_instances.len());
+                display::config("clients", self.client_instances.len());
+                display::config("metrics", self.metrics_instance.is_some());
 
-        display::config(
-            "nodes",
-            self.node_instances
-                .iter()
-                .map(|i| i.ssh_address().to_string())
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
-        display::config(
-            "clients",
-            self.client_instances
-                .iter()
-                .map(|i| i.ssh_address().to_string())
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
-        display::config(
-            "metrics",
-            self.metrics_instance
-                .as_ref()
-                .map(|i| i.ssh_address().to_string())
-                .unwrap_or("<none>".to_string()),
-        );
+                display::config(
+                    "nodes",
+                    self.node_instances
+                        .iter()
+                        .map(|i| i.ssh_address().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+                display::config(
+                    "clients",
+                    self.client_instances
+                        .iter()
+                        .map(|i| i.ssh_address().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+                display::config(
+                    "metrics",
+                    self.metrics_instance
+                        .as_ref()
+                        .map(|i| i.ssh_address().to_string())
+                        .unwrap_or("<none>".to_string()),
+                );
 
         // Update the software on all instances.
         if !self.skip_testbed_update {
@@ -1135,127 +1162,152 @@ done"#
         // Run all benchmarks.
         let mut i = 1;
         let mut latest_committee_size = 0;
-        while let Some(mut parameters) = generator.next() {
-            display::header(format!("Starting benchmark {i}"));
-            display::config("Benchmark type", &parameters.benchmark_type);
-            display::config("Parameters", &parameters);
-            display::newline();
+        let result: TestbedResult<()> = IS_LOOP
+            .scope(true, async {
+                while let Some(mut parameters) = generator.next() {
+                    display::header(format!("Starting benchmark {i}"));
+                    display::config("Benchmark type", &parameters.benchmark_type);
+                    display::config("Parameters", &parameters);
+                    display::newline();
 
-            parameters.benchmark_dir = benchmark_dir.join(format!("{parameters:?}"));
+                    parameters.benchmark_dir =
+                        self.benchmark_dir.join(format!("{parameters:?}"));
 
-            if !self.skip_monitoring {
-                if let Some(metrics) = &self.metrics_instance {
-                    let host_ip = if generator.use_internal_ip_address {
-                        metrics.private_ip
-                    } else {
-                        metrics.main_ip
-                    };
+                    if !self.skip_monitoring {
+                        if let Some(metrics) = &self.metrics_instance {
+                            let host_ip = if generator.use_internal_ip_address {
+                                metrics.private_ip
+                            } else {
+                                metrics.main_ip
+                            };
 
-                    parameters.otel.get_or_insert(crate::benchmark::OtelConfig {
-                        otlp_endpoint: format!(
-                            "http://{}:{}",
-                            host_ip,
-                            crate::monitor::Tempo::OTLP_GRPC_PORT
-                        ),
-                        protocol: "grpc".to_string(),
-                        sampler: "parentbased_traceidratio".to_string(),
-                        sampler_arg: "0.1".to_string(),
-                    });
+                            parameters.otel.get_or_insert(crate::benchmark::OtelConfig {
+                                otlp_endpoint: format!(
+                                    "http://{}:{}",
+                                    host_ip,
+                                    crate::monitor::Tempo::OTLP_GRPC_PORT
+                                ),
+                                protocol: "grpc".to_string(),
+                                sampler: "parentbased_traceidratio".to_string(),
+                                sampler_arg: "0.1".to_string(),
+                            });
+                        }
+                    }
+
+                    // Cleanup the testbed (in case the previous run was not completed).
+                    self.cleanup(true).await?;
+                    // Create benchmark directory.
+                    fs::create_dir_all(&parameters.benchmark_dir)
+                        .expect("Failed to create benchmark directory");
+
+                    // Swap the loop logger to write to this benchmark's log file
+                    let log_file_path = parameters.benchmark_dir.join("logs.txt");
+                    let new_file = OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(log_file_path)
+                        .expect("Failed to open log file");
+                    self.benchmark_writer
+                        .swap(Box::new(new_file))
+                        .expect("Failed to swap log writer");
+
+                    crate::logger::log(
+                        &chrono::Local::now()
+                            .format("Started %y-%m-%d:%H-%M-%S\n")
+                            .to_string(),
+                    );
+
+                    let benchmark_result = async {
+                        // Configure all instances (if not skipped).
+                        if !self.skip_testbed_configuration {
+                            self.configure(&parameters).await?;
+                            latest_committee_size = parameters.nodes;
+                        }
+
+                        // Deploy the validators.
+                        self.run_nodes(&parameters).await?;
+
+                        // Deploy the load generators.
+                        self.run_clients(&parameters).await?;
+
+                        // Wait for the benchmark to terminate. Then save the results and
+                        // print a summary.
+                        self.run(&parameters).await?;
+
+                        // Collect and aggregate metrics
+                        let mut aggregator =
+                            MeasurementsCollection::new(&self.settings, parameters.clone());
+                        self.download_metrics_logs(&parameters.benchmark_dir)
+                            .await?;
+
+                        // Parse and aggregate metrics from downloaded files
+                        aggregator.aggregates_metrics_from_files::<P>(
+                            self.client_instances.len(),
+                            &parameters.benchmark_dir.join("logs"),
+                        );
+
+                        aggregator.display_summary();
+                        aggregator.save(&parameters.benchmark_dir);
+                        generator.register_result(aggregator);
+
+                        // Flush any remaining logs to the benchmark log file
+                        let _ = self.benchmark_writer.flush();
+
+                        TestbedResult::Ok(())
+                    }
+                    .await;
+
+                    // Download benchmark stats if metadata path is provided
+                    if let Some(benchmark_stats_path) = &parameters.benchmark_stats_path {
+                        self.download_benchmark_stats(benchmark_stats_path, &parameters)
+                            .await?;
+                    }
+
+                    // Kill the nodes and clients (without deleting the log files).
+                    self.cleanup(false).await?;
+
+                    // Download the log files.
+                    if self.log_processing {
+                        let error_counter =
+                            self.download_logs(&parameters.benchmark_dir).await?;
+                        error_counter.print_summary();
+                    }
+
+                    // Close the per-benchmark log file
+                    crate::logger::log(
+                        &chrono::Local::now()
+                            .format("Finished %y-%m-%d:%H-%M-%S\n")
+                            .to_string(),
+                    );
+
+                    // Propagate any error that occurred
+                    benchmark_result?;
+
+                    i += 1;
                 }
-            }
-            // Cleanup the testbed (in case the previous run was not completed).
-            self.cleanup(true).await?;
-            // Create benchmark directory.
-            fs::create_dir_all(&parameters.benchmark_dir)
-                .expect("Failed to create benchmark directory");
 
-            // Initialize logger for this benchmark run
-            let log_file = parameters.benchmark_dir.join("logs.txt");
-            crate::logger::init_logger(&log_file).expect("Failed to initialize logger");
-            crate::logger::log(
-                chrono::Local::now()
-                    .format("Started %y-%m-%d:%H-%M-%S")
-                    .to_string()
-                    .as_str(),
-            );
-
-            let benchmark_result = async {
-                // Configure all instances (if not skipped).
-                if !self.skip_testbed_configuration {
-                    self.configure(&parameters).await?;
-                    latest_committee_size = parameters.nodes;
-                }
-
-                // Deploy the validators.
-                self.run_nodes(&parameters).await?;
-
-                // Deploy the load generators.
-                self.run_clients(&parameters).await?;
-
-                // Wait for the benchmark to terminate. Then save the results and print a
-                // summary.
-                self.run(&parameters).await?;
-
-                // Collect and aggregate metrics
-                let mut aggregator =
-                    MeasurementsCollection::new(&self.settings, parameters.clone());
-                self.download_metrics_logs(&parameters.benchmark_dir)
-                    .await?;
-
-                // Parse and aggregate metrics from downloaded files
-                aggregator.aggregates_metrics_from_files::<P>(
-                    self.client_instances.len(),
-                    &parameters.benchmark_dir.join("logs"),
-                );
-
-                aggregator.display_summary();
-                aggregator.save(&parameters.benchmark_dir);
-                generator.register_result(aggregator);
-
-                TestbedResult::Ok(())
-            }
+                Ok(())
+            })
             .await;
 
-            // Download benchmark stats if metadata path is provided
-            if let Some(benchmark_stats_path) = &parameters.benchmark_stats_path {
-                self.download_benchmark_stats(benchmark_stats_path, &parameters)
-                    .await?;
-            }
-
-            // Kill the nodes and clients (without deleting the log files).
-            self.cleanup(false).await?;
-
-            // Download the log files.
-            if self.log_processing {
-                let error_counter = self.download_logs(&parameters.benchmark_dir).await?;
-                error_counter.print_summary();
-            }
-
-            // Close the logger for this benchmark run
-            crate::logger::log(
-                chrono::Local::now()
-                    .format("Finished %y-%m-%d:%H-%M-%S")
-                    .to_string()
-                    .as_str(),
-            );
-            crate::logger::close_logger();
-
-            // Propagate any error that occurred
-            benchmark_result?;
-
-            i += 1;
-        }
+        result?;
 
         if self.settings.enable_prometheus_snapshots {
+            info!("Downloading prometheus snapshot");
             if let Err(e) = self
-                .download_prometheus_snapshot(&benchmark_dir, &timestamp)
+                .download_prometheus_snapshot(&self.benchmark_dir, &timestamp)
                 .await
             {
                 display::error(format!("Failed to download prometheus snapshot: {}", e));
             }
+            info!("Prometheus snapshot download completed");
         }
 
         display::header("Benchmark completed");
         Ok(())
-    }
+    })
+    .await;
+
+    result
+}
 }

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -24,7 +24,7 @@ use crate::{
     display,
     error::{TestbedError, TestbedResult},
     faults::CrashRecoverySchedule,
-    logger::{IS_LOOP, IS_OP, SwappableWriter},
+    logger::{IS_LOOP, SwappableWriter},
     logs::LogsAnalyzer,
     measurement::MeasurementsCollection,
     monitor::{Monitor, Prometheus},
@@ -1108,46 +1108,42 @@ done"#
         &mut self,
         mut generator: BenchmarkParametersGenerator<T>,
     ) -> TestbedResult<()> {
-        info!("Starting benchmarks execution");
+        display::header("Preparing testbed");
+        display::config("Commit", format!("'{}'", &self.settings.repository.commit));
+        display::newline();
 
-        let result = IS_OP
-            .scope(true, async {
-                display::header("Preparing testbed");
-                display::config("Commit", format!("'{}'", &self.settings.repository.commit));
-                display::newline();
+        // Cleanup the testbed (in case the previous run was not completed).
+        self.cleanup(true).await?;
+        let timestamp = chrono::Local::now().format("%y%m%d_%H%M%S").to_string();
 
-                // Cleanup the testbed (in case the previous run was not completed).
-                self.cleanup(true).await?;
-                let timestamp = chrono::Local::now().format("%y%m%d_%H%M%S").to_string();
+        display::config("dedicated_clients", self.dedicated_clients);
+        display::config("nodes", self.node_instances.len());
+        display::config("clients", self.client_instances.len());
+        display::config("metrics", self.metrics_instance.is_some());
 
-                display::config("dedicated_clients", self.dedicated_clients);
-                display::config("nodes", self.node_instances.len());
-                display::config("clients", self.client_instances.len());
-                display::config("metrics", self.metrics_instance.is_some());
-
-                display::config(
-                    "nodes",
-                    self.node_instances
-                        .iter()
-                        .map(|i| i.ssh_address().to_string())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                );
-                display::config(
-                    "clients",
-                    self.client_instances
-                        .iter()
-                        .map(|i| i.ssh_address().to_string())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                );
-                display::config(
-                    "metrics",
-                    self.metrics_instance
-                        .as_ref()
-                        .map(|i| i.ssh_address().to_string())
-                        .unwrap_or("<none>".to_string()),
-                );
+        display::config(
+            "nodes",
+            self.node_instances
+                .iter()
+                .map(|i| i.ssh_address().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        display::config(
+            "clients",
+            self.client_instances
+                .iter()
+                .map(|i| i.ssh_address().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        display::config(
+            "metrics",
+            self.metrics_instance
+                .as_ref()
+                .map(|i| i.ssh_address().to_string())
+                .unwrap_or("<none>".to_string()),
+        );
 
         // Update the software on all instances.
         if !self.skip_testbed_update {
@@ -1158,6 +1154,8 @@ done"#
         // Start the instance monitoring tools.
         self.start_monitoring(generator.use_internal_ip_address, &timestamp)
             .await?;
+
+        display::action("Testbed ready!");
 
         // Run all benchmarks.
         let mut i = 1;
@@ -1170,8 +1168,7 @@ done"#
                     display::config("Parameters", &parameters);
                     display::newline();
 
-                    parameters.benchmark_dir =
-                        self.benchmark_dir.join(format!("{parameters:?}"));
+                    parameters.benchmark_dir = self.benchmark_dir.join(format!("{parameters:?}"));
 
                     if !self.skip_monitoring {
                         if let Some(metrics) = &self.metrics_instance {
@@ -1305,9 +1302,5 @@ done"#
 
         display::header("Benchmark completed");
         Ok(())
-    })
-    .await;
-
-    result
-}
+    }
 }

--- a/crates/iota-aws-orchestrator/src/orchestrator.rs
+++ b/crates/iota-aws-orchestrator/src/orchestrator.rs
@@ -405,6 +405,7 @@ impl<P: ProtocolCommands<T> + ProtocolMetrics, T: BenchmarkType> Orchestrator<P,
                 .start_prometheus(
                     &self.protocol_commands,
                     use_internal_ip_address,
+                    self.settings.use_fullnode_for_execution,
                     snapshot_dir,
                 )
                 .await?;

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -81,7 +81,6 @@ pub struct IotaProtocol {
     use_fullnode_for_execution: bool,
     use_precompiled_binaries: bool,
     build_configs: HashMap<String, BinaryBuildConfig>,
-    additional_setup_commands: HashMap<String, Vec<String>>,
     enable_flamegraph: bool,
 }
 
@@ -95,16 +94,6 @@ impl IotaProtocol {
             use_fullnode_for_execution: settings.use_fullnode_for_execution,
             use_precompiled_binaries: settings.build_cache_enabled(),
             build_configs: settings.build_configs.clone(),
-            additional_setup_commands: settings
-                .env
-                .iter()
-                .map(|(binary, env)| {
-                    (
-                        binary.clone(),
-                        env.iter().map(|(k, v)| format!("export {k}={v}")).collect(),
-                    )
-                })
-                .collect(),
             enable_flamegraph: settings.enable_flamegraph,
         }
     }
@@ -131,12 +120,6 @@ impl IotaProtocol {
             let all_commands: Vec<String> = setup_commands
                 .iter()
                 .map(|s| s.as_ref().to_string())
-                .chain(
-                    self.additional_setup_commands
-                        .get(binary_name)
-                        .cloned()
-                        .unwrap_or_default(),
-                )
                 .chain(std::iter::once(binary_command))
                 .collect();
 

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -219,7 +219,12 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
 
         let iota_command = self.run_binary_command(
             "iota",
-            &[&format!("mkdir -p {working_dir}")],
+            &[
+                // Set protocol config override to disable validator subsidies for benchmarks
+                "export IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1",
+                "export IOTA_PROTOCOL_CONFIG_OVERRIDE_validator_target_reward=0",
+                &format!("mkdir -p {working_dir}")
+            ],
             &[
                 "genesis",
                 &format!("-f --working-dir {working_dir} --benchmark-ips {ips} --admin-interface-address=localhost:1337"),
@@ -281,6 +286,10 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                         }
                     },
                     format!("export MAX_PIPELINE_DELAY={max_pipeline_delay}"),
+                    // Set protocol config override to disable validator subsidies for
+                    // benchmarks
+                    format!("export IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1"),
+                    format!("export IOTA_PROTOCOL_CONFIG_OVERRIDE_validator_target_reward=0"),
                 ];
 
                 if self.enable_flamegraph {
@@ -338,7 +347,10 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                             "export TRACE_FLAMEGRAPH=1".to_string()
                         } else {
                             "".to_string()
-                        }
+                        },
+                        // Set protocol config override to disable validator subsidies for benchmarks
+                        "export IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1".to_string(),
+                        "export IOTA_PROTOCOL_CONFIG_OVERRIDE_validator_target_reward=0".to_string(),
                 ];
                 setup.extend(self.otel_env(parameters, &format!("iota-node-{i}")));
 

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -499,7 +499,7 @@ impl IotaProtocol {
             parameters.epoch_duration_ms,
             parameters.chain_start_timestamp_ms,
             Some(parameters.additional_gas_accounts),
-            u64::MAX,
+            u64::MAX - 1,
         );
         let mut addresses = Vec::new();
         if let Some(validator_configs) = genesis_config.validator_config_info.as_ref() {

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -494,6 +494,9 @@ impl IotaProtocol {
                 false => x.main_ip.to_string(),
             })
             .collect();
+
+        // `u64::MAX - 1` is the max total supply value acceptable by
+        // `iota::balance::increase_supply`
         let genesis_config = GenesisConfig::new_for_benchmarks(
             &ips,
             parameters.epoch_duration_ms,

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -81,6 +81,7 @@ pub struct IotaProtocol {
     use_fullnode_for_execution: bool,
     use_precompiled_binaries: bool,
     build_configs: HashMap<String, BinaryBuildConfig>,
+    additional_setup_commands: HashMap<String, Vec<String>>,
     enable_flamegraph: bool,
 }
 
@@ -94,6 +95,16 @@ impl IotaProtocol {
             use_fullnode_for_execution: settings.use_fullnode_for_execution,
             use_precompiled_binaries: settings.build_cache_enabled(),
             build_configs: settings.build_configs.clone(),
+            additional_setup_commands: settings
+                .env
+                .iter()
+                .map(|(binary, env)| {
+                    (
+                        binary.clone(),
+                        env.iter().map(|(k, v)| format!("export {k}={v}")).collect(),
+                    )
+                })
+                .collect(),
             enable_flamegraph: settings.enable_flamegraph,
         }
     }
@@ -120,6 +131,12 @@ impl IotaProtocol {
             let all_commands: Vec<String> = setup_commands
                 .iter()
                 .map(|s| s.as_ref().to_string())
+                .chain(
+                    self.additional_setup_commands
+                        .get(binary_name)
+                        .cloned()
+                        .unwrap_or_default(),
+                )
                 .chain(std::iter::once(binary_command))
                 .collect();
 

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -209,9 +209,6 @@ pub struct Settings {
     /// Enable prometheus snapshots.
     #[serde(default)]
     pub enable_prometheus_snapshots: bool,
-    /// Binary environment.
-    #[serde(default)]
-    pub env: HashMap<String, HashMap<String, String>>,
 }
 
 fn default_working_dir() -> PathBuf {
@@ -381,7 +378,6 @@ impl Settings {
             build_configs: HashMap::new(),
             enable_flamegraph: false,
             enable_prometheus_snapshots: false,
-            env: HashMap::new(),
         }
     }
 }

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -209,6 +209,9 @@ pub struct Settings {
     /// Enable prometheus snapshots.
     #[serde(default)]
     pub enable_prometheus_snapshots: bool,
+    /// Binary environment.
+    #[serde(default)]
+    pub env: HashMap<String, HashMap<String, String>>,
 }
 
 fn default_working_dir() -> PathBuf {
@@ -378,6 +381,7 @@ impl Settings {
             build_configs: HashMap::new(),
             enable_flamegraph: false,
             enable_prometheus_snapshots: false,
+            env: HashMap::new(),
         }
     }
 }

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -13,6 +13,7 @@ use crate::{
     client::ServerProviderClient,
     display,
     error::{TestbedError, TestbedResult},
+    logger::IS_OP,
     settings::Settings,
     ssh::SshConnection,
 };
@@ -158,92 +159,108 @@ impl<C: ServerProviderClient> Testbed<C> {
     ) -> TestbedResult<()> {
         display::action(format!("Deploying instances ({quantity} per region)"));
 
-        let mut instances: Vec<Instance> = vec![];
+        let result: TestbedResult<()> = IS_OP
+            .scope(true, async {
+                let mut instances: Vec<Instance> = vec![];
 
-        if !skip_monitoring {
-            let metrics_region = self
-                .settings
-                .regions
-                .first()
-                .expect("At least one region must be present")
-                .clone();
-            let metrics_instance = self
-                .client
-                .create_instance(metrics_region, InstanceRole::Metrics, 1, false, id.clone())
-                .await?;
-            instances.extend(metrics_instance);
-        }
+                if !skip_monitoring {
+                    let metrics_region = self
+                        .settings
+                        .regions
+                        .first()
+                        .expect("At least one region must be present")
+                        .clone();
+                    let metrics_instance = self
+                        .client
+                        .create_instance(
+                            metrics_region,
+                            InstanceRole::Metrics,
+                            1,
+                            false,
+                            id.clone(),
+                        )
+                        .await?;
+                    instances.extend(metrics_instance);
+                }
 
-        let node_instances = {
-            // Multi-region case — call create_instance per region in parallel
-            let tasks = self.settings.regions.iter().map(|region| {
-                self.client.create_instance(
-                    region.clone(),
-                    InstanceRole::Node,
-                    quantity,
-                    use_spot_instances,
-                    id.clone(),
-                )
-            });
+                let node_instances = {
+                    // Multi-region case — call create_instance per region in parallel
+                    let tasks = self.settings.regions.iter().map(|region| {
+                        self.client.create_instance(
+                            region.clone(),
+                            InstanceRole::Node,
+                            quantity,
+                            use_spot_instances,
+                            id.clone(),
+                        )
+                    });
 
-            // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
-            try_join_all(tasks)
-                .await?
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>()
-        };
-        instances.extend(node_instances);
+                    // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
+                    try_join_all(tasks)
+                        .await?
+                        .into_iter()
+                        .flatten()
+                        .collect::<Vec<_>>()
+                };
+                instances.extend(node_instances);
 
-        let client_instances = match dedicated_clients {
-            0 => vec![],
-            instance_quantity => {
-                // Multi-region case — call create_instance per region in parallel
-                let tasks = self.settings.regions.iter().map(|region| {
-                    self.client.create_instance(
-                        region.clone(),
-                        InstanceRole::Client,
-                        instance_quantity,
-                        false,
-                        id.clone(),
-                    )
-                });
+                let client_instances = match dedicated_clients {
+                    0 => vec![],
+                    instance_quantity => {
+                        // Multi-region case — call create_instance per region in parallel
+                        let tasks = self.settings.regions.iter().map(|region| {
+                            self.client.create_instance(
+                                region.clone(),
+                                InstanceRole::Client,
+                                instance_quantity,
+                                false,
+                                id.clone(),
+                            )
+                        });
 
-                // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
-                try_join_all(tasks)
-                    .await?
-                    .into_iter()
-                    .flatten()
-                    .collect::<Vec<_>>()
-            }
-        };
+                        // Run them all concurrently, flatten Vec<Vec<Instance>> →Vec<Instance>
+                        try_join_all(tasks)
+                            .await?
+                            .into_iter()
+                            .flatten()
+                            .collect::<Vec<_>>()
+                    }
+                };
 
-        instances.extend(client_instances);
+                instances.extend(client_instances);
 
-        // Wait until the instances are booted.
-        if cfg!(not(test)) {
-            self.wait_until_reachable(instances.iter()).await?;
-        }
-        let node_instances = self
-            .client
-            .list_instances_by_role(InstanceRole::Node)
-            .await?;
-        let client_instances = self
-            .client
-            .list_instances_by_role(InstanceRole::Client)
-            .await?;
-        let metrics_instance = self
-            .client
-            .list_instances_by_role(InstanceRole::Metrics)
-            .await?;
-        self.node_instances = node_instances;
-        self.client_instances = if client_instances.is_empty() {
-            None
-        } else {
-            Some(client_instances)
-        };
-        self.metrics_instance = metrics_instance.into_iter().next();
+                // Wait until the instances are booted.
+                if cfg!(not(test)) {
+                    self.wait_until_reachable(instances.iter()).await?;
+                }
+                let node_instances = self
+                    .client
+                    .list_instances_by_role(InstanceRole::Node)
+                    .await?;
+                let client_instances = self
+                    .client
+                    .list_instances_by_role(InstanceRole::Client)
+                    .await?;
+                let metrics_instance = self
+                    .client
+                    .list_instances_by_role(InstanceRole::Metrics)
+                    .await?;
+                self.node_instances = node_instances;
+                self.client_instances = if client_instances.is_empty() {
+                    None
+                } else {
+                    Some(client_instances)
+                };
+                self.metrics_instance = metrics_instance.into_iter().next();
+                display::action("testing");
 
+                Ok(())
+            })
+            .await;
+
+        result?;
+
+        display::action("Deployment completed\n\n");
         display::done();
         Ok(())
     }

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -13,7 +13,6 @@ use crate::{
     client::ServerProviderClient,
     display,
     error::{TestbedError, TestbedResult},
-    logger::IS_OP,
     settings::Settings,
     ssh::SshConnection,
 };
@@ -159,106 +158,92 @@ impl<C: ServerProviderClient> Testbed<C> {
     ) -> TestbedResult<()> {
         display::action(format!("Deploying instances ({quantity} per region)"));
 
-        let result: TestbedResult<()> = IS_OP
-            .scope(true, async {
-                let mut instances: Vec<Instance> = vec![];
+        let mut instances: Vec<Instance> = vec![];
 
-                if !skip_monitoring {
-                    let metrics_region = self
-                        .settings
-                        .regions
-                        .first()
-                        .expect("At least one region must be present")
-                        .clone();
-                    let metrics_instance = self
-                        .client
-                        .create_instance(
-                            metrics_region,
-                            InstanceRole::Metrics,
-                            1,
-                            false,
-                            id.clone(),
-                        )
-                        .await?;
-                    instances.extend(metrics_instance);
-                }
+        if !skip_monitoring {
+            let metrics_region = self
+                .settings
+                .regions
+                .first()
+                .expect("At least one region must be present")
+                .clone();
+            let metrics_instance = self
+                .client
+                .create_instance(metrics_region, InstanceRole::Metrics, 1, false, id.clone())
+                .await?;
+            instances.extend(metrics_instance);
+        }
 
-                let node_instances = {
-                    // Multi-region case — call create_instance per region in parallel
-                    let tasks = self.settings.regions.iter().map(|region| {
-                        self.client.create_instance(
-                            region.clone(),
-                            InstanceRole::Node,
-                            quantity,
-                            use_spot_instances,
-                            id.clone(),
-                        )
-                    });
+        let node_instances = {
+            // Multi-region case — call create_instance per region in parallel
+            let tasks = self.settings.regions.iter().map(|region| {
+                self.client.create_instance(
+                    region.clone(),
+                    InstanceRole::Node,
+                    quantity,
+                    use_spot_instances,
+                    id.clone(),
+                )
+            });
 
-                    // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
-                    try_join_all(tasks)
-                        .await?
-                        .into_iter()
-                        .flatten()
-                        .collect::<Vec<_>>()
-                };
-                instances.extend(node_instances);
+            // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
+            try_join_all(tasks)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+        };
+        instances.extend(node_instances);
 
-                let client_instances = match dedicated_clients {
-                    0 => vec![],
-                    instance_quantity => {
-                        // Multi-region case — call create_instance per region in parallel
-                        let tasks = self.settings.regions.iter().map(|region| {
-                            self.client.create_instance(
-                                region.clone(),
-                                InstanceRole::Client,
-                                instance_quantity,
-                                false,
-                                id.clone(),
-                            )
-                        });
+        let client_instances = match dedicated_clients {
+            0 => vec![],
+            instance_quantity => {
+                // Multi-region case — call create_instance per region in parallel
+                let tasks = self.settings.regions.iter().map(|region| {
+                    self.client.create_instance(
+                        region.clone(),
+                        InstanceRole::Client,
+                        instance_quantity,
+                        false,
+                        id.clone(),
+                    )
+                });
 
-                        // Run them all concurrently, flatten Vec<Vec<Instance>> →Vec<Instance>
-                        try_join_all(tasks)
-                            .await?
-                            .into_iter()
-                            .flatten()
-                            .collect::<Vec<_>>()
-                    }
-                };
+                // Run them all concurrently, flatten Vec<Vec<Instance>> →Vec<Instance>
+                try_join_all(tasks)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+            }
+        };
 
-                instances.extend(client_instances);
+        instances.extend(client_instances);
 
-                // Wait until the instances are booted.
-                if cfg!(not(test)) {
-                    self.wait_until_reachable(instances.iter()).await?;
-                }
-                let node_instances = self
-                    .client
-                    .list_instances_by_role(InstanceRole::Node)
-                    .await?;
-                let client_instances = self
-                    .client
-                    .list_instances_by_role(InstanceRole::Client)
-                    .await?;
-                let metrics_instance = self
-                    .client
-                    .list_instances_by_role(InstanceRole::Metrics)
-                    .await?;
-                self.node_instances = node_instances;
-                self.client_instances = if client_instances.is_empty() {
-                    None
-                } else {
-                    Some(client_instances)
-                };
-                self.metrics_instance = metrics_instance.into_iter().next();
-                display::action("testing");
-
-                Ok(())
-            })
-            .await;
-
-        result?;
+        // Wait until the instances are booted.
+        if cfg!(not(test)) {
+            self.wait_until_reachable(instances.iter()).await?;
+        }
+        let node_instances = self
+            .client
+            .list_instances_by_role(InstanceRole::Node)
+            .await?;
+        let client_instances = self
+            .client
+            .list_instances_by_role(InstanceRole::Client)
+            .await?;
+        let metrics_instance = self
+            .client
+            .list_instances_by_role(InstanceRole::Metrics)
+            .await?;
+        self.node_instances = node_instances;
+        self.client_instances = if client_instances.is_empty() {
+            None
+        } else {
+            Some(client_instances)
+        };
+        self.metrics_instance = metrics_instance.into_iter().next();
+        display::action("testing");
 
         display::action("Deployment completed\n\n");
         display::done();

--- a/crates/iota-aws-orchestrator/src/testbed.rs
+++ b/crates/iota-aws-orchestrator/src/testbed.rs
@@ -209,7 +209,7 @@ impl<C: ServerProviderClient> Testbed<C> {
                     )
                 });
 
-                // Run them all concurrently, flatten Vec<Vec<Instance>> →Vec<Instance>
+                // Run them all concurrently, flatten Vec<Vec<Instance>> → Vec<Instance>
                 try_join_all(tasks)
                     .await?
                     .into_iter()
@@ -243,7 +243,6 @@ impl<C: ServerProviderClient> Testbed<C> {
             Some(client_instances)
         };
         self.metrics_instance = metrics_instance.into_iter().next();
-        display::action("testing");
 
         display::action("Deployment completed\n\n");
         display::done();

--- a/crates/iota-benchmark/Cargo.toml
+++ b/crates/iota-benchmark/Cargo.toml
@@ -64,8 +64,3 @@ typed-store.workspace = true
 
 [build-dependencies]
 rustc_version_runtime = "0.3"
-
-[[bin]]
-name = "flamegraph"
-path = "src/bin/flamegraph.rs"
-required-features = ["flamegraph-alloc"]

--- a/crates/iota-benchmark/src/bin/stress.rs
+++ b/crates/iota-benchmark/src/bin/stress.rs
@@ -175,13 +175,13 @@ async fn main() -> Result<()> {
                         digest_count: benchmark_stats.digests.len(),
                     });
                     let benchmark_table = benchmark_stats.to_table();
-                    eprintln!("Benchmark Report:");
-                    eprintln!("{benchmark_table}");
+                    println!("Benchmark Report:");
+                    println!("{benchmark_table}");
 
                     if stress_stat_collection {
-                        eprintln!("Stress Performance Report:");
+                        println!("Stress Performance Report:");
                         let stress_stats_table = stress_stats.to_table();
-                        eprintln!("{stress_stats_table}");
+                        println!("{stress_stats_table}");
                     }
 
                     if !prev_benchmark_stats_path.is_empty() {
@@ -192,8 +192,8 @@ async fn main() -> Result<()> {
                             old: &prev_stats,
                         };
                         let cmp_table = cmp.to_table();
-                        eprintln!("Benchmark Comparison Report[{prev_benchmark_stats_path}]:");
-                        eprintln!("{cmp_table}");
+                        println!("Benchmark Comparison Report[{prev_benchmark_stats_path}]:");
+                        println!("{cmp_table}");
                     }
                     if !curr_benchmark_stats_path.is_empty() {
                         let file = std::fs::File::create(&curr_benchmark_stats_path)?;

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -49,7 +49,7 @@ use tonic::{
     metadata::{Ascii, MetadataValue},
     transport::server::TcpConnectInfo,
 };
-use tracing::{Instrument, debug, error, error_span, info};
+use tracing::{Instrument, debug, error, error_span, info, trace_span};
 
 use crate::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
@@ -604,6 +604,7 @@ impl ValidatorService {
             epoch_store
                 .signature_verifier
                 .multi_verify_certs(certificates.into())
+                .instrument(trace_span!("SignatureVerifier::multi_verify_certs"))
                 .await
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()?

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -720,7 +720,7 @@ impl ValidatorService {
         &self,
         request: tonic::Request<Transaction>,
     ) -> WrappedServiceResponse<HandleTransactionResponse> {
-        self.handle_transaction(request).await
+        self.handle_transaction(request).instrument(trace_span!("ValidatorService::handle_transaction")).await
     }
 
     async fn submit_certificate_impl(

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -720,7 +720,9 @@ impl ValidatorService {
         &self,
         request: tonic::Request<Transaction>,
     ) -> WrappedServiceResponse<HandleTransactionResponse> {
-        self.handle_transaction(request).instrument(trace_span!("ValidatorService::handle_transaction")).await
+        self.handle_transaction(request)
+            .instrument(trace_span!("ValidatorService::handle_transaction"))
+            .await
     }
 
     async fn submit_certificate_impl(

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -15,7 +15,7 @@ use iota_types::{
 use prometheus::{IntCounter, Registry, register_int_counter_with_registry};
 use starfish_core;
 use tap::TapFallible;
-use tracing::{info, warn};
+use tracing::{info, instrument, warn};
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
@@ -50,6 +50,7 @@ impl IotaTxValidator {
         }
     }
 
+    #[instrument(level = "trace", skip_all)]
     fn validate_transactions(&self, txs: Vec<ConsensusTransactionKind>) -> Result<(), IotaError> {
         let mut cert_batch = Vec::new();
         let mut ckpt_messages = Vec::new();
@@ -143,6 +144,7 @@ macro_rules! impl_tx_verifier_for {
         error = $err_path:path,
     ) => {
         impl $trait_path for $impl_ty {
+            #[instrument(level = "trace", skip_all)]
             fn verify_batch(&self, batch: &[&[u8]]) -> core::result::Result<(), $err_path> {
                 let _scope = monitored_scope("ValidateBatch");
 

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -308,12 +308,7 @@ impl SignatureVerifier {
             }
         };
 
-        if let Ok(res) = timeout(
-            Duration::from_millis(BATCH_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed)),
-            &mut rx,
-        )
-        .await
-        {
+        if let Ok(res) = timeout(Duration::from_millis(BATCH_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed)), &mut rx).await {
             // unwrap ok - tx cannot have been dropped without sending a result.
             return res.unwrap();
         }

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -39,14 +39,16 @@ use tokio::{
 use tracing::{debug, instrument};
 // Maximum amount of time we wait for a batch to fill up before verifying a
 // partial batch.
-const BATCH_TIMEOUT_MS: Duration = Duration::from_millis(10);
+// const BATCH_TIMEOUT_MS: Duration = Duration::from_millis(10);
+pub static BATCH_TIMEOUT_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(10);
 
 // Maximum size of batch to verify. Increasing this value will slightly improve
 // CPU utilization (batching starts to hit steeply diminishing marginal returns
 // around batch sizes of 16), at the cost of slightly increasing latency
 // (BATCH_TIMEOUT_MS will be hit more frequently if system is not heavily
 // loaded).
-const MAX_BATCH_SIZE: usize = 8;
+// const MAX_BATCH_SIZE: usize = 8;
+pub static MAX_BATCH_SIZE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(8);
 
 type Sender = oneshot::Sender<IotaResult<VerifiedCertificate>>;
 
@@ -197,7 +199,8 @@ impl SignatureVerifier {
         Self::new_with_batch_size(
             committee,
             non_committee_validators,
-            MAX_BATCH_SIZE,
+            // MAX_BATCH_SIZE,
+            MAX_BATCH_SIZE.load(std::sync::atomic::Ordering::Relaxed),
             metrics,
             zklogin_env,
             accept_zklogin_in_multisig,
@@ -302,7 +305,7 @@ impl SignatureVerifier {
             }
         };
 
-        if let Ok(res) = timeout(BATCH_TIMEOUT_MS, &mut rx).await {
+        if let Ok(res) = timeout(Duration::from_millis(BATCH_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed)), &mut rx).await {
             // unwrap ok - tx cannot have been dropped without sending a result.
             return res.unwrap();
         }

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -308,7 +308,12 @@ impl SignatureVerifier {
             }
         };
 
-        if let Ok(res) = timeout(Duration::from_millis(BATCH_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed)), &mut rx).await {
+        if let Ok(res) = timeout(
+            Duration::from_millis(BATCH_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed)),
+            &mut rx,
+        )
+        .await
+        {
             // unwrap ok - tx cannot have been dropped without sending a result.
             return res.unwrap();
         }

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -36,7 +36,7 @@ use tokio::{
     sync::oneshot,
     time::{Duration, timeout},
 };
-use tracing::{debug, instrument};
+use tracing::{Instrument, debug, instrument, trace_span};
 // Maximum amount of time we wait for a batch to fill up before verifying a
 // partial batch.
 // const BATCH_TIMEOUT_MS: Duration = Duration::from_millis(10);
@@ -211,6 +211,7 @@ impl SignatureVerifier {
     }
 
     /// Verifies all certs, returns Ok only if all are valid.
+    #[instrument(level = "trace", skip_all)]
     pub fn verify_certs_and_checkpoints(
         &self,
         certs: Vec<&CertifiedTransaction>,
@@ -299,7 +300,9 @@ impl SignatureVerifier {
             Either::Left(prev_id) => prev_id,
             Either::Right(buffer) => {
                 self.metrics.full_batches.inc();
-                self.process_queue(buffer).await;
+                self.process_queue(buffer)
+                    .instrument(trace_span!("SignatureVerifier::process_queue"))
+                    .await;
                 // unwrap ok - process_queue will have sent the result already
                 return rx.try_recv().unwrap();
             }
@@ -346,6 +349,7 @@ impl SignatureVerifier {
             .expect("Spawn blocking should not fail");
     }
 
+    #[instrument(level = "trace", skip_all)]
     fn process_queue_sync(
         committee: Arc<Committee>,
         metrics: Arc<SignatureVerifierMetrics>,
@@ -428,6 +432,7 @@ impl SignatureVerifier {
         )
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn verify_authority_capabilities(
         &self,
         signed_authority_capabilities: &SignedAuthorityCapabilitiesV1,
@@ -617,6 +622,7 @@ impl SignatureVerifierMetrics {
 }
 
 /// Verifies all certificates - if any fail return error.
+#[instrument(level = "trace", skip_all)]
 pub fn batch_verify_all_certificates_and_checkpoints(
     committee: &Committee,
     certs: &[&CertifiedTransaction],
@@ -633,6 +639,7 @@ pub fn batch_verify_all_certificates_and_checkpoints(
 
 /// Verifies certificates in batch mode, but returns a separate result for each
 /// cert.
+#[instrument(level = "trace", skip_all)]
 pub fn batch_verify_certificates(
     committee: &Committee,
     certs: &[&CertifiedTransaction],

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -39,16 +39,14 @@ use tokio::{
 use tracing::{Instrument, debug, instrument, trace_span};
 // Maximum amount of time we wait for a batch to fill up before verifying a
 // partial batch.
-// const BATCH_TIMEOUT_MS: Duration = Duration::from_millis(10);
-pub static BATCH_TIMEOUT_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(10);
+const BATCH_TIMEOUT_MS: Duration = Duration::from_millis(10);
 
 // Maximum size of batch to verify. Increasing this value will slightly improve
 // CPU utilization (batching starts to hit steeply diminishing marginal returns
 // around batch sizes of 16), at the cost of slightly increasing latency
 // (BATCH_TIMEOUT_MS will be hit more frequently if system is not heavily
 // loaded).
-// const MAX_BATCH_SIZE: usize = 8;
-pub static MAX_BATCH_SIZE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(8);
+const MAX_BATCH_SIZE: usize = 8;
 
 type Sender = oneshot::Sender<IotaResult<VerifiedCertificate>>;
 
@@ -199,8 +197,7 @@ impl SignatureVerifier {
         Self::new_with_batch_size(
             committee,
             non_committee_validators,
-            // MAX_BATCH_SIZE,
-            MAX_BATCH_SIZE.load(std::sync::atomic::Ordering::Relaxed),
+            MAX_BATCH_SIZE,
             metrics,
             zklogin_env,
             accept_zklogin_in_multisig,
@@ -308,7 +305,7 @@ impl SignatureVerifier {
             }
         };
 
-        if let Ok(res) = timeout(Duration::from_millis(BATCH_TIMEOUT_MS.load(std::sync::atomic::Ordering::Relaxed)), &mut rx).await {
+        if let Ok(res) = timeout(BATCH_TIMEOUT_MS, &mut rx).await {
             // unwrap ok - tx cannot have been dropped without sending a result.
             return res.unwrap();
         }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -145,7 +145,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
-use tracing::{Instrument, debug, error, error_span, info, warn};
+use tracing::{Instrument, debug, error, error_span, info, trace_span, warn};
 use typed_store::{
     DBMetrics,
     rocks::{check_and_mark_db_corruption, default_db_options, unmark_db_corruption},
@@ -1833,6 +1833,9 @@ impl IotaNode {
                 spawn_monitored_task!(epoch_store.clone().within_alive_epoch(async move {
                     node_clone
                         .send_signed_capability_notification_to_committee_with_retry(&epoch_store)
+                        .instrument(trace_span!(
+                            "send_signed_capability_notification_to_committee_with_retry"
+                        ))
                         .await;
                 }));
             }

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -66,13 +66,15 @@ fn main() {
             .ok()
             .map(|s| s.parse().unwrap())
             .unwrap_or(1_u64);
-        iota_core::signature_verifier::BATCH_TIMEOUT_MS.store(val, std::sync::atomic::Ordering::Relaxed);
+        iota_core::signature_verifier::BATCH_TIMEOUT_MS
+            .store(val, std::sync::atomic::Ordering::Relaxed);
 
         let val = std::env::var("MAX_BATCH_SIZE")
             .ok()
             .map(|s| s.parse().unwrap())
             .unwrap_or(100_usize);
-        iota_core::signature_verifier::MAX_BATCH_SIZE.store(val, std::sync::atomic::Ordering::Relaxed);
+        iota_core::signature_verifier::MAX_BATCH_SIZE
+            .store(val, std::sync::atomic::Ordering::Relaxed);
 
         // AuthoritySignature batch verification
         let val = std::env::var("MOCK_VERIFY_ALL")

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -61,46 +61,6 @@ fn main() {
     );
     config.supported_protocol_versions = Some(SupportedProtocolVersions::SYSTEM_DEFAULT);
 
-    if std::env::var("MOCK_IOTA_NODE").is_ok() {
-        let val = std::env::var("BATCH_TIMEOUT_MS")
-            .ok()
-            .map(|s| s.parse().unwrap())
-            .unwrap_or(1_u64);
-        iota_core::signature_verifier::BATCH_TIMEOUT_MS.store(val, std::sync::atomic::Ordering::Relaxed);
-
-        let val = std::env::var("MAX_BATCH_SIZE")
-            .ok()
-            .map(|s| s.parse().unwrap())
-            .unwrap_or(100_usize);
-        iota_core::signature_verifier::MAX_BATCH_SIZE.store(val, std::sync::atomic::Ordering::Relaxed);
-
-        // AuthoritySignature batch verification
-        let val = std::env::var("MOCK_VERIFY_ALL")
-            .ok()
-            .map(|s| s.parse().unwrap())
-            .unwrap_or(true);
-        iota_types::crypto::MOCK_VERIFY_ALL.store(val, std::sync::atomic::Ordering::Relaxed);
-
-        // AuthoritySignature aggregation
-        let val = std::env::var("MOCK_ADD_SIGNATURE")
-            .ok()
-            .map(|s| s.parse().unwrap())
-            .unwrap_or(true);
-        iota_types::crypto::MOCK_ADD_SIGNATURE.store(val, std::sync::atomic::Ordering::Relaxed);
-
-        let val = std::env::var("MOCK_NEW_SECURE")
-            .ok()
-            .map(|s| s.parse().unwrap())
-            .unwrap_or(true);
-        iota_types::crypto::MOCK_NEW_SECURE.store(val, std::sync::atomic::Ordering::Relaxed);
-
-        let val = std::env::var("MOCK_VERIFY_SECURE")
-            .ok()
-            .map(|s| s.parse().unwrap())
-            .unwrap_or(true);
-        iota_types::crypto::MOCK_VERIFY_SECURE.store(val, std::sync::atomic::Ordering::Relaxed);
-    }
-
     // match run_with_range args
     // this means that we always modify the config used to start the node
     // for run_with_range. i.e if this is set in the config, it is ignored. only the

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -66,15 +66,13 @@ fn main() {
             .ok()
             .map(|s| s.parse().unwrap())
             .unwrap_or(1_u64);
-        iota_core::signature_verifier::BATCH_TIMEOUT_MS
-            .store(val, std::sync::atomic::Ordering::Relaxed);
+        iota_core::signature_verifier::BATCH_TIMEOUT_MS.store(val, std::sync::atomic::Ordering::Relaxed);
 
         let val = std::env::var("MAX_BATCH_SIZE")
             .ok()
             .map(|s| s.parse().unwrap())
             .unwrap_or(100_usize);
-        iota_core::signature_verifier::MAX_BATCH_SIZE
-            .store(val, std::sync::atomic::Ordering::Relaxed);
+        iota_core::signature_verifier::MAX_BATCH_SIZE.store(val, std::sync::atomic::Ordering::Relaxed);
 
         // AuthoritySignature batch verification
         let val = std::env::var("MOCK_VERIFY_ALL")

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -61,6 +61,46 @@ fn main() {
     );
     config.supported_protocol_versions = Some(SupportedProtocolVersions::SYSTEM_DEFAULT);
 
+    if std::env::var("MOCK_IOTA_NODE").is_ok() {
+        let val = std::env::var("BATCH_TIMEOUT_MS")
+            .ok()
+            .map(|s| s.parse().unwrap())
+            .unwrap_or(1_u64);
+        iota_core::signature_verifier::BATCH_TIMEOUT_MS.store(val, std::sync::atomic::Ordering::Relaxed);
+
+        let val = std::env::var("MAX_BATCH_SIZE")
+            .ok()
+            .map(|s| s.parse().unwrap())
+            .unwrap_or(100_usize);
+        iota_core::signature_verifier::MAX_BATCH_SIZE.store(val, std::sync::atomic::Ordering::Relaxed);
+
+        // AuthoritySignature batch verification
+        let val = std::env::var("MOCK_VERIFY_ALL")
+            .ok()
+            .map(|s| s.parse().unwrap())
+            .unwrap_or(true);
+        iota_types::crypto::MOCK_VERIFY_ALL.store(val, std::sync::atomic::Ordering::Relaxed);
+
+        // AuthoritySignature aggregation
+        let val = std::env::var("MOCK_ADD_SIGNATURE")
+            .ok()
+            .map(|s| s.parse().unwrap())
+            .unwrap_or(true);
+        iota_types::crypto::MOCK_ADD_SIGNATURE.store(val, std::sync::atomic::Ordering::Relaxed);
+
+        let val = std::env::var("MOCK_NEW_SECURE")
+            .ok()
+            .map(|s| s.parse().unwrap())
+            .unwrap_or(true);
+        iota_types::crypto::MOCK_NEW_SECURE.store(val, std::sync::atomic::Ordering::Relaxed);
+
+        let val = std::env::var("MOCK_VERIFY_SECURE")
+            .ok()
+            .map(|s| s.parse().unwrap())
+            .unwrap_or(true);
+        iota_types::crypto::MOCK_VERIFY_SECURE.store(val, std::sync::atomic::Ordering::Relaxed);
+    }
+
     // match run_with_range args
     // this means that we always modify the config used to start the node
     // for run_with_range. i.e if this is set in the config, it is ignored. only the

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -367,7 +367,10 @@ impl GenesisConfig {
         total_available_amount: u64,
     ) -> Self {
         // this translates to an assert in iota::balance::increase_supply
-        assert!(total_available_amount < u64::MAX, "Total available amount must be less than 18446744073709551615u64");
+        assert!(
+            total_available_amount < u64::MAX,
+            "Total available amount must be less than 18446744073709551615u64"
+        );
         // Set the validator's configs. They should be the same across multiple runs to
         // ensure reproducibility.
         let mut rng = StdRng::seed_from_u64(Self::BENCHMARKS_RNG_SEED);

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -366,6 +366,8 @@ impl GenesisConfig {
         num_additional_gas_accounts: Option<usize>,
         total_available_amount: u64,
     ) -> Self {
+        // this translates to an assert in iota::balance::increase_supply
+        assert!(total_available_amount < u64::MAX, "Total available amount must be less than 18446744073709551615u64");
         // Set the validator's configs. They should be the same across multiple runs to
         // ensure reproducibility.
         let mut rng = StdRng::seed_from_u64(Self::BENCHMARKS_RNG_SEED);

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -67,6 +67,11 @@ mod crypto_tests;
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 
+pub static MOCK_VERIFY_ALL: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_ADD_SIGNATURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_NEW_SECURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_VERIFY_SECURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 ////////////////////////////////////////////////////////////////////////
 // Type aliases selecting the signature algorithm for the code base.
 ////////////////////////////////////////////////////////////////////////
@@ -580,6 +585,10 @@ impl IotaAuthoritySignature for AuthoritySignature {
     where
         T: Serialize,
     {
+        if MOCK_NEW_SECURE.load(std::sync::atomic::Ordering::Relaxed) {
+            use fastcrypto::traits::ToFromBytes as _;
+            return Self::from_bytes(&[1; 48]).unwrap();
+        }
         let mut intent_msg_bytes =
             bcs::to_bytes(&value).expect("Message serialization should not fail");
         epoch.write(&mut intent_msg_bytes);
@@ -596,6 +605,9 @@ impl IotaAuthoritySignature for AuthoritySignature {
     where
         T: Serialize,
     {
+        if MOCK_VERIFY_SECURE.load(std::sync::atomic::Ordering::Relaxed) {
+            return Ok(());
+        }
         let mut message = bcs::to_bytes(&value).expect("Message serialization should not fail");
         epoch.write(&mut message);
 
@@ -1609,6 +1621,9 @@ impl<'a> VerificationObligation<'a> {
             .get_mut(idx)
             .ok_or(IotaError::InvalidAuthenticator)?
             .push(public_key);
+        if MOCK_ADD_SIGNATURE.load(std::sync::atomic::Ordering::Relaxed) {
+            return Ok(());
+        }
         self.signatures
             .get_mut(idx)
             .ok_or(IotaError::InvalidAuthenticator)?
@@ -1620,6 +1635,9 @@ impl<'a> VerificationObligation<'a> {
     }
 
     pub fn verify_all(self) -> IotaResult<()> {
+        if MOCK_VERIFY_ALL.load(std::sync::atomic::Ordering::Relaxed) {
+            return Ok(());
+        }
         let mut pks = Vec::with_capacity(self.public_keys.len());
         for pk in self.public_keys.clone() {
             pks.push(pk.into_iter());

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -67,14 +67,10 @@ mod crypto_tests;
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 
-pub static MOCK_VERIFY_ALL: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_ADD_SIGNATURE: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_NEW_SECURE: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_VERIFY_SECURE: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_VERIFY_ALL: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_ADD_SIGNATURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_NEW_SECURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_VERIFY_SECURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 ////////////////////////////////////////////////////////////////////////
 // Type aliases selecting the signature algorithm for the code base.
@@ -591,12 +587,7 @@ impl IotaAuthoritySignature for AuthoritySignature {
     {
         if MOCK_NEW_SECURE.load(std::sync::atomic::Ordering::Relaxed) {
             use fastcrypto::traits::ToFromBytes as _;
-            return Self::from_bytes(&[
-                151, 241, 211, 167, 49, 151, 215, 148, 38, 149, 99, 140, 79, 169, 172, 15, 195,
-                104, 140, 79, 151, 116, 185, 5, 161, 78, 58, 63, 23, 27, 172, 88, 108, 85, 232, 63,
-                249, 122, 26, 239, 251, 58, 240, 10, 219, 34, 198, 187,
-            ])
-            .unwrap();
+            return Self::from_bytes(&[1; 48]).unwrap();
         }
         let mut intent_msg_bytes =
             bcs::to_bytes(&value).expect("Message serialization should not fail");

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -67,10 +67,14 @@ mod crypto_tests;
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 
-pub static MOCK_VERIFY_ALL: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_ADD_SIGNATURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_NEW_SECURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_VERIFY_SECURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_VERIFY_ALL: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_ADD_SIGNATURE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_NEW_SECURE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+pub static MOCK_VERIFY_SECURE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 ////////////////////////////////////////////////////////////////////////
 // Type aliases selecting the signature algorithm for the code base.
@@ -587,7 +591,12 @@ impl IotaAuthoritySignature for AuthoritySignature {
     {
         if MOCK_NEW_SECURE.load(std::sync::atomic::Ordering::Relaxed) {
             use fastcrypto::traits::ToFromBytes as _;
-            return Self::from_bytes(&[1; 48]).unwrap();
+            return Self::from_bytes(&[
+                151, 241, 211, 167, 49, 151, 215, 148, 38, 149, 99, 140, 79, 169, 172, 15, 195,
+                104, 140, 79, 151, 116, 185, 5, 161, 78, 58, 63, 23, 27, 172, 88, 108, 85, 232, 63,
+                249, 122, 26, 239, 251, 58, 240, 10, 219, 34, 198, 187,
+            ])
+            .unwrap();
         }
         let mut intent_msg_bytes =
             bcs::to_bytes(&value).expect("Message serialization should not fail");

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -758,6 +758,7 @@ impl Signature {
         Signer::sign(secret, hashed_msg)
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn Signer<Signature>) -> Self
     where
         T: Serialize,
@@ -1022,6 +1023,7 @@ impl<S: IotaSignatureInner + Sized> IotaSignature for S {
         S::PubKey::SIGNATURE_SCHEME
     }
 
+    #[instrument(level = "trace", skip_all)]
     fn verify_secure<T>(
         &self,
         value: &IntentMessage<T>,
@@ -1108,6 +1110,7 @@ pub struct AuthoritySignInfo {
 }
 
 impl AuthoritySignInfoTrait for AuthoritySignInfo {
+    #[instrument(level = "trace", skip_all)]
     fn verify_secure<T: Serialize>(
         &self,
         data: &T,
@@ -1281,6 +1284,7 @@ static_assertions::assert_not_impl_any!(AuthorityStrongQuorumSignInfo: Hash, Eq,
 impl<const STRONG_THRESHOLD: bool> AuthoritySignInfoTrait
     for AuthorityQuorumSignInfo<STRONG_THRESHOLD>
 {
+    #[instrument(level = "trace", skip_all)]
     fn verify_secure<T: Serialize>(
         &self,
         data: &T,
@@ -1634,6 +1638,7 @@ impl<'a> VerificationObligation<'a> {
         Ok(())
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn verify_all(self) -> IotaResult<()> {
         if MOCK_VERIFY_ALL.load(std::sync::atomic::Ordering::Relaxed) {
             return Ok(());

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -67,11 +67,6 @@ mod crypto_tests;
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 
-pub static MOCK_VERIFY_ALL: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_ADD_SIGNATURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_NEW_SECURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-pub static MOCK_VERIFY_SECURE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
 ////////////////////////////////////////////////////////////////////////
 // Type aliases selecting the signature algorithm for the code base.
 ////////////////////////////////////////////////////////////////////////
@@ -585,10 +580,6 @@ impl IotaAuthoritySignature for AuthoritySignature {
     where
         T: Serialize,
     {
-        if MOCK_NEW_SECURE.load(std::sync::atomic::Ordering::Relaxed) {
-            use fastcrypto::traits::ToFromBytes as _;
-            return Self::from_bytes(&[1; 48]).unwrap();
-        }
         let mut intent_msg_bytes =
             bcs::to_bytes(&value).expect("Message serialization should not fail");
         epoch.write(&mut intent_msg_bytes);
@@ -605,9 +596,6 @@ impl IotaAuthoritySignature for AuthoritySignature {
     where
         T: Serialize,
     {
-        if MOCK_VERIFY_SECURE.load(std::sync::atomic::Ordering::Relaxed) {
-            return Ok(());
-        }
         let mut message = bcs::to_bytes(&value).expect("Message serialization should not fail");
         epoch.write(&mut message);
 
@@ -1625,9 +1613,6 @@ impl<'a> VerificationObligation<'a> {
             .get_mut(idx)
             .ok_or(IotaError::InvalidAuthenticator)?
             .push(public_key);
-        if MOCK_ADD_SIGNATURE.load(std::sync::atomic::Ordering::Relaxed) {
-            return Ok(());
-        }
         self.signatures
             .get_mut(idx)
             .ok_or(IotaError::InvalidAuthenticator)?
@@ -1640,9 +1625,6 @@ impl<'a> VerificationObligation<'a> {
 
     #[instrument(level = "trace", skip_all)]
     pub fn verify_all(self) -> IotaResult<()> {
-        if MOCK_VERIFY_ALL.load(std::sync::atomic::Ordering::Relaxed) {
-            return Ok(());
-        }
         let mut pks = Vec::with_capacity(self.public_keys.len());
         for pk in self.public_keys.clone() {
             pks.push(pk.into_iter());

--- a/crates/iota-types/src/effects/mod.rs
+++ b/crates/iota-types/src/effects/mod.rs
@@ -11,6 +11,7 @@ use iota_sdk_types::crypto::{Intent, IntentScope};
 pub use object_change::{EffectsObjectChange, ObjectIn, ObjectOut};
 use serde::{Deserialize, Serialize};
 pub use test_effects_builder::TestEffectsBuilder;
+use tracing::instrument;
 
 use crate::{
     base_types::{ExecutionDigests, ObjectID, ObjectRef, SequenceNumber},
@@ -411,6 +412,7 @@ pub type VerifiedCertifiedTransactionEffects =
     VerifiedTransactionEffectsEnvelope<AuthorityStrongQuorumSignInfo>;
 
 impl CertifiedTransactionEffects {
+    #[instrument(level = "trace", skip_all)]
     pub fn verify_authority_signatures(&self, committee: &Committee) -> IotaResult {
         self.auth_sig().verify_secure(
             self.data(),
@@ -419,6 +421,7 @@ impl CertifiedTransactionEffects {
         )
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn verify(self, committee: &Committee) -> IotaResult<VerifiedCertifiedTransactionEffects> {
         self.verify_authority_signatures(committee)?;
         Ok(VerifiedCertifiedTransactionEffects::new_from_verified(self))

--- a/crates/iota-types/src/message_envelope.rs
+++ b/crates/iota-types/src/message_envelope.rs
@@ -12,6 +12,7 @@ use iota_sdk_types::crypto::{Intent, IntentScope};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_name::{DeserializeNameAdapter, SerializeNameAdapter};
+use tracing::instrument;
 
 use crate::{
     base_types::AuthorityName,
@@ -180,6 +181,7 @@ where
 }
 
 impl Envelope<SenderSignedData, AuthoritySignInfo> {
+    #[instrument(level = "trace", skip_all)]
     pub fn verify_committee_sigs_only(&self, committee: &Committee) -> IotaResult {
         self.auth_signature.verify_secure(
             self.data(),

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -18,7 +18,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use tap::TapFallible;
-use tracing::warn;
+use tracing::{instrument, warn};
 
 pub use crate::digests::{CheckpointContentsDigest, CheckpointDigest};
 use crate::{
@@ -318,6 +318,7 @@ pub type VerifiedCheckpoint = VerifiedEnvelope<CheckpointSummary, AuthorityStron
 pub type TrustedCheckpoint = TrustedEnvelope<CheckpointSummary, AuthorityStrongQuorumSignInfo>;
 
 impl CertifiedCheckpointSummary {
+    #[instrument(level = "trace", skip_all)]
     pub fn verify_authority_signatures(&self, committee: &Committee) -> IotaResult {
         self.data().verify_epoch(self.auth_sig().epoch)?;
         self.auth_sig().verify_secure(
@@ -368,6 +369,7 @@ impl CertifiedCheckpointSummary {
 }
 
 impl SignedCheckpointSummary {
+    #[instrument(level = "trace", skip_all)]
     pub fn verify_authority_signatures(&self, committee: &Committee) -> IotaResult {
         self.data().verify_epoch(self.auth_sig().epoch)?;
         self.auth_sig().verify_secure(

--- a/crates/iota-types/src/signature.rs
+++ b/crates/iota-types/src/signature.rs
@@ -20,6 +20,7 @@ use im::hashmap::HashMap as ImHashMap;
 use iota_sdk_types::crypto::IntentMessage;
 use schemars::JsonSchema;
 use serde::Serialize;
+use tracing::instrument;
 
 use crate::{
     base_types::IotaAddress,
@@ -320,6 +321,7 @@ impl AuthenticatorTrait for Signature {
         Ok(())
     }
 
+    #[instrument(level = "trace", skip_all)]
     fn verify_claims<T>(
         &self,
         value: &IntentMessage<T>,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -3076,6 +3076,7 @@ impl VerifiedTransaction {
 
 impl VerifiedSignedTransaction {
     /// Use signing key to create a signed object.
+    #[instrument(level = "trace", skip_all)]
     pub fn new(
         epoch: EpochId,
         transaction: VerifiedTransaction,
@@ -3170,6 +3171,7 @@ impl CertifiedTransaction {
 
     // TODO: Eventually we should remove all calls to verify_signature
     // and make sure they all call verify to avoid repeated verifications.
+    #[instrument(level = "trace", skip_all)]
     pub fn verify_signatures_authenticated(
         &self,
         committee: &Committee,

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -1211,7 +1211,7 @@ async fn genesis(
                         * iota_swarm_config::genesis_config::DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT
                             as u64;
                 }
-                let total_available_amount = u64::MAX
+                let total_available_amount = (u64::MAX - 1)
                     .saturating_sub(validator_extra)
                     .saturating_sub(faucet_extra);
 

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -1211,6 +1211,8 @@ async fn genesis(
                         * iota_swarm_config::genesis_config::DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT
                             as u64;
                 }
+                // `u64::MAX - 1` is the max total supply value acceptable by
+                // `iota::balance::increase_supply`
                 let total_available_amount = (u64::MAX - 1)
                     .saturating_sub(validator_extra)
                     .saturating_sub(faucet_extra);

--- a/crates/starfish/config/Cargo.toml
+++ b/crates/starfish/config/Cargo.toml
@@ -16,6 +16,7 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 rand.workspace = true
 rs_merkle.workspace = true
 serde.workspace = true
+tracing.workspace = true
 
 # internal dependencies
 iota-network-stack.workspace = true

--- a/crates/starfish/config/src/crypto.rs
+++ b/crates/starfish/config/src/crypto.rs
@@ -23,6 +23,8 @@ use fastcrypto::{
 use iota_sdk_types::crypto::INTENT_PREFIX_LENGTH;
 use rs_merkle::Hasher;
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
 /// Network key is used for TLS and as the network identity of the authority.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct NetworkPublicKey(ed25519::Ed25519PublicKey);
@@ -88,6 +90,7 @@ impl ProtocolPublicKey {
         Self(key)
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn verify(
         &self,
         message: &[u8],
@@ -114,6 +117,7 @@ impl ProtocolKeyPair {
         ProtocolPublicKey(self.0.public().clone())
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn sign(&self, message: &[u8]) -> ProtocolKeySignature {
         ProtocolKeySignature(self.0.sign(message))
     }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -19,6 +19,7 @@ use starfish_config::{
     AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction, DefaultHashFunctionWrapper, Epoch,
     ProtocolKeyPair, ProtocolKeySignature, ProtocolPublicKey,
 };
+use tracing::instrument;
 
 use crate::{
     commit::CommitVote,
@@ -760,6 +761,7 @@ impl SignedBlockHeader {
 
     /// This method only verifies this block header's signature. Verification of
     /// the full block header should be done via BlockHeaderVerifier.
+    #[instrument(level = "trace", skip_all)]
     pub(crate) fn verify_signature(&self, context: &Context) -> ConsensusResult<()> {
         let block_header = &self.inner;
         ConsensusError::quick_validation_authority_indices(
@@ -810,6 +812,7 @@ fn to_consensus_block_header_intent(
 /// 1. Compute the digest of `BlockHeader`.
 /// 2. Wrap the digest in `IntentMessage`.
 /// 3. Sign the serialized `IntentMessage`, or verify the signature against it.
+#[tracing::instrument(level = "trace", skip_all)]
 fn compute_block_header_signature(
     block_header: &BlockHeader,
     protocol_keypair: &ProtocolKeyPair,
@@ -819,6 +822,7 @@ fn compute_block_header_signature(
         .map_err(ConsensusError::SerializationFailure)?;
     Ok(protocol_keypair.sign(&message))
 }
+#[tracing::instrument(level = "trace", skip_all)]
 fn verify_block_header_signature(
     block_header: &BlockHeader,
     signature: &[u8],

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -4,6 +4,8 @@
 
 use std::{collections::BTreeSet, sync::Arc};
 
+use tracing::instrument;
+
 use crate::{
     Transaction,
     block_header::{
@@ -87,6 +89,7 @@ impl SignedBlockVerifier {
 
 // All block verification logic are implemented below.
 impl BlockVerifier for SignedBlockVerifier {
+    #[instrument(level = "trace", skip_all)]
     fn verify(&self, block: &SignedBlockHeader) -> ConsensusResult<()> {
         let committee = &self.context.committee;
         // The block must belong to the current epoch and have valid authority index,

--- a/crates/telemetry-subscribers/src/flamegraph/metric.rs
+++ b/crates/telemetry-subscribers/src/flamegraph/metric.rs
@@ -54,14 +54,14 @@ impl Stopwatch {
     pub fn stop(&mut self, now: Clock) {
         debug_assert!(self.is_ticking());
         debug_assert!(self.clock <= now, "{:?} <= {now:?}", self.clock);
-        self.total += now.duration_since(self.clock).unwrap();
+        self.total += now.duration_since(self.clock).unwrap_or_default();
         self.reset();
     }
 
     pub fn try_stop(&mut self, now: Clock) {
         if self.is_ticking() {
             debug_assert!(self.clock <= now, "{:?} <= {now:?}", self.clock);
-            self.total += now.duration_since(self.clock).unwrap();
+            self.total += now.duration_since(self.clock).unwrap_or_default();
             self.reset();
         }
     }


### PR DESCRIPTION
# Description of change

* Fix token distribution to avoid overflow
* Relax `flamegraph-alloc` feature constraints for flamegraph binary
* Add more spans to critical consensus methods 
* Make stress print stats to stdout instead stderr
* Added a new `init_logger` function that sets up layered logging with filters, writing to separate files in the benchmark directory.
* Add P50 and P99 latency calculation
* Fix stdev and avg latency calculation


## Links to any relevant issues

part of #9826 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes


