### PR TITLE
fix(iota-indexer): governance api flaky test

### DIFF
--- a/crates/iota-indexer/tests/rpc-tests/governance_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/governance_api.rs
@@ -480,7 +480,6 @@ fn test_timelocked_unstaking() {
 }
 
 #[test]
-#[ignore = "https://github.com/iotaledger/iota/issues/6127"]
 fn get_latest_iota_system_state_v2() {
     let ApiTestSetup {
         runtime,
@@ -490,10 +489,12 @@ fn get_latest_iota_system_state_v2() {
     } = ApiTestSetup::get_or_init();
 
     runtime.block_on(async move {
-        indexer_wait_for_checkpoint(store, 1).await;
-
         // ensure that the system state is updated
         cluster.force_new_epoch().await;
+        // when epoch is advanced, the indexer should catch up the latest checkpoint to
+        // reflect the end of epoch checkpoint changes
+        indexer_wait_for_latest_checkpoint(store, cluster).await;
+
         let system_state = client.get_latest_iota_system_state_v2().await.unwrap();
         let IotaSystemStateSummary::V2(system_state_v2) = system_state else {
             panic!("expected IotaSystemStateSummaryV2");


### PR DESCRIPTION
# Description of change

This PR fixes the `governance_api::get_latest_iota_system_state_v2` flaky test. 

At genesis, the system state is created as V1. The test calls `force_new_epoch()` to trigger the first epoch change, which upgrades the system state from V1 to V2 via the `advance_epoch` transaction. However, the test was querying the indexer immediately after the epoch change without waiting for it to ingest the end-of-epoch checkpoint containing the upgraded V2 system state.

The fix adds `indexer_wait_for_latest_checkpoint(store, cluster).await` to ensure the indexer has caught up before asserting on the V2 system state. The existing `indexer_wait_for_checkpoint(store, 1)` was also removed as it's redundant — the later wait already guarantees the indexer is fully synced.

## Links to any relevant issues

fixes #6127 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran indexer tests 20 times
```bash
cargo test -p iota-indexer --profile simulator --features shared_test_runtime
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> The current patch doe snot affect the normal operation of the indexer, thus no further tests were conducted.