### PR TITLE
fix(workflow): set libpq library path for macOS arm64 release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,13 +132,14 @@ jobs:
       - name: Install postgres (MacOS arm64)
         if: ${{ matrix.os_type == 'macos-arm64' }}
         shell: bash
-        env:
-          PQ_LIB_DIR: "$(brew --prefix libpq)/lib"
-          LIBRARY_PATH: "/opt/homebrew/lib:$LIBRARY_PATH"
-          PKG_CONFIG_PATH: "/opt/homebrew/lib/pkgconfig:$PKG_CONFIG_PATH"
-          PATH: "/opt/homebrew/bin:$PATH"
         run: |
           brew install postgresql
+
+          PQ_PREFIX="$(brew --prefix libpq)"
+          echo "PQ_LIB_DIR=${PQ_PREFIX}/lib" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=${PQ_PREFIX}/lib${LIBRARY_PATH:+:$LIBRARY_PATH}" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=${PQ_PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" >> $GITHUB_ENV
+          echo "${PQ_PREFIX}/bin" >> $GITHUB_PATH
 
       - name: Install protoc (Windows)
         if: ${{ matrix.os_type == 'windows-x86_64' }}


### PR DESCRIPTION
# Description of change

After the `20260303` runner image update the workflow started failing, but the root cause is both yes and no related to the version update, the original workflow’s macOS PostgreSQL installation steps had some issues, the reason it worked before was likely that the older runner image has PostgreSQL pre-installed and had `libpq.dylib` placed at `/usr/local/lib`, but the new image remove that pre-installation, which exposed the problem, the reason I say likely is that the `20260303` release notes don’t mention removing PostgreSQL either, in fact, they never documented having it pre-installed.

---

Homebrew's `libpq` is `keg-only`, so `brew install postgresql` alone does not place `libpq.dylib` in any default linker search path.

`env:` block also had two issues:
- `$(brew --prefix libpq)` was not shell-expanded
- Variables were not propagated to subsequent steps

Fix by using `$GITHUB_ENV` to persist `LIBRARY_PATH`, `PQ_LIB_DIR`, and `PKG_CONFIG_PATH` with the correct libpq prefix across all steps.

## How the change has been tested

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
