### PR TITLE
chore(dapp-kit): Move `@iota/iota-names-sdk` as peer dep in `@iota/dapp-kit`

### DIFF
--- a/.changeset/gorgeous-camels-talk.md
+++ b/.changeset/gorgeous-camels-talk.md
@@ -1,0 +1,5 @@
+---
+'@iota/dapp-kit': minor
+---
+
+`@iota/iota-names-sdk` as peer dep in `@iota/dapp-kit`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1700,6 +1700,9 @@ importers:
       '@iota/build-scripts':
         specifier: workspace:*
         version: link:../build-scripts
+      '@iota/iota-names-sdk':
+        specifier: ^0.6.1
+        version: 0.6.1(@iota/iota-sdk@sdk+typescript)
       '@size-limit/preset-small-lib':
         specifier: ^11.1.4
         version: 11.1.5(size-limit@11.1.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1666,9 +1666,6 @@ importers:
 
   sdk/dapp-kit:
     dependencies:
-      '@iota/iota-names-sdk':
-        specifier: ^0.6.1
-        version: 0.6.1(@iota/iota-sdk@sdk+typescript)
       '@iota/iota-sdk':
         specifier: workspace:*
         version: link:../typescript
@@ -48712,10 +48709,10 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.12.1
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      browserslist: 4.28.1
+      browserslist: 4.24.0
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.17.1
-      es-module-lexer: 1.7.0
+      es-module-lexer: 1.5.4
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -48727,7 +48724,7 @@ snapshots:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(@swc/core@1.15.11(@swc/helpers@0.5.18))(webpack@5.95.0(@swc/core@1.15.11(@swc/helpers@0.5.18)))
-      watchpack: 2.5.1
+      watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'

--- a/sdk/dapp-kit/package.json
+++ b/sdk/dapp-kit/package.json
@@ -75,7 +75,6 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@iota/iota-names-sdk": "^0.6.1",
         "@iota/iota-sdk": "workspace:*",
         "@iota/wallet-standard": "workspace:*",
         "@radix-ui/react-dialog": "^1.1.1",
@@ -89,7 +88,8 @@
     },
     "peerDependencies": {
         "@tanstack/react-query": "^5.50.1",
-        "react": "*"
+        "react": "*",
+        "@iota/iota-names-sdk": "*"
     },
     "sideEffects": [
         "*.css.ts",

--- a/sdk/dapp-kit/package.json
+++ b/sdk/dapp-kit/package.json
@@ -56,6 +56,7 @@
     ],
     "devDependencies": {
         "@iota/build-scripts": "workspace:*",
+        "@iota/iota-names-sdk": "^0.6.1",
         "@size-limit/preset-small-lib": "^11.1.4",
         "@tanstack/react-query": "^5.50.1",
         "@testing-library/dom": "^10.3.1",

--- a/sdk/dapp-kit/package.json
+++ b/sdk/dapp-kit/package.json
@@ -88,9 +88,9 @@
         "zustand": "^4.4.1"
     },
     "peerDependencies": {
+        "@iota/iota-names-sdk": "*",
         "@tanstack/react-query": "^5.50.1",
-        "react": "*",
-        "@iota/iota-names-sdk": "*"
+        "react": "*"
     },
     "sideEffects": [
         "*.css.ts",


### PR DESCRIPTION
This way the dapp importing `@iota/dapp-kit`  decides what version is used (by importing it depending `@iota/iota-names-sdk` itself), and thus not needing to release the dapp-kit for every bump in the names-sdk

[run-ci]