### PR TITLE
refactor(starfish): block suspension in block manager

### DIFF
--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -44,7 +44,7 @@ pub(crate) struct BlockManager {
     /// Keeps full blocks for suspended block headers
     /// TODO: this set can grow to become too big, need to add some eviction
     /// mechanism
-    suspended_blocks: BTreeMap<BlockRef, VerifiedBlock>,
+    suspended_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
     block_suspender: BlockSuspender,
     /// A vector that holds a tuple of (lowest_round, highest_round) of received
     /// blocks per authority. This is used for metrics reporting purposes
@@ -57,7 +57,7 @@ impl BlockManager {
         Self {
             context: context.clone(),
             dag_state,
-            suspended_blocks: BTreeMap::new(),
+            suspended_transactions: BTreeMap::new(),
             block_suspender: BlockSuspender::new(context.clone()),
             received_block_rounds: vec![None; context.committee.size()],
         }
@@ -66,7 +66,7 @@ impl BlockManager {
     /// Reinitialize BlockManager after fast sync completes.
     /// Clears suspended blocks and resets the block suspender.
     pub(crate) fn reinitialize(&mut self) {
-        self.suspended_blocks.clear();
+        self.suspended_transactions.clear();
         self.block_suspender.reinitialize();
         self.received_block_rounds = vec![None; self.context.committee.size()];
     }
@@ -194,10 +194,10 @@ impl BlockManager {
             .collect::<BTreeSet<_>>();
         let mut all_accepted_transactions = vec![];
         for block_ref in block_refs_to_be_accepted.iter() {
-            if let Some(block) = self.suspended_blocks.remove(block_ref) {
+            if let Some(transactions) = self.suspended_transactions.remove(block_ref) {
                 // for this accepted header we already have a block, so we add it to
                 // accepted transactions
-                all_accepted_transactions.push(block.verified_transactions);
+                all_accepted_transactions.push(transactions);
             }
         }
 
@@ -209,7 +209,9 @@ impl BlockManager {
                 {
                     accepted_transactions_from_blocks.push(block.verified_transactions);
                 } else if block.verified_transactions.has_transactions() {
-                    self.suspended_blocks.insert(block.reference(), block);
+                    // optimization to avoid suspending 0 set verified transactions.
+                    self.suspended_transactions
+                        .insert(block.reference(), block.verified_transactions);
                 }
             }
             all_accepted_transactions.extend(accepted_transactions_from_blocks);
@@ -218,7 +220,7 @@ impl BlockManager {
             .metrics
             .node_metrics
             .block_manager_suspended_blocks
-            .set(self.suspended_blocks.len() as i64);
+            .set(self.suspended_transactions.len() as i64);
         all_accepted_transactions
     }
 
@@ -337,7 +339,7 @@ impl BlockManager {
     /// Returns the number of full blocks currently in suspended_blocks
     #[cfg(test)]
     pub(crate) fn suspended_full_blocks_count(&self) -> usize {
-        self.suspended_blocks.len()
+        self.suspended_transactions.len()
     }
 
     fn find_missing_ancestors(

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -41,9 +41,8 @@ pub(crate) struct BlockManager {
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
 
-    /// Keeps full blocks for suspended block headers
+    /// Keeps VerifiedTransactions of blocks whose headers have been suspended.
     /// TODO: this set can grow to become too big, need to add some eviction
-    /// mechanism
     suspended_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
     block_suspender: BlockSuspender,
     /// A vector that holds a tuple of (lowest_round, highest_round) of received
@@ -84,12 +83,17 @@ impl BlockManager {
             .iter()
             .map(|b| b.verified_block_header.clone())
             .collect();
-        let (block_headers_to_accept, missing_block_headers, already_in_dag_state) =
-            self.process_block_headers(block_headers, source);
+        let present_header_and_ancestor_refs_in_dag_state =
+            self.present_header_and_ancestor_refs_in_dag_state(&block_headers);
+        let (block_headers_to_accept, missing_block_headers) = self.process_block_headers(
+            block_headers,
+            &present_header_and_ancestor_refs_in_dag_state,
+            source,
+        );
         // collect suspended transactions for accepted headers.
         let accepted_transactions = self.resolve_transactions(
             &block_headers_to_accept,
-            Some(already_in_dag_state),
+            &present_header_and_ancestor_refs_in_dag_state,
             Some(blocks),
         );
 
@@ -117,10 +121,19 @@ impl BlockManager {
         let _s = monitored_scope("BlockManager::try_accept_block_headers");
         // Headers are added through synchronizer, commit syncer and cordial
         // dissemination.
-        let (block_headers_to_accept, ancestors_to_fetch, _) =
-            self.process_block_headers(block_headers, source);
+        let present_header_and_ancestor_refs_in_dag_state =
+            self.present_header_and_ancestor_refs_in_dag_state(&block_headers);
+        let (block_headers_to_accept, ancestors_to_fetch) = self.process_block_headers(
+            block_headers,
+            &present_header_and_ancestor_refs_in_dag_state,
+            source,
+        );
         // collect transactions we already have for accepted headers.
-        let accepted_transactions = self.resolve_transactions(&block_headers_to_accept, None, None);
+        let accepted_transactions = self.resolve_transactions(
+            &block_headers_to_accept,
+            &present_header_and_ancestor_refs_in_dag_state,
+            None,
+        );
         self.write_block_headers_and_transactions_to_dag_state(
             block_headers_to_accept.clone(),
             accepted_transactions,
@@ -135,21 +148,15 @@ impl BlockManager {
     fn process_block_headers(
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
+        present_header_and_ancestor_refs_in_dag_state: &BTreeSet<BlockRef>,
         source: DataSource,
-    ) -> (
-        Vec<VerifiedBlockHeader>,
-        BTreeSet<BlockRef>,
-        Vec<VerifiedBlockHeader>,
-    ) {
+    ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers_internal");
 
-        let present_header_and_ancestor_refs_in_dag_state =
-            self.present_header_and_ancestor_refs_in_dag_state(&block_headers);
-
         // Filter out already processed and suspended block headers.
-        let (block_headers, already_in_dag_state) = self.filter_out_already_processed_and_sort(
+        let block_headers = self.filter_out_already_processed_and_sort(
             block_headers,
-            &present_header_and_ancestor_refs_in_dag_state,
+            present_header_and_ancestor_refs_in_dag_state,
             source,
         );
         // update received block rounds
@@ -157,14 +164,12 @@ impl BlockManager {
             self.update_block_received_metrics(block_header);
         }
         // Find missing ancestors for the provided block headers in the DAG state.
-        let missing_ancestors = self.find_missing_ancestors(
-            block_headers,
-            &present_header_and_ancestor_refs_in_dag_state,
-        );
+        let missing_ancestors = self
+            .find_missing_ancestors(block_headers, present_header_and_ancestor_refs_in_dag_state);
         let (accepted_headers, missing_ancestors) = self
             .block_suspender
             .accept_or_suspend_received_headers(missing_ancestors);
-        (accepted_headers, missing_ancestors, already_in_dag_state)
+        (accepted_headers, missing_ancestors)
     }
 
     fn write_block_headers_and_transactions_to_dag_state(
@@ -189,15 +194,10 @@ impl BlockManager {
     fn resolve_transactions(
         &mut self,
         block_headers_to_be_accepted: &[VerifiedBlockHeader],
-        block_headers_already_in_dag_state: Option<Vec<VerifiedBlockHeader>>,
+        present_headers_and_ancestor_refs_in_dag_state: &BTreeSet<BlockRef>,
         blocks: Option<Vec<VerifiedBlock>>,
     ) -> Vec<VerifiedTransactions> {
         let block_refs_to_be_accepted = block_headers_to_be_accepted
-            .iter()
-            .map(|h| h.reference())
-            .collect::<BTreeSet<_>>();
-        let block_refs_already_in_dag_state = block_headers_already_in_dag_state
-            .unwrap_or_default()
             .iter()
             .map(|h| h.reference())
             .collect::<BTreeSet<_>>();
@@ -214,7 +214,7 @@ impl BlockManager {
             let mut accepted_transactions_from_blocks = vec![];
             for block in blocks {
                 if block_refs_to_be_accepted.contains(&block.reference())
-                    || block_refs_already_in_dag_state.contains(&block.reference())
+                    || present_headers_and_ancestor_refs_in_dag_state.contains(&block.reference())
                 {
                     accepted_transactions_from_blocks.push(block.verified_transactions);
                 } else if block.verified_transactions.has_transactions() {
@@ -382,15 +382,14 @@ impl BlockManager {
     fn find_missing_ancestors(
         &self,
         incoming_headers: Vec<VerifiedBlockHeader>,
-        present_header_and_ancestor_refs_in_dag_states_in_dag_state: &BTreeSet<BlockRef>,
+        present_header_and_ancestor_refs_in_dag_state: &BTreeSet<BlockRef>,
     ) -> BTreeMap<VerifiedBlockHeader, BTreeSet<BlockRef>> {
         let mut missing_ancestors = BTreeMap::new();
         for incoming_header in incoming_headers {
             let ancestors: &[BlockRef] = incoming_header.ancestors();
             let mut missing_ancestors_set = BTreeSet::new();
             for ancestor in ancestors {
-                let found =
-                    present_header_and_ancestor_refs_in_dag_states_in_dag_state.contains(ancestor);
+                let found = present_header_and_ancestor_refs_in_dag_state.contains(ancestor);
                 if !found {
                     missing_ancestors_set.insert(*ancestor);
                 }
@@ -406,8 +405,7 @@ impl BlockManager {
         block_headers: Vec<VerifiedBlockHeader>,
         present_header_and_ancestor_refs_in_dag_state: &BTreeSet<BlockRef>,
         source: DataSource,
-    ) -> (Vec<VerifiedBlockHeader>, Vec<VerifiedBlockHeader>) {
-        let mut already_in_dag_state_headers = Vec::new();
+    ) -> Vec<VerifiedBlockHeader> {
         let mut filtered = block_headers
             .into_iter()
             .filter_map(|block_header| {
@@ -427,9 +425,6 @@ impl BlockManager {
                             source.as_str(),
                         ])
                         .inc();
-                    if found {
-                        already_in_dag_state_headers.push(block_header);
-                    }
                     None // filter out
                 } else {
                     Some(block_header) // keep
@@ -437,7 +432,7 @@ impl BlockManager {
             })
             .collect::<Vec<_>>();
         filtered.sort_by_key(|h| h.round());
-        (filtered, already_in_dag_state_headers)
+        filtered
     }
 }
 

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -143,15 +143,24 @@ impl BlockManager {
     ) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers_internal");
 
+        let present_header_and_ancestor_refs_in_dag_state =
+            self.present_header_and_ancestor_refs_in_dag_state(&block_headers);
+
         // Filter out already processed and suspended block headers.
-        let (block_headers, already_in_dag_state) =
-            self.filter_out_already_processed_and_sort(block_headers, source);
+        let (block_headers, already_in_dag_state) = self.filter_out_already_processed_and_sort(
+            block_headers,
+            &present_header_and_ancestor_refs_in_dag_state,
+            source,
+        );
         // update received block rounds
         for block_header in &block_headers {
             self.update_block_received_metrics(block_header);
         }
         // Find missing ancestors for the provided block headers in the DAG state.
-        let missing_ancestors = self.find_missing_ancestors(block_headers);
+        let missing_ancestors = self.find_missing_ancestors(
+            block_headers,
+            &present_header_and_ancestor_refs_in_dag_state,
+        );
         let (accepted_headers, missing_ancestors) = self
             .block_suspender
             .accept_or_suspend_received_headers(missing_ancestors);
@@ -341,21 +350,47 @@ impl BlockManager {
     pub(crate) fn suspended_full_blocks_count(&self) -> usize {
         self.suspended_transactions.len()
     }
+    // helper method, to read the dag state once and output all present headers and
+    // ancestors.
+    fn present_header_and_ancestor_refs_in_dag_state(
+        &self,
+        block_headers: &[VerifiedBlockHeader],
+    ) -> BTreeSet<BlockRef> {
+        // make a single vector of references that contains both headers and ancestors
+        // to check.
+        let mut block_refs_and_ancestors = Vec::new();
+        for h in block_headers {
+            block_refs_and_ancestors.push(h.reference());
+            block_refs_and_ancestors.extend(h.ancestors().iter().copied());
+        }
+        // deduplicate
+        block_refs_and_ancestors.sort();
+        block_refs_and_ancestors.dedup();
+        // single dag_state read call
+        let present_flags = self
+            .dag_state
+            .read()
+            .contains_block_headers(block_refs_and_ancestors.clone());
+
+        block_refs_and_ancestors
+            .into_iter()
+            .zip(present_flags)
+            .filter_map(|(block_ref, found)| found.then_some(block_ref))
+            .collect()
+    }
 
     fn find_missing_ancestors(
         &self,
         incoming_headers: Vec<VerifiedBlockHeader>,
+        present_header_and_ancestor_refs_in_dag_states_in_dag_state: &BTreeSet<BlockRef>,
     ) -> BTreeMap<VerifiedBlockHeader, BTreeSet<BlockRef>> {
         let mut missing_ancestors = BTreeMap::new();
-        let dag_state = self.dag_state.read();
         for incoming_header in incoming_headers {
             let ancestors: &[BlockRef] = incoming_header.ancestors();
             let mut missing_ancestors_set = BTreeSet::new();
-            for (found, ancestor) in dag_state
-                .contains_block_headers(ancestors.to_vec())
-                .into_iter()
-                .zip(ancestors.iter())
-            {
+            for ancestor in ancestors {
+                let found =
+                    present_header_and_ancestor_refs_in_dag_states_in_dag_state.contains(ancestor);
                 if !found {
                     missing_ancestors_set.insert(*ancestor);
                 }
@@ -369,18 +404,15 @@ impl BlockManager {
     fn filter_out_already_processed_and_sort(
         &self,
         block_headers: Vec<VerifiedBlockHeader>,
+        present_header_and_ancestor_refs_in_dag_state: &BTreeSet<BlockRef>,
         source: DataSource,
     ) -> (Vec<VerifiedBlockHeader>, Vec<VerifiedBlockHeader>) {
-        let block_references = block_headers
-            .iter()
-            .map(|b| b.reference())
-            .collect::<Vec<_>>();
-        let dag_state = self.dag_state.read();
         let mut already_in_dag_state_headers = Vec::new();
         let mut filtered = block_headers
             .into_iter()
-            .zip(dag_state.contains_block_headers(block_references))
-            .filter_map(|(block_header, found)| {
+            .filter_map(|block_header| {
+                let found = present_header_and_ancestor_refs_in_dag_state
+                    .contains(&block_header.reference());
                 if found
                     || self
                         .block_suspender


### PR DESCRIPTION
# Description of change

refactors block manager code to be more readable and efficient.
- renames suspended_blocks to suspended_transactions
- updates processing logic to read the dag state in a single call and use the result in subsequent processing.

## Links to any relevant issues

fixes #10241.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
