### PR TITLE
fix(starfish): increase per-block lock limit in header synchronizer to prevent peer starvation

### DIFF
--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -65,7 +65,7 @@ const FETCH_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(4_000);
 /// The maximum number of authorities from which we will try to periodically
 /// fetch block header at the same moment. The guard will protect that we will
 /// not ask from more than this number of authorities at the same time.
-const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER: usize = 2;
+const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER: usize = 3;
 
 /// The maximum number of authorities from which the live synchronizer will try
 /// to fetch block headers at the same moment. This is lower than the periodic
@@ -150,7 +150,7 @@ impl InflightBlockHeadersMap {
     ///
     /// Different limits apply based on the sync method:
     /// - Periodic sync: Can lock if total authorities <
-    ///   MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER (2)
+    ///   MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER (3)
     /// - Live sync: Can lock if total authorities <
     ///   MAX_AUTHORITIES_TO_LIVE_FETCH_PER_BLOCK_HEADER (1)
     fn lock_headers(
@@ -1698,12 +1698,12 @@ mod tests {
         ];
         let missing_block_refs = some_block_refs.iter().cloned().collect::<BTreeSet<_>>();
 
-        // Lock & unlock blocks - using Periodic sync method (limit 2)
+        // Lock & unlock blocks - using Periodic sync method (limit 3)
         {
             let mut all_guards = Vec::new();
 
-            // Try to acquire the block locks for authorities 1 & 2 (Periodic limit is 2)
-            for i in 1..=2 {
+            // Try to acquire the block locks for authorities 1, 2, and 3.
+            for i in 1..=3 {
                 let authority = AuthorityIndex::new_for_test(i);
 
                 let guard =
@@ -1719,24 +1719,24 @@ mod tests {
                 assert!(guard.is_none());
             }
 
-            // Trying to acquire for authority 3 it will fail - as we have maxed out the
-            // number of allowed peers (Periodic limit is 2)
-            let authority_3 = AuthorityIndex::new_for_test(3);
+            // Trying to acquire for authority 4 will fail - as we have maxed out the
+            // number of allowed peers (Periodic limit is 3)
+            let authority_4 = AuthorityIndex::new_for_test(4);
 
             let guard = map.lock_headers(
                 missing_block_refs.clone(),
-                authority_3,
+                authority_4,
                 SyncMethod::Periodic,
             );
             assert!(guard.is_none());
 
-            // Explicitly drop the guard of authority 1 and try for authority 3 again - it
+            // Explicitly drop the guard of authority 1 and try for authority 4 again - it
             // will now succeed
             drop(all_guards.remove(0));
 
             let guard = map.lock_headers(
                 missing_block_refs.clone(),
-                authority_3,
+                authority_4,
                 SyncMethod::Periodic,
             );
             let guard = guard.expect("Guard should be successfully acquired");
@@ -1770,7 +1770,7 @@ mod tests {
             let mut all_guards = Vec::new();
             all_guards.push(guard);
             // authority 1 should now be unlocked, so now we can lock the same refs with
-            // authority 3, but not for 4 (limit of 2)
+            // authorities 3 and 4, but not 5 (limit of 3)
             let authority_3 = AuthorityIndex::new_for_test(3);
             let guard = map.lock_headers(
                 missing_block_refs.clone(),
@@ -1785,6 +1785,16 @@ mod tests {
             let guard = map.lock_headers(
                 missing_block_refs.clone(),
                 authority_4,
+                SyncMethod::Periodic,
+            );
+            let guard = guard.expect("Guard should be created");
+            assert_eq!(guard.block_refs.len(), 4);
+            all_guards.push(guard);
+
+            let authority_5 = AuthorityIndex::new_for_test(5);
+            let guard = map.lock_headers(
+                missing_block_refs.clone(),
+                authority_5,
                 SyncMethod::Periodic,
             );
             assert!(guard.is_none());
@@ -1832,7 +1842,7 @@ mod tests {
             drop(guard_2);
         }
 
-        // Test 2: Periodic sync allows more concurrency (2 authorities)
+        // Test 2: Periodic sync allows more concurrency (3 authorities)
         {
             let authority_1 = AuthorityIndex::new_for_test(1);
             let guard_1 = map
@@ -1845,7 +1855,7 @@ mod tests {
 
             assert_eq!(guard_1.block_refs.len(), 2);
 
-            // Authority 2 can also lock with Periodic sync (limit is 2)
+            // Authority 2 can also lock with Periodic sync (limit is 3)
             let authority_2 = AuthorityIndex::new_for_test(2);
             let guard_2 = map
                 .lock_headers(
@@ -1853,26 +1863,39 @@ mod tests {
                     authority_2,
                     SyncMethod::Periodic,
                 )
-                .expect("Should successfully lock - Periodic allows 2 authorities");
+                .expect("Should successfully lock - Periodic allows 3 authorities");
 
             assert_eq!(guard_2.block_refs.len(), 2);
 
-            // But authority 3 cannot lock with Periodic sync (limit of 2 reached)
+            // Authority 3 can also lock with Periodic sync (limit is 3)
             let authority_3 = AuthorityIndex::new_for_test(3);
-            let guard_3 = map.lock_headers(
+            let guard_3 = map
+                .lock_headers(
+                    missing_block_refs.clone(),
+                    authority_3,
+                    SyncMethod::Periodic,
+                )
+                .expect("Should successfully lock - Periodic allows 3 authorities");
+
+            assert_eq!(guard_3.block_refs.len(), 2);
+
+            // But authority 4 cannot lock with Periodic sync (limit of 3 reached)
+            let authority_4 = AuthorityIndex::new_for_test(4);
+            let guard_4 = map.lock_headers(
                 missing_block_refs.clone(),
-                authority_3,
+                authority_4,
                 SyncMethod::Periodic,
             );
 
             assert!(
-                guard_3.is_none(),
-                "Should fail to lock - Periodic limit of 2 reached"
+                guard_4.is_none(),
+                "Should fail to lock - Periodic limit of 3 reached"
             );
 
             // Release locks
             drop(guard_1);
             drop(guard_2);
+            drop(guard_3);
         }
 
         // Test 3: Periodic blocks Live when at Live's limit
@@ -1899,15 +1922,15 @@ mod tests {
                 "Should fail to lock with Live - total already at Live limit of 1"
             );
 
-            // But authority 2 CAN lock with Periodic sync (total would be 2, at Periodic
-            // limit)
+            // But authority 2 CAN lock with Periodic sync (total would be 2, under the
+            // Periodic limit)
             let guard_2_periodic = map
                 .lock_headers(
                     missing_block_refs.clone(),
                     authority_2,
                     SyncMethod::Periodic,
                 )
-                .expect("Should successfully lock with Periodic - under Periodic limit of 2");
+                .expect("Should successfully lock with Periodic - under Periodic limit of 3");
 
             assert_eq!(guard_2_periodic.block_refs.len(), 2);
 
@@ -1935,33 +1958,47 @@ mod tests {
                 "Should fail to lock with Live - would exceed Live limit of 1"
             );
 
-            // But authority 2 CAN lock with Periodic sync (total=2, at Periodic limit)
+            // But authority 2 CAN lock with Periodic sync (total=2, still under the
+            // Periodic limit)
             let guard_2 = map
                 .lock_headers(
                     missing_block_refs.clone(),
                     authority_2,
                     SyncMethod::Periodic,
                 )
-                .expect("Should successfully lock with Periodic - total 2 is at Periodic limit");
+                .expect("Should successfully lock with Periodic - total 2 is under Periodic limit");
 
             assert_eq!(guard_2.block_refs.len(), 2);
 
-            // And authority 3 cannot lock with Periodic sync (would exceed Periodic limit
-            // of 2)
+            // And authority 3 can still lock with Periodic sync (reaching the Periodic
+            // limit)
             let authority_3 = AuthorityIndex::new_for_test(3);
-            let guard_3 = map.lock_headers(
+            let guard_3 = map
+                .lock_headers(
+                    missing_block_refs.clone(),
+                    authority_3,
+                    SyncMethod::Periodic,
+                )
+                .expect("Should successfully lock with Periodic - total 3 reaches Periodic limit");
+
+            assert_eq!(guard_3.block_refs.len(), 2);
+
+            // Authority 4 would exceed the Periodic limit.
+            let authority_4 = AuthorityIndex::new_for_test(4);
+            let guard_4 = map.lock_headers(
                 missing_block_refs.clone(),
-                authority_3,
+                authority_4,
                 SyncMethod::Periodic,
             );
 
             assert!(
-                guard_3.is_none(),
-                "Should fail to lock with Periodic - would exceed Periodic limit of 2"
+                guard_4.is_none(),
+                "Should fail to lock with Periodic - would exceed Periodic limit of 3"
             );
 
             drop(guard_1);
             drop(guard_2);
+            drop(guard_3);
         }
 
         // Test 5: Partial locks with mixed methods
@@ -1979,7 +2016,8 @@ mod tests {
                 .expect("Should lock block A");
             assert_eq!(guard_a.block_refs.len(), 1);
 
-            // Lock block B with authorities 1 & 2 using Periodic (B at limit for Periodic)
+            // Lock block B with authorities 1, 2, and 3 using Periodic (B at limit for
+            // Periodic)
             let guard_b1 = map
                 .lock_headers(
                     [block_b].into(),
@@ -1998,6 +2036,15 @@ mod tests {
                 .expect("Should lock block B with authority 2");
             assert_eq!(guard_b2.block_refs.len(), 1);
 
+            let guard_b3 = map
+                .lock_headers(
+                    [block_b].into(),
+                    AuthorityIndex::new_for_test(3),
+                    SyncMethod::Periodic,
+                )
+                .expect("Should lock block B with authority 3");
+            assert_eq!(guard_b3.block_refs.len(), 1);
+
             // Cannot lock block A with authority 2 using Live (A already at Live limit)
             let guard_a2 = map.lock_headers(
                 [block_a].into(),
@@ -2006,18 +2053,19 @@ mod tests {
             );
             assert!(guard_a2.is_none());
 
-            // Cannot lock block B with authority 3 using Periodic (B already at Periodic
+            // Cannot lock block B with authority 4 using Periodic (B already at Periodic
             // limit)
-            let guard_b3 = map.lock_headers(
+            let guard_b4 = map.lock_headers(
                 [block_b].into(),
-                AuthorityIndex::new_for_test(3),
+                AuthorityIndex::new_for_test(4),
                 SyncMethod::Periodic,
             );
-            assert!(guard_b3.is_none());
+            assert!(guard_b4.is_none());
 
             drop(guard_a);
             drop(guard_b1);
             drop(guard_b2);
+            drop(guard_b3);
         }
     }
 
@@ -2844,13 +2892,15 @@ mod tests {
             // Stub *all* authorities so none panic:
             for i in 1..=9 {
                 let peer = AuthorityIndex::new_for_test(i);
-                let timeout = if i == 1 || i == 3 {
-                    Some(2 * FETCH_REQUEST_TIMEOUT)
+                let latency = if i == 1 {
+                    Some(Duration::from_millis(2))
+                } else if i == 3 {
+                    Some(Duration::from_millis(1))
                 } else {
                     None
                 };
                 network_client
-                    .stub_fetch_headers_response(vec![missing_vbh.clone()], peer, timeout)
+                    .stub_fetch_headers_response(vec![missing_vbh.clone()], peer, latency)
                     .await;
             }
 
@@ -2869,21 +2919,20 @@ mod tests {
             )
             .await;
 
-            // 5) Knowledge-based fetches should go to 2 and 3.
-            // For authoritiy 3 we will have request timeout. After the request
-            // timeout they try to swap locks and request the header from remaining
-            // authorities, first two of them are authorities 4. Assert we
-            // got exactly three fetches - from 2 (knowledge-based), and from 4
-            // (request from remaining authority after timeout)
-            assert_eq!(results.len(), 2);
+            // 5) With MAX_PERIODIC_SYNC_PEERS=4 and MAX_PERIODIC_SYNC_RANDOM_PEERS=2:
+            // - 2 known peers are selected first: 2 and 3
+            // - 2 random peers chosen: 1 and 4, but only peer 1 gets a chunk (all refs fit
+            //   in one chunk), so peer 4 has nothing to request
+            assert_eq!(results.len(), 3);
 
-            // 6) The results should come in the following order: 2, 4, 5
+            // 6) Results in order: peers 2 and 3 (known), then peer 1 (random)
             let peers: Vec<_> = results.iter().map(|(_, _, peer)| *peer).collect();
             assert_eq!(
                 peers,
                 vec![
                     AuthorityIndex::new_for_test(2),
-                    AuthorityIndex::new_for_test(4),
+                    AuthorityIndex::new_for_test(3),
+                    AuthorityIndex::new_for_test(1),
                 ]
             );
 
@@ -3029,7 +3078,7 @@ mod tests {
             missing_block_headers,
             dag_state.clone(),
         )
-            .await;
+        .await;
 
         // 6) Assert we got 4 fetches: peer 2 (timed out) and fallback to 5 (first of
         //    the remaining peers), peer 3, and from 'random' 1 and 4


### PR DESCRIPTION
# Description of change

Increase `MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER` from 2 to 3 to fix header synchronizer starvation when wiped-DB validators saturate per-block lock slots. `MAX_PERIODIC_SYNC_PEERS` stays at 4.

**Observed Problem in testing:** When 3 validators have wiped DBs and their blocks are garbage collected and referenced by a certified commit, the block suspender marks them as "who knows" peers. The header synchronizer then selects 2 of them as known peers (filling `MAX_PERIODIC_SYNC_PEERS - MAX_PERIODIC_SYNC_RANDOM_PEERS = 4 - 2 = 2` slots). With `MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER = 2`, these 2 known peers saturate all per-block lock slots, blocking random peers from fetching. Since wiped validators always fail, the system is stuck.

**Fix:** Increase `MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER` from 2 to 3, allowing 3 concurrent fetchers per block header. Even when both known peers are wiped-DB validators occupying 2 lock slots, 1 slot remains for a random peer to reach a healthy validator. This preserves the original peer count (4) while resolving the starvation.

## Links to any relevant issues

Fixes #10531

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] I have added tests that prove my fix is effective or that my feature works: I run the same simulation scenario in which some validator got stuck and were not able to get synced
- [x] I have checked that new and existing unit tests pass locally with my changes