### PR TITLE
feat(gPRC): type-erased deprecated_db_map test

### DIFF
--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -248,6 +248,71 @@ async fn deprecate_test() {
     }
 }
 
+/// Proves that a deprecated CF can use `(), ()` type parameters even when the
+/// original CF had different key/value types (i32, String). This lets us delete
+/// the old type definitions entirely.
+#[derive(DBMapUtils)]
+struct DeprecatedTablesTypeErased {
+    table1: DBMap<String, String>,
+    #[deprecated_db_map]
+    table2: Option<DBMap<(), ()>>,
+}
+
+#[tokio::test]
+async fn deprecate_type_erased_test() {
+    let dbdir = temp_dir();
+    let key = "key".to_string();
+    let value = "value".to_string();
+
+    // Step 1: Create DB with original types (i32, String) and write data
+    {
+        let original_db =
+            Tables::open_tables_read_write(dbdir.clone(), MetricConf::default(), None, None);
+        original_db.table1.insert(&key, &value).unwrap();
+        original_db.table2.insert(&42, &value).unwrap();
+    }
+
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    // Step 2: Reopen with type-erased `(), ()` — CF should be dropped cleanly
+    {
+        let db = DeprecatedTablesTypeErased::open_tables_read_write(
+            dbdir.clone(),
+            MetricConf::default(),
+            None,
+            None,
+        );
+        assert_eq!(db.table1.get(&key), Ok(Some(value.clone())));
+        assert!(
+            db.table2.is_none(),
+            "deprecated field should be None after cleanup"
+        );
+    }
+
+    // Verify table2 CF was actually removed from disk
+    let tables = typed_store::rocks::list_tables(dbdir.clone()).unwrap();
+    assert!(
+        !tables.contains(&"table2".to_string()),
+        "table2 CF should have been dropped even with type-erased (), ()"
+    );
+
+    // Step 3: Reopen again — must not panic when CF is already gone
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    {
+        let db = DeprecatedTablesTypeErased::open_tables_read_write(
+            dbdir.clone(),
+            MetricConf::default(),
+            None,
+            None,
+        );
+        assert_eq!(db.table1.get(&key), Ok(Some(value.clone())));
+        assert!(
+            db.table2.is_none(),
+            "deprecated field should be None when CF never existed"
+        );
+    }
+}
+
 #[derive(DBMapUtils)]
 struct TablesWithMigration {
     new_table: DBMap<String, String>,


### PR DESCRIPTION
# Description of change

Add a test proving that `#[deprecated_db_map]` works with type-erased `DBMap<(), ()>`. This confirms we can delete the original key/value type definitions when deprecating column families.

## Links to any relevant issues

fixes #10654 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation