### PR TITLE
chore(ts-sdk): Mark AA (Move Authenticator) as @experimental

### DIFF
--- a/.changeset/brave-boxes-begin.md
+++ b/.changeset/brave-boxes-begin.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': minor
+---
+
+Mark all Account Abstraction (Move Authenticator) APIs as experimental.

--- a/sdk/typescript/src/bcs/bcs.ts
+++ b/sdk/typescript/src/bcs/bcs.ts
@@ -320,6 +320,7 @@ export const PasskeyAuthenticator = bcs.struct('PasskeyAuthenticator', {
     userSignature: bcs.vector(bcs.u8()),
 });
 
+/** @experimental */
 const MoveAuthenticatorV1 = bcs.struct('MoveAuthenticatorV1', {
     callArgs: bcs.vector(CallArg),
     typeArgs: bcs.vector(TypeTag),
@@ -327,6 +328,7 @@ const MoveAuthenticatorV1 = bcs.struct('MoveAuthenticatorV1', {
 });
 
 /**
+ * @experimental
  * MoveAuthenticator allows authenticating transactions via a Move function call
  * as part of Account Abstraction.
  * The enum wrapper matches the Rust `MoveAuthenticatorInner` enum, which adds a

--- a/sdk/typescript/src/cryptography/signature-scheme.ts
+++ b/sdk/typescript/src/cryptography/signature-scheme.ts
@@ -8,6 +8,7 @@ export const SIGNATURE_SCHEME_TO_FLAG = {
     Secp256r1: 0x02,
     MultiSig: 0x03,
     Passkey: 0x06,
+    /** @experimental */
     MoveAuthenticator: 0x07,
 } as const;
 
@@ -23,6 +24,7 @@ export const SIGNATURE_FLAG_TO_SCHEME = {
     0x02: 'Secp256r1',
     0x03: 'MultiSig',
     0x06: 'Passkey',
+    /** @experimental */
     0x07: 'MoveAuthenticator',
 } as const;
 
@@ -32,6 +34,7 @@ export type SignatureScheme =
     | 'Secp256r1'
     | 'MultiSig'
     | 'Passkey'
+    /** @experimental */
     | 'MoveAuthenticator';
 
 export type SignatureFlag = keyof typeof SIGNATURE_FLAG_TO_SCHEME;

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -66,6 +66,7 @@ export function parseSerializedSignature(serializedSignature: string) {
                 multisig,
                 bytes,
             };
+        // @experimental
         case 'MoveAuthenticator':
             const moveAuthenticator = bcs.MoveAuthenticator.parse(bytes.slice(1));
             return {

--- a/sdk/typescript/src/keypairs/move-authenticator/builder.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/builder.ts
@@ -6,6 +6,7 @@ import type { IotaClient } from '../../client/index.js';
 import type { MoveAuthenticatorCallArg, MoveAuthenticatorData } from './types.js';
 
 /**
+ * @experimental
  * Error thrown when an invalid argument is provided to MoveAuthenticator.
  */
 export class InvalidMoveAuthArgError extends Error {
@@ -16,6 +17,7 @@ export class InvalidMoveAuthArgError extends Error {
 }
 
 /**
+ * @experimental
  * Error thrown when an invalid objectToAuthenticate is provided to MoveAuthenticator.
  */
 export class InvalidMoveAuthAccountError extends Error {
@@ -26,6 +28,7 @@ export class InvalidMoveAuthAccountError extends Error {
 }
 
 /**
+ * @experimental
  * A function call to authorize a transaction via Move.
  * This builder creates a MoveAuthenticator which can be used to execute
  * a transaction with Account Abstraction.

--- a/sdk/typescript/src/keypairs/move-authenticator/publickey.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/publickey.ts
@@ -8,6 +8,7 @@ import { normalizeIotaAddress } from '../../utils/iota-types.js';
 import { bytesToHex } from '@noble/hashes/utils';
 
 /**
+ * @experimental
  * A MoveAuthenticator public key. Since MoveAuthenticator uses account abstraction,
  * this uses the object ID as the identity rather than a traditional cryptographic public key.
  */

--- a/sdk/typescript/src/keypairs/move-authenticator/signer.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/signer.ts
@@ -26,6 +26,7 @@ function getObjectIdFromCallArg(callArg: ObjectArg): string {
 }
 
 /**
+ * @experimental
  * A Move Authenticator signer for account abstraction.
  * This allows transactions to be authorized via Move functions rather than traditional cryptographic signatures.
  */

--- a/sdk/typescript/src/keypairs/move-authenticator/types.ts
+++ b/sdk/typescript/src/keypairs/move-authenticator/types.ts
@@ -4,6 +4,7 @@
 import type { CallArg, ObjectArg } from '../../bcs/types.js';
 
 /**
+ * @experimental
  * Call arg for specifying how to provide call arguments before resolution.
  */
 export type MoveAuthenticatorCallArg =
@@ -17,11 +18,15 @@ export type MoveAuthenticatorCallArg =
     | { Pure: Uint8Array };
 
 /**
+ * @experimental
  * The resolved MoveAuthenticator data structure, versioned as a discriminated
  * union. Add new variants here when new versions are introduced on the Rust side.
  */
 export type MoveAuthenticatorData = MoveAuthenticatorDataV1; // future: | MoveAuthenticatorDataV2;
 
+/**
+ * @experimental
+ */
 export interface MoveAuthenticatorDataV1 {
     version: 'V1';
     callArgs: CallArg[];

--- a/sdk/typescript/src/verify/verify.ts
+++ b/sdk/typescript/src/verify/verify.ts
@@ -90,6 +90,7 @@ function parseSignature(signature: string) {
         };
     }
 
+    // @experimental
     if (parsedSignature.signatureScheme === 'MoveAuthenticator') {
         const moveAuth = parsedSignature.moveAuthenticator;
         let authenticatedObjectId: string | undefined;
@@ -137,6 +138,7 @@ export function publicKeyFromRawBytes(
             return new MultiSigPublicKey(bytes);
         case 'Passkey':
             return new PasskeyPublicKey(bytes);
+        // @experimental
         case 'MoveAuthenticator':
             return new MoveAuthenticatorPublicKey(bytes);
         default:


### PR DESCRIPTION
Marking it as experimental as it is not enabled on Mainnet.