### PR TITLE
feat(ts-sdk): add function `deriveObjectId` to compute derived addresses

### DIFF
--- a/.changeset/afraid-masks-drive.md
+++ b/.changeset/afraid-masks-drive.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': patch
+---
+
+Adds `deriveObjectID` helper to calculate `derived_object` addresses.

--- a/sdk/typescript/src/utils/derived-objects.ts
+++ b/sdk/typescript/src/utils/derived-objects.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TypeTag } from '../bcs/bcs.js';
+import { TypeTagSerializer } from '../bcs/type-tag-serializer.js';
+import { deriveDynamicFieldID } from './dynamic-fields.js';
+
+/**
+ * Derive the ID of an object that has been created through `derived_object`.
+ */
+export function deriveObjectID(
+    parentId: string,
+    typeTag: typeof TypeTag.$inferInput,
+    key: Uint8Array,
+) {
+    const typeTagStr =
+        typeof typeTag === 'string' ? typeTag : TypeTagSerializer.tagToString(typeTag);
+    return deriveDynamicFieldID(
+        parentId,
+        `0x2::derived_object::DerivedObjectKey<${typeTagStr}>`,
+        key,
+    );
+}

--- a/sdk/typescript/src/utils/index.ts
+++ b/sdk/typescript/src/utils/index.ts
@@ -51,3 +51,5 @@ export {
 } from './constants.js';
 
 export { deriveDynamicFieldID } from './dynamic-fields.js';
+
+export { deriveObjectID } from './derived-objects.js';

--- a/sdk/typescript/test/unit/utils/derived-objects.test.ts
+++ b/sdk/typescript/test/unit/utils/derived-objects.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+
+import { bcs, TypeTagSerializer } from '../../../src/bcs';
+import { deriveObjectID } from '../../../src/utils/derived-objects';
+import { normalizeIotaAddress } from '../../../src/utils';
+
+// Snapshots are recreated from `derived_object_tests.move` file,
+// as well as `crates/iota-types/src/derived_object.rs` file.
+describe('derived object test utils', () => {
+    test('deriveObjectID with primitive type', () => {
+        const key = bcs.vector(bcs.u8()).serialize(new TextEncoder().encode('foo')).toBytes();
+
+        expect(deriveObjectID(normalizeIotaAddress('0x2'), 'vector<u8>', key)).toBe(
+            '0xa2b411aa9588c398d8e3bc97dddbdd430b5ded7f81545d05e33916c3ca0f30c3',
+        );
+        expect(
+            deriveObjectID(
+                normalizeIotaAddress('0x2'),
+                TypeTagSerializer.parseFromStr('vector<u8>'),
+                key,
+            ),
+        ).toBe('0xa2b411aa9588c398d8e3bc97dddbdd430b5ded7f81545d05e33916c3ca0f30c3');
+    });
+
+    test('deriveObjectID with struct type', () => {
+        const structType = bcs.struct('DemoStruct', {
+            value: bcs.u64(),
+        });
+        const key = structType.serialize({ value: 1 }).toBytes();
+
+        expect(deriveObjectID('0x2', `0x2::derived_object_tests::DemoStruct`, key)).toBe(
+            '0x20c58d8790a5d2214c159c23f18a5fdc347211e511186353e785ad543abcea6b',
+        );
+        expect(
+            deriveObjectID(
+                '0x2',
+                TypeTagSerializer.parseFromStr('0x2::derived_object_tests::DemoStruct'),
+                key,
+            ),
+        ).toBe('0x20c58d8790a5d2214c159c23f18a5fdc347211e511186353e785ad543abcea6b');
+    });
+
+    test('deriveObjectID with nested struct type', () => {
+        const structType = bcs.struct('GenericStruct<T>', {
+            value: bcs.u64(),
+        });
+        const key = structType.serialize({ value: 1 }).toBytes();
+
+        expect(deriveObjectID('0x2', `0x2::derived_object_tests::GenericStruct<u64>`, key)).toBe(
+            '0xb497b8dcf1e297ae5fa69c040e4a08ef8240d5373bbc9d6b686ffbd7dfe04cbe',
+        );
+        expect(
+            deriveObjectID(
+                '0x2',
+                TypeTagSerializer.parseFromStr('0x2::derived_object_tests::GenericStruct<u64>'),
+                key,
+            ),
+        ).toBe('0xb497b8dcf1e297ae5fa69c040e4a08ef8240d5373bbc9d6b686ffbd7dfe04cbe');
+    });
+
+    test('deriveObjectID with non-generic primitive type', () => {
+        const key = bcs.U8.serialize(1).toBytes();
+
+        expect(deriveObjectID('0x2', 'u8', key)).toBe(
+            '0x4de7696edddfb592a8dc7c8b66053b1557eb4fa1a9194322562aabf3da9e9239',
+        );
+        expect(deriveObjectID('0x2', TypeTagSerializer.parseFromStr('u8'), key)).toBe(
+            '0x4de7696edddfb592a8dc7c8b66053b1557eb4fa1a9194322562aabf3da9e9239',
+        );
+    });
+});


### PR DESCRIPTION
Ports commit https://github.com/MystenLabs/ts-sdks/commit/3c1741f184c3285ff549ed36c8631be18d8aef4d

Closes #10455 