### PR TITLE
chore: remove unnecessary clones, allocations, and iterations

### DIFF
--- a/crates/iota-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/df_handler.rs
@@ -112,7 +112,7 @@ impl DynamicFieldHandler {
         checkpoint: u64,
         timestamp_ms: u64,
         object: &Object,
-        all_written_objects: &HashMap<ObjectID, Object>,
+        all_written_objects: &HashMap<ObjectID, &Object>,
         state: &mut State,
     ) -> Result<()> {
         let move_obj_opt = object.data.try_as_move();
@@ -161,7 +161,7 @@ impl DynamicFieldHandler {
                 object_id: object.id().to_string(),
                 version: object.version().value(),
                 digest: object.digest().to_string(),
-                object_type: move_object.clone().into_type().into_type_params()[1]
+                object_type: move_object.type_().type_params()[1]
                     .to_canonical_string(/* with_prefix */ true),
             },
             DynamicFieldType::DynamicObject => {
@@ -205,7 +205,7 @@ impl DynamicFieldHandler {
         let all_objects: HashMap<_, _> = checkpoint_transaction
             .output_objects
             .iter()
-            .map(|x| (x.id(), x.clone()))
+            .map(|x| (x.id(), x))
             .collect();
         for object in checkpoint_transaction.output_objects.iter() {
             self.process_dynamic_field(

--- a/crates/iota-archival/src/lib.rs
+++ b/crates/iota-archival/src/lib.rs
@@ -171,9 +171,9 @@ impl Manifest {
             epoch,
         })
     }
-    pub fn files(&self) -> Vec<FileMetadata> {
+    pub fn files(&self) -> &[FileMetadata] {
         match self {
-            Manifest::V1(manifest) => manifest.file_metadata.clone(),
+            Manifest::V1(manifest) => &manifest.file_metadata,
         }
     }
     pub fn epoch_num(&self) -> u64 {
@@ -191,9 +191,9 @@ impl Manifest {
             Manifest::V1(manifest) => {
                 let mut summary_files: Vec<_> = manifest
                     .file_metadata
-                    .clone()
-                    .into_iter()
+                    .iter()
                     .filter(|f| f.file_type == FileType::CheckpointSummary)
+                    .cloned()
                     .collect();
                 summary_files.sort_by_key(|f| f.checkpoint_seq_range.start);
                 assert!(
@@ -216,9 +216,9 @@ impl Manifest {
             Manifest::V1(manifest) => {
                 let mut summary_files: Vec<_> = manifest
                     .file_metadata
-                    .clone()
-                    .into_iter()
+                    .iter()
                     .filter(|f| f.file_type == FileType::CheckpointSummary)
+                    .cloned()
                     .collect();
                 summary_files.sort_by_key(|f| f.checkpoint_seq_range.start);
                 assert_eq!(summary_files.first().unwrap().checkpoint_seq_range.start, 0);
@@ -250,7 +250,7 @@ impl Manifest {
             Manifest::V1(manifest) => {
                 manifest
                     .file_metadata
-                    .extend(vec![checkpoint_file_metadata, summary_file_metadata]);
+                    .extend([checkpoint_file_metadata, summary_file_metadata]);
                 manifest.epoch = epoch_num;
                 manifest.next_checkpoint_seq_num = checkpoint_sequence_number;
             }

--- a/crates/iota-archival/src/reader.rs
+++ b/crates/iota-archival/src/reader.rs
@@ -190,13 +190,14 @@ impl ArchiveReader {
         }
 
         let mut summary_files: Vec<_> = files
-            .clone()
-            .into_iter()
+            .iter()
             .filter(|f| f.file_type == FileType::CheckpointSummary)
+            .cloned()
             .collect();
         let mut contents_files: Vec<_> = files
-            .into_iter()
+            .iter()
             .filter(|f| f.file_type == FileType::CheckpointContent)
+            .cloned()
             .collect();
         assert_eq!(summary_files.len(), contents_files.len());
 

--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -52,8 +52,8 @@ impl FromStr for RunInterval {
 impl std::fmt::Display for RunInterval {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            RunInterval::Count(count) => f.write_str(format!("{count}").as_str()),
-            RunInterval::Time(d) => f.write_str(format!("{}sec", d.as_secs()).as_str()),
+            RunInterval::Count(count) => write!(f, "{count}"),
+            RunInterval::Time(d) => write!(f, "{}sec", d.as_secs()),
         }
     }
 }

--- a/crates/iota-aws-orchestrator/src/client/mod.rs
+++ b/crates/iota-aws-orchestrator/src/client/mod.rs
@@ -180,7 +180,7 @@ pub trait ServerProviderClient: Display {
 
 #[cfg(test)]
 pub mod test_client {
-    use std::{collections::HashMap, fmt::Display, sync::Mutex};
+    use std::{collections::{HashMap, HashSet}, fmt::Display, sync::Mutex};
 
     use serde::Serialize;
 
@@ -241,7 +241,7 @@ pub mod test_client {
         where
             I: Iterator<Item = &'a Instance> + Send,
         {
-            let instance_ids: Vec<_> = instances.map(|x| x.id.clone()).collect();
+            let instance_ids: HashSet<_> = instances.map(|x| x.id.clone()).collect();
             let mut guard = self.instances.lock().unwrap();
             for instance in guard.iter_mut().filter(|x| instance_ids.contains(&x.id)) {
                 instance.status = "running".into();
@@ -253,7 +253,7 @@ pub mod test_client {
         where
             I: Iterator<Item = &'a Instance> + Send,
         {
-            let instance_ids: Vec<_> = instances.map(|x| x.id.clone()).collect();
+            let instance_ids: HashSet<_> = instances.map(|x| x.id.clone()).collect();
             let mut guard = self.instances.lock().unwrap();
             for instance in guard.iter_mut().filter(|x| instance_ids.contains(&x.id)) {
                 instance.status = "stopped".into();

--- a/crates/iota-aws-orchestrator/src/faults.rs
+++ b/crates/iota-aws-orchestrator/src/faults.rs
@@ -126,7 +126,7 @@ impl CrashRecoverySchedule {
             FaultsType::Permanent { faults } => {
                 if self.dead == 0 {
                     self.dead = *faults;
-                    CrashRecoveryAction::kill(self.instances.clone().drain(0..*faults).collect())
+                    CrashRecoveryAction::kill(self.instances[..*faults].to_vec())
                 } else {
                     CrashRecoveryAction::no_op()
                 }
@@ -138,7 +138,7 @@ impl CrashRecoverySchedule {
 
                 // Recover all nodes if we already crashed them all.
                 if self.dead == *max_faults {
-                    let instances: Vec<_> = self.instances.clone().drain(0..*max_faults).collect();
+                    let instances: Vec<_> = self.instances[..*max_faults].to_vec();
                     self.dead = 0;
                     CrashRecoveryAction::boot(instances)
                 }
@@ -152,7 +152,7 @@ impl CrashRecoverySchedule {
                         (2 * min_faults, *max_faults)
                     };
 
-                    let instances: Vec<_> = self.instances.clone().drain(l..h).collect();
+                    let instances: Vec<_> = self.instances[l..h].to_vec();
                     self.dead += h - l;
                     CrashRecoveryAction::kill(instances)
                 }

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -247,7 +247,8 @@ impl Settings {
             .url
             .path_segments()
             .expect("Url should already be checked when loading settings")
-            .collect::<Vec<_>>()[1]
+            .nth(1)
+            .unwrap()
             .split('.')
             .next()
             .unwrap()

--- a/crates/iota-benchmark/src/bank.rs
+++ b/crates/iota-benchmark/src/bank.rs
@@ -109,9 +109,8 @@ impl BenchmarkBank {
         init_coin: &mut Gas,
         gas_price: u64,
     ) -> Result<UpdatedAndNewlyMintedGasCoins> {
-        let recipient_addresses: Vec<IotaAddress> =
-            coin_configs.iter().map(|g| g.address).collect();
-        let amounts: Vec<u64> = coin_configs.iter().map(|c| c.amount).collect();
+        let (recipient_addresses, amounts): (Vec<IotaAddress>, Vec<u64>) =
+            coin_configs.iter().map(|g| (g.address, g.amount)).unzip();
 
         info!(
             "Creating {} coin(s) of balance {}...",

--- a/crates/iota-benchmark/src/drivers/mod.rs
+++ b/crates/iota-benchmark/src/drivers/mod.rs
@@ -43,12 +43,12 @@ impl FromStr for Interval {
 impl std::fmt::Display for Interval {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Interval::Count(count) => f.write_str(format!("{count}").as_str()),
+            Interval::Count(count) => write!(f, "{count}"),
             Interval::Time(d) => {
                 if *d == Duration::MAX {
                     f.write_str("unbounded")
                 } else {
-                    f.write_str(format!("{}sec", d.as_secs()).as_str())
+                    write!(f, "{}sec", d.as_secs())
                 }
             }
         }

--- a/crates/iota-benchmark/src/lib.rs
+++ b/crates/iota-benchmark/src/lib.rs
@@ -472,9 +472,9 @@ impl ValidatorProxy for FullNodeProxy {
         while let Some(object) = stream.try_next().await? {
             let o = object.data;
             if let Some(o) = o {
-                let temp: Object = o.clone().try_into()?;
+                let temp: Object = o.try_into()?;
                 let gas_coin = GasCoin::try_from(&temp)?;
-                values_objects.push((gas_coin.value(), o.clone().try_into()?));
+                values_objects.push((gas_coin.value(), temp));
             }
         }
 

--- a/crates/iota-build-cache-server/src/cache.rs
+++ b/crates/iota-build-cache-server/src/cache.rs
@@ -502,7 +502,7 @@ impl BuildCache {
             .await?;
 
         if output.status.success() {
-            let resolved_commit = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let resolved_commit = String::from_utf8_lossy(&output.stdout).trim().to_owned();
             if resolved_commit.len() >= 7 && resolved_commit.chars().all(|c| c.is_ascii_hexdigit())
             {
                 if commit_ref != resolved_commit {

--- a/crates/iota-config/src/lib.rs
+++ b/crates/iota-config/src/lib.rs
@@ -53,7 +53,7 @@ pub fn iota_config_dir() -> Result<PathBuf, anyhow::Error> {
     }
     .and_then(|dir| {
         if !dir.exists() {
-            fs::create_dir_all(dir.clone())?;
+            fs::create_dir_all(&dir)?;
         }
         Ok(dir)
     })

--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -1107,7 +1107,7 @@ where
                     )
                 },
                 |mut state, name, weight, response| {
-                    let display_name = validator_display_names.get(&name).unwrap_or(&name.concise().to_string()).clone();
+                    let display_name = validator_display_names.get(&name).cloned().unwrap_or_else(|| name.concise().to_string());
                     Box::pin(async move {
                         match self.handle_process_transaction_response(
                             tx_digest, &mut state, response, name, weight,
@@ -1603,7 +1603,7 @@ where
             move |mut state, name, weight, response| {
                 let committee_clone = committee.clone();
                 let metrics = metrics.clone();
-                let display_name = validator_display_names.get(&name).unwrap_or(&name.concise().to_string()).clone();
+                let display_name = validator_display_names.get(&name).cloned().unwrap_or_else(|| name.concise().to_string());
                 Box::pin(async move {
                     // We aggregate the effects response, until we have more than 2f
                     // and return.
@@ -1921,7 +1921,7 @@ where
                 })
             },
             |mut state, name, weight, response| {
-                let display_name = validator_display_names.get(&name).unwrap_or(&name.concise().to_string()).clone();
+                let display_name = validator_display_names.get(&name).cloned().unwrap_or_else(|| name.concise().to_string());
                 Box::pin(async move {
                     match response {
                         Ok(_) => {

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1115,7 +1115,7 @@ impl ValidatorService {
                 direct: client,
                 through_fullnode: None,
                 error_info: error.map(|e| {
-                    let error_type = String::from(e.clone().as_ref());
+                    let error_type = String::from(e.as_ref());
                     let error_weight = normalize(e);
                     (error_weight, error_type)
                 }),

--- a/crates/iota-core/src/db_checkpoint_handler.rs
+++ b/crates/iota-core/src/db_checkpoint_handler.rs
@@ -414,7 +414,6 @@ mod tests {
     use iota_storage::object_store::util::{
         find_all_dirs_with_epoch_prefix, find_missing_epochs_dirs, path_to_filesystem,
     };
-    use itertools::Itertools;
     use tempfile::TempDir;
 
     use crate::db_checkpoint_handler::{
@@ -740,7 +739,7 @@ mod tests {
         )
         .await?;
         let mut expected_missing_epochs: Vec<u64> = (0..100).collect();
-        expected_missing_epochs.extend((101..200).collect_vec().iter());
+        expected_missing_epochs.extend(101..200);
         expected_missing_epochs.push(201);
         assert_eq!(missing_epochs, expected_missing_epochs);
         Ok(())

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -746,7 +746,7 @@ impl IndexStore {
 
         batch.insert_batch(
             &self.tables.event_by_time,
-            events.data.iter().enumerate().map(|(i, _)| {
+            (0..events.data.len()).map(|i| {
                 (
                     (timestamp_ms, (sequence, i)),
                     (event_digest, *digest, timestamp_ms),

--- a/crates/iota-core/src/scoring_decision.rs
+++ b/crates/iota-core/src/scoring_decision.rs
@@ -178,17 +178,17 @@ mod tests {
     fn generate_committees(committee_size: usize) -> (Committee, ConsensusCommittee) {
         let (consensus_committee, _) = local_committee_and_keys(0, vec![1; committee_size]);
 
-        let public_keys = consensus_committee
-            .authorities()
-            .map(|(_i, authority)| authority.authority_key.inner())
-            .collect::<Vec<_>>();
-        let iota_authorities = public_keys
-            .iter()
-            .map(|key| (AuthorityPublicKeyBytes::from(*key), 1))
-            .collect::<Vec<_>>();
         let iota_committee = Committee::new_for_testing_with_normalized_voting_power(
             0,
-            iota_authorities.iter().cloned().collect(),
+            consensus_committee
+                .authorities()
+                .map(|(_i, authority)| {
+                    (
+                        AuthorityPublicKeyBytes::from(authority.authority_key.inner()),
+                        1,
+                    )
+                })
+                .collect(),
         );
 
         (iota_committee, consensus_committee)

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -314,7 +314,7 @@ async fn test_execution_with_dependencies() {
                 .collect_vec()
         })
         .collect_vec();
-    let all_gas_objects = gas_objects.clone().into_iter().flatten().collect_vec();
+    let all_gas_objects = gas_objects.iter().flatten().cloned().collect_vec();
 
     let (aggregator, authorities, _genesis, package) =
         init_local_authorities(4, all_gas_objects.clone()).await;

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -1561,7 +1561,7 @@ async fn test_handle_certificate_errors() {
     // Test handle certificate with invalid user input
     let signed_transaction = VerifiedSignedTransaction::new(
         epoch_store.epoch(),
-        VerifiedTransaction::new_unchecked(transfer_transaction.clone().clone()),
+        VerifiedTransaction::new_unchecked(transfer_transaction.clone()),
         authority_state.name,
         &*authority_state.secret,
     );

--- a/crates/iota-core/src/unit_tests/type_param_tests.rs
+++ b/crates/iota-core/src/unit_tests/type_param_tests.rs
@@ -52,7 +52,7 @@ async fn test_same_module_type_param() {
     .unwrap();
 
     let created_object_id = effects.created()[0].0.0;
-    let type_param = TypeTag::from_str(format!("{}::m1::Object", package.0).as_str()).unwrap();
+    let type_param = TypeTag::from_str(&format!("{}::m1::Object", package.0)).unwrap();
 
     let effects = call_move(
         &authority,
@@ -110,8 +110,7 @@ async fn test_different_module_type_param() {
     .unwrap();
 
     let created_object_id = effects.created()[0].0.0;
-    let type_param =
-        TypeTag::from_str(format!("{}::m2::AnotherObject", package.0).as_str()).unwrap();
+    let type_param = TypeTag::from_str(&format!("{}::m2::AnotherObject", package.0)).unwrap();
 
     let effects = call_move(
         &authority,
@@ -313,8 +312,7 @@ async fn test_different_package_type_param() {
     .unwrap();
 
     let created_object_id = effects.created()[0].0.0;
-    let type_param =
-        TypeTag::from_str(format!("{}::m2::AnotherObject", package.0).as_str()).unwrap();
+    let type_param = TypeTag::from_str(&format!("{}::m2::AnotherObject", package.0)).unwrap();
 
     let effects = call_move(
         &authority,

--- a/crates/iota-e2e-tests/tests/overload_monitor_tests.rs
+++ b/crates/iota-e2e-tests/tests/overload_monitor_tests.rs
@@ -34,9 +34,7 @@ mod simtests {
         );
 
         // Tests (indirectly) that fullnodes don't run overload monitor.
-        assert!(
-            test_cluster.swarm.all_nodes().collect::<Vec<_>>().len() > nodes_with_overload_monitor
-        );
+        assert!(test_cluster.swarm.all_nodes().count() > nodes_with_overload_monitor);
     }
 }
 

--- a/crates/iota-e2e-tests/tests/passkey_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/passkey_e2e_tests.rs
@@ -211,7 +211,7 @@ async fn create_credential_and_sign_test_tx(
     PasskeyResponse {
         user_sig_bytes,
         authenticator_data: authenticator_data.to_vec(),
-        client_data_json: String::from_utf8_lossy(client_data_json).to_string(),
+        client_data_json: String::from_utf8_lossy(client_data_json).into_owned(),
         intent_msg,
     }
 }

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -1430,7 +1430,7 @@ mod tests {
         loop {
             // Assert that all of these are SUCCEEDED
             status_results =
-                futures::future::join_all(response.clone().iter().map(|task| {
+                futures::future::join_all(response.iter().map(|task| {
                     faucet.get_batch_send_status(Uuid::parse_str(&task.task).unwrap())
                 }))
                 .await
@@ -2021,7 +2021,7 @@ mod tests {
         loop {
             // Assert that all of these are SUCCEEDED
             status_results =
-                futures::future::join_all(response.clone().iter().map(|task| {
+                futures::future::join_all(response.iter().map(|task| {
                     faucet.get_batch_send_status(Uuid::parse_str(&task.task).unwrap())
                 }))
                 .await

--- a/crates/iota-framework-snapshot/src/main.rs
+++ b/crates/iota-framework-snapshot/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
 
 fn write_package_to_file(version: u64, package: &SystemPackage) {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.extend(["bytecode_snapshot", version.to_string().as_str()]);
+    path.extend(["bytecode_snapshot", &version.to_string()]);
     fs::create_dir_all(&path)
         .or_else(|e| match e.kind() {
             std::io::ErrorKind::AlreadyExists => Ok(()),

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -400,7 +400,9 @@ impl Builder {
             &self.parameters,
             &token_distribution_schedule,
             self.validators.values(),
-            self.objects.clone().into_values().collect::<Vec<_>>(),
+            std::mem::take(&mut self.objects)
+                .into_values()
+                .collect::<Vec<_>>(),
             &mut self.genesis_stake,
             &mut self.migration_objects,
         );
@@ -456,7 +458,7 @@ impl Builder {
         let committee = Self::committee(&objects);
 
         let checkpoint = {
-            let signatures = self.signatures.clone().into_values().collect();
+            let signatures = self.signatures.into_values().collect();
 
             CertifiedCheckpointSummary::new(checkpoint, signatures, &committee).unwrap()
         };
@@ -650,7 +652,7 @@ impl Builder {
         assert_eq!(system_state.validators.validator_candidates.size, 0);
 
         // Check distribution is correct
-        let token_distribution_schedule = self.token_distribution_schedule.clone().unwrap();
+        let token_distribution_schedule = self.token_distribution_schedule.as_ref().unwrap();
 
         let allocations_amount: u64 = token_distribution_schedule
             .allocations
@@ -684,7 +686,7 @@ impl Builder {
                 })
                 .collect();
 
-        for allocation in token_distribution_schedule.allocations {
+        for allocation in &token_distribution_schedule.allocations {
             if let Some(staked_with_validator) = allocation.staked_with_validator {
                 let staking_pool_id = *address_to_pool_id
                     .get(&staked_with_validator)

--- a/crates/iota-genesis-builder/src/stake.rs
+++ b/crates/iota-genesis-builder/src/stake.rs
@@ -74,7 +74,7 @@ impl GenesisStake {
 
         builder.set_pre_minted_supply(pre_minted_supply);
 
-        for allocation in self.token_allocation.clone() {
+        for allocation in self.token_allocation.iter().cloned() {
             builder.add_allocation(allocation);
         }
         builder.build()
@@ -96,7 +96,7 @@ impl GenesisStake {
     ) -> TokenDistributionSchedule {
         schedule_without_migration
             .allocations
-            .extend(self.token_allocation.clone());
+            .extend(self.token_allocation.iter().cloned());
         schedule_without_migration.pre_minted_supply =
             self.calculate_pre_minted_supply(total_supply_nanos);
         schedule_without_migration.validate();

--- a/crates/iota-genesis-builder/src/stardust/native_token/package_data.rs
+++ b/crates/iota-genesis-builder/src/stardust/native_token/package_data.rs
@@ -121,7 +121,7 @@ impl TryFrom<&FoundryOutput> for NativeTokenPackageData {
             module: NativeTokenModuleData {
                 foundry_id: output.id(),
                 module_name: identifier.clone(),
-                otw_name: identifier.clone().to_ascii_uppercase(),
+                otw_name: identifier.to_ascii_uppercase(),
                 decimals,
                 symbol: identifier,
                 circulating_supply: token_scheme_u64.circulating_supply(),

--- a/crates/iota-graphql-rpc-client/src/simple_client.rs
+++ b/crates/iota-graphql-rpc-client/src/simple_client.rs
@@ -53,7 +53,7 @@ impl SimpleClient {
     ) -> Result<GraphqlResponse, ClientError> {
         if get_usage {
             headers.push((
-                LIMITS_HEADER.clone().as_str().try_into().unwrap(),
+                LIMITS_HEADER.as_str().try_into().unwrap(),
                 HeaderValue::from_static("true"),
             ));
         }

--- a/crates/iota-graphql-rpc/src/data/pg.rs
+++ b/crates/iota-graphql-rpc/src/data/pg.rs
@@ -163,7 +163,7 @@ mod query_cost {
     where
         Q: Query + QueryId + QueryFragment<Pg> + RunQueryDsl<PgConnection>,
     {
-        debug!("Estimating: {}", diesel::debug_query(&query).to_string());
+        debug!("Estimating: {}", diesel::debug_query(&query));
 
         let Some(cost) = explain(conn, query) else {
             warn!("Failed to extract cost from EXPLAIN.");

--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -190,7 +190,7 @@ impl ReadApiServer for ReadApi {
             stored_objects
                 .into_iter()
                 .map(|obj| {
-                    let object_id = ObjectID::try_from(obj.object_id.clone()).map_err(|_| {
+                    let object_id = ObjectID::from_bytes(&obj.object_id).map_err(|_| {
                         IndexerError::PersistentStorageDataCorruption(format!(
                             "failed to parse ObjectID: {:?}",
                             obj.object_id

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -208,14 +208,17 @@ impl PrimaryWorker {
     fn derive_object_versions(
         object_history_changes: &TransactionObjectChangesToCommit,
     ) -> Vec<StoredObjectVersion> {
-        let mut object_versions = vec![];
-        for changed_obj in object_history_changes.changed_objects.iter() {
-            object_versions.push(changed_obj.into());
-        }
-        for deleted_obj in object_history_changes.deleted_objects.iter() {
-            object_versions.push(deleted_obj.into());
-        }
-        object_versions
+        object_history_changes
+            .changed_objects
+            .iter()
+            .map(Into::into)
+            .chain(
+                object_history_changes
+                    .deleted_objects
+                    .iter()
+                    .map(Into::into),
+            )
+            .collect()
     }
 
     async fn index_checkpoint(
@@ -630,7 +633,7 @@ impl PrimaryWorker {
                 data.transactions
                     .iter()
                     .flat_map(|tx| &tx.output_objects)
-                    .filter_map(|o| {
+                    .filter_map(move |o| {
                         if let iota_types::object::Data::Package(p) = &o.data {
                             Some(IndexedPackage {
                                 package_id: o.id(),
@@ -641,7 +644,6 @@ impl PrimaryWorker {
                             None
                         }
                     })
-                    .collect::<Vec<_>>()
             })
             .collect()
     }
@@ -756,11 +758,7 @@ impl ObjectProvider for InMemTxChanges {
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<Object, Self::Error> {
-        let object = self
-            .object_cache
-            .get(id, Some(version))
-            .as_ref()
-            .map(|o| <&Object>::clone(o).clone());
+        let object = self.object_cache.get(id, Some(version)).cloned();
         if let Some(o) = object {
             self.metrics.indexing_get_object_in_mem_hit.inc();
             return Ok(o);
@@ -777,11 +775,7 @@ impl ObjectProvider for InMemTxChanges {
         version: &SequenceNumber,
     ) -> Result<Option<Object>, Self::Error> {
         // First look up the exact version in object_cache.
-        let object = self
-            .object_cache
-            .get(id, Some(version))
-            .as_ref()
-            .map(|o| <&Object>::clone(o).clone());
+        let object = self.object_cache.get(id, Some(version)).cloned();
         if let Some(o) = object {
             self.metrics.indexing_get_object_in_mem_hit.inc();
             return Ok(Some(o));
@@ -790,11 +784,7 @@ impl ObjectProvider for InMemTxChanges {
         // Second look up the latest version in object_cache. This may be
         // called when the object is deleted hence the version at deletion
         // is given.
-        let object = self
-            .object_cache
-            .get(id, None)
-            .as_ref()
-            .map(|o| <&Object>::clone(o).clone());
+        let object = self.object_cache.get(id, None).cloned();
         if let Some(o) = object {
             if o.version() > *version {
                 panic!(

--- a/crates/iota-indexer/src/models/events.rs
+++ b/crates/iota-indexer/src/models/events.rs
@@ -76,7 +76,7 @@ impl StoredEvent {
         self,
         package_resolver: Arc<Resolver<impl PackageStore>>,
     ) -> Result<IotaEvent, IndexerError> {
-        let package_id = ObjectID::from_bytes(self.package.clone()).map_err(|_e| {
+        let package_id = ObjectID::from_bytes(&self.package).map_err(|_e| {
             IndexerError::PersistentStorageDataCorruption(format!(
                 "Failed to parse event package ID: {:?}",
                 self.package

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -166,14 +166,14 @@ impl StoredHistoryObject {
         let object_status = ObjectStatus::try_from(self.object_status).map_err(|_| {
             IndexerError::PersistentStorageDataCorruption(format!(
                 "Object {} has an invalid object status: {}",
-                ObjectID::from_bytes(self.object_id.clone()).unwrap(),
+                ObjectID::from_bytes(&self.object_id).unwrap(),
                 self.object_status
             ))
         })?;
 
         if let ObjectStatus::WrappedOrDeleted = object_status {
             let object_ref = (
-                ObjectID::from_bytes(self.object_id.clone())?,
+                ObjectID::from_bytes(&self.object_id)?,
                 SequenceNumber::from_u64(self.object_version as u64),
                 ObjectDigest::OBJECT_DIGEST_DELETED,
             );
@@ -409,7 +409,7 @@ impl StoredObject {
     }
 
     pub fn get_object_ref(&self) -> Result<ObjectRef, IndexerError> {
-        let object_id = ObjectID::from_bytes(self.object_id.clone()).map_err(|_| {
+        let object_id = ObjectID::from_bytes(&self.object_id).map_err(|_| {
             IndexerError::Serde(format!("Can't convert {:?} to object_id", self.object_id))
         })?;
         let object_digest =

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -523,12 +523,13 @@ pub async fn tx_events_to_iota_tx_events(
 ) -> Result<IotaTransactionBlockEvents, IndexerError> {
     let mut iota_event_futures = vec![];
     let tx_events_data_len = tx_events.data.len();
-    for tx_event in tx_events.data.clone() {
+    for tx_event in &tx_events.data {
         let package_resolver_clone = package_resolver.clone();
+        let event_type = tx_event.type_.clone();
         iota_event_futures.push(tokio::task::spawn(async move {
             let resolver = package_resolver_clone;
             resolver
-                .type_layout(TypeTag::Struct(Box::new(tx_event.type_.clone())))
+                .type_layout(TypeTag::Struct(Box::new(event_type)))
                 .await
         }));
     }

--- a/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
@@ -441,7 +441,7 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         let move_call_metrics: Vec<StoredMoveCallMetrics> = chained
             .into_iter()
             .filter_map(|queried_move_metrics| {
-                let package = ObjectID::from_bytes(queried_move_metrics.move_package.clone()).ok();
+                let package = ObjectID::from_bytes(&queried_move_metrics.move_package).ok();
                 let package_str = match package {
                     Some(p) => p.to_canonical_string(/* with_prefix */ true),
                     None => {

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -644,16 +644,9 @@ impl PgIndexerStore {
         conn: &mut PgConnection,
         deleted_objects_chunk: Vec<StoredDeletedObject>,
     ) -> Result<(), IndexerError> {
-        diesel::delete(
-            objects::table.filter(
-                objects::object_id.eq_any(
-                    deleted_objects_chunk
-                        .iter()
-                        .map(|o| o.object_id.clone())
-                        .collect::<Vec<_>>(),
-                ),
-            ),
-        )
+        diesel::delete(objects::table.filter(
+            objects::object_id.eq_any(deleted_objects_chunk.iter().map(|o| o.object_id.clone())),
+        ))
         .execute(conn)
         .map_err(IndexerError::from)
         .context("Failed to write object deletion to PostgresDB")?;

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -76,8 +76,8 @@ impl IndexedCheckpoint {
             epoch: checkpoint.epoch,
             tx_digests,
             previous_checkpoint_digest: checkpoint.previous_digest,
+            end_of_epoch: checkpoint.end_of_epoch_data.is_some(),
             end_of_epoch_data: checkpoint.end_of_epoch_data.clone(),
-            end_of_epoch: checkpoint.end_of_epoch_data.clone().is_some(),
             total_gas_cost,
             computation_cost: checkpoint.epoch_rolling_gas_cost_summary.computation_cost,
             computation_cost_burned: checkpoint
@@ -221,7 +221,8 @@ impl EventIndex {
             .type_
             .to_canonical_string(/* with_prefix */ true)
             .splitn(3, "::")
-            .collect::<Vec<_>>()[2]
+            .nth(2)
+            .expect("expected module::name::type format")
             .to_string();
         Self {
             tx_sequence_number,

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1343,7 +1343,7 @@ fn move_view_function_call() {
         let IotaMoveValue::Struct(IotaMoveStruct::WithTypes { type_, fields }) = wat else {
             panic!("return value should have been a struct");
         };
-        assert_eq!(type_.name.to_string(), format!("Wat"));
+        assert_eq!(type_.name.to_string(), "Wat");
         assert!(fields.contains_key(&"counter".to_string()));
     });
 }

--- a/crates/iota-json-rpc-tests/tests/transaction_builder_api.rs
+++ b/crates/iota-json-rpc-tests/tests/transaction_builder_api.rs
@@ -77,8 +77,8 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
         .await?
         .data;
 
-    let obj = objects.clone().first().unwrap().object().unwrap().object_id;
-    let gas = objects.clone().last().unwrap().object().unwrap().object_id;
+    let obj = objects.first().unwrap().object().unwrap().object_id;
+    let gas = objects.last().unwrap().object().unwrap().object_id;
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .transfer_object(address, obj, Some(gas), 10_000_000.into(), address)

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -576,9 +576,12 @@ impl IotaObjectResponse {
     /// Returns the object value if there is any, otherwise an Err if
     /// the object does not exist or is deleted.
     pub fn into_object(self) -> Result<IotaObjectData, IotaObjectResponseError> {
-        match self.object() {
-            Ok(data) => Ok(data.clone()),
-            Err(error) => Err(error),
+        if let Some(data) = self.data {
+            Ok(data)
+        } else if let Some(error) = self.error {
+            Err(error)
+        } else {
+            Err(IotaObjectResponseError::Unknown)
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -594,7 +594,7 @@ impl TryInto<Object> for IotaObjectData {
         let data = match self.bcs {
             Some(IotaRawData::MoveObject(o)) => Data::Move({
                 MoveObject::new_from_execution(
-                    o.type_().clone().into(),
+                    o.type_.into(),
                     o.version,
                     o.bcs_bytes,
                     &protocol_config,
@@ -956,10 +956,12 @@ pub struct IotaRawMoveObject {
 
 impl From<MoveObject> for IotaRawMoveObject {
     fn from(o: MoveObject) -> Self {
+        let version = o.version();
+        let (type_, contents) = o.into_inner();
         Self {
-            type_: o.type_().clone().into(),
-            version: o.version(),
-            bcs_bytes: o.into_contents(),
+            type_: type_.into(),
+            version,
+            bcs_bytes: contents,
         }
     }
 }
@@ -969,10 +971,12 @@ impl IotaMoveObject for IotaRawMoveObject {
         object: MoveObject,
         _layout: MoveStructLayout,
     ) -> Result<Self, anyhow::Error> {
+        let version = object.version();
+        let (type_, contents) = object.into_inner();
         Ok(Self {
-            type_: object.type_().clone().into(),
-            version: object.version(),
-            bcs_bytes: object.into_contents(),
+            type_: type_.into(),
+            version,
+            bcs_bytes: contents,
         })
     }
 

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -1118,21 +1118,21 @@ impl Display for IotaTransactionBlockEffects {
         }
 
         if !self.mutated().is_empty() {
-            builder.push_record(vec![format!("Mutated Objects: ")]);
+            builder.push_record(vec!["Mutated Objects: ".to_string()]);
             for oref in self.mutated() {
                 builder.push_record(vec![owned_objref_string(oref)]);
             }
         }
 
         if !self.shared_objects().is_empty() {
-            builder.push_record(vec![format!("Shared Objects: ")]);
+            builder.push_record(vec!["Shared Objects: ".to_string()]);
             for oref in self.shared_objects() {
                 builder.push_record(vec![objref_string(oref)]);
             }
         }
 
         if !self.deleted().is_empty() {
-            builder.push_record(vec![format!("Deleted Objects: ")]);
+            builder.push_record(vec!["Deleted Objects: ".to_string()]);
 
             for oref in self.deleted() {
                 builder.push_record(vec![objref_string(oref)]);
@@ -1140,7 +1140,7 @@ impl Display for IotaTransactionBlockEffects {
         }
 
         if !self.wrapped().is_empty() {
-            builder.push_record(vec![format!("Wrapped Objects: ")]);
+            builder.push_record(vec!["Wrapped Objects: ".to_string()]);
 
             for oref in self.wrapped() {
                 builder.push_record(vec![objref_string(oref)]);
@@ -1148,7 +1148,7 @@ impl Display for IotaTransactionBlockEffects {
         }
 
         if !self.unwrapped().is_empty() {
-            builder.push_record(vec![format!("Unwrapped Objects: ")]);
+            builder.push_record(vec!["Unwrapped Objects: ".to_string()]);
             for oref in self.unwrapped() {
                 builder.push_record(vec![owned_objref_string(oref)]);
             }
@@ -1831,7 +1831,7 @@ impl Display for IotaTransactionBlock {
         let mut builder = TableBuilder::default();
 
         builder.push_record(vec![format!("{}", self.data)]);
-        builder.push_record(vec![format!("Signatures:")]);
+        builder.push_record(vec!["Signatures:".to_string()]);
         for tx_sig in &self.tx_signatures {
             builder.push_record(vec![format!(
                 "   {}\n",

--- a/crates/iota-json-rpc/src/balance_changes.rs
+++ b/crates/iota-json-rpc/src/balance_changes.rs
@@ -77,7 +77,7 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
                 if unwrapped_then_deleted.contains(&id) {
                     return None;
                 }
-                Some((id, version, input_objs_to_digest.get(&id).cloned()))
+                Some((id, version, input_objs_to_digest.get(&id).copied()))
             })
             .collect::<Vec<_>>(),
         &all_mutated,
@@ -196,7 +196,7 @@ impl<P> ObjectProviderCache<P> {
 
         for (object_id, (object_ref, object, _)) in written_objects {
             let key = (object_id, object_ref.1);
-            object_cache.insert(key, object.clone());
+            object_cache.insert(key, object);
 
             match last_version_cache.get_mut(&key) {
                 Some(existing_seq_number) => {
@@ -227,7 +227,7 @@ impl<P> ObjectProviderCache<P> {
             let version = object.version();
 
             let key = (object_id, version);
-            object_cache.insert(key, object.clone());
+            object_cache.insert(key, object);
 
             match last_version_cache.get_mut(&key) {
                 Some(existing_seq_number) => {

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -45,7 +45,7 @@ use crate::{
 
 pub fn parse_to_struct_tag(coin_type: &str) -> Result<StructTag, IotaRpcInputError> {
     parse_iota_struct_tag(coin_type)
-        .map_err(|e| IotaRpcInputError::CannotParseIotaStructTag(format!("{e}")))
+        .map_err(|e| IotaRpcInputError::CannotParseIotaStructTag(e.to_string()))
 }
 
 pub fn parse_to_type_tag(coin_type: Option<String>) -> Result<TypeTag, IotaRpcInputError> {

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -200,9 +200,8 @@ impl GovernanceReadApi {
         );
 
         let system_state = self.get_system_state()?;
-        let system_state_summary = IotaSystemStateSummaryV2::try_from(
-            system_state.clone().into_iota_system_state_summary(),
-        )?;
+        let system_state_summary =
+            IotaSystemStateSummaryV2::try_from(system_state.into_iota_system_state_summary())?;
 
         let rates = exchange_rates(&self.state, system_state_summary.epoch)
             .await?
@@ -268,9 +267,8 @@ impl GovernanceReadApi {
         );
 
         let system_state = self.get_system_state()?;
-        let system_state_summary = IotaSystemStateSummaryV2::try_from(
-            system_state.clone().into_iota_system_state_summary(),
-        )?;
+        let system_state_summary =
+            IotaSystemStateSummaryV2::try_from(system_state.into_iota_system_state_summary())?;
 
         let rates = exchange_rates(&self.state, system_state_summary.epoch)
             .await?

--- a/crates/iota-json-rpc/src/move_utils.rs
+++ b/crates/iota-json-rpc/src/move_utils.rs
@@ -192,7 +192,7 @@ impl MoveUtilsServer for MoveUtils {
             let module = self.internal.get_move_module(package, module_name).await?;
             let structs = module.structs;
             let identifier = Identifier::new(struct_name.as_str())
-                .map_err(|e| IotaRpcInputError::GenericInvalid(format!("{e}")))?;
+                .map_err(|e| IotaRpcInputError::GenericInvalid(e.to_string()))?;
             match structs.get(&identifier) {
                 Some(struct_) => Ok((&**struct_).into()),
                 None => Err(IotaRpcInputError::GenericNotFound(format!(
@@ -215,7 +215,7 @@ impl MoveUtilsServer for MoveUtils {
             let module = self.internal.get_move_module(package, module_name).await?;
             let functions = module.functions;
             let identifier = Identifier::new(function_name.as_str())
-                .map_err(|e| IotaRpcInputError::GenericInvalid(format!("{e}")))?;
+                .map_err(|e| IotaRpcInputError::GenericInvalid(e.to_string()))?;
             match functions.get(&identifier) {
                 Some(function) => Ok((&**function).into()),
                 None => Err(IotaRpcInputError::GenericNotFound(format!(
@@ -262,10 +262,10 @@ impl MoveUtilsServer for MoveUtils {
             }?;
 
             let identifier = Identifier::new(function.as_str())
-                .map_err(|e| IotaRpcInputError::GenericInvalid(format!("{e}")))?;
+                .map_err(|e| IotaRpcInputError::GenericInvalid(e.to_string()))?;
             let parameters = normalized
                 .get(&module)
-                .and_then(|m| m.functions.get(&identifier).map(|f| f.parameters.clone()));
+                .and_then(|m| m.functions.get(&identifier).map(|f| &f.parameters));
 
             match parameters {
                 Some(parameters) => Ok(parameters

--- a/crates/iota-json-rpc/src/object_changes.rs
+++ b/crates/iota-json-rpc/src/object_changes.rs
@@ -40,7 +40,7 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
                     // modify_at_version should always be available for mutated object
                     previous_version: modify_at_version
                         .get(&object_id)
-                        .cloned()
+                        .copied()
                         .unwrap_or_default(),
                     digest,
                 }),

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -229,10 +229,12 @@ impl ReadApi {
 
         if opts.require_input() {
             trace!("getting input");
-            let digests_clone = digests.clone();
-            let transactions =
-                self.transaction_kv_store.multi_get_tx(&digests_clone).await.tap_err(
-                    |err| debug!(digests=?digests_clone, "Failed to multi get transactions: {:?}", err),
+            let transactions = self
+                .transaction_kv_store
+                .multi_get_tx(&digests)
+                .await
+                .tap_err(
+                    |err| debug!(digests=?digests, "Failed to multi get transactions: {:?}", err),
                 )?;
 
             for ((_digest, cache_entry), txn) in
@@ -245,12 +247,11 @@ impl ReadApi {
         // Fetch effects when `show_events` is true because events relies on effects
         if opts.require_effects() {
             trace!("getting effects");
-            let digests_clone = digests.clone();
             let effects_list = self.transaction_kv_store
-                .multi_get_fx_by_tx_digest(&digests_clone)
+                .multi_get_fx_by_tx_digest(&digests)
                 .await
                 .tap_err(
-                    |err| debug!(digests=?digests_clone, "Failed to multi get effects for transactions: {:?}", err),
+                    |err| debug!(digests=?digests, "Failed to multi get effects for transactions: {:?}", err),
                 )?;
             for ((_digest, cache_entry), e) in
                 temp_response.iter_mut().zip(effects_list.into_iter())

--- a/crates/iota-keys/src/keystore.rs
+++ b/crates/iota-keys/src/keystore.rs
@@ -487,8 +487,7 @@ impl FileBasedKeystore {
         };
 
         // check aliases
-        let mut aliases_path = path.clone();
-        aliases_path.set_extension("aliases");
+        let aliases_path = path.with_extension("aliases");
 
         let aliases = if aliases_path.exists() {
             let reader = BufReader::new(File::open(&aliases_path).with_context(|| {
@@ -555,8 +554,7 @@ impl FileBasedKeystore {
     }
 
     fn needs_migration(path: &PathBuf) -> Result<bool, anyhow::Error> {
-        let mut aliases_path = path.clone();
-        aliases_path.set_extension("aliases");
+        let aliases_path = path.with_extension("aliases");
         if aliases_path.exists() {
             // If the aliases file exists, we assume that the keystore is in v1 format
             debug!(
@@ -605,8 +603,7 @@ impl FileBasedKeystore {
                 backup_path.display()
             )
         })?;
-        let mut aliases_path = path.clone();
-        aliases_path.set_extension("aliases");
+        let aliases_path = path.with_extension("aliases");
         let mut backup_aliases_path = aliases_path.clone();
         backup_aliases_path.set_extension("aliases.migrated");
         fs::rename(&aliases_path, &backup_aliases_path).with_context(|| {

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -751,10 +751,10 @@ impl CompiledPackage {
         // the compilation time but are not referenced in the source code.
         Ok(self
             .dependency_ids
-            .clone()
             .published
-            .into_iter()
+            .iter()
             .filter(|(pkg_name, _)| pkgs_to_keep.contains(pkg_name))
+            .map(|(k, v)| (*k, *v))
             .collect())
     }
 }

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -161,7 +161,7 @@ impl BuildConfig {
             let mod_name = u.named_module.module.name().to_string();
             let mod_is_test = u.attributes.is_test_or_test_only();
             for (_, s, info) in &u.function_infos {
-                let fn_name = s.as_str().to_string();
+                let fn_name = s.to_string();
                 let is_test = mod_is_test || info.attributes.is_test_or_test_only();
                 let authenticator_version = info.attributes.get_authenticator();
                 fn_info_map.insert(

--- a/crates/iota-move/src/manage_package.rs
+++ b/crates/iota-move/src/manage_package.rs
@@ -60,7 +60,7 @@ impl ManagePackage {
             bail!(NO_LOCK_FILE)
         };
         let install_dir = build_config.install_dir.unwrap_or(PathBuf::from("."));
-        let mut lock = LockFile::from(install_dir.clone(), &lock_file)?;
+        let mut lock = LockFile::from(install_dir, &lock_file)?;
 
         // Updating managed packages in the Move.lock file is controlled by distinct
         // `Published` and `Upgraded` commands. To set all relevant values, we

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -796,7 +796,7 @@ fn verify_peer_infos(
     // Acquire read lock once to get our peer ID and filter peers by cooldown
     let (our_peer_id, found_peers) = {
         let state_guard = state.read().unwrap();
-        let our_peer_id = state_guard.our_info.clone().unwrap().peer_id;
+        let our_peer_id = state_guard.our_info.as_ref().unwrap().peer_id;
 
         // Filter out peers that are in cooldown while holding the lock
         let filtered_peers: Vec<_> = found_peers

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -839,7 +839,7 @@ async fn test_access_types() {
         "Node 1",
         &network_1,
         &state_1,
-        HashSet::from_iter(vec![]),
+        HashSet::new(),
         HashSet::from_iter(vec![
             peer_id_2, peer_id_3, peer_id_4, peer_id_5, peer_id_6, peer_id_7, peer_id_8, peer_id_9,
             peer_id_10, peer_id_11,
@@ -941,7 +941,7 @@ async fn test_access_types() {
         "Node 9",
         &network_9,
         &state_9,
-        HashSet::from_iter(vec![]),
+        HashSet::new(),
         HashSet::from_iter(vec![
             peer_id_1, peer_id_2, peer_id_3, peer_id_4, peer_id_5, peer_id_6, peer_id_7, peer_id_8,
             peer_id_10, peer_id_11,

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -899,7 +899,7 @@ async fn sync_with_checkpoints_watermark() {
     timeout(Duration::from_secs(3), async {
         for (checkpoint, contents) in ordered_checkpoints[1..]
             .iter()
-            .zip(contents.clone().into_iter().skip(1))
+            .zip(contents.into_iter().skip(1))
         {
             assert_eq!(subscriber_4.recv().await.unwrap().data(), checkpoint.data());
             let content_digest = contents.into_checkpoint_contents_digest();

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1108,7 +1108,7 @@ impl IotaNode {
             (None, false) => Ok((db_checkpoint_config, None)),
             (_, _) => {
                 let handler = DBCheckpointHandler::new(
-                    &db_checkpoint_config.checkpoint_path.clone().unwrap(),
+                    db_checkpoint_config.checkpoint_path.as_ref().unwrap(),
                     db_checkpoint_config.object_store_config.as_ref(),
                     60,
                     db_checkpoint_config

--- a/crates/iota-node/src/metrics.rs
+++ b/crates/iota-node/src/metrics.rs
@@ -163,7 +163,7 @@ impl MetricsCallbackProvider for GrpcMetrics {
 
     fn on_response(&self, path: String, latency: Duration, _status: u16, grpc_status_code: Code) {
         self.grpc_requests
-            .with_label_values(&[path.as_str(), format!("{grpc_status_code:?}").as_str()])
+            .with_label_values(&[path.as_str(), &format!("{grpc_status_code:?}")])
             .inc();
         self.grpc_request_latency
             .with_label_values(&[path.as_str()])

--- a/crates/iota-open-rpc-macros/src/lib.rs
+++ b/crates/iota-open-rpc-macros/src/lib.rs
@@ -266,7 +266,10 @@ fn remove_iota_rpc_attributes(attributes: Attributes) -> TokenStream2 {
     let attrs = attributes
         .attrs
         .into_iter()
-        .filter(|r| !IOTA_RPC_ATTRS.contains(&r.key.to_string().as_str()))
+        .filter(|r| {
+            let key_str = r.key.to_string();
+            !IOTA_RPC_ATTRS.contains(&key_str.as_str())
+        })
         .collect::<Punctuated<Attr, Comma>>();
     quote! {(#attrs)}
 }

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -1101,8 +1101,8 @@ impl RpcExampleProvider {
         let abilities = IotaMoveAbilitySet {
             abilities: vec![IotaMoveAbility::Store, IotaMoveAbility::Key],
         };
-        let fields = vec![].into_iter().collect::<Vec<_>>();
-        let type_parameters = vec![].into_iter().collect::<Vec<_>>();
+        let fields = vec![];
+        let type_parameters = vec![];
         let result = IotaMoveNormalizedStruct {
             abilities,
             fields,

--- a/crates/iota-open-rpc/src/lib.rs
+++ b/crates/iota-open-rpc/src/lib.rs
@@ -354,7 +354,7 @@ impl RpcModuleDocBuilder {
         tag: Option<String>,
         deprecated: bool,
     ) {
-        let tags = tag.map(|t| Tag::new(&t)).into_iter().collect::<Vec<_>>();
+        let tags = tag.into_iter().map(|t| Tag::new(&t)).collect::<Vec<_>>();
         self.add_method_internal(namespace, name, params, result, doc, tags, deprecated)
     }
 
@@ -368,7 +368,7 @@ impl RpcModuleDocBuilder {
         tag: Option<String>,
         deprecated: bool,
     ) {
-        let mut tags = tag.map(|t| Tag::new(&t)).into_iter().collect::<Vec<_>>();
+        let mut tags = tag.into_iter().map(|t| Tag::new(&t)).collect::<Vec<_>>();
         tags.push(Tag::new("Websocket"));
         tags.push(Tag::new("PubSub"));
         self.add_method_internal(namespace, name, params, result, doc, tags, deprecated)

--- a/crates/iota-proto-build/src/main.rs
+++ b/crates/iota-proto-build/src/main.rs
@@ -156,7 +156,7 @@ fn main() {
     let accessor_map = codegen::accessor_config::parse_proto_accessors_from_pool(&descriptor_pool);
 
     let extern_paths = context::extern_paths::ExternPaths::new(&[], true).unwrap();
-    let files = fds.file.clone().into_iter().collect::<Vec<_>>();
+    let files = fds.file.clone();
     let graph = DescriptorGraph::new(files.iter());
     let context = context::Context::new(extern_paths, graph);
     codegen::accessors::generate_accessors(

--- a/crates/iota-proto-build/src/message_graph.rs
+++ b/crates/iota-proto-build/src/message_graph.rs
@@ -71,7 +71,7 @@ impl DescriptorGraph {
     /// would not compile in Rust. To allow recursive messages, the message
     /// graph is used to detect recursion and automatically box the recursive
     /// field. Since repeated messages are already put in a Vec, boxing them
-    /// isn’t necessary even if the reference is recursive.
+    /// isn't necessary even if the reference is recursive.
     fn add_message_edges(&mut self, package: &str, msg: &DescriptorProto) {
         let msg_name = format!("{}.{}", package, msg.name.as_ref().unwrap());
         let msg_index = self.get_or_insert_index(msg_name.clone());
@@ -327,7 +327,7 @@ impl<'a> FileParser<'a> {
         self.path.pop();
 
         self.path.push(4);
-        for (idx, nested_enum) in descriptor.enum_type.clone().into_iter().enumerate() {
+        for (idx, nested_enum) in descriptor.enum_type.iter().cloned().enumerate() {
             self.path.push(idx as i32);
             self.process_enum(nested_enum);
             self.path.pop();
@@ -355,7 +355,7 @@ impl<'a> FileParser<'a> {
         let mut values = Vec::new();
 
         self.path.push(2);
-        for (idx, value) in desc.value.clone().into_iter().enumerate() {
+        for (idx, value) in desc.value.iter().cloned().enumerate() {
             self.path.push(idx as i32);
             values.push(EnumValue {
                 inner: value,

--- a/crates/iota-proxy/src/histogram_relay.rs
+++ b/crates/iota-proxy/src/histogram_relay.rs
@@ -143,7 +143,7 @@ impl HistogramRelay {
             .lock()
             .expect("couldn't get mut lock on HistogramRelay");
 
-        let data: Vec<Wrapper> = queue.drain(..).collect();
+        let data: Vec<Wrapper> = std::mem::take(&mut *queue).into();
         let mut histograms = vec![];
         for mf in data {
             histograms.extend(mf.1);

--- a/crates/iota-proxy/src/middleware.rs
+++ b/crates/iota-proxy/src/middleware.rs
@@ -58,7 +58,8 @@ pub async fn expect_iota_proxy_header(
     request: Request<Body>,
     next: Next,
 ) -> Result<Response, (StatusCode, &'static str)> {
-    match format!("{content_type}").as_str() {
+    let content_type_str = content_type.to_string();
+    match content_type_str.as_str() {
         prometheus::PROTOBUF_FORMAT => Ok(next.run(request).await),
         ct => {
             error!("invalid content-type; {ct}");

--- a/crates/iota-replay/src/data_fetcher.rs
+++ b/crates/iota-replay/src/data_fetcher.rs
@@ -533,14 +533,14 @@ impl DataFetcher for RemoteFetcher {
             .get_epoch_change_events(true)
             .await?
             .into_iter()
-            .find(|ev| match extract_epoch_and_version(ev.clone()) {
+            .find(|ev| match extract_epoch_and_version(ev) {
                 Ok((epoch, _)) => epoch == epoch_id,
                 Err(_) => false,
             })
             .ok_or(ReplayEngineError::EventNotFound { epoch: epoch_id })?;
 
         // Extract protocol version from the event
-        let (_, protocol_version) = extract_epoch_and_version(event.clone())?;
+        let (_, protocol_version) = extract_epoch_and_version(&event)?;
 
         let epoch_change_tx = event.id.tx_digest;
 
@@ -689,15 +689,15 @@ fn obj_from_iota_obj_data(o: &IotaObjectData) -> Result<Object, ReplayEngineErro
     }
 }
 
-pub fn extract_epoch_and_version(ev: IotaEvent) -> Result<(u64, u64), ReplayEngineError> {
-    if let serde_json::Value::Object(w) = ev.parsed_json {
+pub fn extract_epoch_and_version(ev: &IotaEvent) -> Result<(u64, u64), ReplayEngineError> {
+    if let serde_json::Value::Object(ref w) = ev.parsed_json {
         let epoch = u64::from_str(&w["epoch"].to_string().replace('\"', "")).unwrap();
         let version = u64::from_str(&w["protocol_version"].to_string().replace('\"', "")).unwrap();
         return Ok((epoch, version));
     }
 
     Err(ReplayEngineError::UnexpectedEventFormat {
-        event: Box::new(ev),
+        event: Box::new(ev.clone()),
     })
 }
 
@@ -825,8 +825,7 @@ impl DataFetcher for NodeStateDumpFetcher {
             .node_state_dump
             .loaded_child_objects
             .iter()
-            .map(|q| (q.id, q.version, q.digest))
-            .map(|w| (w.0, w.1))
+            .map(|q| (q.id, q.version))
             .collect())
     }
 

--- a/crates/iota-replay/src/lib.rs
+++ b/crates/iota-replay/src/lib.rs
@@ -472,9 +472,10 @@ pub async fn execute_replay_command(
                 start, end, max_tasks, checkpoints_per_task
             );
 
-            let range: Vec<_> = (start..=end).collect();
-            for (task_count, checkpoints) in range.chunks(checkpoints_per_task).enumerate() {
-                let checkpoints = checkpoints.to_vec();
+            for (task_count, chunk_start) in (start..=end).step_by(checkpoints_per_task).enumerate()
+            {
+                let chunk_end = (chunk_start + checkpoints_per_task as u64 - 1).min(end);
+                let checkpoints: Vec<u64> = (chunk_start..=chunk_end).collect();
                 let rpc_url = rpc_url.clone();
                 let safety = safety.clone();
                 handles.push(tokio::spawn(async move {

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -2189,7 +2189,7 @@ fn parse_denied_error_string(error: &str) -> Option<String> {
     .unwrap();
 
     let caps = regulated_regex.captures(error)?;
-    Some(caps.get(1).or(caps.get(2))?.as_str().to_string())
+    Some(caps.get(1).or(caps.get(2))?.as_str().to_owned())
 }
 
 #[cfg(test)]

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -1144,7 +1144,7 @@ impl LocalExec {
         let mut end_epoch_tx_digest = tx_digest;
 
         for event in epoch_change_events {
-            (curr_epoch, curr_protocol_version) = extract_epoch_and_version(event.clone())?;
+            (curr_epoch, curr_protocol_version) = extract_epoch_and_version(&event)?;
             end_epoch_tx_digest = event.id.tx_digest;
 
             if start_protocol_version == curr_protocol_version {
@@ -1388,7 +1388,7 @@ impl LocalExec {
         } else {
             let idx = epoch_change_events
                 .iter()
-                .position(|ev| match extract_epoch_and_version(ev.clone()) {
+                .position(|ev| match extract_epoch_and_version(ev) {
                     Ok((epoch, _)) => epoch == epoch_id,
                     Err(_) => false,
                 })
@@ -1479,15 +1479,14 @@ impl LocalExec {
         assert!(self.is_remote_replay());
         // Fetch full transaction content
         let tx_info = self.fetcher.get_transaction(tx_digest).await?;
-        let sender = match tx_info.clone().transaction.unwrap().data {
+        let sender = match &tx_info.transaction.as_ref().unwrap().data {
             iota_json_rpc_types::IotaTransactionBlockData::V1(tx) => tx.sender,
         };
-        let IotaTransactionBlockEffects::V1(effects) = tx_info.clone().effects.unwrap();
+        let IotaTransactionBlockEffects::V1(effects) = tx_info.effects.clone().unwrap();
 
         let config_objects = self.add_config_objects_if_needed(effects.status());
 
-        let raw_tx_bytes = tx_info.clone().raw_transaction;
-        let orig_tx: SenderSignedData = bcs::from_bytes(&raw_tx_bytes).unwrap();
+        let orig_tx: SenderSignedData = bcs::from_bytes(&tx_info.raw_transaction).unwrap();
         let input_objs = orig_tx
             .transaction_data()
             .input_objects()
@@ -1510,7 +1509,7 @@ impl LocalExec {
                 }
             })
             .collect();
-        let gas_data = match tx_info.clone().transaction.unwrap().data {
+        let gas_data = match tx_info.transaction.unwrap().data {
             iota_json_rpc_types::IotaTransactionBlockData::V1(tx) => tx.gas_data,
         };
         let gas_object_refs: Vec<_> = gas_data
@@ -1605,7 +1604,7 @@ impl LocalExec {
             })
             .collect();
         let gas_data = orig_tx.transaction_data().gas_data();
-        let gas_object_refs: Vec<_> = gas_data.clone().payment;
+        let gas_object_refs: Vec<_> = gas_data.payment.clone();
         let receiving_objs = orig_tx
             .transaction_data()
             .receiving_objects()

--- a/crates/iota-rest-api/src/reader.rs
+++ b/crates/iota-rest-api/src/reader.rs
@@ -51,7 +51,7 @@ impl StateReader {
     pub fn try_get_committee(&self, epoch: EpochId) -> Result<Option<ValidatorCommittee>> {
         self.inner
             .try_get_committee(epoch)
-            .map(|maybe| maybe.map(|committee| (*committee).clone().into()))
+            .map(|maybe| maybe.map(|committee| Arc::unwrap_or_clone(committee).into()))
     }
 
     pub fn get_system_state_summary(&self) -> Result<super::system::SystemStateSummary> {

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -99,7 +99,7 @@ async fn resolve_transaction(
     let (reference_gas_price, protocol_config) = {
         let system_state = state.reader.get_system_state_summary()?;
 
-        let current_protocol_version = state.reader.get_system_state_summary()?.protocol_version;
+        let current_protocol_version = system_state.protocol_version;
 
         let protocol_config = ProtocolConfig::get_for_version_if_supported(
             current_protocol_version.into(),

--- a/crates/iota-rest-kv/src/extractors.rs
+++ b/crates/iota-rest-kv/src/extractors.rs
@@ -42,7 +42,7 @@ where
         match Path::<RequestParams>::from_request_parts(parts, state).await {
             Ok(value) => {
                 // based on the item type and encoded key construct the Key enum
-                let key = Key::new(value.item_type.to_string().as_str(), value.key.as_str())
+                let key = Key::new(&value.item_type.to_string(), value.key.as_str())
                     .map_err(|err| ApiError::BadRequest(format!("invalid input: {err}")))?;
                 Ok(ExtractPath(key))
             }

--- a/crates/iota-rpc-loadgen/src/payload/get_checkpoints.rs
+++ b/crates/iota-rpc-loadgen/src/payload/get_checkpoints.rs
@@ -107,7 +107,7 @@ impl<'a> ProcessPayload<'a, &'a GetCheckpoints> for RpcCommandProcessor {
             if cross_validate {
                 let valid_checkpoint = checkpoints.iter().enumerate().find_map(|(i, x)| {
                     if x.is_some() {
-                        Some((i, x.clone().unwrap()))
+                        Some((i, x.as_ref().unwrap().clone()))
                     } else {
                         None
                     }

--- a/crates/iota-rpc-loadgen/src/payload/pay_iota.rs
+++ b/crates/iota-rpc-loadgen/src/payload/pay_iota.rs
@@ -29,7 +29,7 @@ impl<'a> ProcessPayload<'a, &'a PayIota> for RpcCommandProcessor {
             encoded_keypair,
             gas_budget,
             gas_payment,
-        } = signer_info.clone().unwrap();
+        } = signer_info.as_ref().unwrap().clone();
         let recipient = IotaAddress::random_for_testing_only();
         let amount = 1;
         let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);

--- a/crates/iota-sdk/src/apis/quorum_driver.rs
+++ b/crates/iota-sdk/src/apis/quorum_driver.rs
@@ -55,8 +55,8 @@ impl QuorumDriverApi {
             .api
             .http
             .execute_transaction_block(
-                tx_bytes.clone(),
-                signatures.clone(),
+                tx_bytes,
+                signatures,
                 Some(options.clone()),
                 // Ignore the request type as we emulate WaitForLocalExecution below.
                 // It will default to WaitForEffectsCert on the RPC nodes.

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -452,9 +452,9 @@ impl ReadApi {
             .map_err(|e| Error::Data(format!("Can't get bcs of object {object_id:?}: {e:?}")))?;
         // unwrap: requested bcs data
         let move_object = resp.bcs.unwrap();
-        let raw_move_obj = move_object.try_into_move().ok_or(Error::Data(format!(
-            "Object {object_id:?} is not a MoveObject"
-        )))?;
+        let raw_move_obj = move_object
+            .try_into_move()
+            .ok_or_else(|| Error::Data(format!("Object {object_id:?} is not a MoveObject")))?;
         Ok(raw_move_obj.bcs_bytes)
     }
 

--- a/crates/iota-sdk/src/iota_client_config.rs
+++ b/crates/iota-sdk/src/iota_client_config.rs
@@ -2,9 +2,9 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::{Display, Formatter, Write};
+use std::fmt::{Display, Formatter};
 
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use getset::{Getters, MutGetters};
 use iota_config::Config;
 use iota_keys::keystore::{AccountKeystore, Keystore};
@@ -222,11 +222,14 @@ impl IotaEnv {
             builder = builder.ws_url(ws_url);
         }
         if let Some(basic_auth) = &self.basic_auth {
-            let fields: Vec<_> = basic_auth.split(':').collect();
-            if fields.len() != 2 {
-                bail!("Basic auth should be in the format `username:password`");
-            }
-            builder = builder.basic_auth(fields[0], fields[1]);
+            let mut fields = basic_auth.splitn(2, ':');
+            let username = fields
+                .next()
+                .ok_or_else(|| anyhow!("Basic auth should be in the format `username:password`"))?;
+            let password = fields
+                .next()
+                .ok_or_else(|| anyhow!("Basic auth should be in the format `username:password`"))?;
+            builder = builder.basic_auth(username, password);
         }
 
         if let Some(max_concurrent_requests) = max_concurrent_requests {
@@ -286,26 +289,25 @@ impl IotaEnv {
 
 impl Display for IotaEnv {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut writer = String::new();
-        writeln!(writer, "Active environment: {}", self.alias)?;
-        write!(writer, "RPC URL: {}", self.rpc)?;
+        writeln!(f, "Active environment: {}", self.alias)?;
+        write!(f, "RPC URL: {}", self.rpc)?;
         if let Some(graphql) = &self.graphql {
-            writeln!(writer)?;
-            write!(writer, "GraphQL URL: {graphql}")?;
+            writeln!(f)?;
+            write!(f, "GraphQL URL: {graphql}")?;
         }
         if let Some(ws) = &self.ws {
-            writeln!(writer)?;
-            write!(writer, "Websocket URL: {ws}")?;
+            writeln!(f)?;
+            write!(f, "Websocket URL: {ws}")?;
         }
         if let Some(basic_auth) = &self.basic_auth {
-            writeln!(writer)?;
-            write!(writer, "Basic Auth: {basic_auth}")?;
+            writeln!(f)?;
+            write!(f, "Basic Auth: {basic_auth}")?;
         }
         if let Some(faucet) = &self.faucet {
-            writeln!(writer)?;
-            write!(writer, "Faucet URL: {faucet}")?;
+            writeln!(f)?;
+            write!(f, "Faucet URL: {faucet}")?;
         }
-        write!(f, "{writer}")
+        Ok(())
     }
 }
 
@@ -313,22 +315,16 @@ impl Config for IotaClientConfig {}
 
 impl Display for IotaClientConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut writer = String::new();
-
-        writeln!(
-            writer,
-            "Managed addresses: {}",
-            self.keystore.addresses().len()
-        )?;
-        write!(writer, "Active address: ")?;
+        writeln!(f, "Managed addresses: {}", self.keystore.addresses().len())?;
+        write!(f, "Active address: ")?;
         match self.active_address {
-            Some(r) => writeln!(writer, "{r}")?,
-            None => writeln!(writer, "None")?,
+            Some(r) => writeln!(f, "{r}")?,
+            None => writeln!(f, "None")?,
         };
-        writeln!(writer, "{}", self.keystore)?;
+        writeln!(f, "{}", self.keystore)?;
         if let Ok(env) = self.get_active_env() {
-            write!(writer, "{env}")?;
+            write!(f, "{env}")?;
         }
-        write!(f, "{writer}")
+        Ok(())
     }
 }

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -455,8 +455,9 @@ impl IotaClientBuilder {
         } else {
             Vec::new()
         };
-        let iota_system_state_v2_support =
-            rpc_methods.contains(&"iotax_getLatestIotaSystemStateV2".to_string());
+        let iota_system_state_v2_support = rpc_methods
+            .iter()
+            .any(|m| m == "iotax_getLatestIotaSystemStateV2");
         Ok(ServerInfo {
             rpc_methods,
             subscriptions,

--- a/crates/iota-sdk/src/wallet_context.rs
+++ b/crates/iota-sdk/src/wallet_context.rs
@@ -201,7 +201,7 @@ impl WalletContext {
                 Ok(res) => {
                     if let Some(o) = res.data {
                         match GasCoin::try_from(&o) {
-                            Ok(gas_coin) => Some(Ok((gas_coin.value(), o.clone()))),
+                            Ok(gas_coin) => Some(Ok((gas_coin.value(), o))),
                             Err(e) => Some(Err(anyhow!("{e}"))),
                         }
                     } else {

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -499,11 +499,9 @@ impl StateSnapshotReaderV1 {
 
                             // Gets the sha3 digest of the partition
                             let sha3_digest = sha3_digests_cloned.lock().await;
-                            let bucket_map = sha3_digest
+                            let sha3_digest = *sha3_digest
                                 .get(bucket)
                                 .expect("Bucket not in digest map")
-                                .clone();
-                            let sha3_digest = *bucket_map
                                 .get(part_num)
                                 .expect("sha3 digest not in bucket map");
                             Ok::<(Bytes, FileMetadata, [u8; 32]), anyhow::Error>((

--- a/crates/iota-snapshot/src/writer.rs
+++ b/crates/iota-snapshot/src/writer.rs
@@ -102,7 +102,7 @@ impl LiveObjectSetWriterV1 {
         self.finalize_obj()?;
         self.finalize_ref()?;
         self.sender = None;
-        Ok(self.files.clone())
+        Ok(self.files)
     }
 
     /// Creates a new object file for the provided bucket number and part

--- a/crates/iota-source-validation/src/toolchain.rs
+++ b/crates/iota-source-validation/src/toolchain.rs
@@ -142,8 +142,7 @@ pub(crate) fn units_for_toolchain(
     // replaced by a prior compiler's output.
     for (package, (toolchain_version, local_units)) in package_version_map {
         if toolchain_version.compiler_version == CURRENT_COMPILER_VERSION {
-            let local_units: Vec<_> = local_units.iter().map(|u| (package, u.clone())).collect();
-            units.extend(local_units);
+            units.extend(local_units.iter().map(|u| (package, u.clone())));
             continue;
         }
 

--- a/crates/iota-source-validation/src/toolchain.rs
+++ b/crates/iota-source-validation/src/toolchain.rs
@@ -265,11 +265,13 @@ fn download_and_compile(
         std::fs::rename(dest_binary_os, dest_canonical_binary.clone())?;
     }
 
+    let edition_str = edition.to_string();
+    let flavor_str = flavor.to_string();
     debug!(
         "{} move build --default-move-edition {} --default-move-flavor {} -p {} --install-dir {}",
         dest_canonical_binary.display(),
-        edition.to_string().as_str(),
-        flavor.to_string().as_str(),
+        &edition_str,
+        &flavor_str,
         root.display(),
         install_dir.path().display(),
     );
@@ -284,9 +286,9 @@ fn download_and_compile(
             OsStr::new("move"),
             OsStr::new("build"),
             OsStr::new("--default-move-edition"),
-            OsStr::new(edition.to_string().as_str()),
+            OsStr::new(&edition_str),
             OsStr::new("--default-move-flavor"),
-            OsStr::new(flavor.to_string().as_str()),
+            OsStr::new(&flavor_str),
             OsStr::new("-p"),
             OsStr::new(root.as_path()),
             OsStr::new("--install-dir"),

--- a/crates/iota-storage/src/blob.rs
+++ b/crates/iota-storage/src/blob.rs
@@ -76,7 +76,10 @@ impl Blob {
         blob_size
     }
     pub fn to_bytes(&self) -> Vec<u8> {
-        [vec![self.encoding.into()], self.data.clone()].concat()
+        let mut v = Vec::with_capacity(1 + self.data.len());
+        v.push(self.encoding.into());
+        v.extend_from_slice(&self.data);
+        v
     }
     pub fn from_bytes<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
         let (encoding, data) = bytes.split_first().ok_or(anyhow!("empty bytes"))?;

--- a/crates/iota-storage/src/mutex_table.rs
+++ b/crates/iota-storage/src/mutex_table.rs
@@ -371,7 +371,7 @@ async fn test_acquire_locks() {
         object_1,
     ];
 
-    let locks = mutex_table.acquire_locks(objects.clone().into_iter());
+    let locks = mutex_table.acquire_locks(objects.iter().cloned());
     assert_eq!(locks.len(), 3);
 
     for object in objects.clone() {

--- a/crates/iota-tool/src/db_tool/db_dump.rs
+++ b/crates/iota-tool/src/db_tool/db_dump.rs
@@ -56,18 +56,7 @@ pub fn list_tables(path: PathBuf) -> anyhow::Result<Vec<String>> {
         path,
     )
     .map_err(|e| e.into())
-    .map(|q| {
-        q.iter()
-            .filter_map(|s| {
-                // The `default` table is not used
-                if s != "default" {
-                    Some(s.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    })
+    .map(|q| q.iter().filter(|s| *s != "default").cloned().collect())
 }
 
 pub fn table_summary(

--- a/crates/iota-tool/src/db_tool/index_search.rs
+++ b/crates/iota-tool/src/db_tool/index_search.rs
@@ -216,7 +216,7 @@ where
 
             for result in iter {
                 let (key, value) = result?;
-                entries.push((key.clone(), value.clone()));
+                entries.push((key, value));
             }
         }
         SearchRange::Count(mut count) => {
@@ -225,7 +225,7 @@ where
             while count > 0 {
                 if let Some(result) = iter.next() {
                     let (key, value) = result?;
-                    entries.push((key.clone(), value.clone()));
+                    entries.push((key, value));
                 } else {
                     break;
                 }

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -1063,7 +1063,7 @@ pub async fn download_db_snapshot(
                 let counter_cloned = file_counter.clone();
                 async move {
                     counter_cloned.fetch_add(1, Ordering::Relaxed);
-                    let file_path = get_path(format!("epoch_{epoch}/{file}").as_str());
+                    let file_path = get_path(&format!("epoch_{epoch}/{file}"));
                     copy_file(&file_path, &file_path, &remote_store, &local_store).await?;
                     Ok::<::object_store::path::Path, anyhow::Error>(file_path.clone())
                 }

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -272,7 +272,7 @@ impl TransactionBuilder {
         amounts: Vec<u64>,
     ) -> Result<TransactionKind, anyhow::Error> {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.pay_iota(recipients.clone(), amounts.clone())?;
+        builder.pay_iota(recipients, amounts)?;
         let pt = builder.finish();
         let tx_kind = TransactionKind::programmable(pt);
         Ok(tx_kind)

--- a/crates/iota-transaction-checks/src/deny.rs
+++ b/crates/iota-transaction-checks/src/deny.rs
@@ -55,7 +55,7 @@ fn check_receiving_objects(
 ) -> IotaResult {
     deny_if_true!(
         filter_config.receiving_objects_disabled() && !receiving_objects.is_empty(),
-        "Receiving objects is temporarily disabled".to_string()
+        "Receiving objects is temporarily disabled"
     );
     for (id, _, _) in receiving_objects {
         deny_if_true!(
@@ -170,20 +170,32 @@ fn check_package_dependencies(
     if deny_map.is_empty() {
         return Ok(());
     }
-    let mut dependencies = vec![];
     for command in tx_data.kind().iter_commands() {
         match command {
             Command::Publish(_, deps) => {
                 // It is possible that the deps list is inaccurate since it's provided
                 // by the user. But that's OK because this publish transaction will fail
                 // to execute in the end. Similar reasoning for Upgrade.
-                dependencies.extend(deps.iter().copied());
+                for dep in deps {
+                    deny_if_true!(
+                        deny_map.contains(dep),
+                        format!("Access to package {:?} is temporarily disabled", dep)
+                    );
+                }
             }
             Command::Upgrade(_, deps, package_id, _) => {
-                dependencies.extend(deps.iter().copied());
+                for dep in deps {
+                    deny_if_true!(
+                        deny_map.contains(dep),
+                        format!("Access to package {:?} is temporarily disabled", dep)
+                    );
+                }
                 // It's crucial that we don't allow upgrading a package in the deny list,
                 // otherwise one can bypass the deny list by upgrading a package.
-                dependencies.push(*package_id);
+                deny_if_true!(
+                    deny_map.contains(package_id),
+                    format!("Access to package {:?} is temporarily disabled", package_id)
+                );
             }
             Command::MoveCall(call) => {
                 let package = package_store.get_package_object(&call.package)?.ok_or(
@@ -199,26 +211,26 @@ fn check_package_dependencies(
                 // deny list. This means that we only make sure that the denied package is not
                 // currently used as a dependency. This allows us to deny an older version of
                 // package but permits the use of a newer version.
-                dependencies.extend(
-                    package
-                        .move_package()
-                        .linkage_table()
-                        .values()
-                        .map(|upgrade_info| upgrade_info.upgraded_id),
+                for upgrade_info in package.move_package().linkage_table().values() {
+                    deny_if_true!(
+                        deny_map.contains(&upgrade_info.upgraded_id),
+                        format!(
+                            "Access to package {:?} is temporarily disabled",
+                            upgrade_info.upgraded_id
+                        )
+                    );
+                }
+                let pkg_id = package.move_package().id();
+                deny_if_true!(
+                    deny_map.contains(&pkg_id),
+                    format!("Access to package {:?} is temporarily disabled", pkg_id)
                 );
-                dependencies.push(package.move_package().id());
             }
             Command::TransferObjects(..)
             | &Command::SplitCoins(..)
             | &Command::MergeCoins(..)
             | &Command::MakeMoveVec(..) => {}
         }
-    }
-    for dep in dependencies {
-        deny_if_true!(
-            deny_map.contains(&dep),
-            format!("Access to package {:?} is temporarily disabled", dep)
-        );
     }
     Ok(())
 }

--- a/crates/iota-types/src/unit_tests/passkey_authenticator_test.rs
+++ b/crates/iota-types/src/unit_tests/passkey_authenticator_test.rs
@@ -168,7 +168,7 @@ async fn create_credential_and_sign_test_tx(
     PasskeyResponse {
         user_sig_bytes,
         authenticator_data: authenticator_data.to_vec(),
-        client_data_json: String::from_utf8_lossy(client_data_json).to_string(),
+        client_data_json: String::from_utf8_lossy(client_data_json).into_owned(),
         intent_msg,
         sender,
     }

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3233,13 +3233,12 @@ fn pretty_print_balance(
                 inner_table.push_record(vec![
                     &c.coin_object_id.to_string(),
                     &c.balance.to_string(),
-                    format_balance(
+                    &format_balance(
                         c.balance as u128,
                         coin_decimals,
                         format_decimals,
                         Some(symbol),
-                    )
-                    .as_str(),
+                    ),
                 ]);
             }
             let mut table = inner_table.build();

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -2473,7 +2473,7 @@ impl Display for IotaClientCommandResult {
         match self {
             IotaClientCommandResult::AddAccount(new_account) => {
                 let mut builder = TableBuilder::default();
-                builder.push_record(vec!["address", new_account.address.to_string().as_str()]);
+                builder.push_record(vec!["address", &new_account.address.to_string()]);
                 builder.push_record(vec!["alias", new_account.alias.as_str()]);
 
                 let mut table = builder.build();
@@ -2589,7 +2589,7 @@ impl Display for IotaClientCommandResult {
             IotaClientCommandResult::NewAddress(new_address) => {
                 let mut builder = TableBuilder::default();
                 builder.push_record(vec!["alias", new_address.alias.as_str()]);
-                builder.push_record(vec!["address", new_address.address.to_string().as_str()]);
+                builder.push_record(vec!["address", &new_address.address.to_string()]);
                 builder.push_record(vec![
                     "publicBase64Key",
                     new_address.public_base64_key.as_str(),
@@ -2598,13 +2598,10 @@ impl Display for IotaClientCommandResult {
                     "publicBase64KeyWithFlag",
                     new_address.public_base64_key_with_flag.as_str(),
                 ]);
-                builder.push_record(vec![
-                    "keyScheme",
-                    new_address.key_scheme.to_string().as_str(),
-                ]);
+                builder.push_record(vec!["keyScheme", &new_address.key_scheme.to_string()]);
                 builder.push_record(vec![
                     "recoveryPhrase",
-                    new_address.recovery_phrase.to_string().as_str(),
+                    &new_address.recovery_phrase.to_string(),
                 ]);
 
                 let mut table = builder.build();
@@ -2825,10 +2822,7 @@ impl Display for IotaClientCommandResult {
             }
             IotaClientCommandResult::Sign(sign_data) => {
                 let mut builder = TableBuilder::default();
-                builder.push_record(vec![
-                    "iota_address",
-                    sign_data.iota_address.to_string().as_str(),
-                ]);
+                builder.push_record(vec!["iota_address", &sign_data.iota_address.to_string()]);
                 builder.push_record(vec!["raw_tx_data", sign_data.raw_tx_data.as_str()]);
                 builder.push_record(vec!["intent", &format!("{:?}", sign_data.intent)]);
                 builder.push_record(vec!["raw_intent_msg", sign_data.raw_intent_msg.as_str()]);
@@ -3237,8 +3231,8 @@ fn pretty_print_balance(
             );
             for c in coins {
                 inner_table.push_record(vec![
-                    c.coin_object_id.to_string().as_str(),
-                    c.balance.to_string().as_str(),
+                    &c.coin_object_id.to_string(),
+                    &c.balance.to_string(),
                     format_balance(
                         c.balance as u128,
                         coin_decimals,
@@ -3263,8 +3257,8 @@ fn pretty_print_balance(
         } else {
             table_builder.push_record(vec![
                 name,
-                balance.to_string().as_str(),
-                format_balance(balance, coin_decimals, format_decimals, Some(symbol)).as_str(),
+                &balance.to_string(),
+                &format_balance(balance, coin_decimals, format_decimals, Some(symbol)),
             ]);
         }
     }

--- a/crates/iota/src/displays/ptb_preview.rs
+++ b/crates/iota/src/displays/ptb_preview.rs
@@ -28,10 +28,10 @@ impl Display for PTBPreview {
             }
         }
         if let Some(gas_budget) = self.program_metadata.gas_budget {
-            builder.push_record([GAS_BUDGET, gas_budget.value.to_string().as_str()]);
+            builder.push_record([GAS_BUDGET, &gas_budget.value.to_string()]);
         }
         if let Some(gas_price) = self.program_metadata.gas_price {
-            builder.push_record([GAS_PRICE, gas_price.value.to_string().as_str()]);
+            builder.push_record([GAS_PRICE, &gas_price.value.to_string()]);
         }
         if let Some(gas_sponsor) = self.program_metadata.gas_sponsor {
             builder.push_record([

--- a/crates/iota/src/fire_drill.rs
+++ b/crates/iota/src/fire_drill.rs
@@ -222,10 +222,8 @@ async fn update_next_epoch_metadata(
         account_key,
         "update_validator_next_epoch_authority_pubkey",
         vec![
-            CallArg::Pure(
-                bcs::to_bytes(&new_authority_key_pair_copy.public().as_bytes().to_vec()).unwrap(),
-            ),
-            CallArg::Pure(bcs::to_bytes(&pop.as_bytes().to_vec()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(new_authority_key_pair_copy.public().as_bytes()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(pop.as_bytes()).unwrap()),
         ],
         iota_client,
     )
@@ -236,7 +234,7 @@ async fn update_next_epoch_metadata(
         account_key,
         "update_validator_next_epoch_network_pubkey",
         vec![CallArg::Pure(
-            bcs::to_bytes(&new_network_key_pair_copy.public().as_bytes().to_vec()).unwrap(),
+            bcs::to_bytes(new_network_key_pair_copy.public().as_bytes()).unwrap(),
         )],
         iota_client,
     )
@@ -247,7 +245,7 @@ async fn update_next_epoch_metadata(
         account_key,
         "update_validator_next_epoch_protocol_pubkey",
         vec![CallArg::Pure(
-            bcs::to_bytes(&new_protocol_key_pair_copy.public().as_bytes().to_vec()).unwrap(),
+            bcs::to_bytes(new_protocol_key_pair_copy.public().as_bytes()).unwrap(),
         )],
         iota_client,
     )

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -1866,7 +1866,7 @@ fn format_name_record(f: &mut std::fmt::Formatter, record: &NameRecord) -> std::
 }
 
 fn build_name_record_table(table_builder: &mut TableBuilder, record: &NameRecord) {
-    table_builder.push_record(["NFT ID", record.nft_id.bytes.to_string().as_str()]);
+    table_builder.push_record(["NFT ID", &record.nft_id.bytes.to_string()]);
     table_builder.push_record([
         "Target Address",
         record

--- a/crates/iota/src/upgrade_compatibility/formatting.rs
+++ b/crates/iota/src/upgrade_compatibility/formatting.rs
@@ -21,14 +21,14 @@ impl<S: fmt::Display> fmt::Display for FormattedType<'_, S> {
             write!(
                 f,
                 "{}",
-                format_param(self.type_, self.type_params.to_vec(), &mut Vec::new())
+                format_param(self.type_, self.type_params, &mut Vec::new())
                     .map_err(|_| fmt::Error)?,
             )
         } else {
             write!(
                 f,
                 "'{}'",
-                format_param(self.type_, self.type_params.to_vec(), &mut Vec::new())
+                format_param(self.type_, self.type_params, &mut Vec::new())
                     .map_err(|_| fmt::Error)?,
             )
         }
@@ -86,7 +86,7 @@ impl<S: fmt::Display> fmt::Display for FormattedField<'_, S> {
 /// label to include its location.
 pub(super) fn format_param<S: fmt::Display>(
     param: &Type<S>,
-    type_params: Vec<SourceName>,
+    type_params: &[SourceName],
     secondary: &mut Vec<(Loc, String)>,
 ) -> Result<String, Error> {
     Ok(match param {
@@ -118,7 +118,7 @@ pub(super) fn format_param<S: fmt::Display>(
                 dt.name,
                 dt.type_arguments
                     .iter()
-                    .map(|t| format_param(t, type_params.clone(), secondary))
+                    .map(|t| format_param(t, type_params, secondary))
                     .collect::<Result<Vec<_>, _>>()?
                     .join(", ")
             )

--- a/crates/iota/src/upgrade_compatibility/mod.rs
+++ b/crates/iota/src/upgrade_compatibility/mod.rs
@@ -1288,16 +1288,10 @@ fn function_signature_mismatch_diag(
 
                 let mut secondary = Vec::new();
 
-                let old_param = format_param(
-                    old_param,
-                    func_sourcemap.type_parameters.clone(),
-                    &mut secondary,
-                )?;
-                let new_param = format_param(
-                    new_param,
-                    func_sourcemap.type_parameters.clone(),
-                    &mut Vec::new(),
-                )?;
+                let old_param =
+                    format_param(old_param, &func_sourcemap.type_parameters, &mut secondary)?;
+                let new_param =
+                    format_param(new_param, &func_sourcemap.type_parameters, &mut Vec::new())?;
 
                 let label = format!("Unexpected parameter '{new_param}', expected '{old_param}'");
 
@@ -1448,16 +1442,10 @@ fn function_signature_mismatch_diag(
 
             if old_return != new_return {
                 let mut secondary = Vec::new();
-                let old_return = format_param(
-                    old_return,
-                    func_sourcemap.type_parameters.clone(),
-                    &mut secondary,
-                )?;
-                let new_return = format_param(
-                    new_return,
-                    func_sourcemap.type_parameters.clone(),
-                    &mut Vec::new(),
-                )?;
+                let old_return =
+                    format_param(old_return, &func_sourcemap.type_parameters, &mut secondary)?;
+                let new_return =
+                    format_param(new_return, &func_sourcemap.type_parameters, &mut Vec::new())?;
 
                 let label = if new_function.return_.len() == 1 {
                     format!("Unexpected return type '{new_return}', expected '{old_return}'")

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -175,7 +175,7 @@ fn make_key_files(
         return Ok(());
     } else if is_authority_key {
         let (_, keypair) = get_authority_key_pair();
-        write_authority_keypair_to_file(&keypair, file_name.clone())?;
+        write_authority_keypair_to_file(&keypair, &file_name)?;
         println!("Generated new key file: {file_name:?}.");
     } else {
         let kp = match key {
@@ -263,7 +263,7 @@ impl IotaValidatorCommand {
                 // TODO set key files permission
                 let validator_info_file_name = dir.join("validator.info");
                 let validator_info_bytes = serde_yaml::to_string(&validator_info)?;
-                fs::write(validator_info_file_name.clone(), validator_info_bytes)?;
+                fs::write(&validator_info_file_name, validator_info_bytes)?;
                 println!("Generated validator info file: {validator_info_file_name:?}.");
                 IotaValidatorCommandResponse::MakeValidatorInfo
             }
@@ -282,28 +282,15 @@ impl IotaValidatorCommand {
                         )?)
                         .unwrap(),
                     ),
+                    CallArg::Pure(bcs::to_bytes(validator.network_key().as_bytes()).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(validator.protocol_key().as_bytes()).unwrap()),
                     CallArg::Pure(
-                        bcs::to_bytes(&validator.network_key().as_bytes().to_vec()).unwrap(),
+                        bcs::to_bytes(validator_info.proof_of_possession.as_ref()).unwrap(),
                     ),
-                    CallArg::Pure(
-                        bcs::to_bytes(&validator.protocol_key().as_bytes().to_vec()).unwrap(),
-                    ),
-                    CallArg::Pure(
-                        bcs::to_bytes(&validator_info.proof_of_possession.as_ref().to_vec())
-                            .unwrap(),
-                    ),
-                    CallArg::Pure(
-                        bcs::to_bytes(&validator.name().to_owned().into_bytes()).unwrap(),
-                    ),
-                    CallArg::Pure(
-                        bcs::to_bytes(&validator.description.clone().into_bytes()).unwrap(),
-                    ),
-                    CallArg::Pure(
-                        bcs::to_bytes(&validator.image_url.clone().into_bytes()).unwrap(),
-                    ),
-                    CallArg::Pure(
-                        bcs::to_bytes(&validator.project_url.clone().into_bytes()).unwrap(),
-                    ),
+                    CallArg::Pure(bcs::to_bytes(validator.name().as_bytes()).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(validator.description.as_bytes()).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(validator.image_url.as_bytes()).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(validator.project_url.as_bytes()).unwrap()),
                     CallArg::Pure(bcs::to_bytes(validator.network_address()).unwrap()),
                     CallArg::Pure(bcs::to_bytes(validator.p2p_address()).unwrap()),
                     CallArg::Pure(bcs::to_bytes(validator.primary_address()).unwrap()),
@@ -1034,7 +1021,7 @@ async fn update_metadata(
             let network_pub_key: NetworkPublicKey =
                 read_network_keypair_from_file(file)?.public().clone();
             let args = vec![CallArg::Pure(
-                bcs::to_bytes(&network_pub_key.as_bytes().to_vec()).unwrap(),
+                bcs::to_bytes(network_pub_key.as_bytes()).unwrap(),
             )];
             call_0x5(
                 context,
@@ -1049,7 +1036,7 @@ async fn update_metadata(
             let protocol_pub_key: NetworkPublicKey =
                 read_network_keypair_from_file(file)?.public().clone();
             let args = vec![CallArg::Pure(
-                bcs::to_bytes(&protocol_pub_key.as_bytes().to_vec()).unwrap(),
+                bcs::to_bytes(protocol_pub_key.as_bytes()).unwrap(),
             )];
             call_0x5(
                 context,

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1127,7 +1127,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .collect();
 
         // Track metrics for voting storage hits vs fallbacks
-        let voting_hits = voting_headers.iter().filter(|h| h.is_some()).count();
+        let voting_hits = voting_headers.iter().flatten().count();
         self.context
             .metrics
             .node_metrics

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1682,7 +1682,7 @@ mod test {
                     .build();
                 this_round_blocks.push(VerifiedBlock::new_for_test(block));
             }
-            all_blocks.extend(this_round_blocks.clone());
+            all_blocks.extend(this_round_blocks.iter().cloned());
             last_round_blocks = this_round_blocks;
         }
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -577,12 +577,12 @@ pub(crate) mod tests {
     impl MockCoreThreadDispatcher {
         pub(crate) async fn get_and_drain_blocks(&self) -> Vec<VerifiedBlock> {
             let mut blocks = self.blocks.lock();
-            blocks.drain(0..).collect()
+            std::mem::take(&mut *blocks)
         }
 
         pub(crate) async fn get_and_drain_block_headers(&self) -> Vec<VerifiedBlockHeader> {
             let mut block_headers = self.block_headers.lock();
-            block_headers.drain(0..).collect()
+            std::mem::take(&mut *block_headers)
         }
 
         pub(crate) fn get_blocks(&self) -> Vec<VerifiedBlock> {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2727,7 +2727,7 @@ mod test {
 
         // Now write in store the block headers from the first 4 rounds and the rest to
         // the dag state
-        block_headers.clone().into_iter().for_each(|block_header| {
+        block_headers.iter().cloned().for_each(|block_header| {
             if block_header.round() <= 4 {
                 store
                     .write(
@@ -2907,7 +2907,7 @@ mod test {
 
         // Now write the block headers from the first 4 rounds to the store, and the
         // rest to the dag state
-        block_headers.clone().into_iter().for_each(|block_header| {
+        block_headers.iter().cloned().for_each(|block_header| {
             if block_header.round() <= 4 {
                 store
                     .write(
@@ -3667,7 +3667,7 @@ mod test {
 
         // Now write the transactions from the first 4 rounds to the store and the rest
         // to the dag state
-        blocks.clone().into_iter().for_each(|block| {
+        blocks.iter().cloned().for_each(|block| {
             if block.round() <= 4 {
                 store
                     .write(

--- a/crates/starfish/core/src/decoder.rs
+++ b/crates/starfish/core/src/decoder.rs
@@ -243,8 +243,7 @@ mod tests {
         );
 
         // Case 2: corrupted shard length
-        let mut shards_collection: Vec<Option<Shard>> =
-            shards.clone().into_iter().map(Some).collect();
+        let mut shards_collection: Vec<Option<Shard>> = shards.iter().cloned().map(Some).collect();
         shards_collection[1] = Some(vec![1, 2, 3]); // wrong size
         assert!(
             decoder

--- a/crates/starfish/core/src/decoder.rs
+++ b/crates/starfish/core/src/decoder.rs
@@ -44,7 +44,7 @@ impl ShardsDecoder for ReedSolomonDecoder {
             "Shards collection length must match total_length"
         );
 
-        let shards_count = shards_collection.iter().filter(|x| x.is_some()).count();
+        let shards_count = shards_collection.iter().flatten().count();
         if shards_count < info_length {
             return Err(ConsensusError::InsufficientShardsInDecoder(
                 shards_count,

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -2282,7 +2282,7 @@ mod tests {
         // Stub all headers to the third peer that will be chosen (quasi)-randomly as an
         // additional peer.
         let mut all_expected_headers = expected_block_headers_1.clone();
-        all_expected_headers.extend(expected_block_headers_2.clone());
+        all_expected_headers.extend(expected_block_headers_2.iter().cloned());
         network_client
             .stub_fetch_headers_response(
                 all_expected_headers.clone(),

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -555,7 +555,7 @@ impl DagBuilder {
                 let transaction_acks = if round == 1 {
                     HashMap::new()
                 } else {
-                    connections.clone().into_iter().collect()
+                    connections.iter().cloned().collect()
                 };
                 (transaction_acks, connections)
             }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1409,7 +1409,7 @@ mod tests {
         // returned with TransactionSynchronizerSaturated error.
         // The test should be deterministic because the responses will timeout, so all
         // tasks should be sent to the queue before the first request is processed.
-        let successes = results.iter().filter(|r| r.is_ok()).count();
+        let successes = results.iter().flatten().count();
         let saturated = results
             .iter()
             .filter(|r| matches!(r, Err(ConsensusError::TransactionSynchronizerSaturated)))

--- a/crates/transaction-fuzzer/src/programmable_transaction_gen.rs
+++ b/crates/transaction-fuzzer/src/programmable_transaction_gen.rs
@@ -549,7 +549,7 @@ fn create_unpack_call(
     builder.programmable_move_call(
         package,
         Identifier::from_str("coin_factory").unwrap(),
-        Identifier::from_str(format!("unpack_{input_size}").as_str()).unwrap(),
+        Identifier::from_str(&format!("unpack_{input_size}")).unwrap(),
         vec![],
         vec![Argument::Result(prev_cmd_num as u16)],
     );

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -545,8 +545,8 @@ async fn test_iter_with_bounds() {
     );
 
     // Specify a bound outside of dataset.
-    let db_iter = db.safe_iter_with_bounds(Some(200), Some(300));
-    assert!(db_iter.collect::<Vec<_>>().is_empty());
+    let mut db_iter = db.safe_iter_with_bounds(Some(200), Some(300));
+    assert!(db_iter.next().is_none());
 
     // Skip to first key in the bound (bound is [1, 50))
     let db_iter = get_iter_with_bounds(&db, Some(1), Some(50));

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -108,7 +108,7 @@ pub fn display_var(s: Symbol) -> DisplayVar {
     } else if is_match_temp_name(s) {
         DisplayVar::MatchTmp(s.to_string())
     } else {
-        let mut orig = s.as_str().to_string();
+        let mut orig = s.to_string();
         if let Some(i) = orig.find(NEW_NAME_DELIM) {
             orig.truncate(i)
         }

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1990,7 +1990,7 @@ fn dep_path_from_root(
             for next in i {
                 let dep = match graph.package_graph.edge_weight(*current, *next) {
                     Some(dep) => dep,
-                    None => return Ok(String::from("")),
+                    None => return Ok(String::new()),
                 };
                 path.push(dep.dep_name.as_str());
                 current = next;

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1985,7 +1985,7 @@ fn dep_path_from_root(
             }
             let mut current = match i.next() {
                 Some(dep) => dep,
-                None => return Ok("".to_string()),
+                None => return Ok(String::new()),
             };
             for next in i {
                 let dep = match graph.package_graph.edge_weight(*current, *next) {

--- a/external-crates/move/crates/move-stdlib-natives/src/debug.rs
+++ b/external-crates/move/crates/move-stdlib-natives/src/debug.rs
@@ -214,7 +214,7 @@ mod testing {
 
     fn fmt_error_to_partial_vm_error(e: fmt::Error) -> PartialVMError {
         PartialVMError::new(StatusCode::UNKNOWN_STATUS)
-            .with_message("write! macro failed with: ".to_string() + e.to_string().as_str())
+            .with_message(format!("write! macro failed with: {e}"))
     }
 
     fn to_vec_u8_type_err<E>(_e: E) -> PartialVMError {
@@ -268,9 +268,8 @@ mod testing {
                 .map_err(to_vec_u8_type_err)?;
 
                 let str = String::from_utf8(buf).map_err(|e| {
-                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
-                        "Could not parse UTF8 bytes: ".to_string() + e.to_string().as_str(),
-                    )
+                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                        .with_message(format!("Could not parse UTF8 bytes: {e}"))
                 })?;
 
                 // We need to escape displayed double quotes " as \" and, as a result, also

--- a/external-crates/move/crates/test-generation/src/bytecode_generator.rs
+++ b/external-crates/move/crates/test-generation/src/bytecode_generator.rs
@@ -841,7 +841,7 @@ impl<'a> BytecodeGenerator<'a> {
         let mut call_graph = CallGraph::new(module.function_handles.len());
         for fdef in fdefs.iter_mut() {
             if let Some(code) = &mut fdef.code {
-                let f_handle = &module.function_handles[fdef.function.0 as usize].clone();
+                let f_handle = &module.function_handles[fdef.function.0 as usize];
                 let locals_sigs = module.signatures[code.locals.0 as usize].0.clone();
                 let mut fn_context = FunctionGenerationContext::new(
                     fdef.function,

--- a/external-crates/move/crates/test-generation/src/bytecode_generator.rs
+++ b/external-crates/move/crates/test-generation/src/bytecode_generator.rs
@@ -841,7 +841,7 @@ impl<'a> BytecodeGenerator<'a> {
         let mut call_graph = CallGraph::new(module.function_handles.len());
         for fdef in fdefs.iter_mut() {
             if let Some(code) = &mut fdef.code {
-                let f_handle = &module.function_handles[fdef.function.0 as usize];
+                let f_handle = &module.function_handles[fdef.function.0 as usize].clone();
                 let locals_sigs = module.signatures[code.locals.0 as usize].0.clone();
                 let mut fn_context = FunctionGenerationContext::new(
                     fdef.function,


### PR DESCRIPTION
## Summary

Broad cleanup pass removing redundant operations across 39 Rust files to reduce unnecessary allocations and improve code clarity.

Suggestions from Claude Code.

## Changes

- **Redundant clones**: Remove `.clone()` on Copy types, double `.clone().clone()`, and `&x.clone()` patterns where a reference suffices
- **Allocation anti-patterns**: Replace `String::from("")` with `String::new()`, `format!("literal")` with `"literal".to_string()`, and `.to_string().as_str()` / `format!().as_str()` with proper alternatives
- **Iterator simplifications**: Replace `.collect::<Vec<_>>().len()` with `.count()`, `.iter().map(|x| *x)` with `.copied()`, and remove no-op `.into_iter().collect::<Vec<_>>()` roundtrips
- **String conversions**: Use `.into_owned()` instead of `.to_string()` on `Cow<str>`, pass references to `from_bytes()` instead of cloning byte vectors
- **Filter patterns**: Simplify `.filter(|x| x.is_some()).count()` to `.flatten().count()`

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
