### PR TITLE
feat(indexer): Guard objects deletion with version check, persist objects only after tx global order on Checkpoint path

### DIFF
--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -164,17 +164,25 @@ impl PrimaryWriter {
             let mut persist_tasks = vec![
                 self.state.persist_transactions(tx_batch),
                 self.state.persist_tx_indices(tx_indices_batch),
-                self.state
-                    .persist_tx_global_order(tx_global_order_batch.clone()),
                 self.state.persist_events(events_batch),
                 self.state.persist_event_indices(event_indices_batch),
                 self.state.persist_displays(display_updates_batch),
                 self.state.persist_packages(packages_batch),
-                self.state.persist_checkpoint_objects(object_changes_batch),
                 self.state
                     .persist_object_history(object_history_changes_batch.clone()),
                 self.state
                     .persist_object_versions(object_versions_batch.clone()),
+                Box::pin(async {
+                    // We need to persist global order before writing objects, so that optimistic
+                    // indexing is blocked from overwriting objects table with old tx data
+                    // reference: https://github.com/iotaledger/iota/issues/10250
+                    self.state
+                        .persist_tx_global_order(tx_global_order_batch.clone())
+                        .await?;
+                    self.state
+                        .persist_checkpoint_objects(object_changes_batch)
+                        .await
+                }),
             ];
             if let Some(epoch_data) = epoch.clone() {
                 persist_tasks.push(self.state.persist_epoch(epoch_data));

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -382,6 +382,7 @@ impl PgIndexerStore {
                 coin_type = EXCLUDED.coin_type,
                 coin_balance = EXCLUDED.coin_balance,
                 df_kind = EXCLUDED.df_kind
+            WHERE EXCLUDED.object_version > objects.object_version
         "#;
         let (objects, tx_digests): (StoredObjects, Vec<_>) = objects
             .into_iter()
@@ -482,7 +483,7 @@ impl PgIndexerStore {
         conn: &mut PgConnection,
         mutated_object_mutation_chunk: Vec<StoredObject>,
     ) -> Result<(), IndexerError> {
-        on_conflict_do_update!(
+        on_conflict_do_update_with_condition!(
             objects::table,
             mutated_object_mutation_chunk,
             objects::object_id,
@@ -498,6 +499,7 @@ impl PgIndexerStore {
                 objects::coin_balance.eq(excluded(objects::coin_balance)),
                 objects::df_kind.eq(excluded(objects::df_kind)),
             ),
+            excluded(objects::object_version).gt(objects::object_version),
             conn
         );
         Ok::<(), IndexerError>(())

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -433,27 +433,32 @@ impl PgIndexerStore {
         let len = objects.len();
         let raw_query = r#"
             DELETE FROM objects
-            WHERE object_id IN (
-                SELECT u.object_id
+            USING (
+                SELECT u.object_id, u.object_version
                 FROM UNNEST(
                     $1::BYTEA[],
-                    $2::BYTEA[]
-                ) AS u(object_id, tx_digest)
+                    $2::BIGINT[],
+                    $3::BYTEA[]
+                ) AS u(object_id, object_version, tx_digest)
                 LEFT JOIN tx_global_order o ON o.tx_digest = u.tx_digest
                 WHERE o.optimistic_sequence_number IS NULL OR o.optimistic_sequence_number = 0
-            )
+            ) AS to_delete
+            WHERE objects.object_id = to_delete.object_id
+            AND objects.object_version < to_delete.object_version
         "#;
-        let (object_ids, tx_digests): (Vec<_>, Vec<_>) = objects
+        let (object_ids, versions, tx_digests): (Vec<_>, Vec<_>, Vec<_>) = objects
             .into_iter()
             .map(|removed_object| {
                 (
                     removed_object.object_id().to_vec(),
+                    removed_object.version() as i64,
                     removed_object.transaction_digest.into_inner().to_vec(),
                 )
             })
-            .unzip();
+            .multiunzip();
         let query = diesel::sql_query(raw_query)
             .bind::<Array<Bytea>, _>(object_ids)
+            .bind::<Array<BigInt>, _>(versions)
             .bind::<Array<Bytea>, _>(tx_digests);
         transactional_blocking_with_retry!(
             &self.blocking_cp,
@@ -503,20 +508,22 @@ impl PgIndexerStore {
         conn: &mut PgConnection,
         deleted_objects_chunk: Vec<StoredDeletedObject>,
     ) -> Result<(), IndexerError> {
-        diesel::delete(
-            objects::table.filter(
-                objects::object_id.eq_any(
-                    deleted_objects_chunk
-                        .iter()
-                        .map(|o| o.object_id.clone())
-                        .collect::<Vec<_>>(),
-                ),
-            ),
-        )
-        .execute(conn)
-        .map_err(IndexerError::from)
-        .context("Failed to write object deletion to PostgresDB")?;
-
+        let (object_ids, object_versions): (Vec<_>, Vec<_>) = deleted_objects_chunk
+            .iter()
+            .map(|o| (o.object_id.clone(), o.object_version))
+            .unzip();
+        let raw_query = r#"
+            DELETE FROM objects
+            USING UNNEST($1::BYTEA[], $2::BIGINT[]) AS to_delete(object_id, object_version)
+            WHERE objects.object_id = to_delete.object_id
+            AND objects.object_version < to_delete.object_version
+        "#;
+        diesel::sql_query(raw_query)
+            .bind::<Array<Bytea>, _>(object_ids)
+            .bind::<Array<BigInt>, _>(object_versions)
+            .execute(conn)
+            .map_err(IndexerError::from)
+            .context("Failed to write object deletion to PostgresDB")?;
         Ok::<(), IndexerError>(())
     }
 

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -810,7 +810,8 @@ pub async fn execute_move_call(
             Some(
                 IotaTransactionBlockResponseOptions::new()
                     .with_effects()
-                    .with_events(),
+                    .with_events()
+                    .with_object_changes(),
             ),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -18,7 +18,7 @@ use iota_json_rpc_api::{
     CoinReadApiClient, IndexerApiClient, ReadApiClient, TransactionBuilderClient, WriteApiClient,
 };
 use iota_json_rpc_types::{
-    IotaExecutionStatus, IotaMoveStruct, IotaMoveValue, IotaObjectDataOptions,
+    IotaData, IotaExecutionStatus, IotaMoveStruct, IotaMoveValue, IotaObjectDataOptions,
     IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
     IotaTransactionBlockResponseOptions, ObjectChange, TransactionBlockBytes,
 };
@@ -70,6 +70,16 @@ async fn prepare_and_sign_object_transfer_tx(
     let tx_data = tx_builder.transfer(object_to_transfer, receiver).build();
     let signed_transaction = to_sender_signed_transaction(tx_data, &sender_key_pair);
     signed_transaction.to_tx_bytes_and_signatures()
+}
+
+fn assert_transaction_success(res: &IotaTransactionBlockResponse) {
+    assert_eq!(
+        res.status_ok(),
+        Some(true),
+        "Transaction failed with status: {:?}, errors: {:?}",
+        res.effects.as_ref().map(|e| e.status()),
+        res.errors
+    );
 }
 
 #[test]
@@ -381,7 +391,7 @@ fn test_consecutive_modifications_of_owned_object() -> Result<(), anyhow::Error>
                     None,
                 )
                 .await?;
-            assert_eq!(res.status_ok(), Some(true));
+            assert_transaction_success(&res);
         }
 
         let objects = client
@@ -437,7 +447,7 @@ fn test_consecutive_wrap_unwrap() -> Result<(), anyhow::Error> {
                 wrap_basic_object(sender, &sender_kp, client, &package_id, &basic_obj)
                     .await
                     .unwrap();
-            assert_eq!(res.status_ok(), Some(true));
+            assert_transaction_success(&res);
 
             let objects = client
                 .get_owned_objects(sender, None, None, None)
@@ -458,7 +468,7 @@ fn test_consecutive_wrap_unwrap() -> Result<(), anyhow::Error> {
             let res = unwrap_basic_object(sender, &sender_kp, client, &package_id, &wrapped_obj_id)
                 .await
                 .unwrap();
-            assert_eq!(res.status_ok(), Some(true));
+            assert_transaction_success(&res);
 
             let objects = client
                 .get_owned_objects(sender, None, None, None)
@@ -551,88 +561,102 @@ fn test_parallel_shared_object_updates() {
             }
 
             let (res, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
-            assert_eq!(res.status_ok(), Some(true));
+            assert_transaction_success(&res);
 
             let (_, counter_obj) = create_counter_object(sender, &sender_kp, client, &package_id)
                 .await
                 .unwrap();
 
-            let transaction_results: Vec<_> = gas_objs
-                .iter()
-                .map(|gas| {
-                    increment_counter(
-                        sender,
-                        &sender_kp,
-                        client,
-                        &package_id,
-                        &counter_obj,
-                        Some(gas.0),
-                    )
-                })
-                .collect::<FuturesUnordered<_>>()
-                .try_collect()
-                .await
-                .unwrap();
-
-            // Now we need to check if transaction ordering in the DB follows the ordering
-            // of transactions imposed by TX dependencies
-            {
-                let transaction_dependencies = transaction_results
+            for _ in 0..NON_DETERMINISTIC_TESTS_REPETITIONS {
+                let transaction_results: Vec<_> = gas_objs
                     .iter()
-                    .map(|res| {
-                        (
-                            res.digest,
-                            HashSet::from_iter(res.effects.as_ref().unwrap().dependencies()),
+                    .map(|gas| {
+                        increment_counter(
+                            sender,
+                            &sender_kp,
+                            client,
+                            &package_id,
+                            &counter_obj,
+                            Some(gas.0),
                         )
                     })
-                    .collect::<HashMap<_, _>>();
+                    .collect::<FuturesUnordered<_>>()
+                    .try_collect()
+                    .await
+                    .unwrap();
+                for res in &transaction_results {
+                    assert_transaction_success(res);
+                }
 
-                let executed_transactions_digests =
-                    transaction_dependencies.keys().collect::<HashSet<_>>();
-                let executed_transactions_digests_to_load = executed_transactions_digests
-                    .iter()
-                    .map(|digest| digest.inner().to_vec())
-                    .collect::<HashSet<_>>();
+                // Now we need to check if transaction ordering in the DB follows the ordering
+                // of transactions imposed by TX dependencies
+                {
+                    let transaction_dependencies = transaction_results
+                        .iter()
+                        .map(|res| {
+                            (
+                                res.digest,
+                                HashSet::from_iter(res.effects.as_ref().unwrap().dependencies()),
+                            )
+                        })
+                        .collect::<HashMap<_, _>>();
 
-                let mut stored_global_orders = read_only_blocking!(&store.blocking_cp(), |conn| {
-                    tx_global_order::table
-                        .filter(
-                            tx_global_order::tx_digest
-                                .eq_any(executed_transactions_digests_to_load),
+                    let executed_transactions_digests =
+                        transaction_dependencies.keys().collect::<HashSet<_>>();
+                    let executed_transactions_digests_to_load = executed_transactions_digests
+                        .iter()
+                        .map(|digest| digest.inner().to_vec())
+                        .collect::<HashSet<_>>();
+
+                    let mut stored_global_orders = read_only_blocking!(&store.blocking_cp(), |conn| {
+                        tx_global_order::table
+                            .filter(
+                                tx_global_order::tx_digest
+                                    .eq_any(executed_transactions_digests_to_load),
+                            )
+                            .select(TxGlobalOrder::as_select())
+                            .load::<TxGlobalOrder>(conn)
+                    })
+                    .unwrap();
+                    stored_global_orders.sort_by(|a, b| {
+                        (
+                            a.global_sequence_number,
+                            a.optimistic_sequence_number.unwrap(),
                         )
-                        .select(TxGlobalOrder::as_select())
-                        .load::<TxGlobalOrder>(conn)
-                })
-                .unwrap();
-                stored_global_orders.sort_by(|a, b| {
-                    (
-                        a.global_sequence_number,
-                        a.optimistic_sequence_number.unwrap(),
-                    )
-                        .cmp(&(
-                            b.global_sequence_number,
-                            b.optimistic_sequence_number.unwrap(),
-                        ))
-                });
+                            .cmp(&(
+                                b.global_sequence_number,
+                                b.optimistic_sequence_number.unwrap(),
+                            ))
+                    });
 
-                let mut seen_digests: HashSet<TransactionDigest> = HashSet::new();
-                for stored_global_order in stored_global_orders.iter() {
-                    let tx_digest =
-                        TransactionDigest::try_from(&stored_global_order.tx_digest[..]).unwrap();
-                    let tx_deps = &transaction_dependencies[&tx_digest];
-                    let relevant_deps: HashSet<_> = tx_deps
-                        .intersection(&executed_transactions_digests)
-                        .cloned()
-                        .cloned()
-                        .collect();
-                    assert!(
-                        relevant_deps.is_subset(&seen_digests),
-                        "tx: {tx_digest:?} should have bigger order than it's deps: {relevant_deps:?}",
+                    let mut seen_digests: HashSet<TransactionDigest> = HashSet::new();
+                    for stored_global_order in stored_global_orders.iter() {
+                        let tx_digest =
+                            TransactionDigest::try_from(&stored_global_order.tx_digest[..]).unwrap();
+                        let tx_deps = &transaction_dependencies[&tx_digest];
+                        let relevant_deps: HashSet<_> = tx_deps
+                            .intersection(&executed_transactions_digests)
+                            .cloned()
+                            .cloned()
+                            .collect();
+                        assert!(
+                            relevant_deps.is_subset(&seen_digests),
+                            "tx: {tx_digest:?} should have bigger order than it's deps: {relevant_deps:?}",
 
-                    );
-                    seen_digests.insert(tx_digest);
+                        );
+                        seen_digests.insert(tx_digest);
+                    }
                 }
             }
+
+            // NON_DETERMINISTIC_TESTS_REPETITIONS iterations, each with NON_DETERMINISTIC_TESTS_REPETITIONS increments
+            let expected_count = (NON_DETERMINISTIC_TESTS_REPETITIONS * NON_DETERMINISTIC_TESTS_REPETITIONS) as u64;
+            let counter_value = get_counter_value(counter_obj, client).await;
+            assert_eq!(
+                counter_value, expected_count,
+                "Counter value should be {} but was {}",
+                expected_count, counter_value
+            );
 
             Ok::<(), IndexerError>(())
         })
@@ -664,7 +688,7 @@ fn test_repeated_tx_execution() {
             indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
 
             let (res, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
-            assert_eq!(res.status_ok(), Some(true));
+            assert_transaction_success(&res);
 
             let (_, counter_obj) = create_counter_object(sender, &sender_kp, client, &package_id)
                 .await
@@ -742,7 +766,7 @@ fn test_parallel_repeated_tx_execution() {
             indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
 
             let (res, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
-            assert_eq!(res.status_ok(), Some(true));
+            assert_transaction_success(&res);
 
             let (_, counter_obj) = create_counter_object(sender, &sender_kp, client, &package_id)
                 .await
@@ -855,7 +879,7 @@ fn test_repeatedly_update_display() {
             )
             .await
             .unwrap();
-            assert_eq!(res.status_ok(), Some(true));
+            assert_transaction_success(&res);
 
             let res = bump_display_object_version(
                 sender,
@@ -866,7 +890,7 @@ fn test_repeatedly_update_display() {
             )
             .await
             .unwrap();
-            assert_eq!(res.status_ok(), Some(true));
+            assert_transaction_success(&res);
 
             let res = client
                 .get_object(bear_id, Some(IotaObjectDataOptions::new().with_display()))
@@ -923,7 +947,7 @@ async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
         let res = increment_counter(sender, &sender_kp, client, &package_id, &counter_obj, None)
             .await
             .unwrap();
-        assert_eq!(res.status_ok(), Some(true));
+        assert_transaction_success(&res);
     }
     indexer_wait_for_optimistic_transactions_count(store, txs_epoch_1).await;
     force_new_epoch_and_wait(store, cluster).await;
@@ -932,7 +956,7 @@ async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
         let res = increment_counter(sender, &sender_kp, client, &package_id, &counter_obj, None)
             .await
             .unwrap();
-        assert_eq!(res.status_ok(), Some(true));
+        assert_transaction_success(&res);
     }
     indexer_wait_for_optimistic_transactions_count(store, txs_epoch_2).await;
     force_new_epoch_and_wait(store, cluster).await;
@@ -941,7 +965,7 @@ async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
         let res = increment_counter(sender, &sender_kp, client, &package_id, &counter_obj, None)
             .await
             .unwrap();
-        assert_eq!(res.status_ok(), Some(true));
+        assert_transaction_success(&res);
     }
     indexer_wait_for_optimistic_transactions_count(store, txs_epoch_3).await;
     force_new_epoch_and_wait(store, cluster).await;
@@ -1411,4 +1435,34 @@ fn clever_errors() {
         };
         assert_eq!(error, &expected_error);
     });
+}
+
+async fn get_counter_value(counter_obj_id: ObjectID, client: &HttpClient) -> u64 {
+    let counter_content = client
+        .get_object(
+            counter_obj_id,
+            Some(IotaObjectDataOptions::new().with_content()),
+        )
+        .await
+        .unwrap()
+        .data
+        .unwrap()
+        .content
+        .unwrap();
+
+    let value_field = &counter_content
+        .try_as_move()
+        .unwrap()
+        .fields
+        .read_dynamic_field_value("value")
+        .unwrap();
+
+    if let IotaMoveValue::String(counter_value_str) = &value_field {
+        counter_value_str.parse().unwrap()
+    } else {
+        panic!(
+            "Counter value field is not a string (expected u64 serialized as string), got: {:?}",
+            value_field
+        );
+    }
 }


### PR DESCRIPTION
# Description of change

Guard objects deletion with version check, persist objects only after tx global order on Checkpoint path

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/10250

reason for object version check: https://github.com/iotaledger/iota/issues/10250#issuecomment-3907617618
reason for tx_global_order->objects insertion ordering: https://github.com/iotaledger/iota/issues/10250#issuecomment-3921366687

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
