### PR TITLE
refactor(indexer): use historical storage as checkpoint source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6837,6 +6837,7 @@ dependencies = [
  "moka",
  "move-binary-format",
  "move-core-types",
+ "object_store 0.13.1",
  "prometheus",
  "rand 0.8.5",
  "reqwest",

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -26,6 +26,7 @@ futures.workspace = true
 itertools.workspace = true
 jsonrpsee.workspace = true
 moka.workspace = true
+object_store.workspace = true
 prometheus.workspace = true
 rand = { workspace = true, optional = true }
 reqwest.workspace = true

--- a/crates/iota-indexer/src/backfill/mod.rs
+++ b/crates/iota-indexer/src/backfill/mod.rs
@@ -66,7 +66,7 @@ pub enum BackfillKind {
     Ingestion {
         kind: IngestionBackfillKind,
         #[command(flatten)]
-        config: IngestionConfig,
+        config: Box<IngestionConfig>,
     },
 }
 
@@ -89,7 +89,7 @@ pub(crate) async fn get_backfill(
         BackfillKind::Ingestion { kind, config } => match kind {
             IngestionBackfillKind::TxWrappedOrDeletedObjects => Ok(Arc::new(
                 IngestionBackfillTask::<TxWrappedOrDeletedObjectsBackfill>::new(
-                    config,
+                    *config,
                     range_start as CheckpointSequenceNumber,
                 )
                 .await?,

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -176,8 +176,8 @@ pub struct IngestionSources {
     #[arg(long)]
     pub data_ingestion_path: Option<PathBuf>,
 
-    /// Primary remote checkpoint source. This flag accepts either a fullnode gRPC URL (e.g. http://0.0.0.0:50051) or an
-    /// S3-compatible object store URL hosting batched checkpoint files (e.g. https://checkpoints.mainnet.iota.cafe/ingestion/historical).
+    /// Primary remote checkpoint source. This flag accepts either a fullnode gRPC URL (e.g. `http://0.0.0.0:50051`) or an
+    /// S3-compatible object store URL hosting batched checkpoint files (e.g. `https://checkpoints.mainnet.iota.cafe/ingestion/historical`).
     /// When pointing to an object store, this provides complete checkpoint
     /// coverage from genesis. When pointing to a fullnode, checkpoint
     /// availability depends on the node's pruning configuration.
@@ -185,7 +185,7 @@ pub struct IngestionSources {
     pub remote_store_url: Option<Url>,
 
     /// Optional S3-compatible object store URL serving current epoch
-    /// checkpoints for low-latency ingestion at the network tip (e.g. https://checkpoints.mainnet.iota.cafe/ingestion/live).
+    /// checkpoints for low-latency ingestion at the network tip (e.g. `https://checkpoints.mainnet.iota.cafe/ingestion/live`).
     /// Use alongside `--remote-store-url` pointing to a historical store for
     /// complete coverage with minimal latency.
     #[arg(long, requires = "remote_store_url")]

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -176,20 +176,29 @@ pub struct IngestionSources {
     #[arg(long)]
     pub data_ingestion_path: Option<PathBuf>,
 
-    /// Primary remote checkpoint source. This flag accepts either a fullnode gRPC URL (e.g. `http://0.0.0.0:50051`) or an
-    /// S3-compatible object store URL hosting batched checkpoint files (e.g. `https://checkpoints.mainnet.iota.cafe/ingestion/historical`).
+    /// Primary remote checkpoint source.
+    ///
+    /// Accepts either a fullnode gRPC URL (e.g. `http://0.0.0.0:50051`) or an
+    /// S3-compatible object store URL hosting batched checkpoint files
+    /// (e.g. `https://checkpoints.mainnet.iota.cafe/ingestion/historical`).
+    ///
     /// When pointing to an object store, this provides complete checkpoint
     /// coverage from genesis. When pointing to a fullnode, checkpoint
     /// availability depends on the node's pruning configuration.
     #[arg(long)]
     pub remote_store_url: Option<Url>,
 
-    /// Optional S3-compatible object store URL serving current epoch
-    /// checkpoints for low-latency ingestion at the network tip (e.g. `https://checkpoints.mainnet.iota.cafe/ingestion/live`).
+    /// Optional live checkpoint store for low-latency ingestion at the network
+    /// tip.
+    ///
+    /// S3-compatible object store URL serving individual checkpoint files for
+    /// the current epoch only
+    /// (e.g. `https://checkpoints.mainnet.iota.cafe/ingestion/live`).
+    ///
     /// Use alongside `--remote-store-url` pointing to a historical store for
-    /// complete coverage with minimal latency.
+    /// complete coverage with minimal tip latency.
     #[arg(long, requires = "remote_store_url")]
-    pub current_epoch_store_url: Option<Url>,
+    pub live_checkpoints_store_url: Option<Url>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -667,7 +676,7 @@ pub mod deprecated {
                             remote_store_url: old_conf.remote_store_url.map(|url| {
                                 url.parse().expect("remote store url should be correct")
                             }),
-                            current_epoch_store_url: None,
+                            live_checkpoints_store_url: None,
                         },
                         checkpoint_download_queue_size: download_queue_size,
                         checkpoint_download_timeout: ingestion_reader_timeout_secs,
@@ -765,15 +774,17 @@ mod test {
         ])
         .unwrap();
 
-        // current-epoch-store-url can be provided if remote-store-url is also provided
+        // live-checkpoints-store-url can be provided if remote-store-url is also
+        // provided
         parse_args::<IngestionSources>([
             "--remote-store-url=http://example.com",
-            "--current-epoch-store-url=http://example.com",
+            "--live-checkpoints-store-url=http://example.com",
         ])
         .unwrap();
 
-        // current-epoch-store-url can't be provided if remote-store-url is not provided
-        parse_args::<IngestionSources>(["--current-epoch-store-url=http://example.com"])
+        // live-checkpoints-store-url can't be provided if remote-store-url is not
+        // provided
+        parse_args::<IngestionSources>(["--live-checkpoints-store-url=http://example.com"])
             .unwrap_err();
 
         // At least one must be present

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -791,6 +791,30 @@ mod test {
         ])
         .unwrap();
 
+        // we cannot provide both, they are mutually exclusive
+        parse_args::<IngestionSources>([
+            "--remote-store-url=http://example.com",
+            "--historical-url=http://example.com",
+        ])
+        .unwrap_err();
+
+        // we cannot provide both, they are mutually exclusive
+        parse_args::<IngestionSources>([
+            "--remote-store-url=http://example.com",
+            "--live-url=http://example.com",
+        ])
+        .unwrap_err();
+
+        // live-url can be provided if historical-url is also provided
+        parse_args::<IngestionSources>([
+            "--historical-url=http://example.com",
+            "--live-url=http://example.com",
+        ])
+        .unwrap();
+
+        // live-url can't be provided if historical-url is not provided
+        parse_args::<IngestionSources>(["--live-url=http://example.com"]).unwrap_err();
+
         // At least one must be present
         parse_args::<IngestionSources>([]).unwrap_err();
     }

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
 
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
+use iota_data_ingestion_core::reader::v2::RemoteUrl;
 use iota_names::config::IotaNamesConfig;
 use iota_types::base_types::{IotaAddress, ObjectID};
 use serde::{Deserialize, Serialize};
@@ -172,11 +173,48 @@ impl Default for HistoricFallbackOptions {
 #[derive(Args, Debug, Default, Clone)]
 #[group(required = true, multiple = true)]
 pub struct IngestionSources {
+    /// Ingest checkpoints from the given path.
     #[arg(long)]
     pub data_ingestion_path: Option<PathBuf>,
 
-    #[arg(long)]
+    /// Ingest checkpoints from the given remote store URL.
+    /// The fullnode may not retain historical data if pruning is enabled,
+    /// so this source is only reliable for recent checkpoints. For complete
+    /// data coverage from genesis, use --historical-url instead.
+    #[arg(long, conflicts_with_all = ["historical_url", "live_url"])]
     pub remote_store_url: Option<Url>,
+
+    /// Ingest checkpoints from the historical object store for bulk checkpoint
+    /// ingestion. Contains batched checkpoint files covering complete data
+    /// from genesis to near the network tip. This is the primary source for
+    /// syncing checkpoint data.
+    #[arg(long, conflicts_with = "remote_store_url")]
+    pub historical_url: Option<Url>,
+
+    /// Ingest checkpoints from the live object store for real-time checkpoint
+    /// streaming. Serves individual checkpoint files for the current epoch
+    /// only. When configured alongside the historical URL, the system
+    /// falls back to the live store for checkpoints not yet available
+    /// in the historical batches.
+    #[arg(long, requires = "historical_url", conflicts_with = "remote_store_url")]
+    pub live_url: Option<Url>,
+}
+
+impl IngestionSources {
+    /// Returns the [`RemoteUrl`] to use for checkpoint ingestion, based on the
+    /// provided arguments by the user.
+    pub fn remote_url(&self) -> Option<RemoteUrl> {
+        if let Some(ref url) = self.remote_store_url {
+            return Some(RemoteUrl::Fullnode(url.to_string()));
+        }
+
+        self.historical_url
+            .as_ref()
+            .map(|historical| RemoteUrl::HybridHistoricalStore {
+                historical_url: historical.to_string(),
+                live_url: self.live_url.as_ref().map(ToString::to_string),
+            })
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -654,6 +692,8 @@ pub mod deprecated {
                             remote_store_url: old_conf.remote_store_url.map(|url| {
                                 url.parse().expect("remote store url should be correct")
                             }),
+                            historical_url: None,
+                            live_url: None,
                         },
                         checkpoint_download_queue_size: download_queue_size,
                         checkpoint_download_timeout: ingestion_reader_timeout_secs,

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
 
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
-use iota_data_ingestion_core::reader::v2::RemoteUrl;
 use iota_names::config::IotaNamesConfig;
 use iota_types::base_types::{IotaAddress, ObjectID};
 use serde::{Deserialize, Serialize};
@@ -177,44 +176,20 @@ pub struct IngestionSources {
     #[arg(long)]
     pub data_ingestion_path: Option<PathBuf>,
 
-    /// Ingest checkpoints from the given remote store URL.
-    /// The fullnode may not retain historical data if pruning is enabled,
-    /// so this source is only reliable for recent checkpoints. For complete
-    /// data coverage from genesis, use --historical-url instead.
-    #[arg(long, conflicts_with_all = ["historical_url", "live_url"])]
+    /// Primary remote checkpoint source. This flag accepts either a fullnode gRPC URL (e.g. http://0.0.0.0:50051) or an
+    /// S3-compatible object store URL hosting batched checkpoint files (e.g. https://checkpoints.mainnet.iota.cafe/ingestion/historical).
+    /// When pointing to an object store, this provides complete checkpoint
+    /// coverage from genesis. When pointing to a fullnode, checkpoint
+    /// availability depends on the node's pruning configuration.
+    #[arg(long)]
     pub remote_store_url: Option<Url>,
 
-    /// Ingest checkpoints from the historical object store for bulk checkpoint
-    /// ingestion. Contains batched checkpoint files covering complete data
-    /// from genesis to near the network tip. This is the primary source for
-    /// syncing checkpoint data.
-    #[arg(long, conflicts_with = "remote_store_url")]
-    pub historical_url: Option<Url>,
-
-    /// Ingest checkpoints from the live object store for real-time checkpoint
-    /// streaming. Serves individual checkpoint files for the current epoch
-    /// only. When configured alongside the historical URL, the system
-    /// falls back to the live store for checkpoints not yet available
-    /// in the historical batches.
-    #[arg(long, requires = "historical_url", conflicts_with = "remote_store_url")]
-    pub live_url: Option<Url>,
-}
-
-impl IngestionSources {
-    /// Returns the [`RemoteUrl`] to use for checkpoint ingestion, based on the
-    /// provided arguments by the user.
-    pub fn remote_url(&self) -> Option<RemoteUrl> {
-        if let Some(ref url) = self.remote_store_url {
-            return Some(RemoteUrl::Fullnode(url.to_string()));
-        }
-
-        self.historical_url
-            .as_ref()
-            .map(|historical| RemoteUrl::HybridHistoricalStore {
-                historical_url: historical.to_string(),
-                live_url: self.live_url.as_ref().map(ToString::to_string),
-            })
-    }
+    /// Optional S3-compatible object store URL serving current epoch
+    /// checkpoints for low-latency ingestion at the network tip (e.g. https://checkpoints.mainnet.iota.cafe/ingestion/live).
+    /// Use alongside `--remote-store-url` pointing to a historical store for
+    /// complete coverage with minimal latency.
+    #[arg(long, requires = "remote_store_url")]
+    pub current_epoch_store_url: Option<Url>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -692,8 +667,7 @@ pub mod deprecated {
                             remote_store_url: old_conf.remote_store_url.map(|url| {
                                 url.parse().expect("remote store url should be correct")
                             }),
-                            historical_url: None,
-                            live_url: None,
+                            current_epoch_store_url: None,
                         },
                         checkpoint_download_queue_size: download_queue_size,
                         checkpoint_download_timeout: ingestion_reader_timeout_secs,
@@ -791,29 +765,16 @@ mod test {
         ])
         .unwrap();
 
-        // we cannot provide both, they are mutually exclusive
+        // current-epoch-store-url can be provided if remote-store-url is also provided
         parse_args::<IngestionSources>([
             "--remote-store-url=http://example.com",
-            "--historical-url=http://example.com",
-        ])
-        .unwrap_err();
-
-        // we cannot provide both, they are mutually exclusive
-        parse_args::<IngestionSources>([
-            "--remote-store-url=http://example.com",
-            "--live-url=http://example.com",
-        ])
-        .unwrap_err();
-
-        // live-url can be provided if historical-url is also provided
-        parse_args::<IngestionSources>([
-            "--historical-url=http://example.com",
-            "--live-url=http://example.com",
+            "--current-epoch-store-url=http://example.com",
         ])
         .unwrap();
 
-        // live-url can't be provided if historical-url is not provided
-        parse_args::<IngestionSources>(["--live-url=http://example.com"]).unwrap_err();
+        // current-epoch-store-url can't be provided if remote-store-url is not provided
+        parse_args::<IngestionSources>(["--current-epoch-store-url=http://example.com"])
+            .unwrap_err();
 
         // At least one must be present
         parse_args::<IngestionSources>([]).unwrap_err();

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -58,11 +58,7 @@ impl Indexer {
             .data_ingestion_path
             .clone()
             .unwrap_or(tempfile::tempdir().unwrap().keep());
-        let remote_store_url = config
-            .sources
-            .remote_store_url
-            .as_ref()
-            .map(|url| url.as_str().to_owned());
+        let remote_store_url = config.sources.remote_url();
 
         if let Some(retention_config) = retention_config {
             let pruner = Pruner::new(store.clone(), retention_config, metrics.clone())?;

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
+use std::{env, time::Duration};
 
 use anyhow::{Context, Result};
 use iota_data_ingestion_core::ReaderOptions;
@@ -20,7 +20,8 @@ use crate::{
     errors::IndexerError,
     historical_fallback::reader::HistoricalFallbackReader,
     ingestion::{
-        primary::orchestration::PrimaryPipeline, snapshot::orchestration::SnapshotPipelineBuilder,
+        common::connection::resolve_remote_url, primary::orchestration::PrimaryPipeline,
+        snapshot::orchestration::SnapshotPipelineBuilder,
     },
     metrics::IndexerMetrics,
     processors::processor_orchestrator::ProcessorOrchestrator,
@@ -28,6 +29,9 @@ use crate::{
     read::IndexerReader,
     store::{IndexerAnalyticalStore, IndexerStore, PgIndexerStore},
 };
+
+/// Maximum timeout for resolving the remote checkpoint source.
+const MAX_URL_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct Indexer;
 
@@ -53,12 +57,9 @@ impl Indexer {
             data_limit: config.checkpoint_download_queue_size_bytes,
             ..Default::default()
         };
-        let data_ingestion_path = config
-            .sources
-            .data_ingestion_path
-            .clone()
-            .unwrap_or(tempfile::tempdir().unwrap().keep());
-        let remote_store_url = config.sources.remote_url();
+
+        let remote_store_url =
+            resolve_remote_url(&config.sources, MAX_URL_RESOLUTION_TIMEOUT).await?;
 
         if let Some(retention_config) = retention_config {
             let pruner = Pruner::new(store.clone(), retention_config, metrics.clone())?;
@@ -125,7 +126,7 @@ impl Indexer {
         info!("Starting data ingestion executor...");
         let mut primary_pipeline_handle = primary_pipeline
             .run(
-                data_ingestion_path.clone(),
+                config.sources.data_ingestion_path.clone(),
                 remote_store_url.clone(),
                 extra_reader_options.clone(),
             )

--- a/crates/iota-indexer/src/ingestion/common/connection.rs
+++ b/crates/iota-indexer/src/ingestion/common/connection.rs
@@ -23,9 +23,9 @@ use crate::{
 /// object store URL for historical checkpoint data, this function probes the
 /// URL to determine which type it is:
 ///
-/// 1. **gRPC health check** — attempts to connect and call `GetHealth`. If
+/// 1. **gRPC health check**: attempts to connect and call `GetHealth`. If
 ///    successful, the URL is treated as a fullnode gRPC endpoint.
-/// 2. **Historical manifest fetch** — if gRPC fails, attempts to fetch the
+/// 2. **Historical manifest fetch**: if gRPC fails, attempts to fetch the
 ///    MANIFEST file from the URL as an S3-compatible object store. If
 ///    successful, the URL is treated as a historical checkpoint store.
 ///
@@ -79,7 +79,7 @@ pub async fn resolve_remote_url(
         match backoff.next_backoff() {
             Some(duration) => {
                 warn!(
-                    "remote store not reachable as gRPC or historical, retrying in {}ms",
+                    "remote store not reachable as fullnode gRPC or historical connection, retrying in {}ms",
                     duration.as_millis()
                 );
                 tokio::time::sleep(duration).await;

--- a/crates/iota-indexer/src/ingestion/common/connection.rs
+++ b/crates/iota-indexer/src/ingestion/common/connection.rs
@@ -3,13 +3,14 @@
 
 use std::time::Duration;
 
-use backoff::{self, ExponentialBackoff, backoff::Backoff};
+use backoff::{self, ExponentialBackoff};
+use futures::TryFutureExt;
 use iota_data_ingestion_core::{
     create_remote_store_client, history::manifest::Manifest, reader::v2::RemoteUrl,
 };
 use iota_grpc_client::Client as GrpcClient;
 use object_store::ObjectStoreExt;
-use tracing::{info, warn};
+use tracing::{debug, info};
 
 use crate::{
     config::IngestionSources,
@@ -31,6 +32,10 @@ use crate::{
 ///
 /// Both probes are retried with exponential backoff within the given timeout.
 /// If neither succeeds, returns an error.
+///
+/// When `live_checkpoints_store_url` is provided, the URL is assumed to be a
+/// historical store and the live URL is included in the
+/// [`RemoteUrl::HybridHistoricalStore`].
 pub async fn resolve_remote_url(
     ingestion_sources: &IngestionSources,
     timeout: Duration,
@@ -43,51 +48,67 @@ pub async fn resolve_remote_url(
         return Ok(None);
     };
 
-    let grpc_client = GrpcClient::connect(url.clone()).await?;
+    let live_url = ingestion_sources
+        .live_checkpoints_store_url
+        .as_ref()
+        .map(ToString::to_string);
 
-    // Use a lightweight S3 client to check if the MANIFEST file exists.
-    // We avoid HistoricalReader here as its internal manifest fetch retries
-    // with a 15-minute default backoff and does not have a timeout.
-    let historical =
-        create_remote_store_client(url.clone(), Default::default(), timeout.as_secs())?;
+    // if live URL is provided, remote-store-url can be assumed as a historical
+    // store
+    if live_url.is_some() {
+        return Ok(Some(RemoteUrl::HybridHistoricalStore {
+            historical_url: url,
+            live_url,
+        }));
+    }
 
-    let mut backoff = ExponentialBackoff {
+    let backoff = ExponentialBackoff {
         max_elapsed_time: Some(timeout),
         multiplier: 2.0,
         ..Default::default()
     };
 
-    loop {
-        if grpc_client.get_health(None).await.is_ok() {
-            info!("resolved remote store as fullnode gRPC: {url}");
-            return Ok(Some(RemoteUrl::Fullnode(url)));
-        }
+    backoff::future::retry(backoff, || {
+        let url = url.clone();
+        async move {
+            let grpc_result = GrpcClient::connect(url.clone())
+                .and_then(|client| async move { client.get_health(None).await })
+                .await
+                .inspect_err(|e| debug!("gRPC health check failed: {e}"));
 
-        if historical.head(&Manifest::file_path()).await.is_ok() {
+            if grpc_result.is_ok() {
+                info!("resolved remote store as fullnode gRPC: {url}");
+                return Ok(Some(RemoteUrl::Fullnode(url)));
+            }
+
+            // we use a lightweight S3 client to check if the MANIFEST file exists.
+            // we avoid HistoricalReader here as its internal manifest fetch retries
+            // with a 15-minute default backoff and does not have a timeout.
+            let store =
+                create_remote_store_client(url.clone(), Default::default(), timeout.as_secs())
+                    .map_err(|e| {
+                        debug!("failed to create historical store client: {e}");
+                        backoff::Error::transient(IndexerError::Generic(format!(
+                            "remote store not reachable: {url}"
+                        )))
+                    })?;
+
+            store.head(&Manifest::file_path()).await.map_err(|e| {
+                debug!("historical store MANIFEST not found: {e}");
+                backoff::Error::transient(IndexerError::Generic(format!(
+                    "remote store not reachable: {url}"
+                )))
+            })?;
+
             info!("resolved remote store as historical object store: {url}");
-            let live_url = ingestion_sources
-                .current_epoch_store_url
-                .as_ref()
-                .map(ToString::to_string);
-            return Ok(Some(RemoteUrl::HybridHistoricalStore {
+            Ok(Some(RemoteUrl::HybridHistoricalStore {
                 historical_url: url,
-                live_url,
-            }));
+                live_url: None,
+            }))
         }
-
-        match backoff.next_backoff() {
-            Some(duration) => {
-                warn!(
-                    "remote store not reachable as fullnode gRPC or historical connection, retrying in {}ms",
-                    duration.as_millis()
-                );
-                tokio::time::sleep(duration).await;
-            }
-            None => {
-                return Err(IndexerError::Generic(format!(
-                    "unable to resolve remote store URL after {timeout:?}: {url}"
-                )));
-            }
-        }
-    }
+    })
+    .await
+    .map_err(|_: IndexerError| IndexerError::Generic(format!(
+        "failed to resolve remote store '{url}' after {timeout:?}: not reachable as gRPC or historical store"
+    )))
 }

--- a/crates/iota-indexer/src/ingestion/common/connection.rs
+++ b/crates/iota-indexer/src/ingestion/common/connection.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use backoff::{self, ExponentialBackoff, backoff::Backoff};
+use iota_data_ingestion_core::{
+    create_remote_store_client, history::manifest::Manifest, reader::v2::RemoteUrl,
+};
+use iota_grpc_client::Client as GrpcClient;
+use object_store::ObjectStoreExt;
+use tracing::{info, warn};
+
+use crate::{
+    config::IngestionSources,
+    errors::{IndexerError, IndexerResult},
+};
+
+/// Resolves the remote checkpoint source from the provided
+/// [`remote_store_url`](IngestionSources::remote_store_url).
+///
+/// Since `remote_store_url` accepts either a fullnode gRPC endpoint or an
+/// object store URL for historical checkpoint data, this function probes the
+/// URL to determine which type it is:
+///
+/// 1. **gRPC health check** — attempts to connect and call `GetHealth`. If
+///    successful, the URL is treated as a fullnode gRPC endpoint.
+/// 2. **Historical manifest fetch** — if gRPC fails, attempts to fetch the
+///    MANIFEST file from the URL as an S3-compatible object store. If
+///    successful, the URL is treated as a historical checkpoint store.
+///
+/// Both probes are retried with exponential backoff within the given timeout.
+/// If neither succeeds, returns an error.
+pub async fn resolve_remote_url(
+    ingestion_sources: &IngestionSources,
+    timeout: Duration,
+) -> IndexerResult<Option<RemoteUrl>> {
+    let Some(url) = ingestion_sources
+        .remote_store_url
+        .as_ref()
+        .map(ToString::to_string)
+    else {
+        return Ok(None);
+    };
+
+    let grpc_client = GrpcClient::connect(url.clone()).await?;
+
+    // Use a lightweight S3 client to check if the MANIFEST file exists.
+    // We avoid HistoricalReader here as its internal manifest fetch retries
+    // with a 15-minute default backoff and does not have a timeout.
+    let historical =
+        create_remote_store_client(url.clone(), Default::default(), timeout.as_secs())?;
+
+    let mut backoff = ExponentialBackoff {
+        max_elapsed_time: Some(timeout),
+        initial_interval: Duration::from_millis(500),
+        multiplier: 2.0,
+        ..Default::default()
+    };
+
+    loop {
+        if grpc_client.get_health(None).await.is_ok() {
+            info!("resolved remote store as fullnode gRPC: {url}");
+            return Ok(Some(RemoteUrl::Fullnode(url)));
+        }
+
+        if historical.head(&Manifest::file_path()).await.is_ok() {
+            info!("resolved remote store as historical object store: {url}");
+            let live_url = ingestion_sources
+                .current_epoch_store_url
+                .as_ref()
+                .map(ToString::to_string);
+            return Ok(Some(RemoteUrl::HybridHistoricalStore {
+                historical_url: url,
+                live_url,
+            }));
+        }
+
+        match backoff.next_backoff() {
+            Some(duration) => {
+                warn!(
+                    "remote store not reachable as gRPC or historical, retrying in {}ms",
+                    duration.as_millis()
+                );
+                tokio::time::sleep(duration).await;
+            }
+            None => {
+                return Err(IndexerError::Generic(format!(
+                    "unable to resolve remote store URL after {timeout:?}: {url}"
+                )));
+            }
+        }
+    }
+}

--- a/crates/iota-indexer/src/ingestion/common/connection.rs
+++ b/crates/iota-indexer/src/ingestion/common/connection.rs
@@ -53,7 +53,6 @@ pub async fn resolve_remote_url(
 
     let mut backoff = ExponentialBackoff {
         max_elapsed_time: Some(timeout),
-        initial_interval: Duration::from_millis(500),
         multiplier: 2.0,
         ..Default::default()
     };

--- a/crates/iota-indexer/src/ingestion/common/mod.rs
+++ b/crates/iota-indexer/src/ingestion/common/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod connection;
 pub(crate) mod orchestration;
 pub(crate) mod persist;
 pub mod prepare;

--- a/crates/iota-indexer/src/ingestion/primary/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/primary/orchestration.rs
@@ -79,7 +79,7 @@ impl PrimaryPipeline {
 
     pub async fn run(
         self,
-        data_ingestion_path: std::path::PathBuf,
+        data_ingestion_path: Option<std::path::PathBuf>,
         remote_store_url: Option<RemoteUrl>,
         reader_options: iota_data_ingestion_core::ReaderOptions,
     ) -> JoinHandle<IndexerResult<()>> {
@@ -97,7 +97,7 @@ impl PrimaryPipeline {
             info!("Starting primary executor...");
             let mut executor_handle =
                 tokio::spawn(self.executor.run_with_config(CheckpointReaderConfig {
-                    ingestion_path: Some(data_ingestion_path),
+                    ingestion_path: data_ingestion_path,
                     remote_store_url,
                     reader_options,
                 }));

--- a/crates/iota-indexer/src/ingestion/primary/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/primary/orchestration.rs
@@ -80,7 +80,7 @@ impl PrimaryPipeline {
     pub async fn run(
         self,
         data_ingestion_path: std::path::PathBuf,
-        remote_store_url: Option<String>,
+        remote_store_url: Option<RemoteUrl>,
         reader_options: iota_data_ingestion_core::ReaderOptions,
     ) -> JoinHandle<IndexerResult<()>> {
         let writer_cancel = self.cancel.clone();
@@ -97,9 +97,9 @@ impl PrimaryPipeline {
             info!("Starting primary executor...");
             let mut executor_handle =
                 tokio::spawn(self.executor.run_with_config(CheckpointReaderConfig {
-                    reader_options,
                     ingestion_path: Some(data_ingestion_path),
-                    remote_store_url: remote_store_url.map(RemoteUrl::Fullnode),
+                    remote_store_url,
+                    reader_options,
                 }));
 
             let mut executor_done = false;

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -144,7 +144,7 @@ impl SnapshotPipeline {
 
     pub async fn run(
         self,
-        remote_store_url: Option<String>,
+        remote_store_url: Option<RemoteUrl>,
         reader_options: ReaderOptions,
     ) -> JoinHandle<IndexerResult<()>> {
         let handle = tokio::spawn(async move {
@@ -157,9 +157,9 @@ impl SnapshotPipeline {
             let mut executor_handle = if let Some(executor) = self.executor {
                 info!("Starting snapshot executor");
                 tokio::spawn(executor.run_with_config(CheckpointReaderConfig {
-                    reader_options,
                     ingestion_path: None, // internally it creates a tempdir.
-                    remote_store_url: remote_store_url.map(RemoteUrl::Fullnode),
+                    remote_store_url,
+                    reader_options,
                 }))
             } else {
                 info!("Using shared executor - skipping creation of snapshot executor");


### PR DESCRIPTION
# Description of change

This PR extends the `iota-indexer` to support checkpoint ingestion from S3-compatible historical and live storages as an alternative to a fullnode gRPC endpoint. Since fullnodes can prune their internal databases, syncing the indexer from genesis via a fullnode gRPC URL may result in errors when historical checkpoints are no longer available.

To address this, we extended the `--remote-store-url` argument to accept either a fullnode gRPC URL or an S3-compatible historical checkpoint store URL. When provided, the indexer automatically determines the source type by first attempting a gRPC health check, then falling back to checking for a MANIFEST file on the object store. If neither probe succeeds after retrying with exponential backoff, the indexer returns an error and exits.

For minimal latency at the network tip when using historical storage, the user can optionally provide `--current-epoch-store-url`, which points to a live object store serving individual checkpoint files for the current epoch only.

## Links to any relevant issues

fixes #10723 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

- Ran the indexer to make sure that it actually was syncing from historical and live storage, used testnet data.
```shell
cargo r -- --database-url postgres://postgres:postgrespw@localhost:5432/iota_indexer  indexer --remote-store-url=https://checkpoints.testnet.iota.cafe/ingestion/historical  --current-epoch-store-url=https://checkpoints.testnet.iota.cafe/ingestion/live --reset-db
```

- Verified that `--current-epoch-store-url` requires `--remote-store-url` and cannot be used standalone
```shell
cargo r -- --database-url postgres://postgres:postgrespw@localhost:5432/iota_indexer  indexer --current-epoch-store-url=https://checkpoints.testnet.iota.cafe/ingestion/live  --reset-db

error: the following required arguments were not provided:
  --remote-store-url <REMOTE_STORE_URL>
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: Add the ability to sync checkpoints form historical & live storages as an alternative checkpoint source to fullnode.

