### PR TITLE
fix(ts-sdk): Correct query events fetching order in json rpc transport

### DIFF
--- a/.changeset/mean-trees-clap.md
+++ b/.changeset/mean-trees-clap.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': minor
+---
+
+Fix the default ordering of queryEvents() to be ascending.

--- a/apps/core/src/hooks/useGetObjectOrPastObject.ts
+++ b/apps/core/src/hooks/useGetObjectOrPastObject.ts
@@ -48,6 +48,7 @@ export function useGetObjectOrPastObject(
             ): Promise<IotaObjectResponse> => {
                 const txsWithObjectInput = await client.queryTransactionBlocks({
                     filter: { InputObject: objectId },
+                    order: 'descending',
                     options: {
                         showInput: true,
                     },

--- a/apps/core/src/hooks/useQueryTransactionsByAddress.ts
+++ b/apps/core/src/hooks/useQueryTransactionsByAddress.ts
@@ -38,12 +38,14 @@ export function useQueryTransactionsByAddress(address: string = '') {
                     options: QUERY_OPTIONS,
                     filter: { ToAddress: address },
                     limit: MAX_OBJECTS_PER_REQ,
+                    order: 'descending',
                     cursor: (pageParam as NextCursor)?.nextCursorToAddress,
                 }),
                 rpc.queryTransactionBlocks({
                     options: QUERY_OPTIONS,
                     filter: { FromAddress: address },
                     limit: MAX_OBJECTS_PER_REQ,
+                    order: 'descending',
                     cursor: (pageParam as NextCursor)?.nextCursorFromAddress,
                 }),
             ]);

--- a/sdk/typescript/src/client/client.ts
+++ b/sdk/typescript/src/client/client.ts
@@ -417,7 +417,7 @@ export class IotaClient {
                 } as IotaTransactionBlockResponseQuery,
                 input.cursor,
                 input.limit,
-                (input.order || 'descending') === 'descending',
+                (input.order || 'ascending') === 'descending',
             ],
             signal: input.signal,
         });

--- a/sdk/typescript/src/client/client.ts
+++ b/sdk/typescript/src/client/client.ts
@@ -678,7 +678,7 @@ export class IotaClient {
                 input.query,
                 input.cursor,
                 input.limit,
-                (input.order || 'descending') === 'descending',
+                (input.order || 'ascending') === 'descending',
             ],
             signal: input.signal,
         });


### PR DESCRIPTION
>   /** query result ordering, default to false (ascending order), oldest record first. */