### PR TITLE
feat(protocol): decrease max_auth_gas

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2582,8 +2582,8 @@ impl ProtocolConfig {
                     cfg.auth_context_replace_cost_per_byte = Some(2);
 
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
-                        // Decrease max_auth_gas to 0.00006 IOTA
-                        cfg.max_auth_gas = Some(60_000);
+                        // Decrease max_auth_gas to 0.00025 IOTA
+                        cfg.max_auth_gas = Some(250_000);
                     }
                 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2580,6 +2580,11 @@ impl ProtocolConfig {
                     cfg.auth_context_tx_inputs_cost_per_byte = Some(2);
                     cfg.auth_context_replace_cost_base = Some(30);
                     cfg.auth_context_replace_cost_per_byte = Some(2);
+
+                    if chain != Chain::Testnet && chain != Chain::Mainnet {
+                        // Decrease max_auth_gas to 0.00006 IOTA
+                        cfg.max_auth_gas = Some(60_000);
+                    }
                 }
 
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -119,6 +119,8 @@ pub const MAX_PROTOCOL_VERSION: u64 = 21;
 //             Enable a separate gas price feedback mechanism for transactions
 //             using randomness on testnet.
 //             Enable fast commit syncer for faster recovery in devnet.
+//             Add auth_context_tx native functions costs.
+//             Reduce max_auth_gas in Devnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_21.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_21.snap
@@ -82,7 +82,7 @@ max_move_object_size: 256000
 max_move_package_size: 102400
 max_publish_or_upgrade_per_ptb: 5
 max_tx_gas: 50000000000
-max_auth_gas: 60000
+max_auth_gas: 250000
 max_gas_price: 100000
 max_gas_computation_bucket: 5000000
 gas_rounding_step: 1000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_21.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_21.snap
@@ -82,7 +82,7 @@ max_move_object_size: 256000
 max_move_package_size: 102400
 max_publish_or_upgrade_per_ptb: 5
 max_tx_gas: 50000000000
-max_auth_gas: 250000000
+max_auth_gas: 60000
 max_gas_price: 100000
 max_gas_computation_bucket: 5000000
 gas_rounding_step: 1000


### PR DESCRIPTION
# Description of change

Lowers max_auth_gas to 250000. Makes it enough to run a groth16 verification in an authenticator function (equivalent to 69 cycles of ed25519_verify).
