### PR TITLE
feat(gRPC): add gRPC server request metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6853,6 +6853,7 @@ dependencies = [
  "bcs",
  "fastcrypto",
  "futures",
+ "http 1.3.1",
  "iota-config",
  "iota-grpc-client",
  "iota-grpc-types",
@@ -6864,6 +6865,8 @@ dependencies = [
  "itertools 0.13.0",
  "move-core-types",
  "paste",
+ "pin-project-lite",
+ "prometheus",
  "prost 0.14.1",
  "prost-types 0.14.1",
  "serde",
@@ -6871,6 +6874,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.18",
  "tonic 0.14.2",
+ "tower 0.4.13",
  "tracing",
 ]
 

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -16,8 +16,11 @@ async-stream.workspace = true
 bcs.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
+http.workspace = true
 itertools.workspace = true
 paste = "1.0.15"
+pin-project-lite.workspace = true
+prometheus.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 serde.workspace = true
@@ -25,6 +28,7 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
 tonic = { workspace = true, features = ["tls-ring"] }
+tower.workspace = true
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-grpc-server/src/lib.rs
+++ b/crates/iota-grpc-server/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 pub mod event_filter;
 pub mod ledger_service;
 pub mod merge;
+pub mod metrics;
 pub mod response;
 pub mod server;
 pub mod transaction_execution_service;
@@ -19,6 +20,7 @@ pub mod utils;
 
 // Re-export commonly used types and traits
 pub use ledger_service::LedgerGrpcService;
+pub use metrics::GrpcServerMetrics;
 pub use response::append_info_headers;
 pub use server::{GrpcServerHandle, start_grpc_server};
 pub use transaction_execution_service::TransactionExecutionGrpcService;

--- a/crates/iota-grpc-server/src/metrics.rs
+++ b/crates/iota-grpc-server/src/metrics.rs
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use pin_project_lite::pin_project;
+use prometheus::{
+    HistogramVec, IntCounterVec, IntGaugeVec, Registry, register_histogram_vec_with_registry,
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
+};
+use tonic::{Code, Status};
+use tower::{Layer, Service};
+
+const LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1., 2.5, 5., 10., 20., 30., 60., 90.,
+];
+
+/// Metrics for the public-facing gRPC server.
+///
+/// Tracks in-flight requests, total request counts (by method and gRPC status),
+/// and request latency per RPC method.
+#[derive(Clone)]
+pub struct GrpcServerMetrics {
+    inflight_requests: IntGaugeVec,
+    num_requests: IntCounterVec,
+    request_latency: HistogramVec,
+}
+
+impl GrpcServerMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            inflight_requests: register_int_gauge_vec_with_registry!(
+                "grpc_server_inflight_requests",
+                "Total in-flight gRPC requests per method",
+                &["method"],
+                registry,
+            )
+            .unwrap(),
+            num_requests: register_int_counter_vec_with_registry!(
+                "grpc_server_requests",
+                "Total gRPC requests per method and status code",
+                &["method", "status"],
+                registry,
+            )
+            .unwrap(),
+            request_latency: register_histogram_vec_with_registry!(
+                "grpc_server_request_latency",
+                "Latency of gRPC requests per method in seconds",
+                &["method"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+/// Tower [`Layer`] that adds gRPC request metrics to a service.
+#[derive(Clone)]
+pub struct GrpcMetricsLayer {
+    metrics: Arc<GrpcServerMetrics>,
+}
+
+impl GrpcMetricsLayer {
+    pub fn new(metrics: Arc<GrpcServerMetrics>) -> Self {
+        Self { metrics }
+    }
+}
+
+impl<S> Layer<S> for GrpcMetricsLayer {
+    type Service = GrpcMetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcMetricsService {
+            inner,
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+/// Tower [`Service`] wrapper that records gRPC request metrics.
+#[derive(Clone)]
+pub struct GrpcMetricsService<S> {
+    inner: S,
+    metrics: Arc<GrpcServerMetrics>,
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for GrpcMetricsService<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = GrpcMetricsFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        let method = req.uri().path().to_owned();
+        let metrics = self.metrics.clone();
+
+        metrics
+            .inflight_requests
+            .with_label_values(&[&method])
+            .inc();
+
+        let guard = InFlightGuard {
+            metrics,
+            method,
+            start: Instant::now(),
+            completed: false,
+        };
+
+        let future = self.inner.call(req);
+
+        GrpcMetricsFuture {
+            inner: future,
+            guard,
+        }
+    }
+}
+
+/// RAII guard that tracks in-flight requests and records metrics on drop.
+///
+/// When a request completes normally, [`GrpcMetricsFuture::poll`] records the
+/// response status and marks the guard as completed. If the future is dropped
+/// before completion (e.g. client disconnect), the guard records a `"canceled"`
+/// status instead, matching the REST metrics behavior.
+struct InFlightGuard {
+    metrics: Arc<GrpcServerMetrics>,
+    method: String,
+    start: Instant,
+    completed: bool,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.metrics
+            .inflight_requests
+            .with_label_values(&[&self.method])
+            .dec();
+
+        let latency = self.start.elapsed().as_secs_f64();
+        self.metrics
+            .request_latency
+            .with_label_values(&[&self.method])
+            .observe(latency);
+
+        if !self.completed {
+            self.metrics
+                .num_requests
+                .with_label_values(&[self.method.as_str(), "canceled"])
+                .inc();
+        }
+    }
+}
+
+pin_project! {
+    /// Future that records metrics when the inner response completes.
+    ///
+    /// On normal completion, records the gRPC status from the response headers.
+    /// If dropped before completion (client disconnect), the [`InFlightGuard`]
+    /// records a `"canceled"` status.
+    pub struct GrpcMetricsFuture<F> {
+        #[pin]
+        inner: F,
+        guard: InFlightGuard,
+    }
+}
+
+impl<F, ResBody, E> Future for GrpcMetricsFuture<F>
+where
+    F: Future<Output = Result<http::Response<ResBody>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.inner.poll(cx) {
+            Poll::Ready(result) => {
+                let status = match &result {
+                    Ok(response) => grpc_status_from_response(response),
+                    Err(_) => "transport_error",
+                };
+
+                this.guard
+                    .metrics
+                    .num_requests
+                    .with_label_values(&[this.guard.method.as_str(), status])
+                    .inc();
+
+                this.guard.completed = true;
+
+                Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Extract the gRPC status code from response headers.
+///
+/// Uses [`tonic::Status::from_header_map`] to parse the `grpc-status` header.
+/// If not present, the response is assumed to be OK. For streaming RPCs, errors
+/// sent via trailers are not visible here and will be reported as OK.
+fn grpc_status_from_response<B>(response: &http::Response<B>) -> &'static str {
+    let code = Status::from_header_map(response.headers()).map_or(Code::Ok, |s| s.code());
+    grpc_code_to_str(code)
+}
+
+fn grpc_code_to_str(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "Ok",
+        Code::Cancelled => "Cancelled",
+        Code::Unknown => "Unknown",
+        Code::InvalidArgument => "InvalidArgument",
+        Code::DeadlineExceeded => "DeadlineExceeded",
+        Code::NotFound => "NotFound",
+        Code::AlreadyExists => "AlreadyExists",
+        Code::PermissionDenied => "PermissionDenied",
+        Code::ResourceExhausted => "ResourceExhausted",
+        Code::FailedPrecondition => "FailedPrecondition",
+        Code::Aborted => "Aborted",
+        Code::OutOfRange => "OutOfRange",
+        Code::Unimplemented => "Unimplemented",
+        Code::Internal => "Internal",
+        Code::Unavailable => "Unavailable",
+        Code::DataLoss => "DataLoss",
+        Code::Unauthenticated => "Unauthenticated",
+    }
+}

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -16,7 +16,8 @@ use tokio_util::sync::CancellationToken;
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 
 use crate::{
-    GrpcCheckpointDataBroadcaster, GrpcReader, LedgerGrpcService, TransactionExecutionGrpcService,
+    GrpcCheckpointDataBroadcaster, GrpcReader, GrpcServerMetrics, LedgerGrpcService,
+    TransactionExecutionGrpcService, metrics::GrpcMetricsLayer,
 };
 
 /// Handle to control a running gRPC server
@@ -52,6 +53,56 @@ impl GrpcServerHandle {
     }
 }
 
+/// Adds gRPC services to a server builder and spawns the server.
+///
+/// This macro avoids duplicating the service registration and spawning logic
+/// across the with-metrics and without-metrics code paths, since
+/// `Server::layer()` changes the builder's type parameter.
+macro_rules! build_and_spawn {
+    ($server_builder:expr, $ledger_service:expr, $tx_service:expr, $config:expr,
+     $listener:expr, $actual_addr:expr, $shutdown_token:expr) => {{
+        let mut router = $server_builder.add_service(
+            grpc_ledger_service::ledger_service_server::LedgerServiceServer::new($ledger_service)
+                .max_encoding_message_size($config.max_message_size_bytes() as usize),
+        );
+
+        if let Some(tx_service) = $tx_service {
+            router = router.add_service(
+                grpc_tx_service::transaction_execution_service_server::TransactionExecutionServiceServer::new(tx_service)
+                .max_encoding_message_size($config.max_message_size_bytes() as usize),
+            );
+        }
+
+        let shutdown_token_for_server = $shutdown_token.clone();
+        if $config.tls_config().is_some() {
+            // TLS case: tonic needs to control the entire transport stack for TLS,
+            // so we let it handle binding. We drop our pre-bound listener since
+            // tonic will create its own with proper TLS configuration.
+            drop($listener);
+
+            tokio::spawn(async move {
+                let result = router
+                    .serve_with_shutdown($actual_addr, shutdown_token_for_server.cancelled())
+                    .await;
+                tracing::info!("gRPC server shutdown completed");
+                result
+            })
+        } else {
+            // Non-TLS case: use the existing listener
+            tokio::spawn(async move {
+                let result = router
+                    .serve_with_incoming_shutdown(
+                        TcpListenerStream::new($listener),
+                        shutdown_token_for_server.cancelled(),
+                    )
+                    .await;
+                tracing::info!("gRPC server shutdown completed");
+                result
+            })
+        }
+    }};
+}
+
 /// Start a gRPC server with checkpoint and event services
 ///
 /// This function creates and starts a gRPC server that hosts checkpoint-related
@@ -64,6 +115,7 @@ pub async fn start_grpc_server(
     config: iota_config::node::GrpcApiConfig,
     shutdown_token: CancellationToken,
     chain_id: iota_types::digests::ChainIdentifier,
+    metrics: Option<GrpcServerMetrics>,
 ) -> Result<GrpcServerHandle> {
     // Create broadcast channels
     let (checkpoint_data_tx, _) = broadcast::channel(config.broadcast_buffer_size as usize);
@@ -97,8 +149,10 @@ pub async fn start_grpc_server(
         actual_addr
     );
 
-    // Build the router with services (common for both TLS and non-TLS)
-    let mut router_builder = Server::builder();
+    // Build the server builder with TLS and optional metrics layer.
+    // Server::layer() changes the builder's generic type parameter, so we use
+    // a macro to avoid duplicating the service registration and spawn logic.
+    let mut server_builder = Server::builder();
 
     // Configure TLS if enabled
     if let Some(tls_config) = config.tls_config() {
@@ -118,52 +172,33 @@ pub async fn start_grpc_server(
 
         tracing::info!("gRPC server TLS enabled");
 
-        router_builder = router_builder
+        server_builder = server_builder
             .tls_config(tls)
             .map_err(|e| anyhow::anyhow!("failed to configure TLS: {}", e))?;
     }
 
-    // Add services to the router and configure services with
-    // message size limits
-    let mut router = router_builder.add_service(
-        grpc_ledger_service::ledger_service_server::LedgerServiceServer::new(ledger_service)
-            .max_encoding_message_size(config.max_message_size_bytes() as usize),
-    );
-
-    if let Some(tx_service) = tx_service {
-        router = router.add_service(
-            grpc_tx_service::transaction_execution_service_server::TransactionExecutionServiceServer::new(tx_service)
-            .max_encoding_message_size(config.max_message_size_bytes() as usize),
-        );
-    }
-
-    // Spawn the server task with graceful shutdown
-    let shutdown_token_for_server = shutdown_token.clone();
-    let server_handle = if config.tls_config().is_some() {
-        // TLS case: tonic needs to control the entire transport stack for TLS,
-        // so we let it handle binding. We drop our pre-bound listener since
-        // tonic will create its own with proper TLS configuration.
-        drop(listener);
-
-        tokio::spawn(async move {
-            let result = router
-                .serve_with_shutdown(actual_addr, shutdown_token_for_server.cancelled())
-                .await;
-            tracing::info!("gRPC server shutdown completed");
-            result
-        })
+    // Add services and spawn the server, optionally wrapping with metrics layer
+    let server_handle = if let Some(metrics) = metrics {
+        let mut layered_builder = server_builder.layer(GrpcMetricsLayer::new(Arc::new(metrics)));
+        build_and_spawn!(
+            layered_builder,
+            ledger_service,
+            tx_service,
+            config,
+            listener,
+            actual_addr,
+            shutdown_token
+        )
     } else {
-        // Non-TLS case: use the existing listener
-        tokio::spawn(async move {
-            let result = router
-                .serve_with_incoming_shutdown(
-                    TcpListenerStream::new(listener),
-                    shutdown_token_for_server.cancelled(),
-                )
-                .await;
-            tracing::info!("gRPC server shutdown completed");
-            result
-        })
+        build_and_spawn!(
+            server_builder,
+            ledger_service,
+            tx_service,
+            config,
+            listener,
+            actual_addr,
+            shutdown_token
+        )
     };
 
     Ok(GrpcServerHandle {

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -503,6 +503,7 @@ async fn test_server_and_client_setup<I: Iterator<Item = u64>>(
         config,
         cancellation_token,
         iota_types::digests::ChainIdentifier::default(),
+        None, // No metrics for this test
     )
     .await
     .expect("Failed to start gRPC server");

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -885,8 +885,14 @@ impl IotaNode {
                 .clone()
                 .map(|o| o as Arc<dyn iota_types::transaction_executor::TransactionExecutor>);
 
-        let grpc_server_handle =
-            build_grpc_server(&config, state.clone(), state_sync_store.clone(), executor).await?;
+        let grpc_server_handle = build_grpc_server(
+            &config,
+            state.clone(),
+            state_sync_store.clone(),
+            executor,
+            &registry_service.default_registry(),
+        )
+        .await?;
 
         let validator_components = if state.is_committee_validator(&epoch_store) {
             let (components, _) = futures::join!(
@@ -2422,6 +2428,7 @@ async fn build_grpc_server(
     state: Arc<AuthorityState>,
     state_sync_store: RocksDbStore,
     executor: Option<Arc<dyn iota_types::transaction_executor::TransactionExecutor>>,
+    prometheus_registry: &Registry,
 ) -> Result<Option<GrpcServerHandle>> {
     // Validators do not expose gRPC APIs
     if config.consensus_config().is_some() || !config.enable_grpc_api {
@@ -2446,6 +2453,9 @@ async fn build_grpc_server(
         Some(env!("CARGO_PKG_VERSION").to_string()),
     ));
 
+    // Create gRPC server metrics
+    let grpc_server_metrics = iota_grpc_server::GrpcServerMetrics::new(prometheus_registry);
+
     // Pass the same token to both GrpcReader (already done above) and
     // start_grpc_server
     let handle = start_grpc_server(
@@ -2454,6 +2464,7 @@ async fn build_grpc_server(
         grpc_config.clone(),
         shutdown_token,
         chain_id,
+        Some(grpc_server_metrics),
     )
     .await?;
 

--- a/crates/simulacrum-server/src/grpc_server.rs
+++ b/crates/simulacrum-server/src/grpc_server.rs
@@ -33,7 +33,15 @@ pub async fn start_simulacrum_grpc_server(
     let simulacrum_reader = Arc::new(SimulacrumGrpcReader::new(simulacrum.clone(), chain_id));
     let grpc_reader = Arc::new(GrpcReader::new(simulacrum_reader, None));
 
-    start_grpc_server(grpc_reader, executor, config, shutdown_token, chain_id).await
+    start_grpc_server(
+        grpc_reader,
+        executor,
+        config,
+        shutdown_token,
+        chain_id,
+        None,
+    )
+    .await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description of change

Add request metrics to the gRPC server, mirroring the REST API's metrics instrumentation. Tracks in-flight requests, total request counts by method and gRPC status, and request latency per RPC method. Metrics are registered with the node's Prometheus registry and are optional for test/simulacrum usage.

## Links to any relevant issues

fixes #10653 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation