### PR TITLE
fix(iota-data-ingestion): [cherry-pick] select default crypto provider (#10556)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6392,6 +6392,7 @@ dependencies = [
  "iota-types",
  "object_store 0.13.1",
  "prometheus",
+ "rustls 0.23.35",
  "serde",
  "serde_yaml",
  "telemetry-subscribers",

--- a/crates/iota-data-ingestion/Cargo.toml
+++ b/crates/iota-data-ingestion/Cargo.toml
@@ -20,6 +20,7 @@ bytes.workspace = true
 futures.workspace = true
 object_store.workspace = true
 prometheus.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -108,6 +108,10 @@ fn setup_env(token: CancellationToken) {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
+
     let token = CancellationToken::new();
     let child_token = token.child_token();
     setup_env(token);


### PR DESCRIPTION
# Description of change

This PR fixes an issue started form version `1.17.0` which affected some iota-data-ingestion crates of inability of the program to load the default crypto provider.

## Links to any relevant issues

fixes #10555 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran the binary and made sure that it did not panic with the crypto provider error.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.