### PR TITLE
fix(dashboard): Use `||` instead of `??` for the metadata base url

### DIFF
--- a/apps/wallet-dashboard/lib/constants/metadata.constants.ts
+++ b/apps/wallet-dashboard/lib/constants/metadata.constants.ts
@@ -10,7 +10,7 @@ const METADATA_INFO = {
     title: 'IOTA Wallet Dashboard',
     description: 'IOTA Wallet Dashboard - Connecting you to the decentralized web and IOTA network',
     image: '/metadata-image.png',
-    metadataBase: new URL(`https://${VERCEL_URL ?? PRODUCTION_BASE_URL}`),
+    metadataBase: new URL(`https://${VERCEL_URL || PRODUCTION_BASE_URL}`),
 };
 
 export const METADATA: Metadata = {


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota/actions/runs/22351580669/job/64681140983#step:12:230