### PR TITLE
fix(gPRC): proto build doc

### DIFF
--- a/crates/iota-proto-build/README.md
+++ b/crates/iota-proto-build/README.md
@@ -15,8 +15,7 @@ This tool generates Rust code from `.proto` files with additional field masking 
 Run this tool whenever you modify `.proto` files.
 
 ```bash
-cd crates/iota-grpc-types
-make proto
+./scripts/update_grpc_types.sh
 ```
 
 **NOTE**: After generating files, the tool checks if any generated code changed. If changes are detected, you must commit them before running the tool again. This ensures generated code is never forgotten and stays in sync with proto definitions.


### PR DESCRIPTION
# Description of change

Correct the wrong README at `crates/iota-proto-build/README.md` instructs users to regenerate proto types.

## Links to any relevant issues

None.

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation