### PR TITLE
feat(release): allow homebrew formula update when Windows build fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,10 @@ jobs:
             os_type: macos-arm64
           - os: windows-latest
             os_type: windows-x86_64
+            continue-on-error: true
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.continue-on-error == true }}
     needs: generate-tag
 
     steps:
@@ -258,7 +260,8 @@ jobs:
     name: Update the homebrew-tap formula
     needs: release-build
     runs-on: ubuntu-latest
-    # Releasing iota cli on Testnet and Mainnet releases which are equally stable
+    # Releasing iota cli on Testnet and Mainnet releases which are equally stable.
+    # Windows uses continue-on-error so its failure won't affect the matrix result.
     if: ${{ github.event_name == 'release' && !contains(github.ref, '-alpha') && !contains(github.ref, '-beta')}}
     steps:
       - name: Install Homebrew


### PR DESCRIPTION
# Description of change

## Problem

The `update-homebrew-formula` job depends on `release-build`, a matrix job that builds binaries for Linux (x86_64, arm64), macOS (arm64), and Windows (x86_64). If the Windows build failed for any reason, GitHub would mark the entire `release-build` matrix as failed and block the homebrew job from running — even though homebrew only ships macOS and Linux binaries. A flaky Windows build would prevent a valid release from being published to homebrew.

## Fix

Added `continue-on-error: true` to the Windows matrix entry. GitHub Actions propagates this to the job level via `continue-on-error: ${{ matrix.continue-on-error == true }}`, which means a Windows failure is recorded (the leg shows as orange in the UI) but does not fail the overall matrix job. The Linux and macOS builds must still fully succeed for the homebrew update to proceed.
