### PR TITLE
feat(e2e): refactor the gRPC e2e field mask tests

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/utils.rs
+++ b/crates/iota-e2e-tests/tests/grpc/utils.rs
@@ -158,6 +158,38 @@ macro_rules! impl_field_presence_checker {
         }
     };
 
+    // Transparent-repeated type rule:
+    //
+    // Like `transparent`, but for when the inner field is a `Vec<T>` (repeated
+    // proto field) instead of `Option<T>`.  Delegates to the first element when
+    // the vec is non-empty; reports every field as absent when it is empty.
+    //
+    // Syntax:
+    //   impl_field_presence_checker!(OuterType, transparent_repeated(vec_field) {
+    //       inner_field1,
+    //       inner_field2,
+    //       ...
+    //   });
+    ($type:ty, transparent_repeated($inner_field:ident) { $( $field:ident ),* $(,)? }) => {
+        impl $crate::utils::FieldPresenceChecker for $type {
+            fn top_level_fields(&self) -> &[&'static str] {
+                &[ $( stringify!($field) ),* ]
+            }
+
+            fn check_field_presence(&self, field: &str) -> Option<(bool, Option<&dyn $crate::utils::FieldPresenceChecker>)> {
+                if let Some(first) = self.$inner_field.first() {
+                    first.check_field_presence(field)
+                } else {
+                    // Vec is empty — all inner fields are absent.
+                    match field {
+                        $( stringify!($field) => Some((false, None)), )*
+                        _ => None,
+                    }
+                }
+            }
+        }
+    };
+
     // Helper rule for repeated fields (when `: [Type]` is specified)
     (@field_check $self:ident, $field:ident, [ $nested_type:ty ]) => {{
         // Repeated fields are always present, check if non-empty
@@ -200,15 +232,39 @@ pub fn comma_separated_field_mask_to_paths(mask_str: &str) -> Vec<&str> {
 }
 
 /// Assert field presence/absence for any type implementing
-/// FieldPresenceChecker. This function validates that an object contains
-/// exactly the fields specified (or their absence). It also supports nested
-/// field paths using dot notation (e.g., "reference.object_id").
+/// [`FieldPresenceChecker`].
+///
+/// Each path in `expected_field_paths` is either:
+/// - A **bare** name (no dot), e.g. `"bcs"` or `"effects"`:
+///   - If the field has a nested [`FieldPresenceChecker`], **all** of its
+///     sub-fields are asserted present recursively (mirrors server wildcard
+///     semantics where a parent path returns every sub-field).
+///   - If the field has no nested checker (a leaf), only presence is asserted.
+/// - A **dotted** path, e.g. `"reference.object_id"` — the top-level field must
+///   be present, and exactly the listed sub-paths must be present inside it
+///   (all other sub-fields are asserted absent).
+///
+/// Every top-level field that is *not* listed in `expected_field_paths` (either
+/// bare or as the prefix of a dotted path) is asserted **absent**.
+///
+/// Paths listed in `ignored_field_paths` are skipped entirely — no presence or
+/// absence is asserted for them.  Use this for fields that are optionally
+/// populated depending on server state (e.g. `checkpoint` / `timestamp` that
+/// are always `None` for just-executed transactions).  The format mirrors
+/// `expected_field_paths`: a bare name ignores that field at the current level;
+/// a dotted path (`"executed_transaction.checkpoint"`) ignores the named
+/// sub-field when recursing into `executed_transaction`.
+///
+/// This design lets tests pass read-mask paths directly: a wildcard mask entry
+/// like `"effects"` (all sub-fields) maps to bare `"effects"`, while a specific
+/// entry like `"effects.digest"` maps to the dotted path.
 ///
 /// # Example
 /// ```ignore
 /// assert_field_presence(
 ///     &object,
 ///     &["reference.object_id", "reference.version", "bcs"],
+///     &[],
 ///     "test scenario"
 /// );
 /// ```
@@ -216,12 +272,14 @@ pub fn comma_separated_field_mask_to_paths(mask_str: &str) -> Vec<&str> {
 /// - `reference` is present (inferred because reference.* are listed)
 /// - `reference.object_id` is present
 /// - `reference.version` is present
-/// - `bcs` is present
-/// - All other fields at the top level are absent
-/// - All other fields inside `reference` are absent (like `reference.digest`)
+/// - `bcs` is present (leaf — presence only, no nested inspection)
+/// - All other top-level fields are absent
+/// - Inside `reference`: only `object_id` and `version` are present
+///   (`reference.digest` is absent)
 pub(crate) fn assert_field_presence(
     checker: &dyn FieldPresenceChecker,
     expected_field_paths: &[&str],
+    ignored_field_paths: &[&str],
     scenario: &str,
 ) {
     let mut expected_nested_field_paths: HashMap<&str, Vec<&str>> = HashMap::new();
@@ -241,6 +299,22 @@ pub(crate) fn assert_field_presence(
         }
     }
 
+    // Parse ignored paths: bare names are ignored at this level; dotted paths
+    // are threaded down into the corresponding nested recursion.
+    let mut ignored_nested_field_paths: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut ignored_top_level_fields: HashSet<&str> = HashSet::new();
+
+    for ignored_field_path in ignored_field_paths {
+        if let Some((top_level_field, remaining_path)) = ignored_field_path.split_once('.') {
+            ignored_nested_field_paths
+                .entry(top_level_field)
+                .or_default()
+                .push(remaining_path);
+        } else {
+            ignored_top_level_fields.insert(ignored_field_path);
+        }
+    }
+
     let actual_top_level_fields: HashSet<&str> =
         checker.top_level_fields().iter().copied().collect();
 
@@ -253,8 +327,13 @@ pub(crate) fn assert_field_presence(
         );
     }
 
-    // Check each field at this level for correct presence/absence
+    // Check each field at this level for correct presence/absence.
+    // Fields listed in ignored_top_level_fields are skipped entirely.
     for top_level_field in actual_top_level_fields.clone() {
+        if ignored_top_level_fields.contains(top_level_field) {
+            continue;
+        }
+
         let should_be_present = expected_top_level_fields.contains(top_level_field);
 
         let (is_present, _) = checker
@@ -281,20 +360,45 @@ pub(crate) fn assert_field_presence(
         }
     }
 
-    // Recurse into nested fields
-    for top_level_field in &actual_top_level_fields {
-        // Recurse only if there is a nested checker for this field
+    // Recurse for fields with explicit dotted sub-paths, threading down any
+    // ignored sub-paths that were specified for this field.
+    for (top_level_field, sub_paths) in &expected_nested_field_paths {
         if let Some((_, Some(nested_checker))) = checker.check_field_presence(top_level_field) {
-            let expected_field_paths_nested = expected_nested_field_paths
+            let ignored_sub: &[&str] = ignored_nested_field_paths
                 .get(top_level_field)
-                .map(|v| v.as_slice())
+                .map(Vec::as_slice)
                 .unwrap_or(&[]);
-
-            // Recurse into this nested field
             assert_field_presence(
                 nested_checker,
-                expected_field_paths_nested,
+                sub_paths,
+                ignored_sub,
                 &format!("{scenario}.{top_level_field}"),
+            );
+        }
+    }
+
+    // For bare paths that have a nested checker, auto-recurse and assert that
+    // ALL sub-fields are present (minus any ignored ones).  This mirrors the
+    // server's wildcard behaviour: a mask entry like "effects" returns every
+    // sub-field of effects, so the test expectation "effects" should verify all
+    // of them.
+    // Bare paths that are themselves ignored, or that have no nested checker
+    // (leaf fields), are skipped — their presence was already handled above.
+    for bare_field in &expected_non_nested_field_paths {
+        if ignored_top_level_fields.contains(*bare_field) {
+            continue;
+        }
+        if let Some((true, Some(nested_checker))) = checker.check_field_presence(bare_field) {
+            let all_sub_fields: Vec<&str> = nested_checker.top_level_fields().to_vec();
+            let ignored_sub: &[&str] = ignored_nested_field_paths
+                .get(bare_field)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            assert_field_presence(
+                nested_checker,
+                &all_sub_fields,
+                ignored_sub,
+                &format!("{scenario}.{bare_field}"),
             );
         }
     }

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_objects.rs
@@ -5,6 +5,7 @@
 use futures::StreamExt;
 use iota_grpc_types::{
     field::FieldMaskUtil,
+    read_masks::GET_OBJECTS_READ_MASK,
     v0::{
         ledger_service::{
             GetObjectsRequest, GetObjectsResponse, ObjectRequest, ObjectRequests,
@@ -17,7 +18,7 @@ use iota_macros::sim_test;
 use iota_types::base_types::ObjectID;
 use prost_types::FieldMask;
 
-use crate::utils::{assert_field_presence, setup_grpc_test};
+use crate::utils::{assert_field_presence, comma_separated_field_mask_to_paths, setup_grpc_test};
 
 async fn assert_get_objects_request(
     ledger_client: &mut LedgerServiceClient<iota_grpc_client::InterceptedChannel>,
@@ -58,6 +59,7 @@ async fn assert_get_objects_request(
                 assert_field_presence(
                     object,
                     expected_field_mask_paths,
+                    &[],
                     &format!("{scenario} (response {response_count}, object {idx})"),
                 );
             }
@@ -110,14 +112,7 @@ async fn get_objects_readmask_scenarios() {
         (
             "default readmask",
             None,
-            // GET_OBJECTS_READ_MASK = "reference,bcs"
-            // "reference" is a wildcard that expands to all its sub-fields.
-            vec![
-                "reference.object_id",
-                "reference.version",
-                "reference.digest",
-                "bcs",
-            ],
+            comma_separated_field_mask_to_paths(GET_OBJECTS_READ_MASK),
         ),
         (
             "empty readmask",
@@ -126,20 +121,8 @@ async fn get_objects_readmask_scenarios() {
         ),
         (
             "full readmask",
-            Some(FieldMask::from_paths([
-                "reference.object_id",
-                "reference.version",
-                "reference.digest",
-                "bcs",
-            ])),
-            vec![
-                "reference.object_id",
-                "reference.version", // comment out to check absence of nested field
-                "reference.digest",
-                "bcs", /* comment out to check absence of bcs field
-                        * "reference", // Remove comment to check existence of reference field
-                        * "reference.id", // Remove comment to check existence of nested field */
-            ],
+            Some(FieldMask::from_paths(["reference", "bcs"])),
+            vec!["reference", "bcs"],
         ),
         (
             "partial readmask (reference fields only)",
@@ -267,20 +250,10 @@ async fn get_objects_streaming() {
     let responses = assert_get_objects_request(
         &mut ledger_client,
         requests,
-        Some(FieldMask::from_paths([
-            "reference.object_id",
-            "reference.version",
-            "reference.digest",
-            "bcs",
-        ])),
+        Some(FieldMask::from_paths(["reference", "bcs"])),
         // Use minimum allowed message size to maximize chance of streaming
         Some(1024 * 1024_u32), // 1MB (minimum allowed)
-        &[
-            "reference.object_id",
-            "reference.version",
-            "reference.digest",
-            "bcs",
-        ],
+        &["reference", "bcs"],
         "streaming with 100 objects",
     )
     .await;

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_service_info.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_service_info.rs
@@ -32,7 +32,7 @@ async fn assert_service_info_request(
         .unwrap()
         .into_inner();
 
-    assert_field_presence(&response, expected_fields, scenario);
+    assert_field_presence(&response, expected_fields, &[], scenario);
     response
 }
 

--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/get_transactions.rs
@@ -4,6 +4,7 @@
 use futures::StreamExt;
 use iota_grpc_types::{
     field::FieldMaskUtil,
+    read_masks::GET_TRANSACTIONS_READ_MASK,
     v0::ledger_service::{
         GetTransactionsRequest, GetTransactionsResponse, TransactionRequest, TransactionRequests,
         ledger_service_client::LedgerServiceClient, transaction_result,
@@ -15,7 +16,7 @@ use iota_types::digests::TransactionDigest;
 use prost_types::FieldMask;
 use test_cluster::TestCluster;
 
-use crate::utils::{assert_field_presence, setup_grpc_test};
+use crate::utils::{assert_field_presence, comma_separated_field_mask_to_paths, setup_grpc_test};
 
 /// Helper to create a test transaction and return its digest
 async fn create_test_transaction(test_cluster: &TestCluster) -> TransactionDigest {
@@ -90,6 +91,7 @@ async fn assert_get_transactions_request(
                 assert_field_presence(
                     transaction,
                     expected_field_mask_paths,
+                    &[],
                     &format!("{scenario} (response {response_count}, transaction {idx})"),
                 );
             }
@@ -142,19 +144,10 @@ async fn get_transactions_readmask_scenarios() {
     // fields. So "effects" means "effects.digest" AND "effects.bcs".
     type TestCase<'a> = (&'a str, Option<FieldMask>, Vec<&'a str>);
     let test_cases: Vec<TestCase> = vec![
-        // Default readmask (None) - GET_TRANSACTIONS_READ_MASK =
-        // "transaction,signatures,checkpoint,timestamp" "transaction" is a wildcard that
-        // expands to all its sub-fields.
         (
             "default readmask",
             None,
-            vec![
-                "transaction.digest",
-                "transaction.bcs",
-                "signatures",
-                "checkpoint",
-                "timestamp",
-            ],
+            comma_separated_field_mask_to_paths(GET_TRANSACTIONS_READ_MASK),
         ),
         // Empty readmask - returns no fields
         (
@@ -162,31 +155,21 @@ async fn get_transactions_readmask_scenarios() {
             Some(FieldMask::from_paths(&[] as &[&str])),
             vec![],
         ),
-        // Full readmask - returns all implemented fields with explicit nested paths
-        // Note: events may be None if transaction doesn't emit events
-        // Note: signatures, input_objects, output_objects are leaf fields (not
-        // nested) because their inner fields are Vec, not Option
         (
             "full readmask",
             Some(FieldMask::from_paths([
-                "transaction.digest",
-                "transaction.bcs",
+                "transaction",
                 "signatures",
-                "effects.digest",
-                "effects.bcs",
+                "effects",
                 "events",
                 "checkpoint",
                 "timestamp",
             ])),
-            // "events" is a wildcard → server returns events.digest AND events.events.
             vec![
-                "transaction.digest",
-                "transaction.bcs",
+                "transaction",
                 "signatures",
-                "effects.digest",
-                "effects.bcs",
-                "events.digest",
-                "events.events",
+                "effects",
+                "events",
                 "checkpoint",
                 "timestamp",
             ],
@@ -207,10 +190,9 @@ async fn get_transactions_readmask_scenarios() {
         (
             "partial readmask (effects wildcard)",
             Some(FieldMask::from_paths(["effects"])),
-            vec!["effects.digest", "effects.bcs"],
+            vec!["effects"],
         ),
         // Partial readmask: transaction + signatures
-        // Note: signatures is a leaf field, transaction has nested paths
         (
             "partial readmask (transaction + signatures)",
             Some(FieldMask::from_paths(["transaction.digest", "signatures"])),
@@ -253,14 +235,13 @@ async fn get_transactions_batch() {
         digests.push(digest);
     }
 
-    // Test batch request with partial readmask
-    // Note: "effects" without nested paths means all nested fields are included
+    // Test batch request with partial readmask.
     let responses = assert_get_transactions_request(
         &mut ledger_client,
         digests.clone(),
         Some(FieldMask::from_paths(["transaction.digest", "effects"])),
         None,
-        &["transaction.digest", "effects.digest", "effects.bcs"],
+        &["transaction.digest", "effects"],
         "batch with 3 transactions",
     )
     .await;
@@ -291,11 +272,8 @@ async fn get_transactions_streaming() {
         all_digests.extend(digests.iter().cloned());
     }
 
-    // Test streaming by requesting many transactions with full readmask
-    // Use minimum allowed message size to maximize chance of multi-message
-    // streaming
-    // Note: Parent fields without nested paths are wildcards that include all
-    // nested fields
+    // Test streaming by requesting many transactions with full readmask.
+    // Use minimum allowed message size to maximize multi-message streaming.
     let responses = assert_get_transactions_request(
         &mut ledger_client,
         all_digests,
@@ -310,11 +288,9 @@ async fn get_transactions_streaming() {
         ])),
         Some(1024 * 1024_u32), // 1MB (minimum allowed)
         &[
-            "transaction.digest",
-            "transaction.bcs",
+            "transaction",
             "signatures",
-            "effects.digest",
-            "effects.bcs",
+            "effects",
             "checkpoint",
             "timestamp",
             "input_objects",

--- a/crates/iota-e2e-tests/tests/grpc/v0/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/mod.rs
@@ -77,15 +77,19 @@ impl_field_presence_checker!(CommandOutput {
     bcs,
     json,
 });
-impl_field_presence_checker!(CommandOutputs {
-    outputs: [CommandOutput]
+impl_field_presence_checker!(CommandOutputs, transparent_repeated(outputs) {
+    argument,
+    type_tag,
+    bcs,
+    json,
 });
 impl_field_presence_checker!(CommandResult {
     mutated_by_ref: CommandOutputs,
     return_values: CommandOutputs,
 });
-impl_field_presence_checker!(CommandResults {
-    results: [CommandResult]
+impl_field_presence_checker!(CommandResults, transparent_repeated(results) {
+    mutated_by_ref,
+    return_values,
 });
 impl_field_presence_checker!(ExecutionError {
     bcs_kind,

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/execute.rs
@@ -4,6 +4,7 @@
 
 use iota_grpc_types::{
     field::FieldMaskUtil,
+    read_masks::EXECUTE_TRANSACTION_READ_MASK,
     v0::{
         bcs::BcsData,
         signatures::{UserSignature, UserSignatures},
@@ -18,7 +19,7 @@ use iota_macros::sim_test;
 use iota_test_transaction_builder::make_transfer_iota_transaction;
 use prost_types::FieldMask;
 
-use crate::utils::{assert_field_presence, setup_grpc_test};
+use crate::utils::{assert_field_presence, comma_separated_field_mask_to_paths, setup_grpc_test};
 
 async fn assert_execute_transaction_request(
     exec_client: &mut TransactionExecutionServiceClient<iota_grpc_client::InterceptedChannel>,
@@ -42,7 +43,7 @@ async fn assert_execute_transaction_request(
         .unwrap()
         .into_inner();
 
-    assert_field_presence(&response, expected_fields, scenario);
+    assert_field_presence(&response, expected_fields, &[], scenario);
     response
 }
 
@@ -63,18 +64,9 @@ async fn execute_transaction_readmask_scenarios() {
         (
             "default readmask",
             None,
-            // EXECUTE_TRANSACTION_READ_MASK =
-            // "transaction.digest,effects,events,input_objects,output_objects"
-            // "effects" and "events" are wildcards that expand to all their sub-fields.
-            vec![
-                "transaction.digest",
-                "effects.digest",
-                "effects.bcs",
-                "events.digest",
-                "events.events",
-                "input_objects",
-                "output_objects",
-            ],
+            // Bare paths with nested checkers (effects, events) auto-recurse into
+            // all their sub-fields; "transaction.digest" is specific (bcs absent).
+            comma_separated_field_mask_to_paths(EXECUTE_TRANSACTION_READ_MASK),
         ),
         (
             "empty readmask",
@@ -94,13 +86,10 @@ async fn execute_transaction_readmask_scenarios() {
                 "output_objects",
             ])),
             vec![
-                "transaction.digest",
-                "transaction.bcs",
+                "transaction",
                 "signatures",
-                "effects.digest",
-                "effects.bcs",
-                "events.digest",
-                "events.events",
+                "effects",
+                "events",
                 "input_objects",
                 "output_objects",
             ],
@@ -109,7 +98,7 @@ async fn execute_transaction_readmask_scenarios() {
         (
             "nested readmask (multiple specific fields)",
             Some(FieldMask::from_paths(["transaction.digest", "effects"])),
-            vec!["transaction.digest", "effects.digest", "effects.bcs"],
+            vec!["transaction.digest", "effects"],
         ),
     ];
 

--- a/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/transaction_execution_service/simulate.rs
@@ -4,11 +4,13 @@
 
 use iota_grpc_types::{
     field::FieldMaskUtil,
+    read_masks::SIMULATE_TRANSACTION_READ_MASK,
     v0::{
         bcs::BcsData,
         transaction::Transaction as ProtoTransaction,
         transaction_execution_service::{
             SimulateTransactionRequest, SimulateTransactionResponse,
+            simulate_transaction_response::ExecutionResult,
             transaction_execution_service_client::TransactionExecutionServiceClient,
         },
     },
@@ -20,13 +22,32 @@ use iota_types::{
 };
 use prost_types::FieldMask;
 
-use crate::utils::{assert_field_presence, setup_grpc_test};
+use crate::utils::{assert_field_presence, comma_separated_field_mask_to_paths, setup_grpc_test};
 
+/// Simulate a transaction and assert field presence at three levels:
+///
+/// 1. **`expected_response_paths` / `ignored_response_paths`** — asserted on
+///    the full [`SimulateTransactionResponse`].
+/// 2. **`expected_command_results_paths`** — when non-empty, `execution_result`
+///    is extracted as [`ExecutionResult::CommandResults`] and
+///    [`assert_field_presence`] is called on it.  Paths are relative to
+///    `CommandResults` (i.e. strip the leading
+///    `"execution_result.command_results."` prefix).  Panics if
+///    `execution_result` is not the `CommandResults` variant.
+/// 3. **`expected_execution_error_paths`** — when non-empty, `execution_result`
+///    is extracted as [`ExecutionResult::ExecutionError`] and
+///    [`assert_field_presence`] is called on it.  Paths are relative to
+///    `ExecutionError` (i.e. strip the leading
+///    `"execution_result.execution_error."` prefix).  Panics if
+///    `execution_result` is not the `ExecutionError` variant.
 async fn assert_simulate_transaction_request(
     exec_client: &mut TransactionExecutionServiceClient<iota_grpc_client::InterceptedChannel>,
     transaction: ProtoTransaction,
     read_mask: Option<FieldMask>,
-    expected_fields: &[&str],
+    expected_response_paths: &[&str],
+    ignored_response_paths: &[&str],
+    expected_command_results_paths: &[&str],
+    expected_execution_error_paths: &[&str],
     scenario: &str,
 ) -> SimulateTransactionResponse {
     let response = exec_client
@@ -43,7 +64,46 @@ async fn assert_simulate_transaction_request(
         .unwrap()
         .into_inner();
 
-    assert_field_presence(&response, expected_fields, scenario);
+    assert_field_presence(
+        &response,
+        expected_response_paths,
+        ignored_response_paths,
+        scenario,
+    );
+
+    if !expected_command_results_paths.is_empty() {
+        let command_results = match response.execution_result {
+            Some(ExecutionResult::CommandResults(ref cr)) => cr,
+            Some(ExecutionResult::ExecutionError(_)) => {
+                panic!("{scenario}: expected CommandResults but got ExecutionError")
+            }
+            Some(_) => panic!("{scenario}: expected CommandResults but got unknown variant"),
+            None => panic!("{scenario}: execution_result is None"),
+        };
+        assert_field_presence(
+            command_results,
+            expected_command_results_paths,
+            &[],
+            &format!("{scenario} (command_results)"),
+        );
+    }
+    if !expected_execution_error_paths.is_empty() {
+        let execution_error = match response.execution_result {
+            Some(ExecutionResult::ExecutionError(ref ee)) => ee,
+            Some(ExecutionResult::CommandResults(_)) => {
+                panic!("{scenario}: expected ExecutionError but got CommandResults")
+            }
+            Some(_) => panic!("{scenario}: expected ExecutionError but got unknown variant"),
+            None => panic!("{scenario}: execution_result is None"),
+        };
+        assert_field_presence(
+            execution_error,
+            expected_execution_error_paths,
+            &[],
+            &format!("{scenario} (execution_error)"),
+        );
+    }
+
     response
 }
 
@@ -115,139 +175,310 @@ async fn simulate_transaction_readmask_scenarios() {
 
     let mut exec_client = client.execution_service_client();
 
-    let recipient = iota_types::base_types::IotaAddress::random_for_testing_only();
-
     let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
     gas.sort_by_key(|object_ref| object_ref.0);
-    let obj_to_send = gas.first().unwrap();
     let gas_obj = gas.last().unwrap();
+    let obj_to_split = gas.first().unwrap();
 
-    // Build a simple transfer transaction
-    let tx_data = TransactionData::new_transfer(
-        recipient,
-        *obj_to_send,
+    // Build a SplitCoins programmable transaction so that execution_result
+    // contains real command results (mutated_by_ref + return_values) that the
+    // command-results readmask scenarios below can verify deeply.
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let gas_coin_arg = builder
+        .obj(ObjectArg::ImmOrOwnedObject(*obj_to_split))
+        .unwrap();
+    let amount = builder.pure(1000u64).unwrap();
+    let split_result = builder.command(iota_types::transaction::Command::SplitCoins(
+        gas_coin_arg,
+        vec![amount],
+    ));
+    builder.transfer_arg(sender, split_result);
+    let pt = builder.finish();
+
+    let tx_data = TransactionData::new_programmable(
         sender,
-        *gas_obj,
-        1_000_000, // gas budget
-        1000,      // gas price
+        vec![*gas_obj],
+        pt,
+        10_000_000, // gas budget
+        1000,       // gas price
     );
 
     let create_transaction = || {
-        ProtoTransaction::default()
-            .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap()))
+        Some(
+            ProtoTransaction::default()
+                .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap())),
+        )
     };
 
-    // Tests for readmask scenarios
-    type TestCase<'a> = (&'a str, Option<FieldMask>, Vec<&'a str>);
-    let test_cases: Vec<TestCase> = vec![
-        (
-            "default readmask",
-            None,
-            // SIMULATE_TRANSACTION_READ_MASK = "executed_transaction.transaction,
-            // executed_transaction.effects,executed_transaction.events,
-            // executed_transaction.input_objects,executed_transaction.output_objects,
-            // suggested_gas_price,execution_result"
-            // Wildcard paths expand to all their sub-fields.
-            vec![
-                "executed_transaction.transaction.digest",
-                "executed_transaction.transaction.bcs",
-                "executed_transaction.effects.digest",
-                "executed_transaction.effects.bcs",
-                "executed_transaction.events.digest",
-                "executed_transaction.events.events",
-                "executed_transaction.input_objects",
-                "executed_transaction.output_objects",
-                "suggested_gas_price",
-                "execution_result",
+    // Build a failing transaction: try to split u64::MAX coins from obj_to_split.
+    // The coin's balance is far below u64::MAX so the SplitCoins command aborts,
+    // producing ExecutionResult::ExecutionError (bcs_kind + source +
+    // command_index=0).
+    let mut failing_builder = ProgrammableTransactionBuilder::new();
+    let failing_coin_arg = failing_builder
+        .obj(ObjectArg::ImmOrOwnedObject(*obj_to_split))
+        .unwrap();
+    let huge_amount = failing_builder.pure(u64::MAX).unwrap();
+    failing_builder.command(iota_types::transaction::Command::SplitCoins(
+        failing_coin_arg,
+        vec![huge_amount],
+    ));
+    let failing_pt = failing_builder.finish();
+    let failing_tx_data = TransactionData::new_programmable(
+        sender,
+        vec![*gas_obj],
+        failing_pt,
+        10_000_000, // gas budget
+        1000,       // gas price
+    );
+    let create_failing_transaction = || {
+        Some(
+            ProtoTransaction::default()
+                .with_bcs(BcsData::default().with_data(bcs::to_bytes(&failing_tx_data).unwrap())),
+        )
+    };
+
+    // SplitCoins semantics for the first command result:
+    //   mutated_by_ref — the input coin (modified in-place via mutable reference)
+    //                    has `argument.kind` set because it references an input arg
+    //   return_values  — the newly split coin (a fresh result, not an input arg)
+    //                    has NO `argument` field
+    #[derive(Default)]
+    struct SimulateTestCase<'a> {
+        scenario: &'a str,
+        mask: Option<FieldMask>,
+        /// The transaction to submit.
+        transaction: Option<ProtoTransaction>,
+        /// Paths asserted on the full [`SimulateTransactionResponse`].
+        expected_response: Vec<&'a str>,
+        /// Paths on [`SimulateTransactionResponse`] that are skipped (e.g.
+        /// fields that are legitimately absent in the test environment).
+        ignored_response: Vec<&'a str>,
+        /// When non-empty, `execution_result` is extracted as
+        /// [`ExecutionResult::CommandResults`] and paths are asserted on it
+        /// (relative to `CommandResults`).
+        expected_command_results: Vec<&'a str>,
+        /// When non-empty, `execution_result` is extracted as
+        /// [`ExecutionResult::ExecutionError`] and paths are asserted on it
+        /// (relative to `ExecutionError`).
+        expected_execution_error: Vec<&'a str>,
+    }
+
+    let test_cases: Vec<SimulateTestCase> = vec![
+        SimulateTestCase {
+            scenario: "default readmask",
+            transaction: create_transaction(),
+            mask: None,
+            expected_response: comma_separated_field_mask_to_paths(SIMULATE_TRANSACTION_READ_MASK),
+            expected_command_results: vec![
+                "mutated_by_ref.argument.kind",
+                "mutated_by_ref.type_tag",
+                "mutated_by_ref.bcs",
+                "mutated_by_ref.json",
+                "return_values.type_tag",
+                "return_values.bcs",
+                "return_values.json",
             ],
-        ),
-        (
-            "empty readmask",
-            Some(FieldMask::from_paths(&[] as &[&str])),
-            vec![],
-        ),
-        // Full readmask: requesting parent "executed_transaction" returns ALL nested fields
-        // All fields are present even if empty (simple transfers have no events but events field
-        // is present)
-        (
-            "full readmask",
-            Some(FieldMask::from_paths([
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "empty readmask",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths(&[] as &[&str])),
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "full readmask",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths([
                 "executed_transaction",
                 "suggested_gas_price",
                 "execution_result",
             ])),
-            // "executed_transaction" is a wildcard → all sub-fields returned.
-            // checkpoint and timestamp are absent: simulate/execute transactions
-            // are not yet included in a checkpoint.
-            vec![
-                "executed_transaction.transaction.digest",
-                "executed_transaction.transaction.bcs",
-                "executed_transaction.signatures",
-                "executed_transaction.effects.digest",
-                "executed_transaction.effects.bcs",
-                "executed_transaction.events.digest",
-                "executed_transaction.events.events",
-                "executed_transaction.input_objects",
-                "executed_transaction.output_objects",
+            expected_response: vec![
+                "executed_transaction",
                 "suggested_gas_price",
                 "execution_result",
             ],
-        ),
-        (
-            "partial readmask (executed_transaction only)",
-            Some(FieldMask::from_paths(["executed_transaction"])),
-            // checkpoint and timestamp absent: not yet in a checkpoint.
-            vec![
-                "executed_transaction.transaction.digest",
-                "executed_transaction.transaction.bcs",
-                "executed_transaction.signatures",
-                "executed_transaction.effects.digest",
-                "executed_transaction.effects.bcs",
-                "executed_transaction.events.digest",
-                "executed_transaction.events.events",
-                "executed_transaction.input_objects",
-                "executed_transaction.output_objects",
+            // checkpoint/timestamp are None for not-yet-checkpointed transactions
+            ignored_response: vec![
+                "executed_transaction.checkpoint",
+                "executed_transaction.timestamp",
             ],
-        ),
-        (
-            "partial readmask (execution_result only)",
-            Some(FieldMask::from_paths(["execution_result"])),
-            vec![
-                "execution_result.command_results",
-                "execution_result.execution_error",
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "partial readmask (executed_transaction only)",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths(["executed_transaction"])),
+            expected_response: vec!["executed_transaction"],
+            // checkpoint/timestamp are None for not-yet-checkpointed transactions
+            ignored_response: vec![
+                "executed_transaction.checkpoint",
+                "executed_transaction.timestamp",
             ],
-        ),
-        // Specific nested field masks - only the specified nested fields are returned
-        (
-            "nested readmask (executed_transaction.effects only)",
-            Some(FieldMask::from_paths(["executed_transaction.effects"])),
-            vec![
-                "executed_transaction.effects.digest",
-                "executed_transaction.effects.bcs",
-            ],
-        ),
-        (
-            "nested readmask (multiple specific fields)",
-            Some(FieldMask::from_paths([
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "partial readmask (execution_result only)",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths(["execution_result"])),
+            expected_response: vec!["execution_result"],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "nested readmask (executed_transaction.effects only)",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths(["executed_transaction.effects"])),
+            expected_response: vec!["executed_transaction.effects"],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "nested readmask (executed_transaction.effects + execution_result)",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths([
                 "executed_transaction.effects",
                 "execution_result",
             ])),
-            vec![
-                "executed_transaction.effects.digest",
-                "executed_transaction.effects.bcs",
-                "execution_result.command_results",
-                "execution_result.execution_error",
+            expected_response: vec!["executed_transaction.effects", "execution_result"],
+            ..Default::default()
+        },
+        // ====================================================================
+        // command_results-focused cases: response check just verifies
+        // execution_result is present (and executed_transaction / suggested_gas_price
+        // are absent), then the deep CommandResults structure is verified.
+        // ====================================================================
+        SimulateTestCase {
+            scenario: "command_results: full",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths(["execution_result.command_results"])),
+            expected_response: vec!["execution_result"],
+            expected_command_results: vec![
+                "mutated_by_ref.argument.kind",
+                "mutated_by_ref.type_tag",
+                "mutated_by_ref.bcs",
+                "mutated_by_ref.json",
+                "return_values.type_tag",
+                "return_values.bcs",
+                "return_values.json",
             ],
-        ),
+            ..Default::default()
+        },
+        SimulateTestCase {
+            // Only return_values requested — mutated_by_ref must be absent.
+            scenario: "command_results: return_values only",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths([
+                "execution_result.command_results.return_values",
+            ])),
+            expected_response: vec!["execution_result"],
+            expected_command_results: vec![
+                "return_values.type_tag",
+                "return_values.bcs",
+                "return_values.json",
+            ],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            // Only mutated_by_ref requested — return_values must be absent.
+            scenario: "command_results: mutated_by_ref only",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths([
+                "execution_result.command_results.mutated_by_ref",
+            ])),
+            expected_response: vec!["execution_result"],
+            expected_command_results: vec![
+                "mutated_by_ref.argument.kind",
+                "mutated_by_ref.type_tag",
+                "mutated_by_ref.bcs",
+                "mutated_by_ref.json",
+            ],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "command_results: return_values.type_tag only",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths([
+                "execution_result.command_results.return_values.type_tag",
+            ])),
+            expected_response: vec!["execution_result"],
+            expected_command_results: vec!["return_values.type_tag"],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "command_results: mutated_by_ref.argument only",
+            transaction: create_transaction(),
+            mask: Some(FieldMask::from_paths([
+                "execution_result.command_results.mutated_by_ref.argument",
+            ])),
+            expected_response: vec!["execution_result"],
+            expected_command_results: vec!["mutated_by_ref.argument.kind"],
+            ..Default::default()
+        },
+        // ====================================================================
+        // execution_error-focused cases: the failing transaction (SplitCoins
+        // with u64::MAX amount) aborts at command index 0, producing an
+        // ExecutionResult::ExecutionError with bcs_kind + source +
+        // command_index.
+        // ====================================================================
+        SimulateTestCase {
+            scenario: "execution_error: default readmask",
+            transaction: create_failing_transaction(),
+            mask: None,
+            expected_response: comma_separated_field_mask_to_paths(SIMULATE_TRANSACTION_READ_MASK),
+            expected_execution_error: vec!["bcs_kind", "source", "command_index"],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "execution_error: full fields",
+            transaction: create_failing_transaction(),
+            mask: Some(FieldMask::from_paths(["execution_result.execution_error"])),
+            expected_response: vec!["execution_result"],
+            expected_execution_error: vec!["bcs_kind", "source", "command_index"],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "execution_error: bcs_kind only",
+            transaction: create_failing_transaction(),
+            mask: Some(FieldMask::from_paths([
+                "execution_result.execution_error.bcs_kind",
+            ])),
+            expected_response: vec!["execution_result"],
+            expected_execution_error: vec!["bcs_kind"],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "execution_error: source only",
+            transaction: create_failing_transaction(),
+            mask: Some(FieldMask::from_paths([
+                "execution_result.execution_error.source",
+            ])),
+            expected_response: vec!["execution_result"],
+            expected_execution_error: vec!["source"],
+            ..Default::default()
+        },
+        SimulateTestCase {
+            scenario: "execution_error: command_index only",
+            transaction: create_failing_transaction(),
+            mask: Some(FieldMask::from_paths([
+                "execution_result.execution_error.command_index",
+            ])),
+            expected_response: vec!["execution_result"],
+            expected_execution_error: vec!["command_index"],
+            ..Default::default()
+        },
     ];
 
-    for (scenario, mask, expected_paths) in test_cases {
+    for tc in test_cases {
         assert_simulate_transaction_request(
             &mut exec_client,
-            create_transaction(),
-            mask,
-            &expected_paths,
-            scenario,
+            tc.transaction.expect("test case transaction must be Some"),
+            tc.mask,
+            &tc.expected_response,
+            &tc.ignored_response,
+            &tc.expected_command_results,
+            &tc.expected_execution_error,
+            tc.scenario,
         )
         .await;
     }
@@ -294,159 +525,4 @@ async fn simulate_transaction_empty_request() {
         result.is_err(),
         "Expected error for missing transaction, but got success"
     );
-}
-
-#[sim_test]
-async fn simulate_transaction_command_results() {
-    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
-
-    let mut exec_client = client.execution_service_client();
-
-    let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
-    gas.sort_by_key(|object_ref| object_ref.0);
-    let gas_obj = gas.last().unwrap();
-    let obj_to_split = gas.first().unwrap();
-
-    // Build a programmable transaction that will produce command results
-    // We need to use a Move call that returns values, not just transfer_arg
-    let mut builder = ProgrammableTransactionBuilder::new();
-
-    // Use SplitCoins which returns a value (the split coin)
-    let gas_coin_arg = builder
-        .obj(ObjectArg::ImmOrOwnedObject(*obj_to_split))
-        .unwrap();
-    let amount = builder.pure(1000u64).unwrap();
-
-    // SplitCoins returns the newly created coin, which is an ExecutionResult
-    let split_result = builder.command(iota_types::transaction::Command::SplitCoins(
-        gas_coin_arg,
-        vec![amount],
-    ));
-
-    // Transfer the split coin to sender (this uses the result from the previous
-    // command)
-    builder.transfer_arg(sender, split_result);
-
-    let pt = builder.finish();
-
-    let tx_data = TransactionData::new_programmable(
-        sender,
-        vec![*gas_obj],
-        pt,
-        10_000_000, // gas budget
-        1000,       // gas price
-    );
-
-    let create_transaction = || {
-        ProtoTransaction::default()
-            .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap()))
-    };
-
-    // Test cases for command_results field presence
-    type TestCase<'a> = (&'a str, Option<FieldMask>, Vec<&'a str>);
-    let test_cases: Vec<TestCase> = vec![
-        (
-            "default readmask",
-            None,
-            vec![
-                "executed_transaction.transaction.digest",
-                "executed_transaction.transaction.bcs",
-                "executed_transaction.effects.digest",
-                "executed_transaction.effects.bcs",
-                "executed_transaction.events.digest",
-                "executed_transaction.events.events",
-                "executed_transaction.input_objects",
-                "executed_transaction.output_objects",
-                "suggested_gas_price",
-                // mutated_by_ref has argument since they reference input arguments
-                "execution_result.command_results.results.mutated_by_ref.outputs.argument.kind",
-                "execution_result.command_results.results.mutated_by_ref.outputs.type_tag",
-                "execution_result.command_results.results.mutated_by_ref.outputs.bcs",
-                "execution_result.command_results.results.mutated_by_ref.outputs.json",
-                // return_values don't have argument (they're results, not arguments)
-                "execution_result.command_results.results.return_values.outputs.type_tag",
-                "execution_result.command_results.results.return_values.outputs.bcs",
-                "execution_result.command_results.results.return_values.outputs.json",
-            ],
-        ),
-        (
-            "full command_results readmask",
-            Some(FieldMask::from_paths(["execution_result.command_results"])),
-            vec![
-                // Full mask returns all nested fields
-                // mutated_by_ref has argument since they reference input arguments
-                "execution_result.command_results.results.mutated_by_ref.outputs.argument.kind",
-                "execution_result.command_results.results.mutated_by_ref.outputs.type_tag",
-                "execution_result.command_results.results.mutated_by_ref.outputs.bcs",
-                "execution_result.command_results.results.mutated_by_ref.outputs.json",
-                // return_values don't have argument (they're results, not arguments)
-                "execution_result.command_results.results.return_values.outputs.type_tag",
-                "execution_result.command_results.results.return_values.outputs.bcs",
-                "execution_result.command_results.results.return_values.outputs.json",
-            ],
-        ),
-        (
-            "command_results with nested return_values field",
-            Some(FieldMask::from_paths([
-                "execution_result.command_results.results.return_values",
-            ])),
-            vec![
-                // return_values don't have argument (they're results, not arguments)
-                "execution_result.command_results.results.return_values.outputs.type_tag",
-                "execution_result.command_results.results.return_values.outputs.bcs",
-                "execution_result.command_results.results.return_values.outputs.json",
-            ],
-        ),
-        (
-            "command_results with nested mutated_by_ref field",
-            Some(FieldMask::from_paths([
-                "execution_result.command_results.results.mutated_by_ref",
-            ])),
-            vec![
-                // mutated_by_ref has argument since they reference input arguments
-                "execution_result.command_results.results.mutated_by_ref.outputs.argument.kind",
-                "execution_result.command_results.results.mutated_by_ref.outputs.type_tag",
-                "execution_result.command_results.results.mutated_by_ref.outputs.bcs",
-                "execution_result.command_results.results.mutated_by_ref.outputs.json",
-            ],
-        ),
-        (
-            "command_results return_values outputs with type_tag field",
-            Some(FieldMask::from_paths([
-                "execution_result.command_results.results.return_values.outputs.type_tag",
-            ])),
-            vec!["execution_result.command_results.results.return_values.outputs.type_tag"],
-        ),
-        (
-            "command_results mutated_by_ref outputs with argument field",
-            Some(FieldMask::from_paths([
-                "execution_result.command_results.results.mutated_by_ref.outputs.argument",
-            ])),
-            vec!["execution_result.command_results.results.mutated_by_ref.outputs.argument.kind"],
-        ),
-        (
-            "command_results mutated_by_ref outputs",
-            Some(FieldMask::from_paths([
-                "execution_result.command_results.results.mutated_by_ref.outputs",
-            ])),
-            vec![
-                // mutated_by_ref has argument since they reference input arguments
-                "execution_result.command_results.results.mutated_by_ref.outputs.argument.kind",
-                "execution_result.command_results.results.mutated_by_ref.outputs.type_tag",
-                "execution_result.command_results.results.mutated_by_ref.outputs.bcs",
-                "execution_result.command_results.results.mutated_by_ref.outputs.json",
-            ],
-        ),
-    ];
-
-    for (scenario, mask, expected_paths) in test_cases {
-        assert_simulate_transaction_request(
-            &mut exec_client,
-            create_transaction(),
-            mask,
-            &expected_paths,
-            scenario,
-        )
-        .await;
-    }
 }


### PR DESCRIPTION
# Description of change

Cleanup for the e2e grpc read mask tests.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes