### PR TITLE
feat(indexer): Simplify tx_global_order semantics and track object finality via checkpoint

### DIFF
--- a/crates/iota-graphql-rpc/src/data/pg.rs
+++ b/crates/iota-graphql-rpc/src/data/pg.rs
@@ -224,7 +224,7 @@ mod tests {
         reset_database(&mut conn).unwrap();
 
         let objects: Vec<StoredObject> = BuiltInFramework::iter_system_packages()
-            .map(|pkg| IndexedObject::from_object(1, pkg.genesis_object(), None).into())
+            .map(|pkg| IndexedObject::from_object(Some(1), pkg.genesis_object(), None).into())
             .collect();
 
         let expect = objects.len();

--- a/crates/iota-indexer/migrations/pg/2026-03-17-120000_add_objects_finalized_column/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-03-17-120000_add_objects_finalized_column/down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE objects DROP COLUMN finalized;
+ALTER TABLE objects DROP COLUMN finalized_in_cp;

--- a/crates/iota-indexer/migrations/pg/2026-03-17-120000_add_objects_finalized_column/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-03-17-120000_add_objects_finalized_column/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE objects DROP COLUMN finalized;

--- a/crates/iota-indexer/migrations/pg/2026-03-17-120000_add_objects_finalized_column/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-03-17-120000_add_objects_finalized_column/up.sql
@@ -1,0 +1,10 @@
+-- Indicates that neither checkpoint nor optimistic indexing will write this
+-- object at its current version again, so follow-up operations (e.g. updates,
+-- deletions) can safely proceed without risk of being overwritten by concurrent
+-- indexing.
+--
+-- This flag is only an indicator, not a protection mechanism. The actual write
+-- protection is enforced by the tx status in `tx_global_order`.
+--
+-- Default is true because all existing objects are already finalized.
+ALTER TABLE objects ADD COLUMN finalized bool NOT NULL DEFAULT true;

--- a/crates/iota-indexer/migrations/pg/2026-03-17-120000_add_objects_finalized_column/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-03-17-120000_add_objects_finalized_column/up.sql
@@ -1,10 +1,7 @@
--- Indicates that neither checkpoint nor optimistic indexing will write this
--- object at its current version again, so follow-up operations (e.g. updates,
--- deletions) can safely proceed without risk of being overwritten by concurrent
--- indexing.
+-- Stores the checkpoint sequence number at which this object was, or will be, indexed.
+-- Readers can consider the object finalized when this checkpoint has been
+-- marked as fully indexed.
 --
--- This flag is only an indicator, not a protection mechanism. The actual write
--- protection is enforced by the tx status in `tx_global_order`.
---
--- Default is true because all existing objects are already finalized.
-ALTER TABLE objects ADD COLUMN finalized bool NOT NULL DEFAULT true;
+-- NULL means the object is already finalized (default for existing objects
+-- and objects written by the optimistic path).
+ALTER TABLE objects ADD COLUMN finalized_in_cp bigint DEFAULT NULL;

--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -46,10 +46,7 @@ pub(crate) type HistoricalFallbackCheckpoint = (CertifiedCheckpointSummary, Chec
 impl From<HistoricalFallbackObject> for StoredObject {
     fn from(object: HistoricalFallbackObject) -> Self {
         let df_kind = extract_df_kind(&object);
-        // StoredObject::from implementation does not require a checkpoint sequence
-        // number, in this regard it is safe to hardcode the checkpoint sequence number
-        // to 0.
-        let indexed = IndexedObject::from_object(0, object, df_kind);
+        let indexed = IndexedObject::from_object(None, object, df_kind);
         StoredObject::from(indexed)
     }
 }

--- a/crates/iota-indexer/src/ingestion/common/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/common/prepare.rs
@@ -103,7 +103,7 @@ impl LiveObject {
     ) -> IndexerResult<Self> {
         let df_kind = extract_df_kind(&object);
         let indexed_object =
-            IndexedObject::from_object(checkpoint_sequence_number, object, df_kind);
+            IndexedObject::from_object(Some(checkpoint_sequence_number), object, df_kind);
         Ok(Self {
             indexed_object,
             transaction_digest,

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -155,18 +155,7 @@ impl PrimaryWriter {
         let packages_batch = packages_batch.into_iter().flatten().collect::<Vec<_>>();
         let checkpoint_num = checkpoint_batch.len();
         let tx_count = tx_batch.len();
-
-        // Collect object IDs from the batch before they are consumed, so we can
-        // finalize them after checkpoint persistence is complete.
-        let object_ids_to_finalize: Vec<Vec<u8>> = object_changes_batch
-            .iter()
-            .flat_map(|changes| {
-                changes
-                    .changed_objects
-                    .iter()
-                    .map(|o| o.object().id().to_vec())
-            })
-            .collect();
+        let max_checkpoint_seq = committer_watermark.max_committed_cp;
 
         {
             let _step_1_guard = self
@@ -192,7 +181,7 @@ impl PrimaryWriter {
                         .persist_tx_global_order(tx_global_order_batch.clone())
                         .await?;
                     self.state
-                        .persist_checkpoint_objects(object_changes_batch)
+                        .persist_checkpoint_objects(object_changes_batch, max_checkpoint_seq)
                         .await
                 }),
             ];
@@ -211,22 +200,6 @@ impl PrimaryWriter {
                 .collect::<IndexerResult<Vec<_>>>()
                 .expect("persisting data into DB should not fail.");
         }
-
-        self.state
-            .update_status_for_checkpoint_transactions(tx_global_order_batch)
-            .await
-            .inspect_err(|e| {
-                error!("failed to update tx global order as indexed with error: {e}");
-            })
-            .expect("updating tx global order as indexed should not fail.");
-
-        self.state
-            .finalize_objects(object_ids_to_finalize)
-            .await
-            .inspect_err(|e| {
-                error!("failed to finalize objects with error: {e}");
-            })
-            .expect("finalizing objects should not fail.");
 
         let is_epoch_end = epoch.is_some();
 

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -156,6 +156,18 @@ impl PrimaryWriter {
         let checkpoint_num = checkpoint_batch.len();
         let tx_count = tx_batch.len();
 
+        // Collect object IDs from the batch before they are consumed, so we can
+        // finalize them after checkpoint persistence is complete.
+        let object_ids_to_finalize: Vec<Vec<u8>> = object_changes_batch
+            .iter()
+            .flat_map(|changes| {
+                changes
+                    .changed_objects
+                    .iter()
+                    .map(|o| o.object().id().to_vec())
+            })
+            .collect();
+
         {
             let _step_1_guard = self
                 .metrics
@@ -207,6 +219,14 @@ impl PrimaryWriter {
                 error!("failed to update tx global order as indexed with error: {e}");
             })
             .expect("updating tx global order as indexed should not fail.");
+
+        self.state
+            .finalize_objects(object_ids_to_finalize)
+            .await
+            .inspect_err(|e| {
+                error!("failed to finalize objects with error: {e}");
+            })
+            .expect("finalizing objects should not fail.");
 
         let is_epoch_end = epoch.is_some();
 

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -155,7 +155,6 @@ impl PrimaryWriter {
         let packages_batch = packages_batch.into_iter().flatten().collect::<Vec<_>>();
         let checkpoint_num = checkpoint_batch.len();
         let tx_count = tx_batch.len();
-        let max_checkpoint_seq = committer_watermark.max_committed_cp;
 
         {
             let _step_1_guard = self
@@ -181,7 +180,7 @@ impl PrimaryWriter {
                         .persist_tx_global_order(tx_global_order_batch.clone())
                         .await?;
                     self.state
-                        .persist_checkpoint_objects(object_changes_batch, max_checkpoint_seq)
+                        .persist_checkpoint_objects(object_changes_batch)
                         .await
                 }),
             ];

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -207,15 +207,15 @@ impl PrimaryWorker {
 
     fn derive_object_versions(
         object_history_changes: &TransactionObjectChangesToCommit,
-    ) -> Vec<StoredObjectVersion> {
+    ) -> IndexerResult<Vec<StoredObjectVersion>> {
         let mut object_versions = vec![];
         for changed_obj in object_history_changes.changed_objects.iter() {
-            object_versions.push(changed_obj.into());
+            object_versions.push(changed_obj.try_into()?);
         }
         for deleted_obj in object_history_changes.deleted_objects.iter() {
             object_versions.push(deleted_obj.into());
         }
-        object_versions
+        Ok(object_versions)
     }
 
     async fn index_checkpoint(
@@ -233,7 +233,7 @@ impl PrimaryWorker {
         let object_changes = Self::index_checkpoint_objects(data, &metrics).await?;
         let object_history_changes: TransactionObjectChangesToCommit =
             Self::index_objects_history(data).await?;
-        let object_versions = Self::derive_object_versions(&object_history_changes);
+        let object_versions = Self::derive_object_versions(&object_history_changes)?;
 
         let (checkpoint, db_transactions, db_events, db_tx_indices, db_event_indices, db_displays) = {
             let CheckpointData {
@@ -569,7 +569,7 @@ impl PrimaryWorker {
             .into_iter()
             .map(|o| {
                 let df_kind = extract_df_kind(o);
-                IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind)
+                IndexedObject::from_object(Some(checkpoint_seq), o.clone(), df_kind)
             })
             .collect::<Vec<_>>();
         Ok(TransactionObjectChangesToCommit {
@@ -608,7 +608,7 @@ impl PrimaryWorker {
             .into_iter()
             .map(|o| {
                 let df_kind = extract_df_kind(o);
-                IndexedObject::from_object(checkpoint_seq, o.clone(), df_kind)
+                IndexedObject::from_object(Some(checkpoint_seq), o.clone(), df_kind)
             })
             .collect::<Vec<_>>();
 

--- a/crates/iota-indexer/src/models/obj_indices.rs
+++ b/crates/iota-indexer/src/models/obj_indices.rs
@@ -5,6 +5,7 @@
 use diesel::prelude::*;
 
 use crate::{
+    errors::IndexerError,
     schema::objects_version,
     types::{IndexedDeletedObject, IndexedObject},
 };
@@ -20,13 +21,19 @@ pub struct StoredObjectVersion {
     pub cp_sequence_number: i64,
 }
 
-impl From<&IndexedObject> for StoredObjectVersion {
-    fn from(o: &IndexedObject) -> Self {
-        Self {
+impl TryFrom<&IndexedObject> for StoredObjectVersion {
+    type Error = IndexerError;
+
+    fn try_from(o: &IndexedObject) -> Result<Self, Self::Error> {
+        Ok(Self {
             object_id: o.object.id().to_vec(),
             object_version: o.object.version().value() as i64,
-            cp_sequence_number: o.checkpoint_sequence_number as i64,
-        }
+            cp_sequence_number: o.checkpoint_sequence_number.ok_or_else(|| {
+                IndexerError::InvalidArgument(
+                    "checkpoint_sequence_number is required for StoredObjectVersion".to_string(),
+                )
+            })? as i64,
+        })
     }
 }
 

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -81,13 +81,20 @@ pub struct StoredObjectSnapshot {
     pub df_kind: Option<i16>,
 }
 
-impl From<IndexedObject> for StoredObjectSnapshot {
-    fn from(o: IndexedObject) -> Self {
+impl TryFrom<IndexedObject> for StoredObjectSnapshot {
+    type Error = IndexerError;
+
+    fn try_from(o: IndexedObject) -> Result<Self, Self::Error> {
         let IndexedObject {
             checkpoint_sequence_number,
             object,
             df_kind,
         } = o;
+        let checkpoint_sequence_number = checkpoint_sequence_number.ok_or_else(|| {
+            IndexerError::InvalidArgument(
+                "checkpoint_sequence_number is required for StoredObjectSnapshot".to_string(),
+            )
+        })? as i64;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
             .coin_type_maybe()
@@ -98,12 +105,12 @@ impl From<IndexedObject> for StoredObjectSnapshot {
             None
         };
 
-        Self {
+        Ok(Self {
             object_id: object.id().to_vec(),
             object_version: object.version().value() as i64,
             object_status: ObjectStatus::Active as i16,
             object_digest: Some(object.digest().into_inner().to_vec()),
-            checkpoint_sequence_number: checkpoint_sequence_number as i64,
+            checkpoint_sequence_number,
             owner_type: Some(owner_type as i16),
             owner_id: owner_id.map(|id| id.to_vec()),
             object_type: object
@@ -119,7 +126,7 @@ impl From<IndexedObject> for StoredObjectSnapshot {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
-        }
+        })
     }
 }
 
@@ -241,13 +248,20 @@ impl TryFrom<StoredHistoryObject> for Object {
     }
 }
 
-impl From<IndexedObject> for StoredHistoryObject {
-    fn from(o: IndexedObject) -> Self {
+impl TryFrom<IndexedObject> for StoredHistoryObject {
+    type Error = IndexerError;
+
+    fn try_from(o: IndexedObject) -> Result<Self, Self::Error> {
         let IndexedObject {
             checkpoint_sequence_number,
             object,
             df_kind,
         } = o;
+        let checkpoint_sequence_number = checkpoint_sequence_number.ok_or_else(|| {
+            IndexerError::InvalidArgument(
+                "checkpoint_sequence_number is required for StoredHistoryObject".to_string(),
+            )
+        })? as i64;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
             .coin_type_maybe()
@@ -258,12 +272,12 @@ impl From<IndexedObject> for StoredHistoryObject {
             None
         };
 
-        Self {
+        Ok(Self {
             object_id: object.id().to_vec(),
             object_version: object.version().value() as i64,
             object_status: ObjectStatus::Active as i16,
             object_digest: Some(object.digest().into_inner().to_vec()),
-            checkpoint_sequence_number: checkpoint_sequence_number as i64,
+            checkpoint_sequence_number,
             owner_type: Some(owner_type as i16),
             owner_id: owner_id.map(|id| id.to_vec()),
             object_type: object
@@ -279,7 +293,7 @@ impl From<IndexedObject> for StoredHistoryObject {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
-        }
+        })
     }
 }
 
@@ -333,7 +347,7 @@ pub(crate) struct StoredDeletedHistoryObject {
 impl From<IndexedObject> for StoredObject {
     fn from(o: IndexedObject) -> Self {
         let IndexedObject {
-            checkpoint_sequence_number: _,
+            checkpoint_sequence_number,
             object,
             df_kind,
         } = o;
@@ -365,7 +379,7 @@ impl From<IndexedObject> for StoredObject {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
-            finalized_in_cp: None,
+            finalized_in_cp: checkpoint_sequence_number.map(|cp| cp as i64),
         }
     }
 }
@@ -496,6 +510,7 @@ pub(crate) struct StoredObjects {
     pub(crate) coin_types: Vec<Option<String>>,
     pub(crate) coin_balances: Vec<Option<i64>>,
     pub(crate) df_kinds: Vec<Option<i16>>,
+    pub(crate) finalized_in_cps: Vec<Option<i64>>,
 }
 
 impl Extend<StoredObject> for StoredObjects {
@@ -514,6 +529,7 @@ impl Extend<StoredObject> for StoredObjects {
             self.coin_types.push(object.coin_type);
             self.coin_balances.push(object.coin_balance);
             self.df_kinds.push(object.df_kind);
+            self.finalized_in_cps.push(object.finalized_in_cp);
         }
     }
 }
@@ -598,7 +614,7 @@ mod tests {
     #[test]
     fn test_canonical_string_of_object_type_for_coin() {
         let test_obj = Object::new_gas_for_testing();
-        let indexed_obj = IndexedObject::from_object(1, test_obj, None);
+        let indexed_obj = IndexedObject::from_object(Some(1), test_obj, None);
 
         let stored_obj = StoredObject::from(indexed_obj);
 
@@ -618,7 +634,7 @@ mod tests {
     #[test]
     fn test_convert_stored_obj_to_iota_coin() {
         let test_obj = Object::new_gas_for_testing();
-        let indexed_obj = IndexedObject::from_object(1, test_obj, None);
+        let indexed_obj = IndexedObject::from_object(Some(1), test_obj, None);
 
         let stored_obj = StoredObject::from(indexed_obj);
 
@@ -629,7 +645,7 @@ mod tests {
     #[test]
     fn test_output_format_coin_balance() {
         let test_obj = Object::new_gas_for_testing();
-        let indexed_obj = IndexedObject::from_object(1, test_obj, None);
+        let indexed_obj = IndexedObject::from_object(Some(1), test_obj, None);
 
         let stored_obj = StoredObject::from(indexed_obj);
         let test_balance = CoinBalance {
@@ -680,7 +696,7 @@ mod tests {
         }
         .into();
 
-        let indexed_obj = IndexedObject::from_object(1, object, None);
+        let indexed_obj = IndexedObject::from_object(Some(1), object, None);
 
         let stored_obj = StoredObject::from(indexed_obj);
 

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -52,6 +52,15 @@ pub struct StoredObject {
     // TODO deal with overflow
     pub coin_balance: Option<i64>,
     pub df_kind: Option<i16>,
+    /// When true, neither checkpoint nor optimistic indexing will write this
+    /// object at its current version again. Follow-up operations (e.g.
+    /// updates, deletions) can safely proceed without risk of being
+    /// overwritten by concurrent indexing.
+    ///
+    /// Note: this flag is only an indicator, not a protection mechanism. The
+    /// actual write protection is enforced by the tx status in
+    /// `tx_global_order`.
+    pub finalized: bool,
 }
 
 #[derive(Queryable, Insertable, Selectable, Debug, Identifiable, Clone, QueryableByName)]
@@ -358,6 +367,7 @@ impl From<IndexedObject> for StoredObject {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
+            finalized: false,
         }
     }
 }

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -52,15 +52,13 @@ pub struct StoredObject {
     // TODO deal with overflow
     pub coin_balance: Option<i64>,
     pub df_kind: Option<i16>,
-    /// When true, neither checkpoint nor optimistic indexing will write this
-    /// object at its current version again. Follow-up operations (e.g.
-    /// updates, deletions) can safely proceed without risk of being
-    /// overwritten by concurrent indexing.
+    /// The checkpoint sequence number at which this object was, or will be,
+    /// indexed. Readers can consider the object finalized when this
+    /// checkpoint has been marked as fully indexed.
     ///
-    /// Note: this flag is only an indicator, not a protection mechanism. The
-    /// actual write protection is enforced by the tx status in
-    /// `tx_global_order`.
-    pub finalized: bool,
+    /// `None` means the object is already finalized (default for existing
+    /// objects and objects written by the optimistic path).
+    pub finalized_in_cp: Option<i64>,
 }
 
 #[derive(Queryable, Insertable, Selectable, Debug, Identifiable, Clone, QueryableByName)]
@@ -367,7 +365,7 @@ impl From<IndexedObject> for StoredObject {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
-            finalized: false,
+            finalized_in_cp: None,
         }
     }
 }

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -4,14 +4,7 @@
 
 use std::sync::Arc;
 
-use diesel::{
-    backend::Backend,
-    deserialize::{FromSql, Result as DeserializeResult},
-    expression::AsExpression,
-    prelude::*,
-    serialize::{Output, Result as SerializeResult, ToSql},
-    sql_types::BigInt,
-};
+use diesel::prelude::*;
 use iota_json_rpc_types::{
     BalanceChange, IotaEvent, IotaTransactionBlock, IotaTransactionBlockEffects,
     IotaTransactionBlockEvents, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
@@ -55,81 +48,25 @@ pub struct TxGlobalOrder {
     /// Monotonically increasing number that represents the order
     /// of execution of optimistic transactions.
     ///
-    /// To maintain these semantics the value should be non-positive for
-    /// checkpointed transactions. More specifically we allow values
-    /// in the set `[0, -1]` to represent the index status of checkpointed
-    /// transactions.
-    ///
+    /// Checkpointed transactions use [`CHECKPOINT_TX_OPTIMISTIC_SEQ`] (-1).
     /// Optimistic transactions should set this value to `None`,
     /// so that it is auto-generated on the database.
     #[diesel(deserialize_as = i64)]
     pub optimistic_sequence_number: Option<i64>,
 }
 
-impl From<&IndexedTransaction> for CheckpointTxGlobalOrder {
+/// Value stored in `optimistic_sequence_number` for checkpointed
+/// transactions, to distinguish them from optimistic transactions
+/// which use positive auto-generated values.
+pub const CHECKPOINT_TX_OPTIMISTIC_SEQ: i64 = -1;
+
+impl From<&IndexedTransaction> for TxGlobalOrder {
     fn from(tx: &IndexedTransaction) -> Self {
         Self {
             chk_tx_sequence_number: Some(tx.tx_sequence_number as i64),
             global_sequence_number: tx.tx_sequence_number as i64,
             tx_digest: tx.tx_digest.into_inner().to_vec(),
-            index_status: Some(IndexStatus::Started),
-        }
-    }
-}
-
-/// Stored value for checkpointed transactions.
-///
-/// Differs from [`TxGlobalOrder`] in that it allows values
-/// for `optimistic_sequence_number` in the set `[0, -1]`
-/// that represent the index status.
-#[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
-#[diesel(table_name = tx_global_order)]
-pub struct CheckpointTxGlobalOrder {
-    pub(crate) chk_tx_sequence_number: Option<i64>,
-    pub(crate) global_sequence_number: i64,
-    pub(crate) tx_digest: Vec<u8>,
-    /// The index status of checkpointed transactions.
-    ///
-    /// This essentially reserves the values `[0, -1]` of the
-    /// `optimistic_sequence_number` stored in the table for checkpointed
-    /// transactions, to distinguish from optimistic transactions, and
-    /// assign semantics related to the index status.
-    #[diesel(deserialize_as = IndexStatus, column_name = "optimistic_sequence_number")]
-    pub(crate) index_status: Option<IndexStatus>,
-}
-
-/// Index status.
-#[derive(Clone, Debug, Copy, AsExpression, PartialEq, Eq)]
-#[repr(i64)]
-#[diesel(sql_type = BigInt)]
-pub enum IndexStatus {
-    Started = 0,
-    Completed = -1,
-}
-
-impl<DB> ToSql<BigInt, DB> for IndexStatus
-where
-    DB: Backend,
-    i64: ToSql<BigInt, DB>,
-{
-    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, DB>) -> SerializeResult {
-        match *self {
-            IndexStatus::Started => 0.to_sql(out),
-            IndexStatus::Completed => (-1).to_sql(out),
-        }
-    }
-}
-
-impl<DB> FromSql<BigInt, DB> for IndexStatus
-where
-    DB: Backend,
-    i64: FromSql<BigInt, DB>,
-{
-    fn from_sql(bytes: DB::RawValue<'_>) -> DeserializeResult<Self> {
-        match i64::from_sql(bytes)? {
-            0 => Ok(IndexStatus::Started),
-            -1 => Ok(IndexStatus::Completed),
-            other => Err(format!("invalid index status {other}").into()),
+            optimistic_sequence_number: Some(CHECKPOINT_TX_OPTIMISTIC_SEQ),
         }
     }
 }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -487,8 +487,8 @@ impl OptimisticTransactionExecutor {
 
         self.store.persist_objects_in_existing_transaction(
             conn,
-            vec![object_changes.clone()],
-            true,
+            vec![object_changes],
+            None,
         )?;
         self.store.persist_displays_in_existing_transaction(
             conn,

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -485,11 +485,8 @@ impl OptimisticTransactionExecutor {
     ) -> Result<OptimisticTransaction, IndexerError> {
         let (optimistic_tx, indexed_displays, object_changes) = tx_data_to_commit;
 
-        self.store.persist_objects_in_existing_transaction(
-            conn,
-            vec![object_changes],
-            None,
-        )?;
+        self.store
+            .persist_objects_in_existing_transaction(conn, vec![object_changes])?;
         self.store.persist_displays_in_existing_transaction(
             conn,
             indexed_displays.values().collect::<Vec<_>>(),
@@ -537,11 +534,7 @@ impl<'a> TransactionExtractor<'a> {
             .iter()
             .map(|o| {
                 let df_kind = extract_df_kind(o);
-                IndexedObject::from_object(
-                    0, // checkpoint sequence number, ignored in further processing
-                    o.clone(),
-                    df_kind,
-                )
+                IndexedObject::from_object(None, o.clone(), df_kind)
             })
             .collect::<Vec<_>>();
 

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -78,6 +78,7 @@ impl OptimisticTransactionExecutor {
     ) -> Result<(), IndexerError> {
         let expected_count = input_obj_keys.len();
         let backoff = backoff::ExponentialBackoff {
+            initial_interval: Duration::from_millis(100),
             max_elapsed_time: Some(WAIT_FOR_DEPS_MAX_ELAPSED_TIME),
             ..Default::default()
         };
@@ -327,6 +328,7 @@ impl OptimisticTransactionExecutor {
     ) -> Result<(), IndexerError> {
         backoff::future::retry(
             backoff::ExponentialBackoff {
+                initial_interval: Duration::from_millis(100),
                 max_elapsed_time: Some(Duration::from_secs(30)),
                 ..Default::default()
             },
@@ -483,8 +485,11 @@ impl OptimisticTransactionExecutor {
     ) -> Result<OptimisticTransaction, IndexerError> {
         let (optimistic_tx, indexed_displays, object_changes) = tx_data_to_commit;
 
-        self.store
-            .persist_objects_in_existing_transaction(conn, vec![object_changes])?;
+        self.store.persist_objects_in_existing_transaction(
+            conn,
+            vec![object_changes.clone()],
+            true,
+        )?;
         self.store.persist_displays_in_existing_transaction(
             conn,
             indexed_displays.values().collect::<Vec<_>>(),

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1078,10 +1078,11 @@ impl IndexerReader {
             .join(", ");
 
         let query = format!(
-            "SELECT COUNT(*) as count FROM objects \
+            "WITH max_chk AS (SELECT COALESCE(MAX(sequence_number), -1) AS max_sn FROM checkpoints) \
+             SELECT COUNT(*) as count FROM objects \
              WHERE (object_id, object_version) IN (VALUES {}) \
              AND (finalized_in_cp IS NULL \
-                  OR finalized_in_cp <= (SELECT COALESCE(MAX(sequence_number), -1) FROM checkpoints))",
+                  OR finalized_in_cp <= (SELECT max_sn FROM max_chk))",
             values_clause
         );
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -72,7 +72,7 @@ use crate::{
         objects::{CoinBalance, StoredHistoryObject, StoredObject},
         participation_metrics::StoredParticipationMetrics,
         transactions::{
-            IndexStatus, OptimisticTransaction, StoredTransaction, StoredTransactionEvents,
+            OptimisticTransaction, StoredTransaction, StoredTransactionEvents,
             stored_events_to_events, tx_events_to_iota_tx_events,
         },
         tx_indices::TxSequenceNumber,
@@ -1080,7 +1080,8 @@ impl IndexerReader {
         let query = format!(
             "SELECT COUNT(*) as count FROM objects \
              WHERE (object_id, object_version) IN (VALUES {}) \
-             AND finalized = true",
+             AND (finalized_in_cp IS NULL \
+                  OR finalized_in_cp <= (SELECT COALESCE(MAX(sequence_number), -1) FROM checkpoints))",
             values_clause
         );
 
@@ -1522,25 +1523,51 @@ impl IndexerReader {
             .await
     }
 
-    /// Returns `true` when `tx_global_order.optimistic_sequence_number !=
-    /// IndexStatus::Started`, which means all basic data for the transaction
-    /// (objects, displays, etc.) has been persisted by either checkpoint or
+    /// Returns `true` when all basic data for the transaction (objects,
+    /// displays, etc.) has been persisted by either the checkpoint or
     /// optimistic path.
+    ///
+    /// - Optimistic transactions: `optimistic_sequence_number > 0` (objects are
+    ///   committed atomically with the tx)
+    /// - Checkpoint transactions: the latest indexed checkpoint's
+    ///   `max_tx_sequence_number >= chk_tx_sequence_number`, meaning the
+    ///   checkpoint containing this tx has been fully persisted
     pub(crate) async fn is_transaction_fully_indexed(
         &self,
         digest: TransactionDigest,
     ) -> IndexerResult<bool> {
         self.spawn_blocking(move |this| {
             let digest_bytes = digest.inner().to_vec();
-            run_query!(&this.pool, |conn| {
+            let global_order_entry = run_query!(&this.pool, |conn| {
                 tx_global_order::table
                     .filter(tx_global_order::tx_digest.eq(digest_bytes))
-                    .select(tx_global_order::optimistic_sequence_number)
-                    .first::<i64>(conn)
+                    .select((
+                        tx_global_order::optimistic_sequence_number,
+                        tx_global_order::chk_tx_sequence_number,
+                    ))
+                    .first::<(i64, Option<i64>)>(conn)
                     .optional()
-            })
-            // n = -1 if persisted on checkpoint path, n > 0 if persisted on optimistic path
-            .map(|result| result.is_some_and(|n| n != IndexStatus::Started as i64))
+            })?;
+
+            match global_order_entry {
+                // Optimistic tx: objects committed atomically.
+                Some((opt_seq, _)) if opt_seq > 0 => Ok(true),
+                // Checkpoint tx: check if the latest indexed checkpoint covers this tx.
+                Some((_, Some(tx_seq))) => {
+                    let max_indexed_tx = run_query!(&this.pool, |conn| {
+                        checkpoints::table
+                            .order(checkpoints::sequence_number.desc())
+                            .select(checkpoints::max_tx_sequence_number)
+                            .first::<Option<i64>>(conn)
+                            .optional()
+                    })?;
+                    Ok(max_indexed_tx
+                        .flatten()
+                        .is_some_and(|max_tx| max_tx >= tx_seq))
+                }
+                // Row not found or chk_tx_sequence_number not yet set.
+                _ => Ok(false),
+            }
         })
         .await
     }

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1079,7 +1079,8 @@ impl IndexerReader {
 
         let query = format!(
             "SELECT COUNT(*) as count FROM objects \
-             WHERE (object_id, object_version) IN (VALUES {})",
+             WHERE (object_id, object_version) IN (VALUES {}) \
+             AND finalized = true",
             values_clause
         );
 

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -233,6 +233,7 @@ diesel::table! {
         coin_type -> Nullable<Text>,
         coin_balance -> Nullable<Int8>,
         df_kind -> Nullable<Int2>,
+        finalized -> Bool,
     }
 }
 

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -233,7 +233,7 @@ diesel::table! {
         coin_type -> Nullable<Text>,
         coin_balance -> Nullable<Int8>,
         df_kind -> Nullable<Int2>,
-        finalized -> Bool,
+        finalized_in_cp -> Nullable<Int8>,
     }
 }
 

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -117,6 +117,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         &self,
         conn: &mut PgConnection,
         object_changes: Vec<TransactionObjectChangesToCommit>,
+        finalized: bool,
     ) -> Result<(), IndexerError>;
 
     /// Update the upper bound of the watermarks for the given tables.
@@ -147,6 +148,16 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         &self,
         tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError>;
+
+    /// Mark objects as finalized, indicating that neither checkpoint nor
+    /// optimistic indexing will write these objects at current versions again.
+    /// Once finalized, follow-up operations (e.g. updates, deletions) can
+    /// safely proceed without risk of being overwritten by concurrent indexing.
+    ///
+    /// Note: this flag is only an indicator, not a protection mechanism. The
+    /// actual write protection is enforced by the tx status in
+    /// `tx_global_order`.
+    async fn finalize_objects(&self, object_ids: Vec<Vec<u8>>) -> Result<(), IndexerError>;
 
     async fn persist_tx_global_order(
         &self,

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -117,7 +117,6 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         &self,
         conn: &mut PgConnection,
         object_changes: Vec<TransactionObjectChangesToCommit>,
-        finalized_in_cp: Option<i64>,
     ) -> Result<(), IndexerError>;
 
     /// Update the upper bound of the watermarks for the given tables.
@@ -142,7 +141,6 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn persist_checkpoint_objects(
         &self,
         objects: Vec<CheckpointObjectChanges>,
-        max_checkpoint_seq: u64,
     ) -> Result<(), IndexerError>;
 
     async fn persist_tx_global_order(

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -17,7 +17,7 @@ use crate::{
     models::{
         display::StoredDisplay,
         obj_indices::StoredObjectVersion,
-        transactions::{CheckpointTxGlobalOrder, OptimisticTransaction},
+        transactions::{OptimisticTransaction, TxGlobalOrder},
         watermarks::StoredWatermark,
     },
     pruning::pruner::PrunableTable,
@@ -117,7 +117,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         &self,
         conn: &mut PgConnection,
         object_changes: Vec<TransactionObjectChangesToCommit>,
-        finalized: bool,
+        finalized_in_cp: Option<i64>,
     ) -> Result<(), IndexerError>;
 
     /// Update the upper bound of the watermarks for the given tables.
@@ -142,26 +142,12 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn persist_checkpoint_objects(
         &self,
         objects: Vec<CheckpointObjectChanges>,
+        max_checkpoint_seq: u64,
     ) -> Result<(), IndexerError>;
-
-    async fn update_status_for_checkpoint_transactions(
-        &self,
-        tx_order: Vec<CheckpointTxGlobalOrder>,
-    ) -> Result<(), IndexerError>;
-
-    /// Mark objects as finalized, indicating that neither checkpoint nor
-    /// optimistic indexing will write these objects at current versions again.
-    /// Once finalized, follow-up operations (e.g. updates, deletions) can
-    /// safely proceed without risk of being overwritten by concurrent indexing.
-    ///
-    /// Note: this flag is only an indicator, not a protection mechanism. The
-    /// actual write protection is enforced by the tx status in
-    /// `tx_global_order`.
-    async fn finalize_objects(&self, object_ids: Vec<Vec<u8>>) -> Result<(), IndexerError>;
 
     async fn persist_tx_global_order(
         &self,
-        tx_order: Vec<CheckpointTxGlobalOrder>,
+        tx_order: Vec<TxGlobalOrder>,
     ) -> Result<(), IndexerError>;
 
     async fn persist_tx_indices(&self, indices: Vec<TxIndex>) -> Result<(), IndexerError>;

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -498,6 +498,7 @@ impl PgIndexerStore {
                 objects::coin_type.eq(excluded(objects::coin_type)),
                 objects::coin_balance.eq(excluded(objects::coin_balance)),
                 objects::df_kind.eq(excluded(objects::df_kind)),
+                objects::finalized.eq(excluded(objects::finalized)),
             ),
             excluded(objects::object_version).gt(objects::object_version),
             conn
@@ -880,6 +881,26 @@ impl PgIndexerStore {
         })
         .tap_err(|e| {
             tracing::error!("failed to update `tx_global_order` with error: {e}");
+        })
+    }
+
+    fn finalize_objects_chunk(&self, object_ids: Vec<Vec<u8>>) -> Result<(), IndexerError> {
+        let len = object_ids.len();
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::update(objects::table.filter(objects::object_id.eq_any(&object_ids)))
+                    .set(objects::finalized.eq(true))
+                    .execute(conn)?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            info!("Finalized {len} chunked objects");
+        })
+        .tap_err(|e| {
+            tracing::error!("failed to finalize objects chunk with error: {e}");
         })
     }
 
@@ -1888,6 +1909,7 @@ impl IndexerStore for PgIndexerStore {
         &self,
         conn: &mut PgConnection,
         object_changes: Vec<TransactionObjectChangesToCommit>,
+        finalized: bool,
     ) -> Result<(), IndexerError> {
         if object_changes.is_empty() {
             return Ok(());
@@ -1896,7 +1918,11 @@ impl IndexerStore for PgIndexerStore {
         let (indexed_mutations, indexed_deletions) = retain_latest_indexed_objects(object_changes);
         let object_mutations = indexed_mutations
             .into_iter()
-            .map(StoredObject::from)
+            .map(|o| {
+                let mut stored = StoredObject::from(o);
+                stored.finalized = finalized;
+                stored
+            })
             .collect::<Vec<_>>();
         let object_deletions = indexed_deletions
             .into_iter()
@@ -2425,6 +2451,32 @@ impl IndexerStore for PgIndexerStore {
             elapsed,
             "Updated index status for {len} txs insertion orders"
         );
+        Ok(())
+    }
+
+    async fn finalize_objects(&self, object_ids: Vec<Vec<u8>>) -> Result<(), IndexerError> {
+        if object_ids.is_empty() {
+            return Ok(());
+        }
+        let len = object_ids.len();
+
+        let chunks = chunk!(object_ids, self.config.parallel_chunk_size);
+        let futures = chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.finalize_objects_chunk(c)));
+
+        futures::future::try_join_all(futures)
+            .await
+            .map_err(|e| {
+                tracing::error!("failed to join finalize_objects_chunk futures: {e}");
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!("failed to finalize all object chunks: {e:?}",))
+            })?;
+        info!("Finalized {len} objects");
         Ok(())
     }
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -312,11 +312,7 @@ impl PgIndexerStore {
         Ok(())
     }
 
-    fn persist_changed_objects(
-        &self,
-        objects: Vec<LiveObject>,
-        finalized_in_cp: i64,
-    ) -> Result<(), IndexerError> {
+    fn persist_changed_objects(&self, objects: Vec<LiveObject>) -> Result<(), IndexerError> {
         let guard = self
             .metrics
             .checkpoint_db_commit_latency_objects_chunks
@@ -353,7 +349,7 @@ impl PgIndexerStore {
                 u.coin_type,
                 u.coin_balance,
                 u.df_kind,
-                $15
+                u.finalized_in_cp
             FROM UNNEST(
                 $1::BYTEA[],
                 $2::BIGINT[],
@@ -368,8 +364,9 @@ impl PgIndexerStore {
                 $11::TEXT[],
                 $12::BIGINT[],
                 $13::SMALLINT[],
-                $14::BYTEA[]
-            ) AS u(object_id, object_version, object_digest, owner_type, owner_id, object_type, object_type_package, object_type_module, object_type_name, serialized_object, coin_type, coin_balance, df_kind, tx_digest)
+                $14::BYTEA[],
+                $15::BIGINT[]
+            ) AS u(object_id, object_version, object_digest, owner_type, owner_id, object_type, object_type_package, object_type_module, object_type_name, serialized_object, coin_type, coin_balance, df_kind, tx_digest, finalized_in_cp)
             LEFT JOIN tx_global_order o ON o.tx_digest = u.tx_digest
             WHERE o.optimistic_sequence_number IS NULL OR o.optimistic_sequence_number = -1
             ON CONFLICT (object_id) DO UPDATE
@@ -414,7 +411,7 @@ impl PgIndexerStore {
             .bind::<Array<Nullable<BigInt>>, _>(objects.coin_balances)
             .bind::<Array<Nullable<SmallInt>>, _>(objects.df_kinds)
             .bind::<Array<Bytea>, _>(tx_digests)
-            .bind::<BigInt, _>(finalized_in_cp);
+            .bind::<Array<Nullable<BigInt>>, _>(objects.finalized_in_cps);
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
@@ -1854,7 +1851,6 @@ impl IndexerStore for PgIndexerStore {
         &self,
         conn: &mut PgConnection,
         object_changes: Vec<TransactionObjectChangesToCommit>,
-        finalized_in_cp: Option<i64>,
     ) -> Result<(), IndexerError> {
         if object_changes.is_empty() {
             return Ok(());
@@ -1863,11 +1859,7 @@ impl IndexerStore for PgIndexerStore {
         let (indexed_mutations, indexed_deletions) = retain_latest_indexed_objects(object_changes);
         let object_mutations = indexed_mutations
             .into_iter()
-            .map(|o| {
-                let mut stored = StoredObject::from(o);
-                stored.finalized_in_cp = finalized_in_cp;
-                stored
-            })
+            .map(StoredObject::from)
             .collect::<Vec<_>>();
         let object_deletions = indexed_deletions
             .into_iter()
@@ -1894,13 +1886,13 @@ impl IndexerStore for PgIndexerStore {
         let (indexed_mutations, indexed_deletions) = retain_latest_indexed_objects(object_changes);
         let objects_snapshot = indexed_mutations
             .into_iter()
-            .map(StoredObjectSnapshot::from)
+            .map(StoredObjectSnapshot::try_from)
             .chain(
                 indexed_deletions
                     .into_iter()
-                    .map(StoredObjectSnapshot::from),
+                    .map(|o| Ok(StoredObjectSnapshot::from(o))),
             )
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
         let len = objects_snapshot.len();
         let chunks = chunk!(objects_snapshot, self.config.parallel_objects_chunk_size);
         let futures = chunks
@@ -1940,7 +1932,7 @@ impl IndexerStore for PgIndexerStore {
         if object_changes.is_empty() {
             return Ok(());
         }
-        let objects = make_objects_history_to_commit(object_changes);
+        let objects = make_objects_history_to_commit(object_changes)?;
         let guard = self
             .metrics
             .checkpoint_db_commit_latency_objects_history
@@ -2316,7 +2308,6 @@ impl IndexerStore for PgIndexerStore {
     async fn persist_checkpoint_objects(
         &self,
         objects: Vec<CheckpointObjectChanges>,
-        max_checkpoint_seq: u64,
     ) -> Result<(), IndexerError> {
         if objects.is_empty() {
             return Ok(());
@@ -2332,12 +2323,11 @@ impl IndexerStore for PgIndexerStore {
         let mutation_len = mutations.len();
         let deletion_len = deletions.len();
 
-        let finalized_in_cp = max_checkpoint_seq as i64;
         let mutation_chunks = chunk!(mutations, self.config.parallel_objects_chunk_size);
         let deletion_chunks = chunk!(deletions, self.config.parallel_objects_chunk_size);
-        let mutation_futures = mutation_chunks.into_iter().map(|c| {
-            self.spawn_blocking_task(move |this| this.persist_changed_objects(c, finalized_in_cp))
-        });
+        let mutation_futures = mutation_chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_changed_objects(c)));
         let deletion_futures = deletion_chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_removed_objects(c)));
@@ -2478,7 +2468,7 @@ impl IndexerStore for PgIndexerStore {
 
 fn make_objects_history_to_commit(
     tx_object_changes: Vec<TransactionObjectChangesToCommit>,
-) -> Vec<StoredHistoryObject> {
+) -> Result<Vec<StoredHistoryObject>, IndexerError> {
     let deleted_objects: Vec<StoredHistoryObject> = tx_object_changes
         .clone()
         .into_iter()
@@ -2488,9 +2478,9 @@ fn make_objects_history_to_commit(
     let mutated_objects: Vec<StoredHistoryObject> = tx_object_changes
         .into_iter()
         .flat_map(|changes| changes.changed_objects)
-        .map(|o| o.into())
-        .collect();
-    deleted_objects.into_iter().chain(mutated_objects).collect()
+        .map(StoredHistoryObject::try_from)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(deleted_objects.into_iter().chain(mutated_objects).collect())
 }
 
 /// Partitions object changes into deletions and mutations.

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -56,9 +56,7 @@ use crate::{
             StoredObjects,
         },
         packages::StoredPackage,
-        transactions::{
-            CheckpointTxGlobalOrder, IndexStatus, OptimisticTransaction, StoredTransaction,
-        },
+        transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
         tx_indices::TxIndexSplit,
         watermarks::StoredWatermark,
     },
@@ -314,7 +312,11 @@ impl PgIndexerStore {
         Ok(())
     }
 
-    fn persist_changed_objects(&self, objects: Vec<LiveObject>) -> Result<(), IndexerError> {
+    fn persist_changed_objects(
+        &self,
+        objects: Vec<LiveObject>,
+        finalized_in_cp: i64,
+    ) -> Result<(), IndexerError> {
         let guard = self
             .metrics
             .checkpoint_db_commit_latency_objects_chunks
@@ -334,7 +336,8 @@ impl PgIndexerStore {
                 serialized_object,
                 coin_type,
                 coin_balance,
-                df_kind
+                df_kind,
+                finalized_in_cp
             )
             SELECT
                 u.object_id,
@@ -349,7 +352,8 @@ impl PgIndexerStore {
                 u.serialized_object,
                 u.coin_type,
                 u.coin_balance,
-                u.df_kind
+                u.df_kind,
+                $15
             FROM UNNEST(
                 $1::BYTEA[],
                 $2::BIGINT[],
@@ -367,7 +371,7 @@ impl PgIndexerStore {
                 $14::BYTEA[]
             ) AS u(object_id, object_version, object_digest, owner_type, owner_id, object_type, object_type_package, object_type_module, object_type_name, serialized_object, coin_type, coin_balance, df_kind, tx_digest)
             LEFT JOIN tx_global_order o ON o.tx_digest = u.tx_digest
-            WHERE o.optimistic_sequence_number IS NULL OR o.optimistic_sequence_number = 0
+            WHERE o.optimistic_sequence_number IS NULL OR o.optimistic_sequence_number = -1
             ON CONFLICT (object_id) DO UPDATE
             SET
                 object_version = EXCLUDED.object_version,
@@ -381,7 +385,8 @@ impl PgIndexerStore {
                 serialized_object = EXCLUDED.serialized_object,
                 coin_type = EXCLUDED.coin_type,
                 coin_balance = EXCLUDED.coin_balance,
-                df_kind = EXCLUDED.df_kind
+                df_kind = EXCLUDED.df_kind,
+                finalized_in_cp = EXCLUDED.finalized_in_cp
             WHERE EXCLUDED.object_version > objects.object_version
         "#;
         let (objects, tx_digests): (StoredObjects, Vec<_>) = objects
@@ -408,7 +413,8 @@ impl PgIndexerStore {
             .bind::<Array<Nullable<Text>>, _>(objects.coin_types)
             .bind::<Array<Nullable<BigInt>>, _>(objects.coin_balances)
             .bind::<Array<Nullable<SmallInt>>, _>(objects.df_kinds)
-            .bind::<Array<Bytea>, _>(tx_digests);
+            .bind::<Array<Bytea>, _>(tx_digests)
+            .bind::<BigInt, _>(finalized_in_cp);
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
@@ -442,7 +448,7 @@ impl PgIndexerStore {
                     $3::BYTEA[]
                 ) AS u(object_id, object_version, tx_digest)
                 LEFT JOIN tx_global_order o ON o.tx_digest = u.tx_digest
-                WHERE o.optimistic_sequence_number IS NULL OR o.optimistic_sequence_number = 0
+                WHERE o.optimistic_sequence_number IS NULL OR o.optimistic_sequence_number = -1
             ) AS to_delete
             WHERE objects.object_id = to_delete.object_id
             AND objects.object_version < to_delete.object_version
@@ -498,7 +504,7 @@ impl PgIndexerStore {
                 objects::coin_type.eq(excluded(objects::coin_type)),
                 objects::coin_balance.eq(excluded(objects::coin_balance)),
                 objects::df_kind.eq(excluded(objects::df_kind)),
-                objects::finalized.eq(excluded(objects::finalized)),
+                objects::finalized_in_cp.eq(excluded(objects::finalized_in_cp)),
             ),
             excluded(objects::object_version).gt(objects::object_version),
             conn
@@ -802,7 +808,7 @@ impl PgIndexerStore {
 
     fn persist_tx_global_order_chunk(
         &self,
-        tx_order: Vec<CheckpointTxGlobalOrder>,
+        tx_order: Vec<TxGlobalOrder>,
     ) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -813,7 +819,18 @@ impl PgIndexerStore {
             &self.blocking_cp,
             |conn| {
                 for tx_order_chunk in tx_order.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                    insert_or_ignore_into!(tx_global_order::table, tx_order_chunk, conn);
+                    // Upsert: on conflict (row already inserted by optimistic path),
+                    // set `chk_tx_sequence_number` so checkpoint data is available
+                    // immediately.
+                    on_conflict_do_update_with_condition!(
+                        tx_global_order::table,
+                        tx_order_chunk,
+                        tx_global_order::tx_digest,
+                        tx_global_order::chk_tx_sequence_number
+                            .eq(excluded(tx_global_order::chk_tx_sequence_number)),
+                        tx_global_order::chk_tx_sequence_number.is_null(),
+                        conn
+                    );
                 }
                 Ok::<(), IndexerError>(())
             },
@@ -829,78 +846,6 @@ impl PgIndexerStore {
         })
         .tap_err(|e| {
             tracing::error!("failed to persist txs insertion order with error: {e}");
-        })
-    }
-
-    /// We enforce index-status semantics for checkpointed transactions
-    /// in `tx_global_order`.
-    ///
-    /// Namely, checkpointed transactions (i.e. with `optimistic_sequence_number
-    /// == 0`) are updated to `optimistic_sequence_number == -1` to indicate
-    /// that they have been persisted in the database.
-    fn update_status_for_checkpoint_transactions_chunk(
-        &self,
-        tx_order: Vec<CheckpointTxGlobalOrder>,
-    ) -> Result<(), IndexerError> {
-        let guard = self
-            .metrics
-            .checkpoint_db_commit_latency_tx_insertion_order_chunks
-            .start_timer();
-
-        let num_transactions = tx_order.len();
-        transactional_blocking_with_retry!(
-            &self.blocking_cp,
-            |conn| {
-                on_conflict_do_update_with_condition!(
-                    tx_global_order::table,
-                    tx_order.clone(),
-                    tx_global_order::tx_digest,
-                    tx_global_order::optimistic_sequence_number.eq(IndexStatus::Completed),
-                    tx_global_order::optimistic_sequence_number.eq(IndexStatus::Started),
-                    conn
-                );
-                on_conflict_do_update_with_condition!(
-                    tx_global_order::table,
-                    tx_order.clone(),
-                    tx_global_order::tx_digest,
-                    tx_global_order::chk_tx_sequence_number
-                        .eq(excluded(tx_global_order::chk_tx_sequence_number)),
-                    tx_global_order::chk_tx_sequence_number.is_null(),
-                    conn
-                );
-                Ok::<(), IndexerError>(())
-            },
-            PG_DB_COMMIT_SLEEP_DURATION
-        )
-        .tap_ok(|_| {
-            let elapsed = guard.stop_and_record();
-            info!(
-                elapsed,
-                "Updated {} chunked values of `tx_global_order`", num_transactions
-            );
-        })
-        .tap_err(|e| {
-            tracing::error!("failed to update `tx_global_order` with error: {e}");
-        })
-    }
-
-    fn finalize_objects_chunk(&self, object_ids: Vec<Vec<u8>>) -> Result<(), IndexerError> {
-        let len = object_ids.len();
-        transactional_blocking_with_retry!(
-            &self.blocking_cp,
-            |conn| {
-                diesel::update(objects::table.filter(objects::object_id.eq_any(&object_ids)))
-                    .set(objects::finalized.eq(true))
-                    .execute(conn)?;
-                Ok::<(), IndexerError>(())
-            },
-            PG_DB_COMMIT_SLEEP_DURATION
-        )
-        .tap_ok(|_| {
-            info!("Finalized {len} chunked objects");
-        })
-        .tap_err(|e| {
-            tracing::error!("failed to finalize objects chunk with error: {e}");
         })
     }
 
@@ -1909,7 +1854,7 @@ impl IndexerStore for PgIndexerStore {
         &self,
         conn: &mut PgConnection,
         object_changes: Vec<TransactionObjectChangesToCommit>,
-        finalized: bool,
+        finalized_in_cp: Option<i64>,
     ) -> Result<(), IndexerError> {
         if object_changes.is_empty() {
             return Ok(());
@@ -1920,7 +1865,7 @@ impl IndexerStore for PgIndexerStore {
             .into_iter()
             .map(|o| {
                 let mut stored = StoredObject::from(o);
-                stored.finalized = finalized;
+                stored.finalized_in_cp = finalized_in_cp;
                 stored
             })
             .collect::<Vec<_>>();
@@ -2371,6 +2316,7 @@ impl IndexerStore for PgIndexerStore {
     async fn persist_checkpoint_objects(
         &self,
         objects: Vec<CheckpointObjectChanges>,
+        max_checkpoint_seq: u64,
     ) -> Result<(), IndexerError> {
         if objects.is_empty() {
             return Ok(());
@@ -2386,11 +2332,12 @@ impl IndexerStore for PgIndexerStore {
         let mutation_len = mutations.len();
         let deletion_len = deletions.len();
 
+        let finalized_in_cp = max_checkpoint_seq as i64;
         let mutation_chunks = chunk!(mutations, self.config.parallel_objects_chunk_size);
         let deletion_chunks = chunk!(deletions, self.config.parallel_objects_chunk_size);
-        let mutation_futures = mutation_chunks
-            .into_iter()
-            .map(|c| self.spawn_blocking_task(move |this| this.persist_changed_objects(c)));
+        let mutation_futures = mutation_chunks.into_iter().map(|c| {
+            self.spawn_blocking_task(move |this| this.persist_changed_objects(c, finalized_in_cp))
+        });
         let deletion_futures = deletion_chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_removed_objects(c)));
@@ -2414,75 +2361,9 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn update_status_for_checkpoint_transactions(
-        &self,
-        tx_order: Vec<CheckpointTxGlobalOrder>,
-    ) -> Result<(), IndexerError> {
-        let guard = self
-            .metrics
-            .checkpoint_db_commit_latency_tx_insertion_order
-            .start_timer();
-        let len = tx_order.len();
-
-        let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
-        let futures = chunks.into_iter().map(|c| {
-            self.spawn_blocking_task(move |this| {
-                this.update_status_for_checkpoint_transactions_chunk(c)
-            })
-        });
-
-        futures::future::try_join_all(futures)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "failed to join update_status_for_checkpoint_transactions_chunk futures: {e}",
-                );
-                IndexerError::from(e)
-            })?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                IndexerError::PostgresWrite(format!(
-                    "Failed to update all `tx_global_order` chunks: {e:?}",
-                ))
-            })?;
-        let elapsed = guard.stop_and_record();
-        info!(
-            elapsed,
-            "Updated index status for {len} txs insertion orders"
-        );
-        Ok(())
-    }
-
-    async fn finalize_objects(&self, object_ids: Vec<Vec<u8>>) -> Result<(), IndexerError> {
-        if object_ids.is_empty() {
-            return Ok(());
-        }
-        let len = object_ids.len();
-
-        let chunks = chunk!(object_ids, self.config.parallel_chunk_size);
-        let futures = chunks
-            .into_iter()
-            .map(|c| self.spawn_blocking_task(move |this| this.finalize_objects_chunk(c)));
-
-        futures::future::try_join_all(futures)
-            .await
-            .map_err(|e| {
-                tracing::error!("failed to join finalize_objects_chunk futures: {e}");
-                IndexerError::from(e)
-            })?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                IndexerError::PostgresWrite(format!("failed to finalize all object chunks: {e:?}",))
-            })?;
-        info!("Finalized {len} objects");
-        Ok(())
-    }
-
     async fn persist_tx_global_order(
         &self,
-        tx_order: Vec<CheckpointTxGlobalOrder>,
+        tx_order: Vec<TxGlobalOrder>,
     ) -> Result<(), IndexerError> {
         let guard = self
             .metrics

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -323,14 +323,16 @@ pub enum DynamicFieldKind {
 
 #[derive(Clone, Debug)]
 pub struct IndexedObject {
-    pub checkpoint_sequence_number: CheckpointSequenceNumber,
+    /// The checkpoint at which this object was indexed.
+    /// `None` for objects indexed by the optimistic path (checkpoint unknown).
+    pub checkpoint_sequence_number: Option<CheckpointSequenceNumber>,
     pub object: Object,
     pub df_kind: Option<DynamicFieldType>,
 }
 
 impl IndexedObject {
     pub fn from_object(
-        checkpoint_sequence_number: CheckpointSequenceNumber,
+        checkpoint_sequence_number: Option<CheckpointSequenceNumber>,
         object: Object,
         df_kind: Option<DynamicFieldType>,
     ) -> Self {

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -455,6 +455,45 @@ mod ingestion_tests {
     }
 
     #[tokio::test]
+    pub async fn checkpoint_objects_are_finalized() -> Result<(), IndexerError> {
+        let sim = Simulacrum::new();
+        let data_ingestion_path = tempdir().unwrap().keep();
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+        let transfer_recipient = IotaAddress::random_for_testing_only();
+        let (transaction, _) = sim.transfer_txn(transfer_recipient);
+        let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();
+        assert!(err.is_none());
+
+        sim.create_checkpoint();
+
+        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path,
+            None,
+            Some("indexer_ingestion_tests_db"),
+            None,
+        )
+        .await;
+
+        indexer_wait_for_checkpoint(&pg_store, 1).await;
+
+        let non_finalized_count: i64 = read_only_blocking!(&pg_store.blocking_cp(), |conn| {
+            objects::table
+                .filter(objects::finalized.eq(false))
+                .count()
+                .get_result::<i64>(conn)
+        })
+        .context("Failed reading objects from PostgresDB")?;
+
+        assert_eq!(
+            non_finalized_count, 0,
+            "All objects should be finalized after checkpoint indexing"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     pub async fn test_epoch_boundary() -> Result<(), IndexerError> {
         let tempdir = tempdir().unwrap();
         let sim = Simulacrum::new();

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -74,7 +74,7 @@ mod ingestion_tests {
             .map(|_| CheckpointObjectChanges::random())
             .collect();
         pg_store
-            .persist_checkpoint_objects(checkpoint_objects, 0)
+            .persist_checkpoint_objects(checkpoint_objects)
             .await?;
         Ok(())
     }

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -10,7 +10,8 @@ mod ingestion_tests {
     use std::{sync::Arc, time::Duration};
 
     use diesel::{
-        ExpressionMethods, QueryDsl, RunQueryDsl, SelectableHelper, connection::BoxableConnection,
+        BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl, SelectableHelper,
+        connection::BoxableConnection,
     };
     use iota_indexer::{
         db::get_pool_connection,
@@ -73,7 +74,7 @@ mod ingestion_tests {
             .map(|_| CheckpointObjectChanges::random())
             .collect();
         pg_store
-            .persist_checkpoint_objects(checkpoint_objects)
+            .persist_checkpoint_objects(checkpoint_objects, 0)
             .await?;
         Ok(())
     }
@@ -478,9 +479,16 @@ mod ingestion_tests {
 
         indexer_wait_for_checkpoint(&pg_store, 1).await;
 
+        let max_cp = IndexerStore::get_latest_checkpoint_sequence_number(&pg_store)
+            .await?
+            .unwrap() as i64;
         let non_finalized_count: i64 = read_only_blocking!(&pg_store.blocking_cp(), |conn| {
             objects::table
-                .filter(objects::finalized.eq(false))
+                .filter(
+                    objects::finalized_in_cp
+                        .is_not_null()
+                        .and(objects::finalized_in_cp.gt(max_cp)),
+                )
                 .count()
                 .get_result::<i64>(conn)
         })

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -401,10 +401,20 @@ fn optimistic_objects_are_finalized() {
             .unwrap();
         assert_transaction_success(&res);
 
-        // All objects should be finalized in the DB, whether they were indexed
-        // via the optimistic or checkpoint path. Objects are finalized when
-        // `finalized_in_cp IS NULL` (optimistic/already finalized) or when
-        // the checkpoint they belong to has been indexed.
+        // Objects changed by this transaction should be finalized in the DB.
+        // Finalized means `finalized_in_cp IS NULL` (optimistic/already finalized)
+        // or the checkpoint has been indexed.
+        let changed_object_ids: Vec<Vec<u8>> = res
+            .object_changes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .filter_map(|o| match o {
+                ObjectChange::Created { object_id, .. }
+                | ObjectChange::Mutated { object_id, .. } => Some(object_id.to_vec()),
+                _ => None,
+            })
+            .collect();
         let max_cp: i64 = store
             .get_latest_checkpoint_sequence_number()
             .await
@@ -413,6 +423,7 @@ fn optimistic_objects_are_finalized() {
         let non_finalized_count: i64 = (|| -> Result<_, IndexerError> {
             read_only_blocking!(&store.blocking_cp(), |conn| {
                 objects::table
+                    .filter(objects::object_id.eq_any(&changed_object_ids))
                     .filter(
                         objects::finalized_in_cp
                             .is_not_null()

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -6,7 +6,9 @@ use std::{
     str::FromStr,
 };
 
-use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, expression::SelectableHelper};
+use diesel::{
+    BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl, expression::SelectableHelper,
+};
 use fastcrypto::encoding::Base64;
 use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
 use iota_indexer::{
@@ -15,6 +17,7 @@ use iota_indexer::{
     models::transactions::TxGlobalOrder,
     read_only_blocking,
     schema::{objects, tx_global_order},
+    store::indexer_store::IndexerStore,
     types::IndexerResult,
 };
 use iota_json::{call_arg, call_args, type_args};
@@ -399,11 +402,22 @@ fn optimistic_objects_are_finalized() {
         assert_transaction_success(&res);
 
         // All objects should be finalized in the DB, whether they were indexed
-        // via the optimistic or checkpoint path.
+        // via the optimistic or checkpoint path. Objects are finalized when
+        // `finalized_in_cp IS NULL` (optimistic/already finalized) or when
+        // the checkpoint they belong to has been indexed.
+        let max_cp: i64 = store
+            .get_latest_checkpoint_sequence_number()
+            .await
+            .unwrap()
+            .unwrap() as i64;
         let non_finalized_count: i64 = (|| -> Result<_, IndexerError> {
             read_only_blocking!(&store.blocking_cp(), |conn| {
                 objects::table
-                    .filter(objects::finalized.eq(false))
+                    .filter(
+                        objects::finalized_in_cp
+                            .is_not_null()
+                            .and(objects::finalized_in_cp.gt(max_cp)),
+                    )
                     .count()
                     .get_result::<i64>(conn)
             })

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -10,8 +10,12 @@ use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, expression::SelectableHel
 use fastcrypto::encoding::Base64;
 use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
 use iota_indexer::{
-    config::PruningOptions, errors::IndexerError, models::transactions::TxGlobalOrder,
-    read_only_blocking, schema::tx_global_order, types::IndexerResult,
+    config::PruningOptions,
+    errors::IndexerError,
+    models::transactions::TxGlobalOrder,
+    read_only_blocking,
+    schema::{objects, tx_global_order},
+    types::IndexerResult,
 };
 use iota_json::{call_arg, call_args, type_args};
 use iota_json_rpc_api::{
@@ -337,6 +341,78 @@ fn execute_transaction_block() {
         assert_eq!(
             actual_object_info.data.unwrap().owner.unwrap(),
             Owner::AddressOwner(receiver)
+        );
+    });
+}
+
+#[test]
+fn optimistic_objects_are_finalized() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, key_pair): (_, AccountKeyPair) = get_key_pair();
+        let (receiver, _): (_, AccountKeyPair) = get_key_pair();
+
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(NANOS_PER_IOTA),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+
+        let object_to_transfer = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(NANOS_PER_IOTA),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, object_to_transfer.0, object_to_transfer.1).await;
+
+        let (tx_bytes, signatures) = prepare_and_sign_object_transfer_tx(
+            sender,
+            key_pair,
+            receiver,
+            object_to_transfer,
+            gas_ref,
+        )
+        .await;
+
+        let res = client
+            .execute_transaction_block(
+                tx_bytes,
+                signatures,
+                Some(IotaTransactionBlockResponseOptions::full_content()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_transaction_success(&res);
+
+        // All objects should be finalized in the DB, whether they were indexed
+        // via the optimistic or checkpoint path.
+        let non_finalized_count: i64 = (|| -> Result<_, IndexerError> {
+            read_only_blocking!(&store.blocking_cp(), |conn| {
+                objects::table
+                    .filter(objects::finalized.eq(false))
+                    .count()
+                    .get_result::<i64>(conn)
+            })
+        })()
+        .unwrap();
+
+        assert_eq!(
+            non_finalized_count, 0,
+            "All objects should be finalized after optimistic or checkpoint indexing"
         );
     });
 }


### PR DESCRIPTION
# Description of change

  - **Remove `IndexStatus` enum and dual semantics from `tx_global_order`**: The `optimistic_sequence_number` column no longer encodes indexing status (`Started=0`, `Completed=-1`). Checkpoint transactions simply use `-1`, optimistic transactions use positive auto-generated values.
  - **Track object finality via `finalized_in_cp` column**: Objects store the checkpoint sequence number at which they were (or will be) indexed. Readers consider an object finalized when `finalized_in_cp IS NULL` (optimistic/already finalized) or when the referenced checkpoint has been fully indexed.
  This removes the need for an explicit finalization step after checkpoint persistence.
  - **Eliminate the `update_tx_seq_for_checkpoint_transactions` step**: `chk_tx_sequence_number` is now set via upsert during `persist_tx_global_order`, removing a separate post-persist update step.
  - **Update dependency check in optimistic indexing**: `count_existing_object_keys` now checks `finalized_in_cp IS NULL OR finalized_in_cp <= max indexed checkpoint` ensuring optimistic transactions only proceed when their input objects are fully indexed.
  - **Merge `CheckpointTxGlobalOrder` into `TxGlobalOrder`**: The two structs were identical after removing `IndexStatus`, so they are unified into one.
  - **Update `is_transaction_fully_indexed`**: For optimistic txs, checks `optimistic_sequence_number > 0`. For checkpoint txs, checks whether the latest indexed checkpoint covers the transaction.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/10462

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
