### PR TITLE
fix(ci): turbo-diff should compare against the base branch

### DIFF
--- a/.github/actions/turbo-diffs/action.yml
+++ b/.github/actions/turbo-diffs/action.yml
@@ -10,6 +10,9 @@ runs:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
         fetch-depth: 0
+    - name: Fetch base branch
+      shell: bash
+      run: git fetch origin ${{ github.base_ref || 'develop' }}
     - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
@@ -17,7 +20,7 @@ runs:
     - id: changes
       name: Detect changes
       shell: bash
-      run: echo "packages=$(pnpm --silent dlx turbo@2 run build --filter="...[origin/develop]" --dry=json | jq -c ".packages")" >> $GITHUB_OUTPUT
+      run: echo "packages=$(pnpm --silent dlx turbo@2 run build --filter="...[origin/${{ github.base_ref || 'develop' }}]" --dry=json | jq -c ".packages")" >> $GITHUB_OUTPUT
     - name: Print changes for easy debugging
       shell: bash
       run: echo ${{ steps.changes.outputs.packages }}

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -86,7 +86,7 @@ jobs:
     concurrency:
       group: turbo-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
-    if: (!cancelled() && !failure() && (needs.diff.outputs.isExplorer || needs.diff.outputs.isTypescriptSDK || needs.diff.outputs.isWallet || needs.diff.outputs.isWalletDashboard || needs.diff.outputs.isEvmBridge) && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && (needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isWalletDashboard == 'true' || needs.diff.outputs.isEvmBridge == 'true') && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
# Description of change

In long living feature branches, all localnet tests are run even though the single PRs against the feature branch don't touch those files. This was caused by a hardcoded check against develop. Also we should fetch the base branch before comparison, to be sure to have the correct references.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes