### PR TITLE
feat(ci): cancel complete workflows if jobs fail

### DIFF
--- a/.github/workflows/_docs_lint.yml
+++ b/.github/workflows/_docs_lint.yml
@@ -1,6 +1,11 @@
 name: Docs spellcheck and linting
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: docs-lint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -16,3 +21,13 @@ jobs:
         uses: crate-ci/typos@945d407a5fc9097f020969446a16f581612ab4df # v1.24.5
         with:
           files: ./docs/content
+
+  spelling-cancel:
+    needs: [spelling]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_docusaurus.yml
+++ b/.github/workflows/_docusaurus.yml
@@ -1,6 +1,11 @@
 name: Docusaurus Build
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: docusaurus-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,3 +32,13 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm iota-docs build
+
+  build-cancel:
+    needs: [build]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -333,3 +333,13 @@ jobs:
             echo "Failed test groups: ${failed[*]}"
             exit 1
           fi
+
+  localnet-cancel:
+    needs: [localnet]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_execution_cut.yml
+++ b/.github/workflows/_execution_cut.yml
@@ -1,6 +1,11 @@
 name: Execution cut
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: execution-cut-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,3 +23,13 @@ jobs:
 
       - name: Check execution builds
         run: cargo build -p iota-execution
+
+  execution-cut-cancel:
+    needs: [execution-cut]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_move_ide.yml
+++ b/.github/workflows/_move_ide.yml
@@ -1,6 +1,11 @@
 name: Move IDE
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: move-ide-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -30,6 +35,16 @@ jobs:
         working-directory: ./external-crates/move/crates/move-analyzer/prettier-plugin
         shell: bash
         run: npm run test
+
+  move-auto-formatter-test-cancel:
+    needs: [move-auto-formatter-test]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   move-ide-test:
     name: Move IDE Test
@@ -72,6 +87,16 @@ jobs:
         shell: bash
         run: npm run pretest && DISPLAY=:99.0 npm run test
 
+  move-ide-test-cancel:
+    needs: [move-ide-test]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   move-vscode-extension-build:
     name: Move VSCode extension build
     runs-on: [self-hosted-x64]
@@ -94,3 +119,13 @@ jobs:
       - name: Build VSCode extension
         working-directory: ./external-crates/move/crates/move-analyzer/editors/code
         run: npm run package
+
+  move-vscode-extension-build-cancel:
+    needs: [move-vscode-extension-build]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_rosetta.yml
+++ b/.github/workflows/_rosetta.yml
@@ -1,6 +1,11 @@
 name: Rosetta validation
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: rosetta-validation-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -43,24 +48,39 @@ jobs:
         shell: bash
 
       - name: Start local IOTA network
+        if: (!cancelled() && !failure())
         run: |
           iota start --no-full-node &
         shell: bash
 
       - name: Start Rosetta servers
+        if: (!cancelled() && !failure())
         run: .github/scripts/rosetta/start_rosetta.sh
         shell: bash
 
       - name: Sleep for 20 seconds
+        if: (!cancelled() && !failure())
         run: sleep 20s
         shell: bash
 
       - name: Run check:construction test
+        if: (!cancelled() && !failure())
         run: |
           ./bin/rosetta-cli --configuration-file rosetta_cli.json check:construction
         shell: bash
 
       - name: Run check:data test
+        if: (!cancelled() && !failure())
         run: |
           ./bin/rosetta-cli --configuration-file rosetta_cli.json check:data
         shell: bash
+
+  validation-cancel:
+    needs: [validation]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -14,6 +14,9 @@ on:
         type: boolean
       isMoveExampleUsedByOthers:
         type: boolean
+      isNightly:
+        type: boolean
+        default: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -46,6 +49,7 @@ jobs:
     with:
       isRust: ${{ inputs.isRust }}
       isRustExample: ${{ inputs.isRustExample }}
+      isNightly: ${{ inputs.isNightly }}
 
   crates-changes:
     needs: rust-lints
@@ -91,9 +95,12 @@ jobs:
       testOnlyChangedCrates: ${{ !inputs.isRustWorkspaceConfig }}
       changedCrates: ${{ join(fromJson(needs.crates-changes.outputs.components || '[]'), ' ') }}
       changedExternalCrates: ${{ join(fromJson(needs.external-changes.outputs.components || '[]'), ' ') }}
+      isNightly: ${{ inputs.isNightly }}
 
   execution-cut:
     if: (!cancelled() && !failure() && inputs.isRust)
     needs:
       - rust-lints
     uses: ./.github/workflows/_execution_cut.yml
+    with:
+      isNightly: ${{ inputs.isNightly }}

--- a/.github/workflows/_rust_examples.yml
+++ b/.github/workflows/_rust_examples.yml
@@ -1,6 +1,11 @@
 name: Rust examples
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: rust-examples-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -49,3 +54,13 @@ jobs:
               echo "Checking unused dependencies of $manifest"
               cargo +nightly-2026-01-07 ci-udeps --manifest-path $manifest
           done
+
+  lint-examples-cancel:
+    needs: [lint-examples]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_rust_lints.yml
+++ b/.github/workflows/_rust_lints.yml
@@ -7,6 +7,9 @@ on:
         type: boolean
       isRustExample:
         type: boolean
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: rust-lints-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -44,6 +47,16 @@ jobs:
       - name: Check Rust formatting
         run: cargo +nightly-2026-01-07 ci-fmt
 
+  rustfmt-cancel:
+    needs: [rustfmt]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   cargo-sort:
     if: (!cancelled() && inputs.isRust)
     runs-on: [self-hosted-x64]
@@ -62,9 +75,21 @@ jobs:
             exit 1    # Fail the workflow
           fi
 
+  cargo-sort-cancel:
+    needs: [cargo-sort]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   examples:
     if: (!cancelled() && inputs.isRustExample)
     uses: ./.github/workflows/_rust_examples.yml
+    with:
+      isNightly: ${{ inputs.isNightly }}
 
   clippy:
     if: (!cancelled() && !failure() && inputs.isRust)
@@ -82,3 +107,13 @@ jobs:
         run: |
           git clean -fd
           ./scripts/simtest/clippy.sh
+
+  clippy-cancel:
+    needs: [clippy]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -28,6 +28,9 @@ on:
         type: string
         required: false
         default: "mysticeti"
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: rust-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -122,6 +125,16 @@ jobs:
 
           eval "./scripts/ci_tests/rust_tests.sh $ARGS"
 
+  rust-tests-cancel:
+    needs: [rust-tests]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   rust-simtests:
     name: Run rust simtests
     if: (!cancelled() && inputs.runSimtest && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers))
@@ -185,6 +198,16 @@ jobs:
 
           eval "./scripts/ci_tests/rust_tests.sh $ARGS"
 
+  rust-simtests-cancel:
+    needs: [rust-simtests]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   check-unused-deps:
     name: Check Unused Dependencies (${{ matrix.flags }})
     if: (!cancelled() && !failure())
@@ -201,6 +224,16 @@ jobs:
 
       - name: Run Cargo Udeps (external crates)
         run: cargo +nightly-2026-01-07 ci-udeps-external ${{ matrix.flags }}
+
+  check-unused-deps-cancel:
+    needs: [check-unused-deps]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   test-extra:
     env:
@@ -240,3 +273,13 @@ jobs:
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
         shell: bash
+
+  test-extra-cancel:
+    needs: [test-extra]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -107,6 +107,7 @@ jobs:
     needs:
       - diff
       - dprint-format
+      - license-check
       - typos
     if: (!cancelled() && !failure() && needs.diff.outputs.isRosetta == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_rosetta.yml
@@ -123,6 +124,9 @@ jobs:
   split-cluster:
     needs:
       - diff
+      - dprint-format
+      - license-check
+      - typos
       - rust
     if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_split_cluster.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,6 +67,8 @@ jobs:
   examples:
     if: ${{ !inputs.rustTestsOnly && !inputs.simTestsOnly }}
     uses: ./.github/workflows/_rust_examples.yml
+    with:
+      isNightly: true
 
   tests:
     if: ${{ inputs.rustTestsOnly || !inputs.simTestsOnly }}
@@ -79,6 +81,7 @@ jobs:
       runSimtest: false
       # run all tests by default
       testOnlyChangedCrates: false
+      isNightly: true
 
   tests-with-starfish:
     if: ${{ inputs.rustTestsOnly || !inputs.simTestsOnly }}
@@ -92,6 +95,7 @@ jobs:
       runSimtest: false
       # run all tests by default
       testOnlyChangedCrates: false
+      isNightly: true
 
   deny:
     if: ${{ !inputs.rustTestsOnly && !inputs.simTestsOnly }}
@@ -106,6 +110,8 @@ jobs:
   execution-cut:
     if: ${{ !inputs.rustTestsOnly && !inputs.simTestsOnly }}
     uses: ./.github/workflows/_execution_cut.yml
+    with:
+      isNightly: true
 
   split-cluster:
     if: ${{ !inputs.rustTestsOnly && !inputs.simTestsOnly }}
@@ -118,6 +124,8 @@ jobs:
   rosetta:
     if: ${{ !inputs.rustTestsOnly && !inputs.simTestsOnly }}
     uses: ./.github/workflows/_rosetta.yml
+    with:
+      isNightly: true
 
   simtest:
     if: ${{ inputs.simTestsOnly || !inputs.rustTestsOnly }}

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -79,6 +79,16 @@ jobs:
             exit 1
           fi
 
+  sync-cancel:
+    needs: [sync]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   build:
     name: Lint, Build, and Test
     needs: diff
@@ -139,6 +149,16 @@ jobs:
           path: apps/wallet/web-ext-artifacts/*
           if-no-files-found: error
           retention-days: 7
+
+  build-cancel:
+    needs: [build]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   e2e:
     if: (!cancelled() && !failure() && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))


### PR DESCRIPTION
# Description of change

With this change, all jobs in workflows will be cancelled if specific parallel running jobs in the same workflow report failure.
Most of the times it makes no sense to let expensive jobs continue running, if the dev needs to push again to fix the other tests anyways.