### PR TITLE
upstream(core): Update name of "shared deletion" indicators across the codebase

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5304,7 +5304,7 @@ impl AuthorityState {
     ) -> IotaResult<AuthenticatorFunctionRefForExecution> {
         let account_object = match account_object.object {
             ObjectReadResultKind::Object(object) => Ok(object),
-            ObjectReadResultKind::DeletedSharedObject(version, digest) => {
+            ObjectReadResultKind::ObjectConsensusStreamEnded(version, digest) => {
                 Err(UserInputError::AccountObjectDeleted {
                     account_id: account_object.id(),
                     account_version: version,
@@ -5996,8 +5996,8 @@ impl NodeStateDump {
                         shared_objects.push(ObjDumpFormat::new(w))
                     }
                 }
-                InputSharedObject::ReadDeleted(..)
-                | InputSharedObject::MutateDeleted(..)
+                InputSharedObject::ReadConsensusStreamEnded(..)
+                | InputSharedObject::MutateConsensusStreamEnded(..)
                 | InputSharedObject::Cancelled(..) => (), /* TODO: consider record congested
                                                            * objects. */
             }

--- a/crates/iota-core/src/checkpoints/causal_order.rs
+++ b/crates/iota-core/src/checkpoints/causal_order.rs
@@ -149,14 +149,16 @@ impl RWLockDependencyBuilder {
                             .or_default()
                             .push(obj_key);
                     }
-                    InputSharedObject::ReadDeleted(oid, version) => read_version
+                    InputSharedObject::ReadConsensusStreamEnded(oid, version) => read_version
                         .entry(ObjectKey(oid, version))
                         .or_default()
                         .push(*effect.transaction_digest()),
-                    InputSharedObject::MutateDeleted(oid, version) => overwrite_versions
-                        .entry(*effect.transaction_digest())
-                        .or_default()
-                        .push(ObjectKey(oid, version)),
+                    InputSharedObject::MutateConsensusStreamEnded(oid, version) => {
+                        overwrite_versions
+                            .entry(*effect.transaction_digest())
+                            .or_default()
+                            .push(ObjectKey(oid, version))
+                    }
                     InputSharedObject::Cancelled(..) => (), /* TODO: confirm that
                                                              * consensus_commit_prologue is
                                                              * always at the beginning of the

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -402,16 +402,15 @@ pub trait ObjectCacheRead: Send + Sync {
                     )?;
                 versioned_results.push((*idx, is_available));
             } else if self
-                .try_get_deleted_shared_object_previous_tx_digest(
+                .try_get_consensus_stream_end_tx_digest(
                     &input_key.id(),
                     input_key.version().unwrap(),
                     epoch,
                 )?
                 .is_some()
             {
-                // If the object is an already deleted shared object, mark it as available if
-                // the version for that object is in the shared deleted marker
-                // table.
+                // If the object is an already-removed consensus object, mark it as available if
+                // the version for that object is in the marker table.
                 versioned_results.push((*idx, true));
             } else {
                 versioned_results.push((*idx, false));
@@ -548,52 +547,54 @@ pub trait ObjectCacheRead: Send + Sync {
             .expect("storage access failed")
     }
 
-    /// If the shared object was deleted, return deletion info for the current
-    /// live version
-    fn try_get_last_shared_object_deletion_info(
+    /// If the given consensus object stream was ended, return related
+    /// version and transaction digest.
+    fn try_get_last_consensus_stream_end_info(
         &self,
         object_id: &ObjectID,
         epoch_id: EpochId,
     ) -> IotaResult<Option<(SequenceNumber, TransactionDigest)>> {
         match self.try_get_latest_marker(object_id, epoch_id)? {
-            Some((version, MarkerValue::SharedDeleted(digest))) => Ok(Some((version, digest))),
+            Some((version, MarkerValue::ConsensusStreamEnded(digest))) => {
+                Ok(Some((version, digest)))
+            }
             _ => Ok(None),
         }
     }
 
-    /// Non-fallible version of `try_get_last_shared_object_deletion_info`.
-    fn get_last_shared_object_deletion_info(
+    /// Non-fallible version of `try_get_last_consensus_stream_end_info`.
+    fn get_last_consensus_stream_end_info(
         &self,
         object_id: &ObjectID,
         epoch_id: EpochId,
     ) -> Option<(SequenceNumber, TransactionDigest)> {
-        self.try_get_last_shared_object_deletion_info(object_id, epoch_id)
+        self.try_get_last_consensus_stream_end_info(object_id, epoch_id)
             .expect("storage access failed")
     }
 
-    /// If the shared object was deleted, return deletion info for the specified
-    /// version.
-    fn try_get_deleted_shared_object_previous_tx_digest(
+    /// If the given consensus object stream was ended at the specified version,
+    /// return related transaction digest.
+    fn try_get_consensus_stream_end_tx_digest(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
         epoch_id: EpochId,
     ) -> IotaResult<Option<TransactionDigest>> {
         match self.try_get_marker_value(object_id, version, epoch_id)? {
-            Some(MarkerValue::SharedDeleted(digest)) => Ok(Some(digest)),
+            Some(MarkerValue::ConsensusStreamEnded(digest)) => Ok(Some(digest)),
             _ => Ok(None),
         }
     }
 
     /// Non-fallible version of
-    /// `try_get_deleted_shared_object_previous_tx_digest`.
-    fn get_deleted_shared_object_previous_tx_digest(
+    /// `try_get_consensus_stream_end_tx_digest`.
+    fn get_consensus_stream_end_tx_digest(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
         epoch_id: EpochId,
     ) -> Option<TransactionDigest> {
-        self.try_get_deleted_shared_object_previous_tx_digest(object_id, version, epoch_id)
+        self.try_get_consensus_stream_end_tx_digest(object_id, version, epoch_id)
             .expect("storage access failed")
     }
 

--- a/crates/iota-core/src/transaction_input_loader.rs
+++ b/crates/iota-core/src/transaction_input_loader.rs
@@ -67,27 +67,28 @@ impl TransactionInputLoader {
                         object: ObjectReadResultKind::Object(package),
                     });
                 }
-                InputObjectKind::SharedMoveObject { id, .. } => match self
-                    .cache
-                    .try_get_object(id)?
-                {
-                    Some(object) => {
-                        input_results[i] = Some(ObjectReadResult::new(*kind, object.into()))
-                    }
-                    None => {
-                        if let Some((version, digest)) = self
-                            .cache
-                            .try_get_last_shared_object_deletion_info(id, epoch_id)?
-                        {
-                            input_results[i] = Some(ObjectReadResult {
-                                input_object_kind: *kind,
-                                object: ObjectReadResultKind::DeletedSharedObject(version, digest),
-                            });
-                        } else {
-                            return Err(IotaError::from(kind.object_not_found_error()));
+                InputObjectKind::SharedMoveObject { id, .. } => {
+                    match self.cache.try_get_object(id)? {
+                        Some(object) => {
+                            input_results[i] = Some(ObjectReadResult::new(*kind, object.into()))
+                        }
+                        None => {
+                            if let Some((version, digest)) = self
+                                .cache
+                                .try_get_last_consensus_stream_end_info(id, epoch_id)?
+                            {
+                                input_results[i] = Some(ObjectReadResult {
+                                    input_object_kind: *kind,
+                                    object: ObjectReadResultKind::ObjectConsensusStreamEnded(
+                                        version, digest,
+                                    ),
+                                });
+                            } else {
+                                return Err(IotaError::from(kind.object_not_found_error()));
+                            }
                         }
                     }
-                },
+                }
                 InputObjectKind::ImmOrOwnedMoveObject(objref) => {
                     object_refs.push(*objref);
                     fetch_indices.push(i);
@@ -225,15 +226,17 @@ impl TransactionInputLoader {
                 },
                 (None, InputObjectKind::SharedMoveObject { id, .. }) => {
                     assert!(key.1.is_valid());
-                    // Check if the object was deleted by a concurrently certified tx
+                    // Check if the object was removed from consensus by a concurrently certified tx
                     let version = key.1;
                     if let Some(dependency) = self
                         .cache
-                        .try_get_deleted_shared_object_previous_tx_digest(id, version, epoch_id)?
+                        .try_get_consensus_stream_end_tx_digest(id, version, epoch_id)?
                     {
                         ObjectReadResult {
                             input_object_kind: *input,
-                            object: ObjectReadResultKind::DeletedSharedObject(version, dependency),
+                            object: ObjectReadResultKind::ObjectConsensusStreamEnded(
+                                version, dependency,
+                            ),
                         }
                     } else {
                         panic!(

--- a/crates/iota-core/src/transaction_outputs.rs
+++ b/crates/iota-core/src/transaction_outputs.rs
@@ -75,25 +75,25 @@ impl TransactionOutputs {
                     .get(&object_id)
                     .is_some_and(|object| object.is_shared())
                 {
-                    (object_key, MarkerValue::SharedDeleted(tx_digest))
+                    (object_key, MarkerValue::ConsensusStreamEnded(tx_digest))
                 } else {
                     (object_key, MarkerValue::OwnedDeleted)
                 }
             });
 
-            // We "smear" shared deleted objects in the marker table to allow for proper
-            // sequencing of transactions that are submitted after the deletion
-            // of the shared object. NB: that we do _not_ smear shared objects
+            // We "smear" removed consensus objects in the marker table to allow for proper
+            // sequencing of transactions that are submitted after the consensus stream
+            // ends. NB: that we do _not_ smear shared objects
             // that were taken immutably in the transaction.
-            let smeared_objects = effects.deleted_mutably_accessed_shared_objects();
-            let shared_smears = smeared_objects.into_iter().map(move |object_id| {
+            let smeared_objects = effects.stream_ended_mutably_accessed_consensus_objects();
+            let consensus_smears = smeared_objects.into_iter().map(move |object_id| {
                 (
                     ObjectKey(object_id, lamport_version),
-                    MarkerValue::SharedDeleted(tx_digest),
+                    MarkerValue::ConsensusStreamEnded(tx_digest),
                 )
             });
 
-            received.chain(deleted).chain(shared_smears).collect()
+            received.chain(deleted).chain(consensus_smears).collect()
         };
 
         let live_object_markers_to_delete: Vec<_> = mutable_inputs

--- a/crates/iota-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/iota-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -559,7 +559,7 @@ impl TestRunner {
     ) -> Option<TransactionDigest> {
         self.authority_state
             .get_object_cache_reader()
-            .get_deleted_shared_object_previous_tx_digest(object_id, *version, epoch)
+            .get_consensus_stream_end_tx_digest(object_id, *version, epoch)
     }
 }
 

--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -1150,11 +1150,11 @@ UnchangedSharedKind:
             - TYPENAME: SequenceNumber
             - TYPENAME: ObjectDigest
     1:
-      MutateDeleted:
+      MutateConsensusStreamEnded:
         NEWTYPE:
           TYPENAME: SequenceNumber
     2:
-      ReadDeleted:
+      ReadConsensusStreamEnded:
         NEWTYPE:
           TYPENAME: SequenceNumber
     3:

--- a/crates/iota-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/iota-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -14,6 +14,7 @@ use crate::types::{iota_address::IotaAddress, object_read::ObjectRead, uint53::U
 #[derive(Union)]
 pub(crate) enum UnchangedSharedObject {
     Read(SharedObjectRead),
+    // TODO: Update `Delete` to `ConsensusStreamEnded` to account for ConsensusV2 objects.
     Delete(SharedObjectDelete),
     Cancelled(SharedObjectCancelled),
 }
@@ -74,13 +75,13 @@ impl UnchangedSharedObject {
                 },
             })),
 
-            I::ReadDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {
+            I::ReadConsensusStreamEnded(id, v) => Ok(U::Delete(SharedObjectDelete {
                 address: id.into(),
                 version: v.value().into(),
                 mutable: false,
             })),
 
-            I::MutateDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {
+            I::MutateConsensusStreamEnded(id, v) => Ok(U::Delete(SharedObjectDelete {
                 address: id.into(),
                 version: v.value().into(),
                 mutable: true,

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -1062,7 +1062,10 @@ impl<T: TransactionEffectsAPI> From<T> for IotaTransactionBlockEffectsV1 {
                 native
                     .input_shared_objects()
                     .into_iter()
-                    .map(|kind| kind.object_ref())
+                    .map(|kind| {
+                        #[allow(deprecated)]
+                        kind.object_ref()
+                    })
                     .collect(),
             ),
             transaction_digest: *native.transaction_digest(),

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -1779,7 +1779,7 @@ impl LocalExec {
                     let (digest, version) = deleted_shared_info_map.get(id).unwrap();
                     Some(ObjectReadResult::new(
                         *kind,
-                        ObjectReadResultKind::DeletedSharedObject(*version, *digest),
+                        ObjectReadResultKind::ObjectConsensusStreamEnded(*version, *digest),
                     ))
                 }
             })

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -528,8 +528,8 @@ mod checked {
                         system_transaction,
                     )?;
                 }
-                // We skip checking a deleted shared object because it no longer exists
-                ObjectReadResultKind::DeletedSharedObject(_, _) => (),
+                // We skip checking a removed consensus object because it no longer exists.
+                ObjectReadResultKind::ObjectConsensusStreamEnded(_, _) => (),
                 // We skip checking shared objects from cancelled transactions since we are not
                 // reading it.
                 ObjectReadResultKind::CancelledTransactionSharedObject(_) => (),
@@ -697,7 +697,7 @@ mod checked {
                     check_one_move_authenticator_object(input_object_kind, object)?;
                 }
                 // We skip checking a deleted shared object because it no longer exists.
-                ObjectReadResultKind::DeletedSharedObject(_, _) => (),
+                ObjectReadResultKind::ObjectConsensusStreamEnded(_, _) => (),
                 // We skip checking shared objects from cancelled transactions since we are not
                 // reading it.
                 ObjectReadResultKind::CancelledTransactionSharedObject(_) => (),

--- a/crates/iota-types/src/effects/effects_v1.rs
+++ b/crates/iota-types/src/effects/effects_v1.rs
@@ -125,11 +125,11 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
                         UnchangedSharedKind::ReadOnlyRoot((version, digest)) => {
                             Some(InputSharedObject::ReadOnly((*id, *version, *digest)))
                         }
-                        UnchangedSharedKind::MutateDeleted(seqno) => {
-                            Some(InputSharedObject::MutateDeleted(*id, *seqno))
+                        UnchangedSharedKind::MutateConsensusStreamEnded(seqno) => {
+                            Some(InputSharedObject::MutateConsensusStreamEnded(*id, *seqno))
                         }
-                        UnchangedSharedKind::ReadDeleted(seqno) => {
-                            Some(InputSharedObject::ReadDeleted(*id, *seqno))
+                        UnchangedSharedKind::ReadConsensusStreamEnded(seqno) => {
+                            Some(InputSharedObject::ReadConsensusStreamEnded(*id, *seqno))
                         }
                         UnchangedSharedKind::Cancelled(seqno) => {
                             Some(InputSharedObject::Cancelled(*id, *seqno))
@@ -372,12 +372,15 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
                 obj_ref.0,
                 UnchangedSharedKind::ReadOnlyRoot((obj_ref.1, obj_ref.2)),
             )),
-            InputSharedObject::ReadDeleted(obj_id, seqno) => self
+            InputSharedObject::ReadConsensusStreamEnded(obj_id, seqno) => self
                 .unchanged_shared_objects
-                .push((obj_id, UnchangedSharedKind::ReadDeleted(seqno))),
-            InputSharedObject::MutateDeleted(obj_id, seqno) => self
-                .unchanged_shared_objects
-                .push((obj_id, UnchangedSharedKind::MutateDeleted(seqno))),
+                .push((obj_id, UnchangedSharedKind::ReadConsensusStreamEnded(seqno))),
+            InputSharedObject::MutateConsensusStreamEnded(obj_id, seqno) => {
+                self.unchanged_shared_objects.push((
+                    obj_id,
+                    UnchangedSharedKind::MutateConsensusStreamEnded(seqno),
+                ))
+            }
             InputSharedObject::Cancelled(obj_id, seqno) => self
                 .unchanged_shared_objects
                 .push((obj_id, UnchangedSharedKind::Cancelled(seqno))),
@@ -440,12 +443,12 @@ impl TransactionEffectsV1 {
                         Some((id, UnchangedSharedKind::ReadOnlyRoot((version, digest))))
                     }
                 }
-                SharedInput::Deleted((id, version, mutable, _)) => {
+                SharedInput::ConsensusStreamEnded((id, version, mutable, _)) => {
                     debug_assert!(!changed_objects.contains_key(&id));
                     if mutable {
-                        Some((id, UnchangedSharedKind::MutateDeleted(version)))
+                        Some((id, UnchangedSharedKind::MutateConsensusStreamEnded(version)))
                     } else {
-                        Some((id, UnchangedSharedKind::ReadDeleted(version)))
+                        Some((id, UnchangedSharedKind::ReadConsensusStreamEnded(version)))
                     }
                 }
                 SharedInput::Cancelled((id, version)) => {
@@ -612,10 +615,12 @@ pub enum UnchangedSharedKind {
     /// ObjectDigest for protocol correctness, but it will make it easier to
     /// verify untrusted read.
     ReadOnlyRoot(VersionDigest),
-    /// Deleted shared objects that appear mutably/owned in the input.
-    MutateDeleted(SequenceNumber),
-    /// Deleted shared objects that appear as read-only in the input.
-    ReadDeleted(SequenceNumber),
+    /// Consensus stream ended shared objects that appear mutably/owned in the
+    /// input.
+    MutateConsensusStreamEnded(SequenceNumber),
+    /// Consensus stream ended shared objects that appear as read-only in the
+    /// input.
+    ReadConsensusStreamEnded(SequenceNumber),
     /// Shared objects in cancelled transaction. The sequence number embed
     /// cancellation reason.
     Cancelled(SequenceNumber),

--- a/crates/iota-types/src/effects/mod.rs
+++ b/crates/iota-types/src/effects/mod.rs
@@ -223,11 +223,10 @@ impl TransactionEffects {
             .map(|(r, _)| r)
             .chain(self.mutated().into_iter().map(|(r, _)| r))
             .chain(self.unwrapped().into_iter().map(|(r, _)| r))
-            .chain(
-                self.input_shared_objects()
-                    .into_iter()
-                    .map(|r| r.object_ref()),
-            )
+            .chain(self.input_shared_objects().into_iter().map(|r| {
+                #[allow(deprecated)]
+                r.object_ref()
+            }))
             .chain(self.deleted())
             .chain(self.unwrapped_then_deleted())
             .chain(self.wrapped())
@@ -254,22 +253,29 @@ impl TransactionEffects {
 pub enum InputSharedObject {
     Mutate(ObjectRef),
     ReadOnly(ObjectRef),
-    ReadDeleted(ObjectID, SequenceNumber),
-    MutateDeleted(ObjectID, SequenceNumber),
+    ReadConsensusStreamEnded(ObjectID, SequenceNumber),
+    MutateConsensusStreamEnded(ObjectID, SequenceNumber),
     Cancelled(ObjectID, SequenceNumber),
 }
 
 impl InputSharedObject {
     pub fn id_and_version(&self) -> (ObjectID, SequenceNumber) {
-        let oref = self.object_ref();
-        (oref.0, oref.1)
+        match self {
+            InputSharedObject::Mutate(oref) | InputSharedObject::ReadOnly(oref) => (oref.0, oref.1),
+            InputSharedObject::ReadConsensusStreamEnded(id, version)
+            | InputSharedObject::MutateConsensusStreamEnded(id, version) => (*id, *version),
+            InputSharedObject::Cancelled(id, version) => (*id, *version),
+        }
     }
 
+    // NOTE: When `ObjectDigest::OBJECT_DIGEST_DELETED` is returned, the object's
+    // consensus stream has ended, but it may not be deleted.
+    #[deprecated]
     pub fn object_ref(&self) -> ObjectRef {
         match self {
             InputSharedObject::Mutate(oref) | InputSharedObject::ReadOnly(oref) => *oref,
-            InputSharedObject::ReadDeleted(id, version)
-            | InputSharedObject::MutateDeleted(id, version) => {
+            InputSharedObject::ReadConsensusStreamEnded(id, version)
+            | InputSharedObject::MutateConsensusStreamEnded(id, version) => {
                 (*id, *version, ObjectDigest::OBJECT_DIGEST_DELETED)
             }
             InputSharedObject::Cancelled(id, version) => {
@@ -323,14 +329,14 @@ pub trait TransactionEffectsAPI {
 
     fn gas_cost_summary(&self) -> &GasCostSummary;
 
-    fn deleted_mutably_accessed_shared_objects(&self) -> Vec<ObjectID> {
+    fn stream_ended_mutably_accessed_consensus_objects(&self) -> Vec<ObjectID> {
         self.input_shared_objects()
             .into_iter()
             .filter_map(|kind| match kind {
-                InputSharedObject::MutateDeleted(id, _) => Some(id),
+                InputSharedObject::MutateConsensusStreamEnded(id, _) => Some(id),
                 InputSharedObject::Mutate(..)
                 | InputSharedObject::ReadOnly(..)
-                | InputSharedObject::ReadDeleted(..)
+                | InputSharedObject::ReadConsensusStreamEnded(..)
                 | InputSharedObject::Cancelled(..) => None,
             })
             .collect()

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -18,25 +18,25 @@ use crate::{
     transaction::Argument,
 };
 
-/// A type containing all of the information needed to work with a deleted
-/// shared object in execution and when committing the execution effects of the
-/// transaction. This holds:
-/// 0. The object ID of the deleted shared object.
-/// 1. The version of the shared object.
+/// A type containing all of the information needed to work in execution with an
+/// object whose consensus stream is ended, and when committing the execution
+/// effects of the transaction. This holds:
+/// 0. The object ID.
+/// 1. The version.
 /// 2. Whether the object appeared as mutable (or owned) in the transaction, or
-///    as a read-only shared object.
-/// 3. The transaction digest of the previous transaction that used this shared
-///    object mutably or took it by value.
-pub type DeletedSharedObjectInfo = (ObjectID, SequenceNumber, bool, TransactionDigest);
+///    as read-only.
+/// 3. The transaction digest of the previous transaction that used this object
+///    mutably or took it by value.
+pub type ConsensusStreamEndedInfo = (ObjectID, SequenceNumber, bool, TransactionDigest);
 
-/// A sequence of information about deleted shared objects in the transaction's
-/// inputs.
-pub type DeletedSharedObjects = Vec<DeletedSharedObjectInfo>;
+/// A sequence of information about removed consensus objects in the
+/// transaction's inputs.
+pub type ConsensusStreamEndedObjects = Vec<ConsensusStreamEndedInfo>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SharedInput {
     Existing(ObjectRef),
-    Deleted(DeletedSharedObjectInfo),
+    ConsensusStreamEnded(ConsensusStreamEndedInfo),
     Cancelled((ObjectID, SequenceNumber)),
 }
 

--- a/crates/iota-types/src/inner_temporary_store.rs
+++ b/crates/iota-types/src/inner_temporary_store.rs
@@ -75,11 +75,11 @@ impl InnerTemporaryStore {
             });
         output_keys.extend(deleted_output_keys);
 
-        // For any previously deleted shared objects that appeared mutably in the
+        // For any consensus stream ended objects that appeared mutably in the
         // transaction, synthesize a notification for the next version of the
         // object.
         let smeared_version = self.lamport_version;
-        let deleted_accessed_objects = effects.deleted_mutably_accessed_shared_objects();
+        let deleted_accessed_objects = effects.stream_ended_mutably_accessed_consensus_objects();
         for object_id in deleted_accessed_objects.into_iter() {
             let key = InputKey::VersionedObject {
                 id: object_id,

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -1004,12 +1004,12 @@ impl TryFrom<crate::effects::TransactionEffects> for TransactionEffects {
                                     version: version.value(),
                                     digest: digest.into(),
                                 },
-                                crate::effects::UnchangedSharedKind::MutateDeleted(
+                                crate::effects::UnchangedSharedKind::MutateConsensusStreamEnded(
                                     sequence_number,
                                 ) => UnchangedSharedKind::MutateDeleted {
                                     version: sequence_number.value(),
                                 },
-                                crate::effects::UnchangedSharedKind::ReadDeleted(
+                                crate::effects::UnchangedSharedKind::ReadConsensusStreamEnded(
                                     sequence_number,
                                 ) => UnchangedSharedKind::ReadDeleted {
                                     version: sequence_number.value(),
@@ -1125,12 +1125,12 @@ impl TryFrom<TransactionEffects> for crate::effects::TransactionEffects {
                                             ))
                                         }
                                         UnchangedSharedKind::MutateDeleted { version } => {
-                                            crate::effects::UnchangedSharedKind::MutateDeleted(
+                                            crate::effects::UnchangedSharedKind::MutateConsensusStreamEnded(
                                                 version.into(),
                                             )
                                         }
                                         UnchangedSharedKind::ReadDeleted { version } => {
-                                            crate::effects::UnchangedSharedKind::ReadDeleted(
+                                            crate::effects::UnchangedSharedKind::ReadConsensusStreamEnded(
                                                 version.into(),
                                             )
                                         }
@@ -2498,8 +2498,12 @@ impl From<UnchangedSharedKind> for crate::effects::UnchangedSharedKind {
             UnchangedSharedKind::ReadOnlyRoot { version, digest } => {
                 Self::ReadOnlyRoot((version.into(), digest.into()))
             }
-            UnchangedSharedKind::MutateDeleted { version } => Self::MutateDeleted(version.into()),
-            UnchangedSharedKind::ReadDeleted { version } => Self::ReadDeleted(version.into()),
+            UnchangedSharedKind::MutateDeleted { version } => {
+                Self::MutateConsensusStreamEnded(version.into())
+            }
+            UnchangedSharedKind::ReadDeleted { version } => {
+                Self::ReadConsensusStreamEnded(version.into())
+            }
             UnchangedSharedKind::Cancelled { version } => Self::Cancelled(version.into()),
             UnchangedSharedKind::PerEpochConfig => Self::PerEpochConfig,
             _ => unreachable!("a new enum variant was added and needs to be handled"),
@@ -2516,12 +2520,16 @@ impl From<crate::effects::UnchangedSharedKind> for UnchangedSharedKind {
                     digest: digest.into(),
                 }
             }
-            crate::effects::UnchangedSharedKind::MutateDeleted(version) => Self::MutateDeleted {
-                version: version.into(),
-            },
-            crate::effects::UnchangedSharedKind::ReadDeleted(version) => Self::ReadDeleted {
-                version: version.into(),
-            },
+            crate::effects::UnchangedSharedKind::MutateConsensusStreamEnded(version) => {
+                Self::MutateDeleted {
+                    version: version.into(),
+                }
+            }
+            crate::effects::UnchangedSharedKind::ReadConsensusStreamEnded(version) => {
+                Self::ReadDeleted {
+                    version: version.into(),
+                }
+            }
             crate::effects::UnchangedSharedKind::Cancelled(version) => Self::Cancelled {
                 version: version.into(),
             },

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -122,9 +122,10 @@ pub enum MarkerValue {
     /// An owned object was deleted (or wrapped) at the given version, and is no
     /// longer able to be accessed or used in subsequent transactions.
     OwnedDeleted,
-    /// A shared object was deleted by the transaction and is no longer able to
-    /// be accessed or used in subsequent transactions.
-    SharedDeleted(TransactionDigest),
+    /// A consensus object was deleted or removed from consensus by the
+    /// transaction and is no longer able to be accessed or used in
+    /// subsequent transactions with the same initial shared version.
+    ConsensusStreamEnded(TransactionDigest),
 }
 
 /// DeleteKind together with the old sequence number prior to the deletion, if

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -3379,8 +3379,8 @@ pub struct ObjectReadResult {
 pub enum ObjectReadResultKind {
     Object(Object),
     // The version of the object that the transaction intended to read, and the digest of the tx
-    // that deleted it.
-    DeletedSharedObject(SequenceNumber, TransactionDigest),
+    // that removed it from consensus.
+    ObjectConsensusStreamEnded(SequenceNumber, TransactionDigest),
     // A shared object in a cancelled transaction. The sequence number embeds cancellation reason.
     CancelledTransactionSharedObject(SequenceNumber),
 }
@@ -3391,8 +3391,8 @@ impl std::fmt::Debug for ObjectReadResultKind {
             ObjectReadResultKind::Object(obj) => {
                 write!(f, "Object({:?})", obj.compute_object_reference())
             }
-            ObjectReadResultKind::DeletedSharedObject(seq, digest) => {
-                write!(f, "DeletedSharedObject({seq}, {digest:?})")
+            ObjectReadResultKind::ObjectConsensusStreamEnded(seq, digest) => {
+                write!(f, "ObjectConsensusStreamEnded({seq}, {digest:?})")
             }
             ObjectReadResultKind::CancelledTransactionSharedObject(seq) => {
                 write!(f, "CancelledTransactionSharedObject({seq})")
@@ -3411,10 +3411,10 @@ impl ObjectReadResult {
     pub fn new(input_object_kind: InputObjectKind, object: ObjectReadResultKind) -> Self {
         if let (
             InputObjectKind::ImmOrOwnedMoveObject(_),
-            ObjectReadResultKind::DeletedSharedObject(_, _),
+            ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
         ) = (&input_object_kind, &object)
         {
-            panic!("only shared objects can be DeletedSharedObject");
+            panic!("only consensus objects can be ObjectConsensusStreamEnded");
         }
 
         if let (
@@ -3422,7 +3422,7 @@ impl ObjectReadResult {
             ObjectReadResultKind::CancelledTransactionSharedObject(_),
         ) = (&input_object_kind, &object)
         {
-            panic!("only shared objects can be CancelledTransactionSharedObject");
+            panic!("only consensus objects can be CancelledTransactionSharedObject");
         }
 
         Self {
@@ -3438,7 +3438,7 @@ impl ObjectReadResult {
     pub fn as_object(&self) -> Option<&Object> {
         match &self.object {
             ObjectReadResultKind::Object(object) => Some(object),
-            ObjectReadResultKind::DeletedSharedObject(_, _) => None,
+            ObjectReadResultKind::ObjectConsensusStreamEnded(_, _) => None,
             ObjectReadResultKind::CancelledTransactionSharedObject(_) => None,
         }
     }
@@ -3459,7 +3459,7 @@ impl ObjectReadResult {
             }
             (
                 InputObjectKind::ImmOrOwnedMoveObject(_),
-                ObjectReadResultKind::DeletedSharedObject(_, _),
+                ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
             ) => unreachable!(),
             (
                 InputObjectKind::ImmOrOwnedMoveObject(_),
@@ -3473,13 +3473,13 @@ impl ObjectReadResult {
         self.input_object_kind.is_shared_object()
     }
 
-    pub fn is_deleted_shared_object(&self) -> bool {
-        self.deletion_info().is_some()
+    pub fn is_consensus_stream_ended(&self) -> bool {
+        self.consensus_stream_end_info().is_some()
     }
 
-    pub fn deletion_info(&self) -> Option<(SequenceNumber, TransactionDigest)> {
+    pub fn consensus_stream_end_info(&self) -> Option<(SequenceNumber, TransactionDigest)> {
         match &self.object {
-            ObjectReadResultKind::DeletedSharedObject(v, tx) => Some((*v, *tx)),
+            ObjectReadResultKind::ObjectConsensusStreamEnded(v, tx) => Some((*v, *tx)),
             _ => None,
         }
     }
@@ -3501,7 +3501,7 @@ impl ObjectReadResult {
             }
             (
                 InputObjectKind::ImmOrOwnedMoveObject(_),
-                ObjectReadResultKind::DeletedSharedObject(_, _),
+                ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
             ) => unreachable!(),
             (
                 InputObjectKind::ImmOrOwnedMoveObject(_),
@@ -3523,8 +3523,8 @@ impl ObjectReadResult {
                 ObjectReadResultKind::Object(obj) => {
                     SharedInput::Existing(obj.compute_object_reference())
                 }
-                ObjectReadResultKind::DeletedSharedObject(seq, digest) => {
-                    SharedInput::Deleted((id, *seq, mutable, *digest))
+                ObjectReadResultKind::ObjectConsensusStreamEnded(seq, digest) => {
+                    SharedInput::ConsensusStreamEnded((id, *seq, mutable, *digest))
                 }
                 ObjectReadResultKind::CancelledTransactionSharedObject(seq) => {
                     SharedInput::Cancelled((id, *seq))
@@ -3536,7 +3536,7 @@ impl ObjectReadResult {
     pub fn get_previous_transaction(&self) -> Option<TransactionDigest> {
         match &self.object {
             ObjectReadResultKind::Object(obj) => Some(obj.previous_transaction),
-            ObjectReadResultKind::DeletedSharedObject(_, digest) => Some(*digest),
+            ObjectReadResultKind::ObjectConsensusStreamEnded(_, digest) => Some(*digest),
             ObjectReadResultKind::CancelledTransactionSharedObject(_) => None,
         }
     }
@@ -3606,10 +3606,10 @@ impl InputObjects {
         self.objects.is_empty()
     }
 
-    pub fn contains_deleted_objects(&self) -> bool {
+    pub fn contains_consensus_stream_ended_objects(&self) -> bool {
         self.objects
             .iter()
-            .any(|obj| obj.is_deleted_shared_object())
+            .any(|obj| obj.is_consensus_stream_ended())
     }
 
     // Returns IDs of objects responsible for a transaction being cancelled, and the
@@ -3696,13 +3696,13 @@ impl InputObjects {
                     }
                     (
                         InputObjectKind::ImmOrOwnedMoveObject(_),
-                        ObjectReadResultKind::DeletedSharedObject(_, _),
+                        ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
                     ) => {
                         unreachable!()
                     }
                     (
                         InputObjectKind::SharedMoveObject { .. },
-                        ObjectReadResultKind::DeletedSharedObject(_, _),
+                        ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
                     ) => None,
                     (
                         InputObjectKind::SharedMoveObject { mutable, .. },
@@ -3741,7 +3741,7 @@ impl InputObjects {
                 ObjectReadResultKind::Object(object) => {
                     object.data.try_as_move().map(MoveObject::version)
                 }
-                ObjectReadResultKind::DeletedSharedObject(v, _) => Some(*v),
+                ObjectReadResultKind::ObjectConsensusStreamEnded(v, _) => Some(*v),
                 ObjectReadResultKind::CancelledTransactionSharedObject(_) => None,
             })
             .chain(receiving_objects.iter().map(|object_ref| object_ref.1));

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -122,7 +122,7 @@ mod checked {
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
         let transaction_dependencies = input_objects.transaction_dependencies();
-        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let contains_stream_ended_input = input_objects.contains_consensus_stream_ended_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
 
         let temporary_store = TemporaryStore::new(
@@ -151,7 +151,7 @@ mod checked {
             &mutable_inputs,
             shared_object_refs,
             transaction_dependencies,
-            contains_deleted_input,
+            contains_stream_ended_input,
             cancelled_objects,
             transaction_kind,
             transaction_signer,
@@ -177,7 +177,7 @@ mod checked {
         mutable_inputs: &HashSet<ObjectID>,
         shared_object_refs: Vec<SharedInput>,
         mut transaction_dependencies: BTreeSet<TransactionDigest>,
-        contains_deleted_input: bool,
+        contains_stream_ended_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         transaction_kind: TransactionKind,
         transaction_signer: IotaAddress,
@@ -214,7 +214,7 @@ mod checked {
             metrics,
             enable_expensive_checks,
             deny_cert,
-            contains_deleted_input,
+            contains_stream_ended_input,
             cancelled_objects,
             trace_builder_opt,
             pre_execution_result_opt,
@@ -341,7 +341,7 @@ mod checked {
         let transaction_dependencies = input_objects.transaction_dependencies();
         // Deleted and cancelled objects come from both authentication and transaction
         // inputs
-        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let contains_stream_ended_input = input_objects.contains_consensus_stream_ended_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
 
         // Prepare the temporary store.
@@ -417,7 +417,7 @@ mod checked {
             &mutable_inputs,
             shared_object_refs,
             transaction_dependencies,
-            contains_deleted_input,
+            contains_stream_ended_input,
             cancelled_objects,
             transaction_kind,
             transaction_signer,
@@ -558,7 +558,8 @@ mod checked {
             "No receiving inputs are allowed"
         );
 
-        let contains_deleted_input = authenticator_input_objects.contains_deleted_objects();
+        let contains_stream_ended_input =
+            authenticator_input_objects.contains_consensus_stream_ended_objects();
         let cancelled_objects = authenticator_input_objects.get_cancelled_objects();
 
         // Prepare the authentication context.
@@ -586,7 +587,7 @@ mod checked {
             protocol_config,
             metrics.clone(),
             false,
-            contains_deleted_input,
+            contains_stream_ended_input,
             cancelled_objects,
             trace_builder_opt,
         );
@@ -630,7 +631,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         deny_cert: bool,
-        contains_deleted_input: bool,
+        contains_stream_ended_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> Result<<execution_mode::Authentication as ExecutionMode>::ExecutionResults, ExecutionError>
@@ -646,7 +647,7 @@ mod checked {
         run_inputs_checks(
             protocol_config,
             deny_cert,
-            contains_deleted_input,
+            contains_stream_ended_input,
             cancelled_objects,
         )
         .and_then(|()| {
@@ -727,7 +728,7 @@ mod checked {
         metrics: Arc<LimitsMetrics>,
         enable_expensive_checks: bool,
         deny_cert: bool,
-        contains_deleted_input: bool,
+        contains_stream_ended_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         pre_execution_result_opt: Option<
@@ -762,7 +763,7 @@ mod checked {
             run_inputs_checks(
                 protocol_config,
                 deny_cert,
-                contains_deleted_input,
+                contains_stream_ended_input,
                 cancelled_objects,
             )?;
 
@@ -979,7 +980,7 @@ mod checked {
     fn run_inputs_checks(
         protocol_config: &ProtocolConfig,
         deny_cert: bool,
-        contains_deleted_input: bool,
+        contains_stream_ended_input: bool,
         cancelled_objects: Option<(Vec<ObjectID>, SequenceNumber)>,
     ) -> Result<(), ExecutionError> {
         if deny_cert {
@@ -987,7 +988,7 @@ mod checked {
                 ExecutionErrorKind::CertificateDenied,
                 None,
             ))
-        } else if contains_deleted_input {
+        } else if contains_stream_ended_input {
             Err(ExecutionError::new(
                 ExecutionErrorKind::InputObjectDeleted,
                 None,


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@43a5eba](https://github.com/MystenLabs/sui/commit/43a5ebab73f053e9de08d358fbf5d7ca455c24bd)
- Description:

These are now referred to as "consensus stream ended" (or similar).
ConsensusV2 objects may be removed from consensus without being deleted.

Note:
- GraphQL RPC updates are left for a future PR.
- Actual implementation of marker table writes when a ConsensusV2 object
is transferred to a different owner type is left for a future PR.


## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes