### PR TITLE
upstream(core): Remove checkpoint_input_objects

### DIFF
--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -2,13 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
 use crate::{
-    base_types::{ObjectID, ObjectRef},
+    base_types::ObjectRef,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     iota_system_state::{IotaSystemStateTrait, get_iota_system_state},
     messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents},
@@ -53,28 +53,6 @@ impl CheckpointData {
             }
         }
         eventually_removed_object_refs.into_values().collect()
-    }
-
-    /// Returns all objects that are used as input to the transactions in the
-    /// checkpoint, and already exist prior to the checkpoint.
-    pub fn checkpoint_input_objects(&self) -> BTreeMap<ObjectID, &Object> {
-        let mut output_objects_seen = HashSet::new();
-        let mut checkpoint_input_objects = BTreeMap::new();
-        for tx in self.transactions.iter() {
-            for obj in tx.input_objects.iter() {
-                let id = obj.id();
-                if output_objects_seen.contains(&id) || checkpoint_input_objects.contains_key(&id) {
-                    continue;
-                }
-                checkpoint_input_objects.insert(id, obj);
-            }
-            for obj in tx.output_objects.iter() {
-                // We want to track input objects that are not output objects
-                // in the previous transactions.
-                output_objects_seen.insert(obj.id());
-            }
-        }
-        checkpoint_input_objects
     }
 
     pub fn all_objects(&self) -> Vec<&Object> {


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@01a7f4b](https://github.com/MystenLabs/sui/commit/01a7f4bb31702da798261ad3fb7ddd164f29995e)
- Description:

Skip all the `alt-indexer` changes and only  remove `checkpoint_input_objects`.


This part is not ported, because they remove it later again:

```
/// Get mutable access to all transactions in the current checkpoint
    pub fn transactions_mut(&mut self) -> &mut Vec<CheckpointTransaction> {
        &mut self.checkpoint_builder.transactions
    }

    /// Get mutable access to a specific transaction by index
    pub fn transaction_mut(&mut self, idx: usize) -> Option<&mut CheckpointTransaction> {
        self.checkpoint_builder.transactions.get_mut(idx)
    }
```

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes