### PR TITLE
fix(docs): Use `/* */` for commented examples instead of the JSDoc syntax

### DIFF
--- a/docs/content/developer/iota-identity/getting-started/wasm.mdx
+++ b/docs/content/developer/iota-identity/getting-started/wasm.mdx
@@ -70,7 +70,7 @@ import { IotaDID } from "@iota/identity-wasm/web";
 import { IotaClient } from "@iota/iota-sdk/client";
 import { createDocumentForNetwork, getFundedClient, getMemstorage, NETWORK_URL } from "../util";
 
-/** Demonstrate how to create a DID Document and publish it. */
+/* Demonstrate how to create a DID Document and publish it. */
 export async function createIdentity(): Promise<void> {
     // create new client to connect to IOTA network
     const iotaClient = new IotaClient({ url: NETWORK_URL });

--- a/docs/content/developer/iota-notarization/getting-started/wasm.mdx
+++ b/docs/content/developer/iota-notarization/getting-started/wasm.mdx
@@ -69,7 +69,7 @@ import { TimeLock } from "@iota/notarization/web";
 import { strict as assert } from "assert";
 import { getFundedClient } from "./util";
 
-/** Demonstrate how to create a Locked Notarization and publish it. */
+/* Demonstrate how to create a Locked Notarization and publish it. */
 export async function createLocked(): Promise<void> {
     console.log("Creating a simple locked notarization example");
 

--- a/docs/content/developer/ts-sdk/kiosk/kiosk-client/querying.mdx
+++ b/docs/content/developer/ts-sdk/kiosk/kiosk-client/querying.mdx
@@ -22,7 +22,7 @@ const address = '0xAddress'
 const { kioskOwnerCaps, kioskIds } = await kioskClient.getOwnedKiosks({ address });
 console.log(kioskOwnerCaps);
 
-/**
+/*
  * An example response for an address that owns two kiosks (one of which is personal)
 [
   {
@@ -64,7 +64,7 @@ const res = await kioskClient.getKiosk({
     }
 });
 console.log(res);
-/**
+/*
  * An example response of an existing kiosk
  *
 {
@@ -151,7 +151,7 @@ const extension = await kioskClient.getKioskExtension({
 
 console.log(extension);
 
-/**
+/*
  * An example output of the response
 {
   objectId: 'extensionObjectId',
@@ -207,7 +207,7 @@ const address = '0xAddress';
 const policies = await kioskClient.getOwnedTransferPolicies({ address });
 console.log(policies);
 
-/**
+/*
  * An example output of the response
 [
   {


### PR DESCRIPTION
Before:
<img width="918" height="755" alt="image" src="https://github.com/user-attachments/assets/1dbe424c-460e-4c94-a14b-bf450555557b" />
Now:
<img width="1061" height="782" alt="image" src="https://github.com/user-attachments/assets/5f52e712-8f8b-4106-8927-a62dcc108294" />

