### PR TITLE
feat(ci): add paths filter to changeset workflow

### DIFF
--- a/.github/workflows/changesets_ci.yml
+++ b/.github/workflows/changesets_ci.yml
@@ -3,6 +3,15 @@ name: Changesets CI
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - "apps/**"
+      - "sdk/**"
+      - "dapps/**"
+      - "docs/site/**"
+      - ".changeset/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 jobs:
   validate:


### PR DESCRIPTION
# Description of change

PRs that only touch Rust code will never affect pnpm packages, yet this workflow still runs, installs Node + pnpm, does pnpm install, etc.

We can skip it entirely for those PRs.
