### PR TITLE
feat(types,json-rpc)!: expose effective commission rate for validator summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6921,6 +6921,7 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
+ "derive_more 1.0.0",
  "diesel",
  "diesel_migrations",
  "downcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6773,6 +6773,7 @@ dependencies = [
  "iota-names",
  "iota-network-stack",
  "iota-package-resolver",
+ "iota-protocol-config",
  "iota-rest-api",
  "iota-sdk-types",
  "iota-swarm-config",

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -903,6 +903,7 @@ mod sim_only_tests {
                     .as_ref(),
                 inner.validators.inactive_validators.id,
                 &ID::new(ObjectID::ZERO),
+                Some(system_state.protocol_version()),
             )
             .unwrap();
         } else {
@@ -928,6 +929,7 @@ mod sim_only_tests {
                     .as_ref(),
                 inner.validators.inactive_validators.id,
                 &ID::new(ObjectID::ZERO),
+                Some(system_state.protocol_version()),
             )
             .unwrap();
         } else {

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -903,7 +903,7 @@ mod sim_only_tests {
                     .as_ref(),
                 inner.validators.inactive_validators.id,
                 &ID::new(ObjectID::ZERO),
-                Some(system_state.protocol_version()),
+                Some(inner.protocol_version),
             )
             .unwrap();
         } else {
@@ -929,7 +929,7 @@ mod sim_only_tests {
                     .as_ref(),
                 inner.validators.inactive_validators.id,
                 &ID::new(ObjectID::ZERO),
-                Some(system_state.protocol_version()),
+                None,
             )
             .unwrap();
         } else {

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -553,6 +553,7 @@ async fn test_validator_candidate_pool_read() {
                 _ => panic!("unsupported IotaSystemStateSummary"),
             },
             &address,
+            Some(system_state.protocol_version()),
         )
         .unwrap()
         .staking_pool_id;

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -64,6 +64,7 @@ iota-metrics.workspace = true
 iota-names.workspace = true
 iota-network-stack.workspace = true
 iota-package-resolver.workspace = true
+iota-protocol-config.workspace = true
 iota-rest-api.workspace = true
 iota-sdk-types.workspace = true
 iota-swarm-config.workspace = true

--- a/crates/iota-graphql-rpc/src/types/validator.rs
+++ b/crates/iota-graphql-rpc/src/types/validator.rs
@@ -12,6 +12,7 @@ use async_graphql::{
 use futures::TryFutureExt;
 use iota_indexer::apis::GovernanceReadApi;
 use iota_json_rpc::governance_api::mean_apy_from_exchange_rates;
+use iota_protocol_config::PROTOCOL_VERSION_IIP8;
 use iota_types::{
     base_types::IotaAddress as NativeIotaAddress,
     committee::EpochId,
@@ -39,9 +40,6 @@ use crate::{
         validator_credentials::ValidatorCredentials,
     },
 };
-
-/// The protocol version that IIP8 was put in effect.
-const IIP8_PROTOCOL_VERSION: u64 = 20;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Validator {
@@ -355,7 +353,7 @@ impl Validator {
         .await
         .extend()?;
         if let Some(epoch) = epoch {
-            if epoch.protocol_version() < IIP8_PROTOCOL_VERSION {
+            if epoch.protocol_version() < PROTOCOL_VERSION_IIP8 {
                 // Pre IIP8
                 return Ok(Some(summary.commission_rate));
             }

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -18,6 +18,7 @@ cached.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["env"] }
 dashmap.workspace = true
+derive_more.workspace = true
 diesel = { workspace = true, features = ["chrono", "r2d2", "serde_json", "postgres"] }
 diesel_migrations = "2.2.0"
 downcast.workspace = true

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -434,6 +434,7 @@ impl GovernanceReadApi {
                 system_state_summary.inactive_pools_id(),
                 system_state_summary.inactive_pools_size(),
                 |df| bcs::from_bytes::<ID>(&df.bcs_name).map_err(Into::into),
+                Some(system_state_summary.protocol_version().as_u64()),
             )
             .await?;
 
@@ -482,6 +483,7 @@ impl GovernanceReadApi {
                 system_state_summary.validator_candidates_id(),
                 system_state_summary.validator_candidates_size(),
                 |df| bcs::from_bytes::<IotaAddress>(&df.bcs_name).map_err(Into::into),
+                Some(system_state_summary.protocol_version().as_u64()),
             )
             .await?;
 
@@ -538,6 +540,7 @@ impl GovernanceReadApi {
         table_id: ObjectID,
         validator_size: u64,
         key: F,
+        protocol_version: Option<u64>,
     ) -> Result<Vec<ValidatorTable>, IndexerError>
     where
         F: Fn(DynamicFieldInfo) -> Result<K, IndexerError>,
@@ -555,7 +558,12 @@ impl GovernanceReadApi {
             let validator_candidate = self
                 .inner
                 .spawn_blocking(move |this| {
-                    iota_types::iota_system_state::get_validator_from_table(&this, table_id, &key)
+                    iota_types::iota_system_state::get_validator_from_table(
+                        &this,
+                        table_id,
+                        &key,
+                        protocol_version,
+                    )
                 })
                 .await?;
 

--- a/crates/iota-indexer/src/models/epoch.rs
+++ b/crates/iota-indexer/src/models/epoch.rs
@@ -8,14 +8,13 @@ use diesel::{
 };
 use iota_json_rpc_types::{EndOfEpochInfo, EpochInfo};
 use iota_types::{
-    iota_system_state::iota_system_state_summary::{
-        IotaSystemStateSummary, IotaSystemStateSummaryV1,
-    },
+    iota_system_state::iota_system_state_summary::IotaSystemStateSummary,
     messages_checkpoint::CertifiedCheckpointSummary,
 };
 
 use crate::{
     errors::IndexerError,
+    models::system_state::{StoredSystemState, StoredSystemStateV1},
     schema::{epochs, feature_flags, protocol_configs},
     types::IndexedEpochInfoEvent,
 };
@@ -153,6 +152,7 @@ impl StartOfEpochUpdate {
             Some(event) => (event.total_stake, event.storage_fund_balance),
             None => (0, 0),
         };
+        let stored_system_state = StoredSystemState::from(new_system_state_summary.clone());
         Self {
             epoch: new_system_state_summary.epoch() as i64,
             first_checkpoint_id: first_checkpoint_id as i64,
@@ -162,7 +162,7 @@ impl StartOfEpochUpdate {
             protocol_version: new_system_state_summary.protocol_version().as_u64() as i64,
             total_stake: total_stake as i64,
             storage_fund_balance: storage_fund_balance as i64,
-            system_state: bcs::to_bytes(new_system_state_summary).unwrap(),
+            system_state: bcs::to_bytes(&stored_system_state).unwrap(),
         }
     }
 }
@@ -216,11 +216,11 @@ impl From<&StoredEpochInfo> for Option<EndOfEpochInfo> {
     }
 }
 
-impl TryFrom<&StoredEpochInfo> for IotaSystemStateSummary {
+impl TryFrom<&StoredEpochInfo> for StoredSystemState {
     type Error = IndexerError;
 
     fn try_from(value: &StoredEpochInfo) -> Result<Self, Self::Error> {
-        IotaSystemStateSummaryV1::try_from(value)
+        StoredSystemStateV1::try_from(value)
             .map(Into::into)
             .or_else(|_| {
                 bcs::from_bytes(&value.system_state).map_err(|_| {
@@ -232,7 +232,7 @@ impl TryFrom<&StoredEpochInfo> for IotaSystemStateSummary {
     }
 }
 
-impl TryFrom<&StoredEpochInfo> for IotaSystemStateSummaryV1 {
+impl TryFrom<&StoredEpochInfo> for StoredSystemStateV1 {
     type Error = IndexerError;
 
     fn try_from(value: &StoredEpochInfo) -> Result<Self, Self::Error> {
@@ -250,11 +250,12 @@ impl TryFrom<StoredEpochInfo> for EpochInfo {
     fn try_from(value: StoredEpochInfo) -> Result<Self, Self::Error> {
         let epoch = value.epoch as u64;
         let end_of_epoch_info = (&value).into();
-        let system_state = IotaSystemStateSummary::try_from(&value).map_err(|_| {
+        let stored_system_state = StoredSystemState::try_from(&value).map_err(|_| {
             IndexerError::PersistentStorageDataCorruption(format!(
                 "failed to deserialize `system_state` for epoch {epoch}",
             ))
         })?;
+        let system_state = IotaSystemStateSummary::from(stored_system_state);
         Ok(EpochInfo {
             epoch: value.epoch as u64,
             validators: system_state.active_validators().to_vec(),

--- a/crates/iota-indexer/src/models/mod.rs
+++ b/crates/iota-indexer/src/models/mod.rs
@@ -14,6 +14,7 @@ pub mod obj_indices;
 pub mod objects;
 pub mod packages;
 pub mod participation_metrics;
+pub mod system_state;
 pub mod transactions;
 pub mod tx_count_metrics;
 pub mod tx_indices;

--- a/crates/iota-indexer/src/models/system_state.rs
+++ b/crates/iota-indexer/src/models/system_state.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::encoding::Base64;
+use iota_protocol_config::PROTOCOL_VERSION_IIP8;
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
     iota_serde::{BigInt, Readable},
@@ -12,9 +13,6 @@ use iota_types::{
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-
-/// Protocol version that IIP8 was put in effect.
-const PROTOCOL_VERSION_IIP8: u64 = 20;
 
 /// The representation of system state.
 #[non_exhaustive]

--- a/crates/iota-indexer/src/models/system_state.rs
+++ b/crates/iota-indexer/src/models/system_state.rs
@@ -1,0 +1,895 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use fastcrypto::encoding::Base64;
+use iota_types::{
+    base_types::{IotaAddress, ObjectID},
+    iota_serde::{BigInt, Readable},
+    iota_system_state::iota_system_state_summary::{
+        IotaSystemStateSummary, IotaSystemStateSummaryV1, IotaSystemStateSummaryV2,
+        IotaValidatorSummary,
+    },
+};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+/// Protocol version that IIP8 was put in effect.
+const PROTOCOL_VERSION_IIP8: u64 = 20;
+
+/// The representation of system state.
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize, Clone, derive_more::From)]
+pub enum StoredSystemState {
+    V1(StoredSystemStateV1),
+    V2(StoredSystemStateV2),
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredSystemStateV1 {
+    /// The current epoch ID, starting from 0.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub epoch: u64,
+    /// The current protocol version, starting from 1.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub protocol_version: u64,
+    /// The current version of the system state data structure type.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub system_state_version: u64,
+    /// The current IOTA supply.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub iota_total_supply: u64,
+    /// The `TreasuryCap<IOTA>` object ID.
+    pub iota_treasury_cap_id: ObjectID,
+    /// The storage rebates of all the objects on-chain stored in the storage
+    /// fund.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub storage_fund_total_object_storage_rebates: u64,
+    /// The non-refundable portion of the storage fund coming from
+    /// non-refundable storage rebates and any leftover
+    /// staking rewards.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub storage_fund_non_refundable_balance: u64,
+    /// The reference gas price for the current epoch.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub reference_gas_price: u64,
+    /// Whether the system is running in a downgraded safe mode due to a
+    /// non-recoverable bug. This is set whenever we failed to execute
+    /// advance_epoch, and ended up executing advance_epoch_safe_mode.
+    /// It can be reset once we are able to successfully execute advance_epoch.
+    pub safe_mode: bool,
+    /// Amount of storage charges accumulated (and not yet distributed) during
+    /// safe mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_storage_charges: u64,
+    /// Amount of computation rewards accumulated (and not yet distributed)
+    /// during safe mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_computation_rewards: u64,
+    /// Amount of storage rebates accumulated (and not yet burned) during safe
+    /// mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_storage_rebates: u64,
+    /// Amount of non-refundable storage fee accumulated during safe mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_non_refundable_storage_fee: u64,
+    /// Unix timestamp of the current epoch start
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub epoch_start_timestamp_ms: u64,
+
+    // System parameters
+    /// The duration of an epoch, in milliseconds.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub epoch_duration_ms: u64,
+
+    /// Minimum number of active validators at any moment.
+    /// We do not allow the number of validators in any epoch to go under this.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub min_validator_count: u64,
+
+    /// Maximum number of active validators at any moment.
+    /// We do not allow the number of validators in any epoch to go above this.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub max_validator_count: u64,
+
+    /// Lower-bound on the amount of stake required to become a validator.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub min_validator_joining_stake: u64,
+
+    /// Validators with stake amount below `validator_low_stake_threshold` are
+    /// considered to have low stake and will be escorted out of the
+    /// validator set after being below this threshold for more than
+    /// `validator_low_stake_grace_period` number of epochs.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub validator_low_stake_threshold: u64,
+
+    /// Validators with stake below `validator_very_low_stake_threshold` will be
+    /// removed immediately at epoch change, no grace period.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub validator_very_low_stake_threshold: u64,
+
+    /// A validator can have stake below `validator_low_stake_threshold`
+    /// for this many epochs before being kicked out.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub validator_low_stake_grace_period: u64,
+
+    // Validator set
+    /// Total amount of stake from all active validators at the beginning of the
+    /// epoch.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub total_stake: u64,
+    /// The list of active validators in the current epoch.
+    pub active_validators: Vec<StoredValidator>,
+    /// ID of the object that contains the list of new validators that will join
+    /// at the end of the epoch.
+    pub pending_active_validators_id: ObjectID,
+    /// Number of new validators that will join at the end of the epoch.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub pending_active_validators_size: u64,
+    /// Removal requests from the validators. Each element is an index
+    /// pointing to `active_validators`.
+    #[serde_as(as = "Vec<Readable<BigInt<u64>, _>>")]
+    pub pending_removals: Vec<u64>,
+    /// ID of the object that maps from staking pool's ID to the iota address of
+    /// a validator.
+    pub staking_pool_mappings_id: ObjectID,
+    /// Number of staking pool mappings.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub staking_pool_mappings_size: u64,
+    /// ID of the object that maps from a staking pool ID to the inactive
+    /// validator that has that pool as its staking pool.
+    pub inactive_pools_id: ObjectID,
+    /// Number of inactive staking pools.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub inactive_pools_size: u64,
+    /// ID of the object that stores preactive validators, mapping their
+    /// addresses to their `Validator` structs.
+    pub validator_candidates_id: ObjectID,
+    /// Number of preactive validators.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub validator_candidates_size: u64,
+    /// Map storing the number of epochs for which each validator has been below
+    /// the low stake threshold.
+    #[serde_as(as = "Vec<(_, Readable<BigInt<u64>, _>)>")]
+    pub at_risk_validators: Vec<(IotaAddress, u64)>,
+    /// A map storing the records of validator reporting each other.
+    pub validator_report_records: Vec<(IotaAddress, Vec<IotaAddress>)>,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredSystemStateV2 {
+    /// The current epoch ID, starting from 0.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub epoch: u64,
+    /// The current protocol version, starting from 1.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub protocol_version: u64,
+    /// The current version of the system state data structure type.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub system_state_version: u64,
+    /// The current IOTA supply.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub iota_total_supply: u64,
+    /// The `TreasuryCap<IOTA>` object ID.
+    pub iota_treasury_cap_id: ObjectID,
+    /// The storage rebates of all the objects on-chain stored in the storage
+    /// fund.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub storage_fund_total_object_storage_rebates: u64,
+    /// The non-refundable portion of the storage fund coming from
+    /// non-refundable storage rebates and any leftover
+    /// staking rewards.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub storage_fund_non_refundable_balance: u64,
+    /// The reference gas price for the current epoch.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub reference_gas_price: u64,
+    /// Whether the system is running in a downgraded safe mode due to a
+    /// non-recoverable bug. This is set whenever we failed to execute
+    /// advance_epoch, and ended up executing advance_epoch_safe_mode.
+    /// It can be reset once we are able to successfully execute advance_epoch.
+    pub safe_mode: bool,
+    /// Amount of storage charges accumulated (and not yet distributed) during
+    /// safe mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_storage_charges: u64,
+    /// Amount of computation charges accumulated (and not yet distributed)
+    /// during safe mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_computation_charges: u64,
+    /// Amount of burned computation charges accumulated during safe mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_computation_charges_burned: u64,
+    /// Amount of storage rebates accumulated (and not yet burned) during safe
+    /// mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_storage_rebates: u64,
+    /// Amount of non-refundable storage fee accumulated during safe mode.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub safe_mode_non_refundable_storage_fee: u64,
+    /// Unix timestamp of the current epoch start
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub epoch_start_timestamp_ms: u64,
+
+    // System parameters
+    /// The duration of an epoch, in milliseconds.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub epoch_duration_ms: u64,
+
+    /// Minimum number of active validators at any moment.
+    /// We do not allow the number of validators in any epoch to go under this.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub min_validator_count: u64,
+
+    /// Maximum number of active validators at any moment.
+    /// We do not allow the number of validators in any epoch to go above this.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub max_validator_count: u64,
+
+    /// Lower-bound on the amount of stake required to become a validator.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub min_validator_joining_stake: u64,
+
+    /// Validators with stake amount below `validator_low_stake_threshold` are
+    /// considered to have low stake and will be escorted out of the
+    /// validator set after being below this threshold for more than
+    /// `validator_low_stake_grace_period` number of epochs.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub validator_low_stake_threshold: u64,
+
+    /// Validators with stake below `validator_very_low_stake_threshold` will be
+    /// removed immediately at epoch change, no grace period.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub validator_very_low_stake_threshold: u64,
+
+    /// A validator can have stake below `validator_low_stake_threshold`
+    /// for this many epochs before being kicked out.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub validator_low_stake_grace_period: u64,
+
+    // Validator set
+    /// Total amount of stake from all committee validators at the beginning of
+    /// the epoch.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub total_stake: u64,
+    /// List of committee validators in the current epoch. Each element is an
+    /// index pointing to `active_validators`.
+    #[serde_as(as = "Vec<Readable<BigInt<u64>, _>>")]
+    pub committee_members: Vec<u64>,
+    /// The list of active validators in the current epoch.
+    pub active_validators: Vec<StoredValidator>,
+    /// ID of the object that contains the list of new validators that will join
+    /// at the end of the epoch.
+    pub pending_active_validators_id: ObjectID,
+    /// Number of new validators that will join at the end of the epoch.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub pending_active_validators_size: u64,
+    /// Removal requests from the validators. Each element is an index
+    /// pointing to `active_validators`.
+    #[serde_as(as = "Vec<Readable<BigInt<u64>, _>>")]
+    pub pending_removals: Vec<u64>,
+    /// ID of the object that maps from staking pool's ID to the iota address of
+    /// a validator.
+    pub staking_pool_mappings_id: ObjectID,
+    /// Number of staking pool mappings.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub staking_pool_mappings_size: u64,
+    /// ID of the object that maps from a staking pool ID to the inactive
+    /// validator that has that pool as its staking pool.
+    pub inactive_pools_id: ObjectID,
+    /// Number of inactive staking pools.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub inactive_pools_size: u64,
+    /// ID of the object that stores preactive validators, mapping their
+    /// addresses to their `Validator` structs.
+    pub validator_candidates_id: ObjectID,
+    /// Number of preactive validators.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub validator_candidates_size: u64,
+    /// Map storing the number of epochs for which each validator has been below
+    /// the low stake threshold.
+    #[serde_as(as = "Vec<(_, Readable<BigInt<u64>, _>)>")]
+    pub at_risk_validators: Vec<(IotaAddress, u64)>,
+    /// A map storing the records of validator reporting each other.
+    pub validator_report_records: Vec<(IotaAddress, Vec<IotaAddress>)>,
+}
+
+/// Represent the stored data for IOTA validators.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredValidator {
+    // Metadata
+    pub iota_address: IotaAddress,
+    #[serde_as(as = "Base64")]
+    pub authority_pubkey_bytes: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    pub network_pubkey_bytes: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    pub protocol_pubkey_bytes: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    pub proof_of_possession_bytes: Vec<u8>,
+    pub name: String,
+    pub description: String,
+    pub image_url: String,
+    pub project_url: String,
+    pub net_address: String,
+    pub p2p_address: String,
+    pub primary_address: String,
+    #[serde_as(as = "Option<Base64>")]
+    pub next_epoch_authority_pubkey_bytes: Option<Vec<u8>>,
+    #[serde_as(as = "Option<Base64>")]
+    pub next_epoch_proof_of_possession: Option<Vec<u8>>,
+    #[serde_as(as = "Option<Base64>")]
+    pub next_epoch_network_pubkey_bytes: Option<Vec<u8>>,
+    #[serde_as(as = "Option<Base64>")]
+    pub next_epoch_protocol_pubkey_bytes: Option<Vec<u8>>,
+    pub next_epoch_net_address: Option<String>,
+    pub next_epoch_p2p_address: Option<String>,
+    pub next_epoch_primary_address: Option<String>,
+
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub voting_power: u64,
+    pub operation_cap_id: ObjectID,
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub gas_price: u64,
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub commission_rate: u64,
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub next_epoch_stake: u64,
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub next_epoch_gas_price: u64,
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub next_epoch_commission_rate: u64,
+
+    // Staking pool information
+    /// ID of the staking pool object.
+    pub staking_pool_id: ObjectID,
+    /// The epoch at which this pool became active.
+    #[serde_as(as = "Option<Readable<BigInt<u64>, _>>")]
+    pub staking_pool_activation_epoch: Option<u64>,
+    /// The epoch at which this staking pool ceased to be active. `None` =
+    /// {pre-active, active},
+    #[serde_as(as = "Option<Readable<BigInt<u64>, _>>")]
+    pub staking_pool_deactivation_epoch: Option<u64>,
+    /// The total number of IOTA tokens in this pool.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub staking_pool_iota_balance: u64,
+    /// The epoch stake rewards will be added here at the end of each epoch.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub rewards_pool: u64,
+    /// Total number of pool tokens issued by the pool.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub pool_token_balance: u64,
+    /// Pending stake amount for this epoch.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub pending_stake: u64,
+    /// Pending stake withdrawn during the current epoch, emptied at epoch
+    /// boundaries.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub pending_total_iota_withdraw: u64,
+    /// Pending pool token withdrawn during the current epoch, emptied at epoch
+    /// boundaries.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub pending_pool_token_withdraw: u64,
+    /// ID of the exchange rate table object.
+    pub exchange_rates_id: ObjectID,
+    /// Number of exchange rates in the table.
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub exchange_rates_size: u64,
+}
+
+impl From<IotaValidatorSummary> for StoredValidator {
+    fn from(native: IotaValidatorSummary) -> Self {
+        let IotaValidatorSummary {
+            iota_address,
+            authority_pubkey_bytes,
+            network_pubkey_bytes,
+            protocol_pubkey_bytes,
+            proof_of_possession_bytes,
+            name,
+            description,
+            image_url,
+            project_url,
+            net_address,
+            p2p_address,
+            primary_address,
+            next_epoch_authority_pubkey_bytes,
+            next_epoch_proof_of_possession,
+            next_epoch_network_pubkey_bytes,
+            next_epoch_protocol_pubkey_bytes,
+            next_epoch_net_address,
+            next_epoch_p2p_address,
+            next_epoch_primary_address,
+            voting_power,
+            operation_cap_id,
+            gas_price,
+            commission_rate,
+            effective_commission_rate: _,
+            next_epoch_stake,
+            next_epoch_gas_price,
+            next_epoch_commission_rate,
+            staking_pool_id,
+            staking_pool_activation_epoch,
+            staking_pool_deactivation_epoch,
+            staking_pool_iota_balance,
+            rewards_pool,
+            pool_token_balance,
+            pending_stake,
+            pending_total_iota_withdraw,
+            pending_pool_token_withdraw,
+            exchange_rates_id,
+            exchange_rates_size,
+        } = native;
+        Self {
+            iota_address,
+            authority_pubkey_bytes,
+            network_pubkey_bytes,
+            protocol_pubkey_bytes,
+            proof_of_possession_bytes,
+            name,
+            description,
+            image_url,
+            project_url,
+            net_address,
+            p2p_address,
+            primary_address,
+            next_epoch_authority_pubkey_bytes,
+            next_epoch_proof_of_possession,
+            next_epoch_network_pubkey_bytes,
+            next_epoch_protocol_pubkey_bytes,
+            next_epoch_net_address,
+            next_epoch_p2p_address,
+            next_epoch_primary_address,
+            voting_power,
+            operation_cap_id,
+            gas_price,
+            commission_rate,
+            next_epoch_stake,
+            next_epoch_gas_price,
+            next_epoch_commission_rate,
+            staking_pool_id,
+            staking_pool_activation_epoch,
+            staking_pool_deactivation_epoch,
+            staking_pool_iota_balance,
+            rewards_pool,
+            pool_token_balance,
+            pending_stake,
+            pending_total_iota_withdraw,
+            pending_pool_token_withdraw,
+            exchange_rates_id,
+            exchange_rates_size,
+        }
+    }
+}
+
+impl StoredValidator {
+    pub fn into_iota_validator_summary(self, protocol_version: u64) -> IotaValidatorSummary {
+        let StoredValidator {
+            iota_address,
+            authority_pubkey_bytes,
+            network_pubkey_bytes,
+            protocol_pubkey_bytes,
+            proof_of_possession_bytes,
+            name,
+            description,
+            image_url,
+            project_url,
+            net_address,
+            p2p_address,
+            primary_address,
+            next_epoch_authority_pubkey_bytes,
+            next_epoch_proof_of_possession,
+            next_epoch_network_pubkey_bytes,
+            next_epoch_protocol_pubkey_bytes,
+            next_epoch_net_address,
+            next_epoch_p2p_address,
+            next_epoch_primary_address,
+            voting_power,
+            operation_cap_id,
+            gas_price,
+            commission_rate,
+            next_epoch_stake,
+            next_epoch_gas_price,
+            next_epoch_commission_rate,
+            staking_pool_id,
+            staking_pool_activation_epoch,
+            staking_pool_deactivation_epoch,
+            staking_pool_iota_balance,
+            rewards_pool,
+            pool_token_balance,
+            pending_stake,
+            pending_total_iota_withdraw,
+            pending_pool_token_withdraw,
+            exchange_rates_id,
+            exchange_rates_size,
+        } = self;
+        let effective_commission_rate = (protocol_version >= PROTOCOL_VERSION_IIP8)
+            .then(|| commission_rate.max(voting_power))
+            .or(Some(commission_rate));
+        IotaValidatorSummary {
+            iota_address,
+            authority_pubkey_bytes,
+            network_pubkey_bytes,
+            protocol_pubkey_bytes,
+            proof_of_possession_bytes,
+            name,
+            description,
+            image_url,
+            project_url,
+            net_address,
+            p2p_address,
+            primary_address,
+            next_epoch_authority_pubkey_bytes,
+            next_epoch_proof_of_possession,
+            next_epoch_network_pubkey_bytes,
+            next_epoch_protocol_pubkey_bytes,
+            next_epoch_net_address,
+            next_epoch_p2p_address,
+            next_epoch_primary_address,
+            voting_power,
+            operation_cap_id,
+            gas_price,
+            commission_rate,
+            effective_commission_rate,
+            next_epoch_stake,
+            next_epoch_gas_price,
+            next_epoch_commission_rate,
+            staking_pool_id,
+            staking_pool_activation_epoch,
+            staking_pool_deactivation_epoch,
+            staking_pool_iota_balance,
+            rewards_pool,
+            pool_token_balance,
+            pending_stake,
+            pending_total_iota_withdraw,
+            pending_pool_token_withdraw,
+            exchange_rates_id,
+            exchange_rates_size,
+        }
+    }
+}
+
+impl From<StoredSystemStateV1> for IotaSystemStateSummaryV1 {
+    fn from(stored: StoredSystemStateV1) -> Self {
+        let StoredSystemStateV1 {
+            epoch,
+            protocol_version,
+            system_state_version,
+            iota_total_supply,
+            iota_treasury_cap_id,
+            storage_fund_total_object_storage_rebates,
+            storage_fund_non_refundable_balance,
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_charges,
+            safe_mode_computation_rewards,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            min_validator_count,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            total_stake,
+            active_validators,
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators,
+            validator_report_records,
+        } = stored;
+        Self {
+            epoch,
+            protocol_version,
+            system_state_version,
+            iota_total_supply,
+            iota_treasury_cap_id,
+            storage_fund_total_object_storage_rebates,
+            storage_fund_non_refundable_balance,
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_charges,
+            safe_mode_computation_rewards,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            min_validator_count,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            total_stake,
+            active_validators: active_validators
+                .into_iter()
+                .map(|validator| validator.into_iota_validator_summary(protocol_version))
+                .collect(),
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators,
+            validator_report_records,
+        }
+    }
+}
+
+impl From<IotaSystemStateSummaryV1> for StoredSystemStateV1 {
+    fn from(native: IotaSystemStateSummaryV1) -> Self {
+        let IotaSystemStateSummaryV1 {
+            epoch,
+            protocol_version,
+            system_state_version,
+            iota_total_supply,
+            iota_treasury_cap_id,
+            storage_fund_total_object_storage_rebates,
+            storage_fund_non_refundable_balance,
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_charges,
+            safe_mode_computation_rewards,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            min_validator_count,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            total_stake,
+            active_validators,
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators,
+            validator_report_records,
+        } = native;
+        Self {
+            epoch,
+            protocol_version,
+            system_state_version,
+            iota_total_supply,
+            iota_treasury_cap_id,
+            storage_fund_total_object_storage_rebates,
+            storage_fund_non_refundable_balance,
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_charges,
+            safe_mode_computation_rewards,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            min_validator_count,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            total_stake,
+            active_validators: active_validators.into_iter().map(Into::into).collect(),
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators,
+            validator_report_records,
+        }
+    }
+}
+
+impl From<StoredSystemStateV2> for IotaSystemStateSummaryV2 {
+    fn from(stored: StoredSystemStateV2) -> Self {
+        let StoredSystemStateV2 {
+            epoch,
+            protocol_version,
+            system_state_version,
+            iota_total_supply,
+            iota_treasury_cap_id,
+            storage_fund_total_object_storage_rebates,
+            storage_fund_non_refundable_balance,
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_charges,
+            safe_mode_computation_charges,
+            safe_mode_computation_charges_burned,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            min_validator_count,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            total_stake,
+            committee_members,
+            active_validators,
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators,
+            validator_report_records,
+        } = stored;
+        Self {
+            epoch,
+            protocol_version,
+            system_state_version,
+            iota_total_supply,
+            iota_treasury_cap_id,
+            storage_fund_total_object_storage_rebates,
+            storage_fund_non_refundable_balance,
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_charges,
+            safe_mode_computation_charges,
+            safe_mode_computation_charges_burned,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            min_validator_count,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            total_stake,
+            committee_members,
+            active_validators: active_validators
+                .into_iter()
+                .map(|validator| validator.into_iota_validator_summary(protocol_version))
+                .collect(),
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators,
+            validator_report_records,
+        }
+    }
+}
+
+impl From<IotaSystemStateSummaryV2> for StoredSystemStateV2 {
+    fn from(native: IotaSystemStateSummaryV2) -> Self {
+        let IotaSystemStateSummaryV2 {
+            epoch,
+            protocol_version,
+            system_state_version,
+            iota_total_supply,
+            iota_treasury_cap_id,
+            storage_fund_total_object_storage_rebates,
+            storage_fund_non_refundable_balance,
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_charges,
+            safe_mode_computation_charges,
+            safe_mode_computation_charges_burned,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            min_validator_count,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            total_stake,
+            committee_members,
+            active_validators,
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators,
+            validator_report_records,
+        } = native;
+        Self {
+            epoch,
+            protocol_version,
+            system_state_version,
+            iota_total_supply,
+            iota_treasury_cap_id,
+            storage_fund_total_object_storage_rebates,
+            storage_fund_non_refundable_balance,
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_charges,
+            safe_mode_computation_charges,
+            safe_mode_computation_charges_burned,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            min_validator_count,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            total_stake,
+            committee_members,
+            active_validators: active_validators.into_iter().map(Into::into).collect(),
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators,
+            validator_report_records,
+        }
+    }
+}
+
+impl From<StoredSystemState> for IotaSystemStateSummary {
+    fn from(stored: StoredSystemState) -> Self {
+        match stored {
+            StoredSystemState::V1(inner) => Self::V1(inner.into()),
+            StoredSystemState::V2(inner) => Self::V2(inner.into()),
+        }
+    }
+}
+
+impl From<IotaSystemStateSummary> for StoredSystemState {
+    fn from(native: IotaSystemStateSummary) -> Self {
+        match native {
+            IotaSystemStateSummary::V1(inner) => StoredSystemState::V1(inner.into()),
+            IotaSystemStateSummary::V2(inner) => StoredSystemState::V2(inner.into()),
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/crates/iota-indexer/src/models/system_state.rs
+++ b/crates/iota-indexer/src/models/system_state.rs
@@ -887,7 +887,7 @@ impl From<IotaSystemStateSummary> for StoredSystemState {
         match native {
             IotaSystemStateSummary::V1(inner) => StoredSystemState::V1(inner.into()),
             IotaSystemStateSummary::V2(inner) => StoredSystemState::V2(inner.into()),
-            _ => unimplemented!(),
+            _ => panic!("unsupported native system state"),
         }
     }
 }

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -70,6 +70,7 @@ use crate::{
         obj_indices::StoredObjectVersion,
         objects::{CoinBalance, StoredHistoryObject, StoredObject},
         participation_metrics::StoredParticipationMetrics,
+        system_state::StoredSystemState,
         transactions::{
             IndexStatus, OptimisticTransaction, StoredTransaction, StoredTransactionEvents,
             stored_events_to_events, tx_events_to_iota_tx_events,
@@ -505,7 +506,7 @@ impl IndexerReader {
             None => return Err(IndexerError::InvalidArgument("Invalid epoch".into())),
         };
 
-        (&stored_epoch).try_into()
+        Ok(StoredSystemState::try_from(&stored_epoch)?.into())
     }
 
     pub async fn get_chain_identifier_in_blocking_task(

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -677,6 +677,7 @@ fn inactive_validators_exchange_rates(
         system_state_summary.inactive_pools_id,
         system_state_summary.inactive_pools_size,
         |df| bcs::from_bytes::<ID>(&df.bcs_name).map_err(Into::into),
+        Some(system_state_summary.protocol_version),
     )?;
 
     validator_exchange_rates(state, tables)
@@ -730,6 +731,7 @@ fn candidate_validators_exchange_rate(
         system_state_summary.validator_candidates_id,
         system_state_summary.validator_candidates_size,
         |df| bcs::from_bytes::<IotaAddress>(&df.bcs_name).map_err(Into::into),
+        Some(system_state_summary.protocol_version),
     )?;
 
     validator_exchange_rates(state, tables)
@@ -786,6 +788,7 @@ fn validator_summary_from_system_state<K, F>(
     table_id: ObjectID,
     limit: u64,
     key: F,
+    protocol_version: Option<u64>,
 ) -> RpcInterimResult<Vec<ValidatorTable>>
 where
     F: Fn(DynamicFieldInfo) -> RpcInterimResult<K>,
@@ -797,7 +800,8 @@ where
         .get_dynamic_fields(table_id, None, limit as usize)?
         .into_iter()
         .map(|(_object_id, df)| {
-            let validator_summary = get_validator_from_table(object_store, table_id, &key(df)?)?;
+            let validator_summary =
+                get_validator_from_table(object_store, table_id, &key(df)?, protocol_version)?;
 
             Ok((
                 validator_summary.iota_address,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -9926,7 +9926,7 @@
             "$ref": "#/components/schemas/Base64"
           },
           "commissionRate": {
-            "description": "The fee set by the validator for providing staking services.\n\nThis might be overriden by the protocol, that uses instead an effective commission rate. See more on the associated field.",
+            "description": "The fee set by the validator for providing staking services.\n\nThis might be overridden by the protocol, that uses instead an effective commission rate. See more on the associated field.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/BigInt_for_uint64"

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -9926,10 +9926,26 @@
             "$ref": "#/components/schemas/Base64"
           },
           "commissionRate": {
-            "$ref": "#/components/schemas/BigInt_for_uint64"
+            "description": "The fee set by the validator for providing staking services.\n\nThis might be overriden by the protocol, that uses instead an effective commission rate. See more on the associated field.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              }
+            ]
           },
           "description": {
             "type": "string"
+          },
+          "effectiveCommissionRate": {
+            "description": "The effective fee charged by the validator for staking services.\n\nThis follows [IIP8](https://github.com/iotaledger/IIPs/blob/main/iips/IIP-0008/IIP-0008.md).",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "exchangeRatesId": {
             "description": "ID of the exchange rate table object.",

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -21,6 +21,8 @@ use tracing::{info, warn};
 const MIN_PROTOCOL_VERSION: u64 = 1;
 pub const MAX_PROTOCOL_VERSION: u64 = 21;
 
+/// Protocol version that IIP8 took effect.
+pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 // Record history of protocol version allocations here:
 //
 // Version 1:  Original version.

--- a/crates/iota-proxy/src/peers.rs
+++ b/crates/iota-proxy/src/peers.rs
@@ -139,10 +139,14 @@ impl IotaNodeProvider {
         );
     }
 
-    fn update_pending_validator_set(&self, pending_validators: Vec<ValidatorV1>) {
+    fn update_pending_validator_set(
+        &self,
+        pending_validators: Vec<ValidatorV1>,
+        protocol_version: Option<u64>,
+    ) {
         let summaries = pending_validators
             .into_iter()
-            .map(|v| v.into_iota_validator_summary(self.))
+            .map(|v| v.into_iota_validator_summary(protocol_version))
             .collect_vec();
         let validators = extract_validators_from_summaries(&summaries);
         let mut allow = self.pending_validator_nodes.write().unwrap();
@@ -235,8 +239,10 @@ impl IotaNodeProvider {
                                 .await
                                 {
                                     Ok(pending_validators) => {
-                                        cloned_self
-                                            .update_pending_validator_set(pending_validators);
+                                        cloned_self.update_pending_validator_set(
+                                            pending_validators,
+                                            Some(system_state.protocol_version().as_u64()),
+                                        );
                                         info!("Successfully updated pending validators");
                                     }
                                     Err(e) => {

--- a/crates/iota-proxy/src/peers.rs
+++ b/crates/iota-proxy/src/peers.rs
@@ -142,7 +142,7 @@ impl IotaNodeProvider {
     fn update_pending_validator_set(&self, pending_validators: Vec<ValidatorV1>) {
         let summaries = pending_validators
             .into_iter()
-            .map(|v| v.into_iota_validator_summary())
+            .map(|v| v.into_iota_validator_summary(self.))
             .collect_vec();
         let validators = extract_validators_from_summaries(&summaries);
         let mut allow = self.pending_validator_nodes.write().unwrap();

--- a/crates/iota-rest-api/src/system.rs
+++ b/crates/iota-rest-api/src/system.rs
@@ -379,6 +379,7 @@ impl From<iota_types::iota_system_state::iota_system_state_summary::IotaValidato
             pending_pool_token_withdraw,
             exchange_rates_id,
             exchange_rates_size,
+            effective_commission_rate: _,
         } = value;
 
         Self {

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use fastcrypto::traits::ToFromBytes;
+use iota_protocol_config::PROTOCOL_VERSION_IIP8;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
@@ -40,9 +41,6 @@ const E_METADATA_INVALID_PROTOCOL_PUBKEY: u64 = 3;
 const E_METADATA_INVALID_NET_ADDR: u64 = 4;
 const E_METADATA_INVALID_P2P_ADDR: u64 = 5;
 const E_METADATA_INVALID_PRIMARY_ADDR: u64 = 6;
-
-/// Protocol version that IIP8 took effect.
-const PROTOCOL_VERSION_IIP8: u64 = 20;
 
 /// Rust version of the Move iota::iota_system::SystemParametersV1 type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
@@ -357,6 +357,7 @@ impl ValidatorV1 {
             next_epoch_commission_rate,
             extra_fields: _,
         } = self;
+        let effective_commission_rate = Some(commission_rate.max(voting_power));
         IotaValidatorSummary {
             iota_address,
             authority_pubkey_bytes,
@@ -392,6 +393,7 @@ impl ValidatorV1 {
             pending_total_iota_withdraw,
             pending_pool_token_withdraw,
             commission_rate,
+            effective_commission_rate,
             next_epoch_stake,
             next_epoch_gas_price,
             next_epoch_commission_rate,

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
@@ -41,6 +41,9 @@ const E_METADATA_INVALID_NET_ADDR: u64 = 4;
 const E_METADATA_INVALID_P2P_ADDR: u64 = 5;
 const E_METADATA_INVALID_PRIMARY_ADDR: u64 = 6;
 
+/// Protocol version that IIP8 took effect.
+const PROTOCOL_VERSION_IIP8: u64 = 20;
+
 /// Rust version of the Move iota::iota_system::SystemParametersV1 type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SystemParametersV1 {
@@ -304,7 +307,15 @@ impl ValidatorV1 {
         })
     }
 
-    pub fn into_iota_validator_summary(self) -> IotaValidatorSummary {
+    /// Create the validator summary.
+    ///
+    /// The effective commission rate is evaluated based on the value of the
+    /// `protocol_version` passed. If [`None`] it resolves to the commission
+    /// rate set by the validator.
+    pub fn into_iota_validator_summary(
+        self,
+        protocol_version: Option<u64>,
+    ) -> IotaValidatorSummary {
         let Self {
             metadata:
                 ValidatorMetadataV1 {
@@ -357,7 +368,10 @@ impl ValidatorV1 {
             next_epoch_commission_rate,
             extra_fields: _,
         } = self;
-        let effective_commission_rate = Some(commission_rate.max(voting_power));
+        let effective_commission_rate = Some(match protocol_version {
+            Some(version) if version >= PROTOCOL_VERSION_IIP8 => commission_rate.max(voting_power),
+            _ => commission_rate,
+        });
         IotaValidatorSummary {
             iota_address,
             authority_pubkey_bytes,
@@ -537,7 +551,7 @@ impl IotaSystemStateTrait for IotaSystemStateV1 {
             get_validators_from_table_vec(&object_store, table_id, table_size)?;
         Ok(validators
             .into_iter()
-            .map(|v| v.into_iota_validator_summary())
+            .map(|v| v.into_iota_validator_summary(Some(self.protocol_version)))
             .collect())
     }
 
@@ -648,7 +662,7 @@ impl IotaSystemStateTrait for IotaSystemStateV1 {
             total_stake,
             active_validators: active_validators
                 .into_iter()
-                .map(|v| v.into_iota_validator_summary())
+                .map(|v| v.into_iota_validator_summary(Some(protocol_version)))
                 .collect(),
             pending_active_validators_id,
             pending_active_validators_size,

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
@@ -170,7 +170,7 @@ impl IotaSystemStateTrait for IotaSystemStateV2 {
             get_validators_from_table_vec(&object_store, table_id, table_size)?;
         Ok(validators
             .into_iter()
-            .map(|v| v.into_iota_validator_summary())
+            .map(|v| v.into_iota_validator_summary(Some(self.protocol_version)))
             .collect())
     }
 
@@ -290,7 +290,7 @@ impl IotaSystemStateTrait for IotaSystemStateV2 {
             committee_members,
             active_validators: active_validators
                 .into_iter()
-                .map(|v| v.into_iota_validator_summary())
+                .map(|v| v.into_iota_validator_summary(Some(protocol_version)))
                 .collect(),
             pending_active_validators_id,
             pending_active_validators_size,

--- a/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
@@ -893,7 +893,7 @@ pub struct IotaValidatorSummary {
     pub gas_price: u64,
     /// The fee set by the validator for providing staking services.
     ///
-    /// This might be overriden by the protocol, that uses instead
+    /// This might be overridden by the protocol, that uses instead
     /// an effective commission rate. See more on the associated field.
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "Readable<BigInt<u64>, _>")]

--- a/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
@@ -1104,9 +1104,12 @@ where
     }
     // After that try to find in inactive pools.
     let inactive_table_id = system_state_summary.inactive_pools_id;
-    if let Ok(inactive) =
-        get_validator_from_table(&object_store, inactive_table_id, &ID::new(pool_id))
-    {
+    if let Ok(inactive) = get_validator_from_table(
+        &object_store,
+        inactive_table_id,
+        &ID::new(pool_id),
+        Some(system_state_summary.protocol_version),
+    ) {
         return Ok(inactive);
     }
     // Finally look up the candidates pool.
@@ -1121,7 +1124,12 @@ where
         ))
     })?;
     let candidate_table_id = system_state_summary.validator_candidates_id;
-    get_validator_from_table(&object_store, candidate_table_id, &candidate_address)
+    get_validator_from_table(
+        &object_store,
+        candidate_table_id,
+        &candidate_address,
+        Some(system_state_summary.protocol_version),
+    )
 }
 
 fn get_validator_by_pool_id_v2<S>(
@@ -1151,9 +1159,12 @@ where
     }
     // After that try to find in inactive pools.
     let inactive_table_id = system_state_summary.inactive_pools_id;
-    if let Ok(inactive) =
-        get_validator_from_table(&object_store, inactive_table_id, &ID::new(pool_id))
-    {
+    if let Ok(inactive) = get_validator_from_table(
+        &object_store,
+        inactive_table_id,
+        &ID::new(pool_id),
+        Some(system_state_summary.protocol_version),
+    ) {
         return Ok(inactive);
     }
     // Finally look up the candidates pool.
@@ -1168,5 +1179,10 @@ where
         ))
     })?;
     let candidate_table_id = system_state_summary.validator_candidates_id;
-    get_validator_from_table(&object_store, candidate_table_id, &candidate_address)
+    get_validator_from_table(
+        &object_store,
+        candidate_table_id,
+        &candidate_address,
+        Some(system_state_summary.protocol_version),
+    )
 }

--- a/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
@@ -891,9 +891,20 @@ pub struct IotaValidatorSummary {
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "Readable<BigInt<u64>, _>")]
     pub gas_price: u64,
+    /// The fee set by the validator for providing staking services.
+    ///
+    /// This might be overriden by the protocol, that uses instead
+    /// an effective commission rate. See more on the associated field.
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "Readable<BigInt<u64>, _>")]
     pub commission_rate: u64,
+    /// The effective fee charged by the validator for staking services.
+    ///
+    /// This follows [IIP8](https://github.com/iotaledger/IIPs/blob/main/iips/IIP-0008/IIP-0008.md).
+    #[schemars(with = "Option<BigInt<u64>>")]
+    #[serde_as(as = "Readable<Option<BigInt<u64>>, _>")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_commission_rate: Option<u64>,
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "Readable<BigInt<u64>, _>")]
     pub next_epoch_stake: u64,
@@ -1025,6 +1036,7 @@ impl Default for IotaValidatorSummary {
             operation_cap_id: ObjectID::ZERO,
             gas_price: 0,
             commission_rate: 0,
+            effective_commission_rate: None,
             next_epoch_stake: 0,
             next_epoch_gas_price: 0,
             next_epoch_commission_rate: 0,

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -366,7 +366,7 @@ where
                             err
                         ))
                     })?;
-            Ok(validator.into_iota_validator_summary(protocol_version))
+            Ok(validator.into_iota_validator_summary())
         }
         #[cfg(msim)]
         IOTA_SYSTEM_STATE_SIM_TEST_DEEP_V1 => {
@@ -378,7 +378,7 @@ where
                             err
                         ))
                     })?;
-            Ok(validator.into_iota_validator_summary(protocol_version))
+            Ok(validator.into_iota_validator_summary())
         }
         _ => Err(IotaError::IotaSystemStateRead(format!(
             "Unsupported Validator version: {version}"

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -332,6 +332,7 @@ pub fn get_validator_from_table<K>(
     object_store: &dyn ObjectStore,
     table_id: ObjectID,
     key: &K,
+    protocol_version: Option<u64>,
 ) -> Result<IotaValidatorSummary, IotaError>
 where
     K: MoveTypeTagTrait + Serialize + DeserializeOwned + fmt::Debug,
@@ -353,7 +354,7 @@ where
                             "Failed to load inner validator from the wrapper: {err:?}"
                         ))
                     })?;
-            Ok(validator.into_iota_validator_summary())
+            Ok(validator.into_iota_validator_summary(protocol_version))
         }
         #[cfg(msim)]
         IOTA_SYSTEM_STATE_SIM_TEST_V1 => {
@@ -365,7 +366,7 @@ where
                             err
                         ))
                     })?;
-            Ok(validator.into_iota_validator_summary())
+            Ok(validator.into_iota_validator_summary(protocol_version))
         }
         #[cfg(msim)]
         IOTA_SYSTEM_STATE_SIM_TEST_DEEP_V1 => {
@@ -377,7 +378,7 @@ where
                             err
                         ))
                     })?;
-            Ok(validator.into_iota_validator_summary())
+            Ok(validator.into_iota_validator_summary(protocol_version))
         }
         _ => Err(IotaError::IotaSystemStateRead(format!(
             "Unsupported Validator version: {version}"

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -727,6 +727,7 @@ pub async fn get_validator_summary(
         pending_active_validators_id,
         validator_candidates_id,
         inactive_pools_id,
+        protocol_version,
     ) = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => (
             None,
@@ -734,6 +735,7 @@ pub async fn get_validator_summary(
             v1.pending_active_validators_id,
             v1.validator_candidates_id,
             v1.inactive_pools_id,
+            v1.protocol_version,
         ),
         IotaSystemStateSummary::V2(v2) => (
             Some(v2.committee_members),
@@ -741,6 +743,7 @@ pub async fn get_validator_summary(
             v2.pending_active_validators_id,
             v2.validator_candidates_id,
             v2.inactive_pools_id,
+            v2.protocol_version,
         ),
         _ => bail!(
             "Unsupported IotaSystemStateSummary found. You may need to upgrade your iota binary."
@@ -777,7 +780,7 @@ pub async fn get_validator_summary(
     let pending_validator_summary =
         get_pending_candidate_summary(validator_address, client, pending_active_validators_id)
             .await?
-            .map(|v| v.into_iota_validator_summary());
+            .map(|v| v.into_iota_validator_summary(Some(protocol_version)));
 
     if let Some(pending_validator_summary) = pending_validator_summary {
         return Ok(Some((ValidatorStatus::Pending, pending_validator_summary)));
@@ -795,7 +798,8 @@ pub async fn get_validator_summary(
     if res.error.is_none() {
         let object_id = res.data.expect("no data in result").object_id;
         let validator_summary =
-            get_validator_summary_from_validator_wrapper(client, object_id).await?;
+            get_validator_summary_from_validator_wrapper(client, object_id, Some(protocol_version))
+                .await?;
         return Ok(Some((ValidatorStatus::Candidate, validator_summary)));
     };
 
@@ -807,9 +811,12 @@ pub async fn get_validator_summary(
             .await
     });
     while let Some(dynamic_field_info) = stream.try_next().await? {
-        let validator_summary =
-            get_validator_summary_from_validator_wrapper(client, dynamic_field_info.object_id)
-                .await?;
+        let validator_summary = get_validator_summary_from_validator_wrapper(
+            client,
+            dynamic_field_info.object_id,
+            Some(protocol_version),
+        )
+        .await?;
         if validator_summary.iota_address == validator_address {
             return Ok(Some((ValidatorStatus::Inactive, validator_summary)));
         }
@@ -821,6 +828,7 @@ pub async fn get_validator_summary(
 async fn get_validator_summary_from_validator_wrapper(
     client: &IotaClient,
     validator_object_id: ObjectID,
+    protocol_version: Option<u64>,
 ) -> anyhow::Result<IotaValidatorSummary> {
     let validator = client
         .read_api()
@@ -852,7 +860,9 @@ async fn get_validator_summary_from_validator_wrapper(
         .expect("invalid move type")
         .deserialize::<Field<u64, ValidatorV1>>()?;
 
-    Ok(validator.value.into_iota_validator_summary())
+    Ok(validator
+        .value
+        .into_iota_validator_summary(protocol_version))
 }
 
 async fn display_metadata(


### PR DESCRIPTION
# Description of change

This patch exposes the `effectiveCommissionRate` as part of `IotaValidatorSummary` following [IIP8](https://github.com/iotaledger/IIPs/blob/main/iips/IIP-0008/IIP-0008.md).

Though the change  breaks the Rust API for `IotaValidatorSummary` and by consequence for `IotaSystemStateSummary{,V1,V2}` the JSON representation is backwards compatible. As these types are supposed to represent the system state in the context of JSON-RPC, this is deemed a plausible change.

Nevertheless, the type has been used in various crates which are also affected.

## Links to any relevant issues

Fixes #10305 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [x] JSON-RPC: Expose `effectiveCommissionRate` as part of the `IotaValidatorSummary` in `iotax_getLatestSystemStateV2` following [IIP8](https://github.com/iotaledger/IIPs/blob/main/iips/IIP-0008/IIP-0008.md)
