### PR TITLE
feat(wallet): make inputs human readable

### DIFF
--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/Input.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/Input.tsx
@@ -3,25 +3,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ExplorerLink, ExplorerLinkType } from '_components';
+import { type IotaCallArg } from '@iota/iota-sdk/client';
 import { type TransactionInput } from '@iota/iota-sdk/transactions';
 import { formatAddress, toBase64 } from '@iota/iota-sdk/utils';
 import { KeyValueInfo } from '@iota/apps-ui-kit';
+import type { ReactNode } from 'react';
+import { formatPureInputValue, getPureValueTypeLabel } from './pureValueType';
+
+interface PureInputProps {
+    input: TransactionInput;
+    dryRunInput?: IotaCallArg;
+}
+
+function PureInput({ input, dryRunInput }: PureInputProps) {
+    if (dryRunInput?.type !== 'pure') {
+        const bytes = 'Pure' in input ? input.Pure?.bytes || [] : [];
+        return (
+            <KeyValueInfo
+                keyText="Pure"
+                value={toBase64(new Uint8Array(Buffer.from(bytes)))}
+                fullwidth
+            />
+        );
+    }
+
+    const keyText = getPureValueTypeLabel(dryRunInput.valueType);
+
+    let value: ReactNode;
+    if (dryRunInput.valueType === 'address') {
+        const addr = String(dryRunInput.value);
+        value = (
+            <ExplorerLink type={ExplorerLinkType.Address} address={addr} eventType="address">
+                {formatAddress(addr)}
+            </ExplorerLink>
+        );
+    } else {
+        value = formatPureInputValue(dryRunInput.value, dryRunInput.valueType);
+    }
+
+    return <KeyValueInfo keyText={keyText} value={value} fullwidth />;
+}
 
 interface InputProps {
     input: TransactionInput;
+    dryRunInput?: IotaCallArg;
 }
 
-export function Input({ input }: InputProps) {
+export function Input({ input, dryRunInput }: InputProps) {
     const { objectId } = input?.Object?.ImmOrOwnedObject || input?.Object?.SharedObject || {};
 
     return (
         <div className="flex flex-col gap-y-sm px-md">
             {'Pure' in input ? (
-                <KeyValueInfo
-                    keyText="Pure"
-                    value={toBase64(new Uint8Array(Buffer.from(input.Pure?.bytes || [])))}
-                    fullwidth
-                />
+                <PureInput input={input} dryRunInput={dryRunInput} />
             ) : 'Object' in input ? (
                 <KeyValueInfo
                     keyText="Object"
@@ -36,11 +70,7 @@ export function Input({ input }: InputProps) {
                     }
                     fullwidth
                 />
-            ) : (
-                <span className="text-body-md text-iota-neutral-40 dark:text-iota-neutral-60">
-                    Unknown input value
-                </span>
-            )}
+            ) : null}
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/Input.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/Input.tsx
@@ -70,7 +70,11 @@ export function Input({ input, dryRunInput }: InputProps) {
                     }
                     fullwidth
                 />
-            ) : null}
+            ) : (
+                <span className="text-body-md text-iota-neutral-40 dark:text-iota-neutral-60">
+                    Unknown input value
+                </span>
+            )}
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/index.tsx
@@ -2,8 +2,12 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { useTransactionData } from '_hooks';
-import { type Transaction } from '@iota/iota-sdk/transactions';
+import { useTransactionData, useTransactionDryRun } from '_hooks';
+import type {
+    TransactionInput,
+    Command as TxCommand,
+    Transaction,
+} from '@iota/iota-sdk/transactions';
 import { Command } from './Command';
 import { Input } from './Input';
 import { Collapsible } from '@iota/core';
@@ -53,6 +57,12 @@ export function TransactionDetails({ sender, transaction }: TransactionDetailsPr
         isError,
         error,
     } = useTransactionData(sender, transaction);
+
+    const { data: dryRunData } = useTransactionDryRun(sender, transaction);
+    const dryRunInputs =
+        dryRunData?.input.transaction.kind === 'ProgrammableTransaction'
+            ? dryRunData.input.transaction.inputs
+            : undefined;
     useEffect(() => {
         if (transactionData) {
             const defaultCategory =
@@ -110,17 +120,25 @@ export function TransactionDetails({ sender, transaction }: TransactionDetailsPr
                             {selectedDetailsCategory === DetailsCategory.Commands &&
                                 !!transactionData?.commands.length && (
                                     <div className="flex flex-col gap-md">
-                                        {transactionData?.commands.map((command, index) => (
-                                            <Command key={index} command={command} />
-                                        ))}
+                                        {(transactionData?.commands as TxCommand[]).map(
+                                            (command, index) => (
+                                                <Command key={index} command={command} />
+                                            ),
+                                        )}
                                     </div>
                                 )}
                             {selectedDetailsCategory === DetailsCategory.Inputs &&
                                 !!transactionData?.inputs.length && (
                                     <div className="flex flex-col gap-md">
-                                        {transactionData?.inputs.map((input, index) => (
-                                            <Input key={index} input={input} />
-                                        ))}
+                                        {(transactionData?.inputs as TransactionInput[]).map(
+                                            (input, index) => (
+                                                <Input
+                                                    key={index}
+                                                    input={input}
+                                                    dryRunInput={dryRunInputs?.[index]}
+                                                />
+                                            ),
+                                        )}
                                     </div>
                                 )}
                         </div>

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/pureValueType.ts
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/pureValueType.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+export const PURE_VALUETYPE_LABEL_MAP = {
+    bool: 'bool',
+    u8: 'u8',
+    u16: 'u16',
+    u32: 'u32',
+    u64: 'u64',
+    u128: 'u128',
+    u256: 'u256',
+    address: 'Address',
+    signer: 'Signer',
+    'vector<u8>': 'String',
+    '0x1::string::String': 'String',
+    '0x1::ascii::String': 'String',
+};
+
+const VECTOR_REGEX = /^vector<(.+)>$/;
+
+function isKnownPureValueType(
+    valueType: string,
+): valueType is keyof typeof PURE_VALUETYPE_LABEL_MAP {
+    return valueType in PURE_VALUETYPE_LABEL_MAP;
+}
+
+export function getPureValueTypeLabel(valueType: string | null | undefined): string {
+    if (!valueType) return '';
+
+    if (isKnownPureValueType(valueType)) {
+        return PURE_VALUETYPE_LABEL_MAP[valueType];
+    }
+
+    const isVector = valueType.match(VECTOR_REGEX);
+    if (isVector) {
+        // vector<address> → Address[]
+        return `${getPureValueTypeLabel(isVector[1])}[]`;
+    }
+
+    return valueType;
+}
+
+export function formatPureInputValue(value: unknown, valueType: string | null | undefined): string {
+    if (
+        valueType === 'vector<u8>' ||
+        valueType === '0x1::string::String' ||
+        valueType === '0x1::ascii::String'
+    ) {
+        try {
+            const arr: number[] = Array.isArray(value)
+                ? (value as number[])
+                : JSON.parse(`[${String(value)}]`);
+            return new TextDecoder('utf-8', { fatal: true }).decode(new Uint8Array(arr));
+        } catch {
+            // fall through
+        }
+    }
+
+    if (Array.isArray(value)) {
+        return JSON.stringify(value);
+    }
+
+    const stringified = String(value);
+    const isNumeric = /^\d+$/.test(stringified);
+    if (isNumeric) {
+        try {
+            return BigInt(stringified).toLocaleString();
+        } catch {
+            // fall through
+        }
+    }
+
+    return stringified;
+}

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/pureValueType.ts
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/transaction-details/pureValueType.ts
@@ -2,13 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const PURE_VALUETYPE_LABEL_MAP = {
-    bool: 'bool',
-    u8: 'u8',
-    u16: 'u16',
-    u32: 'u32',
-    u64: 'u64',
-    u128: 'u128',
-    u256: 'u256',
     address: 'Address',
     signer: 'Signer',
     'vector<u8>': 'String',


### PR DESCRIPTION
# Description of change
### iota names tx 
`current | pr state` 
<img width="478" height="404" alt="Screenshot from 2026-02-26 21-10-48" src="https://github.com/user-attachments/assets/02d0b5f9-a606-4ac6-b070-3644daa19230" />

<hr/>

### staking with dashboard
`current | pr state`
<img width="478" height="404" alt="Screenshot from 2026-02-26 21-14-20" src="https://github.com/user-attachments/assets/d442786d-7ecd-453d-b27f-14e2659d0ba0" />


## Links to any relevant issues

Fixes #6873 
