### PR TITLE
refactor(iota-core): safe renaming of certificate occurrences to transaction

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -169,7 +169,7 @@ mod test {
 
         register_fail_point_if("correlated-crash-after-consensus-commit-boundary", || true);
         // TODO: enable this - right now it causes rocksdb errors when re-opening DBs
-        // register_fail_point_if("correlated-crash-process-certificate", || true);
+        // register_fail_point_if("correlated-crash-process-transaction", || true);
 
         let test_cluster = build_test_cluster(4, 10000, 1).await;
         test_simulated_load(test_cluster, 60).await;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1191,7 +1191,7 @@ impl AuthorityState {
     ///
     /// It is caller's responsibility to ensure input objects are available and
     /// locks are set. If this cannot be satisfied by the caller,
-    /// [`execute_certificate()`] should be called instead.
+    /// `execute_certificate()` should be called instead.
     ///
     /// Should only be called within iota-core.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
@@ -1614,7 +1614,7 @@ impl AuthorityState {
         );
     }
 
-    /// [`prepare_transaction()`] validates the transaction input, and executes
+    /// `prepare_transaction()` validates the transaction input, and executes
     /// the transaction, returning effects, output objects, events, etc.
     ///
     /// It reads state from the db (both owned and shared locks), but it has no

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -796,7 +796,7 @@ pub struct AuthorityState {
     epoch_store: ArcSwap<AuthorityPerEpochStore>,
 
     /// This lock denotes current 'execution epoch'.
-    /// Execution acquires read lock, checks certificate epoch and holds it
+    /// Execution acquires read lock, checks transaction epoch and holds it
     /// until all writes are complete. Reconfiguration acquires write lock,
     /// changes the epoch and revert all transactions from previous epoch
     /// that are executed but did not make into checkpoint.
@@ -810,7 +810,7 @@ pub struct AuthorityState {
 
     committee_store: Arc<CommitteeStore>,
 
-    /// Manages pending certificates and their missing input objects.
+    /// Manages pending transactions and their missing input objects.
     transaction_manager: Arc<TransactionManager>,
 
     /// Shuts down the execution task. Used only in testing.
@@ -1180,7 +1180,7 @@ impl AuthorityState {
             .and_then(|r| r)
     }
 
-    /// Internal logic to execute a certificate.
+    /// Internal logic to execute a transaction.
     ///
     /// Guarantees that
     /// - If input objects are available, return no permanent failure.
@@ -1191,26 +1191,26 @@ impl AuthorityState {
     ///
     /// It is caller's responsibility to ensure input objects are available and
     /// locks are set. If this cannot be satisfied by the caller,
-    /// execute_certificate() should be called instead.
+    /// [`execute_certificate()`] should be called instead.
     ///
     /// Should only be called within iota-core.
-    #[instrument(level = "trace", skip_all, fields(tx_digest = ?certificate.digest()))]
+    #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
     pub fn try_execute_immediately(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         expected_effects_digest: Option<TransactionEffectsDigest>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<(TransactionEffects, Option<ExecutionError>)> {
         let _scope = monitored_scope("Execution::try_execute_immediately");
         let _metrics_guard = self.metrics.internal_execution_latency.start_timer();
 
-        let tx_digest = certificate.digest();
+        let tx_digest = transaction.digest();
 
         // Acquire a lock to prevent concurrent executions of the same transaction.
-        let tx_guard = epoch_store.acquire_tx_guard(certificate)?;
+        let tx_guard = epoch_store.acquire_tx_guard(transaction)?;
 
-        // The cert could have been processed by a concurrent attempt of the same cert,
-        // so check if the effects have already been written.
+        // The transaction could have been processed by a concurrent attempt of the
+        // same transaction, so check if the effects have already been written.
         if let Some(effects) = self
             .get_transaction_cache_reader()
             .try_get_executed_effects(tx_digest)?
@@ -1227,7 +1227,7 @@ impl AuthorityState {
         }
 
         let (tx_input_objects, authenticator_input_objects, account_object) =
-            self.read_objects_for_execution(tx_guard.as_lock_guard(), certificate, epoch_store)?;
+            self.read_objects_for_execution(tx_guard.as_lock_guard(), transaction, epoch_store)?;
 
         // If no expected_effects_digest was provided, try to get it from storage.
         // We could be re-executing a previously executed but uncommitted transaction,
@@ -1237,25 +1237,25 @@ impl AuthorityState {
         let expected_effects_digest =
             expected_effects_digest.or(epoch_store.get_signed_effects_digest(tx_digest)?);
 
-        self.process_certificate(
+        self.process_transaction(
             tx_guard,
-            certificate,
+            transaction,
             tx_input_objects,
             account_object,
             authenticator_input_objects,
             expected_effects_digest,
             epoch_store,
         )
-        .tap_err(|e| info!(?tx_digest, "process_certificate failed: {e}"))
+        .tap_err(|e| info!(?tx_digest, "process_transaction failed: {e}"))
         .tap_ok(
-            |(fx, _)| debug!(?tx_digest, fx_digest=?fx.digest(), "process_certificate succeeded"),
+            |(fx, _)| debug!(?tx_digest, fx_digest=?fx.digest(), "process_transaction succeeded"),
         )
     }
 
     pub fn read_objects_for_execution(
         &self,
         tx_lock: &TxLockGuard,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<(InputObjects, Option<InputObjects>, Option<ObjectReadResult>)> {
         let _scope = monitored_scope("Execution::load_input_objects");
@@ -1264,17 +1264,17 @@ impl AuthorityState {
             .execution_load_input_objects_latency
             .start_timer();
 
-        let input_objects = certificate.collect_all_input_object_kind_for_reading()?;
+        let input_objects = transaction.collect_all_input_object_kind_for_reading()?;
 
         let input_objects = self.input_loader.read_objects_for_execution(
             epoch_store,
-            &certificate.key(),
+            &transaction.key(),
             tx_lock,
             &input_objects,
             epoch_store.epoch(),
         )?;
 
-        certificate.split_input_objects_into_groups_for_reading(input_objects)
+        transaction.split_input_objects_into_groups_for_reading(input_objects)
     }
 
     /// Test only wrapper for `try_execute_immediately()` above, useful for
@@ -1328,7 +1328,7 @@ impl AuthorityState {
         effects: &TransactionEffects,
         expected_effects_digest: TransactionEffectsDigest,
         inner_temporary_store: &InnerTemporaryStore,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         debug_dump_config: &StateDebugDumpConfig,
     ) -> IotaResult<PathBuf> {
         let dump_dir = debug_dump_config
@@ -1345,39 +1345,39 @@ impl AuthorityState {
             self.get_object_store().as_ref(),
             &epoch_store,
             inner_temporary_store,
-            certificate,
+            transaction,
         )?
         .write_to_file(&dump_dir)
         .map_err(|e| IotaError::FileIO(e.to_string()))
     }
 
-    #[instrument(name = "process_certificate", level = "trace", skip_all, fields(tx_digest = ?certificate.digest(), sender = ?certificate.data().transaction_data().gas_owner().to_string()))]
-    pub(crate) fn process_certificate(
+    #[instrument(name = "process_transaction", level = "trace", skip_all, fields(tx_digest = ?transaction.digest(), sender = ?transaction.data().transaction_data().gas_owner().to_string()))]
+    pub(crate) fn process_transaction(
         &self,
         tx_guard: TxGuard,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         tx_input_objects: InputObjects,
         account_object: Option<ObjectReadResult>,
         authenticator_input_objects: Option<InputObjects>,
         expected_effects_digest: Option<TransactionEffectsDigest>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<(TransactionEffects, Option<ExecutionError>)> {
-        let process_certificate_start_time = tokio::time::Instant::now();
-        let digest = *certificate.digest();
+        let process_transaction_start_time = tokio::time::Instant::now();
+        let digest = *transaction.digest();
 
         let _scope = monitored_scope("Execution::process_certificate");
 
-        fail_point_if!("correlated-crash-process-certificate", || {
+        fail_point_if!("correlated-crash-process-transaction", || {
             if iota_simulator::random::deterministic_probability_once(digest, 0.01) {
                 iota_simulator::task::kill_current_node(None);
             }
         });
 
-        let execution_guard = self.execution_lock_for_executable_transaction(certificate);
-        // Any caller that verifies the signatures on the certificate will have already
+        let execution_guard = self.execution_lock_for_executable_transaction(transaction);
+        // Any caller that verifies the signatures on the transaction will have already
         // checked the epoch. But paths that don't verify sigs (e.g. execution
         // from checkpoint, reading from db) present the possibility of an epoch
-        // mismatch. If this cert is not finalzied in previous epoch, then it's
+        // mismatch. If this transaction is not finalized in previous epoch, then it's
         // invalid.
         let execution_guard = match execution_guard {
             Ok(execution_guard) => execution_guard,
@@ -1398,14 +1398,14 @@ impl AuthorityState {
             });
         }
 
-        // Errors originating from prepare_certificate may be transient (failure to read
-        // locks) or non-transient (transaction input is invalid, move vm
+        // Errors originating from `prepare_transaction` may be transient (failure to
+        // read locks) or non-transient (transaction input is invalid, move vm
         // errors). However, all errors from this function occur before we have
         // written anything to the db, so we commit the tx guard and rely on the
         // client to retry the tx (if it was transient).
-        let (inner_temporary_store, effects, execution_error_opt) = match self.prepare_certificate(
+        let (inner_temporary_store, effects, execution_error_opt) = match self.prepare_transaction(
             &execution_guard,
-            certificate,
+            transaction,
             tx_input_objects,
             account_object,
             authenticator_input_objects,
@@ -1427,7 +1427,7 @@ impl AuthorityState {
                     &effects,
                     expected_effects_digest,
                     &inner_temporary_store,
-                    certificate,
+                    transaction,
                     &self.config.state_debug_dump_config,
                 ) {
                     Ok(out_path) => {
@@ -1458,8 +1458,8 @@ impl AuthorityState {
 
         fail_point!("crash");
 
-        self.commit_certificate(
-            certificate,
+        self.commit_transaction(
+            transaction,
             inner_temporary_store,
             &effects,
             tx_guard,
@@ -1468,7 +1468,7 @@ impl AuthorityState {
         )?;
 
         if let TransactionKind::AuthenticatorStateUpdateV1(auth_state) =
-            certificate.data().transaction_data().kind()
+            transaction.data().transaction_data().kind()
         {
             if let Some(err) = &execution_error_opt {
                 debug_fatal!("Authenticator state update failed: {:?}", err);
@@ -1499,7 +1499,7 @@ impl AuthorityState {
             }
         }
 
-        let elapsed = process_certificate_start_time.elapsed().as_micros() as f64;
+        let elapsed = process_transaction_start_time.elapsed().as_micros() as f64;
         if elapsed > 0.0 {
             self.metrics
                 .execution_gas_latency_ratio
@@ -1509,9 +1509,9 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    fn commit_certificate(
+    fn commit_transaction(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         inner_temporary_store: InnerTemporaryStore,
         effects: &TransactionEffects,
         tx_guard: TxGuard,
@@ -1522,16 +1522,16 @@ impl AuthorityState {
             monitored_scope("Execution::commit_certificate");
         let _metrics_guard = self.metrics.commit_certificate_latency.start_timer();
 
-        let tx_key = certificate.key();
-        let tx_digest = certificate.digest();
+        let tx_key = transaction.key();
+        let tx_digest = transaction.digest();
         let input_object_count = inner_temporary_store.input_objects.len();
         let shared_object_count = effects.input_shared_objects().len();
 
         let output_keys = inner_temporary_store.get_output_keys(effects);
 
-        // index certificate
+        // index transaction
         let _ = self
-            .post_process_one_tx(certificate, effects, &inner_temporary_store, epoch_store)
+            .post_process_one_tx(transaction, effects, &inner_temporary_store, epoch_store)
             .tap_err(|e| {
                 self.metrics.post_processing_total_failures.inc();
                 error!(?tx_digest, "tx post processing failed: {e}");
@@ -1546,21 +1546,21 @@ impl AuthorityState {
         fail_point!("crash");
 
         let transaction_outputs = TransactionOutputs::build_transaction_outputs(
-            certificate.clone().into_unsigned(),
+            transaction.clone().into_unsigned(),
             effects.clone(),
             inner_temporary_store,
         );
         self.get_cache_writer()
             .try_write_transaction_outputs(epoch_store.epoch(), transaction_outputs.into())?;
 
-        if certificate.transaction_data().is_end_of_epoch_tx() {
+        if transaction.transaction_data().is_end_of_epoch_tx() {
             // At the end of epoch, since system packages may have been upgraded, force
             // reload them in the cache.
             self.get_object_cache_reader()
                 .force_reload_system_packages(&BuiltInFramework::all_package_ids());
         }
 
-        // commit_certificate finished, the tx is fully committed to the store.
+        // `commit_transaction()` finished, the tx is fully committed to the store.
         tx_guard.commit_tx();
 
         // Notifies transaction manager about transaction and output objects committed.
@@ -1569,21 +1569,21 @@ impl AuthorityState {
         self.transaction_manager
             .notify_commit(tx_digest, output_keys, epoch_store);
 
-        self.update_metrics(certificate, input_object_count, shared_object_count);
+        self.update_metrics(transaction, input_object_count, shared_object_count);
 
         Ok(())
     }
 
     fn update_metrics(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         input_object_count: usize,
         shared_object_count: usize,
     ) {
         // count signature by scheme, for zklogin and multisig
-        if certificate.has_zklogin_sig() {
+        if transaction.has_zklogin_sig() {
             self.metrics.zklogin_sig_count.inc();
-        } else if certificate.has_upgraded_multisig() {
+        } else if transaction.has_upgraded_multisig() {
             self.metrics.multisig_sig_count.inc();
         }
 
@@ -1594,7 +1594,7 @@ impl AuthorityState {
             self.metrics.shared_obj_tx.inc();
         }
 
-        if certificate.is_sponsored_tx() {
+        if transaction.is_sponsored_tx() {
             self.metrics.sponsored_tx.inc();
         }
 
@@ -1605,7 +1605,7 @@ impl AuthorityState {
             .num_shared_objects
             .observe(shared_object_count as f64);
         self.metrics.batch_size.observe(
-            certificate
+            transaction
                 .data()
                 .intent_message()
                 .value
@@ -1614,22 +1614,22 @@ impl AuthorityState {
         );
     }
 
-    /// prepare_certificate validates the transaction input, and executes the
-    /// certificate, returning effects, output objects, events, etc.
+    /// [`prepare_transaction()`] validates the transaction input, and executes
+    /// the transaction, returning effects, output objects, events, etc.
     ///
     /// It reads state from the db (both owned and shared locks), but it has no
     /// side effects.
     ///
-    /// It can be generally understood that a failure of prepare_certificate
+    /// It can be generally understood that a failure of `prepare_transaction`
     /// indicates a non-transient error, e.g. the transaction input is
     /// somehow invalid, the correct locks are not held, etc. However, this
     /// is not entirely true, as a transient db read error may also cause
     /// this function to fail.
     #[instrument(level = "trace", skip_all)]
-    fn prepare_certificate(
+    fn prepare_transaction(
         &self,
         _execution_guard: &ExecutionLockReadGuard<'_>,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         tx_input_objects: InputObjects,
         account_object: Option<ObjectReadResult>,
         move_authenticator_input_objects: Option<InputObjects>,
@@ -1641,7 +1641,7 @@ impl AuthorityState {
     )> {
         let _scope = monitored_scope("Execution::prepare_certificate");
         let _metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
-        let prepare_certificate_start_time = tokio::time::Instant::now();
+        let prepare_transaction_start_time = tokio::time::Instant::now();
 
         let protocol_config = epoch_store.protocol_config();
 
@@ -1655,11 +1655,11 @@ impl AuthorityState {
 
         let backing_store = self.get_backing_store().as_ref();
 
-        let tx_digest = *certificate.digest();
+        let tx_digest = *transaction.digest();
 
         // TODO: We need to move this to a more appropriate place to avoid redundant
         // checks.
-        let tx_data = certificate.data().transaction_data();
+        let tx_data = transaction.data().transaction_data();
         tx_data.validity_check(protocol_config)?;
 
         let (kind, signer, gas) = tx_data.execution_parts();
@@ -1668,7 +1668,7 @@ impl AuthorityState {
         let (inner_temp_store, _, mut effects, execution_error_opt) = if let Some(
             move_authenticator,
         ) =
-            certificate.sender_move_authenticator()
+            transaction.sender_move_authenticator()
         {
             // Check if the sender needs to be authenticated in Move and, if so, execute the
             // authentication.
@@ -1708,7 +1708,7 @@ impl AuthorityState {
                 authenticator_checked_input_objects,
                 authenticator_and_tx_checked_input_objects,
             ) = iota_transaction_checks::check_certificate_and_move_authenticator_input(
-                certificate,
+                transaction,
                 tx_input_objects,
                 move_authenticator_input_objects,
                 authenticator_gas_budget,
@@ -1751,7 +1751,7 @@ impl AuthorityState {
             // tolerated.
             let (tx_gas_status, tx_checked_input_objects) =
                 iota_transaction_checks::check_certificate_input(
-                    certificate,
+                    transaction,
                     tx_input_objects,
                     protocol_config,
                     reference_gas_price,
@@ -1783,10 +1783,10 @@ impl AuthorityState {
 
         fail_point_if!("cp_execution_nondeterminism", || {
             #[cfg(msim)]
-            self.create_fail_state(certificate, epoch_store, &mut effects);
+            self.create_fail_state(transaction, epoch_store, &mut effects);
         });
 
-        let elapsed = prepare_certificate_start_time.elapsed().as_micros() as f64;
+        let elapsed = prepare_transaction_start_time.elapsed().as_micros() as f64;
         if elapsed > 0.0 {
             self.metrics
                 .prepare_cert_gas_latency_ratio
@@ -1796,9 +1796,9 @@ impl AuthorityState {
         Ok((inner_temp_store, effects, execution_error_opt.err()))
     }
 
-    pub fn prepare_certificate_for_benchmark(
+    pub fn prepare_transaction_for_benchmark(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         input_objects: InputObjects,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<(
@@ -1809,9 +1809,9 @@ impl AuthorityState {
         let lock = RwLock::new(epoch_store.epoch());
         let execution_guard = lock.try_read().unwrap();
 
-        self.prepare_certificate(
+        self.prepare_transaction(
             &execution_guard,
-            certificate,
+            transaction,
             input_objects,
             None,
             None,
@@ -2440,7 +2440,7 @@ impl AuthorityState {
         indexes: &IndexStore,
         digest: &TransactionDigest,
         // TODO: index_tx really just need the transaction data here.
-        cert: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         effects: &TransactionEffects,
         events: &TransactionEvents,
         timestamp_ms: u64,
@@ -2453,8 +2453,9 @@ impl AuthorityState {
             .tap_err(|e| warn!(tx_digest=?digest, "Failed to process object index, index_tx is skipped: {e}"))?;
 
         indexes.index_tx(
-            cert.data().intent_message().value.sender(),
-            cert.data()
+            transaction.data().intent_message().value.sender(),
+            transaction
+                .data()
                 .intent_message()
                 .value
                 .input_objects()?
@@ -2464,7 +2465,8 @@ impl AuthorityState {
                 .all_changed_objects()
                 .into_iter()
                 .map(|(obj_ref, owner, _kind)| (obj_ref, owner)),
-            cert.data()
+            transaction
+                .data()
                 .intent_message()
                 .value
                 .move_calls()
@@ -2483,7 +2485,7 @@ impl AuthorityState {
     #[cfg(msim)]
     fn create_fail_state(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         effects: &mut TransactionEffects,
     ) {
@@ -2491,7 +2493,7 @@ impl AuthorityState {
         thread_local! {
             static FAIL_STATE: RefCell<(u64, HashSet<AuthorityName>)> = RefCell::new((0, HashSet::new()));
         }
-        if !certificate.data().intent_message().value.is_system_tx() {
+        if !transaction.data().intent_message().value.is_system_tx() {
             let committee = epoch_store.committee();
             let cur_stake = (**committee).weight(&self.name);
             if cur_stake > 0 {
@@ -2762,7 +2764,7 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all, err)]
     fn post_process_one_tx(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         effects: &TransactionEffects,
         inner_temporary_store: &InnerTemporaryStore,
         epoch_store: &Arc<AuthorityPerEpochStore>,
@@ -2773,7 +2775,7 @@ impl AuthorityState {
 
         let _scope = monitored_scope("Execution::post_process_one_tx");
 
-        let tx_digest = certificate.digest();
+        let tx_digest = transaction.digest();
         let timestamp_ms = Self::unixtime_now_ms();
         let events = &inner_temporary_store.events;
         let written = &inner_temporary_store.written;
@@ -2789,7 +2791,7 @@ impl AuthorityState {
                 .index_tx(
                     indexes.as_ref(),
                     tx_digest,
-                    certificate,
+                    transaction,
                     effects,
                     events,
                     timestamp_ms,
@@ -2811,7 +2813,7 @@ impl AuthorityState {
             )?;
             // Emit events
             self.subscription_handler
-                .process_tx(certificate.data().transaction_data(), &effects, &events)
+                .process_tx(transaction.data().transaction_data(), &effects, &events)
                 .tap_ok(|_| {
                     self.metrics
                         .post_processing_total_tx_had_event_processed
@@ -3022,14 +3024,14 @@ impl AuthorityState {
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
 
         let metrics = Arc::new(AuthorityMetrics::new(prometheus_registry));
-        let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
+        let (tx_ready_transactions, rx_ready_transactions) = unbounded_channel();
         let transaction_manager = Arc::new(TransactionManager::new(
             execution_cache_trait_pointers.object_cache_reader.clone(),
             execution_cache_trait_pointers
                 .transaction_cache_reader
                 .clone(),
             &epoch_store,
-            tx_ready_certificates,
+            tx_ready_transactions,
             metrics.clone(),
         ));
         let (tx_execution_shutdown, rx_execution_shutdown) = oneshot::channel();
@@ -3079,11 +3081,11 @@ impl AuthorityState {
             congestion_tracker: Arc::new(CongestionTracker::new(rgp)),
         });
 
-        // Start a task to execute ready certificates.
+        // Start a task to execute ready transactions.
         let authority_state = Arc::downgrade(&state);
         spawn_monitored_task!(execution_process(
             authority_state,
-            rx_ready_certificates,
+            rx_ready_transactions,
             rx_execution_shutdown,
         ));
         spawn_monitored_task!(authority_store_migrations::migrate_events(store));
@@ -3175,10 +3177,10 @@ impl AuthorityState {
     /// execution.
     pub fn enqueue_transactions_for_execution(
         &self,
-        txns: Vec<VerifiedExecutableTransaction>,
+        transactions: Vec<VerifiedExecutableTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
-        self.transaction_manager.enqueue(txns, epoch_store)
+        self.transaction_manager.enqueue(transactions, epoch_store)
     }
 
     /// Adds certificates to transaction manager for ordered execution.
@@ -3193,11 +3195,11 @@ impl AuthorityState {
 
     pub fn enqueue_with_expected_effects_digest(
         &self,
-        certs: Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
+        transactions: Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
         epoch_store: &AuthorityPerEpochStore,
     ) {
         self.transaction_manager
-            .enqueue_with_expected_effects_digest(certs, epoch_store)
+            .enqueue_with_expected_effects_digest(transactions, epoch_store)
     }
 
     fn create_owner_index_if_empty(
@@ -3407,7 +3409,7 @@ impl AuthorityState {
         self.transaction_manager.reconfigure(new_epoch);
         *execution_lock = new_epoch;
         // drop execution_lock after epoch store was updated
-        // see also assert in AuthorityState::process_certificate
+        // see also assert in AuthorityState::process_transaction
         // on the epoch store and execution lock epoch match
         Ok(new_epoch_store)
     }
@@ -5197,7 +5199,7 @@ impl AuthorityState {
         let (input_objects, _, _) =
             self.read_objects_for_execution(&tx_lock, &executable_tx, epoch_store)?;
 
-        let (temporary_store, effects, _execution_error_opt) = self.prepare_certificate(
+        let (temporary_store, effects, _execution_error_opt) = self.prepare_transaction(
             &execution_guard,
             &executable_tx,
             input_objects,
@@ -6000,7 +6002,7 @@ impl NodeStateDump {
         object_store: &dyn ObjectStore,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         inner_temporary_store: &InnerTemporaryStore,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
     ) -> IotaResult<Self> {
         // Epoch info
         let executed_epoch = epoch_store.epoch();
@@ -6074,7 +6076,7 @@ impl NodeStateDump {
             loaded_child_objects,
             modified_at_versions,
             runtime_reads,
-            sender_signed_data: certificate.clone().into_message(),
+            sender_signed_data: transaction.clone().into_message(),
             input_objects: inner_temporary_store
                 .input_objects
                 .values()

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -18,7 +18,7 @@ use std::{
 use anyhow::bail;
 use arc_swap::{ArcSwap, Guard};
 use async_trait::async_trait;
-use authority_per_epoch_store::CertLockGuard;
+use authority_per_epoch_store::TxLockGuard;
 pub use authority_store::{AuthorityStore, ResolverWrapper, UpdateType};
 use fastcrypto::{
     encoding::{Base58, Encoding},
@@ -150,7 +150,7 @@ pub use crate::checkpoints::checkpoint_executor::utils::{
 };
 use crate::{
     authority::{
-        authority_per_epoch_store::{AuthorityPerEpochStore, CertTxGuard},
+        authority_per_epoch_store::{AuthorityPerEpochStore, TxGuard},
         authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner,
         authority_store::{ExecutionLockReadGuard, ObjectLockStatus},
         authority_store_pruner::{AuthorityStorePruner, EPOCH_DURATION_MS_FOR_TESTING},
@@ -1254,7 +1254,7 @@ impl AuthorityState {
 
     pub fn read_objects_for_execution(
         &self,
-        tx_lock: &CertLockGuard,
+        tx_lock: &TxLockGuard,
         certificate: &VerifiedExecutableTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<(InputObjects, Option<InputObjects>, Option<ObjectReadResult>)> {
@@ -1354,7 +1354,7 @@ impl AuthorityState {
     #[instrument(name = "process_certificate", level = "trace", skip_all, fields(tx_digest = ?certificate.digest(), sender = ?certificate.data().transaction_data().gas_owner().to_string()))]
     pub(crate) fn process_certificate(
         &self,
-        tx_guard: CertTxGuard,
+        tx_guard: TxGuard,
         certificate: &VerifiedExecutableTransaction,
         tx_input_objects: InputObjects,
         account_object: Option<ObjectReadResult>,
@@ -1514,7 +1514,7 @@ impl AuthorityState {
         certificate: &VerifiedExecutableTransaction,
         inner_temporary_store: InnerTemporaryStore,
         effects: &TransactionEffects,
-        tx_guard: CertTxGuard,
+        tx_guard: TxGuard,
         _execution_guard: ExecutionLockReadGuard<'_>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3538,7 +3538,7 @@ impl AuthorityPerEpochStore {
             match cancelled_txns.get(txn.digest()) {
                 Some(CancelConsensusTransactionReason::CongestionOnObjects { .. })
                 | Some(CancelConsensusTransactionReason::DkgFailed) => {
-                    let assigned_versions = SharedObjVerManager::assign_versions_for_certificate(
+                    let assigned_versions = SharedObjVerManager::assign_versions_for_transaction(
                         txn,
                         &mut shared_input_next_version,
                         cancelled_txns,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2315,8 +2315,13 @@ impl AuthorityPerEpochStore {
                         .insert(*cert.digest());
                 }
             }
+            // NOTE: We do not insert
+            // `ConsensusTransactionKind::UserTransactionV1` into
+            // `self.pending_consensus_certificates` because, in the
+            // certificate-less scenario, there is no pre-consensus
+            // "promise" (certificate) that `UserTransactionV1` will
+            // be executed before the end of epoch.
         }
-
         Ok(())
     }
 
@@ -2345,8 +2350,12 @@ impl AuthorityPerEpochStore {
                     self.pending_consensus_certificates.write().remove(cert);
                 }
             }
+            // NOTE: We do not need the
+            // `ConsensusTransactionKey::UserTransaction` branch
+            // (certificate-less scenario) here because `UserTransactionV1` are
+            // not inserted into
+            // `self.pending_consensus_certificates`.
         }
-
         Ok(())
     }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2287,7 +2287,6 @@ impl AuthorityPerEpochStore {
     pub fn insert_pending_consensus_transactions(
         &self,
         transactions: &[ConsensusTransaction],
-        lock: Option<&RwLockReadGuard<ReconfigState>>,
     ) -> IotaResult {
         let key_value_pairs = transactions.iter().map(|tx| (tx.key(), tx));
         self.tables()?
@@ -2315,14 +2314,7 @@ impl AuthorityPerEpochStore {
                         .insert(*cert.digest());
                 }
             }
-            // NOTE: We do not insert
-            // `ConsensusTransactionKind::UserTransactionV1` into
-            // `self.pending_consensus_certificates` because, in the
-            // certificate-less scenario, there is no pre-consensus
-            // "promise" (certificate) that `UserTransactionV1` will
-            // be executed before the end of epoch.
         }
-        Ok(())
     }
 
     /// Remove processed by consensus transactions from the persistent

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2287,6 +2287,7 @@ impl AuthorityPerEpochStore {
     pub fn insert_pending_consensus_transactions(
         &self,
         transactions: &[ConsensusTransaction],
+        lock: Option<&RwLockReadGuard<ReconfigState>>,
     ) -> IotaResult {
         let key_value_pairs = transactions.iter().map(|tx| (tx.key(), tx));
         self.tables()?
@@ -2315,6 +2316,8 @@ impl AuthorityPerEpochStore {
                 }
             }
         }
+
+        Ok(())
     }
 
     /// Remove processed by consensus transactions from the persistent
@@ -2343,6 +2346,8 @@ impl AuthorityPerEpochStore {
                 }
             }
         }
+
+        Ok(())
     }
 
     pub fn pending_consensus_certificates_count(&self) -> usize {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -154,22 +154,28 @@ use consensus_quarantine::{
 use iota_types::crypto::AuthorityPublicKey;
 use scorer::Scorer;
 
-// CertLockGuard and CertTxGuard are functionally identical right now, but we
+// `TxLockGuard` and `TxGuard` are functionally identical right now, but we
 // retain a distinction anyway. If we need to support distributed object
 // storage, having this distinction will be useful, as we will most likely have
 // to re-implement a retry / write-ahead-log at that point.
-pub struct CertLockGuard(#[expect(unused)] MutexGuard);
-pub struct CertTxGuard(CertLockGuard);
+//
+// The legacy names (in the certificate era) were `CertLockGuard` and
+// `CertTxGuard`. These are renamed to `TxLockGuard` and `TxGuard`,
+// respectively, because these types now (in the certificate-less era)
+// covers more consensus transaction kinds, not just certificates.
+// The renaming of these internal types is safe and backward-compatible.
+pub struct TxLockGuard(#[expect(unused)] MutexGuard);
+pub struct TxGuard(TxLockGuard);
 
-impl CertTxGuard {
+impl TxGuard {
     pub fn release(self) {}
     pub fn commit_tx(self) {}
-    pub fn as_lock_guard(&self) -> &CertLockGuard {
+    pub fn as_lock_guard(&self) -> &TxLockGuard {
         &self.0
     }
 }
 
-impl CertLockGuard {
+impl TxLockGuard {
     pub fn guard_for_tests() -> Self {
         let lock = Arc::new(parking_lot::Mutex::new(()));
         Self(lock.try_lock_arc().unwrap())
@@ -276,11 +282,11 @@ impl CongestionControlParameters {
     /// from a given consensus commit.
     pub(super) fn get_estimated_execution_duration(
         &self,
-        cert: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
     ) -> ExecutionTime {
         match self.per_object_congestion_control_mode {
             PerObjectCongestionControlMode::None => 0,
-            PerObjectCongestionControlMode::TotalGasBudget => cert.gas_budget(),
+            PerObjectCongestionControlMode::TotalGasBudget => transaction.gas_budget(),
             PerObjectCongestionControlMode::TotalTxCount => 1,
         }
     }
@@ -1458,15 +1464,15 @@ impl AuthorityPerEpochStore {
 
     pub fn acquire_tx_guard(
         &self,
-        cert: &VerifiedExecutableTransaction,
-    ) -> IotaResult<CertTxGuard> {
-        let digest = cert.digest();
-        Ok(CertTxGuard(self.acquire_tx_lock(digest)))
+        transaction: &VerifiedExecutableTransaction,
+    ) -> IotaResult<TxGuard> {
+        let digest = transaction.digest();
+        Ok(TxGuard(self.acquire_tx_lock(digest)))
     }
 
     /// Acquire the lock for a tx without writing to the WAL.
-    pub fn acquire_tx_lock(&self, digest: &TransactionDigest) -> CertLockGuard {
-        CertLockGuard(self.mutex_table.acquire_lock(*digest))
+    pub fn acquire_tx_lock(&self, digest: &TransactionDigest) -> TxLockGuard {
+        TxLockGuard(self.mutex_table.acquire_lock(*digest))
     }
 
     pub fn store_reconfig_state(&self, new_state: &ReconfigState) -> IotaResult {
@@ -1890,7 +1896,7 @@ impl AuthorityPerEpochStore {
     // object was written in a previous epoch, and we initialize
     // next_shared_object_versions to that value. If no version of the
     // object has yet been written, we initialize the object to the initial version
-    // recorded in the certificate (which is a function of the lamport version
+    // recorded in the transaction (which is a function of the lamport version
     // computation of the transaction that created the shared object originally
     // - which transaction may not yet have been executed on this node).
     //
@@ -1980,10 +1986,10 @@ impl AuthorityPerEpochStore {
             .insert_shared_object_assignments(&versions);
     }
 
-    /// Given list of certificates, assign versions for all shared objects used
+    /// Given list of transactions, assign versions for all shared objects used
     /// in them. We start with the current next_shared_object_versions table
     /// for each object, and build up the versions based on the dependencies
-    /// of each certificate. However, in the end we do not update the
+    /// of each transaction. However, in the end we do not update the
     /// next_shared_object_versions table, which keeps this function
     /// idempotent. We should call this function when we are assigning shared
     /// object versions outside of consensus and do not want to taint the
@@ -1991,12 +1997,12 @@ impl AuthorityPerEpochStore {
     pub fn assign_shared_object_versions_idempotent(
         &self,
         cache_reader: &dyn ObjectCacheRead,
-        certificates: &[VerifiedExecutableTransaction],
+        transactions: &[VerifiedExecutableTransaction],
     ) -> IotaResult {
         let assigned_versions = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
-            certificates,
+            transactions,
             None,
             &BTreeMap::new(),
         )?
@@ -2036,7 +2042,7 @@ impl AuthorityPerEpochStore {
                         ) => (digest, (*deferral_key, tx.suggested_gas_price)),
                         _ => {
                             panic!(
-                                "deferred randomness transaction was not a user certificate: {tx:?}"
+                                "deferred randomness transaction was not a user transaction: {tx:?}"
                             )
                         }
                     })
@@ -2190,10 +2196,10 @@ impl AuthorityPerEpochStore {
         }
     }
 
-    #[instrument("transactions_sequencing", level = "trace", skip_all, fields(cert_digest = ?cert.digest(), scheduling_result = tracing::field::Empty))]
+    #[instrument("transactions_sequencing", level = "trace", skip_all, fields(tx_digest = ?transaction.digest(), scheduling_result = tracing::field::Empty))]
     fn try_schedule(
         &self,
-        cert: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         commit_round: CommitRound,
         dkg_failed: bool,
         generating_randomness: bool,
@@ -2203,9 +2209,9 @@ impl AuthorityPerEpochStore {
         // Defer transaction if it uses randomness but we aren't generating any this
         // round. Don't defer if DKG has permanently failed; in that case we
         // need to ignore.
-        if !dkg_failed && !generating_randomness && cert.uses_randomness() {
+        if !dkg_failed && !generating_randomness && transaction.uses_randomness() {
             let deferred_from_round = previously_deferred_tx_digests
-                .get(cert.digest())
+                .get(transaction.digest())
                 .map(|previous_key_suggested_gas_price_pair| {
                     previous_key_suggested_gas_price_pair
                         .0
@@ -2228,12 +2234,12 @@ impl AuthorityPerEpochStore {
         {
             // Initialise the free execution slots for the objects that are not in the
             // tracker.
-            let shared_input_objects = cert.shared_input_objects();
+            let shared_input_objects = transaction.shared_input_objects();
             shared_object_congestion_tracker
                 .initialize_object_execution_slots(&shared_input_objects);
             // Defer transaction if it uses shared objects that are congested.
             match shared_object_congestion_tracker.try_schedule(
-                cert,
+                transaction,
                 previously_deferred_tx_digests,
                 commit_round,
             ) {
@@ -2259,17 +2265,17 @@ impl AuthorityPerEpochStore {
     /// based on the effects of that transaction.
     /// Used by full nodes who don't listen to consensus, and validators who
     /// catch up by state sync.
-    // TODO: We should be able to pass in a vector of certs/effects and acquire them
-    // all at once.
+    // TODO: We should be able to pass in a vector of transactions/effects and
+    // acquire them all at once.
     #[instrument(level = "trace", skip_all)]
     pub fn acquire_shared_version_assignments_from_effects(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         effects: &TransactionEffects,
         cache_reader: &dyn ObjectCacheRead,
     ) -> IotaResult {
         let versions = SharedObjVerManager::assign_versions_from_effects(
-            &[(certificate, effects)],
+            &[(transaction, effects)],
             self,
             cache_reader,
         );
@@ -2808,10 +2814,10 @@ impl AuthorityPerEpochStore {
             .expect("push_consensus_output should not fail");
     }
 
-    fn finish_consensus_certificate_process(&self, certificates: &[VerifiedExecutableTransaction]) {
-        let sigs: Vec<_> = certificates
+    fn finish_consensus_transaction_process(&self, transactions: &[VerifiedExecutableTransaction]) {
+        let sigs: Vec<_> = transactions
             .iter()
-            .map(|certificate| (*certificate.digest(), certificate.tx_signatures().to_vec()))
+            .map(|transaction| (*transaction.digest(), transaction.tx_signatures().to_vec()))
             .collect();
 
         let mut user_sigs = self
@@ -2819,9 +2825,9 @@ impl AuthorityPerEpochStore {
             .user_signatures_for_checkpoints
             .lock();
 
-        user_sigs.reserve(certificates.len());
+        user_sigs.reserve(transactions.len());
         for (digest, sigs) in sigs {
-            // User signatures are written in the same batch as consensus certificate
+            // User signatures are written in the same batch as consensus transaction
             // processed flag, which means we won't attempt to insert this twice
             // for the same tx digest
             assert!(
@@ -3366,7 +3372,7 @@ impl AuthorityPerEpochStore {
                 shared_object_using_randomness_congestion_tracker,
             )
             .await?;
-        self.finish_consensus_certificate_process(&verified_transactions);
+        self.finish_consensus_transaction_process(&verified_transactions);
         output.record_consensus_commit_stats(consensus_stats.clone());
 
         let mut verified_transactions = verified_transactions;
@@ -3681,10 +3687,10 @@ impl AuthorityPerEpochStore {
         }
     }
 
-    /// Depending on the type of the VerifiedSequencedConsensusTransaction
+    /// Depending on the type of the `VerifiedSequencedConsensusTransaction`
     /// wrappers,
-    /// - Verify and initialize the state to execute the certificates. Return
-    ///   VerifiedCertificates for each executable certificate
+    /// - Verify and initialize the state to execute the transactions. Return
+    ///   `VerifiedExecutableTransaction` for each executable transaction
     /// - Or update the state for checkpoint or epoch change protocol.
     #[instrument("process_consensus_transactions", level = "trace", skip_all)]
     #[expect(clippy::type_complexity)]
@@ -3717,7 +3723,7 @@ impl AuthorityPerEpochStore {
         }
 
         let mut sequenced_transactions = Vec::with_capacity(transactions.len());
-        let mut verified_certificates = VecDeque::with_capacity(transactions.len() + 1);
+        let mut verified_transactions = VecDeque::with_capacity(transactions.len() + 1);
         let mut notifications = Vec::with_capacity(transactions.len());
 
         let mut deferred_txns: BTreeMap<DeferralKey, Vec<DeferredTransaction>> = BTreeMap::new();
@@ -3810,7 +3816,7 @@ impl AuthorityPerEpochStore {
                     suggested_gas_price,
                 } => {
                     // Note: record_consensus_message_processed() must be called for this
-                    // cert even though we are not processing it now!
+                    // transaction even though we are not processing it now!
                     deferred_txns
                         .entry(deferral_key)
                         .or_default()
@@ -3822,11 +3828,15 @@ impl AuthorityPerEpochStore {
                         notifications.push(key.clone());
                     }
                 }
-                ConsensusTransactionResult::Cancelled((cert, reason)) => {
+                ConsensusTransactionResult::Cancelled((transaction, reason)) => {
                     notifications.push(key.clone());
-                    assert!(cancelled_txns.insert(*cert.digest(), reason).is_none());
+                    assert!(
+                        cancelled_txns
+                            .insert(*transaction.digest(), reason)
+                            .is_none()
+                    );
                     sequenced_transactions.push((
-                        cert,
+                        transaction,
                         shared_object_congestion_tracker.max_occupied_slot_end_time(),
                     ));
                 }
@@ -3861,10 +3871,10 @@ impl AuthorityPerEpochStore {
         }
 
         // sort the sequenced transactions based on their start_time from the
-        // sequencing result and add these to the verified_certificates.
+        // sequencing result and add these to the `verified_transactions`.
         sequenced_transactions.sort_by_key(|(_, start_time)| *start_time);
         for (tx, _) in sequenced_transactions {
-            verified_certificates.push_back(tx);
+            verified_transactions.push_back(tx);
         }
         let commit_has_deferred_txns = !deferred_txns.is_empty();
         let mut total_deferred_txns = 0;
@@ -3941,19 +3951,19 @@ impl AuthorityPerEpochStore {
         }
 
         // Add the consensus commit prologue transaction to the beginning of
-        // `verified_certificates`.
+        // `verified_transactions`.
         let consensus_commit_prologue_root = self.add_consensus_commit_prologue_transaction(
             output,
-            &mut verified_certificates,
+            &mut verified_transactions,
             consensus_commit_info,
             &cancelled_txns,
         )?;
 
-        let verified_certificates: Vec<_> = verified_certificates.into();
+        let verified_transactions: Vec<_> = verified_transactions.into();
 
         self.process_consensus_transaction_shared_object_versions(
             cache_reader,
-            &verified_certificates,
+            &verified_transactions,
             randomness_round,
             &cancelled_txns,
             output,
@@ -3966,7 +3976,7 @@ impl AuthorityPerEpochStore {
         )?;
 
         Ok((
-            verified_certificates,
+            verified_transactions,
             notifications,
             lock,
             final_round,
@@ -4141,28 +4151,28 @@ impl AuthorityPerEpochStore {
                 // Safe because signatures are verified when consensus called into
                 // IotaTxValidator::validate_batch.
                 let certificate = VerifiedCertificate::new_unchecked(*certificate.clone());
-                let certificate = VerifiedExecutableTransaction::new_from_certificate(certificate);
+                let transaction = VerifiedExecutableTransaction::new_from_certificate(certificate);
 
                 debug!(
                     ?tracking_id,
-                    tx_digest = ?certificate.digest(),
+                    tx_digest = ?transaction.digest(),
                     "handle_consensus_transaction UserTransaction",
                 );
 
                 if !self
                     .get_reconfig_state_read_lock_guard()
                     .should_accept_consensus_certs()
-                    && !previously_deferred_tx_digests.contains_key(certificate.digest())
+                    && !previously_deferred_tx_digests.contains_key(transaction.digest())
                 {
                     debug!(
                         "Ignoring consensus certificate for transaction {:?} because of end of epoch",
-                        certificate.digest()
+                        transaction.digest()
                     );
                     return Ok(ConsensusTransactionResult::Ignored);
                 }
 
                 let scheduling_result = self.try_schedule(
-                    &certificate,
+                    &transaction,
                     commit_round,
                     dkg_failed,
                     generating_randomness,
@@ -4172,7 +4182,7 @@ impl AuthorityPerEpochStore {
 
                 self.handle_scheduling_result(
                     scheduling_result,
-                    certificate,
+                    transaction,
                     previously_deferred_tx_digests,
                     dkg_failed,
                     shared_object_congestion_tracker,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2342,13 +2342,7 @@ impl AuthorityPerEpochStore {
                     self.pending_consensus_certificates.write().remove(cert);
                 }
             }
-            // NOTE: We do not need the
-            // `ConsensusTransactionKey::UserTransaction` branch
-            // (certificate-less scenario) here because `UserTransactionV1` are
-            // not inserted into
-            // `self.pending_consensus_certificates`.
         }
-        Ok(())
     }
 
     pub fn pending_consensus_certificates_count(&self) -> usize {

--- a/crates/iota-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/iota-core/src/authority/shared_object_congestion_tracker.rs
@@ -372,22 +372,22 @@ impl SharedObjectCongestionTracker {
     /// be scheduled, this returns a `start_time`, and if it should be deferred,
     /// this returns the deferral key and the congested objects responsible for
     /// the deferral.
-    #[instrument(level = "trace", skip_all, fields(cert_digest = ?cert.digest()))]
+    #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
     pub(super) fn try_schedule(
         &self,
-        cert: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
         commit_round: CommitRound,
     ) -> SequencingResult {
         let tx_duration = self
             .congestion_control_parameters
-            .get_estimated_execution_duration(cert);
+            .get_estimated_execution_duration(transaction);
         if tx_duration == 0 {
             // This is a zero-duration transaction, no need to defer.
             return SequencingResult::Schedule(0);
         }
 
-        let shared_input_objects = cert.shared_input_objects();
+        let shared_input_objects = transaction.shared_input_objects();
         if shared_input_objects.is_empty() {
             // This is an owned object only transaction. No need to defer.
             return SequencingResult::Schedule(0);
@@ -445,7 +445,7 @@ impl SharedObjectCongestionTracker {
         assert!(!congested_objects.is_empty());
 
         let deferral_key = if let Some(previous_key_suggested_gas_price_pair) =
-            previously_deferred_tx_digests.get(cert.digest())
+            previously_deferred_tx_digests.get(transaction.digest())
         {
             // This transaction has been deferred in previous consensus commit. Use its
             // previous deferred_from_round.
@@ -463,23 +463,23 @@ impl SharedObjectCongestionTracker {
         SequencingResult::Defer(deferral_key, congested_objects)
     }
 
-    /// Update shared objects' execution slots used in `cert` using `cert`'s
-    /// estimated execution duration. This is called when `cert` is scheduled
-    /// for execution.
+    /// Update shared objects' execution slots used in `transaction` using
+    /// `transaction`'s estimated execution duration. This is called when
+    /// `transaction` is scheduled for execution.
     ///
     /// `start_time` provides the start time of the execution slot assigned to
-    /// `cert`.
+    /// `transaction`.
     ///
-    /// Returns `Some(BumpObjectExecutionSlotsResult)` if `cert`'s estimated
-    /// execution duration is non-zero, else returns `None`.
+    /// Returns `Some(BumpObjectExecutionSlotsResult)` if `transaction`'s
+    /// estimated execution duration is non-zero, else returns `None`.
     pub(super) fn bump_object_execution_slots(
         &mut self,
-        cert: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         start_time: ExecutionTime,
     ) -> Option<BumpObjectExecutionSlotsResult> {
         let estimated_execution_duration = self
             .congestion_control_parameters
-            .get_estimated_execution_duration(cert);
+            .get_estimated_execution_duration(transaction);
 
         if estimated_execution_duration == 0 {
             return None;
@@ -489,7 +489,7 @@ impl SharedObjectCongestionTracker {
         let occupied_slot = ExecutionSlot::new(start_time, end_time);
 
         // Find IDs of shared objects for which execution slots should be bumped.
-        let object_ids = cert
+        let object_ids = transaction
             .shared_input_objects()
             .into_iter()
             .filter_map(|obj| obj.mutable.then_some(obj.id))
@@ -506,7 +506,7 @@ impl SharedObjectCongestionTracker {
             object_ids,
             start_time,
             estimated_execution_duration,
-            cert.transaction_data().gas_price(),
+            transaction.transaction_data().gas_price(),
         ))
     }
 
@@ -771,8 +771,8 @@ pub mod shared_object_test_utils {
 
     pub const TEST_ONLY_GAS_PRICE: u64 = 1_000;
 
-    /// Builds a certificate with a list of shared objects and their mutability.
-    /// The certificate is only used to test the
+    /// Builds a transaction with a list of shared objects and their mutability.
+    /// The transaction is only used to test the
     /// `SharedObjectCongestionTracker` functions, therefore the content
     /// other than shared inputs, gas budget and gas price are not
     /// important.
@@ -819,14 +819,14 @@ pub mod shared_object_test_utils {
 
     pub(super) fn initialize_tracker_and_try_schedule(
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
-        cert: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
         commit_round: CommitRound,
     ) -> SequencingResult {
-        let shared_input_objects = cert.shared_input_objects();
+        let shared_input_objects = transaction.shared_input_objects();
         shared_object_congestion_tracker.initialize_object_execution_slots(&shared_input_objects);
         shared_object_congestion_tracker.try_schedule(
-            cert,
+            transaction,
             previously_deferred_tx_digests,
             commit_round,
         )
@@ -1367,22 +1367,22 @@ mod object_cost_tests {
         );
 
         // Read two objects should not change the object execution slots.
-        let cert = build_transaction(
+        let transaction = build_transaction(
             &[(object_id_0, false), (object_id_1, false)],
             10,
             TEST_ONLY_GAS_PRICE,
         );
-        let cert_duration = shared_object_congestion_tracker
+        let tx_duration = shared_object_congestion_tracker
             .congestion_control_parameters
-            .get_estimated_execution_duration(&cert);
+            .get_estimated_execution_duration(&transaction);
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
-            &cert.shared_input_objects(),
-            cert_duration,
+            &transaction.shared_input_objects(),
+            tx_duration,
         )
         .expect("start time should be computable");
 
-        shared_object_congestion_tracker.bump_object_execution_slots(&cert, start_time);
+        shared_object_congestion_tracker.bump_object_execution_slots(&transaction, start_time);
         assert_eq!(
             shared_object_congestion_tracker,
             new_congestion_tracker_with_initial_value_for_test(
@@ -1397,21 +1397,21 @@ mod object_cost_tests {
 
         // Write to object 0 should only bump object 0's execution slots. The start time
         // should be object 1's duration.
-        let cert = build_transaction(
+        let transaction = build_transaction(
             &[(object_id_0, true), (object_id_1, false)],
             10,
             TEST_ONLY_GAS_PRICE,
         );
-        let cert_duration = shared_object_congestion_tracker
+        let tx_duration = shared_object_congestion_tracker
             .congestion_control_parameters
-            .get_estimated_execution_duration(&cert);
+            .get_estimated_execution_duration(&transaction);
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
-            &cert.shared_input_objects(),
-            cert_duration,
+            &transaction.shared_input_objects(),
+            tx_duration,
         )
         .expect("start time should be computable");
-        shared_object_congestion_tracker.bump_object_execution_slots(&cert, start_time);
+        shared_object_congestion_tracker.bump_object_execution_slots(&transaction, start_time);
         let expected_object_0_duration = match mode {
             PerObjectCongestionControlMode::None => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => 20,
@@ -1440,7 +1440,7 @@ mod object_cost_tests {
 
         // Write to all objects should bump all objects' execution durations, including
         // objects that are seen for the first time.
-        let cert = build_transaction(
+        let transaction = build_transaction(
             &[
                 (object_id_0, true),
                 (object_id_1, true),
@@ -1454,16 +1454,16 @@ mod object_cost_tests {
             PerObjectCongestionControlMode::TotalGasBudget => 30,
             PerObjectCongestionControlMode::TotalTxCount => 12,
         };
-        let cert_duration = shared_object_congestion_tracker
+        let tx_duration = shared_object_congestion_tracker
             .congestion_control_parameters
-            .get_estimated_execution_duration(&cert);
+            .get_estimated_execution_duration(&transaction);
         let start_time = initialize_tracker_and_compute_tx_start_time(
             &mut shared_object_congestion_tracker,
-            &cert.shared_input_objects(),
-            cert_duration,
+            &transaction.shared_input_objects(),
+            tx_duration,
         )
         .expect("start time should be computable");
-        shared_object_congestion_tracker.bump_object_execution_slots(&cert, start_time);
+        shared_object_congestion_tracker.bump_object_execution_slots(&transaction, start_time);
         assert_eq!(
             shared_object_congestion_tracker
                 .object_execution_slots
@@ -1587,14 +1587,14 @@ mod object_cost_tests {
             panic!("transaction is congesting, should defer");
         }
 
-        let cert_duration = shared_object_congestion_tracker
+        let tx_duration = shared_object_congestion_tracker
             .congestion_control_parameters
             .get_estimated_execution_duration(&tx);
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,
                 &tx.shared_input_objects(),
-                cert_duration,
+                tx_duration,
             )
             .is_none()
         );
@@ -1641,14 +1641,14 @@ mod object_cost_tests {
             panic!("case 2: object 2 is congested, should defer");
         }
 
-        let cert_duration = shared_object_congestion_tracker
+        let tx_duration = shared_object_congestion_tracker
             .congestion_control_parameters
             .get_estimated_execution_duration(&tx);
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,
                 &tx.shared_input_objects(),
-                cert_duration,
+                tx_duration,
             )
             .is_none()
         );
@@ -1679,14 +1679,14 @@ mod object_cost_tests {
             panic!("case 3: object 0 is congested, should defer");
         }
 
-        let cert_duration = shared_object_congestion_tracker
+        let tx_duration = shared_object_congestion_tracker
             .congestion_control_parameters
             .get_estimated_execution_duration(&tx);
         assert!(
             initialize_tracker_and_compute_tx_start_time(
                 &mut shared_object_congestion_tracker,
                 &tx.shared_input_objects(),
-                cert_duration,
+                tx_duration,
             )
             .is_none()
         );

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -41,12 +41,12 @@ impl SharedObjVerManager {
     pub fn assign_versions_from_consensus(
         epoch_store: &AuthorityPerEpochStore,
         cache_reader: &dyn ObjectCacheRead,
-        certificates: &[VerifiedExecutableTransaction],
+        transactions: &[VerifiedExecutableTransaction],
         randomness_round: Option<RandomnessRound>,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusTransactionReason>,
     ) -> IotaResult<ConsensusSharedObjVerAssignment> {
         let mut shared_input_next_versions = get_or_init_versions(
-            certificates.iter().map(|cert| cert.data()),
+            transactions.iter().map(|tx| tx.data()),
             epoch_store,
             cache_reader,
             randomness_round.is_some(),
@@ -71,19 +71,19 @@ impl SharedObjVerManager {
             ));
             version.increment();
         }
-        for cert in certificates {
-            if !cert.contains_shared_object() {
+        for transaction in transactions {
+            if !transaction.contains_shared_object() {
                 continue;
             }
-            let cert_assigned_versions = Self::assign_versions_for_certificate(
-                cert,
+            let tx_assigned_versions = Self::assign_versions_for_transaction(
+                transaction,
                 &mut shared_input_next_versions,
                 cancelled_txns,
                 epoch_store
                     .protocol_config()
                     .congestion_control_gas_price_feedback_mechanism(),
             );
-            assigned_versions.push((cert.key(), cert_assigned_versions));
+            assigned_versions.push((transaction.key(), tx_assigned_versions));
         }
 
         Ok(ConsensusSharedObjVerAssignment {
@@ -93,7 +93,7 @@ impl SharedObjVerManager {
     }
 
     pub fn assign_versions_from_effects(
-        certs_and_effects: &[(&VerifiedExecutableTransaction, &TransactionEffects)],
+        transactions_and_effects: &[(&VerifiedExecutableTransaction, &TransactionEffects)],
         epoch_store: &AuthorityPerEpochStore,
         cache_reader: &dyn ObjectCacheRead,
     ) -> AssignedTxAndVersions {
@@ -106,36 +106,36 @@ impl SharedObjVerManager {
         // done before we mutate it the first time, otherwise we would be initializing
         // it with the wrong version.
         let _ = get_or_init_versions(
-            certs_and_effects.iter().map(|(cert, _)| cert.data()),
+            transactions_and_effects.iter().map(|(tx, _)| tx.data()),
             epoch_store,
             cache_reader,
             false,
         );
         let mut assigned_versions = Vec::new();
-        for (cert, effects) in certs_and_effects {
-            let cert_assigned_versions: Vec<_> = effects
+        for (transaction, effects) in transactions_and_effects {
+            let tx_assigned_versions: Vec<_> = effects
                 .input_shared_objects()
                 .into_iter()
                 .map(|iso| iso.id_and_version())
                 .collect();
-            let tx_key = cert.key();
+            let tx_key = transaction.key();
             trace!(
                 ?tx_key,
-                ?cert_assigned_versions,
+                ?tx_assigned_versions,
                 "locking shared objects from effects"
             );
-            assigned_versions.push((tx_key, cert_assigned_versions));
+            assigned_versions.push((tx_key, tx_assigned_versions));
         }
         assigned_versions
     }
 
-    pub fn assign_versions_for_certificate(
-        cert: &VerifiedExecutableTransaction,
+    pub fn assign_versions_for_transaction(
+        transaction: &VerifiedExecutableTransaction,
         shared_input_next_versions: &mut HashMap<ObjectID, SequenceNumber>,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusTransactionReason>,
         enable_gas_price_feedback: bool,
     ) -> Vec<(ObjectID, SequenceNumber)> {
-        let tx_digest = cert.digest();
+        let tx_digest = transaction.digest();
 
         // Check if the transaction is cancelled due to congestion.
         let cancellation_info = cancelled_txns.get(tx_digest);
@@ -152,14 +152,14 @@ impl SharedObjVerManager {
         let txn_cancelled = cancellation_info.is_some();
 
         // Make an iterator to update the locks of the transaction's shared objects.
-        let shared_input_objects = cert.shared_input_objects();
+        let shared_input_objects = transaction.shared_input_objects();
 
-        let mut input_object_keys = transaction_non_shared_input_object_keys(cert)
+        let mut input_object_keys = transaction_non_shared_input_object_keys(transaction)
             .expect("Transaction input should have been verified");
         let mut assigned_versions = Vec::with_capacity(shared_input_objects.len());
         let mut is_mutable_input = Vec::with_capacity(shared_input_objects.len());
         // Record receiving object versions towards the shared version computation.
-        let receiving_object_keys = transaction_receiving_object_keys(cert);
+        let receiving_object_keys = transaction_receiving_object_keys(transaction);
         input_object_keys.extend(receiving_object_keys);
 
         if txn_cancelled {
@@ -330,7 +330,7 @@ mod tests {
             .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
             .await;
-        let certs = vec![
+        let transactions = vec![
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, false)], 5),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 9),
@@ -343,7 +343,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
+            &transactions,
             None,
             &BTreeMap::new(),
         )
@@ -363,15 +363,24 @@ mod tests {
         // Check that the version assignment for each transaction is correct.
         // For a transaction that uses the shared object with mutable=false, it won't
         // update the version using lamport version, hence the next transaction
-        // will use the same version number. In the following case, certs[2] has
-        // the same assignment as certs[1] for this reason.
+        // will use the same version number. In the following case, transactions[2] has
+        // the same assignment as transactions[1] for this reason.
         assert_eq!(
             assigned_versions,
             vec![
-                (certs[0].key(), vec![(id, init_shared_version),]),
-                (certs[1].key(), vec![(id, SequenceNumber::from_u64(4)),]),
-                (certs[2].key(), vec![(id, SequenceNumber::from_u64(4)),]),
-                (certs[3].key(), vec![(id, SequenceNumber::from_u64(10)),]),
+                (transactions[0].key(), vec![(id, init_shared_version),]),
+                (
+                    transactions[1].key(),
+                    vec![(id, SequenceNumber::from_u64(4)),]
+                ),
+                (
+                    transactions[2].key(),
+                    vec![(id, SequenceNumber::from_u64(4)),]
+                ),
+                (
+                    transactions[3].key(),
+                    vec![(id, SequenceNumber::from_u64(10)),]
+                ),
             ]
         );
     }
@@ -383,7 +392,7 @@ mod tests {
         let randomness_obj_version = epoch_store
             .epoch_start_config()
             .randomness_obj_initial_shared_version();
-        let certs = vec![
+        let transactions = vec![
             generate_shared_objs_tx_with_gas_version(
                 &[(
                     IOTA_RANDOMNESS_STATE_OBJECT_ID,
@@ -409,7 +418,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
+            &transactions,
             Some(RandomnessRound::new(1)),
             &BTreeMap::new(),
         )
@@ -435,13 +444,13 @@ mod tests {
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, randomness_obj_version),]
                 ),
                 (
-                    certs[0].key(),
+                    transactions[0].key(),
                     // It is critical that the randomness object version is updated before the
                     // assignment.
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, next_randomness_obj_version)]
                 ),
                 (
-                    certs[1].key(),
+                    transactions[1].key(),
                     // It is critical that the randomness object version is updated before the
                     // assignment.
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, next_randomness_obj_version)]
@@ -496,7 +505,7 @@ mod tests {
         // lamport version = 10 due to gas object version = 9   tx5: shared
         // objects assign cancelled version, lamport version = 12 due to gas object
         // version = 11
-        let certs = vec![
+        let transactions = vec![
             generate_shared_objs_tx_with_gas_version(
                 &[
                     (id1, init_shared_version_1, true),
@@ -537,21 +546,21 @@ mod tests {
         let suggested_gas_price = 1_000;
         let cancelled_txns: BTreeMap<TransactionDigest, CancelConsensusTransactionReason> = [
             (
-                *certs[1].digest(),
+                *transactions[1].digest(),
                 CancelConsensusTransactionReason::CongestionOnObjects {
                     congested_objects: vec![id1],
                     suggested_gas_price: Some(suggested_gas_price),
                 },
             ),
             (
-                *certs[3].digest(),
+                *transactions[3].digest(),
                 CancelConsensusTransactionReason::CongestionOnObjects {
                     congested_objects: vec![id2],
                     suggested_gas_price: Some(suggested_gas_price),
                 },
             ),
             (
-                *certs[4].digest(),
+                *transactions[4].digest(),
                 CancelConsensusTransactionReason::DkgFailed,
             ),
         ]
@@ -565,7 +574,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
+            &transactions,
             None,
             &cancelled_txns,
         )
@@ -587,11 +596,11 @@ mod tests {
             assigned_versions,
             vec![
                 (
-                    certs[0].key(),
+                    transactions[0].key(),
                     vec![(id1, init_shared_version_1), (id2, init_shared_version_2)]
                 ),
                 (
-                    certs[1].key(),
+                    transactions[1].key(),
                     vec![
                         (
                             id1,
@@ -602,9 +611,12 @@ mod tests {
                         (id2, SequenceNumber::CANCELLED_READ),
                     ]
                 ),
-                (certs[2].key(), vec![(id1, SequenceNumber::from_u64(4)),]),
                 (
-                    certs[3].key(),
+                    transactions[2].key(),
+                    vec![(id1, SequenceNumber::from_u64(4)),]
+                ),
+                (
+                    transactions[3].key(),
                     vec![
                         (id1, SequenceNumber::CANCELLED_READ),
                         (
@@ -616,7 +628,7 @@ mod tests {
                     ]
                 ),
                 (
-                    certs[4].key(),
+                    transactions[4].key(),
                     vec![
                         (
                             IOTA_RANDOMNESS_STATE_OBJECT_ID,
@@ -644,27 +656,27 @@ mod tests {
             .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
             .await;
-        let certs = [
+        let transactions = [
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, false)], 5),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 9),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 11),
         ];
         let effects = [
-            TestEffectsBuilder::new(certs[0].data()).build(),
-            TestEffectsBuilder::new(certs[1].data())
+            TestEffectsBuilder::new(transactions[0].data()).build(),
+            TestEffectsBuilder::new(transactions[1].data())
                 .with_shared_input_versions(BTreeMap::from([(id, SequenceNumber::from_u64(4))]))
                 .build(),
-            TestEffectsBuilder::new(certs[2].data())
+            TestEffectsBuilder::new(transactions[2].data())
                 .with_shared_input_versions(BTreeMap::from([(id, SequenceNumber::from_u64(4))]))
                 .build(),
-            TestEffectsBuilder::new(certs[3].data())
+            TestEffectsBuilder::new(transactions[3].data())
                 .with_shared_input_versions(BTreeMap::from([(id, SequenceNumber::from_u64(10))]))
                 .build(),
         ];
         let epoch_store = authority.epoch_store_for_testing();
         let assigned_versions = SharedObjVerManager::assign_versions_from_effects(
-            certs
+            transactions
                 .iter()
                 .zip(effects.iter())
                 .collect::<Vec<_>>()
@@ -681,10 +693,19 @@ mod tests {
         assert_eq!(
             assigned_versions,
             vec![
-                (certs[0].key(), vec![(id, init_shared_version),]),
-                (certs[1].key(), vec![(id, SequenceNumber::from_u64(4)),]),
-                (certs[2].key(), vec![(id, SequenceNumber::from_u64(4)),]),
-                (certs[3].key(), vec![(id, SequenceNumber::from_u64(10)),]),
+                (transactions[0].key(), vec![(id, init_shared_version),]),
+                (
+                    transactions[1].key(),
+                    vec![(id, SequenceNumber::from_u64(4)),]
+                ),
+                (
+                    transactions[2].key(),
+                    vec![(id, SequenceNumber::from_u64(4)),]
+                ),
+                (
+                    transactions[3].key(),
+                    vec![(id, SequenceNumber::from_u64(10)),]
+                ),
             ]
         );
     }

--- a/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
+++ b/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
@@ -117,7 +117,7 @@ impl SuggestedGasPriceCalculator {
     /// only be called for scheduled transactions that contain shared object(s);
     /// otherwise, the calculator might wrongly calculate suggested gas price.
     /// `bump_object_execution_slots_result` is the outcome of the
-    /// [`bump_object_execution_slots`] of `SharedObjectCongestionTracker`.
+    /// `bump_object_execution_slots` of `SharedObjectCongestionTracker`.
     pub(super) fn update_congestion_info(
         &mut self,
         bump_object_execution_slots_result: Option<BumpObjectExecutionSlotsResult>,

--- a/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
+++ b/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
@@ -46,24 +46,24 @@ type PerCommitCongestionInfo = HashMap<ObjectID, PerObjectCongestionInfo>;
 /// info from a single consensus commit.
 ///
 /// The congestion info stored by the calculator should only be updated
-/// for scheduled certificates. In contrast, calculations of the suggested
-/// gas price should only be invoked for deferred/cancelled certificates.
+/// for scheduled transactions. In contrast, calculations of the suggested
+/// gas price should only be invoked for deferred/cancelled transactions.
 ///
 /// Roughly speaking, the suggested gas price calculator works as follows:
-/// 1. For every scheduled certificate, obtain its reference gas price,
+/// 1. For every scheduled transaction, obtain its reference gas price,
 ///    execution start time and estimated execution duration.
 /// 2. For every input shared object accessed mutably by the scheduled
 ///    transaction, keep and update a map, ordered by execution start time
-///    (key), whose values store scheduled certificate's gas price and estimated
+///    (key), whose values store scheduled transaction's gas price and estimated
 ///    execution duration.
-/// 3. For every deferred/cancelled certificate, obtain its estimated execution
+/// 3. For every deferred/cancelled transaction, obtain its estimated execution
 ///    duration, as well as all input shared objects.
-/// 4. Calculate a suggested gas price for the deferred/cancelled certificate as
+/// 4. Calculate a suggested gas price for the deferred/cancelled transaction as
 ///    follows:
 ///    - compute its (imaginary) execution start time as congestion limit per
 ///      commit minus its estimated execution duration;
 ///    - for each input shared object, get the maximum gas price over scheduled
-///      certificates whose end execution time is larger than our imaginary
+///      transactions whose end execution time is larger than our imaginary
 ///      start time;
 ///    - take the maximum over the values obtained in the previous step;
 ///    - the suggested gas price equals the maximum value obtained in the
@@ -113,8 +113,8 @@ impl SuggestedGasPriceCalculator {
         }
     }
 
-    /// Update per-commit congestion info for a single certificate. This should
-    /// only be called for scheduled certificates that contain shared object(s);
+    /// Update per-commit congestion info for a single transaction. This should
+    /// only be called for scheduled transactions that contain shared object(s);
     /// otherwise, the calculator might wrongly calculate suggested gas price.
     /// `bump_object_execution_slots_result` is the outcome of the
     /// [`bump_object_execution_slots`] of `SharedObjectCongestionTracker`.
@@ -158,19 +158,19 @@ impl SuggestedGasPriceCalculator {
         }
     }
 
-    /// Calculate a suggested gas price for a deferred/cancelled `certificate`
+    /// Calculate a suggested gas price for a deferred/cancelled `transaction`
     /// using the single-commit congestion info held by the calculator. This
-    /// should only be called for certificates deferred/cancelled due to
+    /// should only be called for transaction deferred/cancelled due to
     /// shared object congestion; otherwise, there is a risk of panic.
     #[instrument(level = "trace", skip_all)]
     pub(super) fn calculate_suggested_gas_price(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
     ) -> u64 {
         if let Some(congestion_limit_per_commit) = self.get_effective_congestion_limit_per_commit()
         {
             let clearing_gas_price =
-                self.find_clearing_gas_price(certificate, congestion_limit_per_commit);
+                self.find_clearing_gas_price(transaction, congestion_limit_per_commit);
 
             // Suggested gas price equals `clearing_gas_price + 1`. We add 1 to make this
             // transaction would be scheduled if the same commit structure was repeated.
@@ -206,26 +206,26 @@ impl SuggestedGasPriceCalculator {
         }
     }
 
-    /// Find the gas price for which a deferred/scheduled certificate would be
+    /// Find the gas price for which a deferred/scheduled transaction would be
     /// scheduled if (i) that gas price was paid, and (ii) if exactly the same
     /// set of transactions appeared in a commit.
     fn find_clearing_gas_price(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        transaction: &VerifiedExecutableTransaction,
         congestion_limit_per_commit: ExecutionTime,
     ) -> Option<u64> {
-        // Imaginary start time of the deferred/cancelled certificate. We consider
+        // Imaginary start time of the deferred/cancelled transaction. We consider
         // only the highest possible (but sufficient for scheduling) start time as
-        // it is very likely that scheduled certificates with lower gas prices
+        // it is very likely that scheduled transactions with lower gas prices
         // appear have higher start times. If a transaction with its estimated
         // execution duration cannot fit within `congestion_limit_per_commit`,
         // set its imaginary start time to 0.
-        let start_time_of_deferred_cert = congestion_limit_per_commit.saturating_sub(
+        let start_time_of_deferred_tx = congestion_limit_per_commit.saturating_sub(
             self.congestion_control_parameters
-                .get_estimated_execution_duration(certificate),
+                .get_estimated_execution_duration(transaction),
         );
 
-        certificate
+        transaction
             .shared_input_objects()
             .into_iter()
             .filter_map(|object| {
@@ -235,30 +235,29 @@ impl SuggestedGasPriceCalculator {
                         per_object_congestion_info
                             .iter()
                             .filter_map(|(execution_start_time, tx_congestion_info)| {
-                                let end_time_of_scheduled_cert = execution_start_time
-                                    .saturating_add(
-                                        tx_congestion_info.estimated_execution_duration,
-                                    );
+                                let end_time_of_scheduled_tx = execution_start_time.saturating_add(
+                                    tx_congestion_info.estimated_execution_duration,
+                                );
 
-                                if end_time_of_scheduled_cert > start_time_of_deferred_cert {
-                                    // Store gas price of that scheduled certificate
+                                if end_time_of_scheduled_tx > start_time_of_deferred_tx {
+                                    // Store gas price of that scheduled transaction
                                     Some(tx_congestion_info.gas_price)
                                 } else {
                                     None
                                 }
                             })
-                            // Take the maximum over all found gas prices of scheduled certificates
+                            // Take the maximum over all found gas prices of scheduled transactions
                             // whose execution end time is larger than the imaginary start time
                             // of the deferred/cancelled transaction. It has to be maximum here
                             // since otherwise the suggested gas price will be insufficient to
-                            // guarantee scheduling if the same set of certificates was repeated
+                            // guarantee scheduling if the same set of transactions was repeated
                             // again in a commit.
                             .max()
                     })
             })
             // Take the maximum over all input shared objects, as we need to consider the
             // "worst-case" (most congested) object; otherwise, the suggested gas price
-            // will be insufficient to guarantee scheduling if the same set of certificates
+            // will be insufficient to guarantee scheduling if the same set of transactions
             // was repeated again in a commit.
             .max()
     }
@@ -297,12 +296,12 @@ pub mod suggested_gas_price_calculator_test_utils {
             match congestion_control_parameters.per_object_congestion_control_mode_for_test() {
                 PerObjectCongestionControlMode::None => {}
                 PerObjectCongestionControlMode::TotalGasBudget => {
-                    let certificate =
+                    let transaction =
                         build_transaction(&[(*object_id, true)], *duration, *gas_price);
 
                     let execution_start_time = initialize_tracker_and_compute_tx_start_time(
                         &mut shared_object_congestion_tracker,
-                        &certificate.shared_input_objects(),
+                        &transaction.shared_input_objects(),
                         *duration,
                     )
                     .expect(
@@ -311,19 +310,19 @@ pub mod suggested_gas_price_calculator_test_utils {
                     );
 
                     let bump_result = shared_object_congestion_tracker
-                        .bump_object_execution_slots(&certificate, execution_start_time);
+                        .bump_object_execution_slots(&transaction, execution_start_time);
 
                     suggested_gas_price_calculator.update_congestion_info(bump_result);
                 }
                 PerObjectCongestionControlMode::TotalTxCount => {
                     let tx_duration = 1; // since this is TotalTxCount mode
                     for _ in 0..*duration {
-                        let certificate =
+                        let transaction =
                             build_transaction(&[(*object_id, true)], tx_duration, *gas_price);
 
                         let execution_start_time = initialize_tracker_and_compute_tx_start_time(
                             &mut shared_object_congestion_tracker,
-                            &certificate.shared_input_objects(),
+                            &transaction.shared_input_objects(),
                             tx_duration,
                         )
                         .expect(
@@ -332,7 +331,7 @@ pub mod suggested_gas_price_calculator_test_utils {
                         );
 
                         let bump_result = shared_object_congestion_tracker
-                            .bump_object_execution_slots(&certificate, execution_start_time);
+                            .bump_object_execution_slots(&transaction, execution_start_time);
 
                         suggested_gas_price_calculator.update_congestion_info(bump_result);
                     }
@@ -410,58 +409,58 @@ mod tests {
         .collect()
     }
 
-    /// Helper function for tests to build a certificate with `tx_data` and
+    /// Helper function for tests to build a transaction with `tx_data` and
     /// then try sequencing it by `shared_object_congestion_tracker`.
-    /// Returns the certificate itself and a result of its sequencing.
-    fn build_and_try_sequencing_certificate(
+    /// Returns the transaction itself and a result of its sequencing.
+    fn build_and_try_sequencing_transaction(
         tx_data: &TransactionData,
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
     ) -> (VerifiedExecutableTransaction, SequencingResult) {
-        let certificate = build_transaction(
+        let transaction = build_transaction(
             &tx_data.input_shared_objects,
             tx_data.gas_budget,
             tx_data.gas_price,
         );
-        let shared_input_objects = certificate.shared_input_objects();
+        let shared_input_objects = transaction.shared_input_objects();
         shared_object_congestion_tracker.initialize_object_execution_slots(&shared_input_objects);
 
         let sequencing_result = shared_object_congestion_tracker.try_schedule(
-            &certificate,
+            &transaction,
             // The remaining inputs are not important for these tests
             &HashMap::new(),
             0,
         );
 
-        (certificate, sequencing_result)
+        (transaction, sequencing_result)
     }
 
     /// Helper function for tests to update data internally stored by
     /// `shared_object_congestion_tracker` and `suggested_gas_price_calculator`
-    /// for a `certificate` scheduled at `execution_start_time`.
-    fn update_data_for_scheduled_certificate(
-        certificate: &VerifiedExecutableTransaction,
+    /// for a `transaction` scheduled at `execution_start_time`.
+    fn update_data_for_scheduled_transaction(
+        transaction: &VerifiedExecutableTransaction,
         execution_start_time: ExecutionTime,
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
         suggested_gas_price_calculator: &mut SuggestedGasPriceCalculator,
     ) {
         let bump_result = shared_object_congestion_tracker
-            .bump_object_execution_slots(certificate, execution_start_time);
+            .bump_object_execution_slots(transaction, execution_start_time);
         suggested_gas_price_calculator.update_congestion_info(bump_result);
     }
 
-    /// Helper function to test if a certificate with and `tx_data` is
-    /// scheduled. Returns execution start time of the certificate if
+    /// Helper function to test if a transaction with and `tx_data` is
+    /// scheduled. Returns execution start time of the transaction if
     /// it is scheduled, otherwise returns `None`.
     fn try_schedule(
         tx_data: &TransactionData,
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
         suggested_gas_price_calculator: &mut SuggestedGasPriceCalculator,
     ) -> Option<ExecutionTime> {
-        let (certificate, sequencing_result) =
-            build_and_try_sequencing_certificate(tx_data, shared_object_congestion_tracker);
+        let (transaction, sequencing_result) =
+            build_and_try_sequencing_transaction(tx_data, shared_object_congestion_tracker);
         if let SequencingResult::Schedule(execution_start_time) = sequencing_result {
-            update_data_for_scheduled_certificate(
-                &certificate,
+            update_data_for_scheduled_transaction(
+                &transaction,
                 execution_start_time,
                 shared_object_congestion_tracker,
                 suggested_gas_price_calculator,
@@ -473,20 +472,20 @@ mod tests {
         }
     }
 
-    /// Helper function to test if a certificate with and `tx_data` is
+    /// Helper function to test if a transaction with and `tx_data` is
     /// deferred. Returns congested objects and suggested gas price if
-    /// the certificate is deferred, otherwise returns `None`.
+    /// the transaction is deferred, otherwise returns `None`.
     fn try_defer(
         tx_data: &TransactionData,
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
         suggested_gas_price_calculator: &mut SuggestedGasPriceCalculator,
     ) -> Option<(Vec<ObjectID>, u64)> {
-        let (certificate, sequencing_result) =
-            build_and_try_sequencing_certificate(tx_data, shared_object_congestion_tracker);
+        let (transaction, sequencing_result) =
+            build_and_try_sequencing_transaction(tx_data, shared_object_congestion_tracker);
         if let SequencingResult::Defer(_key, congested_objects) = sequencing_result {
             Some((
                 congested_objects,
-                suggested_gas_price_calculator.calculate_suggested_gas_price(&certificate),
+                suggested_gas_price_calculator.calculate_suggested_gas_price(&transaction),
             ))
         } else {
             None
@@ -522,14 +521,14 @@ mod tests {
         let object_4 = ObjectID::random();
         let object_5 = ObjectID::random();
 
-        // Construct the first certificate that touches shared objects:
+        // Construct the first transaction that touches shared objects:
         // - `object_1` by mutable reference,
         // - `object_2` by immutable reference.
         let objects_1 = [(object_1, true), (object_2, false)];
         let gas_price_1 = 1_003;
         let execution_start_time_1 = 0;
         let estimated_execution_duration_1 = 3;
-        // Update the calculator's congestion info for this certificate.
+        // Update the calculator's congestion info for this transaction.
         suggested_gas_price_calculator.update_congestion_info(
             max_execution_duration_per_commit.map(|_| {
                 BumpObjectExecutionSlotsResult::new_for_test(
@@ -566,7 +565,7 @@ mod tests {
             );
         }
 
-        // Construct the second certificate that touches shared objects:
+        // Construct the second transaction that touches shared objects:
         // - `object_2` by mutable reference,
         // - `object_3` by immutable reference,
         // - `object_4` by mutable reference.
@@ -574,7 +573,7 @@ mod tests {
         let gas_price_2 = 1_002;
         let execution_start_time_2 = 1;
         let estimated_execution_duration_2 = 2;
-        // Update the calculator's congestion info for this certificate.
+        // Update the calculator's congestion info for this transaction.
         suggested_gas_price_calculator.update_congestion_info(
             max_execution_duration_per_commit.map(|_| {
                 BumpObjectExecutionSlotsResult::new_for_test(
@@ -629,14 +628,14 @@ mod tests {
             );
         }
 
-        // Construct the third certificate that touches shared objects:
+        // Construct the third transaction that touches shared objects:
         // - `object_4` by immutable reference,
         // - `object_5` by mutable reference.
         let objects_3 = [(object_4, false), (object_5, true)];
         let gas_price_3 = 1_001;
         let execution_start_time_3 = 2;
         let estimated_execution_duration_3 = 1;
-        // Update the calculator's congestion info for this certificate.
+        // Update the calculator's congestion info for this transaction.
         suggested_gas_price_calculator.update_congestion_info(
             max_execution_duration_per_commit.map(|_| {
                 BumpObjectExecutionSlotsResult::new_for_test(
@@ -752,11 +751,11 @@ mod tests {
         // |     object_1     |     object_2     | start time |
         // |__________________|__________________|____________|
         // |------------------|------------------|---- 3 -----|
-        // |                  | cert. 2 (g=8000) |            |
+        // |                  |  tx. 2 (g=8000)  |            |
         // |                  |------------------|---- 2      |
-        // |                  | cert. 1 (g=9000) |            |
+        // |                  |  tx. 1 (g=9000)  |            |
         // |------------------|------------------|---- 1      |
-        // | cert. 0 (g=100K) |                  |            |
+        // |  tx. 0 (g=100K)  |                  |            |
         // |-------------------------------------|---- 0 -----|
         (0..=2).for_each(|i| {
             let tx_data = &txs_data[i];
@@ -782,11 +781,11 @@ mod tests {
         // |     object_1     |     object_2     | start time |
         // |__________________|__________________|____________|
         // |------------------|------------------|---- 3 -----|
-        // |                  | cert. 2 (g=8000) |            |
+        // |                  |  tx. 2 (g=8000)  |            |
         // |                  |------------------|---- 2      |
-        // |                  | cert. 1 (g=9000) |            |
+        // |                  |  tx. 1 (g=9000)  |            |
         // |------------------|------------------|---- 1      |
-        // | cert. 0 (g=100K) | cert. 3 (g=7000) |            |
+        // |  tx. 0 (g=100K)  |  tx. 3 (g=7000)  |            |
         // |-------------------------------------|---- 0 -----|
         // If `assign_min_free_exec_slot` is `false`, transaction 3 must be deferred,
         // in which case object 2 must be labeled as congested and suggested gas price
@@ -916,13 +915,13 @@ mod tests {
         // |     object_1     |     object_2     | start time |
         // |__________________|__________________|____________|
         // |------------------|------------------|---- 3 -----|
-        // | cert. 9 (g=5000) | cert. 2 (g=8000) |            |
+        // |  tx. 9 (g=5000)  |  tx. 2 (g=8000)  |            |
         // |------------------|------------------|---- 2      |
-        // | cert. 8 (g=6000) | cert. 1 (g=9000) |            |
+        // |  tx. 8 (g=6000)  |  tx. 1 (g=9000)  |            |
         // |------------------|------------------|---- 1      |
-        // | cert. 0 (g=100K) | cert. 3 (g=7000) |            |
+        // |  tx. 0 (g=100K)  |  tx. 3 (g=7000)  |            |
         // |-------------------------------------|---- 0 -----|
-        // NOTE: certificate 3 will only be scheduled if
+        // NOTE: transaction 3 will only be scheduled if
         // `assign_min_free_exec_slot` is `true`.
         (8..=9).for_each(|i| {
             let tx_data = &txs_data[i];
@@ -1035,16 +1034,16 @@ mod tests {
         // |                        |                        |            |
         // |                        |                        |---- 7M     |
         // |                        |                        |            |
-        // |                        | cert. 2 (g=8000, d=4M) |---- 6M     |
+        // |                        |  tx. 2 (g=8000, d=4M)  |---- 6M     |
         // |                        |                        |            |
         // |                        |                        |---- 5M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 4M     |
-        // |                        | cert. 1 (g=9000, d=1M) |            |
+        // |                        |  tx. 1 (g=9000, d=1M)  |            |
         // |------------------------|------------------------|---- 3M     |
         // |                        |                        |            |
         // |                        |                        |---- 2M     |
-        // | cert. 0 (g=100K, d=3M) |                        |            |
+        // |  tx. 0 (g=100K, d=3M)  |                        |            |
         // |                        |                        |---- 1M     |
         // |                        |                        |            |
         // |-------------------------------------------------|---- 0 -----|
@@ -1104,17 +1103,17 @@ mod tests {
         // |                        |                        |            |
         // |                        |                        |---- 7M     |
         // |                        |                        |            |
-        // |                        | cert. 2 (g=8000, d=4M) |---- 6M     |
+        // |                        |  tx. 2 (g=8000, d=4M)  |---- 6M     |
         // |                        |                        |            |
         // |                        |                        |---- 5M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 4M     |
-        // |                        | cert. 1 (g=9000, d=1M) |            |
+        // |                        |  tx. 1 (g=9000, d=1M)  |            |
         // |------------------------|------------------------|---- 3M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 2M     |
-        // | cert. 0 (g=100K, d=3M) |                        |            |
-        // |                        | cert. 3 (g=7000, d=2M) |---- 1M     |
+        // |  tx. 0 (g=100K, d=3M)  |                        |            |
+        // |                        |  tx. 3 (g=7000, d=2M)  |---- 1M     |
         // |                        |                        |            |
         // |-------------------------------------------------|---- 0 -----|
         // If `assign_min_free_exec_slot` is `false`, transaction 3 must be deferred,
@@ -1275,24 +1274,24 @@ mod tests {
         // |________________________|________________________|____________|
         // |------------------------|------------------------|---- 9M ----|
         // |                        |                        |            |
-        // | cert. 9 (g=5000, d=2M) |------------------------|---- 8M     |
+        // |  tx. 9 (g=5000, d=2M)  |------------------------|---- 8M     |
         // |                        |                        |            |
         // |------------------------|                        |---- 7M     |
         // |                        |                        |            |
-        // |                        | cert. 2 (g=8000, d=4M) |---- 6M     |
+        // |                        |  tx. 2 (g=8000, d=4M)  |---- 6M     |
         // |                        |                        |            |
-        // | cert. 8 (g=6000, d=4M) |                        |---- 5M     |
+        // |  tx. 8 (g=6000, d=4M)  |                        |---- 5M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 4M     |
-        // |                        | cert. 1 (g=9000, d=1M) |            |
+        // |                        |  tx. 1 (g=9000, d=1M)  |            |
         // |------------------------|------------------------|---- 3M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 2M     |
-        // | cert. 0 (g=100K, d=3M) |                        |            |
-        // |                        | cert. 3 (g=7000, d=2M) |---- 1M     |
+        // |  tx. 0 (g=100K, d=3M)  |                        |            |
+        // |                        |  tx. 3 (g=7000, d=2M)  |---- 1M     |
         // |                        |                        |            |
         // |-------------------------------------------------|---- 0 -----|
-        // NOTE: certificate 3 will only be scheduled if
+        // NOTE: transaction 3 will only be scheduled if
         // `assign_min_free_exec_slot` is `true`.
         // 8:
         let tx_data = &txs_data[8];
@@ -1471,11 +1470,11 @@ mod tests {
         // |     object_1     |     object_2     | start time |
         // |__________________|__________________|____________|
         // |------------------|------------------|---- 5 -----|
-        // |                  | cert. 2 (g=8000) |            |
+        // |                  |  tx. 2 (g=8000)  |            |
         // |                  |------------------|---- 4      |
-        // |                  | cert. 1 (g=9000) |            |
+        // |                  |  tx. 1 (g=9000)  |            |
         // |------------------|------------------|---- 3 -----|
-        // | cert. 0 (g=100K) |                  |            |
+        // |  tx. 0 (g=100K)  |                  |            |
         // |------------------|------------------|---- 2      |
         // |                  | init. obj. debts |            |
         // |------------------| init. obj. debts |---- 1      |
@@ -1505,11 +1504,11 @@ mod tests {
         // |     object_1     |     object_2     | start time |
         // |__________________|__________________|____________|
         // |------------------|------------------|---- 5 -----|
-        // |                  | cert. 2 (g=8000) |            |
+        // |                  |  tx. 2 (g=8000)  |            |
         // |                  |------------------|---- 4      |
-        // |                  | cert. 1 (g=9000) |            |
+        // |                  |  tx. 1 (g=9000)  |            |
         // |------------------|------------------|---- 3 -----|
-        // | cert. 0 (g=100K) | cert. 3 (g=7000) |            |
+        // |  tx. 0 (g=100K)  |  tx. 3 (g=7000)  |            |
         // |------------------|------------------|---- 2      |
         // |                  | init. obj. debts |            |
         // |------------------| init. obj. debts |---- 1      |
@@ -1659,17 +1658,17 @@ mod tests {
         // |     object_1     |     object_2     | start time |
         // |__________________|__________________|____________|
         // |------------------|------------------|---- 5 -----|
-        // |                  | cert. 2 (g=8000) |            |
+        // |                  |  tx. 2 (g=8000)  |            |
         // |------------------|------------------|---- 4      |
-        // | cert. 9 (g=5000) | cert. 1 (g=9000) |            |
+        // |  tx. 9 (g=5000)  |  tx. 1 (g=9000)  |            |
         // |------------------|------------------|---- 3 -----|
-        // | cert. 0 (g=100K) | cert. 3 (g=7000) |            |
+        // |  tx. 0 (g=100K)  |  tx. 3 (g=7000)  |            |
         // |------------------|------------------|---- 2      |
-        // | cert. 8 (g=6000) | init. obj. debts |            |
+        // |  tx. 8 (g=6000)  | init. obj. debts |            |
         // |------------------| init. obj. debts |---- 1      |
         // | init. obj. debts | init. obj. debts |            |
         // |-------------------------------------|---- 0 -----|
-        // NOTE: certificate 3 will only be scheduled if
+        // NOTE: transaction 3 will only be scheduled if
         // `assign_min_free_exec_slot` is `true`.
         // Tx 8:
         let tx_data = &txs_data[8];
@@ -1809,16 +1808,16 @@ mod tests {
         // |                        |                        |            |
         // |                        |                        |---- 9M ----|
         // |                        |                        |            |
-        // |                        | cert. 2 (g=8000, d=4M) |---- 8M     |
+        // |                        |  tx. 2 (g=8000, d=4M)  |---- 8M     |
         // |                        |                        |            |
         // |                        |                        |---- 7M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 6M     |
-        // |                        | cert. 1 (g=9000, d=1M) |            |
+        // |                        |  tx. 1 (g=9000, d=1M)  |            |
         // |------------------------|------------------------|---- 5M     |
         // |                        |                        |            |
         // |                        |                        |---- 4M     |
-        // | cert. 0 (g=100K, d=3M) |                        |            |
+        // |  tx. 0 (g=100K, d=3M)  |                        |            |
         // |                        |                        |---- 3M     |
         // |                        |                        |            |
         // |------------------------|                        |---- 2M     |
@@ -1883,19 +1882,19 @@ mod tests {
         // |                        |                        |            |
         // |                        |                        |---- 9M ----|
         // |                        |                        |            |
-        // |                        | cert. 2 (g=8000, d=4M) |---- 8M     |
+        // |                        |  tx. 2 (g=8000, d=4M)  |---- 8M     |
         // |                        |                        |            |
         // |                        |                        |---- 7M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 6M     |
-        // |                        | cert. 1 (g=9000, d=1M) |            |
+        // |                        |  tx. 1 (g=9000, d=1M)  |            |
         // |------------------------|------------------------|---- 5M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 4M     |
-        // | cert. 0 (g=100K, d=3M) | cert. 4 (g=7000, ~d=1M)|            |
+        // |  tx. 0 (g=100K, d=3M)  |  tx. 4 (g=7000, ~d=1M) |            |
         // |                        |------------------------|---- 3M     |
         // |                        |                        |            |
-        // |------------------------| cert. 3 (g=7000, d=2M) |---- 2M ----|
+        // |------------------------|  tx. 3 (g=7000, d=2M)  |---- 2M ----|
         // | initial object debts   |                        |            |
         // | initial object debts   |------------------------|---- 1M     |
         // | initial object debts   | initial object debts   |            |
@@ -2078,28 +2077,28 @@ mod tests {
         // |________________________|________________________|____________|
         // |------------------------|------------------------|---- 11M ---|
         // |                        |                        |            |
-        // | cert. 9 (g=5000, d=2M) |------------------------|---- 10M    |
+        // |  tx. 9 (g=5000, d=2M)  |------------------------|---- 10M    |
         // |                        |                        |            |
         // |------------------------|                        |---- 9M ----|
         // |                        |                        |            |
-        // |                        | cert. 2 (g=8000, d=4M) |---- 8M     |
+        // |                        |  tx. 2 (g=8000, d=4M)  |---- 8M     |
         // |                        |                        |            |
-        // | cert. 8 (g=6000, d=4M) |                        |---- 7M     |
+        // |  tx. 8 (g=6000, d=4M)  |                        |---- 7M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 6M     |
-        // |                        | cert. 1 (g=9000, d=1M) |            |
+        // |                        |  tx. 1 (g=9000, d=1M)  |            |
         // |------------------------|------------------------|---- 5M     |
         // |                        |                        |            |
         // |                        |------------------------|---- 4M     |
-        // | cert. 0 (g=100K, d=3M) | cert. 4 (g=7000, ~d=1M)|            |
+        // |  tx. 0 (g=100K, d=3M)  |  tx. 4 (g=7000, ~d=1M) |            |
         // |                        |------------------------|---- 3M     |
         // |                        |                        |            |
-        // |------------------------| cert. 3 (g=7000, d=2M) |---- 2M ----|
+        // |------------------------|  tx. 3 (g=7000, d=2M)  |---- 2M ----|
         // | initial object debts   |                        |            |
         // | initial object debts   |------------------------|---- 1M     |
         // | initial object debts   | initial object debts   |            |
         // |-------------------------------------------------|---- 0 -----|
-        // NOTE: certificates 3 and 4 will only be scheduled if
+        // NOTE: transactions 3 and 4 will only be scheduled if
         // `assign_min_free_exec_slot` is `true`.
         // 8:
         let tx_data = &txs_data[8];

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -853,7 +853,6 @@ impl ConsensusAdapter {
         debug!("{transaction_keys:?} processed by consensus");
 
         let consensus_keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
-
         epoch_store
             .remove_pending_consensus_transactions(&consensus_keys)
             .expect("Storage error when removing consensus transaction");

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -853,9 +853,19 @@ impl ConsensusAdapter {
         debug!("{transaction_keys:?} processed by consensus");
 
         let consensus_keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
+
+        // Regardless of `enable_white_flag_flow`, we need to remove transactions that
+        // were processed by consensus from the corresponding persistent table.
         epoch_store
             .remove_pending_consensus_transactions(&consensus_keys)
             .expect("Storage error when removing consensus transaction");
+
+        // If the white flag flow is enabled, there are no certificates, so there is
+        // nothing to remove from `pending_consensus_certificates`. So, the below
+        // removal is only for certificates, i.e., when the white flag flow is disabled.
+        if !epoch_store.protocol_config().enable_white_flag_flow() {
+            epoch_store.remove_pending_consensus_certificates(&consensus_keys);
+        }
 
         let is_user_tx = is_soft_bundle
             || if epoch_store.protocol_config().enable_white_flag_flow() {

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -854,18 +854,9 @@ impl ConsensusAdapter {
 
         let consensus_keys: Vec<_> = transactions.iter().map(|t| t.key()).collect();
 
-        // Regardless of `enable_white_flag_flow`, we need to remove transactions that
-        // were processed by consensus from the corresponding persistent table.
         epoch_store
             .remove_pending_consensus_transactions(&consensus_keys)
             .expect("Storage error when removing consensus transaction");
-
-        // If the white flag flow is enabled, there are no certificates, so there is
-        // nothing to remove from `pending_consensus_certificates`. So, the below
-        // removal is only for certificates, i.e., when the white flag flow is disabled.
-        if !epoch_store.protocol_config().enable_white_flag_flow() {
-            epoch_store.remove_pending_consensus_certificates(&consensus_keys);
-        }
 
         let is_user_tx = is_soft_bundle
             || if epoch_store.protocol_config().enable_white_flag_flow() {

--- a/crates/iota-core/src/execution_driver.rs
+++ b/crates/iota-core/src/execution_driver.rs
@@ -12,7 +12,7 @@ use rand::Rng;
 use tokio::sync::{Semaphore, mpsc::UnboundedReceiver, oneshot};
 use tracing::{Instrument, error_span, info, instrument, warn};
 
-use crate::{authority::AuthorityState, transaction_manager::PendingCertificate};
+use crate::{authority::AuthorityState, transaction_manager::PendingTransaction};
 
 #[cfg(test)]
 #[path = "unit_tests/execution_driver_tests.rs"]
@@ -22,13 +22,13 @@ const QUEUEING_DELAY_SAMPLING_RATIO: f64 = 0.05;
 
 /// When a notification that a new pending transaction is received we activate
 /// processing the transaction in a loop.
-#[instrument("start_execute_pending_certs", level = "trace", skip_all)]
+#[instrument("start_execute_pending_transactions", level = "trace", skip_all)]
 pub async fn execution_process(
     authority_state: Weak<AuthorityState>,
-    mut rx_ready_certificates: UnboundedReceiver<PendingCertificate>,
+    mut rx_ready_transactions: UnboundedReceiver<PendingTransaction>,
     mut rx_execution_shutdown: oneshot::Receiver<()>,
 ) {
-    info!("Starting pending certificates execution process.");
+    info!("Starting pending transactions execution process.");
 
     // Rate limit concurrent executions to # of cpus.
     let limit = Arc::new(Semaphore::new(num_cpus::get()));
@@ -37,19 +37,19 @@ pub async fn execution_process(
     loop {
         let _scope = monitored_scope("ExecutionDriver::loop");
 
-        let certificate;
+        let transaction;
         let expected_effects_digest;
         let txn_ready_time;
         tokio::select! {
-            result = rx_ready_certificates.recv() => {
-                if let Some(pending_cert) = result {
-                    certificate = pending_cert.certificate;
-                    expected_effects_digest = pending_cert.expected_effects_digest;
-                    txn_ready_time = pending_cert.stats.ready_time.unwrap();
+            result = rx_ready_transactions.recv() => {
+                if let Some(pending_tx) = result {
+                    transaction = pending_tx.transaction;
+                    expected_effects_digest = pending_tx.expected_effects_digest;
+                    txn_ready_time = pending_tx.stats.ready_time.unwrap();
                 } else {
-                    // Should only happen after the AuthorityState has shut down and tx_ready_certificate
-                    // has been dropped by TransactionManager.
-                    info!("No more certificate will be received. Exiting executor ...");
+                    // Should only happen after the AuthorityState has shut down and
+                    // tx_ready_transaction has been dropped by TransactionManager.
+                    info!("No more transaction will be received. Exiting executor ...");
                     return;
                 };
             }
@@ -63,7 +63,7 @@ pub async fn execution_process(
             authority
         } else {
             // Terminate the execution if authority has already shutdown, even if there can
-            // be more items in rx_ready_certificates.
+            // be more items in rx_ready_transactions.
             info!("Authority state has shutdown. Exiting ...");
             return;
         };
@@ -73,14 +73,14 @@ pub async fn execution_process(
         // each epoch.
         let epoch_store = authority.load_epoch_store_one_call_per_task();
 
-        let digest = *certificate.digest();
+        let digest = *transaction.digest();
 
-        if epoch_store.epoch() != certificate.epoch() {
+        if epoch_store.epoch() != transaction.epoch() {
             info!(
                 ?digest,
                 cur_epoch = epoch_store.epoch(),
-                cert_epoch = certificate.epoch(),
-                "Ignoring certificate from previous epoch."
+                tx_epoch = transaction.epoch(),
+                "Ignoring transaction from previous epoch."
             );
             continue;
         }
@@ -105,7 +105,7 @@ pub async fn execution_process(
 
         authority.metrics.execution_rate_tracker.lock().record();
 
-        // Certificate execution can take significant time, so run it in a separate
+        // Transaction execution can take significant time, so run it in a separate
         // task.
         let epoch_store_clone = epoch_store.clone();
         spawn_monitored_task!(epoch_store.within_alive_epoch(async move {
@@ -118,16 +118,16 @@ pub async fn execution_process(
             fail_point_async!("transaction_execution_delay");
 
             match authority.try_execute_immediately(
-                &certificate,
+                &transaction,
                 expected_effects_digest,
                 &epoch_store_clone,
             ) {
                 Err(IotaError::ValidatorHaltedAtEpochEnd) => {
-                    warn!("Could not execute transaction {digest:?} because validator is halted at epoch end. certificate={certificate:?}");
+                    warn!("Could not execute transaction {digest:?} because validator is halted at epoch end. transaction={transaction:?}");
                     return;
                 }
                 Err(e) => {
-                    fatal!("Failed to execute certified transaction {digest:?}! error={e} certificate={certificate:?}");
+                    fatal!("Failed to execute transaction {digest:?}! error={e} transaction={transaction:?}");
                 }
                 _ => (),
             }
@@ -135,6 +135,6 @@ pub async fn execution_process(
                 .metrics
                 .execution_driver_executed_transactions
                 .inc();
-        }.instrument(error_span!("executing_pending_cert", tx_digest = ?digest))));
+        }.instrument(error_span!("executing_pending_transaction", tx_digest = ?digest))));
     }
 }

--- a/crates/iota-core/src/transaction_input_loader.rs
+++ b/crates/iota-core/src/transaction_input_loader.rs
@@ -19,7 +19,7 @@ use once_cell::unsync::OnceCell;
 use tracing::instrument;
 
 use crate::{
-    authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertLockGuard},
+    authority::authority_per_epoch_store::{AuthorityPerEpochStore, TxLockGuard},
     execution_cache::ObjectCacheRead,
 };
 
@@ -144,7 +144,7 @@ impl TransactionInputLoader {
         // Important to hold the _tx_lock, otherwise it would be possible for a concurrent
         // execution of the same tx to enter this point after the first execution has
         // finished and the shared locks have been deleted.
-        _tx_lock: &CertLockGuard,
+        _tx_lock: &TxLockGuard,
         input_object_kinds: &[InputObjectKind],
         epoch_id: EpochId,
     ) -> IotaResult<InputObjects> {

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -41,19 +41,19 @@ mod transaction_manager_tests;
 /// Minimum capacity of HashMaps used in TransactionManager.
 const MIN_HASHMAP_CAPACITY: usize = 1000;
 
-/// TransactionManager is responsible for managing object dependencies of
+/// `TransactionManager` is responsible for managing object dependencies of
 /// pending transactions, and publishing a stream of certified transactions
-/// (certificates) ready to execute. It receives certificates from consensus,
+/// (certificates) ready to execute. It receives transactions from consensus,
 /// validator RPC handlers, and checkpoint executor. Execution driver subscribes
-/// to the stream of ready certificates from TransactionManager, and
+/// to the stream of ready transactions from `TransactionManager`, and
 /// executes them in parallel.
-/// The actual execution logic is inside AuthorityState. After a transaction
-/// commits and updates storage, committed objects and certificates are notified
-/// back to TransactionManager.
+/// The actual execution logic is inside `AuthorityState`. After a transaction
+/// commits and updates storage, committed objects and transactions are notified
+/// back to `TransactionManager`.
 pub struct TransactionManager {
     object_cache_read: Arc<dyn ObjectCacheRead>,
     transaction_cache_read: Arc<dyn TransactionCacheRead>,
-    tx_ready_certificates: UnboundedSender<PendingCertificate>,
+    tx_ready_transactions: UnboundedSender<PendingTransaction>,
     metrics: Arc<AuthorityMetrics>,
     // inner is a doubly nested lock so that we can enforce that an outer lock (for read) is held
     // before the inner lock (for read or write) can be acquired. During reconfiguration, we
@@ -62,27 +62,52 @@ pub struct TransactionManager {
     inner: RwLock<RwLock<Inner>>,
 }
 
+/// Timing statistics for a pending transaction in the `TransactionManager`.
+///
+/// It tracks when a transaction was enqueued and when it became ready for
+/// execution and it is used for latency metrics.
+///
+/// The legacy name (in the certificate era) was `PendingCertificateStats`.
+/// It is renamed to `PendingTransactionStats` because this type now (in the
+/// certificate-less era) covers more consensus transaction kinds, not just
+/// certificates. The renaming is safe and backward-compatible since this is
+/// a fully internal type.
 #[derive(Clone, Debug)]
-pub struct PendingCertificateStats {
-    // The time this certificate enters transaction manager.
+pub struct PendingTransactionStats {
+    /// The time this transaction entered the transaction manager.
     #[cfg(test)]
     pub enqueue_time: Instant,
-    // The time this certificate becomes ready for execution.
+
+    /// The time this transaction became ready for execution.
     pub ready_time: Option<Instant>,
 }
 
+/// A transaction that is waiting in the `TransactionManager` for its input
+/// objects to become available before it can be sent to the execution driver.
+///
+/// Once all `waiting_input_objects` are available, the transaction is forwarded
+/// to the execution driver via a channel.
+///
+/// The legacy name (in the certificate era) was `PendingCertificate`.
+/// It is renamed to `PendingTransaction` because this type now (in the
+/// certificate-less era) covers more consensus transaction kinds, not
+/// just certificates. The renaming is safe and backward-compatible
+/// since this is a fully internal type.
 #[derive(Clone, Debug)]
-pub struct PendingCertificate {
-    // Certified transaction to be executed.
-    pub certificate: VerifiedExecutableTransaction,
-    // When executing from checkpoint, the certified effects digest is provided, so that forks can
-    // be detected prior to committing the transaction.
+pub struct PendingTransaction {
+    /// The transaction to be executed.
+    pub transaction: VerifiedExecutableTransaction,
+
+    /// When executing from checkpoint, the certified effects digest is
+    /// provided so that forks can be detected prior to committing the
+    /// transaction.
     pub expected_effects_digest: Option<TransactionEffectsDigest>,
-    // The input object this certificate is waiting for to become available in order to be
-    // executed.
+
+    /// The input objects this transaction is waiting for to become available.
     pub waiting_input_objects: BTreeSet<InputKey>,
-    // Stores stats about this transaction.
-    pub stats: PendingCertificateStats,
+
+    /// Timing statistics for this transaction.
+    pub stats: PendingTransactionStats,
 }
 
 struct CacheInner {
@@ -222,30 +247,31 @@ impl AvailableObjectsCache {
 }
 
 struct Inner {
-    // Current epoch of TransactionManager.
+    /// Current epoch of `TransactionManager`.
     epoch: EpochId,
 
-    // Maps missing input objects to transactions in pending_certificates.
+    /// Maps missing input objects to transactions in `pending_transactions`.
     missing_inputs: HashMap<InputKey, BTreeSet<TransactionDigest>>,
 
-    // Stores age info for all transactions depending on each object.
-    // Used for throttling signing and submitting transactions depending on hot objects.
-    // A `TransactionQueue` is used to ensure that the insertion order is preserved.
+    /// Stores age info for all transactions depending on each object.
+    /// Used for throttling signing and submitting transactions depending
+    /// on hot objects. A `TransactionQueue` is used to ensure that the
+    /// insertion order is preserved.
     input_objects: HashMap<ObjectID, TransactionQueue>,
 
-    // Maps object IDs to the highest observed sequence number of the object. When the value is
-    // None, indicates that the object is immutable, corresponding to an InputKey with no sequence
-    // number.
+    /// Maps object IDs to the highest observed sequence number of the object.
+    /// When the value is `None`, indicates that the object is immutable,
+    /// corresponding to an `InputKey` with no sequence number.
     available_objects_cache: AvailableObjectsCache,
 
-    // A transaction enqueued to TransactionManager must be in either pending_certificates or
-    // executing_certificates.
+    // A transaction enqueued to `TransactionManager` must be in either
+    // `pending_transactions` or `executing_transactions`.
+    /// Maps transaction digests to their content and missing input objects.
+    pending_transactions: HashMap<TransactionDigest, PendingTransaction>,
 
-    // Maps transaction digests to their content and missing input objects.
-    pending_certificates: HashMap<TransactionDigest, PendingCertificate>,
-
-    // Transactions that have all input objects available, but have not finished execution.
-    executing_certificates: HashSet<TransactionDigest>,
+    /// Transactions that have all input objects available, but have not
+    /// finished execution.
+    executing_transactions: HashSet<TransactionDigest>,
 }
 
 impl Inner {
@@ -255,8 +281,8 @@ impl Inner {
             missing_inputs: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
             input_objects: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
             available_objects_cache: AvailableObjectsCache::new(metrics),
-            pending_certificates: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
-            executing_certificates: HashSet::with_capacity(MIN_HASHMAP_CAPACITY),
+            pending_transactions: HashMap::with_capacity(MIN_HASHMAP_CAPACITY),
+            executing_transactions: HashSet::with_capacity(MIN_HASHMAP_CAPACITY),
         }
     }
 
@@ -268,16 +294,16 @@ impl Inner {
         input_key: InputKey,
         update_cache: bool,
         metrics: &Arc<AuthorityMetrics>,
-    ) -> Vec<PendingCertificate> {
+    ) -> Vec<PendingTransaction> {
         if update_cache {
             self.available_objects_cache.insert(&input_key);
         }
 
-        let mut ready_certificates = Vec::new();
+        let mut ready_transactions = Vec::new();
 
         let Some(digests) = self.missing_inputs.remove(&input_key) else {
             // No transaction is waiting on the object yet.
-            return ready_certificates;
+            return ready_transactions;
         };
 
         let input_txns = self
@@ -301,28 +327,28 @@ impl Inner {
         }
 
         for digest in digests {
-            // Pending certificate must exist.
-            let pending_cert = self.pending_certificates.get_mut(&digest).unwrap();
-            assert!(pending_cert.waiting_input_objects.remove(&input_key));
-            // When a certificate has all its input objects, it is ready to execute.
-            if pending_cert.waiting_input_objects.is_empty() {
-                let pending_cert = self.pending_certificates.remove(&digest).unwrap();
-                ready_certificates.push(pending_cert);
+            // Pending transaction must exist.
+            let pending_transaction = self.pending_transactions.get_mut(&digest).unwrap();
+            assert!(pending_transaction.waiting_input_objects.remove(&input_key));
+            // When a transaction has all its input objects, it is ready to execute.
+            if pending_transaction.waiting_input_objects.is_empty() {
+                let pending_transaction = self.pending_transactions.remove(&digest).unwrap();
+                ready_transactions.push(pending_transaction);
             } else {
                 // TODO: we should start logging this at a higher level after some period of
                 // time has elapsed.
-                trace!(tx_digest = ?digest,missing = ?pending_cert.waiting_input_objects, "Certificate waiting on missing inputs");
+                trace!(tx_digest = ?digest,missing = ?pending_transaction.waiting_input_objects, "Transaction waiting on missing inputs");
             }
         }
 
-        ready_certificates
+        ready_transactions
     }
 
     fn maybe_reserve_capacity(&mut self) {
         self.missing_inputs.maybe_reserve_capacity();
         self.input_objects.maybe_reserve_capacity();
-        self.pending_certificates.maybe_reserve_capacity();
-        self.executing_certificates.maybe_reserve_capacity();
+        self.pending_transactions.maybe_reserve_capacity();
+        self.executing_transactions.maybe_reserve_capacity();
     }
 
     /// After reaching 1/4 load in hashmaps, decrease capacity to increase load
@@ -330,14 +356,14 @@ impl Inner {
     fn maybe_shrink_capacity(&mut self) {
         self.missing_inputs.maybe_shrink_capacity();
         self.input_objects.maybe_shrink_capacity();
-        self.pending_certificates.maybe_shrink_capacity();
-        self.executing_certificates.maybe_shrink_capacity();
+        self.pending_transactions.maybe_shrink_capacity();
+        self.executing_transactions.maybe_shrink_capacity();
     }
 }
 
 impl TransactionManager {
     /// If a node restarts, transaction manager recovers in-memory data from
-    /// pending_certificates, which contains certified transactions from
+    /// `pending_transactions`, which contains certified transactions from
     /// consensus output and RPC that are not executed. Transactions from
     /// other sources, e.g. checkpoint executor, have own persistent storage to
     /// retry transactions.
@@ -345,7 +371,7 @@ impl TransactionManager {
         object_cache_read: Arc<dyn ObjectCacheRead>,
         transaction_cache_read: Arc<dyn TransactionCacheRead>,
         epoch_store: &AuthorityPerEpochStore,
-        tx_ready_certificates: UnboundedSender<PendingCertificate>,
+        tx_ready_transactions: UnboundedSender<PendingTransaction>,
         metrics: Arc<AuthorityMetrics>,
     ) -> TransactionManager {
         TransactionManager {
@@ -353,7 +379,7 @@ impl TransactionManager {
             transaction_cache_read,
             metrics: metrics.clone(),
             inner: RwLock::new(RwLock::new(Inner::new(epoch_store.epoch(), metrics))),
-            tx_ready_certificates,
+            tx_ready_transactions,
         }
     }
 
@@ -379,29 +405,29 @@ impl TransactionManager {
     #[instrument("transaction_manager_enqueue_transactions", level = "trace", skip_all)]
     pub(crate) fn enqueue(
         &self,
-        certs: Vec<VerifiedExecutableTransaction>,
+        transactions: Vec<VerifiedExecutableTransaction>,
         epoch_store: &AuthorityPerEpochStore,
     ) {
-        let certs = certs.into_iter().map(|cert| (cert, None)).collect();
-        self.enqueue_impl(certs, epoch_store)
+        let transactions = transactions.into_iter().map(|tx| (tx, None)).collect();
+        self.enqueue_impl(transactions, epoch_store)
     }
 
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn enqueue_with_expected_effects_digest(
         &self,
-        certs: Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
+        transactions: Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
         epoch_store: &AuthorityPerEpochStore,
     ) {
-        let certs = certs
+        let transactions = transactions
             .into_iter()
-            .map(|(cert, fx)| (cert, Some(fx)))
+            .map(|(tx, fx)| (tx, Some(fx)))
             .collect();
-        self.enqueue_impl(certs, epoch_store)
+        self.enqueue_impl(transactions, epoch_store)
     }
 
     fn enqueue_impl(
         &self,
-        certs: Vec<(
+        transactions: Vec<(
             VerifiedExecutableTransaction,
             Option<TransactionEffectsDigest>,
         )>,
@@ -409,16 +435,16 @@ impl TransactionManager {
     ) {
         let reconfig_lock = self.inner.read();
 
-        // filter out already executed certs
-        let certs: Vec<_> = {
+        // filter out already executed transactions.
+        let transactions: Vec<_> = {
             let _span = tracing::trace_span!("filter_already_executed_txs").entered();
 
-            certs
+            transactions
                 .into_iter()
-                .filter(|(cert, _)| {
-                    tracing::trace!(tx_digest = ?cert.digest(), "checking if already executed");
+                .filter(|(tx, _)| {
+                    tracing::trace!(tx_digest = ?tx.digest(), "checking if already executed");
 
-                    let digest = *cert.digest();
+                    let digest = *tx.digest();
                     // skip already executed txes
                     if self
                         .transaction_cache_read
@@ -441,43 +467,42 @@ impl TransactionManager {
 
         let mut object_availability: HashMap<InputKey, Option<bool>> = HashMap::new();
         let mut receiving_objects: HashSet<InputKey> = HashSet::new();
-        let certs: Vec<_> = {
+        let transactions: Vec<_> = {
             let _span = tracing::trace_span!("check_tx_input_objects").entered();
 
-            certs
+            transactions
                 .into_iter()
-                .filter_map(|(cert, fx_digest)| {
+                .filter_map(|(tx, fx_digest)| {
                     // Check availability of all transaction associated input objects(transaction +
                     // authenticators).
                     let input_object_kinds =
-                        cert.input_objects().expect("input_objects() cannot fail");
-                    let mut input_object_keys = match epoch_store
-                        .get_input_object_keys(&cert.key(), &input_object_kinds)
-                    {
-                        Ok(keys) => keys,
-                        Err(e) => {
-                            // Because we do not hold the transaction lock during enqueue, it is
-                            // possible that the transaction was executed and the shared version
-                            // assignments deleted since the earlier check. This is a rare race
-                            // condition, and it is better to handle it ad-hoc here than to hold tx
-                            // locks for every cert for the duration of this function in order to
-                            // remove the race.
-                            if self
-                                .transaction_cache_read
-                                .is_tx_already_executed(cert.digest())
-                            {
-                                return None;
+                        tx.input_objects().expect("input_objects() cannot fail");
+                    let mut input_object_keys =
+                        match epoch_store.get_input_object_keys(&tx.key(), &input_object_kinds) {
+                            Ok(keys) => keys,
+                            Err(e) => {
+                                // Because we do not hold the transaction lock during enqueue, it is
+                                // possible that the transaction was executed and the shared version
+                                // assignments deleted since the earlier check. This is a rare race
+                                // condition, and it is better to handle it ad-hoc here than to hold
+                                // tx locks for every transaction for the duration of this function
+                                // in order to remove the race.
+                                if self
+                                    .transaction_cache_read
+                                    .is_tx_already_executed(tx.digest())
+                                {
+                                    return None;
+                                }
+                                fatal!("Failed to get input object keys: {:?}", e);
                             }
-                            fatal!("Failed to get input object keys: {:?}", e);
-                        }
-                    };
+                        };
 
                     if input_object_kinds.len() != input_object_keys.len() {
                         error!("Duplicated input objects: {:?}", input_object_kinds);
                     }
 
                     let receiving_object_entries =
-                        cert.data().intent_message().value.receiving_objects();
+                        tx.data().intent_message().value.receiving_objects();
                     for entry in receiving_object_entries {
                         let key = InputKey::VersionedObject {
                             id: entry.0,
@@ -497,7 +522,7 @@ impl TransactionManager {
                         }
                     }
 
-                    Some((cert, fx_digest, input_object_keys))
+                    Some((tx, fx_digest, input_object_keys))
                 })
                 .collect()
         };
@@ -577,41 +602,41 @@ impl TransactionManager {
         obj_availability_span.exit();
 
         let mut pending = Vec::new();
-        let pending_cert_enqueue_time = Instant::now();
+        let pending_transaction_enqueue_time = Instant::now();
 
-        for (cert, expected_effects_digest, input_object_keys) in certs {
-            pending.push(PendingCertificate {
-                certificate: cert,
+        for (transaction, expected_effects_digest, input_object_keys) in transactions {
+            pending.push(PendingTransaction {
+                transaction,
                 expected_effects_digest,
                 waiting_input_objects: input_object_keys,
-                stats: PendingCertificateStats {
+                stats: PendingTransactionStats {
                     #[cfg(test)]
-                    enqueue_time: pending_cert_enqueue_time,
+                    enqueue_time: pending_transaction_enqueue_time,
                     ready_time: None,
                 },
             });
         }
 
-        for mut pending_cert in pending {
-            let _span = tracing::trace_span!("enqueueing_pending_certificate", cert_digest = %pending_cert.certificate.digest()).entered();
+        for mut pending_transaction in pending {
+            let _span = tracing::trace_span!("enqueueing_pending_transaction", tx_digest = %pending_transaction.transaction.digest()).entered();
             // Tx lock is not held here, which makes it possible to send duplicated
             // transactions to the execution driver after crash-recovery, when
             // the same transaction is recovered from recovery log and pending
-            // certificates table. The transaction will still only execute once,
+            // transactions table. The transaction will still only execute once,
             // because tx lock is acquired in execution driver and executed effects
             // table is consulted. So this behavior is benigh.
-            let digest = *pending_cert.certificate.digest();
+            let digest = *pending_transaction.transaction.digest();
 
-            if inner.epoch != pending_cert.certificate.epoch() {
+            if inner.epoch != pending_transaction.transaction.epoch() {
                 warn!(
-                    "Ignoring enqueued certificate from wrong epoch. Expected={} Certificate={:?}",
-                    inner.epoch, pending_cert.certificate
+                    "Ignoring enqueued transaction from wrong epoch. Expected={} Transaction={:?}",
+                    inner.epoch, pending_transaction.transaction
                 );
                 continue;
             }
 
             // skip already pending txes
-            if inner.pending_certificates.contains_key(&digest) {
+            if inner.pending_transactions.contains_key(&digest) {
                 self.metrics
                     .transaction_manager_num_enqueued_certificates
                     .with_label_values(&["already_pending"])
@@ -619,7 +644,7 @@ impl TransactionManager {
                 continue;
             }
             // skip already executing txes
-            if inner.executing_certificates.contains(&digest) {
+            if inner.executing_transactions.contains(&digest) {
                 self.metrics
                     .transaction_manager_num_enqueued_certificates
                     .with_label_values(&["already_executing"])
@@ -640,40 +665,40 @@ impl TransactionManager {
             let mut waiting_input_objects = BTreeSet::new();
             std::mem::swap(
                 &mut waiting_input_objects,
-                &mut pending_cert.waiting_input_objects,
+                &mut pending_transaction.waiting_input_objects,
             );
             for key in waiting_input_objects {
                 if !object_availability[&key].unwrap() {
                     // The input object is not yet available.
-                    pending_cert.waiting_input_objects.insert(key);
+                    pending_transaction.waiting_input_objects.insert(key);
 
                     assert!(
                         inner.missing_inputs.entry(key).or_default().insert(digest),
-                        "Duplicated certificate {digest:?} for missing object {key:?}"
+                        "Duplicated transaction {digest:?} for missing object {key:?}"
                     );
                     let input_txns = inner.input_objects.entry(key.id()).or_default();
-                    input_txns.insert(digest, pending_cert_enqueue_time);
+                    input_txns.insert(digest, pending_transaction_enqueue_time);
                 }
             }
 
             // Ready transactions can start to execute.
-            if pending_cert.waiting_input_objects.is_empty() {
+            if pending_transaction.waiting_input_objects.is_empty() {
                 self.metrics
                     .transaction_manager_num_enqueued_certificates
                     .with_label_values(&["ready"])
                     .inc();
-                pending_cert.stats.ready_time = Some(Instant::now());
+                pending_transaction.stats.ready_time = Some(Instant::now());
                 // Send to execution driver for execution.
-                self.certificate_ready(&mut inner, pending_cert);
+                self.transaction_ready(&mut inner, pending_transaction);
                 continue;
             }
 
             assert!(
                 inner
-                    .pending_certificates
-                    .insert(digest, pending_cert)
+                    .pending_transactions
+                    .insert(digest, pending_transaction)
                     .is_none(),
-                "Duplicated pending certificate {digest:?}"
+                "Duplicated pending transaction {digest:?}"
             );
 
             self.metrics
@@ -687,7 +712,7 @@ impl TransactionManager {
             .set(inner.missing_inputs.len() as i64);
         self.metrics
             .transaction_manager_num_pending_certificates
-            .set(inner.pending_certificates.len() as i64);
+            .set(inner.pending_transactions.len() as i64);
 
         inner.maybe_reserve_capacity();
     }
@@ -727,11 +752,11 @@ impl TransactionManager {
 
         for input_key in input_keys {
             trace!(?input_key, "object available");
-            for mut ready_cert in
+            for mut ready_transaction in
                 inner.find_ready_transactions(input_key, update_cache, &self.metrics)
             {
-                ready_cert.stats.ready_time = Some(available_time);
-                self.certificate_ready(inner, ready_cert);
+                ready_transaction.stats.ready_time = Some(available_time);
+                self.transaction_ready(inner, ready_transaction);
             }
         }
 
@@ -740,10 +765,10 @@ impl TransactionManager {
             .set(inner.missing_inputs.len() as i64);
         self.metrics
             .transaction_manager_num_pending_certificates
-            .set(inner.pending_certificates.len() as i64);
+            .set(inner.pending_transactions.len() as i64);
         self.metrics
             .transaction_manager_num_executing_certificates
-            .set(inner.executing_certificates.len() as i64);
+            .set(inner.executing_transactions.len() as i64);
     }
 
     /// Notifies TransactionManager about a transaction that has been committed.
@@ -762,7 +787,7 @@ impl TransactionManager {
 
             if inner.epoch != epoch_store.epoch() {
                 warn!(
-                    "Ignoring committed certificate from wrong epoch. Expected={} Actual={} CertificateDigest={:?}",
+                    "Ignoring committed transaction from wrong epoch. Expected={} Actual={} TransactionDigest={:?}",
                     inner.epoch,
                     epoch_store.epoch(),
                     digest
@@ -778,9 +803,9 @@ impl TransactionManager {
                 commit_time,
             );
 
-            if !inner.executing_certificates.remove(digest) {
+            if !inner.executing_transactions.remove(digest) {
                 trace!(
-                    "{:?} not found in executing certificates, likely because it is a system transaction",
+                    "{:?} not found in executing transactions, likely because it is a system transaction",
                     digest
                 );
                 return;
@@ -788,24 +813,24 @@ impl TransactionManager {
 
             self.metrics
                 .transaction_manager_num_executing_certificates
-                .set(inner.executing_certificates.len() as i64);
+                .set(inner.executing_transactions.len() as i64);
 
             inner.maybe_shrink_capacity();
         }
     }
 
-    /// Sends the ready certificate for execution.
-    fn certificate_ready(&self, inner: &mut Inner, pending_certificate: PendingCertificate) {
-        trace!(tx_digest = ?pending_certificate.certificate.digest(), "certificate ready");
-        assert_eq!(pending_certificate.waiting_input_objects.len(), 0);
-        // Record as an executing certificate.
+    /// Sends the ready transaction for execution.
+    fn transaction_ready(&self, inner: &mut Inner, pending_transaction: PendingTransaction) {
+        trace!(tx_digest = ?pending_transaction.transaction.digest(), "transaction ready");
+        assert_eq!(pending_transaction.waiting_input_objects.len(), 0);
+        // Record as an executing transaction.
         assert!(
             inner
-                .executing_certificates
-                .insert(*pending_certificate.certificate.digest())
+                .executing_transactions
+                .insert(*pending_transaction.transaction.digest())
         );
         self.metrics.txn_ready_rate_tracker.lock().record();
-        let _ = self.tx_ready_certificates.send(pending_certificate);
+        let _ = self.tx_ready_transactions.send(pending_transaction);
         self.metrics.transaction_manager_num_ready.inc();
         self.metrics.execution_driver_dispatch_queue.inc();
     }
@@ -835,7 +860,7 @@ impl TransactionManager {
     pub(crate) fn inflight_queue_len(&self) -> usize {
         let reconfig_lock = self.inner.read();
         let inner = reconfig_lock.read();
-        inner.pending_certificates.len() + inner.executing_certificates.len()
+        inner.pending_transactions.len() + inner.executing_transactions.len()
     }
 
     // Reconfigures the TransactionManager for a new epoch. Existing transactions
@@ -918,14 +943,14 @@ impl TransactionManager {
             inner.input_objects
         );
         assert!(
-            inner.pending_certificates.is_empty(),
-            "Pending certificates: {:?}",
-            inner.pending_certificates
+            inner.pending_transactions.is_empty(),
+            "Pending transactions: {:?}",
+            inner.pending_transactions
         );
         assert!(
-            inner.executing_certificates.is_empty(),
-            "Executing certificates: {:?}",
-            inner.executing_certificates
+            inner.executing_transactions.is_empty(),
+            "Executing transactions: {:?}",
+            inner.executing_transactions
         );
     }
 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -6609,7 +6609,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
         .read_objects_for_execution(
             &authority.epoch_store_for_testing(),
             &cancelled_txn.key(),
-            &CertLockGuard::guard_for_tests(),
+            &TxLockGuard::guard_for_tests(),
             &cancelled_txn
                 .data()
                 .transaction_data()

--- a/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
@@ -21,25 +21,25 @@ use tokio::{
 
 use crate::{
     authority::{AuthorityState, authority_tests::init_state_with_objects},
-    transaction_manager::{PendingCertificate, TransactionManager},
+    transaction_manager::{PendingTransaction, TransactionManager},
 };
 
 #[expect(clippy::disallowed_methods)] // allow unbounded_channel()
 fn make_transaction_manager(
     state: &AuthorityState,
-) -> (TransactionManager, UnboundedReceiver<PendingCertificate>) {
+) -> (TransactionManager, UnboundedReceiver<PendingTransaction>) {
     // Create a new transaction manager instead of reusing the authority's, to
-    // examine transaction_manager output from rx_ready_certificates.
-    let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
+    // examine transaction_manager output from rx_ready_transactions.
+    let (tx_ready_transactions, rx_ready_transactions) = unbounded_channel();
     let transaction_manager = TransactionManager::new(
         state.get_object_cache_reader().clone(),
         state.get_transaction_cache_reader().clone(),
         &state.epoch_store_for_testing(),
-        tx_ready_certificates,
+        tx_ready_transactions,
         state.metrics.clone(),
     );
 
-    (transaction_manager, rx_ready_certificates)
+    (transaction_manager, rx_ready_transactions)
 }
 
 fn make_transaction(gas_object: Object, input: Vec<CallArg>) -> VerifiedExecutableTransaction {
@@ -77,11 +77,11 @@ async fn transaction_manager_basics() {
     let state = init_state_with_objects(gas_objects.clone()).await;
 
     // Create a new transaction manager instead of reusing the authority's, to
-    // examine transaction_manager output from rx_ready_certificates.
-    let (transaction_manager, mut rx_ready_certificates) = make_transaction_manager(&state);
+    // examine transaction_manager output from rx_ready_transactions.
+    let (transaction_manager, mut rx_ready_transactions) = make_transaction_manager(&state);
     // TM should output no transaction.
     assert!(
-        rx_ready_certificates
+        rx_ready_transactions
             .try_recv()
             .is_err_and(|err| err == TryRecvError::Empty)
     );
@@ -92,7 +92,7 @@ async fn transaction_manager_basics() {
     transaction_manager.enqueue(vec![], &state.epoch_store_for_testing());
     // TM should output no transaction.
     assert!(
-        rx_ready_certificates
+        rx_ready_transactions
             .try_recv()
             .is_err_and(|err| err == TryRecvError::Empty)
     );
@@ -102,12 +102,12 @@ async fn transaction_manager_basics() {
     let tx_start_time = Instant::now();
     transaction_manager.enqueue(vec![transaction.clone()], &state.epoch_store_for_testing());
     // TM should output the transaction eventually.
-    let pending_certificate = rx_ready_certificates.recv().await.unwrap();
+    let pending_transaction = rx_ready_transactions.recv().await.unwrap();
 
-    // Tests that pending certificate stats are recorded properly.
-    assert!(pending_certificate.stats.enqueue_time >= tx_start_time);
+    // Tests that pending transactions stats are recorded properly.
+    assert!(pending_transaction.stats.enqueue_time >= tx_start_time);
     assert!(
-        pending_certificate.stats.ready_time.unwrap() >= pending_certificate.stats.enqueue_time
+        pending_transaction.stats.ready_time.unwrap() >= pending_transaction.stats.enqueue_time
     );
 
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
@@ -134,7 +134,7 @@ async fn transaction_manager_basics() {
     // TM should output no transaction yet.
     sleep(Duration::from_secs(1)).await;
     assert!(
-        rx_ready_certificates
+        rx_ready_transactions
             .try_recv()
             .is_err_and(|err| err == TryRecvError::Empty)
     );
@@ -145,7 +145,7 @@ async fn transaction_manager_basics() {
     transaction_manager.enqueue(vec![transaction.clone()], &state.epoch_store_for_testing());
     sleep(Duration::from_secs(1)).await;
     assert!(
-        rx_ready_certificates
+        rx_ready_transactions
             .try_recv()
             .is_err_and(|err| err == TryRecvError::Empty)
     );
@@ -158,13 +158,13 @@ async fn transaction_manager_basics() {
         &state.epoch_store_for_testing(),
     );
     // TM should output the transaction eventually.
-    let pending_certificate = rx_ready_certificates.recv().await.unwrap();
+    let pending_transaction = rx_ready_transactions.recv().await.unwrap();
 
-    // Tests that pending certificate stats are recorded properly. The ready time
+    // Tests that pending transaction stats are recorded properly. The ready time
     // should be 2 seconds apart from the enqueue time.
-    assert!(pending_certificate.stats.enqueue_time >= tx_start_time);
+    assert!(pending_transaction.stats.enqueue_time >= tx_start_time);
     assert!(
-        pending_certificate.stats.ready_time.unwrap() - pending_certificate.stats.enqueue_time
+        pending_transaction.stats.ready_time.unwrap() - pending_transaction.stats.enqueue_time
             >= Duration::from_secs(2)
     );
 
@@ -172,7 +172,7 @@ async fn transaction_manager_basics() {
     transaction_manager.enqueue(vec![transaction.clone()], &state.epoch_store_for_testing());
     sleep(Duration::from_secs(1)).await;
     assert!(
-        rx_ready_certificates
+        rx_ready_transactions
             .try_recv()
             .is_err_and(|err| err == TryRecvError::Empty)
     );
@@ -219,10 +219,10 @@ async fn transaction_manager_object_dependency() {
     .await;
 
     // Create a new transaction manager instead of reusing the authority's, to
-    // examine transaction_manager output from rx_ready_certificates.
-    let (transaction_manager, mut rx_ready_certificates) = make_transaction_manager(&state);
+    // examine transaction_manager output from rx_ready_transactions.
+    let (transaction_manager, mut rx_ready_transactions) = make_transaction_manager(&state);
     // TM should output no transaction.
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
 
     // Enqueue two transactions with the same shared object input in read-only mode.
     let shared_version = 1000.into();
@@ -310,7 +310,7 @@ async fn transaction_manager_object_dependency() {
 
     // TM should output no transaction yet.
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
 
     assert_eq!(transaction_manager.inflight_queue_len(), 4);
 
@@ -324,9 +324,9 @@ async fn transaction_manager_object_dependency() {
     );
 
     // TM should output the 3 transactions that are only waiting for this object.
-    let tx_0 = rx_ready_certificates.recv().await.unwrap().certificate;
-    let tx_1 = rx_ready_certificates.recv().await.unwrap().certificate;
-    let tx_2 = rx_ready_certificates.recv().await.unwrap().certificate;
+    let tx_0 = rx_ready_transactions.recv().await.unwrap().transaction;
+    let tx_1 = rx_ready_transactions.recv().await.unwrap().transaction;
+    let tx_2 = rx_ready_transactions.recv().await.unwrap().transaction;
     {
         let mut want_digests = vec![
             transaction_read_0.digest(),
@@ -340,7 +340,7 @@ async fn transaction_manager_object_dependency() {
     }
 
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
 
     assert_eq!(transaction_manager.inflight_queue_len(), 4);
 
@@ -361,11 +361,11 @@ async fn transaction_manager_object_dependency() {
     );
 
     // Now, the transaction waiting for both shared objects can be executed.
-    let tx_3 = rx_ready_certificates.recv().await.unwrap().certificate;
+    let tx_3 = rx_ready_transactions.recv().await.unwrap().transaction;
     assert_eq!(transaction_read_2.digest(), tx_3.digest());
 
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
 
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
 
@@ -389,10 +389,10 @@ async fn transaction_manager_receiving_notify_commit() {
     let state = init_state_with_objects(gas_objects.clone()).await;
 
     // Create a new transaction manager instead of reusing the authority's, to
-    // examine transaction_manager output from rx_ready_certificates.
-    let (transaction_manager, mut rx_ready_certificates) = make_transaction_manager(&state);
+    // examine transaction_manager output from rx_ready_transactions.
+    let (transaction_manager, mut rx_ready_transactions) = make_transaction_manager(&state);
     // TM should output no transaction.
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     // TM should be empty at the beginning.
     transaction_manager.check_empty_for_testing();
 
@@ -426,7 +426,7 @@ async fn transaction_manager_receiving_notify_commit() {
         // ImmOrOwnedObject input.
         transaction_manager.enqueue(vec![txn.clone()], &state.epoch_store_for_testing());
         sleep(Duration::from_secs(1)).await;
-        assert!(rx_ready_certificates.try_recv().is_err());
+        assert!(rx_ready_transactions.try_recv().is_err());
         assert_eq!(transaction_manager.inflight_queue_len(), i + 1);
     }
 
@@ -441,12 +441,12 @@ async fn transaction_manager_receiving_notify_commit() {
     for (i, (object, txn)) in object_arguments.iter().enumerate() {
         // TM should output the transaction eventually now that the receiving object has
         // become available.
-        rx_ready_certificates.recv().await.unwrap();
+        rx_ready_transactions.recv().await.unwrap();
 
         // Only one transaction at a time should become available though. So if we try
         // to get another one it should fail.
         sleep(Duration::from_secs(1)).await;
-        assert!(rx_ready_certificates.try_recv().is_err());
+        assert!(rx_ready_transactions.try_recv().is_err());
 
         // Notify the TM that the transaction has been processed, and that it has
         // written the object at the next version.
@@ -485,10 +485,10 @@ async fn transaction_manager_receiving_object_ready_notifications() {
     let state = init_state_with_objects(gas_objects.clone()).await;
 
     // Create a new transaction manager instead of reusing the authority's, to
-    // examine transaction_manager output from rx_ready_certificates.
-    let (transaction_manager, mut rx_ready_certificates) = make_transaction_manager(&state);
+    // examine transaction_manager output from rx_ready_transactions.
+    let (transaction_manager, mut rx_ready_transactions) = make_transaction_manager(&state);
     // TM should output no transaction.
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     // TM should be empty at the beginning.
     transaction_manager.check_empty_for_testing();
 
@@ -517,7 +517,7 @@ async fn transaction_manager_receiving_object_ready_notifications() {
         &state.epoch_store_for_testing(),
     );
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
 
     // TM should output no transaction yet since waiting on receiving object.
@@ -526,7 +526,7 @@ async fn transaction_manager_receiving_object_ready_notifications() {
         &state.epoch_store_for_testing(),
     );
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 2);
 
     // Duplicate enqueue of receiving object is allowed.
@@ -535,7 +535,7 @@ async fn transaction_manager_receiving_object_ready_notifications() {
         &state.epoch_store_for_testing(),
     );
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 2);
 
     // Notify TM that the receiving object 0 is available.
@@ -546,7 +546,7 @@ async fn transaction_manager_receiving_object_ready_notifications() {
 
     // TM should output the transaction eventually now that the receiving object has
     // become available.
-    rx_ready_certificates.recv().await.unwrap();
+    rx_ready_transactions.recv().await.unwrap();
 
     // Notify TM that the receiving object 0 is available.
     transaction_manager.objects_available(
@@ -556,7 +556,7 @@ async fn transaction_manager_receiving_object_ready_notifications() {
 
     // TM should output the transaction eventually now that the receiving object has
     // become available.
-    rx_ready_certificates.recv().await.unwrap();
+    rx_ready_transactions.recv().await.unwrap();
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -573,10 +573,10 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
     let state = init_state_with_objects(gas_objects.clone()).await;
 
     // Create a new transaction manager instead of reusing the authority's, to
-    // examine transaction_manager output from rx_ready_certificates.
-    let (transaction_manager, mut rx_ready_certificates) = make_transaction_manager(&state);
+    // examine transaction_manager output from rx_ready_transactions.
+    let (transaction_manager, mut rx_ready_transactions) = make_transaction_manager(&state);
     // TM should output no transaction.
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     // TM should be empty at the beginning.
     transaction_manager.check_empty_for_testing();
 
@@ -618,7 +618,7 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
         &state.epoch_store_for_testing(),
     );
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
 
     // TM should output no transaction yet since waiting on receiving object.
@@ -627,7 +627,7 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
         &state.epoch_store_for_testing(),
     );
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 2);
 
     // Different transaction with a duplicate receiving object reference is allowed.
@@ -637,7 +637,7 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
         &state.epoch_store_for_testing(),
     );
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 3);
 
     // Notify TM that the receiving object 0 is available.
@@ -648,19 +648,19 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
 
     // TM should output both transactions depending on the receiving object now that
     // the transaction's receiving object has become available.
-    rx_ready_certificates.recv().await.unwrap();
+    rx_ready_transactions.recv().await.unwrap();
 
-    rx_ready_certificates.recv().await.unwrap();
+    rx_ready_transactions.recv().await.unwrap();
 
     // Only two transactions that were dependent on the receiving object should be
     // output.
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
 
     // Enqueue a transaction with a receiving object that is available at the time
     // it is enqueued. This should be immediately available.
     transaction_manager.enqueue(vec![tx1.clone()], &state.epoch_store_for_testing());
     sleep(Duration::from_secs(1)).await;
-    rx_ready_certificates.recv().await.unwrap();
+    rx_ready_transactions.recv().await.unwrap();
 
     // Notify TM that the receiving object 0 is available.
     transaction_manager.objects_available(
@@ -670,7 +670,7 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
 
     // TM should output the transaction eventually now that the receiving object has
     // become available.
-    rx_ready_certificates.recv().await.unwrap();
+    rx_ready_transactions.recv().await.unwrap();
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -693,10 +693,10 @@ async fn transaction_manager_receiving_object_ready_if_current_version_greater()
     let state = init_state_with_objects(gas_objects.clone()).await;
 
     // Create a new transaction manager instead of reusing the authority's, to
-    // examine transaction_manager output from rx_ready_certificates.
-    let (transaction_manager, mut rx_ready_certificates) = make_transaction_manager(&state);
+    // examine transaction_manager output from rx_ready_transactions.
+    let (transaction_manager, mut rx_ready_transactions) = make_transaction_manager(&state);
     // TM should output no transaction.
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
     // TM should be empty at the beginning.
     transaction_manager.check_empty_for_testing();
 
@@ -743,10 +743,10 @@ async fn transaction_manager_receiving_object_ready_if_current_version_greater()
         &state.epoch_store_for_testing(),
     );
     sleep(Duration::from_secs(1)).await;
-    rx_ready_certificates.recv().await.unwrap();
-    rx_ready_certificates.recv().await.unwrap();
-    rx_ready_certificates.recv().await.unwrap();
-    assert!(rx_ready_certificates.try_recv().is_err());
+    rx_ready_transactions.recv().await.unwrap();
+    rx_ready_transactions.recv().await.unwrap();
+    rx_ready_transactions.recv().await.unwrap();
+    assert!(rx_ready_transactions.try_recv().is_err());
 }
 
 // Tests transaction cancellation logic in transaction manager. Mainly tests
@@ -770,10 +770,10 @@ async fn transaction_manager_with_cancelled_transactions() {
     .await;
 
     // Create a new transaction manager instead of reusing the authority's, to
-    // examine transaction_manager output from rx_ready_certificates.
-    let (transaction_manager, mut rx_ready_certificates) = make_transaction_manager(&state);
+    // examine transaction_manager output from rx_ready_transactions.
+    let (transaction_manager, mut rx_ready_transactions) = make_transaction_manager(&state);
     // TM should output no transaction.
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
 
     // Enqueue one transaction with 2 shared object inputs and 1 owned input.
     let shared_object_arg_1 = ObjectArg::SharedObject {
@@ -823,7 +823,7 @@ async fn transaction_manager_with_cancelled_transactions() {
 
     // TM should output no transaction yet.
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
 
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
 
@@ -837,11 +837,11 @@ async fn transaction_manager_with_cancelled_transactions() {
     );
 
     // TM should output the transaction as soon as the owned object is available.
-    let available_txn = rx_ready_certificates.recv().await.unwrap().certificate;
+    let available_txn = rx_ready_transactions.recv().await.unwrap().transaction;
     assert_eq!(available_txn.digest(), cancelled_transaction.digest());
 
     sleep(Duration::from_secs(1)).await;
-    assert!(rx_ready_certificates.try_recv().is_err());
+    assert!(rx_ready_transactions.try_recv().is_err());
 
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
 

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -14,7 +14,7 @@ pub mod test_adapter;
 use std::{path::Path, sync::Arc};
 
 use iota_core::authority::{
-    AuthorityState, authority_per_epoch_store::CertLockGuard,
+    AuthorityState, authority_per_epoch_store::TxLockGuard,
     authority_test_utils::send_and_confirm_transaction_with_execution_error,
 };
 use iota_json_rpc::authority_state::StateRead;
@@ -142,7 +142,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
 
         let epoch_store = self.validator.load_epoch_store_one_call_per_task().clone();
         self.validator
-            .read_objects_for_execution(&CertLockGuard::guard_for_tests(), &tx, &epoch_store)
+            .read_objects_for_execution(&TxLockGuard::guard_for_tests(), &tx, &epoch_store)
             .map(|(tx_input_objects, _, _)| tx_input_objects)
     }
 

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -161,7 +161,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         let epoch_store = self.validator.load_epoch_store_one_call_per_task().clone();
         let (_, effects, error) =
             self.validator
-                .prepare_certificate_for_benchmark(&tx, input_objects, &epoch_store)?;
+                .prepare_transaction_for_benchmark(&tx, input_objects, &epoch_store)?;
         Ok((effects, error))
     }
 


### PR DESCRIPTION
# Description of change

This PR renames internal identifiers used in the certificate-only era to certificate-less transaction names (the new names also stay clear enough in the certificate-only flow). This is a follow-up to the only two renamings made during the review process of #10615. See #10908 for the rationale.

All changes are safe and backward-compatible as they are performed on internal identifiers - no changes on serialized types, cross-crate public APIs, or metric names. 

<details>
<summary>Summary of renamings</summary>
 The following identifiers were renamed in modules:

### `iota-core/src/authority/authority_per_epoch_store.rs`

- **Types**:
  - `CertLockGuard` ➡️ `TxLockGuard`
  - `CertTxGuard` ➡️ `TxGuard`
- **Methods**:
  - `finish_consensus_certificate_process` ➡️ `finish_consensus_transaction_process`
- **Tracing spans**:
  - Label `cert_digest` ➡️ `tx_digest` on `try_schedule()`

### `iota-core/src/authority/shared_object_congestion_tracker.rs`

- **Tracing spans**:
  - Field `cert_digest` ➡️ `tx_digest`

### `iota-core/src/authority/shared_object_version_manager.rs`

- **Methods**:
  - `assign_versions_for_certificate` ➡️ `assign_versions_for_transaction`

### `iota-core/src/authority/suggested_gas_price_calculator.rs`

- **Methods**:
  - `build_and_try_sequencing_certificate` ➡️ `build_and_try_sequencing_transaction`
  - `update_data_for_scheduled_certificate` ➡️ `update_data_for_scheduled_transaction`

### `iota-core/src/authority.rs`

- **Methods**:
  - `process_certificate` ➡️ `process_transaction`
  - `commit_certificate` ➡️ `commit_transaction`
  - `prepare_certificate` ➡️ `prepare_transaction`
  - `prepare_certificate_for_benchmark` ➡️ `prepare_transaction_for_benchmark`
- **Tracing spans**:
  - `process_certificate` ➡️ `process_transaction`
- **Fail points**:
  - `correlated-crash-process-certificate` ➡️ `correlated-crash-process-transaction`

### `iota-benchmark/tests/simtest.rs`

- **Fail points**:
  - `correlated-crash-process-certificate` ➡️ `correlated-crash-process-transaction`

### `iota-core/src/transaction_manager.rs`

- **Types**:
  - `PendingCertificate` ➡️ `PendingTransaction`
  - `PendingCertificateStats` ➡️ `PendingTransactionStats`
- **Fields**:
  - `tx_ready_certificates` ➡️ `tx_ready_transactions` (in `TransactionManager`)
  - `certificate` ➡️ `transaction` (in now `PendingTransaction`)
  - `pending_certificates` ➡️ `pending_transactions` (in `Inner`)
  - `executing_certificates` ➡️ `.executing_transactions` (in `Inner`)
- **Methods**:
  - `certificate_ready` ➡️ `transaction_ready`
- **Tracing spans**:
  - `enqueueing_pending_certificate` ➡️ `enqueueing_pending_transaction`
  - Label `cert_digest` ➡️ `tx_digest`

### `iota-core/src/execution_driver.rs`

- **Tracing spans**:
  - `start_execute_pending_certs` ➡️ `start_execute_pending_transactions`
  - `executing_pending_cert` ➡️ `executing_pending_transaction`
  - Label `cert_epoch` ➡️ `tx_epoch`

Also renamed variables, parameters, log messages, docstrings, and comments containing `cert` in all of the above modules and in `crates/iota-core/src/unit_tests/transaction_manager_tests.rs`.
</details> 

## Links to any relevant issues

Closes #10908.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes