### PR TITLE
upstream(core): Enable iterator methods for in_memory_db

### DIFF
--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -14,7 +14,7 @@ use iota_types::{
 use serde::{Deserialize, Serialize};
 use tracing::error;
 use typed_store::{
-    DBMapUtils,
+    DBMapUtils, DbIterator,
     metrics::SamplingInterval,
     rocks::{
         DBBatch, DBMap, DBMapTableConfigMap, DBOptions, MetricConf, default_db_options,
@@ -451,7 +451,7 @@ impl AuthorityPerpetualTables {
 
     pub fn iter_live_object_set(&self) -> LiveSetIter<'_> {
         LiveSetIter {
-            iter: self.objects.safe_iter(),
+            iter: Box::new(self.objects.safe_iter()),
             tables: self,
             prev: None,
         }
@@ -466,7 +466,7 @@ impl AuthorityPerpetualTables {
         let upper_bound = upper_bound.as_ref().map(ObjectKey::max_for_id);
 
         LiveSetIter {
-            iter: self.objects.safe_iter_with_bounds(lower_bound, upper_bound),
+            iter: Box::new(self.objects.safe_iter_with_bounds(lower_bound, upper_bound)),
             tables: self,
             prev: None,
         }
@@ -563,8 +563,7 @@ impl ObjectStore for AuthorityPerpetualTables {
 }
 
 pub struct LiveSetIter<'a> {
-    iter:
-        <DBMap<ObjectKey, StoreObjectWrapper> as Map<'a, ObjectKey, StoreObjectWrapper>>::SafeIterator,
+    iter: DbIterator<'a, (ObjectKey, StoreObjectWrapper)>,
     tables: &'a AuthorityPerpetualTables,
     prev: Option<(ObjectKey, StoreObjectWrapper)>,
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -22,15 +22,17 @@ use tracing::{debug, error, instrument, warn};
 use typed_store_error::TypedStoreError;
 
 use crate::{
+    DbIterator,
     memstore::{InMemoryBatch, InMemoryDB},
     metrics::{DBMetrics, RocksDBPerfContext, SamplingInterval},
     rocks::{
-        RocksDB, be_fix_int_ser,
+        RocksDB,
         errors::{typed_store_err_from_bcs_err, typed_store_err_from_rocks_err},
-        rocks_cf,
+        rocks_cf, rocks_util,
         safe_iter::{SafeIter, SafeRevIter},
     },
     traits::{Map, TableSummary},
+    util::{be_fix_int_ser, iterator_bounds, iterator_bounds_with_range},
 };
 
 #[derive(Clone)]
@@ -105,8 +107,6 @@ pub enum StorageWriteBatch {
     Rocks(rocksdb::WriteBatch),
     InMemory(InMemoryBatch),
 }
-
-pub type RawIter<'a> = rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
 
 #[derive(Debug, Default)]
 pub struct MetricConf {
@@ -340,19 +340,6 @@ impl Database {
 
         #[allow(clippy::let_and_return)]
         ret
-    }
-
-    pub(crate) fn raw_iterator_cf<'a: 'b, 'b>(
-        &'a self,
-        cf: &ColumnFamily,
-        readopts: ReadOptions,
-    ) -> RawIter<'b> {
-        match &self.storage {
-            Storage::Rocks(rocksdb) => rocksdb
-                .underlying
-                .raw_iterator_cf_opt(&rocks_cf(rocksdb, cf.name()), readopts),
-            _ => unimplemented!("iterators not yet supported for other backends"),
-        }
     }
 
     pub(crate) fn compact_range_cf<K: AsRef<[u8]>>(
@@ -597,8 +584,8 @@ impl<K, V> DBMap<K, V> {
     }
 
     pub fn compact_range<J: Serialize>(&self, start: &J, end: &J) -> Result<(), TypedStoreError> {
-        let from_buf = be_fix_int_ser(start)?;
-        let to_buf = be_fix_int_ser(end)?;
+        let from_buf = be_fix_int_ser(start);
+        let to_buf = be_fix_int_ser(end);
         self.db
             .compact_range_cf(&self.column_family, Some(from_buf), Some(to_buf));
         Ok(())
@@ -638,13 +625,10 @@ impl<K, V> DBMap<K, V> {
         } else {
             None
         };
-        let keys_bytes: Result<Vec<_>, TypedStoreError> = keys
-            .into_iter()
-            .map(|k| be_fix_int_ser(k.borrow()))
-            .collect();
+        let keys_bytes = keys.into_iter().map(|k| be_fix_int_ser(k.borrow()));
         let results: Result<Vec<_>, TypedStoreError> = self
             .db
-            .multi_get(&self.column_family, keys_bytes?, &self.opts.readopts())
+            .multi_get(&self.column_family, keys_bytes, &self.opts.readopts())
             .into_iter()
             .collect();
         let entries = results?;
@@ -683,7 +667,7 @@ impl<K, V> DBMap<K, V> {
         for item in self.safe_iter() {
             let (key, value) = item?;
             num_keys += 1;
-            let key_len = be_fix_int_ser(key.borrow())?.len();
+            let key_len = be_fix_int_ser(key.borrow()).len();
             let value_len = bcs::to_bytes(value.borrow())?.len();
             key_bytes_total += key_len;
             value_bytes_total += value_len;
@@ -737,41 +721,19 @@ impl<K, V> DBMap<K, V> {
         )
     }
 
-    // Creates a RocksDB read option with specified lower and upper bounds.
-    /// Lower bound is inclusive, and upper bound is exclusive.
-    fn create_read_options_with_bounds(
-        &self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> ReadOptions
-    where
-        K: Serialize,
-    {
-        let mut readopts = self.opts.readopts();
-        if let Some(lower_bound) = lower_bound {
-            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
-            readopts.set_iterate_lower_bound(key_buf);
-        }
-        if let Some(upper_bound) = upper_bound {
-            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
-            readopts.set_iterate_upper_bound(key_buf);
-        }
-        readopts
-    }
-
     /// Creates a safe reversed iterator with optional bounds.
-    /// Upper bound is included.
+    /// Both upper bound and lower bound are included.
+    #[allow(clippy::complexity)]
     pub fn reversed_safe_iter_with_bounds(
         &self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
-    ) -> Result<SafeRevIter<'_, K, V>, TypedStoreError>
+    ) -> Result<DbIterator<'_, (K, V)>, TypedStoreError>
     where
         K: Serialize + DeserializeOwned,
         V: Serialize + DeserializeOwned,
     {
-        let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
-        let readopts = self.create_read_options_with_range((
+        let (it_lower_bound, it_upper_bound) = iterator_bounds_with_range::<K>((
             lower_bound
                 .as_ref()
                 .map(Bound::Included)
@@ -781,71 +743,36 @@ impl<K, V> DBMap<K, V> {
                 .map(Bound::Included)
                 .unwrap_or(Bound::Unbounded),
         ));
-
-        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        let iter = SafeIter::new(
-            self.cf_name().to_string(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        );
-        Ok(SafeRevIter::new(iter, upper_bound_key.transpose()?))
-    }
-
-    // Creates a RocksDB read option with lower and upper bounds set corresponding
-    // to `range`.
-    fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
-    where
-        K: Serialize,
-    {
-        let mut readopts = self.opts.readopts();
-
-        let lower_bound = range.start_bound();
-        let upper_bound = range.end_bound();
-
-        match lower_bound {
-            Bound::Included(lower_bound) => {
-                // Rocksdb lower bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-                readopts.set_iterate_lower_bound(key_buf);
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let readopts = rocks_util::apply_range_bounds(
+                    self.opts.readopts(),
+                    it_lower_bound,
+                    it_upper_bound,
+                );
+                let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
+                let db_iter = db
+                    .underlying
+                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
+                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+                let iter = SafeIter::new(
+                    self.cf_name().to_string(),
+                    db_iter,
+                    _timer,
+                    _perf_ctx,
+                    bytes_scanned,
+                    keys_scanned,
+                    Some(self.db_metrics.clone()),
+                );
+                Ok(Box::new(SafeRevIter::new(iter, upper_bound_key)))
             }
-            Bound::Excluded(lower_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-
-                // Since we want exclusive, we need to increment the key to exclude the previous
-                big_endian_saturating_add_one(&mut key_buf);
-                readopts.set_iterate_lower_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        match upper_bound {
-            Bound::Included(upper_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-
-                // If the key is already at the limit, there's nowhere else to go, so no upper
-                // bound
-                if !is_max(&key_buf) {
-                    // Since we want exclusive, we need to increment the key to get the upper bound
-                    big_endian_saturating_add_one(&mut key_buf);
-                    readopts.set_iterate_upper_bound(key_buf);
-                }
-            }
-            Bound::Excluded(upper_bound) => {
-                // Rocksdb upper bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-                readopts.set_iterate_upper_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        readopts
+            Storage::InMemory(db) => Ok(db.iterator(
+                self.column_family.name(),
+                it_lower_bound,
+                it_upper_bound,
+                true,
+            )),
+        }
     }
 }
 
@@ -1005,7 +932,7 @@ impl DBBatch {
         purged_vals
             .into_iter()
             .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
-                let k_buf = be_fix_int_ser(k.borrow())?;
+                let k_buf = be_fix_int_ser(k.borrow());
                 match (&mut self.batch, &db.column_family) {
                     (StorageWriteBatch::Rocks(b), ColumnFamily::Rocks(name)) => {
                         b.delete_cf(&rocks_cf_from_db(&self.database, name)?, k_buf)
@@ -1041,8 +968,8 @@ impl DBBatch {
             return Err(TypedStoreError::CrossDBBatch);
         }
 
-        let from_buf = be_fix_int_ser(from)?;
-        let to_buf = be_fix_int_ser(to)?;
+        let from_buf = be_fix_int_ser(from);
+        let to_buf = be_fix_int_ser(to);
 
         if let StorageWriteBatch::Rocks(b) = &mut self.batch {
             b.delete_range_cf(
@@ -1067,7 +994,7 @@ impl DBBatch {
         new_vals
             .into_iter()
             .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
-                let k_buf = be_fix_int_ser(k.borrow())?;
+                let k_buf = be_fix_int_ser(k.borrow());
                 let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
                 total += k_buf.len() + v_buf.len();
                 match (&mut self.batch, &db.column_family) {
@@ -1098,11 +1025,10 @@ where
     V: Serialize + DeserializeOwned,
 {
     type Error = TypedStoreError;
-    type SafeIterator = SafeIter<'a, K, V>;
 
     #[instrument(level = "trace", skip_all, err)]
     fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
-        let key_buf = be_fix_int_ser(key)?;
+        let key_buf = be_fix_int_ser(key);
         let readopts = self.opts.readopts();
         Ok(self
             .db
@@ -1138,7 +1064,7 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key)?;
+        let key_buf = be_fix_int_ser(key);
         let res = self
             .db
             .get(&self.column_family, &key_buf, &self.opts.readopts())?;
@@ -1173,7 +1099,7 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key)?;
+        let key_buf = be_fix_int_ser(key);
         let value_buf = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
         self.db_metrics
             .op_metrics
@@ -1218,7 +1144,7 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key)?;
+        let key_buf = be_fix_int_ser(key);
         self.db.delete_cf(&self.column_family, key_buf)?;
         self.db_metrics
             .op_metrics
@@ -1274,54 +1200,82 @@ where
         self.safe_iter().next().is_none()
     }
 
-    fn safe_iter(&'a self) -> Self::SafeIterator {
-        let db_iter = self
-            .db
-            .raw_iterator_cf(&self.column_family, self.opts.readopts());
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf_name().to_string(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
+    fn safe_iter(&'a self) -> DbIterator<'a, (K, V)> {
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let db_iter = db.underlying.raw_iterator_cf_opt(
+                    &rocks_cf(db, self.column_family.name()),
+                    self.opts.readopts(),
+                );
+                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+                Box::new(SafeIter::new(
+                    self.cf_name().to_string(),
+                    db_iter,
+                    _timer,
+                    _perf_ctx,
+                    bytes_scanned,
+                    keys_scanned,
+                    Some(self.db_metrics.clone()),
+                ))
+            }
+            Storage::InMemory(db) => db.iterator(self.column_family.name(), None, None, false),
+        }
     }
 
     fn safe_iter_with_bounds(
         &'a self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
-    ) -> Self::SafeIterator {
-        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
-        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf_name().to_string(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
+    ) -> DbIterator<'a, (K, V)> {
+        let (lower_bound, upper_bound) = iterator_bounds(lower_bound, upper_bound);
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let readopts =
+                    rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, upper_bound);
+                let db_iter = db
+                    .underlying
+                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
+                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+                Box::new(SafeIter::new(
+                    self.cf_name().to_string(),
+                    db_iter,
+                    _timer,
+                    _perf_ctx,
+                    bytes_scanned,
+                    keys_scanned,
+                    Some(self.db_metrics.clone()),
+                ))
+            }
+            Storage::InMemory(db) => {
+                db.iterator(self.column_family.name(), lower_bound, upper_bound, false)
+            }
+        }
     }
 
-    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
-        let readopts = self.create_read_options_with_range(range);
-        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf_name().to_string(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
+        let (lower_bound, upper_bound) = iterator_bounds_with_range(range);
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let readopts =
+                    rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, upper_bound);
+                let db_iter = db
+                    .underlying
+                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
+                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+                Box::new(SafeIter::new(
+                    self.cf_name().to_string(),
+                    db_iter,
+                    _timer,
+                    _perf_ctx,
+                    bytes_scanned,
+                    keys_scanned,
+                    Some(self.db_metrics.clone()),
+                ))
+            }
+            Storage::InMemory(db) => {
+                db.iterator(self.column_family.name(), lower_bound, upper_bound, false)
+            }
+        }
     }
 
     /// Returns a vector of values corresponding to the keys provided.
@@ -1404,57 +1358,4 @@ impl Default for ReadWriteOptions {
             ignore_range_deletions: true,
         }
     }
-}
-
-/// Given a `vec<u8>`, find the value which is one more than the vector
-/// if the vector was a big endian number.
-/// If the vector is already minimum, don't change it.
-pub(crate) fn big_endian_saturating_add_one(v: &mut [u8]) {
-    if is_max(v) {
-        return;
-    }
-    for i in (0..v.len()).rev() {
-        if v[i] == u8::MAX {
-            v[i] = 0;
-        } else {
-            v[i] += 1;
-            break;
-        }
-    }
-}
-
-/// Check if all the bytes in the vector are 0xFF
-pub(crate) fn is_max(v: &[u8]) -> bool {
-    v.iter().all(|&x| x == u8::MAX)
-}
-
-// `clippy::manual_div_ceil` is raised by code expanded by the
-// `uint::construct_uint!` macro so it needs to be fixed by `uint`
-#[expect(clippy::assign_op_pattern, clippy::manual_div_ceil)]
-#[test]
-fn test_helpers() {
-    let v = vec![];
-    assert!(is_max(&v));
-
-    fn check_add(v: Vec<u8>) {
-        let mut v = v;
-        let num = Num32::from_big_endian(&v);
-        big_endian_saturating_add_one(&mut v);
-        assert!(num + 1 == Num32::from_big_endian(&v));
-    }
-
-    uint::construct_uint! {
-        // 32 byte number
-        struct Num32(4);
-    }
-
-    let mut v = vec![255; 32];
-    big_endian_saturating_add_one(&mut v);
-    assert!(Num32::MAX == Num32::from_big_endian(&v));
-
-    check_add(vec![1; 32]);
-    check_add(vec![6; 32]);
-    check_add(vec![254; 32]);
-
-    // TBD: More tests coming with randomized arrays
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -12,10 +12,7 @@ use std::{
 
 use iota_macros::fail_point;
 use prometheus::{Histogram, HistogramTimer};
-use rocksdb::{
-    DBPinnableSlice, DBWithThreadMode, Error, LiveFile, MultiThreaded, ReadOptions, WriteBatch,
-    checkpoint::Checkpoint,
-};
+use rocksdb::{DBPinnableSlice, Error, LiveFile, ReadOptions, WriteBatch, checkpoint::Checkpoint};
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::oneshot;
 use tracing::{debug, error, instrument, warn};

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -14,15 +14,17 @@
 // typed-store
 pub use rocksdb;
 
-pub mod traits;
-pub use traits::Map;
 pub mod database;
+pub mod traits;
+pub use traits::{DbIterator, Map};
 pub mod memstore;
 pub mod metrics;
 pub mod rocks;
 pub mod test_db;
+mod util;
 pub use metrics::DBMetrics;
 pub use typed_store_error::TypedStoreError;
+pub use util::be_fix_int_ser;
 
 pub type StoreError = typed_store_error::TypedStoreError;
 

--- a/crates/typed-store/src/memstore.rs
+++ b/crates/typed-store/src/memstore.rs
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, Bound, HashMap},
     sync::{Arc, RwLock},
 };
+
+use bincode::Options;
+use serde::de::DeserializeOwned;
+use typed_store_error::TypedStoreError;
 
 type InMemoryStoreInternal = Arc<RwLock<HashMap<String, BTreeMap<Vec<u8>, Vec<u8>>>>>;
 
@@ -100,5 +104,39 @@ impl InMemoryDB {
 
     pub fn drop_cf(&self, name: &str) {
         self.data.write().expect("can't write data").remove(name);
+    }
+
+    pub fn iterator<K, V>(
+        &self,
+        cf_name: &str,
+        lower_bound: Option<Vec<u8>>,
+        upper_bound: Option<Vec<u8>>,
+        reverse: bool,
+    ) -> Box<dyn Iterator<Item = Result<(K, V), TypedStoreError>> + '_>
+    where
+        K: DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        let config = bincode::DefaultOptions::new()
+            .with_big_endian()
+            .with_fixint_encoding();
+        let lower_bound = lower_bound.map(Bound::Included).unwrap_or(Bound::Unbounded);
+        let upper_bound = upper_bound.map(Bound::Included).unwrap_or(Bound::Unbounded);
+
+        let data = self.data.read().expect("can't read data");
+        let mut section: Vec<_> = data
+            .get(cf_name)
+            .unwrap_or(&BTreeMap::new())
+            .range((lower_bound, upper_bound))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        if reverse {
+            section.reverse();
+        }
+        Box::new(section.into_iter().map(move |(raw_key, raw_value)| {
+            let key = config.deserialize(&raw_key).unwrap();
+            let value = bcs::from_bytes(&raw_value).unwrap();
+            Ok((key, value))
+        }))
     }
 }

--- a/crates/typed-store/src/memstore.rs
+++ b/crates/typed-store/src/memstore.rs
@@ -121,7 +121,7 @@ impl InMemoryDB {
             .with_big_endian()
             .with_fixint_encoding();
         let lower_bound = lower_bound.map(Bound::Included).unwrap_or(Bound::Unbounded);
-        let upper_bound = upper_bound.map(Bound::Included).unwrap_or(Bound::Unbounded);
+        let upper_bound = upper_bound.map(Bound::Excluded).unwrap_or(Bound::Unbounded);
 
         let data = self.data.read().expect("can't read data");
         let mut section: Vec<_> = data
@@ -134,8 +134,11 @@ impl InMemoryDB {
             section.reverse();
         }
         Box::new(section.into_iter().map(move |(raw_key, raw_value)| {
-            let key = config.deserialize(&raw_key).unwrap();
-            let value = bcs::from_bytes(&raw_value).unwrap();
+            let key = config
+                .deserialize(&raw_key)
+                .map_err(|e| TypedStoreError::Serialization(e.to_string()))?;
+            let value = bcs::from_bytes(&raw_value)
+                .map_err(|e| TypedStoreError::Serialization(e.to_string()))?;
             Ok((key, value))
         }))
     }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod errors;
+pub(crate) mod rocks_util;
 pub(crate) mod safe_iter;
 
 use std::{
@@ -629,11 +630,6 @@ impl DBMapTableConfigMap {
     pub fn to_map(&self) -> BTreeMap<String, DBOptions> {
         self.0.clone()
     }
-}
-
-pub enum RocksDBAccessType {
-    Primary,
-    Secondary(Option<PathBuf>),
 }
 
 // Drops a database if there is no other handle to it, with retries and timeout.

--- a/crates/typed-store/src/rocks/rocks_util.rs
+++ b/crates/typed-store/src/rocks/rocks_util.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) fn apply_range_bounds(
+    mut read_options: rocksdb::ReadOptions,
+    lower_bound: Option<Vec<u8>>,
+    upper_bound: Option<Vec<u8>>,
+) -> rocksdb::ReadOptions {
+    if let Some(lower_bound) = lower_bound {
+        read_options.set_iterate_lower_bound(lower_bound);
+    }
+    if let Some(upper_bound) = upper_bound {
+        read_options.set_iterate_upper_bound(upper_bound);
+    }
+    read_options
+}

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -6,19 +6,16 @@ use std::{marker::PhantomData, sync::Arc};
 
 use bincode::Options;
 use prometheus::{Histogram, HistogramTimer};
-use rocksdb::Direction;
+use rocksdb::{DBWithThreadMode, Direction, MultiThreaded};
 use serde::de::DeserializeOwned;
 use typed_store_error::TypedStoreError;
 
-use crate::{
-    database::RawIter,
-    metrics::{DBMetrics, RocksDBPerfContext},
-};
+use crate::metrics::{DBMetrics, RocksDBPerfContext};
 
 /// An iterator over all key-value pairs in a data map.
 pub struct SafeIter<'a, K, V> {
     cf_name: String,
-    db_iter: RawIter<'a>,
+    db_iter: rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
     is_initialized: bool,
@@ -34,7 +31,7 @@ pub struct SafeIter<'a, K, V> {
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
     pub(crate) fn new(
         cf_name: String,
-        db_iter: RawIter<'a>,
+        db_iter: rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>,
         _timer: Option<HistogramTimer>,
         _perf_ctx: Option<RocksDBPerfContext>,
         bytes_scanned: Option<Histogram>,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -8,11 +8,7 @@ use rstest::rstest;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::*;
-use crate::{
-    reopen,
-    rocks::safe_iter::{SafeIter, SafeRevIter},
-    traits::Map,
-};
+use crate::{reopen, traits::Map};
 
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
@@ -20,36 +16,19 @@ fn temp_dir() -> std::path::PathBuf {
         .keep()
 }
 
-enum TestIteratorWrapper<'a, K, V> {
-    SafeIter(SafeIter<'a, K, V>),
-}
-
-// Implement Iterator for TestIteratorWrapper that returns the same type result
-// for different types of Iterator. For non-safe Iterator, it returns the key
-// value pair. For SafeIterator, it consumes the result (assuming no error), and
-// return they key value pairs.
-impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for TestIteratorWrapper<'_, K, V> {
-    type Item = (K, V);
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            TestIteratorWrapper::SafeIter(iter) => iter.next().map(|result| result.unwrap()),
-        }
-    }
-}
-
-fn get_iter<K, V>(db: &DBMap<K, V>) -> TestIteratorWrapper<'_, K, V>
+fn get_iter<K, V>(db: &DBMap<K, V>) -> impl Iterator<Item = (K, V)> + use<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    TestIteratorWrapper::SafeIter(db.safe_iter())
+    db.safe_iter().map(|item| item.unwrap())
 }
 
 fn get_reverse_iter<K, V>(
     db: &DBMap<K, V>,
     lower_bound: Option<K>,
     upper_bound: Option<K>,
-) -> SafeRevIter<'_, K, V>
+) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + use<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
@@ -62,23 +41,24 @@ fn get_iter_with_bounds<K, V>(
     db: &DBMap<K, V>,
     lower_bound: Option<K>,
     upper_bound: Option<K>,
-) -> TestIteratorWrapper<'_, K, V>
+) -> impl Iterator<Item = (K, V)> + use<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    TestIteratorWrapper::SafeIter(db.safe_iter_with_bounds(lower_bound, upper_bound))
+    db.safe_iter_with_bounds(lower_bound, upper_bound)
+        .map(|item| item.unwrap())
 }
 
-fn get_range_iter<K, V>(
-    db: &DBMap<K, V>,
-    range: impl RangeBounds<K>,
-) -> TestIteratorWrapper<'_, K, V>
+fn get_range_iter<'a, K, V>(
+    db: &'a DBMap<K, V>,
+    range: impl RangeBounds<K> + 'a,
+) -> impl Iterator<Item = (K, V)> + 'a
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    TestIteratorWrapper::SafeIter(db.safe_range_iter(range))
+    db.safe_range_iter(range).map(|item| item.unwrap())
 }
 
 #[tokio::test]

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -20,8 +20,7 @@ use rocksdb::Direction;
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
-    Map, TypedStoreError,
-    rocks::{be_fix_int_ser, errors::typed_store_err_from_bcs_err},
+    DbIterator, Map, TypedStoreError, be_fix_int_ser, rocks::errors::typed_store_err_from_bcs_err,
 };
 
 /// An interface to a btree map backed sally database. This is mainly intended
@@ -103,11 +102,11 @@ impl<'a, K: Serialize, V> TestDBIter<'a, K, V> {
     /// the key.
     pub fn skip_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
         self.with_mut(|fields| {
-            let serialized_key = be_fix_int_ser(key).expect("serialization failed");
+            let serialized_key = be_fix_int_ser(key);
             let mut peekable = fields.iter.peekable();
             let mut peeked = peekable.peek();
             while peeked.is_some() {
-                let serialized = be_fix_int_ser(peeked.unwrap()).expect("serialization failed");
+                let serialized = be_fix_int_ser(peeked.unwrap());
                 if serialized >= serialized_key {
                     break;
                 } else {
@@ -124,11 +123,11 @@ impl<'a, K: Serialize, V> TestDBIter<'a, K, V> {
     /// no element prior to it, it returns an empty iterator.
     pub fn skip_prior_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
         self.with_mut(|fields| {
-            let serialized_key = be_fix_int_ser(key).expect("serialization failed");
+            let serialized_key = be_fix_int_ser(key);
             let mut peekable = fields.iter.peekable();
             let mut peeked = peekable.peek();
             while peeked.is_some() {
-                let serialized = be_fix_int_ser(peeked.unwrap()).expect("serialization failed");
+                let serialized = be_fix_int_ser(peeked.unwrap());
                 if serialized > serialized_key {
                     break;
                 } else {
@@ -222,23 +221,22 @@ where
     V: Serialize + DeserializeOwned,
 {
     type Error = TypedStoreError;
-    type SafeIterator = TestDBIter<'a, K, V>;
 
     fn contains_key(&self, key: &K) -> Result<bool, Self::Error> {
-        let raw_key = be_fix_int_ser(key)?;
+        let raw_key = be_fix_int_ser(key);
         let locked = self.rows.read().unwrap();
         Ok(locked.contains_key(&raw_key))
     }
 
     fn get(&self, key: &K) -> Result<Option<V>, Self::Error> {
-        let raw_key = be_fix_int_ser(key)?;
+        let raw_key = be_fix_int_ser(key);
         let locked = self.rows.read().unwrap();
         let res = locked.get(&raw_key);
         Ok(res.map(|raw_value| bcs::from_bytes(raw_value).ok().unwrap()))
     }
 
     fn insert(&self, key: &K, value: &V) -> Result<(), Self::Error> {
-        let raw_key = be_fix_int_ser(key)?;
+        let raw_key = be_fix_int_ser(key);
         let raw_value = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
         let mut locked = self.rows.write().unwrap();
         locked.insert(raw_key, raw_value);
@@ -246,7 +244,7 @@ where
     }
 
     fn remove(&self, key: &K) -> Result<(), Self::Error> {
-        let raw_key = be_fix_int_ser(key)?;
+        let raw_key = be_fix_int_ser(key);
         let mut locked = self.rows.write().unwrap();
         locked.remove(&raw_key);
         Ok(())
@@ -269,25 +267,29 @@ where
         locked.is_empty()
     }
 
-    fn safe_iter(&'a self) -> Self::SafeIterator {
-        TestDBIterBuilder {
-            rows: self.rows.read().unwrap(),
-            iter_builder: |rows: &mut RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>| rows.iter(),
-            phantom: PhantomData,
-            direction: Direction::Forward,
-        }
-        .build()
+    fn safe_iter(&'a self) -> DbIterator<'a, (K, V)> {
+        Box::new(
+            TestDBIterBuilder {
+                rows: self.rows.read().unwrap(),
+                iter_builder: |rows: &mut RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>| {
+                    rows.iter()
+                },
+                phantom: PhantomData,
+                direction: Direction::Forward,
+            }
+            .build(),
+        )
     }
 
     fn safe_iter_with_bounds(
         &'a self,
         _lower_bound: Option<K>,
         _upper_bound: Option<K>,
-    ) -> Self::SafeIterator {
+    ) -> DbIterator<'a, (K, V)> {
         unimplemented!("unimplemented API");
     }
 
-    fn safe_range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::SafeIterator {
+    fn safe_range_iter(&'a self, _range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
         unimplemented!("unimplemented API");
     }
 
@@ -430,7 +432,7 @@ impl TestDBWriteBatch {
             db.name.clone(),
             purged_vals
                 .into_iter()
-                .map(|key| be_fix_int_ser(&key.borrow()).unwrap())
+                .map(|key| be_fix_int_ser(&key.borrow()))
                 .collect(),
         )));
         Ok(())
@@ -443,8 +445,8 @@ impl TestDBWriteBatch {
         from: &K,
         to: &K,
     ) -> Result<(), TypedStoreError> {
-        let raw_from = be_fix_int_ser(from).unwrap();
-        let raw_to = be_fix_int_ser(to).unwrap();
+        let raw_from = be_fix_int_ser(from);
+        let raw_to = be_fix_int_ser(to);
         self.ops.push_back(WriteBatchOp::DeleteRange((
             db.rows.clone(),
             db.name.clone(),
@@ -465,7 +467,7 @@ impl TestDBWriteBatch {
                 .into_iter()
                 .map(|(key, value)| {
                     (
-                        be_fix_int_ser(&key.borrow()).unwrap(),
+                        be_fix_int_ser(&key.borrow()),
                         bcs::to_bytes(&value.borrow()).unwrap(),
                     )
                 })

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -8,13 +8,14 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::TypedStoreError;
 
+pub type DbIterator<'a, T> = Box<dyn Iterator<Item = Result<T, TypedStoreError>> + 'a>;
+
 pub trait Map<'a, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
     type Error: Error;
-    type SafeIterator: Iterator<Item = Result<(K, V), TypedStoreError>>;
 
     /// Returns true if the map contains a value for the specified key.
     fn contains_key(&self, key: &K) -> Result<bool, Self::Error>;
@@ -51,17 +52,17 @@ where
     fn is_empty(&self) -> bool;
 
     /// Same as `iter` but performs status check.
-    fn safe_iter(&'a self) -> Self::SafeIterator;
+    fn safe_iter(&'a self) -> DbIterator<'a, (K, V)>;
 
     // Same as `iter_with_bounds` but performs status check.
     fn safe_iter_with_bounds(
         &'a self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
-    ) -> Self::SafeIterator;
+    ) -> DbIterator<'a, (K, V)>;
 
     // Same as `range_iter` but performs status check.
-    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator;
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)>;
 
     /// Returns a vector of values corresponding to the keys provided,
     /// non-atomically.

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::{Bound, RangeBounds};
+
+use bincode::Options;
+use serde::Serialize;
+
+#[inline]
+pub fn be_fix_int_ser<S>(t: &S) -> Vec<u8>
+where
+    S: ?Sized + serde::Serialize,
+{
+    bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_fixint_encoding()
+        .serialize(t)
+        .expect("failed to serialize via be_fix_int_ser method")
+}
+
+pub(crate) fn iterator_bounds<K>(
+    lower_bound: Option<K>,
+    upper_bound: Option<K>,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>)
+where
+    K: Serialize,
+{
+    (
+        lower_bound.map(|b| be_fix_int_ser(&b)),
+        upper_bound.map(|b| be_fix_int_ser(&b)),
+    )
+}
+
+pub(crate) fn iterator_bounds_with_range<K>(
+    range: impl RangeBounds<K>,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>)
+where
+    K: Serialize,
+{
+    let iterator_lower_bound = match range.start_bound() {
+        Bound::Included(lower_bound) => {
+            // Rocksdb lower bound is inclusive by default so nothing to do
+            Some(be_fix_int_ser(&lower_bound))
+            // readopts.set_iterate_lower_bound(key_buf);
+        }
+        Bound::Excluded(lower_bound) => {
+            let mut key_buf = be_fix_int_ser(&lower_bound);
+
+            // Since we want exclusive, we need to increment the key to exclude the previous
+            big_endian_saturating_add_one(&mut key_buf);
+            Some(key_buf)
+            // readopts.set_iterate_lower_bound(key_buf);
+        }
+        Bound::Unbounded => None,
+    };
+    let iterator_upper_bound = match range.end_bound() {
+        Bound::Included(upper_bound) => {
+            let mut key_buf = be_fix_int_ser(&upper_bound);
+
+            // If the key is already at the limit, there's nowhere else to go, so no upper
+            // bound
+            if !is_max(&key_buf) {
+                // Since we want exclusive, we need to increment the key to get the upper bound
+                big_endian_saturating_add_one(&mut key_buf);
+                // readopts.set_iterate_upper_bound(key_buf);
+            }
+            Some(key_buf)
+        }
+        Bound::Excluded(upper_bound) => {
+            // Rocksdb upper bound is inclusive by default so nothing to do
+            Some(be_fix_int_ser(&upper_bound))
+            // readopts.set_iterate_upper_bound(key_buf);
+        }
+        Bound::Unbounded => None,
+    };
+    (iterator_lower_bound, iterator_upper_bound)
+}
+
+/// Given a vec<u8>, find the value which is one more than the vector
+/// if the vector was a big endian number.
+/// If the vector is already minimum, don't change it.
+fn big_endian_saturating_add_one(v: &mut [u8]) {
+    if is_max(v) {
+        return;
+    }
+    for i in (0..v.len()).rev() {
+        if v[i] == u8::MAX {
+            v[i] = 0;
+        } else {
+            v[i] += 1;
+            break;
+        }
+    }
+}
+
+/// Check if all the bytes in the vector are 0xFF
+fn is_max(v: &[u8]) -> bool {
+    v.iter().all(|&x| x == u8::MAX)
+}
+
+#[expect(clippy::assign_op_pattern, clippy::manual_div_ceil)]
+#[test]
+fn test_helpers() {
+    let v = vec![];
+    assert!(is_max(&v));
+
+    fn check_add(v: Vec<u8>) {
+        let mut v = v;
+        let num = Num32::from_big_endian(&v);
+        big_endian_saturating_add_one(&mut v);
+        assert!(num + 1 == Num32::from_big_endian(&v));
+    }
+
+    uint::construct_uint! {
+        // 32 byte number
+        struct Num32(4);
+    }
+
+    let mut v = vec![255; 32];
+    big_endian_saturating_add_one(&mut v);
+    assert!(Num32::MAX == Num32::from_big_endian(&v));
+
+    check_add(vec![1; 32]);
+    check_add(vec![6; 32]);
+    check_add(vec![254; 32]);
+
+    // TBD: More tests coming with randomized arrays
+}

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -63,9 +63,10 @@ where
             if !is_max(&key_buf) {
                 // Since we want exclusive, we need to increment the key to get the upper bound
                 big_endian_saturating_add_one(&mut key_buf);
-                // readopts.set_iterate_upper_bound(key_buf);
+                Some(key_buf)
+            } else {
+                None
             }
-            Some(key_buf)
         }
         Bound::Excluded(upper_bound) => {
             // Rocksdb upper bound is inclusive by default so nothing to do

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -42,7 +42,6 @@ where
         Bound::Included(lower_bound) => {
             // Rocksdb lower bound is inclusive by default so nothing to do
             Some(be_fix_int_ser(&lower_bound))
-            // readopts.set_iterate_lower_bound(key_buf);
         }
         Bound::Excluded(lower_bound) => {
             let mut key_buf = be_fix_int_ser(&lower_bound);
@@ -50,7 +49,6 @@ where
             // Since we want exclusive, we need to increment the key to exclude the previous
             big_endian_saturating_add_one(&mut key_buf);
             Some(key_buf)
-            // readopts.set_iterate_lower_bound(key_buf);
         }
         Bound::Unbounded => None,
     };
@@ -69,9 +67,8 @@ where
             }
         }
         Bound::Excluded(upper_bound) => {
-            // Rocksdb upper bound is inclusive by default so nothing to do
+            // Rocksdb upper bound is exclusive by default so nothing to do
             Some(be_fix_int_ser(&upper_bound))
-            // readopts.set_iterate_upper_bound(key_buf);
         }
         Bound::Unbounded => None,
     };

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -9,9 +9,9 @@ use std::{borrow::Borrow, collections::HashSet, fmt::Debug, sync::Mutex, time::D
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use typed_store::{
-    DBMapUtils,
+    DBMapUtils, be_fix_int_ser,
     metrics::SamplingInterval,
-    rocks::{DBMap, MetricConf, be_fix_int_ser, list_tables},
+    rocks::{DBMap, MetricConf, list_tables},
     traits::{Map, TableSummary, TypedStoreDebug},
 };
 
@@ -76,7 +76,7 @@ async fn macro_test() {
     for i in kv_range.clone() {
         let key = i.to_string();
         let value = i.to_string();
-        let k_buf = be_fix_int_ser::<String>(&key).unwrap();
+        let k_buf = be_fix_int_ser::<String>(&key);
         let value_buf = bcs::to_bytes::<String>(&value).unwrap();
         raw_key_bytes1 += k_buf.len();
         raw_value_bytes1 += value_buf.len();
@@ -93,7 +93,7 @@ async fn macro_test() {
     for i in kv_range.clone() {
         let key = i;
         let value = i.to_string();
-        let k_buf = be_fix_int_ser(key.borrow()).unwrap();
+        let k_buf = be_fix_int_ser(key.borrow());
         let value_buf = bcs::to_bytes::<String>(&value).unwrap();
         raw_key_bytes2 += k_buf.len();
         raw_value_bytes2 += value_buf.len();


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@c232615](https://github.com/MystenLabs/sui/commit/c232615066db1ca778acf5b46e6cc3e91abd5dbe)
- Description:

PR enables iterator methods for in_memory_db.

Note: tidehunter-related changes were skipped as that backend is not present.

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes