### PR TITLE
fix(iota-core,iota-types): post-consensus validation fixes

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3036,12 +3036,13 @@ impl AuthorityPerEpochStore {
         let mut current_commit_sequenced_randomness_transactions =
             Vec::with_capacity(verified_transactions.len());
         let mut end_of_publish_transactions = Vec::with_capacity(verified_transactions.len());
+        let enable_white_flag = self.protocol_config.enable_white_flag_flow();
         for tx in verified_transactions {
             if tx.0.is_end_of_publish() {
                 end_of_publish_transactions.push(tx);
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
-            } else if tx.0.is_user_tx_with_randomness() {
+            } else if !enable_white_flag && tx.0.is_user_tx_with_randomness() {
                 current_commit_sequenced_randomness_transactions.push(tx);
             } else {
                 current_commit_sequenced_consensus_transactions.push(tx);
@@ -3074,17 +3075,25 @@ impl AuthorityPerEpochStore {
             })
             .collect();
 
-        // Sequenced_transactions and sequenced_randomness_transactions store all
+        // sequenced_transactions and sequenced_randomness_transactions store all
         // transactions that will be sent to process_consensus_transactions. We
         // put deferred transactions at the beginning of the list before
         // PostConsensusTxReorder::reorder, so that for transactions with the same gas
         // price, deferred transactions will be placed earlier in the execution
         // queue.
+        //
+        // White-flag flow: when enabled, the categorization loop above puts ALL
+        // user transactions (including randomness) into
+        // current_commit_sequenced_consensus_transactions to preserve consensus
+        // DAG ordering during conflict resolution. The deferred-loading paths
+        // below do the same. After validate_and_resolve_conflicts runs on the
+        // combined list, we partition back into regular/randomness for downstream
+        // processing (separate reordering and congestion tracking).
+        let total_user_tx_count = current_commit_sequenced_consensus_transactions.len()
+            + current_commit_sequenced_randomness_transactions.len()
+            + previously_deferred_tx_digests.len();
         let mut sequenced_transactions: Vec<VerifiedSequencedConsensusTransaction> =
-            Vec::with_capacity(
-                current_commit_sequenced_consensus_transactions.len()
-                    + previously_deferred_tx_digests.len(),
-            );
+            Vec::with_capacity(total_user_tx_count);
         let mut sequenced_randomness_transactions: Vec<VerifiedSequencedConsensusTransaction> =
             Vec::with_capacity(
                 current_commit_sequenced_randomness_transactions.len()
@@ -3133,7 +3142,11 @@ impl AuthorityPerEpochStore {
             self.load_and_process_deferred_transactions_for_randomness(
                 &mut output,
                 &mut previously_deferred_tx_digests,
-                &mut sequenced_randomness_transactions,
+                if enable_white_flag {
+                    &mut sequenced_transactions
+                } else {
+                    &mut sequenced_randomness_transactions
+                },
             )?;
         }
 
@@ -3142,7 +3155,7 @@ impl AuthorityPerEpochStore {
             .into_iter()
             .flat_map(|(_, txs)| txs.into_iter())
         {
-            if tx.transaction.0.is_user_tx_with_randomness() {
+            if !enable_white_flag && tx.transaction.0.is_user_tx_with_randomness() {
                 sequenced_randomness_transactions.push(tx.transaction);
             } else {
                 sequenced_transactions.push(tx.transaction);
@@ -3155,7 +3168,7 @@ impl AuthorityPerEpochStore {
         // single pass: validates UserTransactionV1 transactions and resolves
         // lock conflicts before reordering. Deferred txs from previous commits
         // already have persistent locks, giving them natural precedence.
-        if self.protocol_config.enable_white_flag_flow() {
+        if enable_white_flag {
             let (dropped, owned_object_locks) =
                 post_consensus_validation::validate_and_resolve_conflicts(
                     authority_state,
@@ -3174,6 +3187,14 @@ impl AuthorityPerEpochStore {
                     .consensus_handler_validation_dropped_transactions
                     .inc_by(dropped.len() as u64);
             }
+
+            // Split back for downstream processing (separate reordering
+            // and congestion tracking).
+            let (regular, randomness): (Vec<_>, Vec<_>) = sequenced_transactions
+                .into_iter()
+                .partition(|tx| !tx.0.is_user_tx_with_randomness());
+            sequenced_transactions = regular;
+            sequenced_randomness_transactions = randomness;
         }
 
         // Save roots for checkpoint generation. One set for most tx, one for randomness

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1543,12 +1543,12 @@ impl ValidatorService {
                     };
                     let input_objects = state.get_transaction_input_objects(&effects).ok();
                     let output_objects = state.get_transaction_output_objects(&effects).ok();
-                    let details = Some(Box::new(ExecutedData {
+                    let details = Box::new(ExecutedData {
                         effects,
                         events,
                         input_objects: input_objects.unwrap_or_default(),
                         output_objects: output_objects.unwrap_or_default(),
-                    }));
+                    });
                     Ok((
                         tonic::Response::new(SubmitTransactionsResponse {
                             result: SubmitTransactionResult::Executed {

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -120,15 +120,12 @@ pub async fn validate_and_resolve_conflicts(
         let digest = *transaction.digest();
 
         // Check #1: Already executed — silent dedup.
-        match authority_state
+        if authority_state
             .get_transaction_cache_reader()
             .try_is_tx_already_executed(&digest)?
         {
-            true => {
-                keep[i] = false;
-                continue;
-            }
-            false => {}
+            keep[i] = false;
+            continue;
         }
 
         // Check #2: Structural validity.

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -122,23 +122,13 @@ pub async fn validate_and_resolve_conflicts(
         // Check #1: Already executed — silent dedup.
         match authority_state
             .get_transaction_cache_reader()
-            .try_is_tx_already_executed(&digest)
+            .try_is_tx_already_executed(&digest)?
         {
-            Ok(true) => {
+            true => {
                 keep[i] = false;
                 continue;
             }
-            Ok(false) => {}
-            Err(e) => {
-                warn!(
-                    ?digest,
-                    error = ?e,
-                    "Failed to check executed status post-consensus, dropping transaction"
-                );
-                dropped.push((digest, e));
-                keep[i] = false;
-                continue;
-            }
+            false => {}
         }
 
         // Check #2: Structural validity.
@@ -212,44 +202,23 @@ pub async fn validate_and_resolve_conflicts(
                 break 'conflict_check;
             }
 
-            match epoch_store.tables() {
-                Ok(tables) => match tables.get_locked_transaction(obj_ref) {
-                    Ok(Some(locked_by)) => {
-                        debug!(
-                            ?digest,
-                            ?obj_ref,
-                            ?locked_by,
-                            "Transaction conflicts with persistent lock, dropping"
-                        );
-                        conflict = Some(IotaError::ObjectLockConflict {
-                            obj_ref: *obj_ref,
-                            pending_transaction: locked_by,
-                        });
-                        break 'conflict_check;
-                    }
-                    Ok(None) => {
-                        // No lock in DB — this input is free to be locked by
-                        // the current transaction.
-                    }
-                    Err(e) => {
-                        warn!(
-                            ?digest,
-                            ?obj_ref,
-                            error = ?e,
-                            "Failed to check persistent lock post-consensus, dropping"
-                        );
-                        conflict = Some(e);
-                        break 'conflict_check;
-                    }
-                },
-                Err(e) => {
-                    warn!(
+            match epoch_store.tables()?.get_locked_transaction(obj_ref)? {
+                Some(locked_by) => {
+                    debug!(
                         ?digest,
-                        error = ?e,
-                        "Failed to access epoch store tables post-consensus, dropping"
+                        ?obj_ref,
+                        ?locked_by,
+                        "Transaction conflicts with persistent lock, dropping"
                     );
-                    conflict = Some(e);
+                    conflict = Some(IotaError::ObjectLockConflict {
+                        obj_ref: *obj_ref,
+                        pending_transaction: locked_by,
+                    });
                     break 'conflict_check;
+                }
+                None => {
+                    // No lock in DB — this input is free to be locked by
+                    // the current transaction.
                 }
             }
         }
@@ -277,6 +246,9 @@ pub async fn validate_and_resolve_conflicts(
             .handle_transaction_validation_checks(&verified_tx, epoch_store)
             .await
         {
+            if e.is_storage_or_epoch_error() {
+                return Err(e);
+            }
             warn!(
                 ?digest,
                 error = ?e,

--- a/crates/iota-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/iota-core/src/transaction_driver/effects_certifier.rs
@@ -90,7 +90,7 @@ impl EffectsCertifier {
             SubmitTransactionResult::Executed {
                 effects_digest,
                 details,
-            } => details.map(|details| (effects_digest, details)),
+            } => Some((effects_digest, details)),
             SubmitTransactionResult::Rejected { error } => {
                 return Err(TransactionDriverError::ClientInternal {
                     error: format!(

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4665,9 +4665,22 @@ async fn test_shared_object_transaction_ok() {
 // consensus commit prologue transaction to the transactions in the current
 // consensus commit. It will be the first transaction in the batch and the first
 // one that updates the system clock object.
+//
+// When `white_flag` is true, transactions are submitted as UserTransactionV1
+// (the certificate-free path) with white-flag conflict resolution enabled.
+// This verifies that the white-flag merge/split logic produces the same
+// prologue generation and shared-object version assignment behaviour.
+#[rstest::rstest]
 #[tokio::test]
-async fn test_consensus_commit_prologue_generation() {
+async fn test_consensus_commit_prologue_generation(#[values(false, true)] white_flag: bool) {
     telemetry_subscribers::init_for_testing();
+
+    let _guard = white_flag.then(|| {
+        ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_enable_white_flag_flow_for_testing(true);
+            config
+        })
+    });
 
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
 
@@ -4687,45 +4700,83 @@ async fn test_consensus_commit_prologue_generation() {
     .await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
-    let mut certificates = vec![];
-    certificates.push(
-        make_test_transaction(
-            &sender,
-            &sender_key,
-            &[],
-            &[(shared_object_id, initial_shared_version, true)],
-            &gas_objects[1].compute_object_reference(),
-            &[&authority_state],
-            0,
-            None,
-            None,
-        )
-        .await,
-    );
+    // Transaction 1: shared-object Move call.
+    let shared_tx_data = TransactionData::new_move_call(
+        sender,
+        IOTA_FRAMEWORK_PACKAGE_ID,
+        ident_str!("object_basics").to_owned(),
+        ident_str!("set_value").to_owned(),
+        vec![],
+        gas_objects[1].compute_object_reference(),
+        vec![
+            CallArg::Object(ObjectArg::SharedObject {
+                id: shared_object_id,
+                initial_shared_version,
+                mutable: true,
+            }),
+            CallArg::Pure(0u64.to_le_bytes().to_vec()),
+        ],
+        TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
+        rgp,
+    )
+    .unwrap();
+    let shared_tx = to_sender_signed_transaction(shared_tx_data, &sender_key);
 
-    let tx_data = TransactionData::new_move_call(
+    // Transaction 2: clock-using Move call (higher gas price → ordered later).
+    let clock_tx_data = TransactionData::new_move_call(
         sender,
         package_object_ref.0,
         ident_str!("object_basics").to_owned(),
         ident_str!("use_clock").to_owned(),
-        // type_args
         vec![],
         gas_objects[0].compute_object_reference(),
         vec![CallArg::CLOCK_IMM],
         TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
-        rgp * 2, // User transaction that uses the clock has the highest gas price.
+        rgp * 2,
     )
     .unwrap();
+    let clock_tx = to_sender_signed_transaction(clock_tx_data, &sender_key);
 
-    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
-    certificates.push(
-        certify_transaction(&authority_state, transaction)
+    let processed_consensus_transactions = if white_flag {
+        // Submit as UserTransactionV1 — no certificates needed.
+        let transactions = vec![
+            SequencedConsensusTransaction::new_test(ConsensusTransaction {
+                kind: ConsensusTransactionKind::UserTransactionV1(Box::new(shared_tx)),
+                tracking_id: Default::default(),
+            }),
+            SequencedConsensusTransaction::new_test(ConsensusTransaction {
+                kind: ConsensusTransactionKind::UserTransactionV1(Box::new(clock_tx)),
+                tracking_id: Default::default(),
+            }),
+        ];
+        authority_state
+            .epoch_store_for_testing()
+            .process_consensus_transactions_for_tests(
+                transactions,
+                &Arc::new(CheckpointServiceNoop {}),
+                authority_state.get_object_cache_reader().as_ref(),
+                authority_state.get_transaction_cache_reader().as_ref(),
+                &authority_state.metrics,
+                false,
+                &authority_state,
+            )
             .await
-            .unwrap(),
-    );
-
-    let processed_consensus_transactions =
-        send_batch_consensus_no_execution(&authority_state, &certificates, false).await;
+            .unwrap()
+    } else {
+        // Submit as certificates (original path).
+        let mut certificates = vec![];
+        certificates.push(
+            certify_transaction(&authority_state, shared_tx)
+                .await
+                .unwrap(),
+        );
+        certificates.push(
+            certify_transaction(&authority_state, clock_tx)
+                .await
+                .unwrap(),
+        );
+        send_batch_consensus_no_execution(&authority_state, &certificates, false).await
+    };
 
     // Tests that new consensus commit prologue transaction is added to the batch,
     // and it is the first transaction.

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -654,12 +654,8 @@ async fn test_submit_transaction_already_executed() {
     assert!(result.is_ok(), "Expected Ok for already-executed tx");
     let response = result.unwrap().0.into_inner();
     match response.result {
-        SubmitTransactionResult::Executed {
-            effects_digest,
-            details,
-        } => {
+        SubmitTransactionResult::Executed { effects_digest, .. } => {
             assert_eq!(effects_digest, *effects.digest());
-            assert!(details.is_some(), "Expected details to be populated");
         }
         other => panic!("Expected Executed result, got {:?}", other),
     }

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -970,6 +970,19 @@ impl IotaError {
         matches!(self, IotaError::ValidatorOverloadedRetryAfter { .. })
     }
 
+    /// Returns `true` for errors caused by storage or epoch-lifecycle
+    /// failures (RocksDB, epoch store closed) rather than semantic transaction
+    /// problems. Used by post-consensus validation to distinguish fatal errors
+    /// (halt the commit) from per-transaction drops.
+    pub fn is_storage_or_epoch_error(&self) -> bool {
+        matches!(
+            self,
+            IotaError::Storage(..)
+                | IotaError::EpochEnded(..)
+                | IotaError::ValidatorHaltedAtEpochEnd
+        )
+    }
+
     pub fn retry_after_secs(&self) -> u64 {
         match self {
             IotaError::ValidatorOverloadedRetryAfter { retry_after_secs } => *retry_after_secs,

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -379,8 +379,7 @@ pub enum SubmitTransactionResult {
     /// The transaction has already been executed (finalized).
     Executed {
         effects_digest: TransactionEffectsDigest,
-        /// Response should always include details for executed transactions.
-        details: Option<Box<ExecutedData>>,
+        details: Box<ExecutedData>,
     },
     /// The transaction was rejected.
     Rejected { error: IotaError },


### PR DESCRIPTION
# Description of change

Three fixes identified during PR #10379 review:

**Make `SubmitTxResult::Executed` details non-optional**
Remove `Option` from the `details` field — the `Executed` variant is only constructed for already-executed transactions where details are always available. `WaitForEffectsResponse::Executed` keeps `Option` (justified by `include_details` flag and ping responses).

**Propagate storage errors as fatal in post-consensus validation**
Align with the certificate flow where DB errors halt processing via `?`. Storage/epoch errors (RocksDB failures, epoch store closed) now return `Err` immediately instead of being downgraded to per-transaction drops. Add `IotaError::is_storage_or_epoch_error()` to classify errors by variant. Guaranteed-storage sites use `?` directly; mixed sites (`handle_transaction_deny_checks`) use the classifier.

**Include randomness transactions in white-flag conflict resolution**
When white-flag is enabled, keep all user transactions (regular and randomness) in a single list during categorization to preserve consensus DAG ordering. After `validate_and_resolve_conflicts`, partition back into separate lists for downstream processing. Non-white-flag flow is unchanged.

## Links to any relevant issues

Fixes #10761
Fixes #10763
Fixes #10764

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

- `cargo test -p iota-core -- server_tests post_consensus_validation authority_tests::test_consensus_commit_prologue_generation` — all pass
- `test_consensus_commit_prologue_generation` parameterized with rstest to run with/without white-flag + UserTransactionV1