### PR TITLE
upstream(core): Include bin name in server version string

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -137,7 +137,7 @@ pub async fn serve_executor(
     info!("Starting executor server on {}", executor_server_url);
 
     let executor_server_handle = tokio::spawn(async move {
-        iota_rest_api::RestService::new_without_version(executor)
+        iota_rest_api::RestService::new(executor)
             .start_service(executor_server_url)
             .await;
     });

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -432,7 +432,7 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
 ) {
     let server_url = server_url.unwrap_or_else(new_local_tcp_socket_for_testing);
     let server_handle = tokio::spawn(async move {
-        iota_rest_api::RestService::new_without_version(sim)
+        iota_rest_api::RestService::new(sim)
             .start_service(server_url)
             .await;
     });

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -843,7 +843,7 @@ impl IotaNode {
             &transaction_orchestrator.clone(),
             &config,
             &prometheus_registry,
-            server_version,
+            server_version.clone(),
         )
         .await?;
 
@@ -891,6 +891,7 @@ impl IotaNode {
             state_sync_store.clone(),
             executor,
             &registry_service.default_registry(),
+            server_version,
         )
         .await?;
 
@@ -2432,6 +2433,7 @@ async fn build_grpc_server(
     state_sync_store: RocksDbStore,
     executor: Option<Arc<dyn iota_types::transaction_executor::TransactionExecutor>>,
     prometheus_registry: &Registry,
+    server_version: ServerVersion,
 ) -> Result<Option<GrpcServerHandle>> {
     // Validators do not expose gRPC APIs
     if config.consensus_config().is_some() || !config.enable_grpc_api {
@@ -2453,7 +2455,7 @@ async fn build_grpc_server(
     // Create GrpcReader
     let grpc_reader = Arc::new(GrpcReader::from_rest_state_reader(
         rest_read_store,
-        Some(env!("CARGO_PKG_VERSION").to_string()),
+        Some(server_version.to_string()),
     ));
 
     // Create gRPC server metrics

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -101,7 +101,7 @@ use iota_network::{
 };
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
 use iota_protocol_config::ProtocolConfig;
-use iota_rest_api::RestMetrics;
+use iota_rest_api::{RestMetrics, ServerVersion};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
 use iota_snapshot::uploader::StateSnapshotUploader;
 use iota_storage::{
@@ -286,7 +286,12 @@ impl IotaNode {
         config: NodeConfig,
         registry_service: RegistryService,
     ) -> Result<Arc<IotaNode>> {
-        Self::start_async(config, registry_service, "unknown").await
+        Self::start_async(
+            config,
+            registry_service,
+            ServerVersion::new("iota-node", "unknown"),
+        )
+        .await
     }
 
     /// Starts the JWK (JSON Web Key) updater tasks for the specified node
@@ -431,7 +436,7 @@ impl IotaNode {
     pub async fn start_async(
         config: NodeConfig,
         registry_service: RegistryService,
-        software_version: &'static str,
+        server_version: ServerVersion,
     ) -> Result<Arc<IotaNode>> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
         let mut config = config.clone();
@@ -484,7 +489,7 @@ impl IotaNode {
                 } else {
                     "fullnode"
                 },
-                software_version,
+                server_version.version,
                 &chain_identifier.to_string(),
             ))
             .expect("Failed registering uptime metric");
@@ -838,7 +843,7 @@ impl IotaNode {
             &transaction_orchestrator.clone(),
             &config,
             &prometheus_registry,
-            software_version,
+            server_version,
         )
         .await?;
 
@@ -2491,7 +2496,7 @@ pub async fn build_http_server(
     transaction_orchestrator: &Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
     config: &NodeConfig,
     prometheus_registry: &Registry,
-    software_version: &'static str,
+    server_version: ServerVersion,
 ) -> Result<Option<iota_http::ServerHandle>> {
     // Validators do not expose these APIs
     if config.consensus_config().is_some() {
@@ -2560,10 +2565,9 @@ pub async fn build_http_server(
     router = router.merge(json_rpc_router);
 
     if config.enable_rest_api {
-        let mut rest_service = iota_rest_api::RestService::new(
-            Arc::new(RestReadStore::new(state.clone(), store)),
-            software_version,
-        );
+        let mut rest_service =
+            iota_rest_api::RestService::new(Arc::new(RestReadStore::new(state.clone(), store)));
+        rest_service.with_server_version(server_version);
 
         if let Some(config) = config.rest.clone() {
             rest_service.with_config(config);

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -9,6 +9,7 @@ use iota_common::sync::async_once_cell::AsyncOnceCell;
 use iota_config::{Config, NodeConfig, node::RunWithRange};
 use iota_core::runtime::IotaRuntimes;
 use iota_node::{IotaNode, metrics};
+use iota_rest_api::ServerVersion;
 use iota_types::{
     committee::EpochId, messages_checkpoint::CheckpointSequenceNumber, multiaddr::Multiaddr,
     supported_protocol_versions::SupportedProtocolVersions,
@@ -116,8 +117,9 @@ fn main() {
     // let iota-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
+    let server_version = ServerVersion::new(env!("CARGO_BIN_NAME"), VERSION);
     runtimes.iota_node.spawn(async move {
-        match IotaNode::start_async(config, registry_service, VERSION).await {
+        match IotaNode::start_async(config, registry_service, server_version).await {
             Ok(iota_node) => node_once_cell_clone
                 .set(iota_node)
                 .expect("Failed to set node in AsyncOnceCell"),

--- a/crates/iota-rest-api/src/info.rs
+++ b/crates/iota-rest-api/src/info.rs
@@ -72,7 +72,11 @@ async fn get_node_info(State(state): State<RestService>) -> Result<Json<NodeInfo
         epoch: latest_checkpoint.epoch(),
         chain_id: Digest::new(state.chain_id().as_bytes().to_owned()),
         chain: state.chain_id().chain().as_str().into(),
-        software_version: state.software_version().into(),
+        software_version: state
+            .server_version()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+            .into(),
     }
     .pipe(Json)
     .pipe(Ok)

--- a/crates/iota-rest-api/src/lib.rs
+++ b/crates/iota-rest-api/src/lib.rs
@@ -37,6 +37,26 @@ pub use iota_types::full_checkpoint_content::{CheckpointData, CheckpointTransact
 pub use metrics::RestMetrics;
 pub use transactions::ExecuteTransactionQueryParameters;
 
+#[derive(Clone)]
+pub struct ServerVersion {
+    pub bin: &'static str,
+    pub version: &'static str,
+}
+
+impl ServerVersion {
+    pub fn new(bin: &'static str, version: &'static str) -> Self {
+        Self { bin, version }
+    }
+}
+
+impl std::fmt::Display for ServerVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.bin)?;
+        f.write_str("/")?;
+        f.write_str(self.version)
+    }
+}
+
 pub const TEXT_PLAIN_UTF_8: &str = "text/plain; charset=utf-8";
 pub const APPLICATION_BCS: &str = "application/bcs";
 pub const APPLICATION_JSON: &str = "application/json";
@@ -106,7 +126,7 @@ pub struct RestService {
     reader: StateReader,
     executor: Option<Arc<dyn TransactionExecutor>>,
     chain_id: iota_types::digests::ChainIdentifier,
-    software_version: &'static str,
+    server_version: Option<ServerVersion>,
     metrics: Option<Arc<RestMetrics>>,
     config: Config,
 }
@@ -124,20 +144,21 @@ impl axum::extract::FromRef<RestService> for Option<Arc<dyn TransactionExecutor>
 }
 
 impl RestService {
-    pub fn new(reader: Arc<dyn RestStateReader>, software_version: &'static str) -> Self {
+    pub fn new(reader: Arc<dyn RestStateReader>) -> Self {
         let chain_id = reader.get_chain_identifier().unwrap();
         Self {
             reader: StateReader::new(reader),
             executor: None,
             chain_id,
-            software_version,
+            server_version: None,
             metrics: None,
             config: Config::default(),
         }
     }
 
-    pub fn new_without_version(reader: Arc<dyn RestStateReader>) -> Self {
-        Self::new(reader, "unknown")
+    pub fn with_server_version(&mut self, server_version: ServerVersion) -> &mut Self {
+        self.server_version = Some(server_version);
+        self
     }
 
     pub fn with_config(&mut self, config: Config) {
@@ -156,14 +177,18 @@ impl RestService {
         self.chain_id
     }
 
-    pub fn software_version(&self) -> &'static str {
-        self.software_version
+    pub fn server_version(&self) -> Option<&ServerVersion> {
+        self.server_version.as_ref()
     }
 
     pub fn into_router(self) -> Router {
         let metrics = self.metrics.clone();
 
-        let mut api = openapi::Api::new(info(self.software_version()));
+        let version = self
+            .server_version()
+            .map(|v| v.version)
+            .unwrap_or("unknown");
+        let mut api = openapi::Api::new(info(version));
 
         api.register_endpoints(
             ENDPOINTS

--- a/crates/iota-rest-api/src/response.rs
+++ b/crates/iota-rest-api/src/response.rs
@@ -168,5 +168,12 @@ pub async fn append_info_headers(
         );
     }
 
+    if let Some(server_version) = state
+        .server_version()
+        .and_then(|version| version.to_string().try_into().ok())
+    {
+        headers.insert(axum::http::header::SERVER, server_version);
+    }
+
     (headers, response)
 }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@218d8ca](https://github.com/MystenLabs/sui/commit/218d8cad121cb645257d04c571f6ec4860f6ee8d)
- Description:

Include the binary name in the server version string, formatted as `bin/version` (e.g. `iota-node/1.2.3`). This is surfaced in the HTTP `Server` response header and in service info endpoints.

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes