### PR TITLE
feat(iota-core): implement PoC version of certificate-less epoch boundary coordination

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5286,6 +5286,8 @@ impl AuthorityState {
                 self.get_reconfig_api().try_revert_state_update(&digest)?;
             }
             info!("All uncommitted local transactions reverted");
+        } else {
+            info!("Certificate-less mode: skipping revert of uncommitted epoch transactions");
         }
 
         Ok(())

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5254,32 +5254,40 @@ impl AuthorityState {
                 // epoch change locally, but 2f+1 nodes already concluded the
                 // epoch.
                 //
-                // This lock is essentially a barrier for
+                // This lock is essentially a barrier (in the certificate mode only) for
                 // `epoch_store.pending_consensus_certificates` table we are reading on the line
                 // after this block
                 epoch_store.close_user_certs(state);
             }
             // lock is dropped here
         }
-        let pending_certificates = epoch_store.pending_consensus_certificates();
-        info!(
-            "Reverting {} locally executed transactions that was not included in the epoch: {:?}",
-            pending_certificates.len(),
-            pending_certificates,
-        );
-        for digest in pending_certificates {
-            if epoch_store.is_transaction_executed_in_checkpoint(&digest)? {
-                info!(
-                    "Not reverting pending consensus transaction {:?} - it was included in checkpoint",
-                    digest
-                );
-                continue;
+
+        // In the certificate-less mode, the list of pending consensus certificates is
+        // always empty, so the reverting below is only for the certificate mode.
+        if !epoch_store.protocol_config().enable_white_flag_flow() {
+            let pending_certificates = epoch_store.pending_consensus_certificates();
+            info!(
+                "Reverting {} locally executed transactions that was not included in the epoch: \
+                    {:?}",
+                pending_certificates.len(),
+                pending_certificates,
+            );
+            for digest in pending_certificates {
+                if epoch_store.is_transaction_executed_in_checkpoint(&digest)? {
+                    info!(
+                        "Not reverting pending consensus transaction {:?} - it was included in \
+                            checkpoint",
+                        digest
+                    );
+                    continue;
+                }
+                info!("Reverting {:?} at the end of epoch", digest);
+                epoch_store.revert_executed_transaction(&digest)?;
+                self.get_reconfig_api().try_revert_state_update(&digest)?;
             }
-            info!("Reverting {:?} at the end of epoch", digest);
-            epoch_store.revert_executed_transaction(&digest)?;
-            self.get_reconfig_api().try_revert_state_update(&digest)?;
+            info!("All uncommitted local transactions reverted");
         }
-        info!("All uncommitted local transactions reverted");
+
         Ok(())
     }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2240,10 +2240,10 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    /// Insert certified transactions into the in-memory
-    /// `pending_consensus_certificates` set. When submitting a certificate
-    /// caller **must** provide a `ReconfigState` lock guard and verify that
-    /// it allows new user certificates.
+    /// Insert certified transactions that will be submitted to consensus
+    /// into the in-memory `pending_consensus_certificates` set. When
+    /// submitting a certificate caller **must** provide a `ReconfigState`
+    /// lock guard and verify that it allows new user certificates.
     pub fn insert_pending_consensus_certificates(
         &self,
         transactions: &[ConsensusTransaction],
@@ -2265,6 +2265,8 @@ impl AuthorityPerEpochStore {
         }
     }
 
+    /// Remove processed by consensus transactions from the persistent
+    /// `pending_consensus_transactions` table.
     pub fn remove_pending_consensus_transactions(
         &self,
         keys: &[ConsensusTransactionKey],
@@ -2272,18 +2274,19 @@ impl AuthorityPerEpochStore {
         self.tables()?
             .pending_consensus_transactions
             .multi_remove(keys)?;
+
+        Ok(())
+    }
+
+    /// Remove processed by consensus certified transactions from the in-memory
+    /// `pending_consensus_certificates` set.
+    pub fn remove_pending_consensus_certificates(&self, keys: &[ConsensusTransactionKey]) {
         // TODO: lock once for all remove() calls.
         for key in keys {
             if let ConsensusTransactionKey::Certificate(cert) = key {
                 self.pending_consensus_certificates.write().remove(cert);
             }
-            // NOTE: We do not need the
-            // `ConsensusTransactionKey::UserTransaction` branch
-            // (certificate-less scenario) here because `UserTransactionV1` are
-            // not inserted into
-            // `self.pending_consensus_certificates`.
         }
-        Ok(())
     }
 
     pub fn pending_consensus_certificates_count(&self) -> usize {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2031,6 +2031,9 @@ impl AuthorityPerEpochStore {
                         SequencedConsensusTransactionKey::External(
                             ConsensusTransactionKey::Certificate(digest),
                         ) => (digest, (*deferral_key, tx.suggested_gas_price)),
+                        SequencedConsensusTransactionKey::External(
+                            ConsensusTransactionKey::UserTransaction(digest),
+                        ) => (digest, (*deferral_key, tx.suggested_gas_price)),
                         _ => {
                             panic!(
                                 "deferred randomness transaction was not a user certificate: {tx:?}"

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4378,7 +4378,7 @@ impl AuthorityPerEpochStore {
                         certificate_author.concise(),
                         transaction.digest()
                     );
-                    return Ok(ConsensusCertificateResult::Ignored);
+                    return Ok(ConsensusTransactionResult::Ignored);
                 }
                 // TODO: re-think the epoch-switching flow
                 if !self

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -390,18 +390,53 @@ pub(crate) enum SchedulingResult {
     Defer(DeferralKey, DeferralReason),
 }
 
-pub enum CancelConsensusCertificateReason {
+/// The reason a consensus transaction was cancelled rather than successfully
+/// executed.
+///
+/// Cancelled transactions still pass through the execution engine to unlock
+/// owned objects, but they are not executed as normally. The reason is used by
+/// `SharedObjVerManager` when assigning shared object versions to determine
+/// the appropriate cancellation behavior (e.g., whether to include a suggested
+/// gas price in the cancellation error).
+///
+/// The legacy name (in the certificate era) was
+/// `CancelConsensusCertificateReason`. It is renamed to
+/// `CancelConsensusTransactionReason` because this type now (in the
+/// certificate-less era) covers more consensus transaction kinds, not just
+/// certificates. The renaming is safe and backward-compatible since this is a
+/// fully internal type.
+pub enum CancelConsensusTransactionReason {
+    /// Transaction was cancelled due to shared-object congestion.
     CongestionOnObjects {
+        /// List of IDs of congested shared objects.
         congested_objects: Vec<ObjectID>,
+
+        /// Optional suggested gas price from the gas price feedback
+        /// mechanism.
         suggested_gas_price: Option<u64>,
     },
+
+    /// Transaction was cancelled due to randomness unavailable.
     DkgFailed,
 }
 
-pub enum ConsensusCertificateResult {
+/// The outcome of processing a single consensus transaction.
+///
+/// This is returned by `process_consensus_transaction()` and
+/// `process_consensus_system_transaction()` to tell the consensus commit
+/// handler how to handle each transaction: schedule it for execution,
+/// defer it to a future commit, cancel it, or ignore it.
+///
+/// The legacy name (in the certificate era) was `ConsensusCertificateResult`.
+/// It is renamed to `ConsensusTransactionResult` because this type now (in
+/// the certificate-less era) covers all consensus transaction kinds, not just
+/// certificates. The renaming is safe and backward-compatible since this is a
+/// fully internal type.
+pub enum ConsensusTransactionResult {
     /// The consensus message was ignored (e.g. because it has already been
     /// processed).
     Ignored,
+
     /// The transaction is scheduled for execution (can be a user tx or a
     /// system tx) with start_time. The start_time is an ExecutionTime assigned
     /// by the SharedObjectCongestionTracker and it implies its
@@ -415,32 +450,37 @@ pub enum ConsensusCertificateResult {
         transaction: VerifiedExecutableTransaction,
         start_time: ExecutionTime,
     },
+
     /// The transaction should be re-processed at a future commit, specified by
     /// `deferral_key`. If the gas price feedback is enabled,
     /// `suggested_gas_price` is `Some(...)` and indicates a gas price that
-    /// the certificate would need to pay to be scheduled in a consensus
+    /// the transaction would need to pay to be scheduled in a consensus
     /// commit. If the feedback mechanism is not enabled and for
-    /// certificates deferred due to "randomness not available",
+    /// transactions deferred due to "randomness not available",
     /// the `suggested_gas_price` price field will be set to `None`.
     Deferred {
         deferral_key: DeferralKey,
         suggested_gas_price: Option<u64>,
     },
+
     /// A message was processed which updates randomness state.
     RandomnessConsensusMessage,
+
     /// Everything else, e.g. AuthorityCapabilities, CheckpointSignatures, etc.
     ConsensusMessage,
+
     /// A system message in consensus was ignored (e.g. because of end of
     /// epoch).
     IgnoredSystem,
+
     /// A will-be-cancelled transaction. It'll still go through execution engine
     /// (but not be executed), unlock any owned objects, and return
     /// corresponding cancellation error according to
-    /// `CancelConsensusCertificateReason`.
+    /// `CancelConsensusTransactionReason`.
     Cancelled(
         (
             VerifiedExecutableTransaction,
-            CancelConsensusCertificateReason,
+            CancelConsensusTransactionReason,
         ),
     ),
 }
@@ -3473,7 +3513,7 @@ impl AuthorityPerEpochStore {
         output: &mut ConsensusCommitOutput,
         transactions: &mut VecDeque<VerifiedExecutableTransaction>,
         consensus_commit_info: &ConsensusCommitInfo,
-        cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
+        cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusTransactionReason>,
     ) -> IotaResult<Option<TransactionKey>> {
         {
             if consensus_commit_info.skip_consensus_commit_prologue_in_test() {
@@ -3487,8 +3527,8 @@ impl AuthorityPerEpochStore {
         let mut shared_input_next_version = HashMap::new();
         for txn in transactions.iter() {
             match cancelled_txns.get(txn.digest()) {
-                Some(CancelConsensusCertificateReason::CongestionOnObjects { .. })
-                | Some(CancelConsensusCertificateReason::DkgFailed) => {
+                Some(CancelConsensusTransactionReason::CongestionOnObjects { .. })
+                | Some(CancelConsensusTransactionReason::DkgFailed) => {
                     let assigned_versions = SharedObjVerManager::assign_versions_for_certificate(
                         txn,
                         &mut shared_input_next_version,
@@ -3517,16 +3557,16 @@ impl AuthorityPerEpochStore {
         let consensus_commit_prologue_root = match self
             .process_consensus_system_transaction(&transaction)
         {
-            ConsensusCertificateResult::Scheduled {
+            ConsensusTransactionResult::Scheduled {
                 transaction,
                 start_time: _,
             } => {
                 transactions.push_front(transaction.clone());
                 Some(transaction.key())
             }
-            ConsensusCertificateResult::IgnoredSystem => None,
+            ConsensusTransactionResult::IgnoredSystem => None,
             _ => unreachable!(
-                "process_consensus_system_transaction returned unexpected ConsensusCertificateResult."
+                "process_consensus_system_transaction returned unexpected ConsensusTransactionResult."
             ),
         };
 
@@ -3545,7 +3585,7 @@ impl AuthorityPerEpochStore {
         cache_reader: &dyn ObjectCacheRead,
         transactions: &[VerifiedExecutableTransaction],
         randomness_round: Option<RandomnessRound>,
-        cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
+        cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusTransactionReason>,
         output: &mut ConsensusCommitOutput,
     ) -> IotaResult {
         let ConsensusSharedObjVerAssignment {
@@ -3678,7 +3718,7 @@ impl AuthorityPerEpochStore {
         let mut notifications = Vec::with_capacity(transactions.len());
 
         let mut deferred_txns: BTreeMap<DeferralKey, Vec<DeferredTransaction>> = BTreeMap::new();
-        let mut cancelled_txns: BTreeMap<TransactionDigest, CancelConsensusCertificateReason> =
+        let mut cancelled_txns: BTreeMap<TransactionDigest, CancelConsensusTransactionReason> =
             BTreeMap::new();
 
         fail_point_arg!(
@@ -3755,14 +3795,14 @@ impl AuthorityPerEpochStore {
                 )
                 .await?
             {
-                ConsensusCertificateResult::Scheduled {
+                ConsensusTransactionResult::Scheduled {
                     transaction,
                     start_time,
                 } => {
                     notifications.push(key.clone());
                     sequenced_transactions.push((transaction, start_time));
                 }
-                ConsensusCertificateResult::Deferred {
+                ConsensusTransactionResult::Deferred {
                     deferral_key,
                     suggested_gas_price,
                 } => {
@@ -3779,7 +3819,7 @@ impl AuthorityPerEpochStore {
                         notifications.push(key.clone());
                     }
                 }
-                ConsensusCertificateResult::Cancelled((cert, reason)) => {
+                ConsensusTransactionResult::Cancelled((cert, reason)) => {
                     notifications.push(key.clone());
                     assert!(cancelled_txns.insert(*cert.digest(), reason).is_none());
                     sequenced_transactions.push((
@@ -3787,17 +3827,17 @@ impl AuthorityPerEpochStore {
                         shared_object_congestion_tracker.max_occupied_slot_end_time(),
                     ));
                 }
-                ConsensusCertificateResult::RandomnessConsensusMessage => {
+                ConsensusTransactionResult::RandomnessConsensusMessage => {
                     randomness_state_updated = true;
                     notifications.push(key.clone());
                 }
-                ConsensusCertificateResult::ConsensusMessage => notifications.push(key.clone()),
-                ConsensusCertificateResult::IgnoredSystem => {
+                ConsensusTransactionResult::ConsensusMessage => notifications.push(key.clone()),
+                ConsensusTransactionResult::IgnoredSystem => {
                     filter_roots = true;
                 }
                 // Note: ignored external transactions must not be recorded as processed. Otherwise
                 // they may not get reverted after restart during epoch change.
-                ConsensusCertificateResult::Ignored => {
+                ConsensusTransactionResult::Ignored => {
                     ignored = true;
                     filter_roots = true;
                 }
@@ -4053,7 +4093,7 @@ impl AuthorityPerEpochStore {
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
         suggested_gas_price_calculator: &mut SuggestedGasPriceCalculator,
         authority_metrics: &Arc<AuthorityMetrics>,
-    ) -> IotaResult<ConsensusCertificateResult> {
+    ) -> IotaResult<ConsensusTransactionResult> {
         let _scope = monitored_scope("HandleConsensusTransaction");
         let VerifiedSequencedConsensusTransaction(SequencedConsensusTransaction {
             certificate_author_index: _,
@@ -4075,7 +4115,7 @@ impl AuthorityPerEpochStore {
                         certificate.epoch(),
                         self.epoch()
                     );
-                    return Ok(ConsensusCertificateResult::Ignored);
+                    return Ok(ConsensusTransactionResult::Ignored);
                 }
                 if self.has_sent_end_of_publish(certificate_author)?
                     && !previously_deferred_tx_digests.contains_key(certificate.digest())
@@ -4093,7 +4133,7 @@ impl AuthorityPerEpochStore {
                         certificate_author.concise(),
                         certificate.digest()
                     );
-                    return Ok(ConsensusCertificateResult::Ignored);
+                    return Ok(ConsensusTransactionResult::Ignored);
                 }
                 // Safe because signatures are verified when consensus called into
                 // IotaTxValidator::validate_batch.
@@ -4115,7 +4155,7 @@ impl AuthorityPerEpochStore {
                         "Ignoring consensus certificate for transaction {:?} because of end of epoch",
                         certificate.digest()
                     );
-                    return Ok(ConsensusCertificateResult::Ignored);
+                    return Ok(ConsensusTransactionResult::Ignored);
                 }
 
                 let scheduling_result = self.try_schedule(
@@ -4145,7 +4185,7 @@ impl AuthorityPerEpochStore {
                 // can be skipped when a batch is already part of a certificate,
                 // so we must also notify here.
                 checkpoint_service.notify_checkpoint_signature(self, info)?;
-                Ok(ConsensusCertificateResult::ConsensusMessage)
+                Ok(ConsensusTransactionResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::EndOfPublish(_),
@@ -4174,7 +4214,7 @@ impl AuthorityPerEpochStore {
                     // Here we update all counts related to the information in the reports.
                     self.scorer.update_received_reports(authority_index, report);
                 }
-                Ok(ConsensusCertificateResult::ConsensusMessage)
+                Ok(ConsensusTransactionResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::CapabilityNotificationV1(capabilities),
@@ -4197,7 +4237,7 @@ impl AuthorityPerEpochStore {
                         authority.concise()
                     );
                 }
-                Ok(ConsensusCertificateResult::ConsensusMessage)
+                Ok(ConsensusTransactionResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::SignedCapabilityNotificationV1(signed_capabilities),
@@ -4222,7 +4262,7 @@ impl AuthorityPerEpochStore {
                         authority.concise()
                     );
                 }
-                Ok(ConsensusCertificateResult::ConsensusMessage)
+                Ok(ConsensusTransactionResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::NewJWKFetched(authority, jwk_id, jwk),
@@ -4245,7 +4285,7 @@ impl AuthorityPerEpochStore {
                         authority.concise()
                     );
                 }
-                Ok(ConsensusCertificateResult::ConsensusMessage)
+                Ok(ConsensusTransactionResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::RandomnessDkgMessage(authority, bytes),
@@ -4278,7 +4318,7 @@ impl AuthorityPerEpochStore {
                         authority.concise()
                     );
                 }
-                Ok(ConsensusCertificateResult::RandomnessConsensusMessage)
+                Ok(ConsensusTransactionResult::RandomnessConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::RandomnessDkgConfirmation(authority, bytes),
@@ -4313,7 +4353,7 @@ impl AuthorityPerEpochStore {
                         authority.concise()
                     );
                 }
-                Ok(ConsensusCertificateResult::RandomnessConsensusMessage)
+                Ok(ConsensusTransactionResult::RandomnessConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV1(transaction),
@@ -4321,7 +4361,7 @@ impl AuthorityPerEpochStore {
             }) => {
                 if transaction.is_system_tx() {
                     warn!("UserTransactionV1 contains system transaction, ignoring");
-                    return Ok(ConsensusCertificateResult::Ignored);
+                    return Ok(ConsensusTransactionResult::Ignored);
                 }
                 if self.has_sent_end_of_publish(certificate_author)?
                     && !previously_deferred_tx_digests.contains_key(transaction.digest())
@@ -4347,7 +4387,7 @@ impl AuthorityPerEpochStore {
                         "Ignoring white flag transaction {:?} because of end of epoch",
                         transaction.digest()
                     );
-                    return Ok(ConsensusCertificateResult::Ignored);
+                    return Ok(ConsensusTransactionResult::Ignored);
                 }
                 // TODO: verify that all the same validation actions are performed as for a
                 // Certificate. Possibly extract common code to a separate
@@ -4401,7 +4441,7 @@ impl AuthorityPerEpochStore {
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
         suggested_gas_price_calculator: &mut SuggestedGasPriceCalculator,
         authority_metrics: &Arc<AuthorityMetrics>,
-    ) -> IotaResult<ConsensusCertificateResult> {
+    ) -> IotaResult<ConsensusTransactionResult> {
         match scheduling_result {
             SchedulingResult::Defer(deferral_key, deferral_reason) => {
                 debug!(
@@ -4412,7 +4452,7 @@ impl AuthorityPerEpochStore {
                 let deferral_result = match deferral_reason {
                     DeferralReason::RandomnessNotReady => {
                         // Always defer transaction due to randomness not ready.
-                        ConsensusCertificateResult::Deferred {
+                        ConsensusTransactionResult::Deferred {
                             deferral_key,
                             suggested_gas_price: None,
                         }
@@ -4459,7 +4499,7 @@ impl AuthorityPerEpochStore {
                             self.protocol_config()
                                 .max_deferral_rounds_for_congestion_control(),
                         ) {
-                            ConsensusCertificateResult::Deferred {
+                            ConsensusTransactionResult::Deferred {
                                 deferral_key,
                                 suggested_gas_price,
                             }
@@ -4474,9 +4514,9 @@ impl AuthorityPerEpochStore {
                                 verified_executable_tx.transaction_data().gas_price(),
                             );
 
-                            ConsensusCertificateResult::Cancelled((
+                            ConsensusTransactionResult::Cancelled((
                                 verified_executable_tx,
-                                CancelConsensusCertificateReason::CongestionOnObjects {
+                                CancelConsensusTransactionReason::CongestionOnObjects {
                                     congested_objects,
                                     suggested_gas_price,
                                 },
@@ -4495,9 +4535,9 @@ impl AuthorityPerEpochStore {
                         verified_executable_tx.digest(),
                     );
 
-                    return Ok(ConsensusCertificateResult::Cancelled((
+                    return Ok(ConsensusTransactionResult::Cancelled((
                         verified_executable_tx,
-                        CancelConsensusCertificateReason::DkgFailed,
+                        CancelConsensusTransactionReason::DkgFailed,
                     )));
                 }
 
@@ -4520,7 +4560,7 @@ impl AuthorityPerEpochStore {
                     suggested_gas_price_calculator.update_congestion_info(bump_result);
                 }
 
-                Ok(ConsensusCertificateResult::Scheduled {
+                Ok(ConsensusTransactionResult::Scheduled {
                     transaction: verified_executable_tx,
                     start_time,
                 })
@@ -4531,18 +4571,18 @@ impl AuthorityPerEpochStore {
     fn process_consensus_system_transaction(
         &self,
         system_transaction: &VerifiedExecutableTransaction,
-    ) -> ConsensusCertificateResult {
+    ) -> ConsensusTransactionResult {
         if !self.get_reconfig_state_read_lock_guard().should_accept_tx() {
             debug!(
                 "Ignoring system transaction {:?} because of end of epoch",
                 system_transaction.digest()
             );
-            return ConsensusCertificateResult::IgnoredSystem;
+            return ConsensusTransactionResult::IgnoredSystem;
         }
 
         // If needed we can support owned object system transactions as well...
         assert!(system_transaction.contains_shared_object());
-        ConsensusCertificateResult::Scheduled {
+        ConsensusTransactionResult::Scheduled {
             transaction: system_transaction.clone(),
             start_time: 0,
         }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2226,18 +2226,29 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    /// When submitting a certificate caller **must** provide a ReconfigState
-    /// lock guard and verify that it allows new user certificates
+    /// Insert transactions that will be submitted to consensus
+    /// into the persistent `pending_consensus_transactions` table.
     pub fn insert_pending_consensus_transactions(
         &self,
         transactions: &[ConsensusTransaction],
-        lock: Option<&RwLockReadGuard<ReconfigState>>,
     ) -> IotaResult {
         let key_value_pairs = transactions.iter().map(|tx| (tx.key(), tx));
         self.tables()?
             .pending_consensus_transactions
             .multi_insert(key_value_pairs)?;
 
+        Ok(())
+    }
+
+    /// Insert certified transactions into the in-memory
+    /// `pending_consensus_certificates` set. When submitting a certificate
+    /// caller **must** provide a `ReconfigState` lock guard and verify that
+    /// it allows new user certificates.
+    pub fn insert_pending_consensus_certificates(
+        &self,
+        transactions: &[ConsensusTransaction],
+        lock: Option<&RwLockReadGuard<ReconfigState>>,
+    ) {
         // TODO: lock once for all insert() calls.
         for transaction in transactions {
             if let ConsensusTransactionKind::CertifiedTransaction(cert) = &transaction.kind {
@@ -2251,14 +2262,7 @@ impl AuthorityPerEpochStore {
                     .write()
                     .insert(*cert.digest());
             }
-            // NOTE: We do not insert
-            // `ConsensusTransactionKind::UserTransactionV1` into
-            // `self.pending_consensus_certificates` because, in the
-            // certificate-less scenario, there is no pre-consensus
-            // "promise" (certificate) that `UserTransactionV1` will
-            // be executed before the end of epoch.
         }
-        Ok(())
     }
 
     pub fn remove_pending_consensus_transactions(

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2240,33 +2240,24 @@ impl AuthorityPerEpochStore {
 
         // TODO: lock once for all insert() calls.
         for transaction in transactions {
-            let digest_cert_or_tx = match &transaction.kind {
-                ConsensusTransactionKind::CertifiedTransaction(cert) => {
-                    // Branch WITH certification: `CertifiedTransaction` digest will be tracked
-                    // in the pending set
-                    Some((*cert.digest(), "certificate"))
-                }
-                ConsensusTransactionKind::UserTransactionV1(tx) => {
-                    // Branch WITHOUT certification: `UserTransactionV1` digest will be tracked
-                    // in the pending set
-                    Some((*tx.digest(), "transaction"))
-                }
-                _ => None,
-            };
-
-            if let Some((digest, cert_or_tx)) = digest_cert_or_tx {
-                let state = lock.unwrap_or_else(|| {
-                    panic!("Must pass reconfiguration lock when storing {cert_or_tx}");
-                });
+            if let ConsensusTransactionKind::CertifiedTransaction(cert) = &transaction.kind {
+                let state = lock.expect("Must pass reconfiguration lock when storing certificate");
                 // Caller is responsible for performing graceful check
                 assert!(
                     state.should_accept_user_certs(),
-                    "Reconfiguration state should allow accepting user {cert_or_tx}s"
+                    "Reconfiguration state should allow accepting user transactions"
                 );
-                self.pending_consensus_certificates.write().insert(digest);
+                self.pending_consensus_certificates
+                    .write()
+                    .insert(*cert.digest());
             }
+            // NOTE: We do not insert
+            // `ConsensusTransactionKind::UserTransactionV1` into
+            // `self.pending_consensus_certificates` because, in the
+            // certificate-less scenario, there is no pre-consensus
+            // "promise" (certificate) that `UserTransactionV1` will
+            // be executed before the end of epoch.
         }
-
         Ok(())
     }
 
@@ -2277,19 +2268,17 @@ impl AuthorityPerEpochStore {
         self.tables()?
             .pending_consensus_transactions
             .multi_remove(keys)?;
-
         // TODO: lock once for all remove() calls.
         for key in keys {
-            let maybe_digest = match key {
-                ConsensusTransactionKey::Certificate(digest)
-                | ConsensusTransactionKey::UserTransaction(digest) => Some(digest),
-                _ => None,
-            };
-            if let Some(digest) = maybe_digest {
-                self.pending_consensus_certificates.write().remove(digest);
+            if let ConsensusTransactionKey::Certificate(cert) = key {
+                self.pending_consensus_certificates.write().remove(cert);
             }
+            // NOTE: We do not need the
+            // `ConsensusTransactionKey::UserTransaction` branch
+            // (certificate-less scenario) here because `UserTransactionV1` are
+            // not inserted into
+            // `self.pending_consensus_certificates`.
         }
-
         Ok(())
     }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2240,18 +2240,33 @@ impl AuthorityPerEpochStore {
 
         // TODO: lock once for all insert() calls.
         for transaction in transactions {
-            if let ConsensusTransactionKind::CertifiedTransaction(cert) = &transaction.kind {
-                let state = lock.expect("Must pass reconfiguration lock when storing certificate");
+            let digest_cert_or_tx = match &transaction.kind {
+                ConsensusTransactionKind::CertifiedTransaction(cert) => {
+                    // Branch WITH certification: `CertifiedTransaction` digest will be tracked
+                    // in the pending set
+                    Some((*cert.digest(), "certificate"))
+                }
+                ConsensusTransactionKind::UserTransactionV1(tx) => {
+                    // Branch WITHOUT certification: `UserTransactionV1` digest will be tracked
+                    // in the pending set
+                    Some((*tx.digest(), "transaction"))
+                }
+                _ => None,
+            };
+
+            if let Some((digest, cert_or_tx)) = digest_cert_or_tx {
+                let state = lock.unwrap_or_else(|| {
+                    panic!("Must pass reconfiguration lock when storing {cert_or_tx}");
+                });
                 // Caller is responsible for performing graceful check
                 assert!(
                     state.should_accept_user_certs(),
-                    "Reconfiguration state should allow accepting user transactions"
+                    "Reconfiguration state should allow accepting user {cert_or_tx}s"
                 );
-                self.pending_consensus_certificates
-                    .write()
-                    .insert(*cert.digest());
+                self.pending_consensus_certificates.write().insert(digest);
             }
         }
+
         Ok(())
     }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4390,7 +4390,7 @@ impl AuthorityPerEpochStore {
     }
 
     /// Handles `SchedulingResult`, i.e., the output of the
-    /// `self.try_schedule() function, for the given
+    /// `self.try_schedule()` function, for the given
     /// `VerifiedExecutableTransaction`.
     fn handle_scheduling_result(
         &self,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1030,19 +1030,9 @@ impl AuthorityPerEpochStore {
             .expect("Load reconfig state at initialization cannot fail");
 
         let epoch_alive_notify = NotifyOnce::new();
+        // NOTE: `pending_consensus_certificates` will be built after `protocol_config`
+        // is available below.
         let pending_consensus_transactions = tables.get_all_pending_consensus_transactions()?;
-        let pending_consensus_certificates: HashSet<_> = pending_consensus_transactions
-            .iter()
-            .filter_map(|transaction| {
-                if let ConsensusTransactionKind::CertifiedTransaction(certificate) =
-                    &transaction.kind
-                {
-                    Some(*certificate.digest())
-                } else {
-                    None
-                }
-            })
-            .collect();
         assert_eq!(
             epoch_start_configuration.epoch_start_state().epoch(),
             epoch_id
@@ -1070,6 +1060,24 @@ impl AuthorityPerEpochStore {
         );
 
         let protocol_config = ProtocolConfig::get_for_version(protocol_version, chain.1);
+
+        let pending_consensus_certificates: HashSet<_> = if protocol_config.enable_white_flag_flow()
+        {
+            HashSet::new() // no certificates in certificate-less mode
+        } else {
+            pending_consensus_transactions
+                .iter()
+                .filter_map(|transaction| {
+                    if let ConsensusTransactionKind::CertifiedTransaction(certificate) =
+                        &transaction.kind
+                    {
+                        Some(*certificate.digest())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
 
         let execution_component = ExecutionComponents::new(
             &protocol_config,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4119,132 +4119,15 @@ impl AuthorityPerEpochStore {
                     shared_object_congestion_tracker,
                 );
 
-                match scheduling_result {
-                    SchedulingResult::Defer(deferral_key, deferral_reason) => {
-                        debug!(
-                            "Deferring consensus certificate for transaction {:?} until {:?}",
-                            certificate.digest(),
-                            deferral_key
-                        );
-
-                        let deferral_result = match deferral_reason {
-                            DeferralReason::RandomnessNotReady => {
-                                // Always defer transaction due to randomness not ready.
-                                ConsensusCertificateResult::Deferred {
-                                    deferral_key,
-                                    suggested_gas_price: None,
-                                }
-                            }
-                            DeferralReason::SharedObjectCongestion(congested_objects) => {
-                                authority_metrics
-                                    .consensus_handler_congested_transactions
-                                    .inc();
-
-                                let suggested_gas_price = if self
-                                    .protocol_config
-                                    .congestion_control_gas_price_feedback_mechanism()
-                                {
-                                    let current_commit_suggested_gas_price =
-                                        suggested_gas_price_calculator
-                                            .calculate_suggested_gas_price(&certificate);
-
-                                    let suggested_gas_price = previously_deferred_tx_digests
-                                        .get(certificate.digest())
-                                        .map_or_else(
-                                            || current_commit_suggested_gas_price,
-                                            |deferral_key_suggested_gas_price_pair| {
-                                                deferral_key_suggested_gas_price_pair
-                                                    .1
-                                                    // If None, this could mean the certificate was
-                                                    // deferred due to randomness unavailable in
-                                                    // the previous round, but in the current
-                                                    // round, it gets deferred due to congestion.
-                                                    // Since this is the first round the
-                                                    // certificate is deferred due to congestion,
-                                                    // we return the suggested gas price from the
-                                                    // current round.
-                                                    .unwrap_or(current_commit_suggested_gas_price)
-                                                    .min(current_commit_suggested_gas_price)
-                                            },
-                                        );
-
-                                    Some(suggested_gas_price)
-                                } else {
-                                    None
-                                };
-
-                                if transaction_deferral_within_limit(
-                                    &deferral_key,
-                                    self.protocol_config()
-                                        .max_deferral_rounds_for_congestion_control(),
-                                ) {
-                                    ConsensusCertificateResult::Deferred {
-                                        deferral_key,
-                                        suggested_gas_price,
-                                    }
-                                } else {
-                                    // Cancel the transaction that has been deferred for too long.
-
-                                    debug!(
-                                        "Cancelling consensus certificate for transaction {:?} \
-                                            with deferral key {deferral_key:?} due to congestion \
-                                            on objects {congested_objects:?}: actual gas price: \
-                                            {}, suggested gas price: {suggested_gas_price:?}",
-                                        certificate.digest(),
-                                        certificate.transaction_data().gas_price(),
-                                    );
-
-                                    ConsensusCertificateResult::Cancelled((
-                                        certificate,
-                                        CancelConsensusCertificateReason::CongestionOnObjects {
-                                            congested_objects,
-                                            suggested_gas_price,
-                                        },
-                                    ))
-                                }
-                            }
-                        };
-
-                        Ok(deferral_result)
-                    }
-                    SchedulingResult::Schedule(start_time) => {
-                        if dkg_failed && certificate.uses_randomness() {
-                            debug!(
-                                "Canceling randomness-using certificate for transaction {:?} because DKG failed",
-                                certificate.digest(),
-                            );
-
-                            return Ok(ConsensusCertificateResult::Cancelled((
-                                certificate,
-                                CancelConsensusCertificateReason::DkgFailed,
-                            )));
-                        }
-
-                        // This certificate will be scheduled. If it contains shared object(s),
-                        // we have to update the following:
-                        // - shared object execution slots (for congestion tracker);
-                        // - shared object congestion info (for suggested gas price calculator).
-                        if certificate.contains_shared_object()
-                            && shared_object_congestion_tracker
-                                .congestion_control_parameters()
-                                .is_congestion_control_enabled()
-                        {
-                            // We only need to do this if shared-object congestion control is
-                            // enabled, since otherwise this bumping will panic as object
-                            // execution slots are only initialized if
-                            // `max_execution_duration_per_commit` is not `None`.
-                            let bump_result = shared_object_congestion_tracker
-                                .bump_object_execution_slots(&certificate, start_time);
-
-                            suggested_gas_price_calculator.update_congestion_info(bump_result);
-                        }
-
-                        Ok(ConsensusCertificateResult::Scheduled {
-                            transaction: certificate,
-                            start_time,
-                        })
-                    }
-                }
+                self.handle_scheduling_result(
+                    scheduling_result,
+                    certificate,
+                    previously_deferred_tx_digests,
+                    dkg_failed,
+                    shared_object_congestion_tracker,
+                    suggested_gas_price_calculator,
+                    authority_metrics,
+                )
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::CheckpointSignature(info),
@@ -4462,8 +4345,10 @@ impl AuthorityPerEpochStore {
                 // Certificate. Possibly extract common code to a separate
                 // function to avoid code duplication.
 
-                // Create VerifiedExecutableTransaction with ConsensusOrdered proof
-                // Similar to how new_from_quorum_execution works, but using ConsensusOrdered
+                // Create `VerifiedExecutableTransaction` with `ConsensusOrdered` proof.
+                // In contrast to `new_from_certificate` (the proof was authorized by 2f+1
+                // pre-consensus signatures), the `ConsensusOrdered` certificate proof
+                // is authorized by consensus ordering post owned-object conflict resolution.
                 let executable_tx = VerifiedExecutableTransaction::new_unchecked(
                     ExecutableTransaction::new_from_data_and_sig(
                         transaction.data().clone(),
@@ -4480,34 +4365,157 @@ impl AuthorityPerEpochStore {
                     shared_object_congestion_tracker,
                 );
 
-                // Handle scheduling result
-                match scheduling_result {
-                    SchedulingResult::Defer(deferral_key, _deferral_reason) => {
-                        // TODO: Simplified: defer without gas price feedback for PoC
-                        Ok(ConsensusCertificateResult::Deferred {
-                            deferral_key,
-                            suggested_gas_price: None,
-                        })
-                    }
-                    SchedulingResult::Schedule(start_time) => {
-                        if executable_tx.contains_shared_object()
-                            && shared_object_congestion_tracker
-                                .congestion_control_parameters()
-                                .is_congestion_control_enabled()
-                        {
-                            let bump_result = shared_object_congestion_tracker
-                                .bump_object_execution_slots(&executable_tx, start_time);
-                            suggested_gas_price_calculator.update_congestion_info(bump_result);
-                        }
-                        Ok(ConsensusCertificateResult::Scheduled {
-                            transaction: executable_tx,
-                            start_time,
-                        })
-                    }
-                }
+                self.handle_scheduling_result(
+                    scheduling_result,
+                    executable_tx,
+                    previously_deferred_tx_digests,
+                    dkg_failed,
+                    shared_object_congestion_tracker,
+                    suggested_gas_price_calculator,
+                    authority_metrics,
+                )
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {
                 Ok(self.process_consensus_system_transaction(system_transaction))
+            }
+        }
+    }
+
+    /// Handles `SchedulingResult`, i.e., the output of the
+    /// `self.try_schedule() function, for the given
+    /// `VerifiedExecutableTransaction`.
+    fn handle_scheduling_result(
+        &self,
+        scheduling_result: SchedulingResult,
+        verified_executable_tx: VerifiedExecutableTransaction,
+        previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
+        dkg_failed: bool,
+        shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
+        suggested_gas_price_calculator: &mut SuggestedGasPriceCalculator,
+        authority_metrics: &Arc<AuthorityMetrics>,
+    ) -> IotaResult<ConsensusCertificateResult> {
+        match scheduling_result {
+            SchedulingResult::Defer(deferral_key, deferral_reason) => {
+                debug!(
+                    "Deferring verified executable transaction {:?} until {deferral_key:?}",
+                    verified_executable_tx.digest(),
+                );
+
+                let deferral_result = match deferral_reason {
+                    DeferralReason::RandomnessNotReady => {
+                        // Always defer transaction due to randomness not ready.
+                        ConsensusCertificateResult::Deferred {
+                            deferral_key,
+                            suggested_gas_price: None,
+                        }
+                    }
+                    DeferralReason::SharedObjectCongestion(congested_objects) => {
+                        authority_metrics
+                            .consensus_handler_congested_transactions
+                            .inc();
+
+                        let suggested_gas_price = if self
+                            .protocol_config
+                            .congestion_control_gas_price_feedback_mechanism()
+                        {
+                            let current_commit_suggested_gas_price = suggested_gas_price_calculator
+                                .calculate_suggested_gas_price(&verified_executable_tx);
+
+                            let suggested_gas_price = previously_deferred_tx_digests
+                                .get(verified_executable_tx.digest())
+                                .map_or_else(
+                                    || current_commit_suggested_gas_price,
+                                    |deferral_key_suggested_gas_price_pair| {
+                                        deferral_key_suggested_gas_price_pair
+                                            .1
+                                            // If None, this could mean the transaction was
+                                            // deferred due to randomness unavailable in
+                                            // the previous round, but in the current
+                                            // round, it gets deferred due to congestion.
+                                            // Since this is the first round the
+                                            // transaction is deferred due to congestion,
+                                            // we return the suggested gas price from the
+                                            // current round.
+                                            .unwrap_or(current_commit_suggested_gas_price)
+                                            .min(current_commit_suggested_gas_price)
+                                    },
+                                );
+
+                            Some(suggested_gas_price)
+                        } else {
+                            None
+                        };
+
+                        if transaction_deferral_within_limit(
+                            &deferral_key,
+                            self.protocol_config()
+                                .max_deferral_rounds_for_congestion_control(),
+                        ) {
+                            ConsensusCertificateResult::Deferred {
+                                deferral_key,
+                                suggested_gas_price,
+                            }
+                        } else {
+                            // Cancel the transaction that has been deferred for too long.
+                            debug!(
+                                "Cancelling verified executable transaction {:?} with deferral \
+                                    key {deferral_key:?} due to congestion on objects \
+                                    {congested_objects:?}: actual gas price: {}, suggested gas \
+                                    price: {suggested_gas_price:?}",
+                                verified_executable_tx.digest(),
+                                verified_executable_tx.transaction_data().gas_price(),
+                            );
+
+                            ConsensusCertificateResult::Cancelled((
+                                verified_executable_tx,
+                                CancelConsensusCertificateReason::CongestionOnObjects {
+                                    congested_objects,
+                                    suggested_gas_price,
+                                },
+                            ))
+                        }
+                    }
+                };
+
+                Ok(deferral_result)
+            }
+            SchedulingResult::Schedule(start_time) => {
+                if dkg_failed && verified_executable_tx.uses_randomness() {
+                    debug!(
+                        "Canceling randomness-using verified executable transaction {:?} because \
+                            DKG failed",
+                        verified_executable_tx.digest(),
+                    );
+
+                    return Ok(ConsensusCertificateResult::Cancelled((
+                        verified_executable_tx,
+                        CancelConsensusCertificateReason::DkgFailed,
+                    )));
+                }
+
+                // This transaction will be scheduled. If it contains shared object(s),
+                // we have to update the following:
+                // - shared object execution slots (for congestion tracker);
+                // - shared object congestion info (for suggested gas price calculator).
+                if verified_executable_tx.contains_shared_object()
+                    && shared_object_congestion_tracker
+                        .congestion_control_parameters()
+                        .is_congestion_control_enabled()
+                {
+                    // We only need to do this if shared-object congestion control is
+                    // enabled, since otherwise this bumping will panic as object
+                    // execution slots are only initialized if
+                    // `max_execution_duration_per_commit` is not `None`.
+                    let bump_result = shared_object_congestion_tracker
+                        .bump_object_execution_slots(&verified_executable_tx, start_time);
+
+                    suggested_gas_price_calculator.update_congestion_info(bump_result);
+                }
+
+                Ok(ConsensusCertificateResult::Scheduled {
+                    transaction: verified_executable_tx,
+                    start_time,
+                })
             }
         }
     }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2277,12 +2277,19 @@ impl AuthorityPerEpochStore {
         self.tables()?
             .pending_consensus_transactions
             .multi_remove(keys)?;
+
         // TODO: lock once for all remove() calls.
         for key in keys {
-            if let ConsensusTransactionKey::Certificate(cert) = key {
-                self.pending_consensus_certificates.write().remove(cert);
+            let maybe_digest = match key {
+                ConsensusTransactionKey::Certificate(digest)
+                | ConsensusTransactionKey::UserTransaction(digest) => Some(digest),
+                _ => None,
+            };
+            if let Some(digest) = maybe_digest {
+                self.pending_consensus_certificates.write().remove(digest);
             }
         }
+
         Ok(())
     }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2226,47 +2226,55 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    /// Insert transactions that will be submitted to consensus
-    /// into the persistent `pending_consensus_transactions` table.
+    /// Insert transactions that will be submitted to consensus into
+    /// the persistent `pending_consensus_transactions` table.
+    ///
+    /// Additionally, in the certificate mode, insert certified transactions
+    /// into the in-memory `pending_consensus_certificates` set. When
+    /// submitting a certificate caller **must** provide a `ReconfigState`
+    /// lock guard and verify that it allows new user certificates.
     pub fn insert_pending_consensus_transactions(
         &self,
         transactions: &[ConsensusTransaction],
+        lock: Option<&RwLockReadGuard<ReconfigState>>,
     ) -> IotaResult {
         let key_value_pairs = transactions.iter().map(|tx| (tx.key(), tx));
         self.tables()?
             .pending_consensus_transactions
             .multi_insert(key_value_pairs)?;
 
-        Ok(())
-    }
-
-    /// Insert certified transactions that will be submitted to consensus
-    /// into the in-memory `pending_consensus_certificates` set. When
-    /// submitting a certificate caller **must** provide a `ReconfigState`
-    /// lock guard and verify that it allows new user certificates.
-    pub fn insert_pending_consensus_certificates(
-        &self,
-        transactions: &[ConsensusTransaction],
-        lock: Option<&RwLockReadGuard<ReconfigState>>,
-    ) {
-        // TODO: lock once for all insert() calls.
-        for transaction in transactions {
-            if let ConsensusTransactionKind::CertifiedTransaction(cert) = &transaction.kind {
-                let state = lock.expect("Must pass reconfiguration lock when storing certificate");
-                // Caller is responsible for performing graceful check
-                assert!(
-                    state.should_accept_user_certs(),
-                    "Reconfiguration state should allow accepting user transactions"
-                );
-                self.pending_consensus_certificates
-                    .write()
-                    .insert(*cert.digest());
+        // NOTE: If the white flag flow is enabled (certificate-less mode), we do not
+        // insert `UserTransactionV1` into the pending set because there is no
+        // pre-consensus "promise" (a certificate) that `UserTransactionV1` will be
+        // executed before the end of epoch. Thus, the below insertion is only for
+        // certificates, i.e., when the white flag flow is disabled.
+        if !self.protocol_config.enable_white_flag_flow() {
+            // TODO: lock once for all insert() calls.
+            for transaction in transactions {
+                if let ConsensusTransactionKind::CertifiedTransaction(cert) = &transaction.kind {
+                    let state =
+                        lock.expect("Must pass reconfiguration lock when storing certificate");
+                    // Caller is responsible for performing graceful check
+                    assert!(
+                        state.should_accept_user_certs(),
+                        "Reconfiguration state should allow accepting user transactions"
+                    );
+                    self.pending_consensus_certificates
+                        .write()
+                        .insert(*cert.digest());
+                }
             }
         }
+
+        Ok(())
     }
 
     /// Remove processed by consensus transactions from the persistent
     /// `pending_consensus_transactions` table.
+    ///
+    /// Additionally, in the certificate mode, remove certified transactions
+    /// that were processed by consensus from the in-memory
+    /// `pending_consensus_certificates` set.
     pub fn remove_pending_consensus_transactions(
         &self,
         keys: &[ConsensusTransactionKey],
@@ -2275,18 +2283,20 @@ impl AuthorityPerEpochStore {
             .pending_consensus_transactions
             .multi_remove(keys)?;
 
-        Ok(())
-    }
-
-    /// Remove processed by consensus certified transactions from the in-memory
-    /// `pending_consensus_certificates` set.
-    pub fn remove_pending_consensus_certificates(&self, keys: &[ConsensusTransactionKey]) {
-        // TODO: lock once for all remove() calls.
-        for key in keys {
-            if let ConsensusTransactionKey::Certificate(cert) = key {
-                self.pending_consensus_certificates.write().remove(cert);
+        // NOTE: If the white flag flow is enabled, there are no certificates,
+        // so there is nothing to remove from `pending_consensus_certificates`.
+        // Thus, the below removal is only for certificates, i.e., when the white
+        // flag flow is disabled.
+        if !self.protocol_config.enable_white_flag_flow() {
+            // TODO: lock once for all remove() calls.
+            for key in keys {
+                if let ConsensusTransactionKey::Certificate(cert) = key {
+                    self.pending_consensus_certificates.write().remove(cert);
+                }
             }
         }
+
+        Ok(())
     }
 
     pub fn pending_consensus_certificates_count(&self) -> usize {

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -1008,16 +1008,26 @@ impl ConsensusOutputQuarantine {
         };
         let mut shared_input_object_ids: Vec<_> = transactions
             .iter()
-            .filter_map(|tx| {
-                if let SequencedConsensusTransactionKind::External(ConsensusTransaction {
+            .filter_map(|tx| match &tx.0.transaction {
+                SequencedConsensusTransactionKind::External(ConsensusTransaction {
                     kind: ConsensusTransactionKind::CertifiedTransaction(tx),
                     ..
-                }) = &tx.0.transaction
-                {
-                    Some(tx.shared_input_objects().into_iter().map(|obj| obj.id))
-                } else {
-                    None
-                }
+                }) => Some(
+                    tx.shared_input_objects()
+                        .into_iter()
+                        .map(|obj| obj.id)
+                        .collect::<Vec<_>>(),
+                ),
+                SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                    kind: ConsensusTransactionKind::UserTransactionV1(tx),
+                    ..
+                }) => Some(
+                    tx.shared_input_objects()
+                        .into_iter()
+                        .map(|obj| obj.id)
+                        .collect::<Vec<_>>(),
+                ),
+                _ => None,
             })
             .flatten()
             .collect();

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -20,7 +20,7 @@ use tracing::{debug, trace};
 
 use crate::{
     authority::{
-        AuthorityPerEpochStore, authority_per_epoch_store::CancelConsensusCertificateReason,
+        AuthorityPerEpochStore, authority_per_epoch_store::CancelConsensusTransactionReason,
         epoch_start_configuration::EpochStartConfigTrait,
     },
     execution_cache::ObjectCacheRead,
@@ -43,7 +43,7 @@ impl SharedObjVerManager {
         cache_reader: &dyn ObjectCacheRead,
         certificates: &[VerifiedExecutableTransaction],
         randomness_round: Option<RandomnessRound>,
-        cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
+        cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusTransactionReason>,
     ) -> IotaResult<ConsensusSharedObjVerAssignment> {
         let mut shared_input_next_versions = get_or_init_versions(
             certificates.iter().map(|cert| cert.data()),
@@ -132,7 +132,7 @@ impl SharedObjVerManager {
     pub fn assign_versions_for_certificate(
         cert: &VerifiedExecutableTransaction,
         shared_input_next_versions: &mut HashMap<ObjectID, SequenceNumber>,
-        cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
+        cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusTransactionReason>,
         enable_gas_price_feedback: bool,
     ) -> Vec<(ObjectID, SequenceNumber)> {
         let tx_digest = cert.digest();
@@ -140,7 +140,7 @@ impl SharedObjVerManager {
         // Check if the transaction is cancelled due to congestion.
         let cancellation_info = cancelled_txns.get(tx_digest);
         let congested_objects_info: Option<HashSet<_>> =
-            if let Some(CancelConsensusCertificateReason::CongestionOnObjects {
+            if let Some(CancelConsensusTransactionReason::CongestionOnObjects {
                 congested_objects,
                 suggested_gas_price: _,
             }) = &cancellation_info
@@ -168,7 +168,7 @@ impl SharedObjVerManager {
             // any shared objects.
             for SharedInputObject { id, .. } in shared_input_objects.iter() {
                 let assigned_version = match cancellation_info {
-                    Some(CancelConsensusCertificateReason::CongestionOnObjects {
+                    Some(CancelConsensusTransactionReason::CongestionOnObjects {
                         congested_objects: _,
                         suggested_gas_price,
                     }) => {
@@ -195,7 +195,7 @@ impl SharedObjVerManager {
                             SequenceNumber::CANCELLED_READ
                         }
                     }
-                    Some(CancelConsensusCertificateReason::DkgFailed) => {
+                    Some(CancelConsensusTransactionReason::DkgFailed) => {
                         if id == &IOTA_RANDOMNESS_STATE_OBJECT_ID {
                             SequenceNumber::RANDOMNESS_UNAVAILABLE
                         } else {
@@ -535,24 +535,24 @@ mod tests {
 
         // Cancel transactions 2 and 4 due to congestion.
         let suggested_gas_price = 1_000;
-        let cancelled_txns: BTreeMap<TransactionDigest, CancelConsensusCertificateReason> = [
+        let cancelled_txns: BTreeMap<TransactionDigest, CancelConsensusTransactionReason> = [
             (
                 *certs[1].digest(),
-                CancelConsensusCertificateReason::CongestionOnObjects {
+                CancelConsensusTransactionReason::CongestionOnObjects {
                     congested_objects: vec![id1],
                     suggested_gas_price: Some(suggested_gas_price),
                 },
             ),
             (
                 *certs[3].digest(),
-                CancelConsensusCertificateReason::CongestionOnObjects {
+                CancelConsensusTransactionReason::CongestionOnObjects {
                     congested_objects: vec![id2],
                     suggested_gas_price: Some(suggested_gas_price),
                 },
             ),
             (
                 *certs[4].digest(),
-                CancelConsensusCertificateReason::DkgFailed,
+                CancelConsensusTransactionReason::DkgFailed,
             ),
         ]
         .into_iter()

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1500,6 +1500,10 @@ impl ValidatorService {
             // all transactions are either accepted or rejected together.
             let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
             if !reconfiguration_lock.should_accept_user_certs() {
+                // NOTE: `handle_transaction` increments the same counter on the signing path.
+                // But since `handle_transaction` and `submit_transaction_impl` are mutually
+                // exclusive based on the `enable_white_flag_flow` protocol parameter,
+                // it is fine to use `num_rejected_tx_in_epoch_boundary` here.
                 metrics
                     .num_rejected_tx_in_epoch_boundary
                     .inc_by(transactions.len() as u64);

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1773,7 +1773,8 @@ impl ValidatorService {
                 num_inflight_execution_transactions: self
                     .state
                     .transaction_manager()
-                    .inflight_queue_len() as u64,
+                    .inflight_queue_len()
+                    as u64,
                 num_inflight_consensus_transactions: self
                     .consensus_adapter
                     .num_inflight_transactions(),

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -850,11 +850,15 @@ impl ConsensusAdapter {
 
         let is_user_tx = is_soft_bundle
             || if epoch_store.protocol_config().enable_white_flag_flow() {
+                // In the certificate-less mode, `UserTransactionV1` kind corresponds
+                // to user transactions.
                 matches!(
                     transactions[0].kind,
                     ConsensusTransactionKind::UserTransactionV1(_)
                 )
             } else {
+                // In the certificate mode, `CertifiedTransaction` kind corresponds
+                // to user transactions.
                 matches!(
                     transactions[0].kind,
                     ConsensusTransactionKind::CertifiedTransaction(_)
@@ -881,12 +885,12 @@ impl ConsensusAdapter {
 
                     true
                 } else {
-                    // In the certificate mode, we have to check if the list of pending
-                    // consensus certificates is drained; only then issue `EndOfPublish`.
+                    // In certificate mode, `EndOfPublish` is sent only once the list
+                    // of pending consensus certificates is drained.
                     let pending_count = epoch_store.pending_consensus_certificates_count();
                     debug!(epoch=?epoch_store.epoch(), ?pending_count, "Deciding whether to send EndOfPublish");
 
-                    pending_count == 0 // send end of epoch if empty
+                    pending_count == 0 // send end of epoch if no pending certificates
                 }
             } else {
                 false
@@ -1116,10 +1120,11 @@ pub fn get_position_in_list(
 }
 
 impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
-    /// This method is called externally to begin reconfiguration
-    /// It transition reconfig state to reject new certificates from user
-    /// ConsensusAdapter will send EndOfPublish message once pending certificate
-    /// queue is drained.
+    /// This method is called externally to begin reconfiguration.
+    /// It transitions the reconfig state to reject new user transactions.
+    /// `ConsensusAdapter` will send `EndOfPublish` once all pending
+    /// transactions are drained (in the certificate mode) or immediately
+    /// (in the certificate-less mode).
     fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
         let send_end_of_publish = {
             let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
@@ -1127,17 +1132,28 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
                 // Allow caller to call this method multiple times
                 return;
             }
-            // NOTE: In the certificate-less case, `pending_consensus_certificates_count`
-            // is always zero because we do not insert anything into the set of pending
-            // consensus certificates, so there might be room for minor optimization: avoid
-            // reading `pending_consensus_certificates` in the certificate-less scenario.
-            let pending_count = epoch_store.pending_consensus_certificates_count();
-            debug!(epoch=?epoch_store.epoch(), ?pending_count, "Trying to close epoch");
-            let send_end_of_publish = pending_count == 0;
+
+            let send_end_of_publish = if epoch_store.protocol_config().enable_white_flag_flow() {
+                // In certificate-less mode, there are no pending consensus
+                // certificates, so `EndOfPublish` is always sent immediately.
+                debug!(epoch=?epoch_store.epoch(), "Closing epoch in certificate-less mode");
+
+                true
+            } else {
+                // In certificate mode, `EndOfPublish` is sent only once the list
+                // of pending consensus certificates is drained.
+                let pending_count = epoch_store.pending_consensus_certificates_count();
+                debug!(epoch=?epoch_store.epoch(), ?pending_count, "Trying to close epoch");
+
+                pending_count == 0 // send end of epoch if no pending certificates
+            };
+
             epoch_store.close_user_certs(reconfig_guard);
+
             send_end_of_publish
             // reconfig_guard lock is dropped here.
         };
+
         if send_end_of_publish {
             info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
             if let Err(err) = self.submit(

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -342,10 +342,20 @@ impl ConsensusAdapter {
         // be a big deal but can be optimized
         let mut recovered = epoch_store.get_all_pending_consensus_transactions();
 
+        let is_pending_consensus_certificates_empty =
+            if epoch_store.protocol_config().enable_white_flag_flow() {
+                // In the certificate-less mode, the list of pending consensus
+                // certificates is always empty.
+                true
+            } else {
+                epoch_store.pending_consensus_certificates_empty()
+            };
+
+
         if epoch_store
             .get_reconfig_state_read_lock_guard()
             .is_reject_user_certs()
-            && epoch_store.pending_consensus_certificates_empty()
+            && is_pending_consensus_certificates_empty
         {
             // If `recovered` does not contain `EndOfPublish` yet, we need to insert it.
             if !recovered

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -595,20 +595,7 @@ impl ConsensusAdapter {
             }
         }
 
-        // Regardless of `enable_white_flag_flow`, we need to insert transactions that
-        // will be submitted to consensus into the corresponding persistent table.
-        epoch_store.insert_pending_consensus_transactions(transactions)?;
-
-        // If the white flag flow is enabled, there are no certificates, so there is
-        // nothing to insert into `pending_consensus_certificates`. We do not insert
-        // `UserTransactionV1` in the pending set because, in the certificate-less
-        // scenario, there is no pre-consensus "promise" (a certificate) that
-        // `UserTransactionV1` will be executed before the end of epoch. So, the
-        // below insertion is only for certificates, i.e., when the white flag
-        // flow is disabled.
-        if !epoch_store.protocol_config().enable_white_flag_flow() {
-            epoch_store.insert_pending_consensus_certificates(transactions, lock);
-        }
+        epoch_store.insert_pending_consensus_transactions(transactions, lock)?;
 
         Ok(self.submit_unchecked(transactions, epoch_store))
     }
@@ -858,18 +845,9 @@ impl ConsensusAdapter {
 
         let consensus_keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
 
-        // Regardless of `enable_white_flag_flow`, we need to remove transactions that
-        // were processed by consensus from the corresponding persistent table.
         epoch_store
             .remove_pending_consensus_transactions(&consensus_keys)
             .expect("Storage error when removing consensus transaction");
-
-        // If the white flag flow is enabled, there are no certificates, so there is
-        // nothing to remove from `pending_consensus_certificates`. So, the below
-        // removal is only for certificates, i.e., when the white flag flow is disabled.
-        if !epoch_store.protocol_config().enable_white_flag_flow() {
-            epoch_store.remove_pending_consensus_certificates(&consensus_keys);
-        }
 
         let is_user_tx = is_soft_bundle
             || matches!(

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -601,6 +601,7 @@ impl ConsensusAdapter {
         // it immediately, it's dropped. No WAL, no retry, no epoch boundary handling.
         // This will be designed and implemented separately.
         epoch_store.insert_pending_consensus_transactions(transactions, lock)?;
+
         Ok(self.submit_unchecked(transactions, epoch_store))
     }
 

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -595,12 +595,19 @@ impl ConsensusAdapter {
             }
         }
 
-        // TODO: Pending transaction tracking for UserTransactionV1 at epoch boundaries
-        // requires different semantics than certificates (no 2f+1 guarantee).
-        // For now, UserTransactionV1 is fire-and-forget - if consensus doesn't accept
-        // it immediately, it's dropped. No WAL, no retry, no epoch boundary handling.
-        // This will be designed and implemented separately.
-        epoch_store.insert_pending_consensus_transactions(transactions, lock)?;
+        // Regardless of `enable_white_flag_flow`, we need to insert transactions that
+        // will be submitted to consensus into the corresponding persistent table.
+        epoch_store.insert_pending_consensus_transactions(transactions)?;
+
+        // If the white flag flow is enabled, there are no certificates, so there is
+        // nothing to insert into `pending_consensus_certificates`. We do not insert
+        // `UserTransactionV1` in the pending set because, in the certificate-less
+        // scenario, there is no pre-consensus "promise" (a certificate) that
+        // `UserTransactionV1` will be executed before the end of epoch. So, the below
+        // insertion is only for certificates, i.e., the white flag flow is disabled.
+        if !epoch_store.protocol_config().enable_white_flag_flow() {
+            epoch_store.insert_pending_consensus_certificates(transactions, lock);
+        }
 
         Ok(self.submit_unchecked(transactions, epoch_store))
     }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -603,8 +603,9 @@ impl ConsensusAdapter {
         // nothing to insert into `pending_consensus_certificates`. We do not insert
         // `UserTransactionV1` in the pending set because, in the certificate-less
         // scenario, there is no pre-consensus "promise" (a certificate) that
-        // `UserTransactionV1` will be executed before the end of epoch. So, the below
-        // insertion is only for certificates, i.e., the white flag flow is disabled.
+        // `UserTransactionV1` will be executed before the end of epoch. So, the
+        // below insertion is only for certificates, i.e., when the white flag
+        // flow is disabled.
         if !epoch_store.protocol_config().enable_white_flag_flow() {
             epoch_store.insert_pending_consensus_certificates(transactions, lock);
         }
@@ -856,9 +857,19 @@ impl ConsensusAdapter {
         debug!("{transaction_keys:?} processed by consensus");
 
         let consensus_keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
+
+        // Regardless of `enable_white_flag_flow`, we need to remove transactions that
+        // were processed by consensus from the corresponding persistent table.
         epoch_store
             .remove_pending_consensus_transactions(&consensus_keys)
             .expect("Storage error when removing consensus transaction");
+
+        // If the white flag flow is enabled, there are no certificates, so there is
+        // nothing to remove from `pending_consensus_certificates`. So, the below
+        // removal is only for certificates, i.e., when the white flag flow is disabled.
+        if !epoch_store.protocol_config().enable_white_flag_flow() {
+            epoch_store.remove_pending_consensus_certificates(&consensus_keys);
+        }
 
         let is_user_tx = is_soft_bundle
             || matches!(

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -844,20 +844,22 @@ impl ConsensusAdapter {
         debug!("{transaction_keys:?} processed by consensus");
 
         let consensus_keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
-
         epoch_store
             .remove_pending_consensus_transactions(&consensus_keys)
             .expect("Storage error when removing consensus transaction");
 
         let is_user_tx = is_soft_bundle
-            || matches!(
-                transactions[0].kind,
-                // NOTE: We need to check both because `CertifiedTransaction` (scenario with
-                // certificates) and `UserTransactionV1` (certificate-less scenario) are both
-                // user transactions.
-                ConsensusTransactionKind::CertifiedTransaction(_)
-                    | ConsensusTransactionKind::UserTransactionV1(_)
-            );
+            || if epoch_store.protocol_config().enable_white_flag_flow() {
+                matches!(
+                    transactions[0].kind,
+                    ConsensusTransactionKind::UserTransactionV1(_)
+                )
+            } else {
+                matches!(
+                    transactions[0].kind,
+                    ConsensusTransactionKind::CertifiedTransaction(_)
+                )
+            };
         let send_end_of_publish = if is_user_tx {
             // If we are in RejectUserCerts state and we just drained the list we need to
             // send EndOfPublish to signal other validators that we are not submitting more

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -351,7 +351,6 @@ impl ConsensusAdapter {
                 epoch_store.pending_consensus_certificates_empty()
             };
 
-
         if epoch_store
             .get_reconfig_state_read_lock_guard()
             .is_reject_user_certs()

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -857,8 +857,8 @@ impl ConsensusAdapter {
             || matches!(
                 transactions[0].kind,
                 // NOTE: We need to check both because `CertifiedTransaction` (scenario with
-                // certificates) and `UserTransactionV1` (certificate-less scenario) are user
-                // transactions.
+                // certificates) and `UserTransactionV1` (certificate-less scenario) are both
+                // user transactions.
                 ConsensusTransactionKind::CertifiedTransaction(_)
                     | ConsensusTransactionKind::UserTransactionV1(_)
             );

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -861,26 +861,33 @@ impl ConsensusAdapter {
                 )
             };
         let send_end_of_publish = if is_user_tx {
-            // If we are in RejectUserCerts state and we just drained the list we need to
-            // send EndOfPublish to signal other validators that we are not submitting more
-            // certificates to the epoch. Note that there could be a race
-            // condition here where we enter this check in RejectAllCerts state.
-            // In that case we don't need to send EndOfPublish because condition to enter
-            // RejectAllCerts is when 2f+1 other validators already sequenced their
-            // EndOfPublish message. Also note that we could sent multiple
-            // EndOfPublish due to that multiple tasks can enter here with
-            // pending_count == 0. This doesn't affect correctness.
+            // If we are in `RejectUserCerts` state, we need to send `EndOfPublish` to
+            // signal other validators that we are not submitting more user
+            // transactions in the epoch. Note that there could be a race condition
+            // here where we enter this check in `RejectAllCerts` state. In that case
+            // we don't need to send `EndOfPublish` because the condition to enter
+            // `RejectAllCerts` is when 2f+1 other validators already sequenced their
+            // `EndOfPublish` message. Also note that we could send multiple
+            // `EndOfPublish` messages because multiple tasks can enter here
+            // concurrently. This doesn't affect correctness.
             if epoch_store
                 .get_reconfig_state_read_lock_guard()
                 .is_reject_user_certs()
             {
-                // NOTE: In the certificate-less case, `pending_consensus_certificates_count`
-                // is always zero because we do not insert anything into the set of pending
-                // consensus certificates, so there might be room for minor optimization: avoid
-                // reading `pending_consensus_certificates` in the certificate-less scenario.
-                let pending_count = epoch_store.pending_consensus_certificates_count();
-                debug!(epoch=?epoch_store.epoch(), ?pending_count, "Deciding whether to send EndOfPublish");
-                pending_count == 0 // send end of epoch if empty
+                if epoch_store.protocol_config().enable_white_flag_flow() {
+                    // In the certificate-less mode, there are no pending consensus
+                    // certificates, so `EndOfPublish` is always sent immediately.
+                    debug!(epoch=?epoch_store.epoch(), "Sending EndOfPublish in certificate-less mode");
+
+                    true
+                } else {
+                    // In the certificate mode, we have to check if the list of pending
+                    // consensus certificates is drained; only then issue `EndOfPublish`.
+                    let pending_count = epoch_store.pending_consensus_certificates_count();
+                    debug!(epoch=?epoch_store.epoch(), ?pending_count, "Deciding whether to send EndOfPublish");
+
+                    pending_count == 0 // send end of epoch if empty
+                }
             } else {
                 false
             }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -1001,13 +1001,14 @@ impl ConsensusAdapter {
     ) -> ProcessedMethod {
         let notifications = FuturesUnordered::new();
         for transaction_key in transaction_keys {
-            let transaction_digests = if let SequencedConsensusTransactionKey::External(
-                ConsensusTransactionKey::Certificate(digest),
-            ) = transaction_key
-            {
-                vec![digest]
-            } else {
-                vec![]
+            let transaction_digests = match transaction_key {
+                SequencedConsensusTransactionKey::External(
+                    ConsensusTransactionKey::Certificate(digest),
+                )
+                | SequencedConsensusTransactionKey::External(
+                    ConsensusTransactionKey::UserTransaction(digest),
+                ) => vec![digest],
+                _ => vec![],
             };
 
             let checkpoint_synced_future = if let SequencedConsensusTransactionKey::External(

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -856,6 +856,9 @@ impl ConsensusAdapter {
         let is_user_tx = is_soft_bundle
             || matches!(
                 transactions[0].kind,
+                // NOTE: We need to check both because `CertifiedTransaction` (scenario with
+                // certificates) and `UserTransactionV1` (certificate-less scenario) are user
+                // transactions.
                 ConsensusTransactionKind::CertifiedTransaction(_)
                     | ConsensusTransactionKind::UserTransactionV1(_)
             );
@@ -873,6 +876,10 @@ impl ConsensusAdapter {
                 .get_reconfig_state_read_lock_guard()
                 .is_reject_user_certs()
             {
+                // NOTE: In the certificate-less case, `pending_consensus_certificates_count`
+                // is always zero because we do not insert anything into the set of pending
+                // consensus certificates, so there might be room for minor optimization: avoid
+                // reading `pending_consensus_certificates` in the certificate-less scenario.
                 let pending_count = epoch_store.pending_consensus_certificates_count();
                 debug!(epoch=?epoch_store.epoch(), ?pending_count, "Deciding whether to send EndOfPublish");
                 pending_count == 0 // send end of epoch if empty
@@ -1115,6 +1122,10 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
                 // Allow caller to call this method multiple times
                 return;
             }
+            // NOTE: In the certificate-less case, `pending_consensus_certificates_count`
+            // is always zero because we do not insert anything into the set of pending
+            // consensus certificates, so there might be room for minor optimization: avoid
+            // reading `pending_consensus_certificates` in the certificate-less scenario.
             let pending_count = epoch_store.pending_consensus_certificates_count();
             debug!(epoch=?epoch_store.epoch(), ?pending_count, "Trying to close epoch");
             let send_end_of_publish = pending_count == 0;


### PR DESCRIPTION
# Description of change

This PR implements a PoC version of certificate-less epoch boundary coordination.

<details>
  <summary>Background on epoch boundary coordination with certificates</summary>
- Each validator tracks which certificates it has submitted to consensus, but they have not been sequenced by consensus yet - `pending_consensus_certificates`.
- Certificates are the unit of work that a validator must drain before an epoch can close.

The epoch change process has the following phases:
1. **Reconfig state `AcceptAllCerts`**
  - All certificates are accepted and tracked in `pending_consensus_certificates`.
  - Every time a checkpoint is created, its timestamp is compared against `next_reconfiguration_timestamp_ms = epoch_start_timestamp_ms + epoch_duration_ms`.
  - If the timestamp exceeds this threshold, `close_epoch()` is called - the reconfig state moves to `RejectUserCerts`.
2. **Reconfig state `RejectUserCerts`**
  - New certificates are rejected; pending ones must be processed by consensus.
  - The `pending_consensus_certificates` set must be drained; only then `EndOfEpoch` is sent to consensus.
  - When `2f+1` stake worth of `EndOfPublish` is collected, the reconfig state transitions to `RejectAllCerts`.
3. **Reconfig state `RejectAllCerts`**
  - New user and consensus certificates are rejected.
  - At this point, the exact set of transactions in the epoch is determined.
  - Only previously deferred transactions remain to be processed.
  - Once all deferred transactions have been processed, the state transitions to `RejectAllTx`.
4. **Reconfig state `RejectAllTx`**
  - The commit round is labeled as final.
  - The pending checkpoint is labeled as last in the epoch.
  - Epoch is finalized.
</details>   

### Certificate-less epoch boundary coordination

The process to close the epoch in the certificate-less flow stays almost the same as with certificates. The **fundamental difference** is that, in the white flag flow, there are no certificates, so there is nothing to track in `pending_consensus_certificates`. We do not track `UserTransactionV1` because there is no pre-consensus "promise" (like there is with certificates) that the transaction will be executed by the end of the epoch. Thus, validators can send `EndOfPublish` immediately once the reconfig state is `RejectUserCerts`. This PR implements this as a PoC version.

### Summary of changes:

- Behavior of `insert_pending_consensus_transactions`:
  - Keep tracking transactions that will be submitted to consensus in the persistent `pending_consensus_transactions` table, but track `pending_consensus_certificates` only if the white flag flow is disabled.
- Behavior of `remove_pending_consensus_transactions`:
  - Keep removing processed-by-consensus transactions from the persistent `pending_consensus_transactions` table, but remove from `pending_consensus_certificates` only if the white flag flow is disabled.
- Behavior of `revert_uncommitted_epoch_transactions`:
  - Revert uncommitted locally executed pending consensus certificates that were not included in the epoch only if the white flag flow is disabled. For the certificate-less mode, we revert nothing because owned-object transactions are not executed pre-consensus in this mode.
- Condition to send `EndOfPublish`:
  - Send immediately once the reconfig state is `RejectUserCerts`.
  - The `is_user_tx` flag is explicitly set based on the white flag flow: a user transaction is `CertifiedTransaction` in certificate mode and `UserTransactionV1` in certificate-less mode.
- Explicit handling of the `pending_consensus_certificates` set based on the `enable_white_flag_flow` protocol config feature flag wherever the set appears.
  - _This is done for clarity and optimization_: `pending_consensus_certificates` is always empty if `enable_white_flag_flow` is enabled, so we avoid minor overheads such as reading the empty set and counting elements in it.
  - `AuthorityPerEpochStore` is initialized with empty `pending_consensus_certificates` if the white flag flow is enabled - this avoids unnecessary iteration over `pending_consensus_transactions`.
- Added the `num_rejected_tx_in_epoch_boundary` metric to be used in `submit_transaction_impl` to count the number of rejected user transactions.
- New function `handle_scheduling_result` that simply gathers the code that handles `SchedulingResult`, so the function can be used for both `CertifiedTransaction` and `UserTransactionV1`. 

### Multiple fixes not directly related to this PR:

- Applied the same fix as in https://github.com/iotaledger/iota/pull/10578, considering that `pending_consensus_certificates` is always empty in the white flag mode.
- Fixed `load_and_process_deferred_transactions_for_randomness` to also match over white-flag transactions, which are also user transactions that might be deferred due to randomness unavailable; without this fix, the function would panic.
- Fixed `load_initial_object_debts` to also account for white-flag user transactions; otherwise, object debts would not be loaded in the white-flag mode.
- Fixed `await_consensus_or_checkpoint` to construct a list of transaction digests for the white-flag transactions as well; otherwise the list would be empty in the white-flag mode, leading to potential hanging or unnecessary re-submissions.

## Links to any relevant issues

Closes #10376.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
