### PR TITLE
feat(wallet): add missing published object change in tx receipt

### DIFF
--- a/apps/core/src/components/cards/ObjectChanges.tsx
+++ b/apps/core/src/components/cards/ObjectChanges.tsx
@@ -255,7 +255,7 @@ function ObjectChangeByOwnerPanel({
                         </div>
                     </>
                 </Collapsible>
-                {['AddressOwner', 'ObjectOwner', 'Shared'].includes(change.ownerType) ? (
+                {owner ? (
                     <div className="flex flex-col gap-y-sm px-md pb-md">
                         <Divider />
                         <KeyValueInfo

--- a/apps/core/src/components/cards/ObjectChanges.tsx
+++ b/apps/core/src/components/cards/ObjectChanges.tsx
@@ -29,6 +29,7 @@ import {
 import { TriangleDown } from '@iota/apps-ui-icons';
 import { ObjectChange, RenderExplorerLink } from '../../types';
 import { NamedAddressTooltip } from '../NamedAddressTooltip';
+import toast from 'react-hot-toast';
 
 interface ObjectDetailProps {
     change: IotaObjectChangeWithDisplay;
@@ -38,8 +39,32 @@ interface ObjectDetailProps {
 export function ObjectDetail({ change, renderExplorerLink: ExplorerLink }: ObjectDetailProps) {
     const [open, setOpen] = useState(false);
 
-    if (change.type === 'transferred' || change.type === 'published') {
+    if (change.type === 'transferred') {
         return null;
+    }
+
+    if (change.type === 'published') {
+        return (
+            <div className="flex w-full flex-col gap-2 px-md pb-md">
+                <KeyValueInfo
+                    keyText="Package"
+                    fullwidth
+                    copyText={change.packageId}
+                    value={formatAddress(change.packageId)}
+                    onCopySuccess={() => toast.success('Package ID copied to clipboard')}
+                />
+                {change.modules.map((moduleName, index) => (
+                    <KeyValueInfo
+                        key={index}
+                        keyText="Module"
+                        fullwidth
+                        copyText={moduleName}
+                        value={moduleName}
+                        onCopySuccess={() => toast.success('Module name copied to clipboard')}
+                    />
+                ))}
+            </div>
+        );
     }
 
     const [packageId, moduleName, typeName] = change.objectType?.split('<')[0]?.split('::') || [];
@@ -230,7 +255,7 @@ function ObjectChangeByOwnerPanel({
                         </div>
                     </>
                 </Collapsible>
-                {owner ? (
+                {['AddressOwner', 'ObjectOwner', 'Shared'].includes(change.ownerType) ? (
                     <div className="flex flex-col gap-y-sm px-md pb-md">
                         <Divider />
                         <KeyValueInfo


### PR DESCRIPTION
# Description of change

Shows the published object in the tx details, since the objects are not yet published, they don't use links, only copy buttons.

## Links to any relevant issues

Fixes #6726 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.
