### PR TITLE
refactor(dev-tools): pg-services-local use gRPC

### DIFF
--- a/dev-tools/pg-services-local/docker-compose.yaml
+++ b/dev-tools/pg-services-local/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       - "127.0.0.1:9123:9123"
       - "127.0.0.1:50051:50051"
     healthcheck:
-      test: "grpcurl -plaintext -import-path /iota/proto -proto iota/grpc/v0/ledger_service.proto local-network:50051 iota.grpc.v0.ledger_service.LedgerService/GetHealth"
+      test: "grpcurl -plaintext -import-path /iota/proto -proto iota/grpc/v0/ledger_service.proto localhost:50051 iota.grpc.v0.ledger_service.LedgerService/GetHealth"
       interval: 1s
       start_period: 5s
       timeout: 2s

--- a/dev-tools/pg-services-local/docker-compose.yaml
+++ b/dev-tools/pg-services-local/docker-compose.yaml
@@ -1,9 +1,9 @@
 services:
   local-network:
-    image: iota
+    image: iota-localnet
     build:
       context: ../../
-      dockerfile: docker/iota/Dockerfile
+      dockerfile: docker/iota-localnet/Dockerfile
       args:
         - RUST_IMAGE_VERSION=${RUST_IMAGE_VERSION:-trixie}
         - PROFILE=release
@@ -20,21 +20,26 @@ services:
       - RUST_BACKTRACE=1
       - RUST_LOG=info
     command:
-      - /usr/local/bin/iota
-      - start
-      - --with-faucet=0.0.0.0:9123
-      - --fullnode-rpc-port=9000
-      - --epoch-duration-ms=120000
-      - --remote-migration-snapshots=https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/test/stardust_object_snapshot.bin.gz
-      - --force-regenesis
-      - --delegator=0x4f72f788cdf4bb478cf9809e878e6163d5b351c82c11f1ea28750430752e7892
+      - sh
+      - -c
+      - |
+        iota-localnet genesis \
+          --epoch-duration-ms=120000 \
+          --remote-migration-snapshots=https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/test/stardust_object_snapshot.bin.gz \
+          --delegator=0x4f72f788cdf4bb478cf9809e878e6163d5b351c82c11f1ea28750430752e7892 &&
+        sed -i 's/enable-grpc-api: false/enable-grpc-api: true/' /root/.iota/iota_config/fullnode.yaml &&
+        iota-localnet start \
+          --with-faucet=0.0.0.0:9123 \
+          --fullnode-rpc-port=9000
     expose:
       - 9000
+      - 50051
     ports:
       - "127.0.0.1:9000:9000"
       - "127.0.0.1:9123:9123"
+      - "127.0.0.1:50051:50051"
     healthcheck:
-      test: "curl -f http://local-network:9000/api/v1/"
+      test: "grpcurl -plaintext -import-path /iota/proto -proto iota/grpc/v0/ledger_service.proto local-network:50051 iota.grpc.v0.ledger_service.LedgerService/GetHealth"
       interval: 1s
       start_period: 5s
       timeout: 2s
@@ -65,13 +70,21 @@ services:
       - --database-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
       - --metrics-address=0.0.0.0:9181
       - indexer
-      - --remote-store-url=http://local-network:9000/api/v1
+      - --remote-store-url=http://local-network:50051
       - --reset-db
     ports:
       - "127.0.0.1:9181:9181/tcp"
+    healthcheck:
+      test: "curl -sf http://localhost:9181/metrics > /dev/null"
+      interval: 1s
+      start_period: 5s
+      timeout: 2s
+      retries: 3
     depends_on:
-      - local-network
-      - postgres
+      local-network:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
 
   indexer-rpc:
     image: iota-indexer
@@ -89,15 +102,18 @@ services:
       - --database-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
       - --metrics-address=0.0.0.0:9181
       - json-rpc-service
-      - --rpc-client-url=http://local-network:9000
+      - --rpc-client-url=http://local-network:50051
       - --rpc-address=0.0.0.0:9000
     ports:
       - "127.0.0.1:9005:9000/tcp"
       - "127.0.0.1:9182:9181/tcp"
     depends_on:
-      - local-network
-      - postgres
-      - indexer-sync
+      local-network:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      indexer-sync:
+        condition: service_healthy
 
   indexer-analytics:
     image: iota-indexer
@@ -119,9 +135,12 @@ services:
     ports:
       - "127.0.0.1:9184:9181/tcp"
     depends_on:
-      - local-network
-      - postgres
-      - indexer-sync
+      local-network:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      indexer-sync:
+        condition: service_healthy
 
   graphql-server:
     image: iota-graphql-rpc
@@ -151,7 +170,7 @@ services:
       - --port=8000
       - --prom-host=0.0.0.0
       - --prom-port=9181
-      - --node-rpc-url=http://local-network:9000
+      - --node-rpc-url=http://local-network:50051
       - --ide-title="IOTA GraphQL Service"
     ports:
       - "127.0.0.1:8000:8000/tcp"
@@ -163,7 +182,7 @@ services:
       postgres:
         condition: service_healthy
       indexer-sync:
-        condition: service_started
+        condition: service_healthy
 
   postgres:
     image: postgres:15

--- a/dev-tools/pg-services-local/docker-compose.yaml
+++ b/dev-tools/pg-services-local/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
       - RUST_BACKTRACE=1
       - RUST_LOG=info
     command:
+      # We have already an issue in place to simplify this part, since gRPC will be enabled by default.
+      # https://github.com/iotaledger/iota/issues/10777
       - sh
       - -c
       - |

--- a/docker/iota-localnet/Dockerfile
+++ b/docker/iota-localnet/Dockerfile
@@ -1,0 +1,56 @@
+# Build image (the specific rust version can also be passed, e.g. "1.91-trixie")
+ARG RUST_IMAGE_VERSION=trixie
+FROM rust:${RUST_IMAGE_VERSION} AS builder
+
+ARG PROFILE=release
+ARG TARGET_FOLDER=target/release
+ARG CARGO_BUILD_FEATURES
+# The GIT_REVISION environment variable is used during build time inside the rust crates
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+
+WORKDIR "/iota"
+
+# Install build dependencies, including clang and lld for faster linking
+RUN apt update && apt install -y cmake clang lld protobuf-compiler
+
+# Configure Rust to use clang and lld as the linker
+RUN mkdir -p ~/.cargo && \
+    echo -e "[target.x86_64-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-C\", \"link-arg=-fuse-ld=lld\"]" > ~/.cargo/config.toml
+
+# Install additional dependencies
+RUN apt install -y ca-certificates libpq5 libpq-dev
+
+# Copy in all crates, Cargo.toml, and Cargo.lock
+COPY consensus consensus
+COPY crates crates
+COPY external-crates external-crates
+COPY iota-execution iota-execution
+COPY Cargo.toml Cargo.lock ./
+
+# Build the binaries and copy them to the working directory
+RUN cargo build --profile ${PROFILE} \
+      --bin iota-localnet \
+      --features ${CARGO_BUILD_FEATURES:=default} && \
+    cp $TARGET_FOLDER/iota-localnet ./iota-localnet
+
+# Production image
+FROM debian:trixie-slim AS runtime
+
+ARG WORKDIR="/iota"
+WORKDIR "$WORKDIR"
+
+# Install runtime dependencies and tools (grpcurl for gRPC health checks)
+RUN apt update && apt install -y ca-certificates curl libpq5 && \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "${ARCH}" = "amd64" ]; then GRPCURL_ARCH="x86_64"; else GRPCURL_ARCH="${ARCH}"; fi && \
+    curl -sSL "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_${GRPCURL_ARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin grpcurl
+
+COPY --from=builder /iota/iota-localnet /usr/local/bin
+COPY --from=builder /iota/crates/iota-grpc-types/proto /iota/proto
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/docker/iota-localnet/build.sh
+++ b/docker/iota-localnet/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2024 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# Determine script's location to resolve the relative path correctly
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
+# The name of last directory in script's path is used for tag
+BASE_NAME="$(basename "$SCRIPT_DIR")"
+
+DOCKER_BUILDKIT=1 "$SCRIPT_DIR/../utils/build-script.sh" --image-tag "iotaledger/$BASE_NAME"

--- a/docker/iota-localnet/build.sh
+++ b/docker/iota-localnet/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# Modifications Copyright (c) 2024 IOTA Stiftung
+# Modifications Copyright (c) 2026 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
 # Determine script's location to resolve the relative path correctly


### PR DESCRIPTION
# Description of change

This PR fixes the pg-services-local `docker-compose.yaml` file to use the `iota-localnet` crate for bootstrapping a local network with enabled gRPC API. 

Since the gRPC server has a delay when it's started, the container start order has been refined.

## Links to any relevant issues

fixes #10760 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Build docker images
```shell
docker compose build local-network
docker compose build indexer-sync
docker compose build graphql-server
```
- started services
```shell
docker compose up -d 
```
- checked that all containers were healthy and were actually working as expected, ingesting checkpoints, serving JSON-RPC & GraphQL calls ect..

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch doe snot affect the normal operation of the indexer, this no further tests were conducted.