### PR TITLE
upstream(core): Remove unused json_rpc tokio runtime from IotaRuntimes

### DIFF
--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -2,16 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, str::FromStr};
-
 use iota_config::NodeConfig;
-use tap::TapFallible;
 use tokio::runtime::Runtime;
-use tracing::warn;
 
 pub struct IotaRuntimes {
     // Order in this struct is the order in which runtimes are stopped
-    pub json_rpc: Runtime,
     pub iota_node: Runtime,
     pub metrics: Runtime,
 }
@@ -30,25 +25,6 @@ impl IotaRuntimes {
             .build()
             .unwrap();
 
-        let worker_thread = env::var("RPC_WORKER_THREAD")
-            .ok()
-            .and_then(|o| {
-                usize::from_str(&o)
-                    .tap_err(|e| warn!("Cannot parse RPC_WORKER_THREAD to usize: {e}"))
-                    .ok()
-            })
-            .unwrap_or(num_cpus::get() / 2);
-
-        let json_rpc = tokio::runtime::Builder::new_multi_thread()
-            .thread_name("jsonrpc-runtime")
-            .worker_threads(worker_thread)
-            .enable_all()
-            .build()
-            .unwrap();
-        Self {
-            iota_node,
-            metrics,
-            json_rpc,
-        }
+        Self { iota_node, metrics }
     }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -139,7 +139,6 @@ pub use simulator::set_jwk_injector;
 use simulator::*;
 use tap::tap::TapFallible;
 use tokio::{
-    runtime::Handle,
     sync::{Mutex, broadcast, mpsc, watch},
     task::{JoinHandle, JoinSet},
 };
@@ -286,9 +285,8 @@ impl IotaNode {
     pub async fn start(
         config: NodeConfig,
         registry_service: RegistryService,
-        custom_rpc_runtime: Option<Handle>,
     ) -> Result<Arc<IotaNode>> {
-        Self::start_async(config, registry_service, custom_rpc_runtime, "unknown").await
+        Self::start_async(config, registry_service, "unknown").await
     }
 
     /// Starts the JWK (JSON Web Key) updater tasks for the specified node
@@ -433,7 +431,6 @@ impl IotaNode {
     pub async fn start_async(
         config: NodeConfig,
         registry_service: RegistryService,
-        custom_rpc_runtime: Option<Handle>,
         software_version: &'static str,
     ) -> Result<Arc<IotaNode>> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
@@ -841,7 +838,6 @@ impl IotaNode {
             &transaction_orchestrator.clone(),
             &config,
             &prometheus_registry,
-            custom_rpc_runtime,
             software_version,
         )
         .await?;
@@ -2495,7 +2491,6 @@ pub async fn build_http_server(
     transaction_orchestrator: &Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
     config: &NodeConfig,
     prometheus_registry: &Registry,
-    _custom_runtime: Option<Handle>,
     software_version: &'static str,
 ) -> Result<Option<iota_http::ServerHandle>> {
     // Validators do not expose these APIs

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -112,13 +112,12 @@ fn main() {
     // work if it deadlocks.
     let node_once_cell = Arc::new(AsyncOnceCell::<Arc<IotaNode>>::new());
     let node_once_cell_clone = node_once_cell.clone();
-    let rpc_runtime = runtimes.json_rpc.handle().clone();
 
     // let iota-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
     runtimes.iota_node.spawn(async move {
-        match IotaNode::start_async(config, registry_service, Some(rpc_runtime), VERSION).await {
+        match IotaNode::start_async(config, registry_service, VERSION).await {
             Ok(iota_node) => node_once_cell_clone
                 .set(iota_node)
                 .expect("Failed to set node in AsyncOnceCell"),

--- a/crates/iota-swarm/src/memory/container-sim.rs
+++ b/crates/iota-swarm/src/memory/container-sim.rs
@@ -67,9 +67,7 @@ impl Container {
                 let startup_sender = startup_sender.clone();
                 async move {
                     let registry_service = iota_metrics::RegistryService::new(Registry::new());
-                    let server = IotaNode::start(config, registry_service, None)
-                        .await
-                        .unwrap();
+                    let server = IotaNode::start(config, registry_service).await.unwrap();
 
                     startup_sender.send(Arc::downgrade(&server)).ok();
 

--- a/crates/iota-swarm/src/memory/container.rs
+++ b/crates/iota-swarm/src/memory/container.rs
@@ -106,7 +106,7 @@ impl Container {
                     "Started Prometheus HTTP endpoint. To query metrics use\n\tcurl -s http://{}/metrics",
                     config.metrics_address
                 );
-                let server = IotaNode::start(config, registry_service, None).await.unwrap();
+                let server = IotaNode::start(config, registry_service).await.unwrap();
                 // Notify that we've successfully started the node
                 let _ = startup_sender.send(Arc::downgrade(&server));
                 // run until canceled


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@6de0e64](https://github.com/MystenLabs/sui/commit/6de0e644e9ae1d3c9c15a8268cdd4ab437dbd43c)
- Description:

Removes the dedicated `json_rpc` tokio runtime from `IotaRuntimes`. The runtime was originally used to give JSON-RPC its own thread pool (configurable via `RPC_WORKER_THREAD`), but after migrating the JSON-RPC server to Axum it runs on the node's own tokio runtime. The `_custom_runtime` parameter was already marked unused throughout the call chain, so this cleans up the dead code entirely.

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes