### PR TITLE
upstream(core): Use weak ref for metrics thread

### DIFF
--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -478,7 +478,7 @@ impl<K, V> DBMap<K, V> {
         column_family: ColumnFamily,
         is_deprecated: bool,
     ) -> Self {
-        let db_cloned = db.clone();
+        let db_cloned = Arc::downgrade(&db);
         let db_metrics = DBMetrics::get();
         let db_metrics_cloned = db_metrics.clone();
         let cf = column_family.name().to_string();
@@ -491,13 +491,16 @@ impl<K, V> DBMap<K, V> {
                 loop {
                     tokio::select! {
                         _ = interval.tick() => {
-                            let db = db_cloned.clone();
-                            let cf = cf.clone();
-                            let db_metrics = db_metrics.clone();
-                            if let Err(e) = tokio::task::spawn_blocking(move || {
-                                Self::report_rocksdb_metrics(&db, &cf, &db_metrics);
-                            }).await {
-                                error!("Failed to log metrics with error: {}", e);
+                            if let Some(db) = db_cloned.upgrade() {
+                                let cf = cf.clone();
+                                let db_metrics = db_metrics.clone();
+                                if let Err(e) = tokio::task::spawn_blocking(move || {
+                                    Self::report_rocksdb_metrics(&db, &cf, &db_metrics);
+                                }).await {
+                                    error!("Failed to log metrics with error: {}", e);
+                                }
+                            } else {
+                                break;
                             }
                         }
                         _ = &mut recv => break,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -144,6 +144,16 @@ async fn test_contains_key() {
 }
 
 #[tokio::test]
+async fn test_safe_drop_db() {
+    let path = temp_dir();
+    {
+        let db: DBMap<i32, String> = open_map(path.clone(), Some("table"));
+        db.insert(&777, &"123".to_string()).unwrap();
+    }
+    assert!(safe_drop_db(path, Duration::from_secs(5)).await.is_ok());
+}
+
+#[tokio::test]
 async fn test_multi_contain() {
     let db = open_map(temp_dir(), None);
 


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@35156](https://github.com/MystenLabs/sui/commit/35156d3707d589ce202666e0c3d4dcc1be4a6c0c)
- Description:

Regular Arc causes `safe_drop_db` call to fail with `lock hold by current process` exception. Uses a weak reference (`Arc::downgrade`) instead of a strong `Arc` clone for the RocksDB metrics reporting thread to prevent this.

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes