### PR TITLE
feat(docs): add AA overview page

### DIFF
--- a/docs/content/developer/account-abstraction/overview.md
+++ b/docs/content/developer/account-abstraction/overview.md
@@ -1,0 +1,229 @@
+---
+title: Account Abstraction
+description: "Conceptual overview of Account Abstraction in IOTA: components, authentication model, and developer guidance"
+tags:
+  - move-sc
+  - move-vm
+---
+
+# Account Abstraction
+
+## Summary
+
+Account Abstraction in IOTA replaces fixed cryptographic signature verification with a programmable Move function. An abstract account is a Move object whose ObjectID is its address; its authenticator function is registered on-chain via `AuthenticatorFunctionRefV1` and called by the protocol on every incoming AA transaction. The AA transaction sender provides a `MoveAuthenticator` instead of a traditional signature, supplying the arguments the authenticator function needs. The authenticator function receives the account, those arguments, an `AuthContext` describing the AA transaction, and a `TxContext`, and it either returns (authenticated) or aborts (rejected).
+
+## What Is Account Abstraction?
+
+Traditional IOTA accounts, known as Externally Owned Accounts (EOAs), are controlled by a single cryptographic key pair. Every transaction sent from an EOA must be signed with the corresponding private key; the protocol verifies the signature before allowing the transaction to proceed. This model is simple but rigid: authentication is always reduced to possession of a private key.
+
+**Account Abstraction (AA)** replaces this fixed rule with programmable logic.
+
+Instead of forcing the authentication of an account to the checking of a cryptographic signature, the protocol calls a Move function _you_ define. That function decides whether the transaction is authorized. If the function executes successfully, the transaction proceeds; if the function aborts, the transaction is rejected.
+
+This means abstract accounts can authenticated using:
+
+- A cryptographic scheme not natively supported by IOTA (e.g., ECDSA on a custom curve)
+- A weighted threshold of multiple signers (multisig)
+- A time window (only allow transactions before a deadline)
+- A permission check (only allow calls to specific Move functions)
+- Any combination of the above
+- **Anything else expressible in Move**
+
+In the following, the specification for the V1 of the implementation of Account Abstraction in IOTA will be described. Account Abstraction in IOTA is defined by [IIP-0009](https://github.com/iotaledger/IIPs/blob/main/iips/IIP-0009/iip-0009.md).
+
+---
+
+## Main Components
+
+Account Abstraction involves five interconnected components:
+
+| Component                        | Role                                                                                             |
+| -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Abstract Account**             | A Move object whose ObjectID is its address                                                      |
+| **Authenticator Function**       | A Move function that decides if the sender of a transaction is an authenticated abstract account |
+| **`AuthenticatorFunctionRefV1`** | An on-chain, validated reference to an authenticator function                                    |
+| **`MoveAuthenticator`**          | A new transaction signature type used to invoke the authenticator function                       |
+| **`AuthContext`**                | A runtime context passed to the authenticator function describing the transaction                |
+
+---
+
+### Abstract Account
+
+An abstract account is a Move object, that is, any Move struct with the `key` ability. What makes it an abstract account is not its structure, but what is attached to it: an `AuthenticatorFunctionRefV1` dynamic field, which tells the protocol which Move function to call when an AA transaction is sent from this account.
+
+The account's **ObjectID** becomes its on-chain address. Objects that are owned by an abstract account use the "ordinary" ownership model, with the ObjectID serving as the address owning those objects. From the protocol's perspective, abstract accounts are indistinguishable from traditional EOAs at the address level.
+
+Abstract accounts exist in two forms:
+
+- **Mutable shared** (created in Move with `iota::account::create_account_v1`): the main account object use case, that can be modified by anyone on tha basis of an access control implemented in Move code. This is the form used when the account holds mutable state. For example: member lists, approval records, or key stores.
+
+- **Immutable** (created in Move with `iota::account::create_immutable_account_v1`): the account object that can never change state, but that can own other objects. This is appropriate when authentication logic is fully self-contained (or "static") and the account holds no mutable state.
+
+What's worth repeating here, is that **any Move object type can become an account**, even object types already existing today in the ledger (through a Move package upgrade).
+
+The IOTA Move bytecode verifier enforces a critical invariant: the account Move object type passed to `create_account_v1` or `create_immutable_account_v1` must be defined in the **same module** as the call site. This prevents one module from registering an unauthorized abstract accounts using another module's object type.
+
+---
+
+### Authenticator Function
+
+The authenticator function is the core of Account Abstraction: it is the logic that decides whether an AA transaction is allowed to use an abstract account as sender.
+
+An authenticator function is a regular Move function with an `#[authenticator]` attribute. It must conform to a strict signature:
+
+1. **Public, non-entry**: the function must be `public` and must **not** be `entry`.
+2. **First parameter**: an immutable reference to the account object type (`&Account`).
+3. **Middle parameters**: any number of additional inputs, each of which must be read-only: either pure values or references to shared or immutable objects. No owned objects, no mutable references.
+4. **Second-to-last parameter**: `&AuthContext`, a set of data extracted from the transaction that is being authorized, not present in the `TxContext` and useful for authenticating.
+5. **Last parameter**: `&TxContext`, the context of the transaction that is being authorized.
+6. **No return type**: authentication is expressed by control flow, not by a return value; a successful return means "authenticated"; an abort means "rejected".
+
+The `#[authenticator]` attribute is what makes the function eligible for use as an authenticator. Any public, non-entry function annotated with this attribute and satisfying the signature rules can be referenced.
+
+**The authenticator function must not have mutable effects.** All its inputs are read-only: it can inspect the account, read shared state, and examine the AA transaction, but it cannot write anything.
+
+The authenticator function's signature constraints are enforced at publication time by the bytecode verifier and validated on-chain via `PackageMetadataV1` ([IIP-0010](https://github.com/iotaledger/IIPs/blob/main/iips/IIP-0010/iip-0010.md)), an immutable object created exclusively by the protocol during publish and upgrade operations, making it a trusted source of package metadata.
+
+---
+
+### `AuthenticatorFunctionRefV1`
+
+`AuthenticatorFunctionRefV1<T>` is the on-chain proof that a specific Move function is a valid authenticator for a specific account type. It is created using a `PackageMetadataV1`. In fact, a `PackageMetadataV1` includes information related to a specific package, for all its modules and all functions. So, using this on-chain source of information, a `AuthenticatorFunctionRefV1<T>` is created by encapsulating three values:
+
+- `package`: the ID of the package containing the authenticator function
+- `module_name`: the module within that package containing the authenticator function
+- `function_name`: the authenticator function name
+
+The type parameter `T` binds the reference to a specific account type. This ensures you cannot attach a multisig authenticator designed for `T: MultisigAccount` to a `T: FunctionKeysAccount`.
+
+To create an `AuthenticatorFunctionRefV1`, you must call `iota::authenticator_function::create_auth_function_ref_v1` with a valid `PackageMetadataV1` object. The function validates that the referenced function exists in the metadata and that its account type matches the type parameter. You cannot create an `AuthenticatorFunctionRefV1` by hand, but it must always be produced through this validated path.
+
+Once created, _an `AuthenticatorFunctionRefV1` is stored as a dynamic field on the account object_. The protocol uses this known dynamic field to locate the authenticator function when an AA transaction arrives.
+
+**Authenticator rotation** is supported via `iota::authenticator_function::rotate_auth_function_ref_v1`. This replaces the current authenticator with a new one without changing the abstract account's address. The old `AuthenticatorFunctionRefV1` is returned, and the new one is installed.
+
+---
+
+### `MoveAuthenticator`
+
+`MoveAuthenticator` is a new variant of IOTA's `GenericSignature` type within the SDK. It is what a transaction sender provides instead of a traditional cryptographic signature when sending a transaction from an abstract account.
+
+A `MoveAuthenticator` (in its V1) contains:
+
+- **`object_to_authenticate`**: A reference to the account object that is the AA transaction sender. This object's ID determines the sender address. It must be a reference to an immutable or non-mutable shared object. _Owned objects and mutable shared objects are not allowed_.
+- **`call_args`**: A vector of additional arguments (`CallArg`) that will be forwarded to the authenticator function. These correspond to the "middle parameters" described above.
+- **`type_arguments`**: Type arguments for the authenticator function, if it is generic.
+
+The sender address is derived directly from the account object's ID. The protocol validates that the `object_to_authenticate` field matches the declared sender of the AA transaction.
+
+When the protocol processes the AA transaction, it reads the `AuthenticatorFunctionRefV1` dynamic field from the referenced account object, constructs a Move call to the corresponding authenticator function with the provided `call_args` arguments, and executes it. _The `MoveAuthenticator` carries no cryptographic material itself, all authentication logic lives in Move_.
+
+---
+
+### `AuthContext`
+
+The `AuthContext` is a struct passed by the protocol to the authenticator function as its second-to-last parameter. It describes the transaction being authorized:
+
+- **`auth_digest`**: The digest of the `MoveAuthenticator` itself. This uniquely identifies the authenticator invocation.
+- **`tx_inputs`**: The full list of inputs to the Programmable Transaction Block (PTB); this allows to read the object references and pure values passed as input to the AA transaction.
+- **`tx_commands`**: The ordered list of commands in the PTB; this allows to parse all the commands that are going to be executed for the AA transaction if the authentication is successful.
+
+The `AuthContext` allows to authenticator function inspect what the AA transaction will do before allowing it. This enables **intent-aware authentication**: for example, a function-keys authenticator can verify that the AA transaction calls only an approved Move function; a spending-limit authenticator can check that coin transfers do not exceed a threshold (in a specific scenario).
+
+---
+
+## The Authentication Lifecycle Example
+
+The components interact as follows:
+
+```
+[Package Publication]
+  └─► PackageMetadataV1 created automatically
+        └─► create_auth_function_ref_v1(metadata, module, function)
+              └─► AuthenticatorFunctionRefV1<Account>
+                    └─► create_account_v1(account_object, auth_ref)
+                          └─► Account is now an abstract account (shared object)
+                                └─► account.id == sender address
+
+[Transaction Submission]
+  └─► MoveAuthenticator { object_to_authenticate, call_args, type_arguments }
+        └─► Protocol reads AuthenticatorFunctionRefV1 from account dynamic field
+              └─► Calls authenticator_function(account, ...call_args, auth_context, tx_context)
+                    ├─► Returns normally → transaction authorized
+                    └─► Aborts → transaction rejected
+```
+
+### 1. Package publication
+
+When a developer publishes a package containing an `#[authenticator]` function, the IOTA protocol automatically creates a `PackageMetadataV1` immutable object. This object records the function name and account type. The developer receives the package object id and its associated metadata object id in the transaction effects.
+
+### 2. Account creation
+
+Any user (also through sponsorship) can call the package function for creating an account, which:
+
+1. Creates the account object (a Move struct with `key`) of type `CustomDevAccount`.
+2. Calls `iota::authenticator_function::create_auth_function_ref_v1` with the object id of the `PackageMetadataV1`, the module name, and the authenticator function name as inputs (this produces an `AuthenticatorFunctionRefV1<CustomDevAccount>`).
+3. Calls `iota::account::create_account_v1(account, authenticator_ref)`, which:
+   - Attaches the `AuthenticatorFunctionRefV1<CustomDevAccount>` as a dynamic field on the account.
+   - Shares the object.
+   - Emits a `MutableAccountCreated` event.
+
+After this point, the account's ObjectID is a valid IOTA address, and any transaction claiming to come from that address must "pass" the attached authenticator function.
+
+### 3. AA Transaction submission
+
+A client that wants to send an AA transaction from the abstract account constructs:
+
+- A `TransactionData` with the account's address as the sender.
+- A `MoveAuthenticator` containing:
+  - A reference to the `CustomDevAccount` object.
+  - The arguments the authenticator function needs (signatures, proofs, digests, etc.).
+
+The `MoveAuthenticator` is placed in the AA transaction's signature field.
+
+### 4. Validator's authentication process
+
+- **Pre-consensus**: Before an AA transaction reaches consensus, each validator independently invokes the authenticator function. This optimistic check allows validators to reject obviously invalid transactions early, without waiting for consensus and without charging gas.
+  If the authenticator function aborts in this phase, the transaction is rejected before consensus.
+- **Post-consensus**: After consensus, the authenticator function is called again with the full resolved AA transaction context and inputs. If it aborts, the transaction is aborted and gas is deducted.
+  If it returns successfully, the AA transaction proceeds to normal execution.
+
+### 5. Authenticator rotation
+
+When an account's security policy needs to change, for example, to add a new member, rotate a key, or upgrade to a new authenticator, the account calls `iota::authenticator_function::rotate_auth_function_ref_v1`. Because this is an AA transaction sent from the abstract account itself, it must first pass the existing authenticator. Once authorized, the old `AuthenticatorFunctionRefV1` is replaced with the new one. The account's address is unchanged.
+
+---
+
+## Design Principles for Third-Party Developers
+
+### Authenticator functions are read-only by construction
+
+The type system prevents an authenticator function from modifying any state. All its inputs are immutable. This is intentional: authentication must be a direct decision, it reads the ledger state and says yes or no. If you need mutable state during authentication (for example, to record that a one-time code has been used), that state must be managed through the account object itself, which can be done during the execution of the AA transaction.
+
+### Account state lives as dynamic fields
+
+The best approach to design abstract accounts is typically to use stateless structs and store meaningful data as dynamic fields. This allows the account struct itself to be minimal while allowing arbitrary extensions/plug-ins that enable additional authenticator functions. When defining an abstract account, store authentication-relevant state, member lists, key stores, approval tables, nonces, as dynamic fields under the account's UID. The authenticator function receives a read-only reference to the account and can traverse those dynamic fields.
+
+### The `AuthContext` enables intent-aware authentication
+
+The `tx_inputs` and `tx_commands` fields of `AuthContext` expose the full PTB. Authenticator functions can use this to inspect what the AA transaction will do and enforce policies over it. This makes authentication aware of intent, not just identity: rather than simply verifying who is sending the transaction, the authenticator can also verify what the AA transaction does, checking which functions are called, which objects are involved, and what values are passed, before deciding whether to allow execution.
+
+### Authenticatation is signaled by execution, not return value
+
+The authenticator function has no return type. Returning succesfully means "authenticated"; aborting means "rejected". Use `assert!` and standard Move abort patterns to express rejection conditions.
+
+Avoid silent failures: if authentication should fail, abort with a descriptive error.
+
+### Authenticator references are version-aware but decoupled from compile-time dependencies
+
+`AuthenticatorFunctionRefV1` stores a runtime reference to a package, module, and function. This reference is not a compile-time import. When you rotate to a new authenticator version, you create a new `AuthenticatorFunctionRefV1` pointing to the new package. Old transactions that were authorized by the old authenticator remain valid; new transactions go through the new one. This decoupling means you can upgrade authentication logic without redeploying the account type itself.
+
+However, this also means that an upgrade to any authenticator function will not be automatically enforced for all accounts using it. Users MUST opt-in to use the new authenticator function version by rotating the `AuthenticatorFunctionRefV1`.
+
+### Immutable accounts have fixed authenticators
+
+`iota::account::create_immutable_account_v1` creates an account whose object can never change. This means the `AuthenticatorFunctionRefV1` is permanently fixed. Use this only when your authentication logic is entirely stateless and needs no future update path. This can be used, for instance, for throwaway accounts. Mutable shared accounts created with `iota::account::create_account_v1` are the typical choice for any production use case.
+
+### The bytecode verifier enforces module-local account creation
+
+The IOTA Move bytecode verifier requires that the `Account` type argument to `iota::account::create_account_v1` be defined in the same module that calls it. This cannot be circumvented. It ensures that no module can create an abstract account impersonating a type defined elsewhere, and that account creation is always an authorized operation within the module that owns the type.

--- a/docs/content/developer/account-abstraction/overview.md
+++ b/docs/content/developer/account-abstraction/overview.md
@@ -1,5 +1,4 @@
 ---
-title: Account Abstraction
 description: "Conceptual overview of Account Abstraction in IOTA: components, authentication model, and developer guidance"
 tags:
   - move-sc

--- a/docs/content/developer/account-abstraction/overview.md
+++ b/docs/content/developer/account-abstraction/overview.md
@@ -54,7 +54,7 @@ The account's **ObjectID** becomes its on-chain address. Objects that are owned 
 
 Abstract accounts exist in two forms:
 
-- **Mutable shared** (created in Move with `iota::account::create_account_v1`): the main account object use case, that can be modified by anyone on tha basis of an access control implemented in Move code. This is the form used when the account holds mutable state. For example: member lists, approval records, or key stores.
+- **Mutable shared** (created in Move with `iota::account::create_account_v1`): the main account object use case, that can be modified by anyone on the basis of an access control implemented in Move code. This is the form used when the account holds mutable state. For example: member lists, approval records, or key stores.
 
 - **Immutable** (created in Move with `iota::account::create_immutable_account_v1`): the account object that can never change state, but that can own other objects. This is appropriate when authentication logic is fully self-contained (or "static") and the account holds no mutable state.
 


### PR DESCRIPTION
# Description of change

Adds a doc page for the overview of account abstraction. Maybe the page is overloaded with too much info, so it could be split in 2 or even 3 pages.

## Links to any relevant issues

Partially fixes #10000 
