### PR TITLE
feat(explorer): display digest for objects

### DIFF
--- a/apps/explorer/src/index.css
+++ b/apps/explorer/src/index.css
@@ -118,19 +118,19 @@ body,
         grid-template-areas:
             'heroImage name'
             'heroImage description'
-            'objectId type'
+            'objectId digest'
             'owner storageRebate'
             'version lastTxBlock'
-            'digest digest';
+            'type type';
     }
 
     .address-grid-container-top.no-description.no-image {
         @apply grid grid-cols-2 gap-4;
         grid-template-areas:
             'objectId version'
-            'owner type'
+            'owner digest'
             'lastTxBlock storageRebate'
-            'digest digest';
+            'type type';
     }
 
     @screen md {
@@ -140,23 +140,23 @@ body,
                 'heroImage name owner'
                 'heroImage description storageRebate'
                 'heroImage objectId version'
-                'heroImage type lastTxBlock'
-                'heroImage digest digest';
+                'heroImage digest lastTxBlock'
+                'heroImage type type';
         }
         .address-grid-container-top.no-description.no-image {
             @apply grid grid-cols-3 grid-rows-2;
             grid-template-areas:
                 'objectId version owner'
-                'type lastTxBlock storageRebate'
-                'digest digest digest';
+                'digest lastTxBlock storageRebate'
+                'type type type';
         }
         .address-grid-container-top.no-image {
             @apply grid grid-cols-3 grid-rows-3;
             grid-template-areas:
-                'name description type'
-                'objectId version type'
+                'name description digest'
+                'objectId version digest'
                 'owner lastTxBlock storageRebate'
-                'digest digest digest';
+                'type type type';
         }
     }
 }

--- a/apps/explorer/src/index.css
+++ b/apps/explorer/src/index.css
@@ -118,45 +118,43 @@ body,
         grid-template-areas:
             'heroImage name'
             'heroImage description'
-            'objectId digest'
-            'owner storageRebate'
-            'version lastTxBlock'
-            'type type';
+            'objectId version'
+            'digest owner'
+            'type type'
+            'lastTxBlock storageRebate';
     }
 
     .address-grid-container-top.no-description.no-image {
         @apply grid grid-cols-2 gap-4;
         grid-template-areas:
             'objectId version'
-            'owner digest'
-            'lastTxBlock storageRebate'
-            'type type';
+            'digest owner'
+            'type type'
+            'lastTxBlock storageRebate';
     }
 
     @screen md {
         .address-grid-container-top {
-            @apply grid-cols-[300px,1fr,1fr] grid-rows-2 gap-md;
+            @apply grid-cols-[300px,1fr,1fr] gap-md;
             grid-template-areas:
-                'heroImage name owner'
-                'heroImage description storageRebate'
+                'heroImage name description'
                 'heroImage objectId version'
-                'heroImage digest lastTxBlock'
-                'heroImage type type';
+                'heroImage digest owner'
+                'heroImage type type'
+                'heroImage lastTxBlock storageRebate';
         }
         .address-grid-container-top.no-description.no-image {
-            @apply grid grid-cols-3 grid-rows-2;
+            @apply grid grid-cols-4;
             grid-template-areas:
-                'objectId version owner'
-                'digest lastTxBlock storageRebate'
-                'type type type';
+                'objectId version digest owner'
+                'type type lastTxBlock storageRebate';
         }
         .address-grid-container-top.no-image {
-            @apply grid grid-cols-3 grid-rows-3;
+            @apply grid grid-cols-4;
             grid-template-areas:
-                'name description digest'
-                'objectId version digest'
-                'owner lastTxBlock storageRebate'
-                'type type type';
+                'name objectId version digest'
+                'description owner lastTxBlock storageRebate'
+                'type type type type';
         }
     }
 }

--- a/apps/explorer/src/index.css
+++ b/apps/explorer/src/index.css
@@ -120,7 +120,8 @@ body,
             'heroImage description'
             'objectId type'
             'owner storageRebate'
-            'version lastTxBlock';
+            'version lastTxBlock'
+            'digest digest';
     }
 
     .address-grid-container-top.no-description.no-image {
@@ -128,7 +129,8 @@ body,
         grid-template-areas:
             'objectId version'
             'owner type'
-            'lastTxBlock storageRebate';
+            'lastTxBlock storageRebate'
+            'digest digest';
     }
 
     @screen md {
@@ -138,20 +140,23 @@ body,
                 'heroImage name owner'
                 'heroImage description storageRebate'
                 'heroImage objectId version'
-                'heroImage type lastTxBlock';
+                'heroImage type lastTxBlock'
+                'heroImage digest digest';
         }
         .address-grid-container-top.no-description.no-image {
             @apply grid grid-cols-3 grid-rows-2;
             grid-template-areas:
                 'objectId version owner'
-                'type lastTxBlock storageRebate';
+                'type lastTxBlock storageRebate'
+                'digest digest digest';
         }
         .address-grid-container-top.no-image {
             @apply grid grid-cols-3 grid-rows-3;
             grid-template-areas:
                 'name description type'
                 'objectId version type'
-                'owner lastTxBlock storageRebate';
+                'owner lastTxBlock storageRebate'
+                'digest digest digest';
         }
     }
 }

--- a/apps/explorer/src/pages/object-result/views/ObjectView.tsx
+++ b/apps/explorer/src/pages/object-result/views/ObjectView.tsx
@@ -153,6 +153,21 @@ function LastTxBlockCard({ digest }: LastTxBlockCardProps): JSX.Element {
     );
 }
 
+interface DigestCardProps {
+    digest: string;
+}
+
+function DigestCard({ digest }: DigestCardProps): JSX.Element {
+    return (
+        <DisplayStats
+            label="Object Digest"
+            value={formatDigest(digest)}
+            copyText={digest}
+            onCopySuccess={onCopySuccess}
+        />
+    );
+}
+
 function getOwnerDisplay(objOwner: ObjectOwner): 'Shared' | 'Immutable' | string {
     if (objOwner === 'Immutable') {
         return 'Immutable';
@@ -227,6 +242,7 @@ export function ObjectView({ data }: ObjectViewProps): JSX.Element {
     const storageRebate = data.data?.storageRebate;
     const objectId = data.data?.objectId;
     const lastTransactionBlockDigest = data.data?.previousTransaction;
+    const objectDigest = data.data?.digest;
 
     const heroImageTitle = name || display?.description || trimStdLibPrefix(objectType);
     const heroImageSubtitle = `1 ${capitalize(nftFileType)} File`;
@@ -291,6 +307,11 @@ export function ObjectView({ data }: ObjectViewProps): JSX.Element {
                 {storageRebate && (
                     <div style={{ gridArea: 'storageRebate' }}>
                         <StorageRebateCard storageRebate={storageRebate} />
+                    </div>
+                )}
+                {objectDigest && (
+                    <div style={{ gridArea: 'digest' }}>
+                        <DigestCard digest={objectDigest} />
                     </div>
                 )}
             </div>


### PR DESCRIPTION
# Description of change

Display digest for objects, can be useful for devs similar to version, is needed for object input references and is currently missing

object page
<img width="1349" height="437" alt="image" src="https://github.com/user-attachments/assets/60229420-764d-4a16-8a1c-6b1845b8ab31" />
nft page with image
<img width="1305" height="759" alt="image" src="https://github.com/user-attachments/assets/8fe7a74f-e942-4459-8076-58339af8cdd8" />

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/8687

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

