### PR TITLE
feat(core): remove deprecated tables config and unmark json-index tables as deprecated

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -103,9 +103,6 @@ pub struct NodeConfig {
     #[serde(default = "default_enable_index_processing")]
     pub enable_index_processing: bool,
 
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub remove_deprecated_tables: bool,
-
     // only allow websocket connections for jsonrpc traffic
     #[serde(default)]
     /// Determines the jsonrpc server type as either:

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -340,7 +340,6 @@ impl<'a> TestAuthorityBuilder<'a> {
                 epoch_store
                     .protocol_config()
                     .max_move_identifier_len_as_option(),
-                false,
             )))
         };
         let rest_index = if self.disable_indexer {

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -167,12 +167,10 @@ pub struct IndexStoreTables {
     transactions_to_addr: DBMap<(IotaAddress, TxSequenceNumber), TransactionDigest>,
 
     /// Index from object id to transactions that used that object id as input.
-    #[deprecated]
     transactions_by_input_object_id: DBMap<(ObjectID, TxSequenceNumber), TransactionDigest>,
 
     /// Index from object id to transactions that modified/created that object
     /// id.
-    #[deprecated]
     transactions_by_mutated_object_id: DBMap<(ObjectID, TxSequenceNumber), TransactionDigest>,
 
     /// Index from package id, module and function identifier to transactions
@@ -236,7 +234,6 @@ pub struct IndexStore {
     caches: IndexStoreCaches,
     metrics: Arc<IndexStoreMetrics>,
     max_type_length: u64,
-    remove_deprecated_tables: bool,
     pruner_watermark: Arc<AtomicU64>,
 }
 
@@ -330,12 +327,7 @@ fn coin_index_table_default_config() -> DBOptions {
 }
 
 impl IndexStore {
-    pub fn new(
-        path: PathBuf,
-        registry: &Registry,
-        max_type_length: Option<u64>,
-        remove_deprecated_tables: bool,
-    ) -> Self {
+    pub fn new(path: PathBuf, registry: &Registry, max_type_length: Option<u64>) -> Self {
         let db_options = default_db_options().disable_write_throttling();
         let pruner_watermark = Arc::new(AtomicU64::new(0));
         let compaction_metrics = JsonRpcCompactionMetrics::new(registry);
@@ -443,12 +435,11 @@ impl IndexStore {
                 ),
             ),
         ]));
-        let tables = IndexStoreTables::open_tables_read_write_with_deprecation_option(
+        let tables = IndexStoreTables::open_tables_read_write(
             path,
             MetricConf::new("index"),
             Some(db_options.options),
             Some(table_options),
-            remove_deprecated_tables,
         );
 
         let metrics = IndexStoreMetrics::new(registry);
@@ -480,7 +471,6 @@ impl IndexStore {
             caches,
             metrics: Arc::new(metrics),
             max_type_length: max_type_length.unwrap_or(128),
-            remove_deprecated_tables,
             pruner_watermark,
         }
     }
@@ -660,20 +650,17 @@ impl IndexStore {
             std::iter::once(((sender, sequence), *digest)),
         )?;
 
-        #[allow(deprecated)]
-        if !self.remove_deprecated_tables {
-            batch.insert_batch(
-                &self.tables.transactions_by_input_object_id,
-                active_inputs.map(|id| ((id, sequence), *digest)),
-            )?;
+        batch.insert_batch(
+            &self.tables.transactions_by_input_object_id,
+            active_inputs.map(|id| ((id, sequence), *digest)),
+        )?;
 
-            batch.insert_batch(
-                &self.tables.transactions_by_mutated_object_id,
-                mutated_objects
-                    .clone()
-                    .map(|(obj_ref, _)| ((obj_ref.0, sequence), *digest)),
-            )?;
-        }
+        batch.insert_batch(
+            &self.tables.transactions_by_mutated_object_id,
+            mutated_objects
+                .clone()
+                .map(|(obj_ref, _)| ((obj_ref.0, sequence), *digest)),
+        )?;
 
         batch.insert_batch(
             &self.tables.transactions_by_move_function,
@@ -919,10 +906,6 @@ impl IndexStore {
         limit: Option<usize>,
         reverse: bool,
     ) -> IotaResult<Vec<TransactionDigest>> {
-        if self.remove_deprecated_tables {
-            return Ok(vec![]);
-        }
-        #[allow(deprecated)]
         Self::get_transactions_from_index(
             &self.tables.transactions_by_input_object_id,
             input_object,
@@ -939,10 +922,6 @@ impl IndexStore {
         limit: Option<usize>,
         reverse: bool,
     ) -> IotaResult<Vec<TransactionDigest>> {
-        if self.remove_deprecated_tables {
-            return Ok(vec![]);
-        }
-        #[allow(deprecated)]
         Self::get_transactions_from_index(
             &self.tables.transactions_by_mutated_object_id,
             mutated_object,
@@ -1747,7 +1726,7 @@ mod tests {
         // again and read balance. The balance should be 700 and verified from
         // both db and cache. This tests make sure we are invalidating entries
         // in the cache and always reading latest balance.
-        let index_store = IndexStore::new(temp_dir(), &Registry::default(), Some(128), false);
+        let index_store = IndexStore::new(temp_dir(), &Registry::default(), Some(128));
         let address: IotaAddress = AccountAddress::random().into();
         let mut written_objects = BTreeMap::new();
         let mut object_map = BTreeMap::new();
@@ -1862,7 +1841,7 @@ mod tests {
         use iota_types::base_types::ObjectID;
         use typed_store::Map;
 
-        let index_store = IndexStore::new(temp_dir(), &Registry::default(), Some(128), false);
+        let index_store = IndexStore::new(temp_dir(), &Registry::default(), Some(128));
         let db = &index_store.tables.transactions_by_move_function;
         db.insert(
             &(

--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -187,7 +187,7 @@ impl IndexStoreTables {
         }) || self.is_indexed_watermark_out_of_date(checkpoint_store)
     }
 
-    // Check if the index watermark is behind the highets_executed watermark.
+    // Check if the index watermark is behind the highest_executed_checkpoint.
     fn is_indexed_watermark_out_of_date(&self, checkpoint_store: &CheckpointStore) -> bool {
         let highest_executed_checkpoint = checkpoint_store
             .get_highest_executed_checkpoint_seq_number()

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -663,7 +663,6 @@ impl IotaNode {
                 epoch_store
                     .protocol_config()
                     .max_move_identifier_len_as_option(),
-                config.remove_deprecated_tables,
             )))
         } else {
             None

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -213,7 +213,6 @@ impl ValidatorConfigBuilder {
                 .to_socket_addr()
                 .unwrap(),
             consensus_config: Some(consensus_config),
-            remove_deprecated_tables: false,
             enable_index_processing: default_enable_index_processing(),
             genesis: Genesis::new_empty(),
             migration_tx_data_path,
@@ -574,7 +573,6 @@ impl FullnodeConfigBuilder {
                 .unwrap_or(local_ip_utils::new_local_tcp_socket_for_testing()),
             json_rpc_address: self.json_rpc_address.unwrap_or(json_rpc_address),
             consensus_config: None,
-            remove_deprecated_tables: false,
             enable_index_processing: default_enable_index_processing(),
             genesis,
             migration_tx_data_path,


### PR DESCRIPTION
# Description of change

This PR removes the `remove_deprecated_tables` config flag. 

It shouldn't be controlled by the users when we decide to deprecate and remove tables from the database, but decided by the devs. Otherwise it could lead to massive allocated storage from tables on disc that we removed long time ago from the code. We will implement another mechanism in another PR. 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Remove `remove_deprecated_tables` config flag
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
