### PR TITLE
fix(gRPC): encode chain_id header as base58 digest

### DIFF
--- a/crates/iota-grpc-server/src/response.rs
+++ b/crates/iota-grpc-server/src/response.rs
@@ -19,8 +19,8 @@ pub fn append_info_headers<T>(
     let headers = response.metadata_mut();
 
     if let Ok(chain_id) = grpc_reader.get_chain_identifier() {
-        if let Ok(chain_id) = chain_id.to_string().parse() {
-            headers.insert(headers::X_IOTA_CHAIN_ID, chain_id);
+        if let Ok(chain_id_value) = chain_id.digest().base58_encode().parse() {
+            headers.insert(headers::X_IOTA_CHAIN_ID, chain_id_value);
         }
 
         if let Ok(chain) = chain_id.chain().as_str().parse() {


### PR DESCRIPTION
# Description of change

Fixed the nightly test fail.

The `x-iota-chain-id` response header was using `ChainIdentifier::to_string()` which only outputs the first 4 bytes as hex. The client reads this header with `Digest::from_base58()` expecting a full 32-byte base58 string, so parsing always failed and `chain_id()` always returned `None`.

Validated by using `./scripts/ci_tests/rust_tests.sh --run-sim-tests --filter-overwrite "package(iota-e2e-tests) and test(metadata_envelope_headers)"`

## Links to any relevant issues

No.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

