### PR TITLE
upstream(core): Increase certificate signature cache size

### DIFF
--- a/crates/iota-types/src/signature_verification.rs
+++ b/crates/iota-types/src/signature_verification.rs
@@ -18,12 +18,12 @@ use crate::{
     transaction::{SenderSignedData, TransactionDataAPI},
 };
 
-// Cache up to 20000 verified certs. We will need to tune this number in the
+// Cache up to this many verified certs. We will need to tune this number in the
 // future - a decent guess to start with is that it should be 10-20 times larger
 // than peak transactions per second, on the assumption that we should see most
 // certs twice within about 10-20 seconds at most: Once via RPC, once via
 // consensus.
-const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 20000;
+const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 100_000;
 
 pub struct VerifiedDigestCache<D> {
     inner: RwLock<LruCache<D, ()>>,


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.45.3, v1.46.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/2509b471cfe12e13688c2623f3fcb1058b7df380
- Description:

Increase certificate signature cache size


## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

