### PR TITLE
feat(types): create AuthContextCommand and AuthContextCallArg

### DIFF
--- a/crates/iota-framework/packages/iota-framework/sources/auth_context.move
+++ b/crates/iota-framework/packages/iota-framework/sources/auth_context.move
@@ -25,25 +25,25 @@ public struct AuthContext has drop {}
 
 // === Public functions ===
 
-public fun digest(_: &AuthContext): vector<u8> {
+public fun digest(_ctx: &AuthContext): &vector<u8> {
     native_digest()
 }
 
-public fun tx_commands(_: &AuthContext): vector<Command> {
-    native_tx_commands()
+public fun tx_inputs(_ctx: &AuthContext): &vector<CallArg> {
+    native_tx_inputs()
 }
 
-public fun tx_inputs(_: &AuthContext): vector<CallArg> {
-    native_tx_inputs()
+public fun tx_commands(_ctx: &AuthContext): &vector<Command> {
+    native_tx_commands()
 }
 
 // === Native functions ===
 
-native fun native_digest(): vector<u8>;
+native fun native_digest(): &vector<u8>;
 
-native fun native_tx_commands<C>(): vector<C>;
+native fun native_tx_inputs<I>(): &vector<I>;
 
-native fun native_tx_inputs<I>(): vector<I>;
+native fun native_tx_commands<C>(): &vector<C>;
 
 // === Test-only functions ===
 

--- a/crates/iota-framework/packages/iota-framework/tests/auth_context_tests.move
+++ b/crates/iota-framework/packages/iota-framework/tests/auth_context_tests.move
@@ -488,8 +488,9 @@ fun test_programmable_transaction() {
 
     // Also verify round-trip through auth context
     let ctx = new_with_tx_inputs(DIGEST, inputs, commands);
+    let digest = DIGEST;
 
-    assert!(ctx.digest() == DIGEST);
+    assert!(ctx.digest() == &digest);
     assert!(ctx.tx_inputs() == inputs);
     assert!(ctx.tx_inputs().length() == 4);
     assert!(ctx.tx_commands() == commands);
@@ -597,8 +598,9 @@ fun test_all_argument_variants_in_move_call() {
 #[test]
 fun test_empty_inputs_and_commands() {
     let ctx = new_with_tx_inputs(DIGEST, vector[], vector[]);
+    let digest = DIGEST;
 
-    assert!(ctx.digest() == DIGEST);
+    assert!(ctx.digest() == &digest);
     assert!(ctx.tx_inputs().length() == 0);
     assert!(ctx.tx_commands().length() == 0);
 }

--- a/crates/iota-framework/packages/iota-framework/tests/auth_context_tests.move
+++ b/crates/iota-framework/packages/iota-framework/tests/auth_context_tests.move
@@ -5,56 +5,625 @@
 module iota::auth_context_tests;
 
 use iota::auth_context::{new_with_tx_inputs, digest};
+use iota::ptb::new_programmable_transaction_for_testing;
 use iota::ptb_call_arg::{
     new_call_arg_pure_for_testing,
+    new_call_arg_object_for_testing,
+    new_object_arg_imm_or_owned_for_testing,
     new_object_arg_shared_for_testing,
-    new_call_arg_object_for_testing
+    new_object_arg_receiving_for_testing,
+    new_object_ref_for_testing
 };
 use iota::ptb_command::{
+    new_gas_coin_argument_for_testing,
     new_input_argument_for_testing,
+    new_result_argument_for_testing,
+    new_nested_result_argument_for_testing,
     new_programmable_move_call_for_testing,
-    new_move_call_command_for_testing
+    new_move_call_command_for_testing,
+    new_transfer_objects_for_testing,
+    new_transfer_objects_command_for_testing,
+    new_split_coins_for_testing,
+    new_split_coins_command_for_testing,
+    new_merge_coins_for_testing,
+    new_merge_coins_command_for_testing,
+    new_publish_for_testing,
+    new_publish_command_for_testing,
+    new_make_move_vec_for_testing,
+    new_make_move_vec_command_for_testing,
+    new_upgrade_for_testing,
+    new_upgrade_command_for_testing
 };
 use std::type_name;
 
+const DIGEST: vector<u8> = b"00000000000000000000000000000001";
+const OBJECT_DIGEST: vector<u8> = b"00000000000000000000000000000002";
+
+// ---------------------------------------------------------------------------
+// CallArg variants
+// ---------------------------------------------------------------------------
+
 #[test]
-fun create_auth_context() {
-    let package_id = object::id_from_bytes(iota::hash::blake2b256(&b"0x123"));
-    let mut arguments = vector[];
-    let input_arg = new_input_argument_for_testing(0);
+fun test_call_arg_pure_data() {
+    let pure_arg = new_call_arg_pure_for_testing(b"hello");
+    let cmd = make_noop_move_call_command();
 
-    let mut type_names = vector[];
-    let tn = type_name::get<u16>();
-    type_names.push_back(tn);
-    arguments.push_back(input_arg);
+    let ctx = new_with_tx_inputs(DIGEST, vector[pure_arg], vector[cmd]);
 
-    let programmable_move_call = new_programmable_move_call_for_testing(
-        package_id,
-        b"aabb".to_ascii_string(), // module name
-        b"ccdd".to_ascii_string(), // function name
-        type_names,
-        arguments,
+    let inputs = ctx.tx_inputs();
+    assert!(inputs.length() == 1);
+    assert!(inputs[0].is_pure_data());
+    assert!(inputs[0].as_pure_data() == option::some(b"hello"));
+}
+
+#[test]
+fun test_call_arg_object_data() {
+    let obj_ref = new_object_ref_for_testing(
+        object::id_from_address(@0xA),
+        42,
+        OBJECT_DIGEST,
     );
+    let obj_arg = new_object_arg_imm_or_owned_for_testing(obj_ref);
+    let call_arg = new_call_arg_object_for_testing(obj_arg);
+    let cmd = make_noop_move_call_command();
 
-    let call = new_move_call_command_for_testing(programmable_move_call);
+    let ctx = new_with_tx_inputs(DIGEST, vector[call_arg], vector[cmd]);
 
-    let pure_call_arg = new_call_arg_pure_for_testing(b"pure");
-    let shared_obj_arg = new_object_arg_shared_for_testing(
-        object::id_from_address(@0x123),
-        1,
+    let inputs = ctx.tx_inputs();
+    assert!(inputs.length() == 1);
+    assert!(inputs[0].is_object_data());
+}
+
+// ---------------------------------------------------------------------------
+// ObjectArg variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fun test_object_arg_imm_or_owned() {
+    let obj_ref = new_object_ref_for_testing(
+        object::id_from_address(@0xB),
+        10,
+        OBJECT_DIGEST,
+    );
+    let obj_arg = new_object_arg_imm_or_owned_for_testing(obj_ref);
+    let call_arg = new_call_arg_object_for_testing(obj_arg);
+    let cmd = make_noop_move_call_command();
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[call_arg], vector[cmd]);
+
+    let inputs = ctx.tx_inputs();
+    let extracted_obj = inputs[0].as_object_data().destroy_some();
+    assert!(extracted_obj.is_imm_or_owned_object());
+    assert!(!extracted_obj.is_shared_object());
+    assert!(!extracted_obj.is_receiving_object());
+    assert!(extracted_obj.object_id().destroy_some().to_address() == @0xB);
+    assert!(extracted_obj.object_version().destroy_some() == 10);
+    assert!(extracted_obj.object_digest().destroy_some() == OBJECT_DIGEST);
+}
+
+#[test]
+fun test_object_arg_shared() {
+    let shared_arg = new_object_arg_shared_for_testing(
+        object::id_from_address(@0xC),
+        5,
         true,
     );
-    let shared_obj_call_arg = new_call_arg_object_for_testing(shared_obj_arg);
+    let call_arg = new_call_arg_object_for_testing(shared_arg);
+    let cmd = make_noop_move_call_command();
 
-    let digest = b"00000000000000000000000000000001";
+    let ctx = new_with_tx_inputs(DIGEST, vector[call_arg], vector[cmd]);
 
-    let ctx = new_with_tx_inputs(
-        digest,
-        vector[pure_call_arg, shared_obj_call_arg],
-        vector[call],
+    let inputs = ctx.tx_inputs();
+    let extracted_obj = inputs[0].as_object_data().destroy_some();
+    assert!(extracted_obj.is_shared_object());
+    assert!(!extracted_obj.is_imm_or_owned_object());
+    assert!(!extracted_obj.is_receiving_object());
+    assert!(extracted_obj.object_id().destroy_some().to_address() == @0xC);
+    assert!(extracted_obj.object_version().destroy_some() == 5);
+    assert!(extracted_obj.is_mutable_shared_object().destroy_some() == true);
+}
+
+#[test]
+fun test_object_arg_shared_immutable() {
+    let shared_arg = new_object_arg_shared_for_testing(
+        object::id_from_address(@0xD),
+        7,
+        false,
+    );
+    let call_arg = new_call_arg_object_for_testing(shared_arg);
+    let cmd = make_noop_move_call_command();
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[call_arg], vector[cmd]);
+
+    let inputs = ctx.tx_inputs();
+    let extracted_obj = inputs[0].as_object_data().destroy_some();
+    assert!(extracted_obj.is_shared_object());
+    assert!(extracted_obj.is_mutable_shared_object().destroy_some() == false);
+}
+
+#[test]
+fun test_object_arg_receiving() {
+    let obj_ref = new_object_ref_for_testing(
+        object::id_from_address(@0xE),
+        99,
+        OBJECT_DIGEST,
+    );
+    let recv_arg = new_object_arg_receiving_for_testing(obj_ref);
+    let call_arg = new_call_arg_object_for_testing(recv_arg);
+    let cmd = make_noop_move_call_command();
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[call_arg], vector[cmd]);
+
+    let inputs = ctx.tx_inputs();
+    let extracted_obj = inputs[0].as_object_data().destroy_some();
+    assert!(extracted_obj.is_receiving_object());
+    assert!(!extracted_obj.is_imm_or_owned_object());
+    assert!(!extracted_obj.is_shared_object());
+    assert!(extracted_obj.object_id().destroy_some().to_address() == @0xE);
+    assert!(extracted_obj.object_version().destroy_some() == 99);
+}
+
+// ---------------------------------------------------------------------------
+// Argument variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fun test_argument_gas_coin() {
+    let gas = new_gas_coin_argument_for_testing();
+    let move_call = new_programmable_move_call_for_testing(
+        object::id_from_bytes(iota::hash::blake2b256(&b"pkg")),
+        b"mod".to_ascii_string(),
+        b"fun".to_ascii_string(),
+        vector[],
+        vector[gas],
+    );
+    let cmd = new_move_call_command_for_testing(move_call);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    let call = commands[0].as_move_call().destroy_some();
+    let args = call.arguments();
+    assert!(args.length() == 1);
+    assert!(args[0].is_gas_coin());
+}
+
+#[test]
+fun test_argument_input() {
+    let input_arg = new_input_argument_for_testing(3);
+    let move_call = new_programmable_move_call_for_testing(
+        object::id_from_bytes(iota::hash::blake2b256(&b"pkg")),
+        b"mod".to_ascii_string(),
+        b"fun".to_ascii_string(),
+        vector[],
+        vector[input_arg],
+    );
+    let cmd = new_move_call_command_for_testing(move_call);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    let call = commands[0].as_move_call().destroy_some();
+    let args = call.arguments();
+    assert!(args[0].is_input());
+    assert!(args[0].input_index().destroy_some() == 3);
+}
+
+#[test]
+fun test_argument_result() {
+    let result_arg = new_result_argument_for_testing(1);
+    let move_call = new_programmable_move_call_for_testing(
+        object::id_from_bytes(iota::hash::blake2b256(&b"pkg")),
+        b"mod".to_ascii_string(),
+        b"fun".to_ascii_string(),
+        vector[],
+        vector[result_arg],
+    );
+    let cmd = new_move_call_command_for_testing(move_call);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    let call = commands[0].as_move_call().destroy_some();
+    let args = call.arguments();
+    assert!(args[0].is_result());
+    assert!(args[0].result_command_index().destroy_some() == 1);
+}
+
+#[test]
+fun test_argument_nested_result() {
+    let nested_arg = new_nested_result_argument_for_testing(2, 5);
+    let move_call = new_programmable_move_call_for_testing(
+        object::id_from_bytes(iota::hash::blake2b256(&b"pkg")),
+        b"mod".to_ascii_string(),
+        b"fun".to_ascii_string(),
+        vector[],
+        vector[nested_arg],
+    );
+    let cmd = new_move_call_command_for_testing(move_call);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    let call = commands[0].as_move_call().destroy_some();
+    let args = call.arguments();
+    assert!(args[0].is_nested_result());
+    assert!(args[0].nested_result_command_index().destroy_some() == 2);
+    assert!(args[0].nested_result_inner_index().destroy_some() == 5);
+}
+
+// ---------------------------------------------------------------------------
+// Command variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fun test_command_move_call() {
+    let package_id = object::id_from_bytes(iota::hash::blake2b256(&b"0x123"));
+    let tn = type_name::get<u16>();
+    let input_arg = new_input_argument_for_testing(0);
+
+    let move_call = new_programmable_move_call_for_testing(
+        package_id,
+        b"my_module".to_ascii_string(),
+        b"my_function".to_ascii_string(),
+        vector[tn],
+        vector[input_arg],
+    );
+    let cmd = new_move_call_command_for_testing(move_call);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    assert!(commands.length() == 1);
+    assert!(commands[0].is_move_call());
+    let call = commands[0].as_move_call().destroy_some();
+    assert!(*call.module_name() == b"my_module".to_ascii_string());
+    assert!(*call.function() == b"my_function".to_ascii_string());
+    assert!(call.type_arguments().length() == 1);
+    assert!(call.arguments().length() == 1);
+}
+
+#[test]
+fun test_command_transfer_objects() {
+    let objects = vector[new_input_argument_for_testing(0), new_result_argument_for_testing(1)];
+    let recipient = new_input_argument_for_testing(2);
+    let data = new_transfer_objects_for_testing(objects, recipient);
+    let cmd = new_transfer_objects_command_for_testing(data);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    assert!(commands[0].is_transfer_objects());
+    let extracted = commands[0].as_transfer_objects().destroy_some();
+    assert!(extracted.objects().length() == 2);
+    assert!(extracted.recipient().is_input());
+    assert!(extracted.recipient().input_index().destroy_some() == 2);
+}
+
+#[test]
+fun test_command_split_coins() {
+    let coin = new_gas_coin_argument_for_testing();
+    let amounts = vector[new_input_argument_for_testing(0), new_input_argument_for_testing(1)];
+    let data = new_split_coins_for_testing(coin, amounts);
+    let cmd = new_split_coins_command_for_testing(data);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    assert!(commands[0].is_split_coins());
+    let extracted = commands[0].as_split_coins().destroy_some();
+    assert!(extracted.coin().is_gas_coin());
+    assert!(extracted.amounts().length() == 2);
+}
+
+#[test]
+fun test_command_merge_coins() {
+    let target = new_gas_coin_argument_for_testing();
+    let sources = vector[new_result_argument_for_testing(0), new_result_argument_for_testing(1)];
+    let data = new_merge_coins_for_testing(target, sources);
+    let cmd = new_merge_coins_command_for_testing(data);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    assert!(commands[0].is_merge_coins());
+    let extracted = commands[0].as_merge_coins().destroy_some();
+    assert!(extracted.target_coin().is_gas_coin());
+    assert!(extracted.source_coins().length() == 2);
+}
+
+#[test]
+fun test_command_publish() {
+    let modules = vector[b"module_bytes_1", b"module_bytes_2"];
+    let dep_id = object::id_from_address(@0xF1);
+    let data = new_publish_for_testing(modules, vector[dep_id]);
+    let cmd = new_publish_command_for_testing(data);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    assert!(commands[0].is_publish());
+    let extracted = commands[0].as_publish().destroy_some();
+    assert!(extracted.modules().length() == 2);
+    assert!(extracted.dependencies().length() == 1);
+}
+
+#[test]
+fun test_command_make_move_vec() {
+    let tn = type_name::get<u64>();
+    let elements = vector[new_input_argument_for_testing(0), new_input_argument_for_testing(1)];
+    let data = new_make_move_vec_for_testing(option::some(tn), elements);
+    let cmd = new_make_move_vec_command_for_testing(data);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    assert!(commands[0].is_make_move_vec());
+    let extracted = commands[0].as_make_move_vec().destroy_some();
+    assert!(extracted.type_arg().is_some());
+    assert!(extracted.elements().length() == 2);
+}
+
+#[test]
+fun test_command_make_move_vec_no_type() {
+    let elements = vector[new_input_argument_for_testing(0)];
+    let data = new_make_move_vec_for_testing(option::none(), elements);
+    let cmd = new_make_move_vec_command_for_testing(data);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    assert!(commands[0].is_make_move_vec());
+    let extracted = commands[0].as_make_move_vec().destroy_some();
+    assert!(extracted.type_arg().is_none());
+}
+
+#[test]
+fun test_command_upgrade() {
+    let modules = vector[b"upgraded_module_bytes"];
+    let dep_id = object::id_from_address(@0xF2);
+    let package_id = object::id_from_address(@0xF3);
+    let ticket = new_input_argument_for_testing(0);
+    let data = new_upgrade_for_testing(modules, vector[dep_id], package_id, ticket);
+    let cmd = new_upgrade_command_for_testing(data);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let commands = ctx.tx_commands();
+    assert!(commands[0].is_upgrade());
+    let extracted = commands[0].as_upgrade().destroy_some();
+    assert!(extracted.upgrade_modules().length() == 1);
+    assert!(extracted.upgrade_dependencies().length() == 1);
+    assert!(extracted.upgrade_package().to_address() == @0xF3);
+    assert!(extracted.upgrade_ticket().is_input());
+}
+
+// ---------------------------------------------------------------------------
+// ProgrammableTransaction
+// ---------------------------------------------------------------------------
+
+#[test]
+fun test_programmable_transaction() {
+    let pure_arg = new_call_arg_pure_for_testing(b"data");
+    let obj_ref = new_object_ref_for_testing(
+        object::id_from_address(@0x1),
+        1,
+        OBJECT_DIGEST,
+    );
+    let imm_arg = new_call_arg_object_for_testing(new_object_arg_imm_or_owned_for_testing(obj_ref));
+    let shared_arg = new_call_arg_object_for_testing(
+        new_object_arg_shared_for_testing(object::id_from_address(@0x2), 3, true),
+    );
+    let recv_ref = new_object_ref_for_testing(
+        object::id_from_address(@0x3),
+        4,
+        OBJECT_DIGEST,
+    );
+    let recv_arg = new_call_arg_object_for_testing(
+        new_object_arg_receiving_for_testing(recv_ref),
     );
 
-    assert!(ctx.digest() == digest);
-    assert!(ctx.tx_inputs() == vector[pure_call_arg, shared_obj_call_arg]);
-    assert!(ctx.tx_commands() == vector[call]);
+    let inputs = vector[pure_arg, imm_arg, shared_arg, recv_arg];
+
+    // Build a variety of commands
+    let move_call_cmd = new_move_call_command_for_testing(
+        new_programmable_move_call_for_testing(
+            object::id_from_bytes(iota::hash::blake2b256(&b"pkg")),
+            b"mod".to_ascii_string(),
+            b"fn".to_ascii_string(),
+            vector[],
+            vector[new_input_argument_for_testing(0)],
+        ),
+    );
+    let transfer_cmd = new_transfer_objects_command_for_testing(
+        new_transfer_objects_for_testing(
+            vector[new_result_argument_for_testing(0)],
+            new_input_argument_for_testing(1),
+        ),
+    );
+    let split_cmd = new_split_coins_command_for_testing(
+        new_split_coins_for_testing(
+            new_gas_coin_argument_for_testing(),
+            vector[new_input_argument_for_testing(0)],
+        ),
+    );
+    let merge_cmd = new_merge_coins_command_for_testing(
+        new_merge_coins_for_testing(
+            new_gas_coin_argument_for_testing(),
+            vector[new_result_argument_for_testing(2)],
+        ),
+    );
+    let publish_cmd = new_publish_command_for_testing(
+        new_publish_for_testing(vector[b"mod_bytes"], vector[]),
+    );
+    let make_vec_cmd = new_make_move_vec_command_for_testing(
+        new_make_move_vec_for_testing(
+            option::some(type_name::get<u8>()),
+            vector[new_input_argument_for_testing(0)],
+        ),
+    );
+    let upgrade_cmd = new_upgrade_command_for_testing(
+        new_upgrade_for_testing(
+            vector[b"upgraded"],
+            vector[],
+            object::id_from_address(@0xAA),
+            new_input_argument_for_testing(0),
+        ),
+    );
+
+    let commands = vector[
+        move_call_cmd,
+        transfer_cmd,
+        split_cmd,
+        merge_cmd,
+        publish_cmd,
+        make_vec_cmd,
+        upgrade_cmd,
+    ];
+
+    // Test via ProgrammableTransaction struct
+    let ptb = new_programmable_transaction_for_testing(inputs, commands);
+    assert!(ptb.inputs().length() == 4);
+    assert!(ptb.commands().length() == 7);
+
+    // Also verify round-trip through auth context
+    let ctx = new_with_tx_inputs(DIGEST, inputs, commands);
+
+    assert!(ctx.digest() == DIGEST);
+    assert!(ctx.tx_inputs() == inputs);
+    assert!(ctx.tx_inputs().length() == 4);
+    assert!(ctx.tx_commands() == commands);
+    assert!(ctx.tx_commands().length() == 7);
+
+    // Verify individual command variants survived the round-trip
+    let rt_commands = ctx.tx_commands();
+    assert!(rt_commands[0].is_move_call());
+    assert!(rt_commands[1].is_transfer_objects());
+    assert!(rt_commands[2].is_split_coins());
+    assert!(rt_commands[3].is_merge_coins());
+    assert!(rt_commands[4].is_publish());
+    assert!(rt_commands[5].is_make_move_vec());
+    assert!(rt_commands[6].is_upgrade());
+
+    // Verify individual input variants survived the round-trip
+    let rt_inputs = ctx.tx_inputs();
+    assert!(rt_inputs[0].is_pure_data());
+    assert!(rt_inputs[1].is_object_data());
+    assert!(rt_inputs[1].as_object_data().destroy_some().is_imm_or_owned_object());
+    assert!(rt_inputs[2].is_object_data());
+    assert!(rt_inputs[2].as_object_data().destroy_some().is_shared_object());
+    assert!(rt_inputs[3].is_object_data());
+    assert!(rt_inputs[3].as_object_data().destroy_some().is_receiving_object());
+}
+
+// ---------------------------------------------------------------------------
+// All inputs combined
+// ---------------------------------------------------------------------------
+
+#[test]
+fun test_all_call_arg_and_object_arg_variants() {
+    let pure = new_call_arg_pure_for_testing(b"bytes");
+
+    let imm_ref = new_object_ref_for_testing(
+        object::id_from_address(@0x10),
+        1,
+        OBJECT_DIGEST,
+    );
+    let imm = new_call_arg_object_for_testing(new_object_arg_imm_or_owned_for_testing(imm_ref));
+
+    let shared = new_call_arg_object_for_testing(
+        new_object_arg_shared_for_testing(object::id_from_address(@0x20), 2, false),
+    );
+
+    let recv_ref = new_object_ref_for_testing(
+        object::id_from_address(@0x30),
+        3,
+        OBJECT_DIGEST,
+    );
+    let recv = new_call_arg_object_for_testing(new_object_arg_receiving_for_testing(recv_ref));
+
+    let all_inputs = vector[pure, imm, shared, recv];
+    let cmd = make_noop_move_call_command();
+
+    let ctx = new_with_tx_inputs(DIGEST, all_inputs, vector[cmd]);
+
+    let rt = ctx.tx_inputs();
+    assert!(rt.length() == 4);
+    assert!(rt[0].is_pure_data());
+    assert!(rt[1].as_object_data().destroy_some().is_imm_or_owned_object());
+    assert!(rt[2].as_object_data().destroy_some().is_shared_object());
+    assert!(rt[3].as_object_data().destroy_some().is_receiving_object());
+}
+
+// ---------------------------------------------------------------------------
+// All argument variants in a single command
+// ---------------------------------------------------------------------------
+
+#[test]
+fun test_all_argument_variants_in_move_call() {
+    let gas = new_gas_coin_argument_for_testing();
+    let input = new_input_argument_for_testing(0);
+    let result = new_result_argument_for_testing(1);
+    let nested = new_nested_result_argument_for_testing(2, 3);
+
+    let move_call = new_programmable_move_call_for_testing(
+        object::id_from_bytes(iota::hash::blake2b256(&b"pkg")),
+        b"m".to_ascii_string(),
+        b"f".to_ascii_string(),
+        vector[],
+        vector[gas, input, result, nested],
+    );
+    let cmd = new_move_call_command_for_testing(move_call);
+
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[cmd]);
+
+    let call = ctx.tx_commands()[0].as_move_call().destroy_some();
+    let args = call.arguments();
+    assert!(args.length() == 4);
+    assert!(args[0].is_gas_coin());
+    assert!(args[1].is_input());
+    assert!(args[1].input_index().destroy_some() == 0);
+    assert!(args[2].is_result());
+    assert!(args[2].result_command_index().destroy_some() == 1);
+    assert!(args[3].is_nested_result());
+    assert!(args[3].nested_result_command_index().destroy_some() == 2);
+    assert!(args[3].nested_result_inner_index().destroy_some() == 3);
+}
+
+// ---------------------------------------------------------------------------
+// Edge case: empty inputs and commands
+// ---------------------------------------------------------------------------
+
+#[test]
+fun test_empty_inputs_and_commands() {
+    let ctx = new_with_tx_inputs(DIGEST, vector[], vector[]);
+
+    assert!(ctx.digest() == DIGEST);
+    assert!(ctx.tx_inputs().length() == 0);
+    assert!(ctx.tx_commands().length() == 0);
+}
+
+// ---------------------------------------------------------------------------
+// Error case: bad digest length
+// ---------------------------------------------------------------------------
+
+#[test]
+#[expected_failure(abort_code = iota::auth_context::EBadAuthDigestLength)]
+fun test_bad_digest_length() {
+    let _ctx = new_with_tx_inputs(b"too_short", vector[], vector[]);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fun make_noop_move_call_command(): iota::ptb_command::Command {
+    let move_call = new_programmable_move_call_for_testing(
+        object::id_from_bytes(iota::hash::blake2b256(&b"noop")),
+        b"noop".to_ascii_string(),
+        b"noop".to_ascii_string(),
+        vector[],
+        vector[],
+    );
+    new_move_call_command_for_testing(move_call)
 }

--- a/crates/iota-types/src/auth_context.rs
+++ b/crates/iota-types/src/auth_context.rs
@@ -4,20 +4,142 @@
 use move_binary_format::{CompiledModule, file_format::SignatureToken};
 use move_bytecode_utils::resolve_struct;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
-use serde::{
-    Serialize, Serializer,
-    ser::{SerializeStruct, SerializeStructVariant, SerializeTupleVariant},
-};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     IOTA_FRAMEWORK_ADDRESS,
+    base_types::ObjectID,
     digests::MoveAuthenticatorDigest,
-    transaction::{CallArg, Command, ProgrammableTransaction},
+    transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableTransaction},
     type_input::TypeName,
 };
 
 pub const AUTH_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("auth_context");
 pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
+
+/// Mirrors [`crate::transaction::ProgrammableMoveCall`] for use in
+/// [`AuthContextCommandV1`], substituting [`TypeName`] for
+/// [`crate::type_input::TypeInput`] so that the type can derive
+/// [`Serialize`]/[`Deserialize`] without a custom implementation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthContextMoveCall {
+    pub package: ObjectID,
+    pub module: String,
+    pub function: String,
+    pub type_arguments: Vec<TypeName>,
+    pub arguments: Vec<Argument>,
+}
+
+/// V1 command layout for [`AuthContextCommand`].
+///
+/// Mirrors [`crate::transaction::Command`], substituting [`TypeName`] for
+/// [`crate::type_input::TypeInput`] in `MoveCall` and `MakeMoveVec` so that
+/// the type matches the BCS layout expected by the Move-side
+/// `ptb_command::Command`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AuthContextCommandV1 {
+    MoveCall(Box<AuthContextMoveCall>),
+    TransferObjects(Vec<Argument>, Argument),
+    SplitCoins(Argument, Vec<Argument>),
+    MergeCoins(Argument, Vec<Argument>),
+    Publish(Vec<Vec<u8>>, Vec<ObjectID>),
+    MakeMoveVec(Option<TypeName>, Vec<Argument>),
+    Upgrade(Vec<Vec<u8>>, Vec<ObjectID>, ObjectID, Argument),
+}
+
+impl From<&Command> for AuthContextCommandV1 {
+    fn from(cmd: &Command) -> Self {
+        match cmd {
+            Command::MoveCall(m) => {
+                AuthContextCommandV1::MoveCall(Box::new(AuthContextMoveCall {
+                    package: m.package,
+                    module: m.module.clone(),
+                    function: m.function.clone(),
+                    type_arguments: m.type_arguments.iter().map(TypeName::from).collect(),
+                    arguments: m.arguments.clone(),
+                }))
+            }
+            Command::TransferObjects(objects, recipient) => {
+                AuthContextCommandV1::TransferObjects(objects.clone(), *recipient)
+            }
+            Command::SplitCoins(coin, amounts) => {
+                AuthContextCommandV1::SplitCoins(*coin, amounts.clone())
+            }
+            Command::MergeCoins(target_coin, source_coins) => {
+                AuthContextCommandV1::MergeCoins(*target_coin, source_coins.clone())
+            }
+            Command::Publish(modules, dependencies) => {
+                AuthContextCommandV1::Publish(modules.clone(), dependencies.clone())
+            }
+            Command::MakeMoveVec(type_arg, elements) => AuthContextCommandV1::MakeMoveVec(
+                type_arg.as_ref().map(TypeName::from),
+                elements.clone(),
+            ),
+            Command::Upgrade(modules, dependencies, package, upgrade_ticket) => {
+                AuthContextCommandV1::Upgrade(
+                    modules.clone(),
+                    dependencies.clone(),
+                    *package,
+                    *upgrade_ticket,
+                )
+            }
+        }
+    }
+}
+
+/// Versioned command type stored in [`AuthContext`].
+///
+/// Each variant corresponds to a version of the Move-side
+/// `ptb_command::Command` BCS layout. When passing commands to Move native
+/// functions, the inner versioned value (e.g. [`AuthContextCommandV1`]) must
+/// be serialized directly, without the outer variant tag.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AuthContextCommand {
+    V1(AuthContextCommandV1),
+}
+
+impl From<&Command> for AuthContextCommand {
+    fn from(cmd: &Command) -> Self {
+        AuthContextCommand::V1(AuthContextCommandV1::from(cmd))
+    }
+}
+
+/// V1 call-argument layout for [`AuthContextCallArg`].
+///
+/// Mirrors [`crate::transaction::CallArg`], matching the BCS layout expected
+/// by the Move-side `ptb_call_arg::CallArg`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AuthContextCallArgV1 {
+    Pure(Vec<u8>),
+    Object(ObjectArg),
+}
+
+impl From<&CallArg> for AuthContextCallArgV1 {
+    fn from(arg: &CallArg) -> Self {
+        match arg {
+            CallArg::Pure(bytes) => AuthContextCallArgV1::Pure(bytes.clone()),
+            CallArg::Object(obj_arg) => AuthContextCallArgV1::Object(*obj_arg),
+        }
+    }
+}
+
+/// Versioned call-argument type stored in [`AuthContext`].
+///
+/// Each variant corresponds to a version of the Move-side
+/// `ptb_call_arg::CallArg` BCS layout. When passing inputs to Move native
+/// functions, the inner versioned value (e.g. [`AuthContextCallArgV1`]) must
+/// be serialized directly, without the outer variant tag.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AuthContextCallArg {
+    V1(AuthContextCallArgV1),
+}
+
+impl From<&CallArg> for AuthContextCallArg {
+    fn from(arg: &CallArg) -> Self {
+        AuthContextCallArg::V1(AuthContextCallArgV1::from(arg))
+    }
+}
+
 
 /// `AuthContext` provides a lightweight execution context used during the
 /// authentication phase of a transaction.
@@ -44,14 +166,14 @@ pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
 /// ```
 // Conceptually similar to `TxContext`, but designed specifically for use in the authentication
 // flow.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct AuthContext {
     /// The digest of the MoveAuthenticator
     auth_digest: MoveAuthenticatorDigest,
     /// The authentication input objects or primitive values
-    tx_inputs: Vec<CallArg>,
+    tx_inputs: Vec<AuthContextCallArg>,
     /// The authentication commands to be executed sequentially.
-    tx_commands: Vec<Command>,
+    tx_commands: Vec<AuthContextCommand>,
 }
 
 impl AuthContext {
@@ -61,8 +183,8 @@ impl AuthContext {
     ) -> Self {
         Self {
             auth_digest,
-            tx_inputs: ptb.inputs.clone(),
-            tx_commands: ptb.commands.clone(),
+            tx_inputs: ptb.inputs.iter().map(AuthContextCallArg::from).collect(),
+            tx_commands: ptb.commands.iter().map(AuthContextCommand::from).collect(),
         }
     }
 
@@ -78,11 +200,11 @@ impl AuthContext {
         &self.auth_digest
     }
 
-    pub fn tx_inputs(&self) -> &Vec<CallArg> {
+    pub fn tx_inputs(&self) -> &Vec<AuthContextCallArg> {
         &self.tx_inputs
     }
 
-    pub fn tx_commands(&self) -> &Vec<Command> {
+    pub fn tx_commands(&self) -> &Vec<AuthContextCommand> {
         &self.tx_commands
     }
 
@@ -123,112 +245,12 @@ impl AuthContext {
     pub fn replace(
         &mut self,
         auth_digest: MoveAuthenticatorDigest,
-        tx_inputs: Vec<CallArg>,
-        tx_commands: Vec<Command>,
+        tx_inputs: Vec<AuthContextCallArg>,
+        tx_commands: Vec<AuthContextCommand>,
     ) {
         self.auth_digest = auth_digest;
         self.tx_inputs = tx_inputs;
         self.tx_commands = tx_commands;
-    }
-}
-
-// TODO: add a deserializer that can handle the Command::MoveCall and
-// Command::MakeMoveVec variants properly. For now, we only need serialization
-// for inclusion in the tx authenticator input, so we implement Serialize only.
-// Alternatively, a custom Command struct could be created for de/serialization
-// purposes or to add new functionalities.
-impl Serialize for AuthContext {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("AuthContext", 3)?;
-        state.serialize_field("auth_digest", &self.auth_digest)?;
-        state.serialize_field("tx_inputs", &self.tx_inputs)?;
-
-        // Serialize tx_commands as a Vec of enums, matching the original logic
-        struct CommandSer<'a>(&'a Command);
-
-        impl<'a> Serialize for CommandSer<'a> {
-            fn serialize<SC>(&self, serializer: SC) -> Result<SC::Ok, SC::Error>
-            where
-                SC: Serializer,
-            {
-                match self.0 {
-                    Command::MoveCall(m) => {
-                        let mut s =
-                            serializer.serialize_struct_variant("Command", 0, "MoveCall", 5)?;
-                        s.serialize_field("package", &m.package)?;
-                        s.serialize_field("module", &m.module)?;
-                        s.serialize_field("function", &m.function)?;
-                        s.serialize_field(
-                            "type_arguments",
-                            &m.type_arguments
-                                .iter()
-                                .map(TypeName::from)
-                                .collect::<Vec<_>>(),
-                        )?;
-                        s.serialize_field("arguments", &m.arguments)?;
-                        s.end()
-                    }
-                    Command::TransferObjects(objects, recipient) => {
-                        let mut s = serializer.serialize_struct_variant(
-                            "Command",
-                            1,
-                            "TransferObjects",
-                            2,
-                        )?;
-                        s.serialize_field("objects", objects)?;
-                        s.serialize_field("recipient", recipient)?;
-                        s.end()
-                    }
-                    Command::SplitCoins(coin, amounts) => {
-                        let mut s =
-                            serializer.serialize_struct_variant("Command", 2, "SplitCoins", 2)?;
-                        s.serialize_field("coin", coin)?;
-                        s.serialize_field("amounts", amounts)?;
-                        s.end()
-                    }
-                    Command::MergeCoins(target_coin, source_coins) => {
-                        let mut s =
-                            serializer.serialize_struct_variant("Command", 3, "MergeCoins", 2)?;
-                        s.serialize_field("target_coin", target_coin)?;
-                        s.serialize_field("source_coins", source_coins)?;
-                        s.end()
-                    }
-                    Command::Publish(modules, dependencies) => {
-                        let mut s =
-                            serializer.serialize_struct_variant("Command", 4, "Publish", 2)?;
-                        s.serialize_field("modules", modules)?;
-                        s.serialize_field("dependencies", dependencies)?;
-                        s.end()
-                    }
-                    Command::MakeMoveVec(type_arg, elements) => {
-                        let mut s =
-                            serializer.serialize_tuple_variant("Command", 5, "MakeMoveVec", 2)?;
-                        s.serialize_field(&type_arg.as_ref().map(TypeName::from))?;
-                        s.serialize_field(elements)?;
-                        s.end()
-                    }
-                    Command::Upgrade(modules, dependencies, package, upgrade_ticket) => {
-                        let mut s =
-                            serializer.serialize_struct_variant("Command", 6, "Upgrade", 4)?;
-                        s.serialize_field("modules", modules)?;
-                        s.serialize_field("dependencies", dependencies)?;
-                        s.serialize_field("package", package)?;
-                        s.serialize_field("upgrade_ticket", upgrade_ticket)?;
-                        s.end()
-                    }
-                }
-            }
-        }
-
-        state.serialize_field(
-            "tx_commands",
-            &self.tx_commands.iter().map(CommandSer).collect::<Vec<_>>(),
-        )?;
-
-        state.end()
     }
 }
 
@@ -257,4 +279,388 @@ pub fn is_auth_context(
     module_addr == &IOTA_FRAMEWORK_ADDRESS
         && module_name == AUTH_CONTEXT_MODULE_NAME
         && struct_name == AUTH_CONTEXT_STRUCT_NAME
+}
+
+#[cfg(test)]
+mod tests {
+    use move_core_types::account_address::AccountAddress;
+
+    use super::*;
+    use crate::{
+        base_types::{ObjectDigest, ObjectID, SequenceNumber},
+        transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall,
+            ProgrammableTransaction},
+        type_input::{StructInput, TypeInput},
+    };
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    fn obj_id() -> ObjectID {
+        ObjectID::from_hex_literal("0x0000000000000000000000000000000000000001").unwrap()
+    }
+
+    fn obj_ref() -> (ObjectID, SequenceNumber, ObjectDigest) {
+        (obj_id(), SequenceNumber::from(1), ObjectDigest::new([1u8; 32]))
+    }
+
+    /// BCS round-trip helper.
+    fn round_trip<T>(value: &T) -> T
+    where
+        T: serde::Serialize + for<'de> serde::Deserialize<'de> + PartialEq + std::fmt::Debug,
+    {
+        let bytes = bcs::to_bytes(value).unwrap();
+        bcs::from_bytes(&bytes).unwrap()
+    }
+
+    // ── AuthContextCallArgV1 ─────────────────────────────────────────────────
+
+    #[test]
+    fn call_arg_v1_pure_round_trip() {
+        let arg = AuthContextCallArgV1::Pure(vec![1, 2, 3]);
+        assert_eq!(round_trip(&arg), arg);
+    }
+
+    #[test]
+    fn call_arg_v1_imm_or_owned_round_trip() {
+        let arg = AuthContextCallArgV1::Object(ObjectArg::ImmOrOwnedObject(obj_ref()));
+        assert_eq!(round_trip(&arg), arg);
+    }
+
+    #[test]
+    fn call_arg_v1_shared_object_round_trip() {
+        let arg = AuthContextCallArgV1::Object(ObjectArg::SharedObject {
+            id: obj_id(),
+            initial_shared_version: SequenceNumber::from(5),
+            mutable: true,
+        });
+        assert_eq!(round_trip(&arg), arg);
+    }
+
+    #[test]
+    fn call_arg_v1_receiving_round_trip() {
+        let arg = AuthContextCallArgV1::Object(ObjectArg::Receiving(obj_ref()));
+        assert_eq!(round_trip(&arg), arg);
+    }
+
+    // ── From<&CallArg> for AuthContextCallArgV1 ──────────────────────────────
+
+    #[test]
+    fn call_arg_v1_from_pure() {
+        let data = vec![10, 20, 30];
+        let converted = AuthContextCallArgV1::from(&CallArg::Pure(data.clone()));
+        assert_eq!(converted, AuthContextCallArgV1::Pure(data));
+    }
+
+    #[test]
+    fn call_arg_v1_from_object() {
+        let obj_arg = ObjectArg::ImmOrOwnedObject(obj_ref());
+        let converted = AuthContextCallArgV1::from(&CallArg::Object(obj_arg));
+        assert_eq!(converted, AuthContextCallArgV1::Object(obj_arg));
+    }
+
+    // ── AuthContextCallArg versioned wrapper ─────────────────────────────────
+
+    #[test]
+    fn call_arg_versioned_round_trip() {
+        let arg = AuthContextCallArg::V1(AuthContextCallArgV1::Pure(vec![42]));
+        assert_eq!(round_trip(&arg), arg);
+    }
+
+    #[test]
+    fn call_arg_versioned_from_call_arg() {
+        let call_arg = CallArg::Pure(vec![99]);
+        let versioned = AuthContextCallArg::from(&call_arg);
+        assert!(matches!(versioned, AuthContextCallArg::V1(AuthContextCallArgV1::Pure(_))));
+    }
+
+    /// The versioned wrapper adds one byte (the V1 variant tag = 0x00) before
+    /// the inner content. This property is what `native_tx_inputs` relies on
+    /// when it unwraps the V1 variant before serializing for Move.
+    #[test]
+    fn call_arg_versioned_bcs_has_outer_tag() {
+        let inner = AuthContextCallArgV1::Pure(vec![1]);
+        let versioned = AuthContextCallArg::V1(inner.clone());
+
+        let inner_bytes = bcs::to_bytes(&inner).unwrap();
+        let versioned_bytes = bcs::to_bytes(&versioned).unwrap();
+
+        // versioned = [V1 tag (0x00)] ++ inner_bytes
+        assert_eq!(versioned_bytes[0], 0x00, "V1 variant tag must be 0");
+        assert_eq!(&versioned_bytes[1..], inner_bytes.as_slice());
+    }
+
+    // ── AuthContextCommandV1 round-trips ─────────────────────────────────────
+
+    fn sample_move_call_v1() -> AuthContextCommandV1 {
+        AuthContextCommandV1::MoveCall(Box::new(AuthContextMoveCall {
+            package: obj_id(),
+            module: "my_module".to_string(),
+            function: "my_func".to_string(),
+            type_arguments: vec![TypeName { name: "u64".to_string() }],
+            arguments: vec![Argument::GasCoin, Argument::Input(0)],
+        }))
+    }
+
+    #[test]
+    fn command_v1_move_call_round_trip() {
+        assert_eq!(round_trip(&sample_move_call_v1()), sample_move_call_v1());
+    }
+
+    #[test]
+    fn command_v1_transfer_objects_round_trip() {
+        let cmd = AuthContextCommandV1::TransferObjects(
+            vec![Argument::Input(0), Argument::Result(1)],
+            Argument::Input(2),
+        );
+        assert_eq!(round_trip(&cmd), cmd);
+    }
+
+    #[test]
+    fn command_v1_split_coins_round_trip() {
+        let cmd =
+            AuthContextCommandV1::SplitCoins(Argument::GasCoin, vec![Argument::Input(0)]);
+        assert_eq!(round_trip(&cmd), cmd);
+    }
+
+    #[test]
+    fn command_v1_merge_coins_round_trip() {
+        let cmd = AuthContextCommandV1::MergeCoins(
+            Argument::GasCoin,
+            vec![Argument::Input(0), Argument::Input(1)],
+        );
+        assert_eq!(round_trip(&cmd), cmd);
+    }
+
+    #[test]
+    fn command_v1_publish_round_trip() {
+        let cmd = AuthContextCommandV1::Publish(vec![vec![1, 2, 3]], vec![obj_id()]);
+        assert_eq!(round_trip(&cmd), cmd);
+    }
+
+    #[test]
+    fn command_v1_make_move_vec_with_type_round_trip() {
+        let cmd = AuthContextCommandV1::MakeMoveVec(
+            Some(TypeName { name: "0x2::coin::Coin<u64>".to_string() }),
+            vec![Argument::Input(0)],
+        );
+        assert_eq!(round_trip(&cmd), cmd);
+    }
+
+    #[test]
+    fn command_v1_make_move_vec_no_type_round_trip() {
+        let cmd = AuthContextCommandV1::MakeMoveVec(None, vec![Argument::Result(0)]);
+        assert_eq!(round_trip(&cmd), cmd);
+    }
+
+    #[test]
+    fn command_v1_upgrade_round_trip() {
+        let cmd = AuthContextCommandV1::Upgrade(
+            vec![vec![0xde, 0xad]],
+            vec![obj_id()],
+            obj_id(),
+            Argument::Result(0),
+        );
+        assert_eq!(round_trip(&cmd), cmd);
+    }
+
+    // ── From<&Command> for AuthContextCommandV1 ──────────────────────────────
+
+    /// Primitive TypeInput variants (Bool, U8, …) must be converted to their
+    /// canonical string representation as TypeName.
+    #[test]
+    fn command_v1_from_move_call_primitive_type_input() {
+        let cases = [
+            (TypeInput::Bool, "bool"),
+            (TypeInput::U8, "u8"),
+            (TypeInput::U64, "u64"),
+            (TypeInput::U128, "u128"),
+            (TypeInput::U16, "u16"),
+            (TypeInput::U32, "u32"),
+            (TypeInput::U256, "u256"),
+            (TypeInput::Address, "address"),
+        ];
+        for (type_input, expected_name) in cases {
+            let cmd = Command::MoveCall(Box::new(ProgrammableMoveCall {
+                package: obj_id(),
+                module: "m".to_string(),
+                function: "f".to_string(),
+                type_arguments: vec![type_input],
+                arguments: vec![],
+            }));
+            let AuthContextCommandV1::MoveCall(call) = AuthContextCommandV1::from(&cmd) else {
+                panic!("expected MoveCall");
+            };
+            assert_eq!(
+                call.type_arguments,
+                vec![TypeName { name: expected_name.to_string() }],
+                "failed for {expected_name}"
+            );
+        }
+    }
+
+    /// Struct TypeInput must be converted to its canonical qualified name.
+    #[test]
+    fn command_v1_from_move_call_struct_type_input() {
+        let type_input = TypeInput::Struct(Box::new(StructInput {
+            address: AccountAddress::from_hex_literal("0x2").unwrap(),
+            module: "coin".to_string(),
+            name: "Coin".to_string(),
+            type_params: vec![TypeInput::U64],
+        }));
+        let expected = TypeName::from(&type_input);
+
+        let cmd = Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package: obj_id(),
+            module: "m".to_string(),
+            function: "f".to_string(),
+            type_arguments: vec![type_input],
+            arguments: vec![],
+        }));
+        let AuthContextCommandV1::MoveCall(call) = AuthContextCommandV1::from(&cmd) else {
+            panic!("expected MoveCall");
+        };
+        assert_eq!(call.type_arguments, vec![expected]);
+    }
+
+    #[test]
+    fn command_v1_from_make_move_vec_type_input_becomes_type_name() {
+        let type_input = TypeInput::Bool;
+        let expected = TypeName::from(&type_input);
+        let cmd = Command::MakeMoveVec(Some(type_input), vec![Argument::Input(0)]);
+        let AuthContextCommandV1::MakeMoveVec(name, _) = AuthContextCommandV1::from(&cmd) else {
+            panic!("expected MakeMoveVec");
+        };
+        assert_eq!(name, Some(expected));
+    }
+
+    #[test]
+    fn command_v1_from_make_move_vec_none_type() {
+        let cmd = Command::MakeMoveVec(None, vec![]);
+        let AuthContextCommandV1::MakeMoveVec(name, elements) = AuthContextCommandV1::from(&cmd)
+        else {
+            panic!("expected MakeMoveVec");
+        };
+        assert!(name.is_none());
+        assert!(elements.is_empty());
+    }
+
+    // ── AuthContextCommand versioned wrapper ─────────────────────────────────
+
+    #[test]
+    fn command_versioned_round_trip() {
+        let cmd = AuthContextCommand::V1(sample_move_call_v1());
+        assert_eq!(round_trip(&cmd), cmd);
+    }
+
+    #[test]
+    fn command_versioned_from_command() {
+        let cmd = Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package: obj_id(),
+            module: "m".to_string(),
+            function: "f".to_string(),
+            type_arguments: vec![TypeInput::U8],
+            arguments: vec![],
+        }));
+        let versioned = AuthContextCommand::from(&cmd);
+        assert!(matches!(versioned, AuthContextCommand::V1(_)));
+    }
+
+    /// The versioned wrapper adds one byte (the V1 tag = 0x00) before the
+    /// inner content. This is the invariant that `native_tx_commands` depends
+    /// on when it unwraps before passing bytes to Move.
+    #[test]
+    fn command_versioned_bcs_has_outer_tag() {
+        let inner = sample_move_call_v1();
+        let versioned = AuthContextCommand::V1(inner.clone());
+
+        let inner_bytes = bcs::to_bytes(&inner).unwrap();
+        let versioned_bytes = bcs::to_bytes(&versioned).unwrap();
+
+        assert_eq!(versioned_bytes[0], 0x00, "V1 variant tag must be 0");
+        assert_eq!(&versioned_bytes[1..], inner_bytes.as_slice());
+    }
+
+    // ── Native-function unwrap pattern ───────────────────────────────────────
+
+    /// Simulates what `native_tx_commands` does: match on the version variant,
+    /// take a reference to the inner V1 value, then serialize it. The resulting
+    /// bytes must be identical to serializing `AuthContextCommandV1` directly,
+    /// and must NOT contain the outer variant tag.
+    #[test]
+    fn native_unwrap_v1_bytes_equal_direct_v1_serialization() {
+        let inner = sample_move_call_v1();
+        let versioned = AuthContextCommand::V1(inner.clone());
+
+        let AuthContextCommand::V1(unwrapped) = &versioned;
+        let native_bytes = bcs::to_bytes(unwrapped).unwrap();
+        let direct_bytes = bcs::to_bytes(&inner).unwrap();
+
+        assert_eq!(native_bytes, direct_bytes);
+    }
+
+    /// The bytes produced by the native-function unwrap pattern must differ
+    /// from those of the versioned wrapper (which carries the extra tag byte).
+    #[test]
+    fn native_unwrap_bytes_differ_from_versioned_bytes() {
+        let inner = sample_move_call_v1();
+        let versioned = AuthContextCommand::V1(inner.clone());
+
+        let AuthContextCommand::V1(unwrapped) = &versioned;
+        let unwrapped_bytes = bcs::to_bytes(unwrapped).unwrap();
+        let versioned_bytes = bcs::to_bytes(&versioned).unwrap();
+
+        assert_ne!(unwrapped_bytes, versioned_bytes);
+    }
+
+    // ── AuthContext struct ───────────────────────────────────────────────────
+
+    #[test]
+    fn auth_context_new_from_components_wraps_as_v1() {
+        let ptb = ProgrammableTransaction {
+            inputs: vec![CallArg::Pure(vec![0xab])],
+            commands: vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
+                package: obj_id(),
+                module: "mod".to_string(),
+                function: "fun".to_string(),
+                type_arguments: vec![TypeInput::U8],
+                arguments: vec![Argument::GasCoin],
+            }))],
+        };
+
+        let ctx = AuthContext::new_from_components(MoveAuthenticatorDigest::default(), &ptb);
+
+        assert_eq!(ctx.tx_inputs().len(), 1);
+        assert_eq!(ctx.tx_commands().len(), 1);
+
+        // Inputs must be wrapped as V1.
+        assert!(matches!(ctx.tx_inputs()[0], AuthContextCallArg::V1(_)));
+
+        // Commands must be wrapped as V1 with TypeName substituted for TypeInput.
+        let AuthContextCommand::V1(AuthContextCommandV1::MoveCall(call)) = &ctx.tx_commands()[0]
+        else {
+            panic!("expected V1 MoveCall");
+        };
+        assert_eq!(call.type_arguments, vec![TypeName { name: "u8".to_string() }]);
+    }
+
+    #[test]
+    fn auth_context_to_bcs_bytes_is_deterministic() {
+        let ctx = AuthContext::new_for_testing();
+        assert_eq!(ctx.to_bcs_bytes(), ctx.to_bcs_bytes());
+    }
+
+    #[test]
+    fn auth_context_to_bcs_bytes_reflects_content() {
+        let mut ctx = AuthContext::new_for_testing();
+        let empty_bytes = ctx.to_bcs_bytes();
+
+        ctx.replace(
+            MoveAuthenticatorDigest::default(),
+            vec![AuthContextCallArg::V1(AuthContextCallArgV1::Pure(vec![1]))],
+            vec![],
+        );
+        let non_empty_bytes = ctx.to_bcs_bytes();
+
+        assert_ne!(empty_bytes, non_empty_bytes);
+    }
 }

--- a/crates/iota-types/src/auth_context.rs
+++ b/crates/iota-types/src/auth_context.rs
@@ -18,7 +18,7 @@ pub const AUTH_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("auth_context");
 pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
 
 /// Mirrors [`crate::transaction::ProgrammableMoveCall`] for use in
-/// [`AuthContextCommandV1`], substituting [`TypeName`] for
+/// [`AuthContextCommand`], substituting [`TypeName`] for
 /// [`crate::type_input::TypeInput`] so that the type can derive
 /// [`Serialize`]/[`Deserialize`] without a custom implementation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -30,14 +30,12 @@ pub struct AuthContextMoveCall {
     pub arguments: Vec<Argument>,
 }
 
-/// V1 command layout for [`AuthContextCommand`].
-///
 /// Mirrors [`crate::transaction::Command`], substituting [`TypeName`] for
 /// [`crate::type_input::TypeInput`] in `MoveCall` and `MakeMoveVec` so that
 /// the type matches the BCS layout expected by the Move-side
 /// `ptb_command::Command`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AuthContextCommandV1 {
+pub enum AuthContextCommand {
     MoveCall(Box<AuthContextMoveCall>),
     TransferObjects(Vec<Argument>, Argument),
     SplitCoins(Argument, Vec<Argument>),
@@ -47,36 +45,34 @@ pub enum AuthContextCommandV1 {
     Upgrade(Vec<Vec<u8>>, Vec<ObjectID>, ObjectID, Argument),
 }
 
-impl From<&Command> for AuthContextCommandV1 {
+impl From<&Command> for AuthContextCommand {
     fn from(cmd: &Command) -> Self {
         match cmd {
-            Command::MoveCall(m) => {
-                AuthContextCommandV1::MoveCall(Box::new(AuthContextMoveCall {
-                    package: m.package,
-                    module: m.module.clone(),
-                    function: m.function.clone(),
-                    type_arguments: m.type_arguments.iter().map(TypeName::from).collect(),
-                    arguments: m.arguments.clone(),
-                }))
-            }
+            Command::MoveCall(m) => AuthContextCommand::MoveCall(Box::new(AuthContextMoveCall {
+                package: m.package,
+                module: m.module.clone(),
+                function: m.function.clone(),
+                type_arguments: m.type_arguments.iter().map(TypeName::from).collect(),
+                arguments: m.arguments.clone(),
+            })),
             Command::TransferObjects(objects, recipient) => {
-                AuthContextCommandV1::TransferObjects(objects.clone(), *recipient)
+                AuthContextCommand::TransferObjects(objects.clone(), *recipient)
             }
             Command::SplitCoins(coin, amounts) => {
-                AuthContextCommandV1::SplitCoins(*coin, amounts.clone())
+                AuthContextCommand::SplitCoins(*coin, amounts.clone())
             }
             Command::MergeCoins(target_coin, source_coins) => {
-                AuthContextCommandV1::MergeCoins(*target_coin, source_coins.clone())
+                AuthContextCommand::MergeCoins(*target_coin, source_coins.clone())
             }
             Command::Publish(modules, dependencies) => {
-                AuthContextCommandV1::Publish(modules.clone(), dependencies.clone())
+                AuthContextCommand::Publish(modules.clone(), dependencies.clone())
             }
-            Command::MakeMoveVec(type_arg, elements) => AuthContextCommandV1::MakeMoveVec(
+            Command::MakeMoveVec(type_arg, elements) => AuthContextCommand::MakeMoveVec(
                 type_arg.as_ref().map(TypeName::from),
                 elements.clone(),
             ),
             Command::Upgrade(modules, dependencies, package, upgrade_ticket) => {
-                AuthContextCommandV1::Upgrade(
+                AuthContextCommand::Upgrade(
                     modules.clone(),
                     dependencies.clone(),
                     *package,
@@ -87,59 +83,22 @@ impl From<&Command> for AuthContextCommandV1 {
     }
 }
 
-/// Versioned command type stored in [`AuthContext`].
-///
-/// Each variant corresponds to a version of the Move-side
-/// `ptb_command::Command` BCS layout. When passing commands to Move native
-/// functions, the inner versioned value (e.g. [`AuthContextCommandV1`]) must
-/// be serialized directly, without the outer variant tag.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AuthContextCommand {
-    V1(AuthContextCommandV1),
-}
-
-impl From<&Command> for AuthContextCommand {
-    fn from(cmd: &Command) -> Self {
-        AuthContextCommand::V1(AuthContextCommandV1::from(cmd))
-    }
-}
-
-/// V1 call-argument layout for [`AuthContextCallArg`].
-///
 /// Mirrors [`crate::transaction::CallArg`], matching the BCS layout expected
 /// by the Move-side `ptb_call_arg::CallArg`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AuthContextCallArgV1 {
+pub enum AuthContextCallArg {
     Pure(Vec<u8>),
     Object(ObjectArg),
 }
 
-impl From<&CallArg> for AuthContextCallArgV1 {
+impl From<&CallArg> for AuthContextCallArg {
     fn from(arg: &CallArg) -> Self {
         match arg {
-            CallArg::Pure(bytes) => AuthContextCallArgV1::Pure(bytes.clone()),
-            CallArg::Object(obj_arg) => AuthContextCallArgV1::Object(*obj_arg),
+            CallArg::Pure(bytes) => AuthContextCallArg::Pure(bytes.clone()),
+            CallArg::Object(obj_arg) => AuthContextCallArg::Object(*obj_arg),
         }
     }
 }
-
-/// Versioned call-argument type stored in [`AuthContext`].
-///
-/// Each variant corresponds to a version of the Move-side
-/// `ptb_call_arg::CallArg` BCS layout. When passing inputs to Move native
-/// functions, the inner versioned value (e.g. [`AuthContextCallArgV1`]) must
-/// be serialized directly, without the outer variant tag.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AuthContextCallArg {
-    V1(AuthContextCallArgV1),
-}
-
-impl From<&CallArg> for AuthContextCallArg {
-    fn from(arg: &CallArg) -> Self {
-        AuthContextCallArg::V1(AuthContextCallArgV1::from(arg))
-    }
-}
-
 
 /// `AuthContext` provides a lightweight execution context used during the
 /// authentication phase of a transaction.
@@ -288,8 +247,9 @@ mod tests {
     use super::*;
     use crate::{
         base_types::{ObjectDigest, ObjectID, SequenceNumber},
-        transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall,
-            ProgrammableTransaction},
+        transaction::{
+            Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, ProgrammableTransaction,
+        },
         type_input::{StructInput, TypeInput},
     };
 
@@ -300,7 +260,11 @@ mod tests {
     }
 
     fn obj_ref() -> (ObjectID, SequenceNumber, ObjectDigest) {
-        (obj_id(), SequenceNumber::from(1), ObjectDigest::new([1u8; 32]))
+        (
+            obj_id(),
+            SequenceNumber::from(1),
+            ObjectDigest::new([1u8; 32]),
+        )
     }
 
     /// BCS round-trip helper.
@@ -312,23 +276,23 @@ mod tests {
         bcs::from_bytes(&bytes).unwrap()
     }
 
-    // ── AuthContextCallArgV1 ─────────────────────────────────────────────────
+    // ── AuthContextCallArg ───────────────────────────────────────────────────
 
     #[test]
-    fn call_arg_v1_pure_round_trip() {
-        let arg = AuthContextCallArgV1::Pure(vec![1, 2, 3]);
+    fn call_arg_pure_round_trip() {
+        let arg = AuthContextCallArg::Pure(vec![1, 2, 3]);
         assert_eq!(round_trip(&arg), arg);
     }
 
     #[test]
-    fn call_arg_v1_imm_or_owned_round_trip() {
-        let arg = AuthContextCallArgV1::Object(ObjectArg::ImmOrOwnedObject(obj_ref()));
+    fn call_arg_imm_or_owned_round_trip() {
+        let arg = AuthContextCallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref()));
         assert_eq!(round_trip(&arg), arg);
     }
 
     #[test]
-    fn call_arg_v1_shared_object_round_trip() {
-        let arg = AuthContextCallArgV1::Object(ObjectArg::SharedObject {
+    fn call_arg_shared_object_round_trip() {
+        let arg = AuthContextCallArg::Object(ObjectArg::SharedObject {
             id: obj_id(),
             initial_shared_version: SequenceNumber::from(5),
             mutable: true,
@@ -337,78 +301,56 @@ mod tests {
     }
 
     #[test]
-    fn call_arg_v1_receiving_round_trip() {
-        let arg = AuthContextCallArgV1::Object(ObjectArg::Receiving(obj_ref()));
+    fn call_arg_receiving_round_trip() {
+        let arg = AuthContextCallArg::Object(ObjectArg::Receiving(obj_ref()));
         assert_eq!(round_trip(&arg), arg);
     }
 
-    // ── From<&CallArg> for AuthContextCallArgV1 ──────────────────────────────
+    // ── From<&CallArg> for AuthContextCallArg ────────────────────────────────
 
     #[test]
-    fn call_arg_v1_from_pure() {
+    fn call_arg_from_pure() {
         let data = vec![10, 20, 30];
-        let converted = AuthContextCallArgV1::from(&CallArg::Pure(data.clone()));
-        assert_eq!(converted, AuthContextCallArgV1::Pure(data));
+        let converted = AuthContextCallArg::from(&CallArg::Pure(data.clone()));
+        assert_eq!(converted, AuthContextCallArg::Pure(data));
     }
 
     #[test]
-    fn call_arg_v1_from_object() {
+    fn call_arg_from_object() {
         let obj_arg = ObjectArg::ImmOrOwnedObject(obj_ref());
-        let converted = AuthContextCallArgV1::from(&CallArg::Object(obj_arg));
-        assert_eq!(converted, AuthContextCallArgV1::Object(obj_arg));
-    }
-
-    // ── AuthContextCallArg versioned wrapper ─────────────────────────────────
-
-    #[test]
-    fn call_arg_versioned_round_trip() {
-        let arg = AuthContextCallArg::V1(AuthContextCallArgV1::Pure(vec![42]));
-        assert_eq!(round_trip(&arg), arg);
+        let converted = AuthContextCallArg::from(&CallArg::Object(obj_arg));
+        assert_eq!(converted, AuthContextCallArg::Object(obj_arg));
     }
 
     #[test]
-    fn call_arg_versioned_from_call_arg() {
+    fn call_arg_from_call_arg() {
         let call_arg = CallArg::Pure(vec![99]);
-        let versioned = AuthContextCallArg::from(&call_arg);
-        assert!(matches!(versioned, AuthContextCallArg::V1(AuthContextCallArgV1::Pure(_))));
+        let converted = AuthContextCallArg::from(&call_arg);
+        assert!(matches!(converted, AuthContextCallArg::Pure(_)));
     }
 
-    /// The versioned wrapper adds one byte (the V1 variant tag = 0x00) before
-    /// the inner content. This property is what `native_tx_inputs` relies on
-    /// when it unwraps the V1 variant before serializing for Move.
-    #[test]
-    fn call_arg_versioned_bcs_has_outer_tag() {
-        let inner = AuthContextCallArgV1::Pure(vec![1]);
-        let versioned = AuthContextCallArg::V1(inner.clone());
+    // ── AuthContextCommand round-trips ────────────────────────────────────────
 
-        let inner_bytes = bcs::to_bytes(&inner).unwrap();
-        let versioned_bytes = bcs::to_bytes(&versioned).unwrap();
-
-        // versioned = [V1 tag (0x00)] ++ inner_bytes
-        assert_eq!(versioned_bytes[0], 0x00, "V1 variant tag must be 0");
-        assert_eq!(&versioned_bytes[1..], inner_bytes.as_slice());
-    }
-
-    // ── AuthContextCommandV1 round-trips ─────────────────────────────────────
-
-    fn sample_move_call_v1() -> AuthContextCommandV1 {
-        AuthContextCommandV1::MoveCall(Box::new(AuthContextMoveCall {
+    fn sample_move_call() -> AuthContextCommand {
+        AuthContextCommand::MoveCall(Box::new(AuthContextMoveCall {
             package: obj_id(),
             module: "my_module".to_string(),
             function: "my_func".to_string(),
-            type_arguments: vec![TypeName { name: "u64".to_string() }],
+            type_arguments: vec![TypeName {
+                name: "u64".to_string(),
+            }],
             arguments: vec![Argument::GasCoin, Argument::Input(0)],
         }))
     }
 
     #[test]
-    fn command_v1_move_call_round_trip() {
-        assert_eq!(round_trip(&sample_move_call_v1()), sample_move_call_v1());
+    fn command_move_call_round_trip() {
+        assert_eq!(round_trip(&sample_move_call()), sample_move_call());
     }
 
     #[test]
-    fn command_v1_transfer_objects_round_trip() {
-        let cmd = AuthContextCommandV1::TransferObjects(
+    fn command_transfer_objects_round_trip() {
+        let cmd = AuthContextCommand::TransferObjects(
             vec![Argument::Input(0), Argument::Result(1)],
             Argument::Input(2),
         );
@@ -416,15 +358,14 @@ mod tests {
     }
 
     #[test]
-    fn command_v1_split_coins_round_trip() {
-        let cmd =
-            AuthContextCommandV1::SplitCoins(Argument::GasCoin, vec![Argument::Input(0)]);
+    fn command_split_coins_round_trip() {
+        let cmd = AuthContextCommand::SplitCoins(Argument::GasCoin, vec![Argument::Input(0)]);
         assert_eq!(round_trip(&cmd), cmd);
     }
 
     #[test]
-    fn command_v1_merge_coins_round_trip() {
-        let cmd = AuthContextCommandV1::MergeCoins(
+    fn command_merge_coins_round_trip() {
+        let cmd = AuthContextCommand::MergeCoins(
             Argument::GasCoin,
             vec![Argument::Input(0), Argument::Input(1)],
         );
@@ -432,29 +373,31 @@ mod tests {
     }
 
     #[test]
-    fn command_v1_publish_round_trip() {
-        let cmd = AuthContextCommandV1::Publish(vec![vec![1, 2, 3]], vec![obj_id()]);
+    fn command_publish_round_trip() {
+        let cmd = AuthContextCommand::Publish(vec![vec![1, 2, 3]], vec![obj_id()]);
         assert_eq!(round_trip(&cmd), cmd);
     }
 
     #[test]
-    fn command_v1_make_move_vec_with_type_round_trip() {
-        let cmd = AuthContextCommandV1::MakeMoveVec(
-            Some(TypeName { name: "0x2::coin::Coin<u64>".to_string() }),
+    fn command_make_move_vec_with_type_round_trip() {
+        let cmd = AuthContextCommand::MakeMoveVec(
+            Some(TypeName {
+                name: "0x2::coin::Coin<u64>".to_string(),
+            }),
             vec![Argument::Input(0)],
         );
         assert_eq!(round_trip(&cmd), cmd);
     }
 
     #[test]
-    fn command_v1_make_move_vec_no_type_round_trip() {
-        let cmd = AuthContextCommandV1::MakeMoveVec(None, vec![Argument::Result(0)]);
+    fn command_make_move_vec_no_type_round_trip() {
+        let cmd = AuthContextCommand::MakeMoveVec(None, vec![Argument::Result(0)]);
         assert_eq!(round_trip(&cmd), cmd);
     }
 
     #[test]
-    fn command_v1_upgrade_round_trip() {
-        let cmd = AuthContextCommandV1::Upgrade(
+    fn command_upgrade_round_trip() {
+        let cmd = AuthContextCommand::Upgrade(
             vec![vec![0xde, 0xad]],
             vec![obj_id()],
             obj_id(),
@@ -463,12 +406,12 @@ mod tests {
         assert_eq!(round_trip(&cmd), cmd);
     }
 
-    // ── From<&Command> for AuthContextCommandV1 ──────────────────────────────
+    // ── From<&Command> for AuthContextCommand ────────────────────────────────
 
     /// Primitive TypeInput variants (Bool, U8, …) must be converted to their
     /// canonical string representation as TypeName.
     #[test]
-    fn command_v1_from_move_call_primitive_type_input() {
+    fn command_from_move_call_primitive_type_input() {
         let cases = [
             (TypeInput::Bool, "bool"),
             (TypeInput::U8, "u8"),
@@ -487,12 +430,14 @@ mod tests {
                 type_arguments: vec![type_input],
                 arguments: vec![],
             }));
-            let AuthContextCommandV1::MoveCall(call) = AuthContextCommandV1::from(&cmd) else {
+            let AuthContextCommand::MoveCall(call) = AuthContextCommand::from(&cmd) else {
                 panic!("expected MoveCall");
             };
             assert_eq!(
                 call.type_arguments,
-                vec![TypeName { name: expected_name.to_string() }],
+                vec![TypeName {
+                    name: expected_name.to_string()
+                }],
                 "failed for {expected_name}"
             );
         }
@@ -500,7 +445,7 @@ mod tests {
 
     /// Struct TypeInput must be converted to its canonical qualified name.
     #[test]
-    fn command_v1_from_move_call_struct_type_input() {
+    fn command_from_move_call_struct_type_input() {
         let type_input = TypeInput::Struct(Box::new(StructInput {
             address: AccountAddress::from_hex_literal("0x2").unwrap(),
             module: "coin".to_string(),
@@ -516,44 +461,35 @@ mod tests {
             type_arguments: vec![type_input],
             arguments: vec![],
         }));
-        let AuthContextCommandV1::MoveCall(call) = AuthContextCommandV1::from(&cmd) else {
+        let AuthContextCommand::MoveCall(call) = AuthContextCommand::from(&cmd) else {
             panic!("expected MoveCall");
         };
         assert_eq!(call.type_arguments, vec![expected]);
     }
 
     #[test]
-    fn command_v1_from_make_move_vec_type_input_becomes_type_name() {
+    fn command_from_make_move_vec_type_input_becomes_type_name() {
         let type_input = TypeInput::Bool;
         let expected = TypeName::from(&type_input);
         let cmd = Command::MakeMoveVec(Some(type_input), vec![Argument::Input(0)]);
-        let AuthContextCommandV1::MakeMoveVec(name, _) = AuthContextCommandV1::from(&cmd) else {
+        let AuthContextCommand::MakeMoveVec(name, _) = AuthContextCommand::from(&cmd) else {
             panic!("expected MakeMoveVec");
         };
         assert_eq!(name, Some(expected));
     }
 
     #[test]
-    fn command_v1_from_make_move_vec_none_type() {
+    fn command_from_make_move_vec_none_type() {
         let cmd = Command::MakeMoveVec(None, vec![]);
-        let AuthContextCommandV1::MakeMoveVec(name, elements) = AuthContextCommandV1::from(&cmd)
-        else {
+        let AuthContextCommand::MakeMoveVec(name, elements) = AuthContextCommand::from(&cmd) else {
             panic!("expected MakeMoveVec");
         };
         assert!(name.is_none());
         assert!(elements.is_empty());
     }
 
-    // ── AuthContextCommand versioned wrapper ─────────────────────────────────
-
     #[test]
-    fn command_versioned_round_trip() {
-        let cmd = AuthContextCommand::V1(sample_move_call_v1());
-        assert_eq!(round_trip(&cmd), cmd);
-    }
-
-    #[test]
-    fn command_versioned_from_command() {
+    fn command_from_command() {
         let cmd = Command::MoveCall(Box::new(ProgrammableMoveCall {
             package: obj_id(),
             module: "m".to_string(),
@@ -561,61 +497,14 @@ mod tests {
             type_arguments: vec![TypeInput::U8],
             arguments: vec![],
         }));
-        let versioned = AuthContextCommand::from(&cmd);
-        assert!(matches!(versioned, AuthContextCommand::V1(_)));
-    }
-
-    /// The versioned wrapper adds one byte (the V1 tag = 0x00) before the
-    /// inner content. This is the invariant that `native_tx_commands` depends
-    /// on when it unwraps before passing bytes to Move.
-    #[test]
-    fn command_versioned_bcs_has_outer_tag() {
-        let inner = sample_move_call_v1();
-        let versioned = AuthContextCommand::V1(inner.clone());
-
-        let inner_bytes = bcs::to_bytes(&inner).unwrap();
-        let versioned_bytes = bcs::to_bytes(&versioned).unwrap();
-
-        assert_eq!(versioned_bytes[0], 0x00, "V1 variant tag must be 0");
-        assert_eq!(&versioned_bytes[1..], inner_bytes.as_slice());
-    }
-
-    // ── Native-function unwrap pattern ───────────────────────────────────────
-
-    /// Simulates what `native_tx_commands` does: match on the version variant,
-    /// take a reference to the inner V1 value, then serialize it. The resulting
-    /// bytes must be identical to serializing `AuthContextCommandV1` directly,
-    /// and must NOT contain the outer variant tag.
-    #[test]
-    fn native_unwrap_v1_bytes_equal_direct_v1_serialization() {
-        let inner = sample_move_call_v1();
-        let versioned = AuthContextCommand::V1(inner.clone());
-
-        let AuthContextCommand::V1(unwrapped) = &versioned;
-        let native_bytes = bcs::to_bytes(unwrapped).unwrap();
-        let direct_bytes = bcs::to_bytes(&inner).unwrap();
-
-        assert_eq!(native_bytes, direct_bytes);
-    }
-
-    /// The bytes produced by the native-function unwrap pattern must differ
-    /// from those of the versioned wrapper (which carries the extra tag byte).
-    #[test]
-    fn native_unwrap_bytes_differ_from_versioned_bytes() {
-        let inner = sample_move_call_v1();
-        let versioned = AuthContextCommand::V1(inner.clone());
-
-        let AuthContextCommand::V1(unwrapped) = &versioned;
-        let unwrapped_bytes = bcs::to_bytes(unwrapped).unwrap();
-        let versioned_bytes = bcs::to_bytes(&versioned).unwrap();
-
-        assert_ne!(unwrapped_bytes, versioned_bytes);
+        let converted = AuthContextCommand::from(&cmd);
+        assert!(matches!(converted, AuthContextCommand::MoveCall(_)));
     }
 
     // ── AuthContext struct ───────────────────────────────────────────────────
 
     #[test]
-    fn auth_context_new_from_components_wraps_as_v1() {
+    fn auth_context_new_from_components() {
         let ptb = ProgrammableTransaction {
             inputs: vec![CallArg::Pure(vec![0xab])],
             commands: vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
@@ -632,15 +521,18 @@ mod tests {
         assert_eq!(ctx.tx_inputs().len(), 1);
         assert_eq!(ctx.tx_commands().len(), 1);
 
-        // Inputs must be wrapped as V1.
-        assert!(matches!(ctx.tx_inputs()[0], AuthContextCallArg::V1(_)));
+        assert!(matches!(ctx.tx_inputs()[0], AuthContextCallArg::Pure(_)));
 
-        // Commands must be wrapped as V1 with TypeName substituted for TypeInput.
-        let AuthContextCommand::V1(AuthContextCommandV1::MoveCall(call)) = &ctx.tx_commands()[0]
-        else {
-            panic!("expected V1 MoveCall");
+        // Commands must have TypeName substituted for TypeInput.
+        let AuthContextCommand::MoveCall(call) = &ctx.tx_commands()[0] else {
+            panic!("expected MoveCall");
         };
-        assert_eq!(call.type_arguments, vec![TypeName { name: "u8".to_string() }]);
+        assert_eq!(
+            call.type_arguments,
+            vec![TypeName {
+                name: "u8".to_string()
+            }]
+        );
     }
 
     #[test]
@@ -656,7 +548,7 @@ mod tests {
 
         ctx.replace(
             MoveAuthenticatorDigest::default(),
-            vec![AuthContextCallArg::V1(AuthContextCallArgV1::Pure(vec![1]))],
+            vec![AuthContextCallArg::Pure(vec![1])],
             vec![],
         );
         let non_empty_bytes = ctx.to_bcs_bytes();

--- a/crates/iota-types/src/auth_context/fields_v1.rs
+++ b/crates/iota-types/src/auth_context/fields_v1.rs
@@ -1,21 +1,39 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::{CompiledModule, file_format::SignatureToken};
-use move_bytecode_utils::resolve_struct;
-use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     IOTA_FRAMEWORK_ADDRESS,
     base_types::ObjectID,
-    digests::MoveAuthenticatorDigest,
-    transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableTransaction},
+    transaction::{Argument, CallArg, Command, ObjectArg},
     type_input::TypeName,
 };
 
-pub const AUTH_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("auth_context");
-pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
+// ---------------------------------------------------------------------------
+// Module / struct name constants
+// ---------------------------------------------------------------------------
+
+pub const CALL_ARG_MODULE_NAME: &IdentStr = ident_str!("ptb_call_arg");
+pub const CALL_ARG_STRUCT_NAME: &IdentStr = ident_str!("CallArg");
+pub const OBJECT_ARG_STRUCT_NAME: &IdentStr = ident_str!("ObjectArg");
+pub const OBJECT_REF_STRUCT_NAME: &IdentStr = ident_str!("ObjectRef");
+
+pub const COMMAND_MODULE_NAME: &IdentStr = ident_str!("ptb_command");
+pub const COMMAND_STRUCT_NAME: &IdentStr = ident_str!("Command");
+pub const ARGUMENT_STRUCT_NAME: &IdentStr = ident_str!("Argument");
+pub const PROGRAMMABLE_MOVE_CALL_STRUCT_NAME: &IdentStr = ident_str!("ProgrammableMoveCall");
+pub const TRANSFER_OBJECTS_DATA_STRUCT_NAME: &IdentStr = ident_str!("TransferObjectsData");
+pub const SPLIT_COINS_DATA_STRUCT_NAME: &IdentStr = ident_str!("SplitCoinsData");
+pub const MERGE_COINS_DATA_STRUCT_NAME: &IdentStr = ident_str!("MergeCoinsData");
+pub const PUBLISH_DATA_STRUCT_NAME: &IdentStr = ident_str!("PublishData");
+pub const MAKE_MOVE_VEC_DATA_STRUCT_NAME: &IdentStr = ident_str!("MakeMoveVecData");
+pub const UPGRADE_DATA_STRUCT_NAME: &IdentStr = ident_str!("UpgradeData");
+
+// ---------------------------------------------------------------------------
+// AuthContextMoveCall
+// ---------------------------------------------------------------------------
 
 /// Mirrors [`crate::transaction::ProgrammableMoveCall`] for use in
 /// [`AuthContextCommand`], substituting [`TypeName`] for
@@ -29,6 +47,10 @@ pub struct AuthContextMoveCall {
     pub type_arguments: Vec<TypeName>,
     pub arguments: Vec<Argument>,
 }
+
+// ---------------------------------------------------------------------------
+// AuthContextCommand
+// ---------------------------------------------------------------------------
 
 /// Mirrors [`crate::transaction::Command`], substituting [`TypeName`] for
 /// [`crate::type_input::TypeInput`] in `MoveCall` and `MakeMoveVec` so that
@@ -83,6 +105,21 @@ impl From<&Command> for AuthContextCommand {
     }
 }
 
+impl AuthContextCommand {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: IOTA_FRAMEWORK_ADDRESS,
+            module: COMMAND_MODULE_NAME.to_owned(),
+            name: COMMAND_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AuthContextCallArg
+// ---------------------------------------------------------------------------
+
 /// Mirrors [`crate::transaction::CallArg`], matching the BCS layout expected
 /// by the Move-side `ptb_call_arg::CallArg`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -100,144 +137,15 @@ impl From<&CallArg> for AuthContextCallArg {
     }
 }
 
-/// `AuthContext` provides a lightweight execution context used during the
-/// authentication phase of a transaction.
-///
-/// It allows authenticator functions to:
-/// - Identify the transaction sender
-/// - Inspect the programmable transaction block (PTB) inputs and commands
-/// - Perform function-level permission checks
-/// - Support OTP, time-locked auth, or regulatory rule enforcement
-///
-/// This struct is **immutable** during the auth phase and must not allow
-/// mutation of state or access to storage beyond what is declared.
-///
-/// It is guaranteed to be available to all smart accounts implementing a
-/// custom authenticator function.
-///
-/// Typical use:
-/// ```move
-/// public fun authenticate(tx_hash: vector<u8>, input: &MyAuthInput, ctx: &AuthContext) {
-///     assert!(ed25519::ed25519_verify(&input.sig, &input.pk, &tx_hash), 0);
-///     assert!(verify_digest(ctx.digest()), 1);
-///     ...
-/// }
-/// ```
-// Conceptually similar to `TxContext`, but designed specifically for use in the authentication
-// flow.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
-pub struct AuthContext {
-    /// The digest of the MoveAuthenticator
-    auth_digest: MoveAuthenticatorDigest,
-    /// The authentication input objects or primitive values
-    tx_inputs: Vec<AuthContextCallArg>,
-    /// The authentication commands to be executed sequentially.
-    tx_commands: Vec<AuthContextCommand>,
-}
-
-impl AuthContext {
-    pub fn new_from_components(
-        auth_digest: MoveAuthenticatorDigest,
-        ptb: &ProgrammableTransaction,
-    ) -> Self {
-        Self {
-            auth_digest,
-            tx_inputs: ptb.inputs.iter().map(AuthContextCallArg::from).collect(),
-            tx_commands: ptb.commands.iter().map(AuthContextCommand::from).collect(),
+impl AuthContextCallArg {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: IOTA_FRAMEWORK_ADDRESS,
+            module: CALL_ARG_MODULE_NAME.to_owned(),
+            name: CALL_ARG_STRUCT_NAME.to_owned(),
+            type_params: vec![],
         }
     }
-
-    pub fn new_for_testing() -> Self {
-        Self {
-            auth_digest: MoveAuthenticatorDigest::default(),
-            tx_inputs: Vec::new(),
-            tx_commands: Vec::new(),
-        }
-    }
-
-    pub fn digest(&self) -> &MoveAuthenticatorDigest {
-        &self.auth_digest
-    }
-
-    pub fn tx_inputs(&self) -> &Vec<AuthContextCallArg> {
-        &self.tx_inputs
-    }
-
-    pub fn tx_commands(&self) -> &Vec<AuthContextCommand> {
-        &self.tx_commands
-    }
-
-    pub fn to_bcs_bytes(&self) -> Vec<u8> {
-        bcs::to_bytes(&self).unwrap()
-    }
-
-    pub fn to_move_bcs_bytes(&self) -> Vec<u8> {
-        bcs::to_bytes(&MoveAuthContext::default()).unwrap()
-    }
-
-    /// Returns whether the type signature is &mut AuthContext, &AuthContext, or
-    /// none of the above.
-    pub fn kind(module: &CompiledModule, token: &SignatureToken) -> AuthContextKind {
-        use SignatureToken as S;
-
-        let (kind, token) = match token {
-            S::MutableReference(token) => (AuthContextKind::Mutable, token),
-            S::Reference(token) => (AuthContextKind::Immutable, token),
-            _ => return AuthContextKind::None,
-        };
-
-        let S::Datatype(idx) = &**token else {
-            return AuthContextKind::None;
-        };
-
-        let (module_addr, module_name, struct_name) = resolve_struct(module, *idx);
-
-        if is_auth_context(module_addr, module_name, struct_name) {
-            kind
-        } else {
-            AuthContextKind::None
-        }
-    }
-
-    // Move test only API
-    //
-    pub fn replace(
-        &mut self,
-        auth_digest: MoveAuthenticatorDigest,
-        tx_inputs: Vec<AuthContextCallArg>,
-        tx_commands: Vec<AuthContextCommand>,
-    ) {
-        self.auth_digest = auth_digest;
-        self.tx_inputs = tx_inputs;
-        self.tx_commands = tx_commands;
-    }
-}
-
-#[derive(Default, Serialize)]
-pub struct MoveAuthContext {
-    // An empty Move struct contains a 1-byte dummy bool field because empty fields are not
-    // allowed in the bytecode.
-    dummy_field: bool,
-}
-
-#[derive(PartialEq, Eq, Clone, Copy)]
-pub enum AuthContextKind {
-    // Not AuthContext
-    None,
-    // &mut AuthContext
-    Mutable,
-    // &AuthContext
-    Immutable,
-}
-
-pub fn is_auth_context(
-    module_addr: &AccountAddress,
-    module_name: &IdentStr,
-    struct_name: &IdentStr,
-) -> bool {
-    module_addr == &IOTA_FRAMEWORK_ADDRESS
-        && module_name == AUTH_CONTEXT_MODULE_NAME
-        && struct_name == AUTH_CONTEXT_STRUCT_NAME
 }
 
 #[cfg(test)]
@@ -247,9 +155,7 @@ mod tests {
     use super::*;
     use crate::{
         base_types::{ObjectDigest, ObjectID, SequenceNumber},
-        transaction::{
-            Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, ProgrammableTransaction,
-        },
+        transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall},
         type_input::{StructInput, TypeInput},
     };
 
@@ -499,60 +405,5 @@ mod tests {
         }));
         let converted = AuthContextCommand::from(&cmd);
         assert!(matches!(converted, AuthContextCommand::MoveCall(_)));
-    }
-
-    // ── AuthContext struct ───────────────────────────────────────────────────
-
-    #[test]
-    fn auth_context_new_from_components() {
-        let ptb = ProgrammableTransaction {
-            inputs: vec![CallArg::Pure(vec![0xab])],
-            commands: vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
-                package: obj_id(),
-                module: "mod".to_string(),
-                function: "fun".to_string(),
-                type_arguments: vec![TypeInput::U8],
-                arguments: vec![Argument::GasCoin],
-            }))],
-        };
-
-        let ctx = AuthContext::new_from_components(MoveAuthenticatorDigest::default(), &ptb);
-
-        assert_eq!(ctx.tx_inputs().len(), 1);
-        assert_eq!(ctx.tx_commands().len(), 1);
-
-        assert!(matches!(ctx.tx_inputs()[0], AuthContextCallArg::Pure(_)));
-
-        // Commands must have TypeName substituted for TypeInput.
-        let AuthContextCommand::MoveCall(call) = &ctx.tx_commands()[0] else {
-            panic!("expected MoveCall");
-        };
-        assert_eq!(
-            call.type_arguments,
-            vec![TypeName {
-                name: "u8".to_string()
-            }]
-        );
-    }
-
-    #[test]
-    fn auth_context_to_bcs_bytes_is_deterministic() {
-        let ctx = AuthContext::new_for_testing();
-        assert_eq!(ctx.to_bcs_bytes(), ctx.to_bcs_bytes());
-    }
-
-    #[test]
-    fn auth_context_to_bcs_bytes_reflects_content() {
-        let mut ctx = AuthContext::new_for_testing();
-        let empty_bytes = ctx.to_bcs_bytes();
-
-        ctx.replace(
-            MoveAuthenticatorDigest::default(),
-            vec![AuthContextCallArg::Pure(vec![1])],
-            vec![],
-        );
-        let non_empty_bytes = ctx.to_bcs_bytes();
-
-        assert_ne!(empty_bytes, non_empty_bytes);
     }
 }

--- a/crates/iota-types/src/auth_context/mod.rs
+++ b/crates/iota-types/src/auth_context/mod.rs
@@ -1,0 +1,240 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+mod fields_v1;
+
+pub use fields_v1::*;
+use move_binary_format::{CompiledModule, file_format::SignatureToken};
+use move_bytecode_utils::resolve_struct;
+use move_core_types::{
+    account_address::AccountAddress,
+    ident_str,
+    identifier::IdentStr,
+    language_storage::StructTag,
+    runtime_value::{MoveStructLayout, MoveTypeLayout},
+};
+use serde::Serialize;
+
+use crate::{
+    IOTA_FRAMEWORK_ADDRESS, digests::MoveAuthenticatorDigest, transaction::ProgrammableTransaction,
+};
+
+pub const AUTH_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("auth_context");
+pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
+
+/// `AuthContext` provides a lightweight execution context used during the
+/// authentication phase of a transaction.
+///
+/// It allows authenticator functions to:
+/// - Identify the transaction sender
+/// - Inspect the programmable transaction block (PTB) inputs and commands
+/// - Perform function-level permission checks
+/// - Support OTP, time-locked auth, or regulatory rule enforcement
+///
+/// This struct is **immutable** during the auth phase and must not allow
+/// mutation of state or access to storage beyond what is declared.
+///
+/// It is guaranteed to be available to all smart accounts implementing a
+/// custom authenticator function.
+///
+/// Typical use:
+/// ```move
+/// public fun authenticate(tx_hash: vector<u8>, input: &MyAuthInput, ctx: &AuthContext) {
+///     assert!(ed25519::ed25519_verify(&input.sig, &input.pk, &tx_hash), 0);
+///     assert!(verify_digest(ctx.digest()), 1);
+///     ...
+/// }
+/// ```
+// Conceptually similar to `TxContext`, but designed specifically for use in the authentication
+// flow.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct AuthContext {
+    /// The digest of the MoveAuthenticator
+    auth_digest: MoveAuthenticatorDigest,
+    /// The authentication input objects or primitive values
+    tx_inputs: Vec<AuthContextCallArg>,
+    /// The authentication commands to be executed sequentially.
+    tx_commands: Vec<AuthContextCommand>,
+}
+
+impl AuthContext {
+    pub fn new_from_components(
+        auth_digest: MoveAuthenticatorDigest,
+        ptb: &ProgrammableTransaction,
+    ) -> Self {
+        Self {
+            auth_digest,
+            tx_inputs: ptb.inputs.iter().map(AuthContextCallArg::from).collect(),
+            tx_commands: ptb.commands.iter().map(AuthContextCommand::from).collect(),
+        }
+    }
+
+    pub fn new_for_testing() -> Self {
+        Self {
+            auth_digest: MoveAuthenticatorDigest::default(),
+            tx_inputs: Vec::new(),
+            tx_commands: Vec::new(),
+        }
+    }
+
+    pub fn digest(&self) -> &MoveAuthenticatorDigest {
+        &self.auth_digest
+    }
+
+    pub fn tx_inputs(&self) -> &Vec<AuthContextCallArg> {
+        &self.tx_inputs
+    }
+
+    pub fn tx_commands(&self) -> &Vec<AuthContextCommand> {
+        &self.tx_commands
+    }
+
+    pub fn to_bcs_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(&self).unwrap()
+    }
+
+    pub fn to_move_bcs_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(&MoveAuthContext::default()).unwrap()
+    }
+
+    /// Returns whether the type signature is &mut AuthContext, &AuthContext, or
+    /// none of the above.
+    pub fn kind(module: &CompiledModule, token: &SignatureToken) -> AuthContextKind {
+        use SignatureToken as S;
+
+        let (kind, token) = match token {
+            S::MutableReference(token) => (AuthContextKind::Mutable, token),
+            S::Reference(token) => (AuthContextKind::Immutable, token),
+            _ => return AuthContextKind::None,
+        };
+
+        let S::Datatype(idx) = &**token else {
+            return AuthContextKind::None;
+        };
+
+        let (module_addr, module_name, struct_name) = resolve_struct(module, *idx);
+
+        if is_auth_context(module_addr, module_name, struct_name) {
+            kind
+        } else {
+            AuthContextKind::None
+        }
+    }
+
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: IOTA_FRAMEWORK_ADDRESS,
+            module: AUTH_CONTEXT_MODULE_NAME.to_owned(),
+            name: AUTH_CONTEXT_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+
+    pub fn layout_with_custom_field(custom_field: MoveTypeLayout) -> MoveTypeLayout {
+        MoveTypeLayout::Struct(Box::new(MoveStructLayout(Box::new(vec![custom_field]))))
+    }
+
+    // Move test only API
+    //
+    pub fn replace(
+        &mut self,
+        auth_digest: MoveAuthenticatorDigest,
+        tx_inputs: Vec<AuthContextCallArg>,
+        tx_commands: Vec<AuthContextCommand>,
+    ) {
+        self.auth_digest = auth_digest;
+        self.tx_inputs = tx_inputs;
+        self.tx_commands = tx_commands;
+    }
+}
+
+#[derive(Default, Serialize)]
+pub struct MoveAuthContext {
+    // An empty Move struct contains a 1-byte dummy bool field because empty fields are not
+    // allowed in the bytecode.
+    dummy_field: bool,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum AuthContextKind {
+    // Not AuthContext
+    None,
+    // &mut AuthContext
+    Mutable,
+    // &AuthContext
+    Immutable,
+}
+
+pub fn is_auth_context(
+    module_addr: &AccountAddress,
+    module_name: &IdentStr,
+    struct_name: &IdentStr,
+) -> bool {
+    module_addr == &IOTA_FRAMEWORK_ADDRESS
+        && module_name == AUTH_CONTEXT_MODULE_NAME
+        && struct_name == AUTH_CONTEXT_STRUCT_NAME
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::{
+        base_types::ObjectID,
+        transaction::{Argument, CallArg, Command, ProgrammableMoveCall, ProgrammableTransaction},
+        type_input::{TypeInput, TypeName},
+    };
+
+    #[test]
+    fn auth_context_new_from_components() {
+        let ptb = ProgrammableTransaction {
+            inputs: vec![CallArg::Pure(vec![0xab])],
+            commands: vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
+                package: ObjectID::from_hex_literal("0x0000000000000000000000000000000000000001")
+                    .unwrap(),
+                module: "mod".to_string(),
+                function: "fun".to_string(),
+                type_arguments: vec![TypeInput::U8],
+                arguments: vec![Argument::GasCoin],
+            }))],
+        };
+
+        let ctx = AuthContext::new_from_components(MoveAuthenticatorDigest::default(), &ptb);
+
+        assert_eq!(ctx.tx_inputs().len(), 1);
+        assert_eq!(ctx.tx_commands().len(), 1);
+
+        assert!(matches!(ctx.tx_inputs()[0], AuthContextCallArg::Pure(_)));
+
+        // Commands must have TypeName substituted for TypeInput.
+        let AuthContextCommand::MoveCall(call) = &ctx.tx_commands()[0] else {
+            panic!("expected MoveCall");
+        };
+        assert_eq!(
+            call.type_arguments,
+            vec![TypeName {
+                name: "u8".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn auth_context_to_bcs_bytes_is_deterministic() {
+        let ctx = AuthContext::new_for_testing();
+        assert_eq!(ctx.to_bcs_bytes(), ctx.to_bcs_bytes());
+    }
+
+    #[test]
+    fn auth_context_to_bcs_bytes_reflects_content() {
+        let mut ctx = AuthContext::new_for_testing();
+        let empty_bytes = ctx.to_bcs_bytes();
+
+        ctx.replace(
+            MoveAuthenticatorDigest::default(),
+            vec![AuthContextCallArg::Pure(vec![1])],
+            vec![],
+        );
+        let non_empty_bytes = ctx.to_bcs_bytes();
+
+        assert_ne!(empty_bytes, non_empty_bytes);
+    }
+}

--- a/iota-execution/latest/iota-move-natives/src/auth_context.rs
+++ b/iota-execution/latest/iota-move-natives/src/auth_context.rs
@@ -4,8 +4,10 @@
 use std::collections::VecDeque;
 
 use iota_types::{
+    auth_context::{
+        AuthContextCallArg, AuthContextCallArgV1, AuthContextCommand, AuthContextCommandV1,
+    },
     digests::MoveAuthenticatorDigest,
-    transaction::{CallArg, Command},
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
@@ -86,7 +88,14 @@ pub fn native_tx_commands(
 
     let auth_context: &AuthenticationContext = get_extension!(context)?;
 
-    let commands_value = to_value(&auth_context.tx_commands(), &commands_move_layout)?;
+    // Unwrap the version tag: Move expects the V1 layout directly, without the
+    // outer `AuthContextCommand` variant discriminant.
+    let commands = auth_context.tx_commands();
+    let v1_commands: Vec<_> = commands
+        .iter()
+        .map(|AuthContextCommand::V1(v1)| v1)
+        .collect();
+    let commands_value = to_value(&v1_commands, &commands_move_layout)?;
 
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -126,7 +135,11 @@ pub fn native_tx_inputs(
 
     let auth_context: &AuthenticationContext = get_extension!(context)?;
 
-    let inputs_value = to_value(&auth_context.tx_inputs(), &inputs_move_layout)?;
+    // Unwrap the version tag: Move expects the V1 layout directly, without the
+    // outer `AuthContextCallArg` variant discriminant.
+    let inputs = auth_context.tx_inputs();
+    let v1_inputs: Vec<_> = inputs.iter().map(|AuthContextCallArg::V1(v1)| v1).collect();
+    let inputs_value = to_value(&v1_inputs, &inputs_move_layout)?;
 
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -163,18 +176,22 @@ pub fn native_replace(
     let command_type = ty_args.pop().unwrap();
     let command_move_layout = resolve_move_layout(context, &command_type)?;
 
+    // Move sends V1 layout without a version tag, so deserialize into the V1
+    // type directly, then wrap with the version variant.
     let tx_commands = pop_arg!(args, Vec<Value>)
         .into_iter()
-        .map(|value| from_value(value, &command_move_layout))
-        .collect::<PartialVMResult<Vec<Command>>>()?;
+        .map(|value| from_value::<AuthContextCommandV1>(value, &command_move_layout))
+        .map(|r| r.map(AuthContextCommand::V1))
+        .collect::<PartialVMResult<Vec<AuthContextCommand>>>()?;
 
     let input_type = ty_args.pop().unwrap();
     let input_move_layout = resolve_move_layout(context, &input_type)?;
 
     let tx_inputs = pop_arg!(args, Vec<Value>)
         .into_iter()
-        .map(|value| from_value(value, &input_move_layout))
-        .collect::<PartialVMResult<Vec<CallArg>>>()?;
+        .map(|value| from_value::<AuthContextCallArgV1>(value, &input_move_layout))
+        .map(|r| r.map(AuthContextCallArg::V1))
+        .collect::<PartialVMResult<Vec<AuthContextCallArg>>>()?;
 
     let auth_digest = MoveAuthenticatorDigest::try_from(pop_arg!(args, Vec<u8>).as_slice())
         .map_err(|err| {

--- a/iota-execution/latest/iota-move-natives/src/auth_context.rs
+++ b/iota-execution/latest/iota-move-natives/src/auth_context.rs
@@ -3,19 +3,17 @@
 
 use std::collections::VecDeque;
 
-use iota_types::{
-    auth_context::{AuthContextCallArg, AuthContextCommand},
-    digests::MoveAuthenticatorDigest,
-};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     gas_algebra::InternalGas, runtime_value::MoveTypeLayout, vm_status::StatusCode,
 };
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
 use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{StructRef, Value},
 };
-use serde::{Serialize, de::DeserializeOwned};
 use smallvec::smallvec;
 
 use crate::{
@@ -30,7 +28,8 @@ pub struct AuthContextDigestCostParams {
 
 /// ****************************************************************************
 /// native fun native_digest
-/// Implementation of the Move native function `fun native_digest(): vector<u8>`
+/// Implementation of the Move native function `fun native_digest():
+/// &vector<u8>`
 /// ****************************************************************************
 pub fn native_digest(
     context: &mut NativeContext,
@@ -48,10 +47,16 @@ pub fn native_digest(
         auth_context_digest_cost_params.auth_context_digest_cost_base
     );
 
-    let auth_context: &AuthenticationContext = get_extension!(context)?;
+    let auth_context: &mut AuthenticationContext = get_extension_mut!(context)?;
 
-    let digest = Value::vector_u8(auth_context.digest().into_inner());
-    Ok(NativeResult::ok(context.gas_used(), smallvec![digest]))
+    let digest_ref = auth_context
+        .struct_with_digest()?
+        .borrow_global()
+        .inspect_err(|err| assert!(err.major_status() != StatusCode::MISSING_DATA))?
+        .value_as::<StructRef>()?
+        .borrow_field(0)?;
+
+    Ok(NativeResult::ok(context.gas_used(), smallvec![digest_ref]))
 }
 
 #[derive(Clone)]
@@ -61,8 +66,8 @@ pub struct AuthContextTxCommandsCostParams {
 
 /// ****************************************************************************
 /// native fun native_tx_commands
-/// Implementation of the Move native function `fun native_tx_commands<C>():
-/// vector<C>`
+/// Implementation of the Move native function `fun native_tx_commands():
+/// &vector<Command>`
 /// ****************************************************************************
 pub fn native_tx_commands(
     context: &mut NativeContext,
@@ -82,15 +87,18 @@ pub fn native_tx_commands(
 
     let command_type = ty_args.pop().unwrap();
     let command_move_layout = resolve_move_layout(context, &command_type)?;
-    let commands_move_layout = MoveTypeLayout::Vector(Box::new(command_move_layout));
 
-    let auth_context: &AuthenticationContext = get_extension!(context)?;
-
-    let commands_value = to_value(&auth_context.tx_commands(), &commands_move_layout)?;
+    let auth_context: &mut AuthenticationContext = get_extension_mut!(context)?;
+    let tx_commands_ref = auth_context
+        .struct_with_tx_commands(command_move_layout)?
+        .borrow_global()
+        .inspect_err(|err| assert!(err.major_status() != StatusCode::MISSING_DATA))?
+        .value_as::<StructRef>()?
+        .borrow_field(0)?;
 
     Ok(NativeResult::ok(
         context.gas_used(),
-        smallvec![commands_value],
+        smallvec![tx_commands_ref],
     ))
 }
 
@@ -122,15 +130,19 @@ pub fn native_tx_inputs(
 
     let input_type = ty_args.pop().unwrap();
     let input_move_layout = resolve_move_layout(context, &input_type)?;
-    let inputs_move_layout = MoveTypeLayout::Vector(Box::new(input_move_layout));
 
-    let auth_context: &AuthenticationContext = get_extension!(context)?;
+    let auth_context: &mut AuthenticationContext = get_extension_mut!(context)?;
 
-    let inputs_value = to_value(&auth_context.tx_inputs(), &inputs_move_layout)?;
+    let tx_inputs_ref = auth_context
+        .struct_with_tx_inputs(input_move_layout)?
+        .borrow_global()
+        .inspect_err(|err| assert!(err.major_status() != StatusCode::MISSING_DATA))?
+        .value_as::<StructRef>()?
+        .borrow_field(0)?;
 
     Ok(NativeResult::ok(
         context.gas_used(),
-        smallvec![inputs_value],
+        smallvec![tx_inputs_ref],
     ))
 }
 
@@ -141,8 +153,8 @@ pub struct AuthContextReplaceCostParams {
 
 /// ****************************************************************************
 /// native fun replace
-/// Implementation of the Move native function `fun native_replace<I,
-/// C>(auth_digest: vector<u8>, tx_inputs: vector<I>, tx_commands: vector<C>)`
+/// Implementation of the Move native function `fun native_replace(auth_digest:
+/// vector<u8>,tx_inputs: vector<CallArg>,tx_commands: vector<Command>)`
 /// ****************************************************************************
 pub fn native_replace(
     context: &mut NativeContext,
@@ -162,59 +174,25 @@ pub fn native_replace(
 
     let command_type = ty_args.pop().unwrap();
     let command_move_layout = resolve_move_layout(context, &command_type)?;
-
-    let tx_commands = pop_arg!(args, Vec<Value>)
-        .into_iter()
-        .map(|value| from_value::<AuthContextCommand>(value, &command_move_layout))
-        .collect::<PartialVMResult<Vec<AuthContextCommand>>>()?;
+    let tx_commands_value = pop_arg!(args, Vec<Value>);
 
     let input_type = ty_args.pop().unwrap();
     let input_move_layout = resolve_move_layout(context, &input_type)?;
+    let tx_inputs_value = pop_arg!(args, Vec<Value>);
 
-    let tx_inputs = pop_arg!(args, Vec<Value>)
-        .into_iter()
-        .map(|value| from_value::<AuthContextCallArg>(value, &input_move_layout))
-        .collect::<PartialVMResult<Vec<AuthContextCallArg>>>()?;
-
-    let auth_digest = MoveAuthenticatorDigest::try_from(pop_arg!(args, Vec<u8>).as_slice())
-        .map_err(|err| {
-            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                .with_message(err.to_string())
-        })?;
+    let auth_digest_value = pop_arg!(args, Vec<u8>);
 
     let auth_context: &mut AuthenticationContext = get_extension_mut!(context)?;
 
-    auth_context.replace(auth_digest, tx_inputs, tx_commands)?;
+    auth_context.replace(
+        auth_digest_value,
+        tx_inputs_value,
+        input_move_layout,
+        tx_commands_value,
+        command_move_layout,
+    )?;
 
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
-}
-
-fn to_value<T: ?Sized + Serialize>(
-    input: &T,
-    input_move_layout: &MoveTypeLayout,
-) -> PartialVMResult<Value> {
-    let bytes = bcs::to_bytes(input).map_err(|err| {
-        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-            .with_message(format!("Failed to serialize an input: {err}"))
-    })?;
-    Value::simple_deserialize(&bytes, input_move_layout).ok_or_else(|| {
-        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-            .with_message("Failed to deserialize an input to a Move value".to_string())
-    })
-}
-
-fn from_value<T: DeserializeOwned>(
-    value: Value,
-    value_move_layout: &MoveTypeLayout,
-) -> PartialVMResult<T> {
-    let bytes = value.simple_serialize(value_move_layout).ok_or_else(|| {
-        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-            .with_message("Failed to serialize a value".to_string())
-    })?;
-    bcs::from_bytes::<T>(&bytes).map_err(|err| {
-        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-            .with_message(format!("Failed to deserialize a value: {err}"))
-    })
 }
 
 fn resolve_move_layout(context: &NativeContext, ty: &Type) -> PartialVMResult<MoveTypeLayout> {

--- a/iota-execution/latest/iota-move-natives/src/auth_context.rs
+++ b/iota-execution/latest/iota-move-natives/src/auth_context.rs
@@ -4,9 +4,7 @@
 use std::collections::VecDeque;
 
 use iota_types::{
-    auth_context::{
-        AuthContextCallArg, AuthContextCallArgV1, AuthContextCommand, AuthContextCommandV1,
-    },
+    auth_context::{AuthContextCallArg, AuthContextCommand},
     digests::MoveAuthenticatorDigest,
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
@@ -88,14 +86,7 @@ pub fn native_tx_commands(
 
     let auth_context: &AuthenticationContext = get_extension!(context)?;
 
-    // Unwrap the version tag: Move expects the V1 layout directly, without the
-    // outer `AuthContextCommand` variant discriminant.
-    let commands = auth_context.tx_commands();
-    let v1_commands: Vec<_> = commands
-        .iter()
-        .map(|AuthContextCommand::V1(v1)| v1)
-        .collect();
-    let commands_value = to_value(&v1_commands, &commands_move_layout)?;
+    let commands_value = to_value(&auth_context.tx_commands(), &commands_move_layout)?;
 
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -135,11 +126,7 @@ pub fn native_tx_inputs(
 
     let auth_context: &AuthenticationContext = get_extension!(context)?;
 
-    // Unwrap the version tag: Move expects the V1 layout directly, without the
-    // outer `AuthContextCallArg` variant discriminant.
-    let inputs = auth_context.tx_inputs();
-    let v1_inputs: Vec<_> = inputs.iter().map(|AuthContextCallArg::V1(v1)| v1).collect();
-    let inputs_value = to_value(&v1_inputs, &inputs_move_layout)?;
+    let inputs_value = to_value(&auth_context.tx_inputs(), &inputs_move_layout)?;
 
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -176,12 +163,9 @@ pub fn native_replace(
     let command_type = ty_args.pop().unwrap();
     let command_move_layout = resolve_move_layout(context, &command_type)?;
 
-    // Move sends V1 layout without a version tag, so deserialize into the V1
-    // type directly, then wrap with the version variant.
     let tx_commands = pop_arg!(args, Vec<Value>)
         .into_iter()
-        .map(|value| from_value::<AuthContextCommandV1>(value, &command_move_layout))
-        .map(|r| r.map(AuthContextCommand::V1))
+        .map(|value| from_value::<AuthContextCommand>(value, &command_move_layout))
         .collect::<PartialVMResult<Vec<AuthContextCommand>>>()?;
 
     let input_type = ty_args.pop().unwrap();
@@ -189,8 +173,7 @@ pub fn native_replace(
 
     let tx_inputs = pop_arg!(args, Vec<Value>)
         .into_iter()
-        .map(|value| from_value::<AuthContextCallArgV1>(value, &input_move_layout))
-        .map(|r| r.map(AuthContextCallArg::V1))
+        .map(|value| from_value::<AuthContextCallArg>(value, &input_move_layout))
         .collect::<PartialVMResult<Vec<AuthContextCallArg>>>()?;
 
     let auth_digest = MoveAuthenticatorDigest::try_from(pop_arg!(args, Vec<u8>).as_slice())

--- a/iota-execution/latest/iota-move-natives/src/authentication_context.rs
+++ b/iota-execution/latest/iota-move-natives/src/authentication_context.rs
@@ -9,8 +9,10 @@ use iota_types::{
     digests::MoveAuthenticatorDigest,
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
-use move_core_types::vm_status::StatusCode;
+use move_core_types::{runtime_value::MoveTypeLayout, vm_status::StatusCode};
 use move_vm_runtime::native_extensions::NativeExtensionMarker;
+use move_vm_types::values::{GlobalValue, Value};
+use serde::{Serialize, de::DeserializeOwned};
 
 // AuthenticationContext is a wrapper around AuthContext that is exposed to
 // NativeContextExtensions in order to provide authentication context
@@ -20,6 +22,9 @@ use move_vm_runtime::native_extensions::NativeExtensionMarker;
 pub struct AuthenticationContext {
     pub(crate) auth_context: Rc<RefCell<AuthContext>>,
     test_only: bool,
+    cached_with_digest: Option<GlobalValue>,
+    cached_with_tx_inputs: Option<GlobalValue>,
+    cached_with_tx_commands: Option<GlobalValue>,
 }
 
 impl NativeExtensionMarker<'_> for AuthenticationContext {}
@@ -29,6 +34,9 @@ impl AuthenticationContext {
         Self {
             auth_context,
             test_only: false,
+            cached_with_digest: None,
+            cached_with_tx_inputs: None,
+            cached_with_tx_commands: None,
         }
     }
 
@@ -36,28 +44,131 @@ impl AuthenticationContext {
         Self {
             auth_context,
             test_only: true,
+            cached_with_digest: None,
+            cached_with_tx_inputs: None,
+            cached_with_tx_commands: None,
         }
     }
 
-    pub fn digest(&self) -> MoveAuthenticatorDigest {
-        self.auth_context.borrow().digest().to_owned()
+    /// Returns a `GlobalValue` containing a struct with the auth digest field.
+    /// Caches the result to avoid redundant conversions and allocations on
+    /// subsequent calls.
+    ///
+    /// The returned `GlobalValue` is expected to be used as a reference in
+    /// native functions, so it should not be mutated or stored beyond the
+    /// scope of a single native function call.
+    pub fn struct_with_digest(&mut self) -> PartialVMResult<&GlobalValue> {
+        if self.cached_with_digest.is_none() {
+            let auth_context_ref = self.auth_context.borrow();
+            // Wrap in a tuple to match the expected Move layout of
+            // `struct AuthContext {
+            //     digest: vector<u8>
+            // }`
+            let struct_value_rust = (auth_context_ref.digest(),);
+            let digest_move_layout = MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8));
+            let value = to_value(
+                &struct_value_rust,
+                &AuthContext::layout_with_custom_field(digest_move_layout),
+            )?;
+            self.cached_with_digest =
+                Some(GlobalValue::cached(value).expect("Failed to cache global value"));
+        }
+
+        Ok(self.cached_with_digest.as_ref().unwrap())
     }
 
-    pub fn tx_commands(&self) -> Vec<AuthContextCommand> {
-        self.auth_context.borrow().tx_commands().to_owned()
+    /// Returns a `GlobalValue` containing a struct with the auth tx inputs.
+    /// Caches the result to avoid redundant conversions and allocations on
+    /// subsequent calls.
+    ///
+    /// The returned `GlobalValue` is expected to be used as a reference in
+    /// native functions, so it should not be mutated or stored beyond the
+    /// scope of a single native function call.
+    pub fn struct_with_tx_inputs(
+        &mut self,
+        input_move_layout: MoveTypeLayout,
+    ) -> PartialVMResult<&GlobalValue> {
+        // For fields V1 the tx inputs are a vector<CallArg>, so check that
+        // input_move_layout is an Enum, i.e. a CallArg enum
+        if !matches!(input_move_layout, MoveTypeLayout::Enum(_)) {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    format!("Unexpected `MoveTypeLayout` for tx inputs: {input_move_layout:?}"),
+                ),
+            );
+        }
+
+        if self.cached_with_tx_inputs.is_none() {
+            let auth_context_ref = self.auth_context.borrow();
+            // Wrap in a tuple to match the expected Move layout of
+            // `struct AuthContext {
+            //     tx_inputs: vector<CallArg>
+            // }`
+            let struct_value_rust = (auth_context_ref.tx_inputs(),);
+            let vector_input_move_layout = MoveTypeLayout::Vector(Box::new(input_move_layout));
+            let value = to_value(
+                &struct_value_rust,
+                &AuthContext::layout_with_custom_field(vector_input_move_layout),
+            )?;
+            self.cached_with_tx_inputs =
+                Some(GlobalValue::cached(value).expect("Failed to cache valid global value"));
+        }
+
+        Ok(self.cached_with_tx_inputs.as_ref().unwrap())
     }
 
-    pub fn tx_inputs(&self) -> Vec<AuthContextCallArg> {
-        self.auth_context.borrow().tx_inputs().to_owned()
+    /// Returns a `GlobalValue` containing a struct with the auth tx commands.
+    /// Caches the result to avoid redundant conversions and allocations on
+    /// subsequent calls.
+    ///
+    /// The returned `GlobalValue` is expected to be used as a reference in
+    /// native functions, so it should not be mutated or stored beyond the
+    /// scope of a single native function call.
+    pub fn struct_with_tx_commands(
+        &mut self,
+        command_move_layout: MoveTypeLayout,
+    ) -> PartialVMResult<&GlobalValue> {
+        // For fields V1 the tx commands are a vector<Command>, so check that
+        // command_move_layout is an Enum, i.e. a Command enum
+        if !matches!(command_move_layout, MoveTypeLayout::Enum(_)) {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    format!("Unexpected `MoveTypeLayout` for tx commands: {command_move_layout:?}"),
+                ),
+            );
+        }
+
+        if self.cached_with_tx_commands.is_none() {
+            let auth_context_ref = self.auth_context.borrow();
+            // Wrap in a tuple to match the expected Move layout of
+            //`struct AuthContext {
+            //     tx_commands: vector<Command>
+            // }`
+            let struct_value_rust = (auth_context_ref.tx_commands(),);
+            let vector_command_move_layout = MoveTypeLayout::Vector(Box::new(command_move_layout));
+            let value = to_value(
+                &struct_value_rust,
+                &AuthContext::layout_with_custom_field(vector_command_move_layout),
+            )?;
+            self.cached_with_tx_commands =
+                Some(GlobalValue::cached(value).expect("Failed to cache global value"));
+        }
+
+        Ok(self.cached_with_tx_commands.as_ref().unwrap())
     }
 
-    // Test only function
-    //
+    /// Replaces the contents of the `AuthContext` with the provided values.
+    /// Only callable in testing scenarios.
+    /// Expects the input values to be values, then it tries to convert them
+    /// back to their original rust types and updates the `AuthContext` with
+    /// the new values.
     pub fn replace(
         &self,
-        auth_digest: MoveAuthenticatorDigest,
-        tx_inputs: Vec<AuthContextCallArg>,
-        tx_commands: Vec<AuthContextCommand>,
+        auth_digest_value: Vec<u8>,
+        tx_inputs_value: Vec<Value>,
+        input_move_layout: MoveTypeLayout,
+        tx_commands_value: Vec<Value>,
+        command_move_layout: MoveTypeLayout,
     ) -> PartialVMResult<()> {
         if !self.test_only {
             return Err(
@@ -65,9 +176,75 @@ impl AuthenticationContext {
                     .with_message("`replace` called on a non testing scenario".to_string()),
             );
         }
+
+        // For fields V1 the tx inputs are a vector<CallArg>, so check that
+        // input_move_layout is an Enum, i.e. a CallArg enum
+        if !matches!(input_move_layout, MoveTypeLayout::Enum(_)) {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    format!("Unexpected `MoveTypeLayout` for tx inputs: {input_move_layout:?}"),
+                ),
+            );
+        }
+
+        // For fields V1 the tx commands are a vector<Command>, so check that
+        // command_move_layout is an Enum, i.e. a Command enum
+        if !matches!(command_move_layout, MoveTypeLayout::Enum(_)) {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    format!("Unexpected `MoveTypeLayout` for tx commands: {command_move_layout:?}"),
+                ),
+            );
+        }
+
+        let tx_commands = tx_commands_value
+            .into_iter()
+            .map(|value| from_value::<AuthContextCommand>(value, &command_move_layout))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+
+        let tx_inputs = tx_inputs_value
+            .into_iter()
+            .map(|value| from_value::<AuthContextCallArg>(value, &input_move_layout))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+
+        let auth_digest =
+            MoveAuthenticatorDigest::try_from(auth_digest_value.as_slice()).map_err(|err| {
+                PartialVMError::new(StatusCode::UNEXPECTED_DESERIALIZATION_ERROR)
+                    .with_message(err.to_string())
+            })?;
+
         self.auth_context
             .borrow_mut()
             .replace(auth_digest, tx_inputs, tx_commands);
+
         Ok(())
     }
+}
+
+fn to_value<T: ?Sized + Serialize>(
+    input: &T,
+    input_move_layout: &MoveTypeLayout,
+) -> PartialVMResult<Value> {
+    let bytes = bcs::to_bytes(input).map_err(|err| {
+        PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR)
+            .with_message(format!("Failed to serialize an input: {err}"))
+    })?;
+    Value::simple_deserialize(&bytes, input_move_layout).ok_or_else(|| {
+        PartialVMError::new(StatusCode::UNEXPECTED_DESERIALIZATION_ERROR)
+            .with_message("Failed to deserialize an input to a Move value".to_string())
+    })
+}
+
+fn from_value<T: DeserializeOwned>(
+    value: Value,
+    value_move_layout: &MoveTypeLayout,
+) -> PartialVMResult<T> {
+    let bytes = value.simple_serialize(value_move_layout).ok_or_else(|| {
+        PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR)
+            .with_message("Failed to serialize a value".to_string())
+    })?;
+    bcs::from_bytes::<T>(&bytes).map_err(|err| {
+        PartialVMError::new(StatusCode::UNEXPECTED_DESERIALIZATION_ERROR)
+            .with_message(format!("Failed to deserialize a value: {err}"))
+    })
 }

--- a/iota-execution/latest/iota-move-natives/src/authentication_context.rs
+++ b/iota-execution/latest/iota-move-natives/src/authentication_context.rs
@@ -5,9 +5,8 @@ use std::{cell::RefCell, rc::Rc};
 
 use better_any::{Tid, TidAble};
 use iota_types::{
-    auth_context::AuthContext,
+    auth_context::{AuthContext, AuthContextCallArg, AuthContextCommand},
     digests::MoveAuthenticatorDigest,
-    transaction::{CallArg, Command},
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::vm_status::StatusCode;
@@ -44,11 +43,11 @@ impl AuthenticationContext {
         self.auth_context.borrow().digest().to_owned()
     }
 
-    pub fn tx_commands(&self) -> Vec<Command> {
+    pub fn tx_commands(&self) -> Vec<AuthContextCommand> {
         self.auth_context.borrow().tx_commands().to_owned()
     }
 
-    pub fn tx_inputs(&self) -> Vec<CallArg> {
+    pub fn tx_inputs(&self) -> Vec<AuthContextCallArg> {
         self.auth_context.borrow().tx_inputs().to_owned()
     }
 
@@ -57,8 +56,8 @@ impl AuthenticationContext {
     pub fn replace(
         &self,
         auth_digest: MoveAuthenticatorDigest,
-        tx_inputs: Vec<CallArg>,
-        tx_commands: Vec<Command>,
+        tx_inputs: Vec<AuthContextCallArg>,
+        tx_commands: Vec<AuthContextCommand>,
     ) -> PartialVMResult<()> {
         if !self.test_only {
             return Err(


### PR DESCRIPTION
# Description of change

This PR makes it so that `AuthContext` fields use dedicated types instead of reusing the `PTB::Command` and `PTB::CallArg` types.  `AuthContextCommand` and `AuthContextCallArg` are created in such a way that `AuthContext` de/serialization from/to Move is straightforward.  

