### PR TITLE
feat(gRPC): add `filter_checkpoints` flag to skip checkpoints in the stream that don't match the given filters

### DIFF
--- a/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
@@ -97,8 +97,8 @@ use iota_sdk_types::{CheckpointSequenceNumber, Digest};
 use crate::{
     Client, Error,
     api::{
-        CheckpointResponse, GET_CHECKPOINT_READ_MASK, MetadataEnvelope, Result, TryFromProtoError,
-        field_mask_with_default,
+        CheckpointResponse, CheckpointStreamItem, GET_CHECKPOINT_READ_MASK, MetadataEnvelope,
+        Result, TryFromProtoError, field_mask_with_default,
     },
 };
 
@@ -274,11 +274,17 @@ impl Client {
         let reassembled = Self::reassemble_checkpoint_data_stream(stream);
         futures::pin_mut!(reassembled);
 
-        let checkpoint = reassembled
-            .next()
-            .await
-            .ok_or_else(|| TryFromProtoError::missing("checkpoint data").into())
-            .and_then(|r| r)?;
+        // Skip any progress messages and find the first checkpoint
+        let checkpoint = loop {
+            match reassembled.next().await {
+                Some(Ok(CheckpointStreamItem::Checkpoint(cp))) => break *cp,
+                Some(Ok(CheckpointStreamItem::Progress { .. })) => continue,
+                Some(Err(e)) => return Err(e),
+                None => {
+                    return Err(TryFromProtoError::missing("checkpoint data").into());
+                }
+            }
+        };
 
         Ok(MetadataEnvelope::new(checkpoint, metadata))
     }
@@ -286,7 +292,12 @@ impl Client {
     /// Stream checkpoints across a range of checkpoints.
     ///
     /// Returns a stream of [`CheckpointResponse`] objects, each representing
-    /// a complete checkpoint with its transactions and events.
+    /// a complete checkpoint with its transactions and events. Every checkpoint
+    /// in the range is yielded, even if the filters produce no matching
+    /// transactions or events within it.
+    ///
+    /// To skip non-matching checkpoints entirely, use
+    /// [`stream_checkpoints_filtered`](Self::stream_checkpoints_filtered).
     ///
     /// **Note:** The metadata in the returned [`MetadataEnvelope`] is captured
     /// from the initial gRPC response headers when the stream is opened. It is
@@ -332,6 +343,129 @@ impl Client {
         events_filter: Option<grpc_filter::EventFilter>,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointResponse>> + Send>>>>
     {
+        let envelope = self
+            .stream_checkpoints_raw(
+                start_sequence_number,
+                end_sequence_number,
+                read_mask,
+                transactions_filter,
+                events_filter,
+                false,
+                None,
+            )
+            .await?;
+
+        let (stream, metadata) = envelope.into_parts();
+
+        // remove the wrapping CheckpointStreamItem layer since we know
+        // filter_checkpoints is false and thus only Checkpoint items will be produced
+        let filtered = stream.filter_map(|item| async {
+            match item {
+                Ok(CheckpointStreamItem::Checkpoint(cp)) => Some(Ok(*cp)),
+                Ok(CheckpointStreamItem::Progress { .. }) => None,
+                Err(e) => Some(Err(e)),
+            }
+        });
+
+        Ok(MetadataEnvelope::new(Box::pin(filtered), metadata))
+    }
+
+    /// Stream checkpoints, skipping those with no matching data.
+    ///
+    /// Unlike [`stream_checkpoints`](Self::stream_checkpoints), this method
+    /// sets `filter_checkpoints = true` on the server, which means checkpoints
+    /// without any matching transactions or events are skipped entirely.
+    ///
+    /// The returned stream yields [`CheckpointStreamItem`], which is either a
+    /// [`CheckpointStreamItem::Checkpoint`] or a
+    /// [`CheckpointStreamItem::Progress`]. Progress messages are sent
+    /// periodically during scanning to indicate liveness and the current scan
+    /// position (default every 2 seconds, configurable via
+    /// `progress_interval_ms`).
+    ///
+    /// For liveness detection, wrap `stream.next()` in
+    /// `tokio::time::timeout()` — if neither a `Checkpoint` nor a `Progress`
+    /// arrives within your chosen duration plus some buffer for connection
+    /// latency, the connection is likely dead.
+    ///
+    /// At least one of `transactions_filter` or `events_filter` must be set.
+    ///
+    /// # Parameters
+    ///
+    /// * `start_sequence_number` - Optional starting checkpoint. If `None`,
+    ///   starts from the latest checkpoint.
+    /// * `end_sequence_number` - Optional ending checkpoint. If `None`, streams
+    ///   indefinitely.
+    /// * `read_mask` - Optional field mask specifying which fields to include.
+    ///   If `None`, uses [`crate::api::GET_CHECKPOINT_READ_MASK`] as default.
+    ///   See [module-level documentation](crate::api::ledger::checkpoints) for
+    ///   all available fields.
+    /// * `transactions_filter` - Optional filter to apply to transactions
+    /// * `events_filter` - Optional filter to apply to events
+    /// * `progress_interval_ms` - Optional progress message interval in
+    ///   milliseconds. Defaults to 2000ms. Minimum 500ms.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_grpc_client::{Client, CheckpointStreamItem};
+    /// # use futures::StreamExt;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("http://localhost:9000").await?;
+    /// let mut stream = client
+    ///     .stream_checkpoints_filtered(Some(0), None, None, None, None, None)
+    ///     .await?;
+    ///
+    /// while let Some(item) = stream.next().await {
+    ///     match item? {
+    ///         CheckpointStreamItem::Checkpoint(cp) => {
+    ///             println!("Matched checkpoint {}", cp.sequence_number);
+    ///         }
+    ///         CheckpointStreamItem::Progress {
+    ///             latest_scanned_sequence_number,
+    ///         } => {
+    ///             println!("Scanned up to {latest_scanned_sequence_number}");
+    ///         }
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn stream_checkpoints_filtered(
+        &self,
+        start_sequence_number: Option<CheckpointSequenceNumber>,
+        end_sequence_number: Option<CheckpointSequenceNumber>,
+        read_mask: Option<&str>,
+        transactions_filter: Option<grpc_filter::TransactionFilter>,
+        events_filter: Option<grpc_filter::EventFilter>,
+        progress_interval_ms: Option<u32>,
+    ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointStreamItem>> + Send>>>>
+    {
+        self.stream_checkpoints_raw(
+            start_sequence_number,
+            end_sequence_number,
+            read_mask,
+            transactions_filter,
+            events_filter,
+            true,
+            progress_interval_ms,
+        )
+        .await
+    }
+
+    /// Internal helper that builds the stream request and returns the raw
+    /// [`CheckpointStreamItem`] stream.
+    async fn stream_checkpoints_raw(
+        &self,
+        start_sequence_number: Option<CheckpointSequenceNumber>,
+        end_sequence_number: Option<CheckpointSequenceNumber>,
+        read_mask: Option<&str>,
+        transactions_filter: Option<grpc_filter::TransactionFilter>,
+        events_filter: Option<grpc_filter::EventFilter>,
+        filter_checkpoints: bool,
+        progress_interval_ms: Option<u32>,
+    ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointStreamItem>> + Send>>>>
+    {
         let mut request = CheckpointDataStreamRequest::default()
             .with_read_mask(field_mask_with_default(read_mask, GET_CHECKPOINT_READ_MASK));
 
@@ -346,6 +480,12 @@ impl Client {
         }
         if let Some(ef) = events_filter {
             request = request.with_events_filter(ef);
+        }
+        if filter_checkpoints {
+            request = request.with_filter_checkpoints(true);
+        }
+        if let Some(ms) = progress_interval_ms {
+            request = request.with_progress_interval_ms(ms);
         }
         if let Some(max_size) = self.max_decoding_message_size().map(|s| s as u32) {
             request = request.with_max_message_size_bytes(max_size);
@@ -367,13 +507,16 @@ impl Client {
     /// - `Checkpoint` - Contains the checkpoint summary and contents
     /// - `Transactions` - Contains executed transactions
     /// - `Events` - Contains events from transactions
+    /// - `Progress` - Liveness indicator during filtered scanning
     /// - `EndMarker` - Signals the end of one checkpoint's data
     ///
-    /// This function buffers the chunks and yields complete
-    /// [`CheckpointResponse`] objects when an `EndMarker` is received.
+    /// This function buffers the chunks and yields [`CheckpointStreamItem`]
+    /// values: either complete [`CheckpointResponse`] objects when an
+    /// `EndMarker` is received, or [`CheckpointStreamItem::Progress`] when
+    /// a progress message arrives.
     fn reassemble_checkpoint_data_stream<S, E>(
         stream: S,
-    ) -> impl Stream<Item = Result<CheckpointResponse>>
+    ) -> impl Stream<Item = Result<CheckpointStreamItem>>
     where
         S: Stream<
             Item = std::result::Result<iota_grpc_types::v0::ledger_service::CheckpointData, E>,
@@ -463,7 +606,13 @@ impl Client {
                             events: std::mem::take(&mut current_events),
                         };
 
-                        yield response;
+                        yield CheckpointStreamItem::Checkpoint(Box::new(response));
+                    }
+
+                    Some(checkpoint_data::Payload::Progress(progress)) => {
+                        yield CheckpointStreamItem::Progress {
+                            latest_scanned_sequence_number: progress.latest_scanned_sequence_number,
+                        };
                     }
 
                     None => {

--- a/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
@@ -409,14 +409,17 @@ impl Client {
     ///
     /// ```no_run
     /// # use iota_grpc_client::{Client, CheckpointStreamItem};
+    /// # use iota_grpc_types::v0::filter as grpc_filter;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::connect("http://localhost:9000").await?;
+    /// // At least one filter is required
+    /// let tx_filter = grpc_filter::TransactionFilter::default();
     /// let mut stream = client
-    ///     .stream_checkpoints_filtered(Some(0), None, None, None, None, None)
+    ///     .stream_checkpoints_filtered(Some(0), None, None, Some(tx_filter), None, None)
     ///     .await?;
     ///
-    /// while let Some(item) = stream.next().await {
+    /// while let Some(item) = stream.body_mut().next().await {
     ///     match item? {
     ///         CheckpointStreamItem::Checkpoint(cp) => {
     ///             println!("Matched checkpoint {}", cp.sequence_number);

--- a/crates/iota-grpc-client/src/api/mod.rs
+++ b/crates/iota-grpc-client/src/api/mod.rs
@@ -25,6 +25,60 @@ pub use iota_grpc_types::read_masks::{
 };
 pub use metadata::MetadataEnvelope;
 
+/// An item from a checkpoint data stream.
+///
+/// When `filter_checkpoints` is enabled, the server may skip checkpoints that
+/// don't match the provided filters. In that case, `Progress` items are sent
+/// periodically to indicate liveness and the current scan position. When
+/// `filter_checkpoints` is disabled, only `Checkpoint` items are produced.
+///
+/// For liveness detection with `filter_checkpoints`, wrap `stream.next()` in
+/// `tokio::time::timeout()` — if neither a `Checkpoint` nor a `Progress`
+/// arrives within your chosen duration plus some buffer for connection latency,
+/// the connection is likely dead.
+#[derive(Debug, Clone)]
+pub enum CheckpointStreamItem {
+    /// A complete checkpoint with its transactions and events.
+    Checkpoint(Box<CheckpointResponse>),
+    /// A progress indicator sent during filtered scanning.
+    /// Contains the sequence number of the latest scanned checkpoint.
+    Progress {
+        latest_scanned_sequence_number: CheckpointSequenceNumber,
+    },
+}
+
+impl CheckpointStreamItem {
+    /// Returns the contained checkpoint, or `None` if this is a progress
+    /// message.
+    pub fn into_checkpoint(self) -> Option<CheckpointResponse> {
+        match self {
+            Self::Checkpoint(c) => Some(*c),
+            Self::Progress { .. } => None,
+        }
+    }
+
+    /// Returns the progress sequence number, or `None` if this is a
+    /// checkpoint.
+    pub fn into_progress(self) -> Option<CheckpointSequenceNumber> {
+        match self {
+            Self::Checkpoint(_) => None,
+            Self::Progress {
+                latest_scanned_sequence_number,
+            } => Some(latest_scanned_sequence_number),
+        }
+    }
+
+    /// Returns `true` if this is a checkpoint item.
+    pub fn is_checkpoint(&self) -> bool {
+        matches!(self, Self::Checkpoint(_))
+    }
+
+    /// Returns `true` if this is a progress item.
+    pub fn is_progress(&self) -> bool {
+        matches!(self, Self::Progress { .. })
+    }
+}
+
 /// Response for a checkpoint query.
 ///
 /// Contains checkpoint summary, signature, contents, transactions, and events.

--- a/crates/iota-grpc-client/src/lib.rs
+++ b/crates/iota-grpc-client/src/lib.rs
@@ -37,9 +37,9 @@ pub mod api;
 
 // Re-export types for convenience
 pub use api::{
-    CheckpointResponse, EXECUTE_TRANSACTION_READ_MASK, Error, GET_CHECKPOINT_READ_MASK,
-    GET_EPOCH_READ_MASK, GET_OBJECTS_READ_MASK, GET_SERVICE_INFO_READ_MASK,
-    GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, Result, RpcStatus,
+    CheckpointResponse, CheckpointStreamItem, EXECUTE_TRANSACTION_READ_MASK, Error,
+    GET_CHECKPOINT_READ_MASK, GET_EPOCH_READ_MASK, GET_OBJECTS_READ_MASK,
+    GET_SERVICE_INFO_READ_MASK, GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, Result, RpcStatus,
     SIMULATE_TRANSACTION_READ_MASK,
 };
 

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -328,10 +328,17 @@ pub(crate) fn stream_checkpoint_data(
     let start_sequence_number = req.start_sequence_number;
     let end_sequence_number = req.end_sequence_number;
     let client_max_message_size_bytes = req.max_message_size_bytes;
+    let filter_checkpoints = req.filter_checkpoints.unwrap_or(false);
+    let progress_interval =
+        std::time::Duration::from_millis(req.progress_interval_ms.unwrap_or(2000).max(500) as u64);
 
     debug!(
-        "stream_checkpoints called with start={:?}, end={:?}, max_size={:?}",
-        start_sequence_number, end_sequence_number, client_max_message_size_bytes
+        "stream_checkpoints called with start={:?}, end={:?}, max_size={:?}, filter_checkpoints={}, progress_interval={:?}",
+        start_sequence_number,
+        end_sequence_number,
+        client_max_message_size_bytes,
+        filter_checkpoints,
+        progress_interval
     );
 
     let max_message_size_bytes = service
@@ -353,6 +360,24 @@ pub(crate) fn stream_checkpoint_data(
     let (transaction_filter, event_filter) =
         convert_and_validate_filters(req.transactions_filter, req.events_filter)?;
 
+    // Validate filter_checkpoints constraints
+    if filter_checkpoints && transaction_filter.is_none() && event_filter.is_none() {
+        return Err(Status::invalid_argument(
+            "filter_checkpoints requires at least one of transactions_filter or events_filter",
+        )
+        .into());
+    }
+
+    if transaction_filter.is_some() && transactions_mask.is_none() {
+        return Err(Status::invalid_argument(
+            "transactions_filter requires transactions in read_mask",
+        )
+        .into());
+    }
+    if event_filter.is_some() && events_mask.is_none() {
+        return Err(Status::invalid_argument("events_filter requires events in read_mask").into());
+    }
+
     let rx = service.checkpoint_data_broadcaster.subscribe();
     let stream = Box::pin(service.reader.create_checkpoint_data_stream(
         rx,
@@ -365,6 +390,8 @@ pub(crate) fn stream_checkpoint_data(
         service.cancellation_token.clone(),
         transaction_filter,
         event_filter,
+        filter_checkpoints,
+        progress_interval,
     ));
     Ok(stream)
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -284,6 +284,16 @@ pub(crate) fn get_checkpoint_data(
     let (transaction_filter, event_filter) =
         convert_and_validate_filters(req.transactions_filter, req.events_filter)?;
 
+    if transaction_filter.is_some() && transactions_mask.is_none() {
+        return Err(Status::invalid_argument(
+            "transactions_filter requires transactions in read_mask",
+        )
+        .into());
+    }
+    if event_filter.is_some() && events_mask.is_none() {
+        return Err(Status::invalid_argument("events_filter requires events in read_mask").into());
+    }
+
     Ok(service.reader.get_checkpoint_data(
         sequence_number,
         checkpoint_mask,

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -987,16 +987,18 @@ impl GrpcReader {
             *last_msg_time.lock().unwrap() = tokio::time::Instant::now();
             Ok(FilterCheckResult::Matched)
         } else {
-            let elapsed = last_msg_time.lock().unwrap().elapsed();
-            let progress = if elapsed >= progress_interval {
-                *last_msg_time.lock().unwrap() = tokio::time::Instant::now();
-                Some(
-                    grpc_ledger_service::CheckpointData::default().with_progress(
-                        Progress::default().with_latest_scanned_sequence_number(seq),
-                    ),
-                )
-            } else {
-                None
+            let progress = {
+                let mut guard = last_msg_time.lock().unwrap();
+                if guard.elapsed() >= progress_interval {
+                    *guard = tokio::time::Instant::now();
+                    Some(
+                        grpc_ledger_service::CheckpointData::default().with_progress(
+                            Progress::default().with_latest_scanned_sequence_number(seq),
+                        ),
+                    )
+                } else {
+                    None
+                }
             };
             Ok(FilterCheckResult::Skipped(progress))
         }

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -5,6 +5,7 @@ use std::{pin::Pin, sync::Arc};
 
 use anyhow::Result;
 use futures::StreamExt;
+use grpc_ledger_service::checkpoint_data::Progress;
 use iota_grpc_types::{
     field::FieldMaskTree,
     proto::timestamp_ms_to_proto,
@@ -129,6 +130,15 @@ impl GrpcCheckpointDataBroadcaster {
 pub type ObjectsStreamResult = Result<grpc_ledger_service::GetObjectsResponse, Status>;
 pub type TransactionsStreamResult = Result<grpc_ledger_service::GetTransactionsResponse, Status>;
 pub type CheckpointStreamResult = Result<grpc_ledger_service::CheckpointData, Status>;
+
+/// Result of [`GrpcReader::match_checkpoint_filter_or_report_progress`].
+enum FilterCheckResult {
+    /// The checkpoint contains matching data; proceed with full processing.
+    Matched,
+    /// The checkpoint should be skipped, with an optional progress message to
+    /// yield before returning.
+    Skipped(Option<grpc_ledger_service::CheckpointData>),
+}
 
 // Storage abstraction traits for gRPC access
 // These traits provide an abstraction layer over the storage backend,
@@ -910,6 +920,88 @@ impl GrpcReader {
         }
     }
 
+    /// Lightweight check to determine if a checkpoint has any matching data
+    /// without performing full SDK conversion or Merge operations.
+    /// Returns true on first match (OR semantics when both filters are set).
+    async fn has_matching_data<S>(
+        state_reader: Arc<dyn GrpcStateReader>,
+        transaction_stream: S,
+        transaction_filter: &Option<crate::transaction_filter::TransactionFilter>,
+        event_filter: &Option<crate::event_filter::EventFilter>,
+    ) -> Result<bool, Status>
+    where
+        S: futures::Stream<Item = anyhow::Result<IotaTypesCheckpointTransaction>> + Send,
+    {
+        let mut transaction_stream = std::pin::pin!(transaction_stream);
+        while let Some(result) = transaction_stream.next().await {
+            let checkpoint_transaction =
+                result.map_err(|e| Status::internal(format!("failed to read transaction: {e}")))?;
+
+            if let Some(ref tx_filter) = transaction_filter {
+                if tx_filter.matches_transaction(state_reader.clone(), &checkpoint_transaction) {
+                    return Ok(true);
+                }
+            }
+
+            if let Some(ref evt_filter) = event_filter {
+                if let Some(ref tx_events) = checkpoint_transaction.events {
+                    for event in &tx_events.data {
+                        if evt_filter.matches_event(state_reader.clone(), event) {
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// Tests whether any transaction in a checkpoint matches the active
+    /// filters (transaction and/or event).
+    ///
+    /// Returns [`FilterCheckResult::Matched`] if at least one transaction
+    /// matches, signalling that the checkpoint should be fully processed.
+    /// Returns [`FilterCheckResult::Skipped`] otherwise, attaching a
+    /// progress heartbeat when `progress_interval` has elapsed since the
+    /// last emitted message.
+    async fn match_checkpoint_filter_or_report_progress<S>(
+        state_reader: Arc<dyn GrpcStateReader>,
+        transaction_stream: S,
+        transaction_filter: &Option<crate::transaction_filter::TransactionFilter>,
+        event_filter: &Option<crate::event_filter::EventFilter>,
+        last_msg_time: &std::sync::Mutex<tokio::time::Instant>,
+        progress_interval: std::time::Duration,
+        seq: u64,
+    ) -> Result<FilterCheckResult, Status>
+    where
+        S: futures::Stream<Item = anyhow::Result<IotaTypesCheckpointTransaction>> + Send,
+    {
+        if Self::has_matching_data(
+            state_reader.clone(),
+            transaction_stream,
+            transaction_filter,
+            event_filter,
+        )
+        .await?
+        {
+            *last_msg_time.lock().unwrap() = tokio::time::Instant::now();
+            Ok(FilterCheckResult::Matched)
+        } else {
+            let elapsed = last_msg_time.lock().unwrap().elapsed();
+            let progress = if elapsed >= progress_interval {
+                *last_msg_time.lock().unwrap() = tokio::time::Instant::now();
+                Some(
+                    grpc_ledger_service::CheckpointData::default().with_progress(
+                        Progress::default().with_latest_scanned_sequence_number(seq),
+                    ),
+                )
+            } else {
+                None
+            };
+            Ok(FilterCheckResult::Skipped(progress))
+        }
+    }
+
     /// Create a checkpoint stream implementation
     pub fn create_checkpoint_data_stream(
         &self,
@@ -923,9 +1015,15 @@ impl GrpcReader {
         cancellation_token: CancellationToken,
         transaction_filter: Option<crate::transaction_filter::TransactionFilter>,
         event_filter: Option<crate::event_filter::EventFilter>,
+        filter_checkpoints: bool,
+        progress_interval: std::time::Duration,
     ) -> Box<dyn futures::Stream<Item = CheckpointStreamResult> + Send + Unpin> {
         let reader = self.clone();
         let state_reader_clone = self.state_reader.clone();
+
+        // Shared timer for progress messages (used only when filter_checkpoints is
+        // true)
+        let last_message_time = Arc::new(std::sync::Mutex::new(tokio::time::Instant::now()));
 
         // Clone for closures
         let checkpoint_mask_historical = checkpoint_mask.clone();
@@ -953,6 +1051,7 @@ impl GrpcReader {
             // Historical data processor - uses transaction stream from DB
             {
                 let state_reader_historical = state_reader_clone.clone();
+                let last_message_time_historical = last_message_time.clone();
                 move |item: Arc<(CertifiedCheckpointSummary, CheckpointContents)>| {
                     let state_reader_inner = state_reader_historical.clone();
                     let checkpoint_summary = item.0.clone();
@@ -962,8 +1061,36 @@ impl GrpcReader {
                     let ev_mask = events_mask_historical.clone();
                     let tx_filter = transaction_filter_historical.clone();
                     let ev_filter = event_filter_historical.clone();
+                    let last_msg_time = last_message_time_historical.clone();
                     {
                         Box::pin(async_stream::stream! {
+                            let seq = checkpoint_summary.data().sequence_number;
+
+                            // Pass 1: lightweight filter check when filter_checkpoints is enabled
+                            if filter_checkpoints {
+                                let scan_stream = state_reader_inner.stream_checkpoint_transactions(checkpoint_contents.clone());
+                                match Self::match_checkpoint_filter_or_report_progress(
+                                    state_reader_inner.clone(),
+                                    scan_stream,
+                                    &tx_filter,
+                                    &ev_filter,
+                                    &last_msg_time,
+                                    progress_interval,
+                                    seq,
+                                ).await? {
+                                    FilterCheckResult::Matched => {}
+                                    FilterCheckResult::Skipped(progress) => {
+                                        if let Some(msg) = progress {
+                                            yield Ok(msg);
+                                        }
+
+                                        // no filter match, skip processing this checkpoint
+                                        return;
+                                    }
+                                }
+                            }
+
+                            // Pass 2 (or normal mode): full processing
                             let transaction_stream = state_reader_inner.stream_checkpoint_transactions(checkpoint_contents.clone());
                             let mut stream = Box::pin(Self::create_checkpoint_messages_stream(
                                 state_reader_inner.clone(),
@@ -988,6 +1115,7 @@ impl GrpcReader {
             // Live data processor - extracts transactions from CheckpointData
             {
                 let state_reader_live = state_reader_clone.clone();
+                let last_message_time_live = last_message_time;
                 move |item: Arc<IotaTypesCheckpointData>| {
                     let state_reader_inner = state_reader_live.clone();
                     let cp_mask = checkpoint_mask.clone();
@@ -995,28 +1123,62 @@ impl GrpcReader {
                     let ev_mask = events_mask.clone();
                     let tx_filter = transaction_filter.clone();
                     let ev_filter = event_filter.clone();
-                    Box::pin(
-                        {
+                    let last_msg_time = last_message_time_live.clone();
+                    Box::pin(async_stream::stream! {
+                        let seq = *item.checkpoint_summary.sequence_number();
+
+                        // Pass 1: lightweight filter check when filter_checkpoints is enabled
+                        if filter_checkpoints {
                             // Convert the transactions Vec to a stream
-                            let transaction_stream = futures::stream::iter(
+                            let scan_stream = futures::stream::iter(
                                 item.transactions.clone().into_iter().map(Ok)
                             );
-
-                            // Use the unified streaming function
-                            Self::create_checkpoint_messages_stream(
+                            match Self::match_checkpoint_filter_or_report_progress(
                                 state_reader_inner.clone(),
-                                item.checkpoint_summary.clone(),
-                                item.checkpoint_contents.clone(),
-                                transaction_stream,
-                                &cp_mask,
-                                tx_mask,
-                                ev_mask,
-                                max_message_size_bytes as usize,
-                                tx_filter,
-                                ev_filter,
-                            )
+                                scan_stream,
+                                &tx_filter,
+                                &ev_filter,
+                                &last_msg_time,
+                                progress_interval,
+                                seq,
+                            ).await? {
+                                FilterCheckResult::Matched => {}
+                                FilterCheckResult::Skipped(progress) => {
+                                    if let Some(msg) = progress {
+                                        yield Ok(msg);
+                                    }
+
+                                    // no filter match, skip processing this checkpoint
+                                    return;
+                                }
+                            }
                         }
-                    )
+
+                        // Pass 2 (or normal mode): full processing
+
+                        // Convert the transactions Vec to a stream
+                        let transaction_stream = futures::stream::iter(
+                            item.transactions.clone().into_iter().map(Ok)
+                        );
+
+                        // Use the unified streaming function
+                        let mut stream = Box::pin(Self::create_checkpoint_messages_stream(
+                            state_reader_inner.clone(),
+                            item.checkpoint_summary.clone(),
+                            item.checkpoint_contents.clone(),
+                            transaction_stream,
+                            &cp_mask,
+                            tx_mask,
+                            ev_mask,
+                            max_message_size_bytes as usize,
+                            tx_filter,
+                            ev_filter,
+                        ));
+
+                        while let Some(item) = stream.next().await {
+                            yield item;
+                        }
+                    })
                 }
             },
         )))

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -1063,7 +1063,7 @@ async fn test_filter_checkpoints_streaming() {
 
     let mut results = Vec::new();
     tokio::time::timeout(Duration::from_secs(10), async {
-        while let Some(res) = stream.next().await {
+        while let Some(res) = stream.body_mut().next().await {
             match res {
                 Ok(CheckpointStreamItem::Checkpoint(response)) => {
                     results.push(response.sequence_number());
@@ -1117,7 +1117,7 @@ async fn test_filter_checkpoints_streaming() {
 
     let mut results = Vec::new();
     tokio::time::timeout(Duration::from_secs(10), async {
-        while let Some(res) = stream.next().await {
+        while let Some(res) = stream.body_mut().next().await {
             match res {
                 Ok(CheckpointStreamItem::Checkpoint(response)) => {
                     results.push(response.sequence_number());

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -8,11 +8,11 @@ use std::{
 };
 
 use iota_config::{local_ip_utils, node::GrpcApiConfig};
-use iota_grpc_client::Client;
+use iota_grpc_client::{CheckpointStreamItem, Client};
 use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
-    base_types::{ObjectID, random_object_ref},
+    base_types::{IotaAddress, ObjectID, random_object_ref},
     committee::EpochId,
     crypto::{AccountKeyPair, AuthorityStrongQuorumSignInfo, get_key_pair},
     effects::TestEffectsBuilder,
@@ -84,6 +84,31 @@ fn mock_checkpoint_data(sequence_number: u64) -> CheckpointData {
         checkpoint_summary: summary.clone(),
         checkpoint_contents: MOCK_CHECKPOINT_CONTENTS.clone(),
         transactions: vec![],
+    }
+}
+
+/// Create checkpoint data with a transaction from a specific sender.
+fn mock_checkpoint_data_with_sender(
+    sequence_number: u64,
+    sender: IotaAddress,
+    key: &AccountKeyPair,
+) -> CheckpointData {
+    let summary = mock_summary(sequence_number);
+    let gas = random_object_ref();
+    let transaction = TestTransactionBuilder::new(sender, gas, 1000)
+        .transfer(random_object_ref(), sender)
+        .build_and_sign(key);
+    let effects = TestEffectsBuilder::new(transaction.data()).build();
+    CheckpointData {
+        checkpoint_summary: summary,
+        checkpoint_contents: MOCK_CHECKPOINT_CONTENTS.clone(),
+        transactions: vec![CheckpointTransaction {
+            transaction,
+            effects,
+            events: None,
+            input_objects: vec![],
+            output_objects: vec![],
+        }],
     }
 }
 
@@ -946,6 +971,168 @@ async fn test_chunked_checkpoint_streaming() {
     assert_eq!(streamed_summary.epoch, 0);
 
     // Clean up
+    server_handle
+        .shutdown()
+        .await
+        .expect("Failed to shutdown server");
+}
+
+#[tokio::test]
+async fn test_filter_checkpoints_validation() {
+    use iota_grpc_types::v0::filter;
+
+    let (server_handle, client, _) = test_server_and_client_setup(0..=5, |_| {}, None, None).await;
+
+    // filter_checkpoints=true with no filters should fail
+    let result = client
+        .stream_checkpoints_filtered(Some(0), Some(5), None, None, None, None)
+        .await;
+    assert!(result.is_err(), "expected error when no filters are set");
+
+    // tx filter without transactions in read_mask should fail
+    let (sender, _): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let sender_bytes = sender.to_inner();
+    let tx_filter = filter::TransactionFilter::default().with_sender(
+        filter::AddressFilter::default().with_address(
+            iota_grpc_types::v0::types::Address::default().with_address(sender_bytes.to_vec()),
+        ),
+    );
+
+    let result = client
+        .stream_checkpoints_filtered(
+            Some(0),
+            Some(5),
+            Some("checkpoint"),
+            Some(tx_filter),
+            None,
+            None,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected error when tx filter is set but transactions not in read_mask"
+    );
+
+    server_handle
+        .shutdown()
+        .await
+        .expect("Failed to shutdown server");
+}
+
+#[tokio::test]
+async fn test_filter_checkpoints_streaming() {
+    let (server_handle, client, _) = test_server_and_client_setup(0..=0, |_| {}, None, None).await;
+
+    let (sender, key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let sender_bytes = sender.to_inner();
+
+    // Create a sender filter matching our known sender
+    let make_tx_filter = || {
+        iota_grpc_types::v0::filter::TransactionFilter::default().with_sender(
+            iota_grpc_types::v0::filter::AddressFilter::default().with_address(
+                iota_grpc_types::v0::types::Address::default().with_address(sender_bytes.to_vec()),
+            ),
+        )
+    };
+
+    // Scenario 1: matching txs are returned, non-matching are skipped
+    let mut stream = client
+        .stream_checkpoints_filtered(
+            None,
+            None,
+            Some("checkpoint,transactions"),
+            Some(make_tx_filter()),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Broadcast checkpoint 1 with matching sender
+    server_handle
+        .checkpoint_data_broadcaster()
+        .send_traced(&mock_checkpoint_data_with_sender(1, sender, &key));
+    // Broadcast checkpoint 2 with no transactions (should be skipped)
+    server_handle
+        .checkpoint_data_broadcaster()
+        .send_traced(&mock_checkpoint_data(2));
+    // Broadcast checkpoint 3 with matching sender
+    server_handle
+        .checkpoint_data_broadcaster()
+        .send_traced(&mock_checkpoint_data_with_sender(3, sender, &key));
+
+    let mut results = Vec::new();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(res) = stream.next().await {
+            match res {
+                Ok(CheckpointStreamItem::Checkpoint(response)) => {
+                    results.push(response.sequence_number());
+                    if results.len() >= 2 {
+                        break;
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => panic!("Unexpected error: {e:?}"),
+            }
+        }
+    })
+    .await
+    .expect("waiting for stream timed out");
+    // Only checkpoints 1 and 3 should be received (checkpoint 2 was filtered out)
+    assert_eq!(results, vec![1, 3]);
+    drop(stream);
+
+    // Scenario 2: non-matching checkpoints are skipped until a match
+    let mut stream = client
+        .stream_checkpoints_filtered(
+            None,
+            None,
+            Some("checkpoint,transactions"),
+            Some(make_tx_filter()),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Broadcast checkpoints with no transactions (should all be skipped)
+    for i in 1..=5 {
+        server_handle
+            .checkpoint_data_broadcaster()
+            .send_traced(&mock_checkpoint_data(i));
+    }
+    // Broadcast checkpoint with a different sender (should be skipped)
+    let (other_sender, other_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    server_handle
+        .checkpoint_data_broadcaster()
+        .send_traced(&mock_checkpoint_data_with_sender(
+            6,
+            other_sender,
+            &other_key,
+        ));
+    // Finally broadcast one with the matching sender
+    server_handle
+        .checkpoint_data_broadcaster()
+        .send_traced(&mock_checkpoint_data_with_sender(7, sender, &key));
+
+    let mut results = Vec::new();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(res) = stream.next().await {
+            match res {
+                Ok(CheckpointStreamItem::Checkpoint(response)) => {
+                    results.push(response.sequence_number());
+                    return; // Just collect the first match
+                }
+                Ok(_) => {}
+                Err(e) => panic!("Unexpected error: {e:?}"),
+            }
+        }
+    })
+    .await
+    .expect("waiting for stream timed out");
+    // Only checkpoint 7 should be received (all others were filtered out)
+    assert_eq!(results, vec![7]);
+
     server_handle
         .shutdown()
         .await

--- a/crates/iota-grpc-types/proto/iota/grpc/v0/ledger_service.proto
+++ b/crates/iota-grpc-types/proto/iota/grpc/v0/ledger_service.proto
@@ -235,12 +235,28 @@ message CheckpointDataStreamRequest {
   // if no filter is passed, all events are included (if mentioned in the read_mask)
   optional iota.grpc.v0.filter.EventFilter events_filter = 5;
 
+  // When true, checkpoints with no matching transactions or events are skipped entirely.
+  // At least one of transactions_filter or events_filter must be set.
+  // A Progress message is sent periodically to indicate liveness and scan position.
+  optional bool filter_checkpoints = 6;
+
+  // Progress message interval in milliseconds when filter_checkpoints is enabled.
+  // Defaults to 2000ms. Minimum value is 500ms; lower values are clamped.
+  optional uint32 progress_interval_ms = 7;
+
   // Optional maximum message size the client can receive (1MB - 128MB)
   // If not specified, server uses default chunking threshold (4MB)
-  optional uint32 max_message_size_bytes = 6;
+  optional uint32 max_message_size_bytes = 8;
 }
 
 message CheckpointData {
+  message Progress {
+    option (iota.grpc.message_accessors) = "with";
+
+    // The sequence number of the latest scanned checkpoint.
+    uint64 latest_scanned_sequence_number = 1;
+  }
+
   message EndMarker {
     option (iota.grpc.message_accessors) = "with";
 
@@ -254,7 +270,8 @@ message CheckpointData {
     iota.grpc.v0.checkpoint.Checkpoint checkpoint = 1;
     iota.grpc.v0.transaction.ExecutedTransactions executed_transactions = 2;
     iota.grpc.v0.event.Events events = 3;
-    EndMarker end_marker = 4;
+    Progress progress = 4;
+    EndMarker end_marker = 5;
   }
 }
 

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.accessors.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.accessors.rs
@@ -35,6 +35,15 @@ mod _accessor_impls {
             self.payload = Some(super::checkpoint_data::Payload::Events(field.into()));
             self
         }
+        /// Sets `progress` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_progress<T: Into<super::checkpoint_data::Progress>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.payload = Some(super::checkpoint_data::Payload::Progress(field.into()));
+            self
+        }
         /// Sets `end_marker` with the provided value.
         /// If any other oneof field in the same oneof is set, it will be cleared.
         pub fn with_end_marker<T: Into<super::checkpoint_data::EndMarker>>(
@@ -51,6 +60,13 @@ mod _accessor_impls {
         /// Sets `sequence_number` with the provided value.
         pub fn with_sequence_number(mut self, field: u64) -> Self {
             self.sequence_number = Some(field);
+            self
+        }
+    }
+    impl super::checkpoint_data::Progress {
+        /// Sets `latest_scanned_sequence_number` with the provided value.
+        pub fn with_latest_scanned_sequence_number(mut self, field: u64) -> Self {
+            self.latest_scanned_sequence_number = field;
             self
         }
     }
@@ -86,6 +102,16 @@ mod _accessor_impls {
             field: T,
         ) -> Self {
             self.events_filter = Some(field.into());
+            self
+        }
+        /// Sets `filter_checkpoints` with the provided value.
+        pub fn with_filter_checkpoints(mut self, field: bool) -> Self {
+            self.filter_checkpoints = Some(field);
+            self
+        }
+        /// Sets `progress_interval_ms` with the provided value.
+        pub fn with_progress_interval_ms(mut self, field: u32) -> Self {
+            self.progress_interval_ms = Some(field);
             self
         }
         /// Sets `max_message_size_bytes` with the provided value.

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.field_info.rs
@@ -48,9 +48,51 @@ mod _field_impls {
     #[allow(unused_imports)]
     use crate::v0::types::ObjectReferenceFieldPathBuilder;
     #[allow(unused_imports)]
+    use crate::v0::ledger_service::checkpoint_data::Progress;
+    #[allow(unused_imports)]
     use crate::v0::ledger_service::checkpoint_data::EndMarker;
     pub mod checkpoint_data {
         use super::*;
+        impl Progress {
+            pub const LATEST_SCANNED_SEQUENCE_NUMBER_FIELD: &'static MessageField = &MessageField {
+                name: "latest_scanned_sequence_number",
+                json_name: "latestScannedSequenceNumber",
+                number: 1i32,
+                is_optional: false,
+                is_map: false,
+                message_fields: None,
+            };
+        }
+        impl MessageFields for Progress {
+            const FIELDS: &'static [&'static MessageField] = &[
+                Self::LATEST_SCANNED_SEQUENCE_NUMBER_FIELD,
+            ];
+        }
+        impl Progress {
+            pub fn path_builder() -> ProgressFieldPathBuilder {
+                ProgressFieldPathBuilder::new()
+            }
+        }
+        pub struct ProgressFieldPathBuilder {
+            path: Vec<&'static str>,
+        }
+        impl ProgressFieldPathBuilder {
+            #[allow(clippy::new_without_default)]
+            pub fn new() -> Self {
+                Self { path: Default::default() }
+            }
+            #[doc(hidden)]
+            pub fn new_with_base(base: Vec<&'static str>) -> Self {
+                Self { path: base }
+            }
+            pub fn finish(self) -> String {
+                self.path.join(".")
+            }
+            pub fn latest_scanned_sequence_number(mut self) -> String {
+                self.path.push(Progress::LATEST_SCANNED_SEQUENCE_NUMBER_FIELD.name);
+                self.finish()
+            }
+        }
         impl EndMarker {
             pub const SEQUENCE_NUMBER_FIELD: &'static MessageField = &MessageField {
                 name: "sequence_number",
@@ -1023,10 +1065,26 @@ mod _field_impls {
             is_map: false,
             message_fields: Some(EventFilter::FIELDS),
         };
+        pub const FILTER_CHECKPOINTS_FIELD: &'static MessageField = &MessageField {
+            name: "filter_checkpoints",
+            json_name: "filterCheckpoints",
+            number: 6i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const PROGRESS_INTERVAL_MS_FIELD: &'static MessageField = &MessageField {
+            name: "progress_interval_ms",
+            json_name: "progressIntervalMs",
+            number: 7i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
         pub const MAX_MESSAGE_SIZE_BYTES_FIELD: &'static MessageField = &MessageField {
             name: "max_message_size_bytes",
             json_name: "maxMessageSizeBytes",
-            number: 6i32,
+            number: 8i32,
             is_optional: true,
             is_map: false,
             message_fields: None,
@@ -1039,6 +1097,8 @@ mod _field_impls {
             Self::READ_MASK_FIELD,
             Self::TRANSACTIONS_FILTER_FIELD,
             Self::EVENTS_FILTER_FIELD,
+            Self::FILTER_CHECKPOINTS_FIELD,
+            Self::PROGRESS_INTERVAL_MS_FIELD,
             Self::MAX_MESSAGE_SIZE_BYTES_FIELD,
         ];
     }
@@ -1083,6 +1143,14 @@ mod _field_impls {
             self.path.push(CheckpointDataStreamRequest::EVENTS_FILTER_FIELD.name);
             EventFilterFieldPathBuilder::new_with_base(self.path)
         }
+        pub fn filter_checkpoints(mut self) -> String {
+            self.path.push(CheckpointDataStreamRequest::FILTER_CHECKPOINTS_FIELD.name);
+            self.finish()
+        }
+        pub fn progress_interval_ms(mut self) -> String {
+            self.path.push(CheckpointDataStreamRequest::PROGRESS_INTERVAL_MS_FIELD.name);
+            self.finish()
+        }
         pub fn max_message_size_bytes(mut self) -> String {
             self.path
                 .push(CheckpointDataStreamRequest::MAX_MESSAGE_SIZE_BYTES_FIELD.name);
@@ -1114,10 +1182,18 @@ mod _field_impls {
             is_map: false,
             message_fields: Some(Event::FIELDS),
         };
+        pub const PROGRESS_FIELD: &'static MessageField = &MessageField {
+            name: "progress",
+            json_name: "progress",
+            number: 4i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(Progress::FIELDS),
+        };
         pub const END_MARKER_FIELD: &'static MessageField = &MessageField {
             name: "end_marker",
             json_name: "endMarker",
-            number: 4i32,
+            number: 5i32,
             is_optional: false,
             is_map: false,
             message_fields: Some(EndMarker::FIELDS),
@@ -1131,6 +1207,7 @@ mod _field_impls {
             Self::CHECKPOINT_FIELD,
             Self::EXECUTED_TRANSACTIONS_FIELD,
             Self::EVENTS_FIELD,
+            Self::PROGRESS_FIELD,
             Self::END_MARKER_FIELD,
         ];
     }
@@ -1165,6 +1242,10 @@ mod _field_impls {
         pub fn events(mut self) -> EventFieldPathBuilder {
             self.path.push(CheckpointData::EVENTS_FIELD.name);
             EventFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn progress(mut self) -> checkpoint_data::ProgressFieldPathBuilder {
+            self.path.push(CheckpointData::PROGRESS_FIELD.name);
+            checkpoint_data::ProgressFieldPathBuilder::new_with_base(self.path)
         }
         pub fn end_marker(mut self) -> checkpoint_data::EndMarkerFieldPathBuilder {
             self.path.push(CheckpointData::END_MARKER_FIELD.name);

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.rs
@@ -226,19 +226,35 @@ pub struct CheckpointDataStreamRequest {
     /// if no filter is passed, all events are included (if mentioned in the read_mask)
     #[prost(message, optional, tag = "5")]
     pub events_filter: ::core::option::Option<super::filter::EventFilter>,
+    /// When true, checkpoints with no matching transactions or events are skipped entirely.
+    /// At least one of transactions_filter or events_filter must be set.
+    /// A Progress message is sent periodically to indicate liveness and scan position.
+    #[prost(bool, optional, tag = "6")]
+    pub filter_checkpoints: ::core::option::Option<bool>,
+    /// Progress message interval in milliseconds when filter_checkpoints is enabled.
+    /// Defaults to 2000ms. Minimum value is 500ms; lower values are clamped.
+    #[prost(uint32, optional, tag = "7")]
+    pub progress_interval_ms: ::core::option::Option<u32>,
     /// Optional maximum message size the client can receive (1MB - 128MB)
     /// If not specified, server uses default chunking threshold (4MB)
-    #[prost(uint32, optional, tag = "6")]
+    #[prost(uint32, optional, tag = "8")]
     pub max_message_size_bytes: ::core::option::Option<u32>,
 }
 #[non_exhaustive]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckpointData {
-    #[prost(oneof = "checkpoint_data::Payload", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "checkpoint_data::Payload", tags = "1, 2, 3, 4, 5")]
     pub payload: ::core::option::Option<checkpoint_data::Payload>,
 }
 /// Nested message and enum types in `CheckpointData`.
 pub mod checkpoint_data {
+    #[non_exhaustive]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Progress {
+        /// The sequence number of the latest scanned checkpoint.
+        #[prost(uint64, tag = "1")]
+        pub latest_scanned_sequence_number: u64,
+    }
     #[non_exhaustive]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct EndMarker {
@@ -256,6 +272,8 @@ pub mod checkpoint_data {
         #[prost(message, tag = "3")]
         Events(super::super::event::Events),
         #[prost(message, tag = "4")]
+        Progress(Progress),
+        #[prost(message, tag = "5")]
         EndMarker(EndMarker),
     }
 }


### PR DESCRIPTION
# Description of change

This PR adds the option to skip checkpoints in the checkpoint stream that don't match any given transaction or events filter. That makes is possible for users to dramatically reduce the amount of checkpoints that are sent over the wire, if they are only interested in the data for their own use case anyways.

Merge after #10644 and #10650 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes