### PR TITLE
feat(move): Support custom attributes on enums

### DIFF
--- a/external-crates/move/crates/move-compiler/src/shared/known_attributes.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/known_attributes.rs
@@ -185,6 +185,7 @@ impl AttributePosition {
         Self::Friend,
         Self::Constant,
         Self::Struct,
+        Self::Enum,
         Self::Function,
         Self::Spec,
     ];

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/enum_custom_attribute.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/enum_custom_attribute.move
@@ -1,0 +1,7 @@
+module 0x42::M;
+
+#[ext(custom_attr)]
+public enum E {
+    A,
+    B,
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/enum_custom_attribute.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/enum_custom_attribute.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+


### PR DESCRIPTION
# Description of change

Enum variant added to the list of supported attribute targets, so enums can accept custom attributes. Test case and its snapshot added as well.

## Links to any relevant issues
fixes #10280 


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes