### PR TITLE
fix(starfish): follow-up fixes for fast commit syncer

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,6 +17,7 @@ filter = '''
 (package(iota-cluster-test) and (test(test_iota_cluster)))
 or (package(iota-graphql-rpc) and (binary(e2e_tests) or (test(test_query_cost)) or binary(examples_validation_tests)))
 or (package(iota-indexer) and (binary(ingestion_tests)))
+or (package(starfish-simtests) and test(test_sequential_restarts_persistent_db_short_run_long_stop))
 '''
 
 [[profile.default.overrides]]

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -14,7 +14,7 @@ use std::{
 use consensus_config::AuthorityIndex;
 use itertools::Itertools as _;
 use tokio::time::Instant;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     CommittedSubDag,
@@ -846,11 +846,11 @@ impl DagState {
     pub(crate) fn add_commit(&mut self, commit: TrustedCommit) {
         let time_diff = if let Some(last_commit) = &self.last_commit {
             if commit.index() <= last_commit.index() {
-                error!(
+                warn!(
                     "New commit index {} <= last commit index {}!",
                     commit.index(),
                     last_commit.index()
-                );
+                ); // This could happen in case of fast commit syncer downloading transactions from last solid commit (not pending).
                 return;
             }
             assert_eq!(commit.index(), last_commit.index() + 1);

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -484,9 +484,8 @@ mod test {
         run_sequential_restarts_test(RestartMode::PersistAll, true, false).await;
     }
 
-    // TODO: This test is expected to panic due to fast sync failure when it is
-    // aborted before full sync catch-up. It should be added once the fix for
-    // fast syncing is applied.
+    // TODO: This test is flaky when running with many other tests in parallel.
+    // It passes consistently when running individually.
     // /// Persistent DB after each restart, short run before stop, long stop
     // duration.
     #[sim_test(config = "test_config()")]


### PR DESCRIPTION
# Description of change

Follow-up fixes for flaky test after merging the fast commit syncer (#9585):

- **Add flaky simtest to nextest single-threaded profile**: ensures CI runs it single-threaded to avoid spurious failures.

Other small changes
- **Downgrade duplicate commit log from `error!` to `warn!`**: during fast sync the commit syncer can re-download commits starting from the last solid commit (not just pending), so receiving a duplicate is expected behavior — not an error.
- **Update stale TODO comment on flaky simtest**: the old comment referenced a fast-sync panic that has since been fixed. The test (`test_sequential_restarts_persistent_db_short_run_long_stop`) is now known to be flaky only under parallel execution.

## Links to any relevant issues

Fixes #10520

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes