### PR TITLE
feat(indexer): Add tx seq indexes to pruned tables, increase pruned batch for cp pruning

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-02-20-104335_add_tx_seq_index_on_tx_kinds/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104335_add_tx_seq_index_on_tx_kinds/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_tx_kinds_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104335_add_tx_seq_index_on_tx_kinds/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104335_add_tx_seq_index_on_tx_kinds/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104335_add_tx_seq_index_on_tx_kinds/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104335_add_tx_seq_index_on_tx_kinds/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_kinds_tx_seq ON tx_kinds (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104336_add_tx_seq_index_on_tx_senders/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104336_add_tx_seq_index_on_tx_senders/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_tx_senders_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104336_add_tx_seq_index_on_tx_senders/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104336_add_tx_seq_index_on_tx_senders/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104336_add_tx_seq_index_on_tx_senders/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104336_add_tx_seq_index_on_tx_senders/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_senders_tx_seq ON tx_senders (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104337_add_tx_seq_index_on_tx_recipients/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104337_add_tx_seq_index_on_tx_recipients/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_tx_recipients_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104337_add_tx_seq_index_on_tx_recipients/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104337_add_tx_seq_index_on_tx_recipients/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104337_add_tx_seq_index_on_tx_recipients/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104337_add_tx_seq_index_on_tx_recipients/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_recipients_tx_seq ON tx_recipients (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104338_add_tx_seq_index_on_tx_calls_pkg/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104338_add_tx_seq_index_on_tx_calls_pkg/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_tx_calls_pkg_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104338_add_tx_seq_index_on_tx_calls_pkg/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104338_add_tx_seq_index_on_tx_calls_pkg/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104338_add_tx_seq_index_on_tx_calls_pkg/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104338_add_tx_seq_index_on_tx_calls_pkg/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_calls_pkg_tx_seq ON tx_calls_pkg (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104339_add_tx_seq_index_on_tx_calls_mod/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104339_add_tx_seq_index_on_tx_calls_mod/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_tx_calls_mod_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104339_add_tx_seq_index_on_tx_calls_mod/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104339_add_tx_seq_index_on_tx_calls_mod/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104339_add_tx_seq_index_on_tx_calls_mod/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104339_add_tx_seq_index_on_tx_calls_mod/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_calls_mod_tx_seq ON tx_calls_mod (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104340_add_tx_seq_index_on_tx_calls_fun/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104340_add_tx_seq_index_on_tx_calls_fun/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_tx_calls_fun_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104340_add_tx_seq_index_on_tx_calls_fun/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104340_add_tx_seq_index_on_tx_calls_fun/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104340_add_tx_seq_index_on_tx_calls_fun/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104340_add_tx_seq_index_on_tx_calls_fun/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_calls_fun_tx_seq ON tx_calls_fun (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104341_add_tx_seq_index_on_event_emit_package/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104341_add_tx_seq_index_on_event_emit_package/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_event_emit_package_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104341_add_tx_seq_index_on_event_emit_package/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104341_add_tx_seq_index_on_event_emit_package/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104341_add_tx_seq_index_on_event_emit_package/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104341_add_tx_seq_index_on_event_emit_package/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_emit_package_tx_seq ON event_emit_package (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104342_add_tx_seq_index_on_event_emit_module/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104342_add_tx_seq_index_on_event_emit_module/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_event_emit_module_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104342_add_tx_seq_index_on_event_emit_module/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104342_add_tx_seq_index_on_event_emit_module/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104342_add_tx_seq_index_on_event_emit_module/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104342_add_tx_seq_index_on_event_emit_module/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_emit_module_tx_seq ON event_emit_module (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104343_add_tx_seq_index_on_event_senders/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104343_add_tx_seq_index_on_event_senders/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_event_senders_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104343_add_tx_seq_index_on_event_senders/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104343_add_tx_seq_index_on_event_senders/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104343_add_tx_seq_index_on_event_senders/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104343_add_tx_seq_index_on_event_senders/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_senders_tx_seq ON event_senders (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104344_add_tx_seq_index_on_event_struct_instantiation/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104344_add_tx_seq_index_on_event_struct_instantiation/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_event_struct_inst_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104344_add_tx_seq_index_on_event_struct_instantiation/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104344_add_tx_seq_index_on_event_struct_instantiation/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104344_add_tx_seq_index_on_event_struct_instantiation/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104344_add_tx_seq_index_on_event_struct_instantiation/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_struct_inst_tx_seq ON event_struct_instantiation (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104345_add_tx_seq_index_on_event_struct_module/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104345_add_tx_seq_index_on_event_struct_module/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_event_struct_module_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104345_add_tx_seq_index_on_event_struct_module/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104345_add_tx_seq_index_on_event_struct_module/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104345_add_tx_seq_index_on_event_struct_module/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104345_add_tx_seq_index_on_event_struct_module/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_struct_module_tx_seq ON event_struct_module (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104346_add_tx_seq_index_on_event_struct_name/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104346_add_tx_seq_index_on_event_struct_name/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_event_struct_name_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104346_add_tx_seq_index_on_event_struct_name/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104346_add_tx_seq_index_on_event_struct_name/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104346_add_tx_seq_index_on_event_struct_name/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104346_add_tx_seq_index_on_event_struct_name/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_struct_name_tx_seq ON event_struct_name (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104347_add_tx_seq_index_on_event_struct_package/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104347_add_tx_seq_index_on_event_struct_package/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_event_struct_package_tx_seq;

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104347_add_tx_seq_index_on_event_struct_package/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104347_add_tx_seq_index_on_event_struct_package/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-02-20-104347_add_tx_seq_index_on_event_struct_package/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-20-104347_add_tx_seq_index_on_event_struct_package/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_struct_package_tx_seq ON event_struct_package (tx_sequence_number);

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -36,7 +36,7 @@ const MAX_TRANSACTIONS_PER_PRUNE_BATCH: u64 = 1000;
 
 /// Maximum number of checkpoints to prune in a single batch for ByCheckpoint
 /// strategy
-const MAX_CHECKPOINTS_PER_PRUNE_BATCH: u64 = 100;
+const MAX_CHECKPOINTS_PER_PRUNE_BATCH: u64 = 1000;
 
 /// Interval for running the pruning task
 const PRUNING_TASK_INTERVAL: Duration = Duration::from_secs(5);


### PR DESCRIPTION
# Description of change

Increase pruning performance by adding indexes to tx seq column, and by increasing batch size for cp based pruning

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/10467

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Performance was tested by running benchmark on staging server, all tables were pruning with good performance.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
