### PR TITLE
fix(consensus): fix flaky simtest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,7 +17,6 @@ filter = '''
 (package(iota-cluster-test) and (test(test_iota_cluster)))
 or (package(iota-graphql-rpc) and (binary(e2e_tests) or (test(test_query_cost)) or binary(examples_validation_tests)))
 or (package(iota-indexer) and (binary(ingestion_tests)))
-or (package(starfish-simtests) and test(test_sequential_restarts_persistent_db_short_run_long_stop))
 '''
 
 [[profile.default.overrides]]

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -53,7 +53,6 @@ pub struct ConsensusAuthority {
     network_manager: TonicManager<AuthorityService<ChannelCoreThreadDispatcher>>,
     #[cfg(msim)]
     store: Arc<RocksDBStore>,
-    #[cfg(test)]
     dag_state: Arc<RwLock<DagState>>,
     #[cfg(test)]
     sync_last_known_own_block: bool,
@@ -300,7 +299,6 @@ impl ConsensusAuthority {
             network_manager,
             #[cfg(msim)]
             store,
-            #[cfg(test)]
             dag_state: dag_state.clone(),
             #[cfg(test)]
             sync_last_known_own_block,
@@ -362,6 +360,9 @@ impl ConsensusAuthority {
         // Shutdown Core to stop block productions and broadcast.
         // When using streaming, all subscribers to broadcast blocks stop after this.
         self.core_thread_handle.stop().await;
+        // Final flush to ensure all buffered data (including pending transactions
+        // referenced by not-yet-solid commits) is persisted before shutdown.
+        self.dag_state.write().flush();
         // Stop outgoing long-lived streams before stopping network server.
         self.subscriber.stop();
         self.network_manager.stop().await;

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1613,7 +1613,7 @@ mod tests {
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
             SerializedTransactionsV1, SerializedTransactionsV2, TransactionFetchMode,
         },
-        storage::{Store, mem_store::MemStore},
+        storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
         transaction::TransactionConsumer,
         transaction_ref::GenericTransactionRef,
@@ -3775,7 +3775,7 @@ mod tests {
         let all_headers: Vec<VerifiedBlockHeader> = dag_builder.block_headers(1..=rounds);
         store
             .write(
-                crate::storage::WriteBatch::new(vec![], all_headers, vec![], vec![], vec![], Some(false)),
+                WriteBatch::new(vec![], all_headers, vec![], vec![], vec![], Some(false)),
                 context.clone(),
             )
             .expect("Failed to write block headers to store");

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -3775,7 +3775,7 @@ mod tests {
         let all_headers: Vec<VerifiedBlockHeader> = dag_builder.block_headers(1..=rounds);
         store
             .write(
-                crate::storage::WriteBatch::new(vec![], all_headers, vec![], vec![], vec![], false),
+                crate::storage::WriteBatch::new(vec![], all_headers, vec![], vec![], vec![], Some(false)),
                 context.clone(),
             )
             .expect("Failed to write block headers to store");

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -119,15 +119,10 @@ impl CommitObserver {
         self.linearizer.clear_state();
         self.last_sent_commit_index = last_commit_index;
 
-        // Recover linearizer and solidifier state directly.
-        // Don't go through recover_and_send_commits which skips Phase 2
-        // when store.read_fast_sync_ongoing() returns true (stale read).
-        // Phase 1 (resend unprocessed commits) is a no-op since
-        // last_sent == last_commit after fast sync.
-        self.recover_linearizer_and_solidifier_state(
-            last_commit_index,
-            CommittedSubDagSource::FastCommitSyncer,
-        );
+        // Recover linearizer and solidifier state via the standard path.
+        // The fast_sync_ongoing flag will have been flushed to false by now,
+        // so recover_and_send_commits will correctly run Phase 2.
+        self.recover_and_send_commits(last_commit_index, CommittedSubDagSource::FastCommitSyncer);
 
         info!(
             "CommitObserver reinitialized at commit index {}, took {:?}",

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -111,17 +111,20 @@ impl CommitObserver {
         observer
     }
 
-    /// Reinitialize the CommitObserver at a new commit index after fast sync.
+    /// Reinitialize the CommitObserver at a new commit index.
+    /// Uses the existing `recover_and_send_commits` method which handles:
+    /// - Recovering linearizer state (transaction ack tracker, traversed
+    ///   headers)
+    /// - Only re-sends commits that are > last_commit_index (none in this case)
     pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
         let now = Instant::now();
 
-        // Clear linearizer state for clean recovery
+        // Clear linearizer state
         self.linearizer.clear_state();
         self.last_sent_commit_index = last_commit_index;
 
-        // Recover linearizer and solidifier state via the standard path.
-        // The fast_sync_ongoing flag will have been flushed to false by now,
-        // so recover_and_send_commits will correctly run Phase 2.
+        // Reuse existing recovery logic - it won't resend commits since
+        // they're all <= last_commit_index
         self.recover_and_send_commits(last_commit_index, CommittedSubDagSource::FastCommitSyncer);
 
         info!(

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -487,6 +487,22 @@ impl CommitObserver {
             committed_subdags.push(committed_subdag);
         }
 
+        // If we couldn't resend any commits, still initialize
+        // last_solid_subdag_base from last_processed so fast sync
+        // starts from the right position instead of index 0.
+        if committed_subdags.is_empty() && last_processed_commit_index > 0 {
+            if let Some(commit) = self
+                .store
+                .scan_commits((last_processed_commit_index..=last_processed_commit_index).into())
+                .ok()
+                .and_then(|commits| commits.into_iter().next())
+            {
+                if let Some(subdag) = self.build_committed_subdag_from_commit(&commit, vec![]) {
+                    self.update_with_solid_subdags_and_flush(&[subdag]);
+                }
+            }
+        }
+
         self.finalize_and_send_solid_subdags(&[], &committed_subdags, source)
             .expect("We should successfully send committed subdags during resend");
     }

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -111,21 +111,23 @@ impl CommitObserver {
         observer
     }
 
-    /// Reinitialize the CommitObserver at a new commit index.
-    /// Uses the existing `recover_and_send_commits` method which handles:
-    /// - Recovering linearizer state (transaction ack tracker, traversed
-    ///   headers)
-    /// - Only re-sends commits that are > last_commit_index (none in this case)
+    /// Reinitialize the CommitObserver at a new commit index after fast sync.
     pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
         let now = Instant::now();
 
-        // Clear linearizer state
+        // Clear linearizer state for clean recovery
         self.linearizer.clear_state();
         self.last_sent_commit_index = last_commit_index;
 
-        // Reuse existing recovery logic - it won't resend commits since
-        // they're all <= last_commit_index
-        self.recover_and_send_commits(last_commit_index, CommittedSubDagSource::FastCommitSyncer);
+        // Recover linearizer and solidifier state directly.
+        // Don't go through recover_and_send_commits which skips Phase 2
+        // when store.read_fast_sync_ongoing() returns true (stale read).
+        // Phase 1 (resend unprocessed commits) is a no-op since
+        // last_sent == last_commit after fast sync.
+        self.recover_linearizer_and_solidifier_state(
+            last_commit_index,
+            CommittedSubDagSource::FastCommitSyncer,
+        );
 
         info!(
             "CommitObserver reinitialized at commit index {}, took {:?}",

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -222,11 +222,22 @@ impl CommitObserver {
         reputation_scores: Vec<(AuthorityIndex, u64)>,
     ) -> Option<CommittedSubDag> {
         let tx_refs = commit.committed_transactions();
-        let transactions = self
+        let transactions = match self
             .dag_state
             .read()
             .try_get_all_verified_transactions(&tx_refs)
-            .ok()?;
+        {
+            Ok(transactions) => transactions,
+            Err(missing_refs) => {
+                warn!(
+                    "Missing {} transactions for commit {}: {:?}",
+                    missing_refs.len(),
+                    commit.index(),
+                    missing_refs,
+                );
+                return None;
+            }
+        };
 
         Some(CommittedSubDag::new(
             commit.leader(),

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -210,7 +210,7 @@ pub(crate) struct DagState {
     voting_block_headers_to_write: Vec<VerifiedBlockHeader>,
 
     /// Fast sync ongoing flag to be flushed to storage.
-    fast_sync_ongoing_flag_to_write: bool,
+    fast_sync_ongoing_flag_to_write: Option<bool>,
 
     /// Buffer the reputation scores & last_committed_rounds to be flushed with
     /// the next dag state flush. This is okay because we can recover
@@ -321,7 +321,7 @@ impl DagState {
             block_headers_to_write: vec![],
             commits_to_write: vec![],
             voting_block_headers_to_write: vec![],
-            fast_sync_ongoing_flag_to_write: fast_sync_ongoing,
+            fast_sync_ongoing_flag_to_write: None,
             commit_info_to_write: vec![],
             pending_acknowledgments: BTreeSet::new(),
             scoring_subdag,
@@ -591,7 +591,7 @@ impl DagState {
     }
 
     pub(crate) fn set_fast_sync_ongoing_flag(&mut self, flag: bool) {
-        self.fast_sync_ongoing_flag_to_write = flag;
+        self.fast_sync_ongoing_flag_to_write = Some(flag);
     }
 
     pub(crate) fn fast_sync_ongoing(&self) -> bool {
@@ -2180,7 +2180,7 @@ impl DagState {
         let commits = std::mem::take(&mut self.commits_to_write);
         let commit_info = std::mem::take(&mut self.commit_info_to_write);
         let voting_block_headers = std::mem::take(&mut self.voting_block_headers_to_write);
-        let fast_commit_sync_flag = self.fast_sync_ongoing_flag_to_write;
+        let fast_commit_sync_flag = self.fast_sync_ongoing_flag_to_write.take();
 
         // Early return if there's nothing to flush
         if transactions.is_empty()
@@ -2188,6 +2188,7 @@ impl DagState {
             && commits.is_empty()
             && commit_info.is_empty()
             && voting_block_headers.is_empty()
+            && fast_commit_sync_flag.is_none()
         {
             return;
         }
@@ -2212,6 +2213,8 @@ impl DagState {
                 .map(|(commit_ref, _)| commit_ref.to_string())
                 .join(","),
             fast_commit_sync_flag
+                .map(|f| f.to_string())
+                .unwrap_or_else(|| "unchanged".to_string())
         );
 
         // Write all buffered data to storage

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -148,7 +148,9 @@ impl Store for MemStore {
             inner.voting_block_headers.insert(key, header);
         }
 
-        inner.fast_sync_ongoing = write_batch.fast_commit_sync_flag;
+        if let Some(flag) = write_batch.fast_commit_sync_flag {
+            inner.fast_sync_ongoing = flag;
+        }
 
         Ok(())
     }

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -186,7 +186,7 @@ pub(crate) struct WriteBatch {
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
     pub(crate) voting_block_headers: Vec<VerifiedBlockHeader>,
-    pub(crate) fast_commit_sync_flag: bool,
+    pub(crate) fast_commit_sync_flag: Option<bool>,
 }
 
 impl WriteBatch {
@@ -196,7 +196,7 @@ impl WriteBatch {
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
         voting_block_headers: Vec<VerifiedBlockHeader>,
-        fast_commit_sync_flag: bool,
+        fast_commit_sync_flag: Option<bool>,
     ) -> Self {
         WriteBatch {
             transactions,

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -298,14 +298,16 @@ impl Store for RocksDBStore {
             }
         }
 
-        if write_batch.fast_commit_sync_flag {
-            batch
-                .insert_batch(&self.fast_commit_sync_flag, [((), ())])
-                .map_err(ConsensusError::RocksDBFailure)?;
-        } else {
-            batch
-                .delete_batch(&self.fast_commit_sync_flag, [()])
-                .map_err(ConsensusError::RocksDBFailure)?;
+        if let Some(flag) = write_batch.fast_commit_sync_flag {
+            if flag {
+                batch
+                    .insert_batch(&self.fast_commit_sync_flag, [((), ())])
+                    .map_err(ConsensusError::RocksDBFailure)?;
+            } else {
+                batch
+                    .delete_batch(&self.fast_commit_sync_flag, [()])
+                    .map_err(ConsensusError::RocksDBFailure)?;
+            }
         }
 
         batch.write()?;

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -484,10 +484,8 @@ mod test {
         run_sequential_restarts_test(RestartMode::PersistAll, true, false).await;
     }
 
-    // TODO: This test is flaky when running with many other tests in parallel.
-    // It passes consistently when running individually.
-    // /// Persistent DB after each restart, short run before stop, long stop
-    // duration.
+    /// Persistent DB after each restart, short run before stop, long stop
+    /// duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_persistent_db_short_run_long_stop() {
         run_sequential_restarts_test(RestartMode::PersistAll, false, true).await;


### PR DESCRIPTION
# Description of change

Fixes flaky `test_sequential_restarts_persistent_db_short_run_long_stop` simtest caused by the `fast_sync_ongoing` flag not being reliably persisted to storage.

The `flush()` early-return guard in `DagState` checked whether blocks, transactions, commits, and voting headers were empty — but did **not** check the `fast_sync_ongoing` flag. When fast sync completed and set the flag to `false`, if there was no other buffered data to write, `flush()` would bail out early and
  never persist the flag change. On restart, the authority still believed fast sync was ongoing, causing `recover_and_send_commits` to skip Phase 2 recovery and leaving the commit pipeline in an inconsistent state.

 A secondary issue was that `fast_sync_ongoing_flag_to_write` was a plain `bool` (always carrying a value), making it impossible to distinguish "flag was explicitly changed" from "flag is unchanged". This prevented a clean inclusion in the early-return check.

 ### Fix

 - **Make `fast_sync_ongoing_flag_to_write` an `Option<bool>`**: initialized to `None`, only set to `Some(...)` when `set_fast_sync_ongoing_flag()` is called. `flush()` uses `.take()` so it's only written when actually dirty.
 - **Include the flag in the flush early-return check**: `fast_commit_sync_flag.is_none()` is now part of the "nothing to flush" guard, so a pending flag change is never silently skipped.
 - **Flush `DagState` on authority stop**: added `dag_state.write().flush()` in `ConsensusAuthority::stop()` to ensure all buffered data (including the flag) is persisted before shutdown.

 ### Additional improvements

 - **Better logging for missing transactions**: `build_committed_subdag_from_commit` now logs a `warn!` with the count and list of missing transaction refs instead of silently returning `None`.
 - **`last_solid_subdag_base` fallback**: in `resend_unprocessed_solid_commits`, if all unprocessed commits fail to build (due to missing transactions), `last_solid_subdag_base` is initialized from the last processed commit so fast sync starts from the correct position instead of index 0.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
