### PR TITLE
feat(indexer): Tune vacuuming for pruned indexer tables

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-02-26-220600_add_vacuum_settings/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-26-220600_add_vacuum_settings/down.sql
@@ -1,25 +1,25 @@
 -- Revert custom autovacuum and index cleanup settings back to default
-ALTER TABLE checkpoints RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE pruner_cp_watermark RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE checkpoints RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE pruner_cp_watermark RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
 
-ALTER TABLE event_emit_package RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE event_emit_module RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE event_senders RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE event_struct_instantiation RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE event_struct_module RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE event_struct_name RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE event_struct_package RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE event_emit_package RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE event_emit_module RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE event_senders RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE event_struct_instantiation RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE event_struct_module RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE event_struct_name RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE event_struct_package RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
 
-ALTER TABLE tx_calls_pkg RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_calls_mod RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_calls_fun RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_changed_objects RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_digests RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_input_objects RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_kinds RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_recipients RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_senders RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_wrapped_or_deleted_objects RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
-ALTER TABLE tx_global_order RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_calls_pkg RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_calls_mod RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_calls_fun RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_changed_objects RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_digests RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_input_objects RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_kinds RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_recipients RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_senders RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_wrapped_or_deleted_objects RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
+ALTER TABLE tx_global_order RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);
 
-ALTER TABLE optimistic_transactions RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE optimistic_transactions RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit);

--- a/crates/iota-indexer/migrations/pg/2026-02-26-220600_add_vacuum_settings/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-26-220600_add_vacuum_settings/down.sql
@@ -1,0 +1,25 @@
+-- Revert custom autovacuum and index cleanup settings back to default
+ALTER TABLE checkpoints RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE pruner_cp_watermark RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+
+ALTER TABLE event_emit_package RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE event_emit_module RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE event_senders RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE event_struct_instantiation RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE event_struct_module RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE event_struct_name RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE event_struct_package RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+
+ALTER TABLE tx_calls_pkg RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_calls_mod RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_calls_fun RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_changed_objects RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_digests RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_input_objects RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_kinds RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_recipients RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_senders RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_wrapped_or_deleted_objects RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+ALTER TABLE tx_global_order RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);
+
+ALTER TABLE optimistic_transactions RESET (vacuum_index_cleanup, autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_limit, autovacuum_vacuum_cost_delay, autovacuum_enabled);

--- a/crates/iota-indexer/migrations/pg/2026-02-26-220600_add_vacuum_settings/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-26-220600_add_vacuum_settings/up.sql
@@ -1,0 +1,25 @@
+-- Apply more frequent autovacuum and index cleanup settings to prunable tables
+ALTER TABLE checkpoints SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE pruner_cp_watermark SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+
+ALTER TABLE event_emit_package SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE event_emit_module SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE event_senders SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE event_struct_instantiation SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE event_struct_module SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE event_struct_name SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE event_struct_package SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+
+ALTER TABLE tx_calls_pkg SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_calls_mod SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_calls_fun SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_changed_objects SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_digests SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_input_objects SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_kinds SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_recipients SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_senders SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_wrapped_or_deleted_objects SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_global_order SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+
+ALTER TABLE optimistic_transactions SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);

--- a/crates/iota-indexer/migrations/pg/2026-02-26-220600_add_vacuum_settings/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-02-26-220600_add_vacuum_settings/up.sql
@@ -1,25 +1,25 @@
 -- Apply more frequent autovacuum and index cleanup settings to prunable tables
-ALTER TABLE checkpoints SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE pruner_cp_watermark SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE checkpoints SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE pruner_cp_watermark SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
 
-ALTER TABLE event_emit_package SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE event_emit_module SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE event_senders SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE event_struct_instantiation SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE event_struct_module SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE event_struct_name SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE event_struct_package SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE event_emit_package SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE event_emit_module SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE event_senders SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE event_struct_instantiation SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE event_struct_module SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE event_struct_name SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE event_struct_package SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
 
-ALTER TABLE tx_calls_pkg SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_calls_mod SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_calls_fun SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_changed_objects SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_digests SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_input_objects SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_kinds SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_recipients SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_senders SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_wrapped_or_deleted_objects SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
-ALTER TABLE tx_global_order SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE tx_calls_pkg SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_calls_mod SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_calls_fun SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_changed_objects SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_digests SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_input_objects SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_kinds SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_recipients SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_senders SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_wrapped_or_deleted_objects SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
+ALTER TABLE tx_global_order SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);
 
-ALTER TABLE optimistic_transactions SET (vacuum_index_cleanup=on, autovacuum_vacuum_scale_factor=0.01, autovacuum_enabled=on);
+ALTER TABLE optimistic_transactions SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_cost_limit=500);


### PR DESCRIPTION
# Description of change

Make vacuuming more frequent for pruned tables.
This change makes sure pruned tables are vacuumed often enough, which results in table size staying at a constant level and not evergrowing with dead tuples accumulating and space not reused. 

This needs to also be combined with setting appropriate `shm_size` parameter on docker container where postgres is running so that postgres has enough memory to actually vacuum the big tables. e.g. `shm_size: 2g` was tested to be working on tables of > 100GB size. 

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9888

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

this was tested on staging server, all pruned tables were vacuumed correctly and their size was kept on more or less the same level, ingestion speed was not visibly affected

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
