### PR TITLE
feat(gRPC): gRPC e2e test for transfer output verification

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -4,6 +4,8 @@
 use iota_grpc_client::Error;
 use iota_macros::sim_test;
 use iota_sdk_types::UserSignature;
+use iota_test_transaction_builder::make_transfer_iota_transaction;
+use iota_types::base_types::IotaAddress;
 
 use super::{
     super::utils::setup_grpc_test,
@@ -46,6 +48,42 @@ async fn execute_transaction_transfer() {
     assert!(
         result.output_objects.is_some(),
         "Output objects should be present with default mask"
+    );
+}
+
+/// Verify that a transfer creates the expected output objects: the mutated gas
+/// coin for the sender and a new coin for the recipient.
+#[sim_test]
+async fn execute_transaction_transfer_outputs() {
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+    let recipient = IotaAddress::random_for_testing_only();
+    let amount = 9;
+
+    let tx =
+        make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(amount)).await;
+    let signed_tx: iota_sdk_types::SignedTransaction =
+        tx.try_into().expect("SDK type conversion failed");
+
+    let result = client
+        .execute_transaction(signed_tx, None)
+        .await
+        .expect("Failed to execute transaction");
+
+    let effects = result
+        .effects()
+        .expect("Failed to get effects")
+        .effects()
+        .expect("Failed to get inner effects");
+
+    assert!(is_success(effects.status()), "Transaction should succeed");
+
+    // A SplitCoins + TransferObjects transfer produces at least 2 output objects:
+    // the mutated gas coin (sender) and the new coin (recipient).
+    let output_objects = result.output_objects.as_ref().expect("output objects");
+    assert!(
+        output_objects.objects.len() >= 2,
+        "Expected at least 2 output objects (gas + recipient coin), got {}",
+        output_objects.objects.len()
     );
 }
 


### PR DESCRIPTION
# Description of change

Add a gRPC e2e test that executes a transfer and verifies the expected output objects. Replaces coverage lost when the REST API e2e tests were removed.

## Links to any relevant issues

fixes #10656 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation