### PR TITLE
feat(iota-indexer): replaces JSON RPC dry_run with gRPC simulate api

### DIFF
--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -23,11 +23,15 @@ use iota_protocol_config::Chain;
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     base_types::IotaAddress,
-    effects::{TransactionEffects, TransactionEvents},
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
+    error::ExecutionError,
     iota_serde::BigInt,
     quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,
-    transaction::{SenderSignedData, TransactionData},
+    transaction::{
+        GasData, SenderSignedData, TransactionData, TransactionDataV1, TransactionExpiration,
+        TransactionKind,
+    },
 };
 use jsonrpsee::{RpcModule, core::RpcResult, http_client::HttpClient};
 
@@ -52,6 +56,22 @@ const DRY_RUN_TRANSACTION_READ_MASK: &[&str] = &[
     "executed_transaction.output_objects.bcs",
     "suggested_gas_price",
     "execution_result.execution_error.source",
+];
+const DEV_INSPECT_TRANSACTION_READ_MASK: &[&str] = &[
+    "executed_transaction.effects.bcs",
+    "executed_transaction.events.events.bcs",
+    "execution_result.execution_error.bcs_kind",
+    "execution_result.execution_error.source",
+    "execution_result.execution_error.command_index",
+    "execution_result.command_results.mutated_by_ref.argument",
+    "execution_result.command_results.mutated_by_ref.type_tag",
+    "execution_result.command_results.mutated_by_ref.bcs",
+    "execution_result.command_results.return_values.type_tag",
+    "execution_result.command_results.return_values.bcs",
+];
+const EPOCH_READ_MASK: &[&str] = &[
+    "reference_gas_price",
+    "protocol_config.attributes.max_tx_gas",
 ];
 
 #[derive(Clone)]
@@ -174,6 +194,146 @@ impl WriteApi {
             execution_error_source,
         })
     }
+
+    async fn dev_inspect_transaction_block_impl(
+        &self,
+        sender_address: IotaAddress,
+        tx_bytes: Base64,
+        gas_price: Option<BigInt<u64>>,
+        additional_args: Option<DevInspectArgs>,
+        package_resolver: &Arc<Resolver<impl PackageStore>>,
+    ) -> IndexerResult<DevInspectResults> {
+        let DevInspectArgs {
+            gas_sponsor,
+            gas_budget,
+            gas_objects,
+            show_raw_txn_data_and_effects,
+            skip_checks: _,
+        } = additional_args.unwrap_or_default();
+
+        let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
+
+        let (price, budget) = match (gas_price, gas_budget) {
+            (Some(price), Some(budget)) => (price.into_inner(), budget.into_inner()),
+            (price, budget) => {
+                let (ref_price, max_gas) = self.reference_gas_price_and_max_tx_gas().await?;
+                (
+                    price.map(BigInt::into_inner).unwrap_or(ref_price),
+                    budget.map(BigInt::into_inner).unwrap_or(max_gas),
+                )
+            }
+        };
+
+        let owner = gas_sponsor.unwrap_or(sender_address);
+        let payment = gas_objects.unwrap_or_default();
+
+        let kind = bcs::from_bytes::<TransactionKind>(&tx_bytes.to_vec()?)?;
+
+        let transaction_data = TransactionData::V1(TransactionDataV1 {
+            kind,
+            sender: sender_address,
+            gas_data: GasData {
+                payment,
+                owner,
+                price,
+                budget,
+            },
+            expiration: TransactionExpiration::None,
+        });
+
+        let raw_txn_data = show_raw_txn_data_and_effects
+            .then(|| bcs::to_bytes(&transaction_data))
+            .transpose()?
+            .unwrap_or_default();
+
+        let readmask = FieldMask::from_paths(DEV_INSPECT_TRANSACTION_READ_MASK)
+            .display()
+            .to_string();
+
+        let simulate_tx_response = self
+            .fullnode_grpc_client
+            .simulate_transaction(
+                transaction_data.try_into()?,
+                true,
+                false,
+                Some(readmask.as_str()),
+            )
+            .await?;
+
+        let executed_transaction = simulate_tx_response.executed_transaction()?;
+
+        let tx_effects: TransactionEffects =
+            executed_transaction.effects()?.effects()?.try_into()?;
+
+        let raw_effects = show_raw_txn_data_and_effects
+            .then(|| bcs::to_bytes(&tx_effects))
+            .transpose()?
+            .unwrap_or_default();
+
+        let tx_events = TransactionEvents::try_from(executed_transaction.events()?.events()?)?;
+
+        let tx_digest = *tx_effects.transaction_digest();
+        // timestamp is None because it represent a checkpoint one, on a dev inspect
+        // operation we don't have this information.
+        let events =
+            tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, None).await?;
+
+        let execution_error = simulate_tx_response
+            .execution_error()
+            .map(|execution_error| -> IndexerResult<_> {
+                let exec_err = execution_error.error_kind()?;
+                let source = execution_error
+                    .source
+                    .clone()
+                    .map(|s| -> Box<dyn std::error::Error + Send + Sync> { s.into() });
+
+                let mut error = ExecutionError::new(exec_err.into(), source);
+                if let Some(command_index) = execution_error.command_index {
+                    error = error.with_command_index(command_index as usize);
+                }
+                Ok(error.to_string())
+            })
+            .transpose()?;
+
+        let results = simulate_tx_response
+            .command_results()
+            .map(|command_results| grpc_conversion::command_results(command_results.clone()))
+            .transpose()?;
+
+        Ok(DevInspectResults {
+            effects: tx_effects.try_into()?,
+            events,
+            results,
+            error: execution_error,
+            raw_txn_data,
+            raw_effects,
+        })
+    }
+
+    /// Gets the reference gas price and max transaction gas from the gRPC API.
+    async fn reference_gas_price_and_max_tx_gas(&self) -> IndexerResult<(u64, u64)> {
+        let readmask = FieldMask::from_paths(EPOCH_READ_MASK).display().to_string();
+
+        let epoch = self
+            .fullnode_grpc_client
+            .get_epoch(
+                None, // we're requesting the information for the current epoch.
+                Some(readmask.as_str()),
+            )
+            .await?;
+
+        let max_tx_gas = epoch
+            .protocol_config()?
+            .attributes()?
+            .get("max_tx_gas")
+            .ok_or_else(|| {
+                IndexerError::Grpc("protocol_config's `max_tx_gas` should be available".into())
+            })?
+            .parse::<u64>()
+            .map_err(|e| IndexerError::Grpc(e.to_string()))?;
+
+        Ok((epoch.reference_gas_price(), max_tx_gas))
+    }
 }
 
 impl OptimisticWriteApi {
@@ -219,13 +379,21 @@ impl WriteApiServer for WriteApi {
 
     async fn dev_inspect_transaction_block(
         &self,
-        _sender_address: IotaAddress,
-        _tx_bytes: Base64,
-        _gas_price: Option<BigInt<u64>>,
+        sender_address: IotaAddress,
+        tx_bytes: Base64,
+        gas_price: Option<BigInt<u64>>,
         _epoch: Option<BigInt<u64>>,
-        _additional_args: Option<DevInspectArgs>,
+        additional_args: Option<DevInspectArgs>,
     ) -> RpcResult<DevInspectResults> {
-        todo!("waiting issue: #10390 and #10391 to be resolved");
+        self.dev_inspect_transaction_block_impl(
+            sender_address,
+            tx_bytes,
+            gas_price,
+            additional_args,
+            &self.package_resolver,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn dry_run_transaction_block(

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -6,34 +6,56 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use fastcrypto::encoding::Base64;
+use futures::{FutureExt, TryFutureExt};
 use iota_grpc_client::Client as GrpcClient;
+use iota_grpc_types::field::{FieldMask, FieldMaskUtil};
 use iota_json::IotaJsonValue;
 use iota_json_rpc::IotaRpcModule;
 use iota_json_rpc_api::WriteApiServer;
 use iota_json_rpc_types::{
     DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, IotaMoveViewCallResults,
-    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, IotaTypeTag,
-    MoveFunctionName,
+    IotaTransactionBlock, IotaTransactionBlockEffects, IotaTransactionBlockResponse,
+    IotaTransactionBlockResponseOptions, IotaTypeTag, MoveFunctionName,
 };
 use iota_open_rpc::Module;
-use iota_package_resolver::Resolver;
+use iota_package_resolver::{PackageStore, Resolver};
 use iota_protocol_config::Chain;
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
-    base_types::IotaAddress, iota_serde::BigInt, quorum_driver_types::ExecuteTransactionRequestType,
+    base_types::IotaAddress,
+    effects::{TransactionEffects, TransactionEvents},
+    iota_serde::BigInt,
+    quorum_driver_types::ExecuteTransactionRequestType,
+    signature::GenericSignature,
+    transaction::{SenderSignedData, TransactionData},
 };
 use jsonrpsee::{RpcModule, core::RpcResult, http_client::HttpClient};
 
 use crate::{
-    apis::error::Error as ApiError, errors::IndexerError,
-    optimistic_indexing::OptimisticTransactionExecutor, read::IndexerReader,
+    apis::error::Error as ApiError,
+    errors::{IndexerError, IndexerResult},
+    ingestion::primary::prepare::InMemTxChanges,
+    metrics::IndexerMetrics,
+    models::transactions::tx_events_to_iota_tx_events,
+    optimistic_indexing::OptimisticTransactionExecutor,
+    read::IndexerReader,
     store::package_resolver::IndexerStorePackageResolver,
-    types::IotaTransactionBlockResponseWithOptions,
+    types::{IotaTransactionBlockResponseWithOptions, grpc_conversion},
 };
+
+// As an optimization, we're trying to request only the fields we actually need.
+const DRY_RUN_TRANSACTION_READ_MASK: &[&str] = &[
+    "executed_transaction.signatures.bcs",
+    "executed_transaction.effects.bcs",
+    "executed_transaction.events.events.bcs",
+    "executed_transaction.input_objects.bcs",
+    "executed_transaction.output_objects.bcs",
+    "suggested_gas_price",
+    "execution_result.execution_error.source",
+];
 
 #[derive(Clone)]
 pub struct WriteApi {
-    #[allow(dead_code)]
     fullnode_grpc_client: GrpcClient,
     transaction_builder: TransactionBuilder,
     package_resolver: Arc<Resolver<IndexerStorePackageResolver>>,
@@ -54,6 +76,103 @@ impl WriteApi {
             transaction_builder: TransactionBuilder::new(data_reader),
             package_resolver: Arc::new(Resolver::new(package_resolver)),
         }
+    }
+
+    async fn dry_run_transaction_block_impl(
+        &self,
+        tx_bytes: Base64,
+        package_resolver: &Arc<Resolver<impl PackageStore>>,
+    ) -> IndexerResult<DryRunTransactionBlockResponse> {
+        let transaction_data = bcs::from_bytes::<TransactionData>(&tx_bytes.to_vec()?)?;
+        let tx_digest = transaction_data.digest();
+
+        let readmask = FieldMask::from_paths(DRY_RUN_TRANSACTION_READ_MASK)
+            .display()
+            .to_string();
+
+        let simulate_tx_response = self
+            .fullnode_grpc_client
+            .simulate_transaction(
+                transaction_data.clone().try_into()?,
+                false,
+                false,
+                Some(readmask.as_str()),
+            )
+            .await?;
+
+        let executed_transaction = simulate_tx_response.executed_transaction()?;
+        let execution_error_source = simulate_tx_response
+            .execution_error()
+            .and_then(|e| e.source.clone());
+        let suggested_gas_price = simulate_tx_response.suggested_gas_price;
+
+        let input_objects = grpc_conversion::objects(executed_transaction.input_objects()?)?;
+        let output_objects = grpc_conversion::objects(executed_transaction.output_objects()?)?;
+
+        let objects = input_objects
+            .iter()
+            .chain(output_objects.iter())
+            .collect::<Vec<_>>();
+
+        let tx_effects: TransactionEffects =
+            executed_transaction.effects()?.effects()?.try_into()?;
+
+        let tx_signatures = executed_transaction
+            .signatures()?
+            .signatures
+            .iter()
+            .map(|s| -> IndexerResult<_> { Ok(GenericSignature::try_from(s.signature()?)?) })
+            .collect::<IndexerResult<Vec<GenericSignature>>>()?;
+
+        let sender_signed_data = SenderSignedData::new(transaction_data.clone(), tx_signatures);
+
+        let tx_events = TransactionEvents::try_from(executed_transaction.events()?.events()?)?;
+
+        let in_mem_tx_changes =
+            InMemTxChanges::new(&objects, IndexerMetrics::new(&Default::default()));
+
+        // as a minor optimization we will run concurrently the following four futures
+        let fut1 = in_mem_tx_changes
+            .get_changes(&transaction_data, &tx_effects, &tx_digest)
+            .map_ok(|(balance_changes, object_changes)| {
+                (
+                    balance_changes,
+                    object_changes
+                        .into_iter()
+                        .map(iota_json_rpc_types::ObjectChange::from)
+                        .collect::<Vec<_>>(),
+                )
+            });
+
+        let fut2 = IotaTransactionBlock::try_from_with_package_resolver(
+            sender_signed_data,
+            package_resolver,
+            tx_digest,
+        )
+        .map_err(Into::into);
+
+        // timestamp is None because it represent a checkpoint one, on a dry run
+        // operation we don't have this information.
+        let fut3 = tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, None);
+
+        let fut4 = IotaTransactionBlockEffects::from_native_with_clever_error(
+            tx_effects.clone(),
+            package_resolver,
+        )
+        .map(Ok);
+
+        let ((balance_changes, object_changes), transaction_block, events, effects) =
+            futures::future::try_join4(fut1, fut2, fut3, fut4).await?;
+
+        Ok(DryRunTransactionBlockResponse {
+            effects,
+            events,
+            object_changes,
+            balance_changes,
+            input: transaction_block.data,
+            suggested_gas_price,
+            execution_error_source,
+        })
     }
 }
 
@@ -111,9 +230,11 @@ impl WriteApiServer for WriteApi {
 
     async fn dry_run_transaction_block(
         &self,
-        _tx_bytes: Base64,
+        tx_bytes: Base64,
     ) -> RpcResult<DryRunTransactionBlockResponse> {
-        todo!("waiting issue: #10390 and #10391 to be resolved");
+        self.dry_run_transaction_block_impl(tx_bytes, &self.package_resolver)
+            .await
+            .map_err(Into::into)
     }
 
     async fn view_function_call(

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -749,8 +749,15 @@ impl From<IotaTransactionBlockResponseWithOptions> for IotaTransactionBlockRespo
 
 /// Provides conversion methods from gRPC types to iota core types.
 pub(crate) mod grpc_conversion {
-    use iota_grpc_types::v0::object::Objects as GrpcObjects;
-    use iota_types::object::Object;
+
+    use iota_grpc_types::v0::{
+        command::{CommandOutputs as GrpcCommandOutputs, CommandResults as GrpcCommandResults},
+        object::Objects as GrpcObjects,
+    };
+    use iota_json_rpc_types::{IotaArgument, IotaExecutionResult, IotaTypeTag};
+    use iota_types::{
+        iota_sdk_types_conversions::type_tag_sdk_to_core, object::Object, transaction::Argument,
+    };
 
     use crate::types::IndexerResult;
 
@@ -760,6 +767,62 @@ pub(crate) mod grpc_conversion {
             .objects
             .iter()
             .map(|o| -> IndexerResult<_> { Ok(Object::try_from(o.object()?)?) })
+            .collect()
+    }
+
+    fn convert_command_outputs_into_mutated_by_ref(
+        command_outputs: GrpcCommandOutputs,
+    ) -> IndexerResult<Vec<(IotaArgument, Vec<u8>, IotaTypeTag)>> {
+        command_outputs
+            .outputs
+            .into_iter()
+            .map(|command_output| -> IndexerResult<_> {
+                Ok((
+                    IotaArgument::from(Argument::from(command_output.argument()?)),
+                    command_output.output_bcs()?.to_vec(),
+                    type_tag_sdk_to_core(&command_output.type_tag()?)?.into(),
+                ))
+            })
+            .collect()
+    }
+
+    fn convert_command_outputs_into_return_values(
+        command_outputs: GrpcCommandOutputs,
+    ) -> IndexerResult<Vec<(Vec<u8>, IotaTypeTag)>> {
+        command_outputs
+            .outputs
+            .into_iter()
+            .map(|command_output| -> IndexerResult<_> {
+                Ok((
+                    command_output.output_bcs()?.to_vec(),
+                    type_tag_sdk_to_core(&command_output.type_tag()?)?.into(),
+                ))
+            })
+            .collect()
+    }
+
+    /// Converts [`GrpcCommandResults`] into [`IotaExecutionResult`]
+    pub(crate) fn command_results(
+        command_results: GrpcCommandResults,
+    ) -> IndexerResult<Vec<IotaExecutionResult>> {
+        command_results
+            .results
+            .into_iter()
+            .map(|command_result| -> IndexerResult<_> {
+                let mutable_reference_outputs = command_result
+                    .mutated_by_ref()
+                    .map_err(Into::into)
+                    .and_then(|c| convert_command_outputs_into_mutated_by_ref(c.clone()))?;
+                let return_values = command_result
+                    .return_values()
+                    .map_err(Into::into)
+                    .and_then(|c| convert_command_outputs_into_return_values(c.clone()))?;
+
+                Ok(IotaExecutionResult {
+                    mutable_reference_outputs,
+                    return_values,
+                })
+            })
             .collect()
     }
 }


### PR DESCRIPTION
# Description of change

This PR replaces the iota-indexer JSON RPC `dry_run_transaction_block` with gRPC simulate api.

## Links to any relevant issues

fixes #10315 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

- Ran indexer tests, made sure that the `dry_run_transaction_block` test case passed.

 ```shell
cargo test -p iota-indexer --profile simulator --features shared_test_runtime
```

> [!NOTE]
> indexer dev_inspect tests are expected to fails since they are not using grpc api, we have a dedicated issue to integrate dev_inspect with grpc simulate api. Same goes for the graphql tests.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.