### PR TITLE
feat(gRPC): add transaction filters for commands and execution status

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/client/event_filters.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/event_filters.rs
@@ -203,13 +203,14 @@ async fn test_event_filter_scenarios() {
     );
 
     // --- Scenario D: Negation (NOT sender_1) ---
+    // 0x0 events: 1 DisplayCreated + 1 VersionUpdated = 2
     // sender_2 events: 1 NFTMinted + 1 TimeEvent = 2
     let not_sender_1_filter = grpc_filter::EventFilter::default()
         .with_negation(grpc_filter::NotEventFilter::default().with_filter(sender_1_filter.clone()));
     let count = stream_and_count_events(not_sender_1_filter).await;
     assert_eq!(
-        count, 2,
-        "Scenario D: NOT sender_1 should match 2 events from sender_2"
+        count, 4,
+        "Scenario D: NOT sender_1 should match 4 events from 0x0 and sender_2"
     );
 
     // --- Scenario E: All (AND) — sender_1 AND NFTMinted ---

--- a/crates/iota-e2e-tests/tests/grpc/client/event_filters.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/event_filters.rs
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! E2E tests for event filters on the gRPC checkpoint stream.
+//!
+//! A single test cluster is set up, several event-producing transactions are
+//! executed, and then multiple event filter scenarios are verified against the
+//! same stream range.
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use iota_grpc_types::v0::{filter as grpc_filter, types as grpc_types};
+use iota_macros::sim_test;
+use iota_types::{effects::TransactionEffectsAPI, transaction::CallArg};
+use tokio::time::timeout;
+
+use super::super::utils::setup_grpc_test;
+
+const NFT_PACKAGE: &str = "nft";
+const BASICS_PACKAGE: &str = "basics";
+const NFT_MODULE: &str = "testnet_nft";
+const CLOCK_MODULE: &str = "clock";
+const CLOCK_ACCESS_FUNCTION: &str = "access";
+const NFT_MINTED_EVENT: &str = "NFTMinted";
+
+/// Single test exercising multiple event filter scenarios.
+///
+/// Setup:
+///   1. Publish NFT package (sender_1)
+///   2. Publish Basics package (sender_1)
+///   3. Mint 2 NFTs (sender_1)  →  2 × NFTMinted events
+///   4. Mint 1 NFT (sender_2)   →  1 × NFTMinted event
+///   5. clock::access (sender_2) →  1 × TimeEvent
+///
+/// Total user events: 4
+///   - 3 NFTMinted (2 from sender_1, 1 from sender_2)
+///   - 1 TimeEvent (from sender_2)
+///
+/// Scenarios verified:
+///   A. Sender filter (sender_1 events only)
+///   B. MoveEventType filter (NFTMinted only)
+///   C. MovePackageAndModule filter
+///   D. Negation filter (NOT sender_1 → only sender_2 events)
+///   E. All (AND) — sender_1 AND NFTMinted
+///   F. Any (OR) — sender_1 OR NFTMinted
+#[sim_test]
+async fn test_event_filter_scenarios() {
+    let (cluster, client) = setup_grpc_test(None, None).await;
+
+    let sender_1 = cluster.get_address_0();
+    let sender_2 = cluster.get_address_1();
+
+    // --- Setup: publish packages and execute event-producing transactions ---
+
+    // 1. Publish NFT package
+    let nft_tx = cluster
+        .test_transaction_builder_with_sender(sender_1)
+        .await
+        .publish_examples(NFT_PACKAGE)
+        .build();
+    let signed_tx = cluster.sign_transaction(&nft_tx);
+    let (effects, _) = cluster
+        .execute_transaction_return_raw_effects(signed_tx)
+        .await
+        .expect("NFT publishing should succeed");
+    let nft_package_id = effects
+        .created()
+        .iter()
+        .find(|obj| obj.1.is_immutable())
+        .map(|obj| obj.0.0)
+        .expect("Should have created NFT package");
+
+    // 2. Publish Basics package
+    let basics_tx = cluster
+        .test_transaction_builder_with_sender(sender_1)
+        .await
+        .publish_examples(BASICS_PACKAGE)
+        .build();
+    let signed_tx = cluster.sign_transaction(&basics_tx);
+    let (effects, _) = cluster
+        .execute_transaction_return_raw_effects(signed_tx)
+        .await
+        .expect("Basics publishing should succeed");
+    let basics_package_id = effects
+        .created()
+        .iter()
+        .find(|obj| obj.1.is_immutable())
+        .map(|obj| obj.0.0)
+        .expect("Should have created basics package");
+
+    // 3. Mint 2 NFTs from sender_1
+    for _ in 0..2 {
+        let mint_tx = cluster
+            .test_transaction_builder_with_sender(sender_1)
+            .await
+            .call_nft_create(nft_package_id)
+            .build();
+        let signed_tx = cluster.sign_transaction(&mint_tx);
+        cluster.execute_transaction(signed_tx).await;
+    }
+
+    // 4. Mint 1 NFT from sender_2
+    let mint_tx = cluster
+        .test_transaction_builder_with_sender(sender_2)
+        .await
+        .call_nft_create(nft_package_id)
+        .build();
+    let signed_tx = cluster.sign_transaction(&mint_tx);
+    cluster.execute_transaction(signed_tx).await;
+
+    // 5. clock::access from sender_2 (emits TimeEvent)
+    let clock_tx = cluster
+        .test_transaction_builder_with_sender(sender_2)
+        .await
+        .move_call(
+            basics_package_id,
+            CLOCK_MODULE,
+            CLOCK_ACCESS_FUNCTION,
+            vec![CallArg::CLOCK_IMM],
+        )
+        .build();
+    let signed_tx = cluster.sign_transaction(&clock_tx);
+    cluster.execute_transaction(signed_tx).await;
+
+    // Wait for checkpoints
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let latest_seq = client
+        .get_checkpoint_latest(Some(""), None, None)
+        .await
+        .expect("get latest checkpoint")
+        .body()
+        .sequence_number();
+
+    // --- Helper: stream checkpoints with event filter and count events ---
+    let stream_and_count_events = |event_filter: grpc_filter::EventFilter| {
+        let client = client.clone();
+        async move {
+            let mut stream = client
+                .stream_checkpoints(
+                    Some(0),
+                    Some(latest_seq),
+                    Some("events"),
+                    None,
+                    Some(event_filter),
+                )
+                .await
+                .expect("Failed to create stream");
+
+            let mut event_count = 0usize;
+            timeout(Duration::from_secs(10), async {
+                while let Some(result) = stream.body_mut().next().await {
+                    let cp = result.expect("stream error");
+                    event_count += cp.events().len();
+                }
+            })
+            .await
+            .expect("stream timed out");
+
+            event_count
+        }
+    };
+
+    // --- Scenario A: Sender filter (sender_1 only) ---
+    // sender_1 produced: 2 NFTMinted events
+    let sender_1_filter = grpc_filter::EventFilter::default().with_sender(
+        grpc_filter::AddressFilter::default()
+            .with_address(grpc_types::Address::default().with_address(sender_1.to_vec())),
+    );
+    let count = stream_and_count_events(sender_1_filter.clone()).await;
+    assert_eq!(
+        count, 2,
+        "Scenario A: sender_1 should have 2 events (NFTMinted)"
+    );
+
+    // --- Scenario B: MoveEventType filter (NFTMinted) ---
+    // 3 NFTMinted events total (2 from sender_1, 1 from sender_2)
+    let nft_event_type_filter = grpc_filter::EventFilter::default().with_move_event_type(
+        grpc_filter::MoveEventTypeFilter::default().with_struct_tag(format!(
+            "{nft_package_id}::{NFT_MODULE}::{NFT_MINTED_EVENT}"
+        )),
+    );
+    let count = stream_and_count_events(nft_event_type_filter.clone()).await;
+    assert_eq!(
+        count, 3,
+        "Scenario B: should match 3 NFTMinted events from both senders"
+    );
+
+    // --- Scenario C: MovePackageAndModule filter (basics::clock) ---
+    // 1 TimeEvent from clock::access
+    let basics_clock_filter = grpc_filter::EventFilter::default().with_move_package_and_module(
+        grpc_filter::MovePackageAndModuleFilter::default()
+            .with_package_id(
+                grpc_types::Address::default().with_address(basics_package_id.to_vec()),
+            )
+            .with_module(CLOCK_MODULE.to_string()),
+    );
+    let count = stream_and_count_events(basics_clock_filter).await;
+    assert_eq!(
+        count, 1,
+        "Scenario C: should match 1 event from basics::clock"
+    );
+
+    // --- Scenario D: Negation (NOT sender_1) ---
+    // sender_2 events: 1 NFTMinted + 1 TimeEvent = 2
+    let not_sender_1_filter = grpc_filter::EventFilter::default()
+        .with_negation(grpc_filter::NotEventFilter::default().with_filter(sender_1_filter.clone()));
+    let count = stream_and_count_events(not_sender_1_filter).await;
+    assert_eq!(
+        count, 2,
+        "Scenario D: NOT sender_1 should match 2 events from sender_2"
+    );
+
+    // --- Scenario E: All (AND) — sender_1 AND NFTMinted ---
+    // sender_1's NFTMinted events = 2
+    let sender_1_and_nft = grpc_filter::EventFilter::default().with_all(
+        grpc_filter::AllEventFilter::default()
+            .with_filters(vec![sender_1_filter.clone(), nft_event_type_filter.clone()]),
+    );
+    let count = stream_and_count_events(sender_1_and_nft).await;
+    assert_eq!(
+        count, 2,
+        "Scenario E: sender_1 AND NFTMinted should match 2 events"
+    );
+
+    // --- Scenario F: Any (OR) — sender_1 OR NFTMinted ---
+    // sender_1 events (2 NFTMinted) ∪ all NFTMinted (3) = 3 unique events
+    // (sender_1's 2 NFTMinted are a subset of all 3 NFTMinted)
+    let sender_1_or_nft = grpc_filter::EventFilter::default().with_any(
+        grpc_filter::AnyEventFilter::default()
+            .with_filters(vec![sender_1_filter, nft_event_type_filter]),
+    );
+    let count = stream_and_count_events(sender_1_or_nft).await;
+    assert_eq!(
+        count, 3,
+        "Scenario F: sender_1 OR NFTMinted should match 3 events"
+    );
+}

--- a/crates/iota-e2e-tests/tests/grpc/client/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/mod.rs
@@ -4,9 +4,11 @@
 mod checkpoints;
 mod common;
 mod epochs;
+mod event_filters;
 mod execute;
 mod health;
 mod metadata;
 mod objects;
 mod simulate;
+mod transaction_filters;
 mod transactions;

--- a/crates/iota-e2e-tests/tests/grpc/client/transaction_filters.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transaction_filters.rs
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! E2E tests for transaction filters on the gRPC checkpoint stream.
+//!
+//! A single test cluster is set up, several transaction types are executed, and
+//! then multiple filter scenarios are verified against the same stream range to
+//! avoid spawning the test framework multiple times.
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use iota_grpc_types::v0::{filter as grpc_filter, types as grpc_types};
+use iota_macros::sim_test;
+use iota_types::{effects::TransactionEffectsAPI, transaction::CallArg};
+use tokio::time::timeout;
+
+use super::super::utils::setup_grpc_test;
+
+const NFT_PACKAGE: &str = "nft";
+const BASICS_PACKAGE: &str = "basics";
+const CLOCK_MODULE: &str = "clock";
+const CLOCK_ACCESS_FUNCTION: &str = "access";
+
+/// Single test exercising multiple transaction filter scenarios.
+///
+/// Setup:
+///   1. Publish NFT package (sender_1)  →  Publish command
+///   2. Publish Basics package (sender_1)  →  Publish command
+///   3. Mint NFT (sender_1)  →  MoveCall command (with events)
+///   4. Transfer IOTA (sender_2)  →  TransferObjects + SplitCoins commands
+///   5. MoveCall clock::access (sender_2)  →  MoveCall command (with events)
+///
+/// Scenarios verified:
+///   A. Sender filter (sender_1 only)
+///   B. Command filter — Publish
+///   C. Command filter — MoveCall with package/module
+///   D. Execution status — Success
+///   E. Combined: Sender AND Command
+///   F. Any (OR) of two Command filters
+#[sim_test]
+async fn test_transaction_filter_scenarios() {
+    let (cluster, client) = setup_grpc_test(None, None).await;
+
+    let sender_1 = cluster.get_address_0();
+    let sender_2 = cluster.get_address_1();
+
+    // --- Setup: execute transactions ---
+
+    // 1. Publish NFT package (sender_1)
+    let nft_tx = cluster
+        .test_transaction_builder_with_sender(sender_1)
+        .await
+        .publish_examples(NFT_PACKAGE)
+        .build();
+    let signed_tx = cluster.sign_transaction(&nft_tx);
+    let (effects, _) = cluster
+        .execute_transaction_return_raw_effects(signed_tx)
+        .await
+        .expect("NFT publishing should succeed");
+    let nft_package_id = effects
+        .created()
+        .iter()
+        .find(|obj| obj.1.is_immutable())
+        .map(|obj| obj.0.0)
+        .expect("Should have created NFT package");
+
+    // 2. Publish Basics package (sender_1)
+    let basics_tx = cluster
+        .test_transaction_builder_with_sender(sender_1)
+        .await
+        .publish_examples(BASICS_PACKAGE)
+        .build();
+    let signed_tx = cluster.sign_transaction(&basics_tx);
+    let (effects, _) = cluster
+        .execute_transaction_return_raw_effects(signed_tx)
+        .await
+        .expect("Basics publishing should succeed");
+    let basics_package_id = effects
+        .created()
+        .iter()
+        .find(|obj| obj.1.is_immutable())
+        .map(|obj| obj.0.0)
+        .expect("Should have created basics package");
+
+    // 3. Mint NFT (sender_1) — MoveCall to nft_package
+    let mint_tx = cluster
+        .test_transaction_builder_with_sender(sender_1)
+        .await
+        .call_nft_create(nft_package_id)
+        .build();
+    let signed_tx = cluster.sign_transaction(&mint_tx);
+    cluster.execute_transaction(signed_tx).await;
+
+    // 4. Transfer IOTA (sender_2) — generates TransferObjects + SplitCoins
+    let transfer_tx = cluster
+        .test_transaction_builder_with_sender(sender_2)
+        .await
+        .transfer_iota(Some(100), sender_1)
+        .build();
+    let signed_tx = cluster.sign_transaction(&transfer_tx);
+    cluster.execute_transaction(signed_tx).await;
+
+    // 5. MoveCall clock::access (sender_2)
+    let clock_tx = cluster
+        .test_transaction_builder_with_sender(sender_2)
+        .await
+        .move_call(
+            basics_package_id,
+            CLOCK_MODULE,
+            CLOCK_ACCESS_FUNCTION,
+            vec![CallArg::CLOCK_IMM],
+        )
+        .build();
+    let signed_tx = cluster.sign_transaction(&clock_tx);
+    cluster.execute_transaction(signed_tx).await;
+
+    // Wait for all transactions to land in checkpoints
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let latest_seq = client
+        .get_checkpoint_latest(Some(""), None, None)
+        .await
+        .expect("get latest checkpoint")
+        .body()
+        .sequence_number();
+
+    // --- Helper closure to stream and collect matching transactions ---
+    let stream_and_collect = |tx_filter: grpc_filter::TransactionFilter| {
+        let client = client.clone();
+        async move {
+            let mut stream = client
+                .stream_checkpoints(
+                    Some(0),
+                    Some(latest_seq),
+                    Some("transactions.transaction.bcs,transactions.effects.bcs"),
+                    Some(tx_filter),
+                    None,
+                )
+                .await
+                .expect("Failed to create stream");
+
+            let mut tx_count = 0usize;
+            timeout(Duration::from_secs(10), async {
+                while let Some(result) = stream.body_mut().next().await {
+                    let cp = result.expect("stream error");
+                    tx_count += cp.executed_transactions.len();
+                }
+            })
+            .await
+            .expect("stream timed out");
+
+            tx_count
+        }
+    };
+
+    // --- Scenario A: Sender filter (sender_1) ---
+    // sender_1 did: publish NFT, publish basics, mint NFT = 3 transactions
+    let sender_filter = grpc_filter::TransactionFilter::default().with_sender(
+        grpc_filter::AddressFilter::default()
+            .with_address(grpc_types::Address::default().with_address(sender_1.to_vec())),
+    );
+    let count = stream_and_collect(sender_filter).await;
+    assert_eq!(count, 3, "Scenario A: sender_1 should have 3 transactions");
+
+    // --- Scenario B: Command filter — Publish ---
+    // 2 publish transactions (NFT + Basics)
+    let publish_filter = grpc_filter::TransactionFilter::default().with_command(
+        grpc_filter::CommandFilter::default()
+            .with_publish(grpc_filter::PublishCommandFilter::default()),
+    );
+    let count = stream_and_collect(publish_filter).await;
+    assert_eq!(count, 2, "Scenario B: should match 2 Publish transactions");
+
+    // --- Scenario C: Command filter — MoveCall with package ---
+    // MoveCall to nft_package: mint NFT (1 tx)
+    let move_call_filter = grpc_filter::TransactionFilter::default().with_command(
+        grpc_filter::CommandFilter::default().with_move_call(
+            grpc_filter::MoveCallCommandFilter::default().with_package_id(
+                grpc_types::Address::default().with_address(nft_package_id.to_vec()),
+            ),
+        ),
+    );
+    let count = stream_and_collect(move_call_filter).await;
+    assert_eq!(
+        count, 1,
+        "Scenario C: should match 1 MoveCall to NFT package"
+    );
+
+    // --- Scenario D: Execution status — Success ---
+    // All 5 user transactions should succeed (system transactions too, but
+    // we filter by ProgrammableTransaction kind to count only user txns)
+    let success_and_programmable = grpc_filter::TransactionFilter::default().with_all(
+        grpc_filter::AllTransactionFilter::default().with_filters(vec![
+            grpc_filter::TransactionFilter::default().with_execution_status(
+                grpc_filter::ExecutionStatusFilter::default().with_success(true),
+            ),
+            grpc_filter::TransactionFilter::default().with_transaction_kinds(
+                grpc_filter::TransactionKindsFilter::default().with_kinds(vec![
+                    grpc_filter::TransactionKind::ProgrammableTransaction.into(),
+                ]),
+            ),
+        ]),
+    );
+    let count = stream_and_collect(success_and_programmable).await;
+    assert_eq!(
+        count, 5,
+        "Scenario D: all 5 programmable transactions should be successful"
+    );
+
+    // --- Scenario E: Combined — sender_1 AND Publish ---
+    // sender_1 published 2 packages
+    let sender_and_publish = grpc_filter::TransactionFilter::default().with_all(
+        grpc_filter::AllTransactionFilter::default().with_filters(vec![
+            grpc_filter::TransactionFilter::default().with_sender(
+                grpc_filter::AddressFilter::default()
+                    .with_address(grpc_types::Address::default().with_address(sender_1.to_vec())),
+            ),
+            grpc_filter::TransactionFilter::default().with_command(
+                grpc_filter::CommandFilter::default()
+                    .with_publish(grpc_filter::PublishCommandFilter::default()),
+            ),
+        ]),
+    );
+    let count = stream_and_collect(sender_and_publish).await;
+    assert_eq!(
+        count, 2,
+        "Scenario E: sender_1 AND Publish should match 2 transactions"
+    );
+
+    // --- Scenario F: Any (OR) of Publish or MoveCall to basics ---
+    // Publish (2) + MoveCall to basics/clock (1) = 3 unique transactions
+    // Note: publish basics is already counted in Publish
+    let any_filter = grpc_filter::TransactionFilter::default().with_any(
+        grpc_filter::AnyTransactionFilter::default().with_filters(vec![
+            grpc_filter::TransactionFilter::default().with_command(
+                grpc_filter::CommandFilter::default()
+                    .with_publish(grpc_filter::PublishCommandFilter::default()),
+            ),
+            grpc_filter::TransactionFilter::default().with_command(
+                grpc_filter::CommandFilter::default().with_move_call(
+                    grpc_filter::MoveCallCommandFilter::default().with_package_id(
+                        grpc_types::Address::default().with_address(basics_package_id.to_vec()),
+                    ),
+                ),
+            ),
+        ]),
+    );
+    let count = stream_and_collect(any_filter).await;
+    assert_eq!(
+        count, 3,
+        "Scenario F: Publish OR MoveCall(basics) should match 3 transactions"
+    );
+}

--- a/crates/iota-grpc-server/src/transaction_filter.rs
+++ b/crates/iota-grpc-server/src/transaction_filter.rs
@@ -9,9 +9,10 @@ use iota_metrics::monitored_scope;
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
     effects::TransactionEffectsAPI,
+    execution_status::ExecutionStatus,
     full_checkpoint_content::CheckpointTransaction,
     object::Owner,
-    transaction::TransactionDataAPI,
+    transaction::{Command, TransactionDataAPI},
 };
 use serde::{Deserialize, Serialize};
 
@@ -86,6 +87,130 @@ impl TryFrom<proto_filter::TransactionKind> for TransactionKind {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum CommandFilter {
+    /// Match a MoveCall command.
+    /// Package is required; module and function are optional.
+    MoveCall {
+        package: ObjectID,
+        module: Option<String>,
+        function: Option<String>,
+    },
+    /// Match a TransferObjects command.
+    TransferObjects,
+    /// Match a SplitCoins command.
+    SplitCoins,
+    /// Match a MergeCoins command.
+    MergeCoins,
+    /// Match a Publish command.
+    Publish,
+    /// Match a MakeMoveVec command.
+    MakeMoveVec,
+    /// Match an Upgrade command.
+    /// Optionally filter by the specific package being upgraded.
+    Upgrade { package: Option<ObjectID> },
+}
+
+impl CommandFilter {
+    /// Returns true if any of the given commands match this filter.
+    pub fn matches_commands(&self, commands: &[Command]) -> bool {
+        commands.iter().any(|cmd| match (self, cmd) {
+            (
+                CommandFilter::MoveCall {
+                    package,
+                    module,
+                    function,
+                },
+                Command::MoveCall(call),
+            ) => {
+                call.package == *package
+                    && (module.is_none() || matches!(module, Some(m) if m == &call.module))
+                    && (function.is_none() || matches!(function, Some(f) if f == &call.function))
+            }
+            (CommandFilter::TransferObjects, Command::TransferObjects(..)) => true,
+            (CommandFilter::SplitCoins, Command::SplitCoins(..)) => true,
+            (CommandFilter::MergeCoins, Command::MergeCoins(..)) => true,
+            (CommandFilter::Publish, Command::Publish(..)) => true,
+            (CommandFilter::MakeMoveVec, Command::MakeMoveVec(..)) => true,
+            (CommandFilter::Upgrade { package }, Command::Upgrade(_, _, pkg_id, _)) => {
+                package.is_none() || matches!(package, Some(p) if p == pkg_id)
+            }
+            _ => false,
+        })
+    }
+}
+
+impl TryFrom<proto_filter::CommandFilter> for CommandFilter {
+    type Error = String;
+
+    fn try_from(proto: proto_filter::CommandFilter) -> Result<Self, Self::Error> {
+        use proto_filter::command_filter::Filter as ProtoCommandFilter;
+
+        let filter = proto.filter.ok_or("command filter is missing")?;
+
+        match filter {
+            ProtoCommandFilter::MoveCall(call_filter) => {
+                let package_bytes = call_filter
+                    .package_id
+                    .ok_or("package_id is missing")?
+                    .address;
+                let package = ObjectID::from_bytes(&package_bytes)
+                    .map_err(|e| format!("invalid package_id: {}", e))?;
+                Ok(CommandFilter::MoveCall {
+                    package,
+                    module: call_filter.module,
+                    function: call_filter.function,
+                })
+            }
+            ProtoCommandFilter::TransferObjects(_) => Ok(CommandFilter::TransferObjects),
+            ProtoCommandFilter::SplitCoins(_) => Ok(CommandFilter::SplitCoins),
+            ProtoCommandFilter::MergeCoins(_) => Ok(CommandFilter::MergeCoins),
+            ProtoCommandFilter::Publish(_) => Ok(CommandFilter::Publish),
+            ProtoCommandFilter::MakeMoveVec(_) => Ok(CommandFilter::MakeMoveVec),
+            ProtoCommandFilter::Upgrade(upgrade_filter) => {
+                let package = upgrade_filter
+                    .package_id
+                    .map(|addr| {
+                        ObjectID::from_bytes(&addr.address)
+                            .map_err(|e| format!("invalid package_id: {}", e))
+                    })
+                    .transpose()?;
+                Ok(CommandFilter::Upgrade { package })
+            }
+            _ => Err("Unsupported command filter type".to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ExecutionStatusFilter {
+    /// Match successful transactions.
+    Success,
+    /// Match failed transactions (cancelled, execution error, or any other
+    /// failure).
+    Failure,
+}
+
+impl ExecutionStatusFilter {
+    /// Returns true if the given execution status matches this filter.
+    pub fn matches_status(&self, status: &ExecutionStatus) -> bool {
+        match self {
+            ExecutionStatusFilter::Success => status.is_ok(),
+            ExecutionStatusFilter::Failure => status.is_err(),
+        }
+    }
+}
+
+impl From<proto_filter::ExecutionStatusFilter> for ExecutionStatusFilter {
+    fn from(proto: proto_filter::ExecutionStatusFilter) -> Self {
+        if proto.success {
+            ExecutionStatusFilter::Success
+        } else {
+            ExecutionStatusFilter::Failure
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TransactionFilter {
     // Logical AND of several filters.
     All(Vec<TransactionFilter>),
@@ -106,18 +231,14 @@ pub enum TransactionFilter {
     /// Filter for transactions that touch this object.
     AffectedObject(ObjectID),
 
-    /// Filter by move package, module (optional) and function (optional).
-    MoveCall {
-        /// the Move package ID
-        package: ObjectID,
-        /// the module name
-        module: Option<String>,
-        /// the function name
-        function: Option<String>,
-    },
+    /// Filter by command type with optional criteria.
+    Command(CommandFilter),
 
     /// Filter transactions that contain events matching the given event filter.
     Events(EventFilter),
+
+    /// Filter by transaction execution status.
+    ExecutionStatus(ExecutionStatusFilter),
 }
 
 // Proto-to-internal filter conversion
@@ -191,23 +312,16 @@ impl TryFrom<proto_filter::TransactionFilter> for TransactionFilter {
                     .map_err(|e| format!("invalid object_id: {}", e))?;
                 Ok(TransactionFilter::AffectedObject(object_id))
             }
-            ProtoFilter::MoveCall(call_filter) => {
-                // TODO: is this correct?
-                let package_bytes = call_filter
-                    .package_id
-                    .ok_or("package_id is missing")?
-                    .address;
-                let package = ObjectID::from_bytes(&package_bytes)
-                    .map_err(|e| format!("invalid package_id: {}", e))?;
-                Ok(TransactionFilter::MoveCall {
-                    package,
-                    module: call_filter.module,
-                    function: call_filter.function,
-                })
+            ProtoFilter::Command(command_filter) => {
+                let internal_command_filter = CommandFilter::try_from(command_filter)?;
+                Ok(TransactionFilter::Command(internal_command_filter))
             }
             ProtoFilter::Event(event_filter) => {
                 let internal_event_filter = EventFilter::try_from(event_filter)?;
                 Ok(TransactionFilter::Events(internal_event_filter))
+            }
+            ProtoFilter::ExecutionStatus(status_filter) => {
+                Ok(TransactionFilter::ExecutionStatus(status_filter.into()))
             }
             _ => Err("Unsupported transaction filter type".to_string()),
         }
@@ -271,21 +385,22 @@ impl TransactionFilter {
                 .iter()
                 .any(|obj_ref| &obj_ref.0 == o),
 
-            TransactionFilter::MoveCall {
-                package,
-                module,
-                function,
-            } => tx_data.move_calls().into_iter().any(|(p, m, f)| {
-                p == package
-                    && (module.is_none() || matches!(module,  Some(m2) if m2 == &m.to_string()))
-                    && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
-            }),
+            TransactionFilter::Command(cmd_filter) => match tx_data.kind() {
+                iota_types::transaction::TransactionKind::ProgrammableTransaction(pt) => {
+                    cmd_filter.matches_commands(&pt.commands)
+                }
+                _ => false,
+            },
 
             TransactionFilter::Events(event_filter) => item.events.as_ref().is_some_and(|evts| {
                 evts.data
                     .iter()
                     .any(|event| event_filter.matches_event(state_reader.clone(), event))
             }),
+
+            TransactionFilter::ExecutionStatus(status_filter) => {
+                status_filter.matches_status(item.effects.status())
+            }
         }
     }
 
@@ -387,7 +502,10 @@ impl TransactionFilter {
 
 #[cfg(test)]
 mod tests {
-    use iota_types::base_types::ObjectID;
+    use iota_types::{
+        base_types::ObjectID,
+        transaction::{Argument, Command, ProgrammableMoveCall},
+    };
 
     use super::*;
 
@@ -481,5 +599,279 @@ mod tests {
 
         assert!(complex_filter.validate_depth().is_ok());
         assert_eq!(complex_filter.max_depth(), 3);
+    }
+
+    // --- CommandFilter matching tests ---
+
+    fn make_move_call_cmd(package: ObjectID, module: &str, function: &str) -> Command {
+        Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package,
+            module: module.to_string(),
+            function: function.to_string(),
+            type_arguments: vec![],
+            arguments: vec![],
+        }))
+    }
+
+    #[test]
+    fn test_command_filter_move_call_exact() {
+        let pkg = ObjectID::random();
+        let commands = vec![make_move_call_cmd(pkg, "my_module", "my_func")];
+
+        // Exact match
+        let filter = CommandFilter::MoveCall {
+            package: pkg,
+            module: Some("my_module".into()),
+            function: Some("my_func".into()),
+        };
+        assert!(filter.matches_commands(&commands));
+
+        // Wrong function
+        let filter = CommandFilter::MoveCall {
+            package: pkg,
+            module: Some("my_module".into()),
+            function: Some("other_func".into()),
+        };
+        assert!(!filter.matches_commands(&commands));
+
+        // Wrong module
+        let filter = CommandFilter::MoveCall {
+            package: pkg,
+            module: Some("other_module".into()),
+            function: None,
+        };
+        assert!(!filter.matches_commands(&commands));
+
+        // Wrong package
+        let filter = CommandFilter::MoveCall {
+            package: ObjectID::random(),
+            module: None,
+            function: None,
+        };
+        assert!(!filter.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_move_call_optional_fields() {
+        let pkg = ObjectID::random();
+        let commands = vec![make_move_call_cmd(pkg, "my_module", "my_func")];
+
+        // Package only — matches any module/function
+        let filter = CommandFilter::MoveCall {
+            package: pkg,
+            module: None,
+            function: None,
+        };
+        assert!(filter.matches_commands(&commands));
+
+        // Package + module — matches any function
+        let filter = CommandFilter::MoveCall {
+            package: pkg,
+            module: Some("my_module".into()),
+            function: None,
+        };
+        assert!(filter.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_transfer_objects() {
+        let commands = vec![Command::TransferObjects(
+            vec![Argument::Input(0)],
+            Argument::Input(1),
+        )];
+
+        assert!(CommandFilter::TransferObjects.matches_commands(&commands));
+        assert!(!CommandFilter::SplitCoins.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_split_coins() {
+        let commands = vec![Command::SplitCoins(
+            Argument::Input(0),
+            vec![Argument::Input(1)],
+        )];
+
+        assert!(CommandFilter::SplitCoins.matches_commands(&commands));
+        assert!(!CommandFilter::MergeCoins.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_merge_coins() {
+        let commands = vec![Command::MergeCoins(
+            Argument::Input(0),
+            vec![Argument::Input(1)],
+        )];
+
+        assert!(CommandFilter::MergeCoins.matches_commands(&commands));
+        assert!(!CommandFilter::SplitCoins.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_publish() {
+        let commands = vec![Command::Publish(vec![vec![1, 2, 3]], vec![])];
+
+        assert!(CommandFilter::Publish.matches_commands(&commands));
+        assert!(!CommandFilter::TransferObjects.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_make_move_vec() {
+        let commands = vec![Command::MakeMoveVec(None, vec![Argument::Input(0)])];
+
+        assert!(CommandFilter::MakeMoveVec.matches_commands(&commands));
+        assert!(!CommandFilter::Publish.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_upgrade_any() {
+        let pkg = ObjectID::random();
+        let commands = vec![Command::Upgrade(
+            vec![vec![1, 2, 3]],
+            vec![],
+            pkg,
+            Argument::Input(0),
+        )];
+
+        // Match any upgrade
+        let filter = CommandFilter::Upgrade { package: None };
+        assert!(filter.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_upgrade_specific_package() {
+        let pkg = ObjectID::random();
+        let other_pkg = ObjectID::random();
+        let commands = vec![Command::Upgrade(
+            vec![vec![1, 2, 3]],
+            vec![],
+            pkg,
+            Argument::Input(0),
+        )];
+
+        // Match specific package
+        let filter = CommandFilter::Upgrade { package: Some(pkg) };
+        assert!(filter.matches_commands(&commands));
+
+        // Wrong package
+        let filter = CommandFilter::Upgrade {
+            package: Some(other_pkg),
+        };
+        assert!(!filter.matches_commands(&commands));
+    }
+
+    #[test]
+    fn test_command_filter_empty_commands() {
+        let commands: Vec<Command> = vec![];
+
+        assert!(!CommandFilter::Publish.matches_commands(&commands));
+        assert!(!CommandFilter::TransferObjects.matches_commands(&commands));
+        assert!(
+            !CommandFilter::MoveCall {
+                package: ObjectID::random(),
+                module: None,
+                function: None,
+            }
+            .matches_commands(&commands)
+        );
+    }
+
+    #[test]
+    fn test_command_filter_multiple_commands() {
+        let pkg = ObjectID::random();
+        let commands = vec![
+            Command::SplitCoins(Argument::Input(0), vec![Argument::Input(1)]),
+            make_move_call_cmd(pkg, "m", "f"),
+            Command::TransferObjects(vec![Argument::Result(0)], Argument::Input(2)),
+        ];
+
+        // All three types should match
+        assert!(CommandFilter::SplitCoins.matches_commands(&commands));
+        assert!(
+            CommandFilter::MoveCall {
+                package: pkg,
+                module: Some("m".into()),
+                function: Some("f".into()),
+            }
+            .matches_commands(&commands)
+        );
+        assert!(CommandFilter::TransferObjects.matches_commands(&commands));
+
+        // But Publish doesn't
+        assert!(!CommandFilter::Publish.matches_commands(&commands));
+    }
+
+    // --- Depth/complexity for new filter types ---
+
+    #[test]
+    fn test_command_filter_depth_and_complexity() {
+        let filter = TransactionFilter::Command(CommandFilter::Publish);
+        assert!(filter.validate_depth().is_ok());
+        assert_eq!(filter.max_depth(), 0);
+        assert_eq!(filter.count_nodes(), 1);
+    }
+
+    #[test]
+    fn test_execution_status_depth_and_complexity() {
+        let filter = TransactionFilter::ExecutionStatus(ExecutionStatusFilter::Success);
+        assert!(filter.validate_depth().is_ok());
+        assert_eq!(filter.max_depth(), 0);
+        assert_eq!(filter.count_nodes(), 1);
+
+        let filter = TransactionFilter::ExecutionStatus(ExecutionStatusFilter::Failure);
+        assert!(filter.validate_depth().is_ok());
+        assert_eq!(filter.max_depth(), 0);
+        assert_eq!(filter.count_nodes(), 1);
+    }
+
+    #[test]
+    fn test_combined_new_filters_in_any() {
+        let filter = TransactionFilter::Any(vec![
+            TransactionFilter::Command(CommandFilter::Publish),
+            TransactionFilter::Command(CommandFilter::Upgrade { package: None }),
+            TransactionFilter::ExecutionStatus(ExecutionStatusFilter::Failure),
+        ]);
+        assert!(filter.validate_depth().is_ok());
+        assert_eq!(filter.max_depth(), 1);
+        assert_eq!(filter.count_nodes(), 4); // Any + 3 children
+    }
+
+    // --- ExecutionStatusFilter matching tests ---
+
+    #[test]
+    fn test_execution_status_filter_success() {
+        let filter = ExecutionStatusFilter::Success;
+
+        assert!(filter.matches_status(&ExecutionStatus::Success));
+        assert!(!filter.matches_status(&ExecutionStatus::Failure {
+            error: iota_types::execution_status::ExecutionFailureStatus::InsufficientGas,
+            command: None,
+        }));
+    }
+
+    #[test]
+    fn test_execution_status_filter_failure() {
+        let filter = ExecutionStatusFilter::Failure;
+
+        assert!(!filter.matches_status(&ExecutionStatus::Success));
+
+        // Regular failure
+        assert!(filter.matches_status(&ExecutionStatus::Failure {
+            error: iota_types::execution_status::ExecutionFailureStatus::InsufficientGas,
+            command: None,
+        }));
+
+        // Cancelled due to congestion
+        assert!(filter.matches_status(&ExecutionStatus::Failure {
+            error: iota_types::execution_status::ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestion {
+                congested_objects: iota_types::execution_status::CongestedObjects(vec![]),
+            },
+            command: None,
+        }));
+
+        // Cancelled due to randomness
+        assert!(filter.matches_status(&ExecutionStatus::Failure {
+            error: iota_types::execution_status::ExecutionFailureStatus::ExecutionCancelledDueToRandomnessUnavailable,
+            command: None,
+        }));
     }
 }

--- a/crates/iota-grpc-types/proto/iota/grpc/v0/filter.proto
+++ b/crates/iota-grpc-types/proto/iota/grpc/v0/filter.proto
@@ -132,13 +132,73 @@ message ObjectIdFilter {
   iota.grpc.v0.types.ObjectReference object_ref = 1;
 }
 
+// --- Command filter messages ---
+
 // Filter by move package, module (optional) and function (optional).
-message MoveCallFilter {
+message MoveCallCommandFilter {
   option (iota.grpc.message_accessors) = "with";
 
   iota.grpc.v0.types.Address package_id = 1;
   optional string module = 2;
   optional string function = 3;
+}
+
+// Match a TransferObjects command.
+message TransferObjectsCommandFilter {
+  option (iota.grpc.message_accessors) = "with";
+}
+
+// Match a SplitCoins command.
+message SplitCoinsCommandFilter {
+  option (iota.grpc.message_accessors) = "with";
+}
+
+// Match a MergeCoins command.
+message MergeCoinsCommandFilter {
+  option (iota.grpc.message_accessors) = "with";
+}
+
+// Match a Publish command.
+message PublishCommandFilter {
+  option (iota.grpc.message_accessors) = "with";
+}
+
+// Match a MakeMoveVec command.
+message MakeMoveVecCommandFilter {
+  option (iota.grpc.message_accessors) = "with";
+}
+
+// Match an Upgrade command. Optionally filter by the specific package being upgraded.
+message UpgradeCommandFilter {
+  option (iota.grpc.message_accessors) = "with";
+
+  optional iota.grpc.v0.types.Address package_id = 1;
+}
+
+// Filter by command type.
+message CommandFilter {
+  option (iota.grpc.message_accessors) = "with";
+
+  oneof filter {
+    MoveCallCommandFilter move_call = 1;
+    TransferObjectsCommandFilter transfer_objects = 2;
+    SplitCoinsCommandFilter split_coins = 3;
+    MergeCoinsCommandFilter merge_coins = 4;
+    PublishCommandFilter publish = 5;
+    MakeMoveVecCommandFilter make_move_vec = 6;
+    UpgradeCommandFilter upgrade = 7;
+  }
+}
+
+// --- Execution status filter ---
+
+// Filter by transaction execution status.
+// Set `success` to `true` to match successful transactions,
+// or `false` to match failed transactions (cancelled, execution error, etc.).
+message ExecutionStatusFilter {
+  option (iota.grpc.message_accessors) = "with";
+
+  bool success = 1;
 }
 
 // Filter for transactions.
@@ -156,19 +216,22 @@ message TransactionFilter {
     // Filter transactions of any given kind in the filter.
     TransactionKindsFilter transaction_kinds = 4;
 
+    // Filter by transaction execution success/failure.
+    ExecutionStatusFilter execution_status = 5;
+
     // Filter by sender address.
-    AddressFilter sender = 5;
+    AddressFilter sender = 6;
     // Filter by recipient address. The recipient is determined by
     // checking the owners of mutated and unwrapped objects.
-    AddressFilter receiver = 6;
+    AddressFilter receiver = 7;
 
     // Filter for transactions that touch this object.
-    ObjectIdFilter affected_object = 7;
+    ObjectIdFilter affected_object = 8;
 
-    // Filter by move package, module (optional) and function (optional).
-    MoveCallFilter move_call = 8;
+    // Filter by command type.
+    CommandFilter command = 9;
 
     // Filter transactions that contain events matching the given event filter.
-    EventFilter event = 9;
+    EventFilter event = 10;
   }
 }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.accessors.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.accessors.rs
@@ -42,6 +42,73 @@ mod _accessor_impls {
             self
         }
     }
+    impl super::CommandFilter {
+        /// Sets `move_call` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_move_call<T: Into<super::MoveCallCommandFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.filter = Some(super::command_filter::Filter::MoveCall(field.into()));
+            self
+        }
+        /// Sets `transfer_objects` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_transfer_objects<T: Into<super::TransferObjectsCommandFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.filter = Some(
+                super::command_filter::Filter::TransferObjects(field.into()),
+            );
+            self
+        }
+        /// Sets `split_coins` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_split_coins<T: Into<super::SplitCoinsCommandFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.filter = Some(super::command_filter::Filter::SplitCoins(field.into()));
+            self
+        }
+        /// Sets `merge_coins` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_merge_coins<T: Into<super::MergeCoinsCommandFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.filter = Some(super::command_filter::Filter::MergeCoins(field.into()));
+            self
+        }
+        /// Sets `publish` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_publish<T: Into<super::PublishCommandFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.filter = Some(super::command_filter::Filter::Publish(field.into()));
+            self
+        }
+        /// Sets `make_move_vec` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_make_move_vec<T: Into<super::MakeMoveVecCommandFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.filter = Some(super::command_filter::Filter::MakeMoveVec(field.into()));
+            self
+        }
+        /// Sets `upgrade` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_upgrade<T: Into<super::UpgradeCommandFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.filter = Some(super::command_filter::Filter::Upgrade(field.into()));
+            self
+        }
+    }
     impl super::EventFilter {
         /// Sets `all` with the provided value.
         /// If any other oneof field in the same oneof is set, it will be cleared.
@@ -101,7 +168,14 @@ mod _accessor_impls {
             self
         }
     }
-    impl super::MoveCallFilter {
+    impl super::ExecutionStatusFilter {
+        /// Sets `success` with the provided value.
+        pub fn with_success(mut self, field: bool) -> Self {
+            self.success = field;
+            self
+        }
+    }
+    impl super::MoveCallCommandFilter {
         /// Sets `package_id` with the provided value.
         pub fn with_package_id<T: Into<super::super::types::Address>>(
             mut self,
@@ -212,6 +286,17 @@ mod _accessor_impls {
             );
             self
         }
+        /// Sets `execution_status` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_execution_status<T: Into<super::ExecutionStatusFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.filter = Some(
+                super::transaction_filter::Filter::ExecutionStatus(field.into()),
+            );
+            self
+        }
         /// Sets `sender` with the provided value.
         /// If any other oneof field in the same oneof is set, it will be cleared.
         pub fn with_sender<T: Into<super::AddressFilter>>(mut self, field: T) -> Self {
@@ -237,15 +322,10 @@ mod _accessor_impls {
             );
             self
         }
-        /// Sets `move_call` with the provided value.
+        /// Sets `command` with the provided value.
         /// If any other oneof field in the same oneof is set, it will be cleared.
-        pub fn with_move_call<T: Into<super::MoveCallFilter>>(
-            mut self,
-            field: T,
-        ) -> Self {
-            self.filter = Some(
-                super::transaction_filter::Filter::MoveCall(field.into()),
-            );
+        pub fn with_command<T: Into<super::CommandFilter>>(mut self, field: T) -> Self {
+            self.filter = Some(super::transaction_filter::Filter::Command(field.into()));
             self
         }
         /// Sets `event` with the provided value.
@@ -259,6 +339,16 @@ mod _accessor_impls {
         /// Sets `kinds` with the provided value.
         pub fn with_kinds(mut self, field: Vec<i32>) -> Self {
             self.kinds = field;
+            self
+        }
+    }
+    impl super::UpgradeCommandFilter {
+        /// Sets `package_id` with the provided value.
+        pub fn with_package_id<T: Into<super::super::types::Address>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.package_id = Some(field.into());
             self
         }
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.field_info.rs
@@ -573,7 +573,7 @@ mod _field_impls {
             ObjectReferenceFieldPathBuilder::new_with_base(self.path)
         }
     }
-    impl MoveCallFilter {
+    impl MoveCallCommandFilter {
         pub const PACKAGE_ID_FIELD: &'static MessageField = &MessageField {
             name: "package_id",
             json_name: "packageId",
@@ -599,22 +599,22 @@ mod _field_impls {
             message_fields: None,
         };
     }
-    impl MessageFields for MoveCallFilter {
+    impl MessageFields for MoveCallCommandFilter {
         const FIELDS: &'static [&'static MessageField] = &[
             Self::PACKAGE_ID_FIELD,
             Self::MODULE_FIELD,
             Self::FUNCTION_FIELD,
         ];
     }
-    impl MoveCallFilter {
-        pub fn path_builder() -> MoveCallFilterFieldPathBuilder {
-            MoveCallFilterFieldPathBuilder::new()
+    impl MoveCallCommandFilter {
+        pub fn path_builder() -> MoveCallCommandFilterFieldPathBuilder {
+            MoveCallCommandFilterFieldPathBuilder::new()
         }
     }
-    pub struct MoveCallFilterFieldPathBuilder {
+    pub struct MoveCallCommandFilterFieldPathBuilder {
         path: Vec<&'static str>,
     }
-    impl MoveCallFilterFieldPathBuilder {
+    impl MoveCallCommandFilterFieldPathBuilder {
         #[allow(clippy::new_without_default)]
         pub fn new() -> Self {
             Self { path: Default::default() }
@@ -627,15 +627,339 @@ mod _field_impls {
             self.path.join(".")
         }
         pub fn package_id(mut self) -> AddressFieldPathBuilder {
-            self.path.push(MoveCallFilter::PACKAGE_ID_FIELD.name);
+            self.path.push(MoveCallCommandFilter::PACKAGE_ID_FIELD.name);
             AddressFieldPathBuilder::new_with_base(self.path)
         }
         pub fn module(mut self) -> String {
-            self.path.push(MoveCallFilter::MODULE_FIELD.name);
+            self.path.push(MoveCallCommandFilter::MODULE_FIELD.name);
             self.finish()
         }
         pub fn function(mut self) -> String {
-            self.path.push(MoveCallFilter::FUNCTION_FIELD.name);
+            self.path.push(MoveCallCommandFilter::FUNCTION_FIELD.name);
+            self.finish()
+        }
+    }
+    impl TransferObjectsCommandFilter {}
+    impl MessageFields for TransferObjectsCommandFilter {
+        const FIELDS: &'static [&'static MessageField] = &[];
+    }
+    impl TransferObjectsCommandFilter {
+        pub fn path_builder() -> TransferObjectsCommandFilterFieldPathBuilder {
+            TransferObjectsCommandFilterFieldPathBuilder::new()
+        }
+    }
+    pub struct TransferObjectsCommandFilterFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl TransferObjectsCommandFilterFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+    }
+    impl SplitCoinsCommandFilter {}
+    impl MessageFields for SplitCoinsCommandFilter {
+        const FIELDS: &'static [&'static MessageField] = &[];
+    }
+    impl SplitCoinsCommandFilter {
+        pub fn path_builder() -> SplitCoinsCommandFilterFieldPathBuilder {
+            SplitCoinsCommandFilterFieldPathBuilder::new()
+        }
+    }
+    pub struct SplitCoinsCommandFilterFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl SplitCoinsCommandFilterFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+    }
+    impl MergeCoinsCommandFilter {}
+    impl MessageFields for MergeCoinsCommandFilter {
+        const FIELDS: &'static [&'static MessageField] = &[];
+    }
+    impl MergeCoinsCommandFilter {
+        pub fn path_builder() -> MergeCoinsCommandFilterFieldPathBuilder {
+            MergeCoinsCommandFilterFieldPathBuilder::new()
+        }
+    }
+    pub struct MergeCoinsCommandFilterFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl MergeCoinsCommandFilterFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+    }
+    impl PublishCommandFilter {}
+    impl MessageFields for PublishCommandFilter {
+        const FIELDS: &'static [&'static MessageField] = &[];
+    }
+    impl PublishCommandFilter {
+        pub fn path_builder() -> PublishCommandFilterFieldPathBuilder {
+            PublishCommandFilterFieldPathBuilder::new()
+        }
+    }
+    pub struct PublishCommandFilterFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl PublishCommandFilterFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+    }
+    impl MakeMoveVecCommandFilter {}
+    impl MessageFields for MakeMoveVecCommandFilter {
+        const FIELDS: &'static [&'static MessageField] = &[];
+    }
+    impl MakeMoveVecCommandFilter {
+        pub fn path_builder() -> MakeMoveVecCommandFilterFieldPathBuilder {
+            MakeMoveVecCommandFilterFieldPathBuilder::new()
+        }
+    }
+    pub struct MakeMoveVecCommandFilterFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl MakeMoveVecCommandFilterFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+    }
+    impl UpgradeCommandFilter {
+        pub const PACKAGE_ID_FIELD: &'static MessageField = &MessageField {
+            name: "package_id",
+            json_name: "packageId",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Address::FIELDS),
+        };
+    }
+    impl MessageFields for UpgradeCommandFilter {
+        const FIELDS: &'static [&'static MessageField] = &[Self::PACKAGE_ID_FIELD];
+    }
+    impl UpgradeCommandFilter {
+        pub fn path_builder() -> UpgradeCommandFilterFieldPathBuilder {
+            UpgradeCommandFilterFieldPathBuilder::new()
+        }
+    }
+    pub struct UpgradeCommandFilterFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl UpgradeCommandFilterFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn package_id(mut self) -> AddressFieldPathBuilder {
+            self.path.push(UpgradeCommandFilter::PACKAGE_ID_FIELD.name);
+            AddressFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl CommandFilter {
+        pub const MOVE_CALL_FIELD: &'static MessageField = &MessageField {
+            name: "move_call",
+            json_name: "moveCall",
+            number: 1i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(MoveCallCommandFilter::FIELDS),
+        };
+        pub const TRANSFER_OBJECTS_FIELD: &'static MessageField = &MessageField {
+            name: "transfer_objects",
+            json_name: "transferObjects",
+            number: 2i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(TransferObjectsCommandFilter::FIELDS),
+        };
+        pub const SPLIT_COINS_FIELD: &'static MessageField = &MessageField {
+            name: "split_coins",
+            json_name: "splitCoins",
+            number: 3i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(SplitCoinsCommandFilter::FIELDS),
+        };
+        pub const MERGE_COINS_FIELD: &'static MessageField = &MessageField {
+            name: "merge_coins",
+            json_name: "mergeCoins",
+            number: 4i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(MergeCoinsCommandFilter::FIELDS),
+        };
+        pub const PUBLISH_FIELD: &'static MessageField = &MessageField {
+            name: "publish",
+            json_name: "publish",
+            number: 5i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(PublishCommandFilter::FIELDS),
+        };
+        pub const MAKE_MOVE_VEC_FIELD: &'static MessageField = &MessageField {
+            name: "make_move_vec",
+            json_name: "makeMoveVec",
+            number: 6i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(MakeMoveVecCommandFilter::FIELDS),
+        };
+        pub const UPGRADE_FIELD: &'static MessageField = &MessageField {
+            name: "upgrade",
+            json_name: "upgrade",
+            number: 7i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(UpgradeCommandFilter::FIELDS),
+        };
+    }
+    impl CommandFilter {
+        pub const FILTER_ONEOF: &'static str = "filter";
+    }
+    impl MessageFields for CommandFilter {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::MOVE_CALL_FIELD,
+            Self::TRANSFER_OBJECTS_FIELD,
+            Self::SPLIT_COINS_FIELD,
+            Self::MERGE_COINS_FIELD,
+            Self::PUBLISH_FIELD,
+            Self::MAKE_MOVE_VEC_FIELD,
+            Self::UPGRADE_FIELD,
+        ];
+    }
+    impl CommandFilter {
+        pub fn path_builder() -> CommandFilterFieldPathBuilder {
+            CommandFilterFieldPathBuilder::new()
+        }
+    }
+    pub struct CommandFilterFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl CommandFilterFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn move_call(mut self) -> MoveCallCommandFilterFieldPathBuilder {
+            self.path.push(CommandFilter::MOVE_CALL_FIELD.name);
+            MoveCallCommandFilterFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn transfer_objects(
+            mut self,
+        ) -> TransferObjectsCommandFilterFieldPathBuilder {
+            self.path.push(CommandFilter::TRANSFER_OBJECTS_FIELD.name);
+            TransferObjectsCommandFilterFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn split_coins(mut self) -> SplitCoinsCommandFilterFieldPathBuilder {
+            self.path.push(CommandFilter::SPLIT_COINS_FIELD.name);
+            SplitCoinsCommandFilterFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn merge_coins(mut self) -> MergeCoinsCommandFilterFieldPathBuilder {
+            self.path.push(CommandFilter::MERGE_COINS_FIELD.name);
+            MergeCoinsCommandFilterFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn publish(mut self) -> PublishCommandFilterFieldPathBuilder {
+            self.path.push(CommandFilter::PUBLISH_FIELD.name);
+            PublishCommandFilterFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn make_move_vec(mut self) -> MakeMoveVecCommandFilterFieldPathBuilder {
+            self.path.push(CommandFilter::MAKE_MOVE_VEC_FIELD.name);
+            MakeMoveVecCommandFilterFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn upgrade(mut self) -> UpgradeCommandFilterFieldPathBuilder {
+            self.path.push(CommandFilter::UPGRADE_FIELD.name);
+            UpgradeCommandFilterFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl ExecutionStatusFilter {
+        pub const SUCCESS_FIELD: &'static MessageField = &MessageField {
+            name: "success",
+            json_name: "success",
+            number: 1i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: None,
+        };
+    }
+    impl MessageFields for ExecutionStatusFilter {
+        const FIELDS: &'static [&'static MessageField] = &[Self::SUCCESS_FIELD];
+    }
+    impl ExecutionStatusFilter {
+        pub fn path_builder() -> ExecutionStatusFilterFieldPathBuilder {
+            ExecutionStatusFilterFieldPathBuilder::new()
+        }
+    }
+    pub struct ExecutionStatusFilterFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ExecutionStatusFilterFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn success(mut self) -> String {
+            self.path.push(ExecutionStatusFilter::SUCCESS_FIELD.name);
             self.finish()
         }
     }
@@ -672,10 +996,18 @@ mod _field_impls {
             is_map: false,
             message_fields: Some(TransactionKindsFilter::FIELDS),
         };
+        pub const EXECUTION_STATUS_FIELD: &'static MessageField = &MessageField {
+            name: "execution_status",
+            json_name: "executionStatus",
+            number: 5i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ExecutionStatusFilter::FIELDS),
+        };
         pub const SENDER_FIELD: &'static MessageField = &MessageField {
             name: "sender",
             json_name: "sender",
-            number: 5i32,
+            number: 6i32,
             is_optional: false,
             is_map: false,
             message_fields: Some(AddressFilter::FIELDS),
@@ -683,7 +1015,7 @@ mod _field_impls {
         pub const RECEIVER_FIELD: &'static MessageField = &MessageField {
             name: "receiver",
             json_name: "receiver",
-            number: 6i32,
+            number: 7i32,
             is_optional: false,
             is_map: false,
             message_fields: Some(AddressFilter::FIELDS),
@@ -691,23 +1023,23 @@ mod _field_impls {
         pub const AFFECTED_OBJECT_FIELD: &'static MessageField = &MessageField {
             name: "affected_object",
             json_name: "affectedObject",
-            number: 7i32,
+            number: 8i32,
             is_optional: false,
             is_map: false,
             message_fields: Some(ObjectIdFilter::FIELDS),
         };
-        pub const MOVE_CALL_FIELD: &'static MessageField = &MessageField {
-            name: "move_call",
-            json_name: "moveCall",
-            number: 8i32,
+        pub const COMMAND_FIELD: &'static MessageField = &MessageField {
+            name: "command",
+            json_name: "command",
+            number: 9i32,
             is_optional: false,
             is_map: false,
-            message_fields: Some(MoveCallFilter::FIELDS),
+            message_fields: Some(CommandFilter::FIELDS),
         };
         pub const EVENT_FIELD: &'static MessageField = &MessageField {
             name: "event",
             json_name: "event",
-            number: 9i32,
+            number: 10i32,
             is_optional: false,
             is_map: false,
             message_fields: Some(EventFilter::FIELDS),
@@ -722,10 +1054,11 @@ mod _field_impls {
             Self::ANY_FIELD,
             Self::NEGATION_FIELD,
             Self::TRANSACTION_KINDS_FIELD,
+            Self::EXECUTION_STATUS_FIELD,
             Self::SENDER_FIELD,
             Self::RECEIVER_FIELD,
             Self::AFFECTED_OBJECT_FIELD,
-            Self::MOVE_CALL_FIELD,
+            Self::COMMAND_FIELD,
             Self::EVENT_FIELD,
         ];
     }
@@ -765,6 +1098,10 @@ mod _field_impls {
             self.path.push(TransactionFilter::TRANSACTION_KINDS_FIELD.name);
             TransactionKindsFilterFieldPathBuilder::new_with_base(self.path)
         }
+        pub fn execution_status(mut self) -> ExecutionStatusFilterFieldPathBuilder {
+            self.path.push(TransactionFilter::EXECUTION_STATUS_FIELD.name);
+            ExecutionStatusFilterFieldPathBuilder::new_with_base(self.path)
+        }
         pub fn sender(mut self) -> AddressFilterFieldPathBuilder {
             self.path.push(TransactionFilter::SENDER_FIELD.name);
             AddressFilterFieldPathBuilder::new_with_base(self.path)
@@ -777,9 +1114,9 @@ mod _field_impls {
             self.path.push(TransactionFilter::AFFECTED_OBJECT_FIELD.name);
             ObjectIdFilterFieldPathBuilder::new_with_base(self.path)
         }
-        pub fn move_call(mut self) -> MoveCallFilterFieldPathBuilder {
-            self.path.push(TransactionFilter::MOVE_CALL_FIELD.name);
-            MoveCallFilterFieldPathBuilder::new_with_base(self.path)
+        pub fn command(mut self) -> CommandFilterFieldPathBuilder {
+            self.path.push(TransactionFilter::COMMAND_FIELD.name);
+            CommandFilterFieldPathBuilder::new_with_base(self.path)
         }
         pub fn event(mut self) -> EventFilterFieldPathBuilder {
             self.path.push(TransactionFilter::EVENT_FIELD.name);

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.filter.rs
@@ -130,7 +130,7 @@ pub struct ObjectIdFilter {
 /// Filter by move package, module (optional) and function (optional).
 #[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct MoveCallFilter {
+pub struct MoveCallCommandFilter {
     #[prost(message, optional, tag = "1")]
     pub package_id: ::core::option::Option<super::types::Address>,
     #[prost(string, optional, tag = "2")]
@@ -138,11 +138,78 @@ pub struct MoveCallFilter {
     #[prost(string, optional, tag = "3")]
     pub function: ::core::option::Option<::prost::alloc::string::String>,
 }
+/// Match a TransferObjects command.
+#[non_exhaustive]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct TransferObjectsCommandFilter {}
+/// Match a SplitCoins command.
+#[non_exhaustive]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SplitCoinsCommandFilter {}
+/// Match a MergeCoins command.
+#[non_exhaustive]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct MergeCoinsCommandFilter {}
+/// Match a Publish command.
+#[non_exhaustive]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PublishCommandFilter {}
+/// Match a MakeMoveVec command.
+#[non_exhaustive]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct MakeMoveVecCommandFilter {}
+/// Match an Upgrade command. Optionally filter by the specific package being upgraded.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct UpgradeCommandFilter {
+    #[prost(message, optional, tag = "1")]
+    pub package_id: ::core::option::Option<super::types::Address>,
+}
+/// Filter by command type.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CommandFilter {
+    #[prost(oneof = "command_filter::Filter", tags = "1, 2, 3, 4, 5, 6, 7")]
+    pub filter: ::core::option::Option<command_filter::Filter>,
+}
+/// Nested message and enum types in `CommandFilter`.
+pub mod command_filter {
+    #[non_exhaustive]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Filter {
+        #[prost(message, tag = "1")]
+        MoveCall(super::MoveCallCommandFilter),
+        #[prost(message, tag = "2")]
+        TransferObjects(super::TransferObjectsCommandFilter),
+        #[prost(message, tag = "3")]
+        SplitCoins(super::SplitCoinsCommandFilter),
+        #[prost(message, tag = "4")]
+        MergeCoins(super::MergeCoinsCommandFilter),
+        #[prost(message, tag = "5")]
+        Publish(super::PublishCommandFilter),
+        #[prost(message, tag = "6")]
+        MakeMoveVec(super::MakeMoveVecCommandFilter),
+        #[prost(message, tag = "7")]
+        Upgrade(super::UpgradeCommandFilter),
+    }
+}
+/// Filter by transaction execution status.
+/// Set `success` to `true` to match successful transactions,
+/// or `false` to match failed transactions (cancelled, execution error, etc.).
+#[non_exhaustive]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ExecutionStatusFilter {
+    #[prost(bool, tag = "1")]
+    pub success: bool,
+}
 /// Filter for transactions.
 #[non_exhaustive]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionFilter {
-    #[prost(oneof = "transaction_filter::Filter", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
+    #[prost(
+        oneof = "transaction_filter::Filter",
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
+    )]
     pub filter: ::core::option::Option<transaction_filter::Filter>,
 }
 /// Nested message and enum types in `TransactionFilter`.
@@ -162,21 +229,24 @@ pub mod transaction_filter {
         /// Filter transactions of any given kind in the filter.
         #[prost(message, tag = "4")]
         TransactionKinds(super::TransactionKindsFilter),
-        /// Filter by sender address.
+        /// Filter by transaction execution success/failure.
         #[prost(message, tag = "5")]
+        ExecutionStatus(super::ExecutionStatusFilter),
+        /// Filter by sender address.
+        #[prost(message, tag = "6")]
         Sender(super::AddressFilter),
         /// Filter by recipient address. The recipient is determined by
         /// checking the owners of mutated and unwrapped objects.
-        #[prost(message, tag = "6")]
+        #[prost(message, tag = "7")]
         Receiver(super::AddressFilter),
         /// Filter for transactions that touch this object.
-        #[prost(message, tag = "7")]
-        AffectedObject(super::ObjectIdFilter),
-        /// Filter by move package, module (optional) and function (optional).
         #[prost(message, tag = "8")]
-        MoveCall(super::MoveCallFilter),
-        /// Filter transactions that contain events matching the given event filter.
+        AffectedObject(super::ObjectIdFilter),
+        /// Filter by command type.
         #[prost(message, tag = "9")]
+        Command(super::CommandFilter),
+        /// Filter transactions that contain events matching the given event filter.
+        #[prost(message, tag = "10")]
         Event(super::EventFilter),
     }
 }

--- a/crates/iota-proto-build/src/codegen/accessors.rs
+++ b/crates/iota-proto-build/src/codegen/accessors.rs
@@ -619,13 +619,25 @@ fn generate_selective_accessors_for_field(
         }
 
         if accessor_types.contains(AccessorTypes::WITH) {
-            accessors.extend(quote! {
-                #( #[doc = #set_name_comments] )*
-                pub fn #with_name #with_param_type -> Self {
-                    self.#name = Some(#setter_assignment_value);
-                    self
-                }
-            });
+            // For optional enum fields, prost stores as Option<i32>.
+            // Take the enum type and convert via .into().
+            if field.is_enum() {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                        self.#name = Some(field.into());
+                        self
+                    }
+                });
+            } else {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name #with_param_type -> Self {
+                        self.#name = Some(#setter_assignment_value);
+                        self
+                    }
+                });
+            }
         }
 
         accessors
@@ -633,6 +645,33 @@ fn generate_selective_accessors_for_field(
         // maybe required or implicit optional
 
         let mut accessors = TokenStream::new();
+
+        // For enum fields, prost stores the value as i32 but
+        // field_type_path resolves to the enum type. We need special
+        // handling: take the enum type as parameter and convert via
+        // .into() for assignment.
+        if field.is_enum() {
+            if accessor_types.contains(AccessorTypes::SET) {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #set_name(&mut self, field: #field_type_path) {
+                        self.#name = field.into();
+                    }
+                });
+            }
+
+            if accessor_types.contains(AccessorTypes::WITH) {
+                accessors.extend(quote! {
+                    #( #[doc = #set_name_comments] )*
+                    pub fn #with_name(mut self, field: #field_type_path) -> Self {
+                        self.#name = field.into();
+                        self
+                    }
+                });
+            }
+
+            return accessors;
+        }
 
         if field.inner.r#type() != Type::Bytes && accessor_types.contains(AccessorTypes::MUT) {
             accessors.extend(quote! {


### PR DESCRIPTION
# Description of change

This PR adds new transaction filter to match against the different command types in a programmable transaction. It also adds a filter for execution status of the transaction.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes