### PR TITLE
feat: enable Move-based account authentication in testnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -126,6 +126,7 @@ pub const MAX_PROTOCOL_VERSION: u64 = 22;
 //             mechanism on all networks.
 //             Enable a separate gas price feedback mechanism for transactions
 //             using randomness on all networks.
+//             Enable Move-based account authentication in testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2607,6 +2608,20 @@ impl ProtocolConfig {
                     // randomness on all networks.
                     cfg.feature_flags
                         .separate_gas_price_feedback_mechanism_for_randomness = true;
+
+                    if chain != Chain::Mainnet {
+                        // Enable storing metadata in module bytes and then
+                        // publishing package metadata in testnet
+                        cfg.feature_flags.metadata_in_module_bytes = true;
+                        cfg.feature_flags.publish_package_metadata = true;
+                        // Enable Move authentication in testnet
+                        cfg.feature_flags.enable_move_authentication = true;
+                        // Max_auth_gas is 0.00025 IOTA
+                        cfg.max_auth_gas = Some(250_000);
+                        // Increase the base cost for transfer receive object in testnet, since the
+                        // implementation now does check if parent is not an account.
+                        cfg.transfer_receive_object_cost_base = Some(100);
+                    }
                 }
 
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_22.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_22.snap
@@ -35,6 +35,9 @@ feature_flags:
   consensus_commit_transactions_only_for_traversed_headers: true
   congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
   separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
   pass_validator_scores_to_advance_epoch: true
   calculate_validator_scores: true
 max_tx_size_bytes: 131072
@@ -71,6 +74,7 @@ max_move_object_size: 256000
 max_move_package_size: 102400
 max_publish_or_upgrade_per_ptb: 5
 max_tx_gas: 50000000000
+max_auth_gas: 250000
 max_gas_price: 100000
 max_gas_computation_bucket: 5000000
 gas_rounding_step: 1000
@@ -160,7 +164,7 @@ object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
-transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_base: 100
 tx_context_derive_id_cost_base: 52
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2


### PR DESCRIPTION
# Description of change

Enable Move-based account authentication in testnet.

### Release Notes

- [x] Protocol: Enable Move-based account authentication in testnet. Only `transaction.sender` authentication is supported currently.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
