### PR TITLE
feat(gRPC): cleanup server side error handling

### DIFF
--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -20,22 +20,29 @@ pub struct RpcError {
 }
 
 impl RpcError {
-    pub fn new<T: Into<String>>(code: Code, message: T) -> Self {
+    pub fn new<T: std::fmt::Display>(code: Code, message: T) -> Self {
         Self {
             code,
-            message: Some(message.into()),
+            message: Some(message.to_string()),
             details: None,
         }
     }
 
     /// Add context to an existing error
-    pub fn with_context<T: Into<String>>(mut self, context: T) -> Self {
-        let context_str = context.into();
+    pub fn with_context<T: std::fmt::Display>(mut self, context: T) -> Self {
         self.message = Some(match self.message {
-            Some(existing) => format!("{}: {}", context_str, existing),
-            None => context_str,
+            Some(existing) => format!("{}: {}", context, existing),
+            None => context.to_string(),
         });
         self
+    }
+
+    pub fn internal() -> Self {
+        Self {
+            code: Code::Internal,
+            message: None,
+            details: None,
+        }
     }
 
     pub fn not_found() -> Self {
@@ -82,41 +89,25 @@ impl From<RpcError> for Status {
 
 impl From<anyhow::Error> for RpcError {
     fn from(value: anyhow::Error) -> Self {
-        Self {
-            code: Code::Internal,
-            message: Some(value.to_string()),
-            details: None,
-        }
+        Self::internal().with_context(value)
     }
 }
 
 impl From<iota_types::iota_sdk_types_conversions::SdkTypeConversionError> for RpcError {
     fn from(value: iota_types::iota_sdk_types_conversions::SdkTypeConversionError) -> Self {
-        Self {
-            code: Code::Internal,
-            message: Some(value.to_string()),
-            details: None,
-        }
+        Self::internal().with_context(value)
     }
 }
 
 impl From<bcs::Error> for RpcError {
     fn from(value: bcs::Error) -> Self {
-        Self {
-            code: Code::Internal,
-            message: Some(value.to_string()),
-            details: None,
-        }
+        Self::internal().with_context(value)
     }
 }
 
 impl From<iota_grpc_types::proto::GrpcConversionError> for RpcError {
     fn from(value: iota_grpc_types::proto::GrpcConversionError) -> Self {
-        Self {
-            code: Code::Internal,
-            message: Some(value.to_string()),
-            details: None,
-        }
+        Self::internal().with_context(value)
     }
 }
 
@@ -225,7 +216,7 @@ impl std::error::Error for ObjectNotFoundError {}
 
 impl From<ObjectNotFoundError> for RpcError {
     fn from(value: ObjectNotFoundError) -> Self {
-        Self::new(tonic::Code::NotFound, value.to_string())
+        Self::not_found().with_context(value)
     }
 }
 
@@ -242,7 +233,7 @@ impl std::error::Error for TransactionNotFoundError {}
 
 impl From<TransactionNotFoundError> for RpcError {
     fn from(value: TransactionNotFoundError) -> Self {
-        Self::new(tonic::Code::NotFound, value.to_string())
+        Self::not_found().with_context(value)
     }
 }
 

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -28,6 +28,16 @@ impl RpcError {
         }
     }
 
+    /// Add context to an existing error
+    pub fn with_context<T: Into<String>>(mut self, context: T) -> Self {
+        let context_str = context.into();
+        self.message = Some(match self.message {
+            Some(existing) => format!("{}: {}", context_str, existing),
+            None => context_str,
+        });
+        self
+    }
+
     pub fn not_found() -> Self {
         Self {
             code: Code::NotFound,
@@ -44,6 +54,15 @@ impl RpcError {
                 .details
                 .map(ErrorDetails::into_status_details)
                 .unwrap_or_default(),
+        }
+    }
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.message {
+            Some(msg) => write!(f, "{:?}: {}", self.code, msg),
+            None => write!(f, "{:?}", self.code),
         }
     }
 }
@@ -83,6 +102,16 @@ impl From<iota_types::iota_sdk_types_conversions::SdkTypeConversionError> for Rp
 
 impl From<bcs::Error> for RpcError {
     fn from(value: bcs::Error) -> Self {
+        Self {
+            code: Code::Internal,
+            message: Some(value.to_string()),
+            details: None,
+        }
+    }
+}
+
+impl From<iota_grpc_types::proto::GrpcConversionError> for RpcError {
+    fn from(value: iota_grpc_types::proto::GrpcConversionError) -> Self {
         Self {
             code: Code::Internal,
             message: Some(value.to_string()),
@@ -155,11 +184,6 @@ impl ErrorDetails {
     }
 }
 
-// NOTE: Similar errors exist in iota-rest-api, but are intentionally duplicated
-// here. The REST API will be deprecated soon, so we avoid creating a shared
-// dependency. This keeps the gRPC server independent and allows the REST API to
-// be removed cleanly without impacting gRPC error handling.
-// TODO: Remove the above comments when the REST API is removed.
 #[derive(Debug, Clone)]
 pub struct ObjectNotFoundError {
     object_id: ObjectID,

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -51,7 +51,7 @@ impl Merge<&EpochReadSource> for Epoch {
             source
                 .reader
                 .get_epoch_info(source.epoch)
-                .map_err(|e| format!("Failed to get epoch info: {e}"))?
+                .map_err(|e| RpcError::from(e).with_context("failed to get epoch info"))?
         } else {
             None
         };
@@ -98,15 +98,17 @@ impl Merge<&EpochReadSource> for Epoch {
                 source
                     .reader
                     .get_system_state()
-                    .map_err(|e| format!("Failed to get system state: {e}"))?
+                    .map_err(|e| RpcError::from(e).with_context("failed to get system state"))?
             } else if let Some(ref info) = epoch_info {
                 info.system_state.clone()
             } else {
-                return Err(format!(
-                    "Cannot get system state for historical epoch {}: epoch info not available",
-                    source.epoch
-                )
-                .into());
+                return Err(RpcError::new(
+                    tonic::Code::Internal,
+                    format!(
+                        "cannot get system state for historical epoch {}: epoch info not available",
+                        source.epoch
+                    ),
+                ));
             };
             self.bcs_system_state = Some(BcsData::serialize(&system_state)?);
         }
@@ -115,7 +117,7 @@ impl Merge<&EpochReadSource> for Epoch {
             let committee = source
                 .reader
                 .get_committee(source.epoch)
-                .map_err(|e| format!("Failed to get committee: {e}"))?
+                .map_err(|e| RpcError::from(e).with_context("failed to get committee"))?
                 .ok_or_else(|| CommitteeNotFoundError::new(source.epoch))?;
             let sdk_committee: iota_sdk_types::ValidatorCommittee =
                 committee.as_ref().clone().into();
@@ -193,7 +195,7 @@ pub fn get_epoch(
     };
 
     let message = Epoch::merge_from(&source, &read_mask)
-        .map_err(|e| Status::internal(format!("Failed to build epoch response: {e}")))?;
+        .map_err(|e| e.with_context("failed to merge epoch"))?;
 
     Ok(GetEpochResponse::default().with_epoch(message))
 }
@@ -217,9 +219,9 @@ impl std::fmt::Display for CommitteeNotFoundError {
 
 impl std::error::Error for CommitteeNotFoundError {}
 
-impl From<CommitteeNotFoundError> for Status {
+impl From<CommitteeNotFoundError> for RpcError {
     fn from(value: CommitteeNotFoundError) -> Self {
-        Status::not_found(value.to_string())
+        RpcError::new(tonic::Code::NotFound, value.to_string())
     }
 }
 
@@ -242,8 +244,8 @@ impl std::fmt::Display for ProtocolVersionNotFoundError {
 
 impl std::error::Error for ProtocolVersionNotFoundError {}
 
-impl From<ProtocolVersionNotFoundError> for Status {
+impl From<ProtocolVersionNotFoundError> for RpcError {
     fn from(value: ProtocolVersionNotFoundError) -> Self {
-        Status::not_found(value.to_string())
+        RpcError::new(tonic::Code::NotFound, value.to_string())
     }
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -102,13 +102,10 @@ impl Merge<&EpochReadSource> for Epoch {
             } else if let Some(ref info) = epoch_info {
                 info.system_state.clone()
             } else {
-                return Err(RpcError::new(
-                    tonic::Code::Internal,
-                    format!(
-                        "cannot get system state for historical epoch {}: epoch info not available",
-                        source.epoch
-                    ),
-                ));
+                return Err(RpcError::internal().with_context(format!(
+                    "cannot get system state for historical epoch {}: epoch info not available",
+                    source.epoch
+                )));
             };
             self.bcs_system_state = Some(BcsData::serialize(&system_state)?);
         }
@@ -221,7 +218,7 @@ impl std::error::Error for CommitteeNotFoundError {}
 
 impl From<CommitteeNotFoundError> for RpcError {
     fn from(value: CommitteeNotFoundError) -> Self {
-        RpcError::new(tonic::Code::NotFound, value.to_string())
+        RpcError::not_found().with_context(value)
     }
 }
 
@@ -246,6 +243,6 @@ impl std::error::Error for ProtocolVersionNotFoundError {}
 
 impl From<ProtocolVersionNotFoundError> for RpcError {
     fn from(value: ProtocolVersionNotFoundError) -> Self {
-        RpcError::new(tonic::Code::NotFound, value.to_string())
+        RpcError::not_found().with_context(value)
     }
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -19,7 +19,7 @@ use iota_types::committee::EpochId;
 use prost_types::FieldMask;
 use tonic::Status;
 
-use crate::{ledger_service::LedgerGrpcService, merge::Merge, types::GrpcReader};
+use crate::{error::RpcError, ledger_service::LedgerGrpcService, merge::Merge, types::GrpcReader};
 
 /// Source for building `Epoch` using the `Merge` trait.
 pub struct EpochReadSource {
@@ -30,11 +30,9 @@ pub struct EpochReadSource {
 }
 
 impl Merge<&EpochReadSource> for Epoch {
-    fn merge(
-        &mut self,
-        source: &EpochReadSource,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    type Error = RpcError;
+
+    fn merge(&mut self, source: &EpochReadSource, mask: &FieldMaskTree) -> Result<(), Self::Error> {
         if mask.contains(Self::EPOCH_FIELD.name) {
             self.epoch = Some(source.epoch);
         }

--- a/crates/iota-grpc-server/src/ledger_service/get_objects.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_objects.rs
@@ -144,10 +144,5 @@ fn get_object_impl(
             .ok_or_else(|| ObjectNotFoundError::new(object_id))?
     };
 
-    Object::merge_from(object, read_mask).map_err(|e| {
-        RpcError::new(
-            tonic::Code::Internal,
-            format!("Failed to build object response: {e}"),
-        )
-    })
+    Object::merge_from(object, read_mask).map_err(|e| e.with_context("failed to merge object"))
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
@@ -187,10 +187,6 @@ fn get_transaction_impl(
         output_objects: tx_read.output_objects,
     };
 
-    ExecutedTransaction::merge_from(&source, read_mask).map_err(|e| {
-        RpcError::new(
-            tonic::Code::Internal,
-            format!("failed to build executed transaction in get_transaction response: {e}"),
-        )
-    })
+    ExecutedTransaction::merge_from(&source, read_mask)
+        .map_err(|e| e.with_context("failed to merge transaction"))
 }

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::error::Error;
-
 use iota_grpc_types::{
     field::FieldMaskTree,
     v0::{
@@ -21,10 +19,14 @@ use iota_grpc_types::{
 use iota_protocol_config::{ProtocolConfig as IotaProtocolConfig, ProtocolConfigValue};
 use iota_types::iota_sdk_types_conversions::SdkTypeConversionError;
 
-pub trait Merge<T> {
-    fn merge(&mut self, source: T, mask: &FieldMaskTree) -> Result<(), Box<dyn Error>>;
+use crate::error::RpcError;
 
-    fn merge_from(source: T, mask: &FieldMaskTree) -> Result<Self, Box<dyn Error>>
+pub trait Merge<T> {
+    type Error;
+
+    fn merge(&mut self, source: T, mask: &FieldMaskTree) -> Result<(), Self::Error>;
+
+    fn merge_from(source: T, mask: &FieldMaskTree) -> Result<Self, Self::Error>
     where
         Self: std::default::Default,
     {
@@ -35,11 +37,13 @@ pub trait Merge<T> {
 }
 
 impl Merge<&IotaProtocolConfig> for ProtocolConfig {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &IotaProtocolConfig,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::PROTOCOL_VERSION_FIELD.name) {
             self.protocol_version = Some(source.version.as_u64());
         }
@@ -96,11 +100,13 @@ fn protocol_config_value_to_string(v: ProtocolConfigValue) -> String {
 
 // Signature implementations
 impl Merge<iota_types::signature::GenericSignature> for UserSignature {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_types::signature::GenericSignature,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if !mask.contains(Self::BCS_FIELD.name) {
             // No need to convert if no field is requested
             return Ok(());
@@ -115,11 +121,13 @@ impl Merge<iota_types::signature::GenericSignature> for UserSignature {
 }
 
 impl Merge<iota_sdk_types::UserSignature> for UserSignature {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_sdk_types::UserSignature,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::BCS_FIELD.name) {
             self.bcs = Some(BcsData::serialize(&source)?);
         }
@@ -129,11 +137,9 @@ impl Merge<iota_sdk_types::UserSignature> for UserSignature {
 }
 
 impl Merge<&UserSignature> for UserSignature {
-    fn merge(
-        &mut self,
-        source: &UserSignature,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    type Error = RpcError;
+
+    fn merge(&mut self, source: &UserSignature, mask: &FieldMaskTree) -> Result<(), Self::Error> {
         let UserSignature { bcs, .. } = source;
 
         if mask.contains(Self::BCS_FIELD.name) {
@@ -145,11 +151,13 @@ impl Merge<&UserSignature> for UserSignature {
 }
 
 impl Merge<iota_types::transaction::Transaction> for UserSignatures {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_types::transaction::Transaction,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Get signatures directly from transaction without converting the whole
         // transaction
         let tx_signatures = source.tx_signatures();
@@ -171,11 +179,13 @@ impl Merge<iota_types::transaction::Transaction> for UserSignatures {
 }
 
 impl Merge<&iota_sdk_types::SignedTransaction> for UserSignatures {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &iota_sdk_types::SignedTransaction,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Use mask directly — UserSignatures is a transparent wrapper
         self.signatures = source
             .signatures
@@ -188,11 +198,9 @@ impl Merge<&iota_sdk_types::SignedTransaction> for UserSignatures {
 }
 
 impl Merge<&UserSignatures> for UserSignatures {
-    fn merge(
-        &mut self,
-        source: &UserSignatures,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    type Error = RpcError;
+
+    fn merge(&mut self, source: &UserSignatures, mask: &FieldMaskTree) -> Result<(), Self::Error> {
         // Use mask directly — UserSignatures is a transparent wrapper
         self.signatures = source
             .signatures
@@ -206,11 +214,13 @@ impl Merge<&UserSignatures> for UserSignatures {
 
 // Event implementations
 impl Merge<&iota_sdk_types::TransactionEvents> for Events {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &iota_sdk_types::TransactionEvents,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Use mask directly — Events is a transparent wrapper
         // TransactionEvents is a tuple struct with Vec<Event> at index 0
         self.events = source
@@ -226,11 +236,13 @@ impl Merge<&iota_sdk_types::TransactionEvents> for Events {
 }
 
 impl Merge<&iota_sdk_types::Event> for Event {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &iota_sdk_types::Event,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::BCS_FIELD.name) {
             self.bcs = Some(BcsData::serialize(&VersionedEvent::V1(source.clone()))?);
         }
@@ -267,11 +279,13 @@ impl Merge<&iota_sdk_types::Event> for Event {
 
 // Object implementations
 impl Merge<iota_types::object::Object> for Object {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_types::object::Object,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if !mask.contains(Self::REFERENCE_FIELD.name) && !mask.contains(Self::BCS_FIELD.name) {
             // No need to convert if no field is requested
             return Ok(());
@@ -286,11 +300,13 @@ impl Merge<iota_types::object::Object> for Object {
 }
 
 impl Merge<&iota_sdk_types::object::Object> for Object {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &iota_sdk_types::object::Object,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::BCS_FIELD.name) {
             self.bcs = Some(BcsData::serialize(&VersionedObject::V1(source.clone()))?);
         }
@@ -329,11 +345,9 @@ impl Merge<&iota_sdk_types::object::Object> for Object {
 }
 
 impl Merge<&Object> for Object {
-    fn merge(
-        &mut self,
-        source: &Object,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    type Error = RpcError;
+
+    fn merge(&mut self, source: &Object, mask: &FieldMaskTree) -> Result<(), Self::Error> {
         if mask.contains(Self::REFERENCE_FIELD.name) {
             self.reference = source.reference.clone();
         }
@@ -347,11 +361,13 @@ impl Merge<&Object> for Object {
 }
 
 impl Merge<Option<Vec<iota_types::object::Object>>> for Objects {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: Option<Vec<iota_types::object::Object>>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Use mask directly — Objects is a transparent wrapper
         if let Some(objects) = source {
             self.objects = objects
@@ -365,11 +381,9 @@ impl Merge<Option<Vec<iota_types::object::Object>>> for Objects {
 }
 
 impl Merge<&Objects> for Objects {
-    fn merge(
-        &mut self,
-        source: &Objects,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    type Error = RpcError;
+
+    fn merge(&mut self, source: &Objects, mask: &FieldMaskTree) -> Result<(), Self::Error> {
         // Use mask directly — Objects is a transparent wrapper
         self.objects = source
             .objects
@@ -383,11 +397,13 @@ impl Merge<&Objects> for Objects {
 
 // Checkpoint implementations
 impl Merge<iota_sdk_types::CheckpointSummary> for CheckpointSummary {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_sdk_types::CheckpointSummary,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::BCS_FIELD.name) {
             self.bcs = Some(BcsData::serialize(&VersionedCheckpointSummary::V1(
                 source.clone(),
@@ -403,11 +419,13 @@ impl Merge<iota_sdk_types::CheckpointSummary> for CheckpointSummary {
 }
 
 impl Merge<&CheckpointSummary> for CheckpointSummary {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &CheckpointSummary,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         let CheckpointSummary { bcs, digest, .. } = source;
 
         if mask.contains(Self::DIGEST_FIELD.name) {
@@ -423,11 +441,13 @@ impl Merge<&CheckpointSummary> for CheckpointSummary {
 }
 
 impl Merge<iota_sdk_types::CheckpointContents> for CheckpointContents {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_sdk_types::CheckpointContents,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::BCS_FIELD.name) {
             // CheckpointContents has a custom Serialize impl that embeds
             // a BCS enum discriminant byte, so no versioned wrapper needed.
@@ -443,11 +463,13 @@ impl Merge<iota_sdk_types::CheckpointContents> for CheckpointContents {
 }
 
 impl Merge<&CheckpointContents> for CheckpointContents {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &CheckpointContents,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         let CheckpointContents { bcs, digest, .. } = source;
 
         if mask.contains(Self::BCS_FIELD.name) {
@@ -463,11 +485,13 @@ impl Merge<&CheckpointContents> for CheckpointContents {
 }
 
 impl Merge<&iota_sdk_types::CheckpointSummary> for Checkpoint {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &iota_sdk_types::CheckpointSummary,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if let Some(submask) = mask.subtree(Self::SUMMARY_FIELD.name) {
             self.summary = Some(CheckpointSummary::merge_from(source.clone(), &submask)?);
         }
@@ -477,11 +501,13 @@ impl Merge<&iota_sdk_types::CheckpointSummary> for Checkpoint {
 }
 
 impl Merge<iota_sdk_types::ValidatorAggregatedSignature> for Checkpoint {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_sdk_types::ValidatorAggregatedSignature,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::SIGNATURE_FIELD.name) {
             self.signature = Some(source.into());
         }
@@ -491,11 +517,13 @@ impl Merge<iota_sdk_types::ValidatorAggregatedSignature> for Checkpoint {
 }
 
 impl Merge<iota_sdk_types::CheckpointContents> for Checkpoint {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_sdk_types::CheckpointContents,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if let Some(submask) = mask.subtree(Self::CONTENTS_FIELD.name) {
             self.contents = Some(CheckpointContents::merge_from(source, &submask)?);
         }
@@ -505,11 +533,9 @@ impl Merge<iota_sdk_types::CheckpointContents> for Checkpoint {
 }
 
 impl Merge<&Checkpoint> for Checkpoint {
-    fn merge(
-        &mut self,
-        source: &Checkpoint,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    type Error = RpcError;
+
+    fn merge(&mut self, source: &Checkpoint, mask: &FieldMaskTree) -> Result<(), Self::Error> {
         let Checkpoint {
             sequence_number,
             summary,
@@ -546,11 +572,13 @@ impl Merge<&Checkpoint> for Checkpoint {
 
 // Transaction implementations
 impl Merge<iota_types::effects::TransactionEffects> for TransactionEffects {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_types::effects::TransactionEffects,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if !mask.contains(Self::DIGEST_FIELD.name) && !mask.contains(Self::BCS_FIELD.name) {
             // No need to convert if no field is requested
             return Ok(());
@@ -566,11 +594,13 @@ impl Merge<iota_types::effects::TransactionEffects> for TransactionEffects {
 }
 
 impl Merge<&iota_sdk_types::TransactionEffects> for TransactionEffects {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &iota_sdk_types::TransactionEffects,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Set digest if requested
         if mask.contains(Self::DIGEST_FIELD.name) {
             self.digest = Some(source.digest().into());
@@ -586,11 +616,13 @@ impl Merge<&iota_sdk_types::TransactionEffects> for TransactionEffects {
 }
 
 impl Merge<&TransactionEffects> for TransactionEffects {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &TransactionEffects,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::DIGEST_FIELD.name) {
             self.digest = source.digest.clone();
         }
@@ -604,11 +636,13 @@ impl Merge<&TransactionEffects> for TransactionEffects {
 }
 
 impl Merge<iota_types::effects::TransactionEvents> for TransactionEvents {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_types::effects::TransactionEvents,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if !mask.contains(Self::DIGEST_FIELD.name) && !mask.contains(Self::EVENTS_FIELD.name) {
             // No need to convert if no field is requested
             return Ok(());
@@ -623,11 +657,13 @@ impl Merge<iota_types::effects::TransactionEvents> for TransactionEvents {
 }
 
 impl Merge<&iota_sdk_types::TransactionEvents> for TransactionEvents {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &iota_sdk_types::TransactionEvents,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Set digest if requested
         if mask.contains(Self::DIGEST_FIELD.name) {
             self.digest = Some(source.digest().into());
@@ -642,11 +678,13 @@ impl Merge<&iota_sdk_types::TransactionEvents> for TransactionEvents {
 }
 
 impl Merge<&TransactionEvents> for TransactionEvents {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &TransactionEvents,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::DIGEST_FIELD.name) {
             self.digest = source.digest.clone();
         }
@@ -660,11 +698,13 @@ impl Merge<&TransactionEvents> for TransactionEvents {
 }
 
 impl Merge<&ExecutedTransaction> for ExecutedTransaction {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &ExecutedTransaction,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         let ExecutedTransaction {
             transaction,
             signatures,
@@ -726,11 +766,13 @@ impl Merge<&ExecutedTransaction> for ExecutedTransaction {
 }
 
 impl Merge<iota_types::transaction::Transaction> for Transaction {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: iota_types::transaction::Transaction,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if !mask.contains(Self::DIGEST_FIELD.name) && !mask.contains(Self::BCS_FIELD.name) {
             // No need to convert if no field is requested
             return Ok(());
@@ -747,11 +789,13 @@ impl Merge<iota_types::transaction::Transaction> for Transaction {
 }
 
 impl Merge<&iota_sdk_types::Transaction> for Transaction {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &iota_sdk_types::Transaction,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::DIGEST_FIELD.name) {
             self.digest = Some((source.digest()).into());
         }
@@ -765,11 +809,9 @@ impl Merge<&iota_sdk_types::Transaction> for Transaction {
 }
 
 impl Merge<&Transaction> for Transaction {
-    fn merge(
-        &mut self,
-        source: &Transaction,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    type Error = RpcError;
+
+    fn merge(&mut self, source: &Transaction, mask: &FieldMaskTree) -> Result<(), Self::Error> {
         let Transaction { bcs, digest, .. } = source;
 
         if mask.contains(Self::DIGEST_FIELD.name) {

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -112,9 +112,10 @@ impl Merge<iota_types::signature::GenericSignature> for UserSignature {
             return Ok(());
         }
 
-        let sdk_signature: iota_sdk_types::UserSignature = source
-            .try_into()
-            .map_err(|e| format!("Failed to convert signature: {}", e))?;
+        let sdk_signature: iota_sdk_types::UserSignature =
+            source.try_into().map_err(|e: bcs::Error| {
+                RpcError::from(e).with_context("failed to convert signature")
+            })?;
 
         Merge::merge(self, sdk_signature, mask)
     }
@@ -166,10 +167,10 @@ impl Merge<iota_types::transaction::Transaction> for UserSignatures {
             .iter()
             .map(|sig| {
                 // Convert iota_types signature to SDK signature, then merge
-                let sdk_sig: iota_sdk_types::UserSignature = sig
-                    .clone()
-                    .try_into()
-                    .map_err(|e| format!("Failed to convert signature: {e}"))?;
+                let sdk_sig: iota_sdk_types::UserSignature =
+                    sig.clone().try_into().map_err(|e: bcs::Error| {
+                        RpcError::from(e).with_context("failed to convert signature")
+                    })?;
                 UserSignature::merge_from(sdk_sig, mask)
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -226,9 +227,7 @@ impl Merge<&iota_sdk_types::TransactionEvents> for Events {
         self.events = source
             .0
             .iter()
-            .map(|event| -> Result<_, Box<dyn std::error::Error>> {
-                Merge::merge_from(event, mask)
-            })
+            .map(|event| Merge::merge_from(event, mask))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(())
@@ -291,9 +290,10 @@ impl Merge<iota_types::object::Object> for Object {
             return Ok(());
         }
 
-        let sdk_object: iota_sdk_types::object::Object = source
-            .try_into()
-            .map_err(|e: SdkTypeConversionError| format!("Failed to convert SDK object: {}", e))?;
+        let sdk_object: iota_sdk_types::object::Object =
+            source.try_into().map_err(|e: SdkTypeConversionError| {
+                RpcError::from(e).with_context("failed to convert object")
+            })?;
 
         Merge::merge(self, &sdk_object, mask)
     }
@@ -585,9 +585,10 @@ impl Merge<iota_types::effects::TransactionEffects> for TransactionEffects {
         }
 
         // Convert iota_types to iota_sdk_types types for external compatibility
-        let sdk_effects: iota_sdk_types::TransactionEffects = source
-            .try_into()
-            .map_err(|e| format!("failed to convert effects to SDK type: {e}"))?;
+        let sdk_effects: iota_sdk_types::TransactionEffects =
+            source.try_into().map_err(|e: SdkTypeConversionError| {
+                RpcError::from(e).with_context("failed to convert effects")
+            })?;
 
         Merge::merge(self, &sdk_effects, mask)
     }
@@ -648,9 +649,10 @@ impl Merge<iota_types::effects::TransactionEvents> for TransactionEvents {
             return Ok(());
         }
 
-        let sdk_events: iota_sdk_types::TransactionEvents = source
-            .try_into()
-            .map_err(|e| format!("failed to convert events to SDK type: {e}"))?;
+        let sdk_events: iota_sdk_types::TransactionEvents =
+            source.try_into().map_err(|e: SdkTypeConversionError| {
+                RpcError::from(e).with_context("failed to convert events")
+            })?;
 
         Merge::merge(self, &sdk_events, mask)
     }
@@ -782,7 +784,9 @@ impl Merge<iota_types::transaction::Transaction> for Transaction {
             .transaction_data()
             .clone()
             .try_into()
-            .map_err(|e| format!("failed to convert transaction to SDK type: {e}"))?;
+            .map_err(|e: SdkTypeConversionError| {
+                RpcError::from(e).with_context("failed to convert transaction")
+            })?;
 
         Merge::merge(self, &sdk_transaction, mask)
     }

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -227,7 +227,9 @@ impl Merge<&iota_sdk_types::TransactionEvents> for Events {
         self.events = source
             .0
             .iter()
-            .map(|event| Merge::merge_from(event, mask))
+            .map(|event| {
+                Event::merge_from(event, mask).map_err(|e| e.with_context("failed to merge event"))
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(())

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -292,12 +292,8 @@ pub async fn execute_transaction(
 
     Ok(
         ExecuteTransactionResponse::default().with_executed_transaction(
-            ExecutedTransaction::merge_from(&source, &read_mask).map_err(|e| {
-                RpcError::new(
-                    tonic::Code::Internal,
-                    format!("failed to build executed transaction in execution response: {e}"),
-                )
-            })?,
+            ExecutedTransaction::merge_from(&source, &read_mask)
+                .map_err(|e| e.with_context("failed to merge executed transaction"))?,
         ),
     )
 }

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -331,12 +331,8 @@ pub async fn simulate_transaction(
         };
 
         response.executed_transaction = Some(
-            ExecutedTransaction::merge_from(&source, &tx_mask).map_err(|e| {
-                RpcError::new(
-                    tonic::Code::Internal,
-                    format!("failed to build executed transaction in simulation response: {e}"),
-                )
-            })?,
+            ExecutedTransaction::merge_from(&source, &tx_mask)
+                .map_err(|e| e.with_context("failed to merge executed transaction"))?,
         );
     }
 
@@ -366,16 +362,9 @@ pub async fn simulate_transaction(
                         execution_results: execution_results.clone(),
                     };
 
-                    let command_results = CommandResults::merge_from(
-                        &cmd_source,
-                        &command_results_mask,
-                    )
-                    .map_err(|e| {
-                        RpcError::new(
-                            tonic::Code::Internal,
-                            format!("failed to build command results in execution result: {e}"),
-                        )
-                    })?;
+                    let command_results =
+                        CommandResults::merge_from(&cmd_source, &command_results_mask)
+                            .map_err(|e| e.with_context("failed to merge command results"))?;
 
                     response.execution_result =
                         Some(ExecutionResult::CommandResults(command_results));

--- a/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
@@ -15,7 +15,7 @@ use iota_grpc_types::{
 };
 use iota_types::iota_sdk_types_conversions::type_tag_core_to_sdk;
 
-use crate::{GrpcReader, merge::Merge, utils::render_json};
+use crate::{GrpcReader, error::RpcError, merge::Merge, utils::render_json};
 
 /// Source for building ExecutedTransaction using the Merge trait
 pub struct TransactionReadSource<'a> {
@@ -32,11 +32,13 @@ pub struct TransactionReadSource<'a> {
 }
 
 impl Merge<&TransactionReadSource<'_>> for grpc_tx::ExecutedTransaction {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &TransactionReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Set transaction if requested
         if let Some(tx_mask) = mask.subtree(Self::TRANSACTION_FIELD.name) {
             self.transaction = Some(grpc_tx::Transaction::merge_from(source, &tx_mask)?);
@@ -96,11 +98,13 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::ExecutedTransaction {
 }
 
 impl Merge<&TransactionReadSource<'_>> for grpc_tx::Transaction {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &TransactionReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if !mask.contains(Self::DIGEST_FIELD.name) && !mask.contains(Self::BCS_FIELD.name) {
             // No need to convert if no field is requested
             return Ok(());
@@ -123,11 +127,13 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::Transaction {
 }
 
 impl Merge<&TransactionReadSource<'_>> for grpc_tx::TransactionEffects {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &TransactionReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         let Some(effects) = source.effects.as_ref() else {
             return Ok(());
         };
@@ -137,11 +143,13 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::TransactionEffects {
 }
 
 impl Merge<&TransactionReadSource<'_>> for grpc_tx::TransactionEvents {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &TransactionReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Use unwrap_or_default so that when no events were emitted we still
         // compute a real digest (hash of the empty list) and populate an empty
         // events vec — to distinguish between "no events" and "events
@@ -179,11 +187,13 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::TransactionEvents {
 // UserSignatures
 //
 impl Merge<&TransactionReadSource<'_>> for grpc_sig::UserSignatures {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &TransactionReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Use mask directly — UserSignatures is a transparent wrapper
         if let Some(signatures) = source.signatures.as_ref() {
             self.signatures = signatures
@@ -204,11 +214,13 @@ pub struct CommandResultsReadSource<'a> {
 }
 
 impl Merge<&CommandResultsReadSource<'_>> for CommandResults {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &CommandResultsReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Use mask directly — CommandResults is a transparent wrapper
         self.results = source
             .execution_results
@@ -223,6 +235,7 @@ impl Merge<&CommandResultsReadSource<'_>> for CommandResults {
                 CommandResult::merge_from(&result_source, mask)
             })
             .collect::<Result<Vec<_>, _>>()?;
+
         Ok(())
     }
 }
@@ -240,11 +253,13 @@ struct CommandResultReadSource<'a> {
 }
 
 impl Merge<&CommandResultReadSource<'_>> for CommandResult {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &CommandResultReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if let Some(mutated_mask) = mask.subtree(Self::MUTATED_BY_REF_FIELD.name) {
             let outputs_source = CommandOutputsReadSource {
                 reader: source.reader,
@@ -289,11 +304,13 @@ struct CommandOutputsReadSource<'a> {
 }
 
 impl Merge<&CommandOutputsReadSource<'_>> for CommandOutputs {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &CommandOutputsReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         // Use mask directly — CommandOutputs is a transparent wrapper
         self.outputs = source
             .outputs
@@ -309,6 +326,7 @@ impl Merge<&CommandOutputsReadSource<'_>> for CommandOutputs {
                 CommandOutput::merge_from(&output_source, mask)
             })
             .collect::<Result<Vec<_>, _>>()?;
+
         Ok(())
     }
 }
@@ -323,11 +341,13 @@ struct CommandOutputReadSource<'a> {
 }
 
 impl Merge<&CommandOutputReadSource<'_>> for CommandOutput {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: &CommandOutputReadSource<'_>,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if mask.contains(Self::ARGUMENT_FIELD.name) {
             self.argument = source
                 .arg

--- a/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
@@ -110,7 +110,10 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::Transaction {
             return Ok(());
         }
 
-        let transaction = source.transaction.as_ref().ok_or("missing transaction")?;
+        let transaction = source
+            .transaction
+            .as_ref()
+            .ok_or_else(|| RpcError::new(tonic::Code::Internal, "missing transaction"))?;
 
         // Set digest if requested
         if mask.contains(Self::DIGEST_FIELD.name) {
@@ -351,9 +354,11 @@ impl Merge<&CommandOutputReadSource<'_>> for CommandOutput {
         if mask.contains(Self::ARGUMENT_FIELD.name) {
             self.argument = source
                 .arg
-                .map(|arg| -> Result<_, Box<dyn std::error::Error>> {
+                .map(|arg| -> Result<_, RpcError> {
                     let sdk_arg: iota_sdk_types::Argument = arg.into();
-                    sdk_arg.try_into().map_err(Into::into)
+                    sdk_arg
+                        .try_into()
+                        .map_err(|e| RpcError::from(e).with_context("failed to merge argument"))
                 })
                 .transpose()?;
         }
@@ -361,7 +366,7 @@ impl Merge<&CommandOutputReadSource<'_>> for CommandOutput {
         if mask.contains(Self::TYPE_TAG_FIELD.name) {
             self.type_tag = Some({
                 let sdk_type_tag = type_tag_core_to_sdk(source.ty.clone())
-                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+                    .map_err(|e| RpcError::from(e).with_context("failed to convert type tag"))?;
                 (&sdk_type_tag).into()
             });
         }

--- a/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
@@ -113,7 +113,7 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::Transaction {
         let transaction = source
             .transaction
             .as_ref()
-            .ok_or_else(|| RpcError::new(tonic::Code::Internal, "missing transaction"))?;
+            .ok_or_else(|| RpcError::internal().with_context("missing transaction"))?;
 
         // Set digest if requested
         if mask.contains(Self::DIGEST_FIELD.name) {

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -591,11 +591,11 @@ impl GrpcReader {
 
             // Use Merge to populate based on mask
             Merge::merge(&mut checkpoint_proto, &sdk_summary, &checkpoint_mask)
-                .map_err(|e: RpcError| Status::from(e.with_context("failed to merge summary")))?;
+                .map_err(|e| e.with_context("failed to merge summary"))?;
             Merge::merge(&mut checkpoint_proto, sdk_contents, &checkpoint_mask)
-                .map_err(|e: RpcError| Status::from(e.with_context("failed to merge contents")))?;
+                .map_err(|e| e.with_context("failed to merge contents"))?;
             Merge::merge(&mut checkpoint_proto, sdk_signature, &checkpoint_mask)
-                .map_err(|e: RpcError| Status::from(e.with_context("failed to merge signature")))?;
+                .map_err(|e| e.with_context("failed to merge signature"))?;
 
             yield Ok(grpc_ledger_service::CheckpointData::default().with_checkpoint(checkpoint_proto));
 
@@ -637,7 +637,7 @@ impl GrpcReader {
                                             .try_into()
                                             .map_err(|e| Status::internal(format!("event conversion error: {e}")))?;
                                         let grpc_event = grpc_event::Event::merge_from(&sdk_event, &events_submask)
-                                            .map_err(|e: RpcError| Status::from(e.with_context("failed to merge event")))?;
+                                            .map_err(|e| e.with_context("failed to merge event"))?;
                                         let event_size = grpc_event.encoded_len();
 
                                         // Check if adding this event would exceed limit
@@ -675,7 +675,7 @@ impl GrpcReader {
                                     checkpoint_tx_ctx,
                                     &tx_mask,
                                 )
-                                .map_err(|e: RpcError| Status::from(e.with_context("failed to merge transaction")))?;
+                                .map_err(|e| e.with_context("failed to merge transaction"))?;
                                 let tx_size = executed_tx.encoded_len();
 
                                 // Check if adding this tx would exceed limit

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -591,11 +591,11 @@ impl GrpcReader {
 
             // Use Merge to populate based on mask
             Merge::merge(&mut checkpoint_proto, &sdk_summary, &checkpoint_mask)
-                .map_err(|e| Status::internal(format!("merge error for summary: {e}")))?;
+                .map_err(|e: RpcError| Status::from(e.with_context("failed to merge summary")))?;
             Merge::merge(&mut checkpoint_proto, sdk_contents, &checkpoint_mask)
-                .map_err(|e| Status::internal(format!("merge error for contents: {e}")))?;
+                .map_err(|e: RpcError| Status::from(e.with_context("failed to merge contents")))?;
             Merge::merge(&mut checkpoint_proto, sdk_signature, &checkpoint_mask)
-                .map_err(|e| Status::internal(format!("merge error for signature: {e}")))?;
+                .map_err(|e: RpcError| Status::from(e.with_context("failed to merge signature")))?;
 
             yield Ok(grpc_ledger_service::CheckpointData::default().with_checkpoint(checkpoint_proto));
 
@@ -637,7 +637,7 @@ impl GrpcReader {
                                             .try_into()
                                             .map_err(|e| Status::internal(format!("event conversion error: {e}")))?;
                                         let grpc_event = grpc_event::Event::merge_from(&sdk_event, &events_submask)
-                                            .map_err(|e| Status::internal(format!("event merge error: {e}")))?;
+                                            .map_err(|e: RpcError| Status::from(e.with_context("failed to merge event")))?;
                                         let event_size = grpc_event.encoded_len();
 
                                         // Check if adding this event would exceed limit
@@ -675,7 +675,7 @@ impl GrpcReader {
                                     checkpoint_tx_ctx,
                                     &tx_mask,
                                 )
-                                .map_err(|e| Status::internal(format!("transaction merge error: {e}")))?;
+                                .map_err(|e: RpcError| Status::from(e.with_context("failed to merge transaction")))?;
                                 let tx_size = executed_tx.encoded_len();
 
                                 // Check if adding this tx would exceed limit

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -33,7 +33,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::Status;
 use tracing::debug;
 
-use crate::merge::Merge;
+use crate::{error::RpcError, merge::Merge};
 
 /// Flags indicating which optional transaction fields to fetch from storage.
 /// Derived from a `FieldMaskTree` to skip unnecessary storage reads.
@@ -1214,11 +1214,13 @@ impl CheckpointTransactionWithContext {
 impl Merge<CheckpointTransactionWithContext>
     for iota_grpc_types::v0::transaction::ExecutedTransaction
 {
+    type Error = RpcError;
+
     fn merge(
         &mut self,
         source: CheckpointTransactionWithContext,
         mask: &FieldMaskTree,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Self::Error> {
         if let Some(submask) = mask.subtree(Self::TRANSACTION_FIELD.name) {
             self.transaction = Some(iota_grpc_types::v0::transaction::Transaction::merge_from(
                 source.transaction.transaction.clone(),


### PR DESCRIPTION
# Description of change

This PR removes the anti-pattern where `format!("{e}") → String → RpcError` happened, which lost error codes and type info via the From<String> catch-all.

The `Merge` trait now has an associated error type.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes