### PR TITLE
upstream(core): Provide the tls_single_cert convenience method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6873,6 +6873,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "iota-tls",
  "pin-project-lite",
  "reqwest",
  "socket2 0.5.7",

--- a/crates/iota-http/Cargo.toml
+++ b/crates/iota-http/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+# external dependencies
 bytes.workspace = true
 http.workspace = true
 http-body.workspace = true
@@ -16,11 +17,14 @@ hyper-util.workspace = true
 pin-project-lite.workspace = true
 socket2 = { version = "0.5", features = ["all"] }
 tokio = { workspace = true, features = ["macros"] }
-# TLS support
 tokio-rustls.workspace = true
 tokio-util.workspace = true
 tower.workspace = true
 tracing.workspace = true
+
+# internal dependencies
+# TLS support
+iota-tls.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/iota-http/src/lib.rs
+++ b/crates/iota-http/src/lib.rs
@@ -10,7 +10,7 @@ use http::{Request, Response};
 use hyper_util::service::TowerToHyperService;
 use io::ServerIo;
 use tokio::task::JoinSet;
-use tokio_rustls::TlsAcceptor;
+use tokio_rustls::{TlsAcceptor, rustls};
 use tower::{Service, ServiceBuilder, ServiceExt};
 use tracing::trace;
 
@@ -37,7 +37,7 @@ const ALPN_H1: &[u8] = b"http/1.1";
 #[derive(Default)]
 pub struct Builder {
     config: Config,
-    tls_config: Option<tokio_rustls::rustls::ServerConfig>,
+    tls_config: Option<rustls::ServerConfig>,
 }
 
 impl Builder {
@@ -50,7 +50,27 @@ impl Builder {
         self
     }
 
-    pub fn tls_config(mut self, tls_config: tokio_rustls::rustls::ServerConfig) -> Self {
+    // Convenience method for configuring TLS with a single server cert
+    //
+    // Attempts to load PEM formatted files for the certificate chain and private
+    // key material from the provided file system paths.
+    pub fn tls_single_cert(
+        self,
+        cert_file: impl AsRef<std::path::Path>,
+        private_key_file: impl AsRef<std::path::Path>,
+    ) -> Result<Self, BoxError> {
+        use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+
+        let certs = CertificateDer::pem_file_iter(cert_file)?.collect::<Result<_, _>>()?;
+        let private_key = PrivateKeyDer::from_pem_file(private_key_file)?;
+        let tls_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, private_key)?;
+
+        Ok(self.tls_config(tls_config))
+    }
+
+    pub fn tls_config(mut self, tls_config: rustls::ServerConfig) -> Self {
         self.tls_config = Some(tls_config);
         self
     }
@@ -208,7 +228,7 @@ type ConnectingOutput<Io, Addr> = Result<(ServerIo<Io>, Addr), crate::BoxError>;
 
 struct Server<L: Listener> {
     config: Config,
-    tls_config: Option<Arc<tokio_rustls::rustls::ServerConfig>>,
+    tls_config: Option<Arc<rustls::ServerConfig>>,
 
     listener: L,
     local_addr: L::Addr,

--- a/crates/iota-http/src/lib.rs
+++ b/crates/iota-http/src/lib.rs
@@ -59,14 +59,8 @@ impl Builder {
         cert_file: impl AsRef<std::path::Path>,
         private_key_file: impl AsRef<std::path::Path>,
     ) -> Result<Self, BoxError> {
-        use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
-
-        let certs = CertificateDer::pem_file_iter(cert_file)?.collect::<Result<_, _>>()?;
-        let private_key = PrivateKeyDer::from_pem_file(private_key_file)?;
-        let tls_config = rustls::ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(certs, private_key)?;
-
+        let tls_config =
+            iota_tls::create_rustls_server_config_from_pem(cert_file, private_key_file)?;
         Ok(self.tls_config(tls_config))
     }
 

--- a/crates/iota-tls/src/lib.rs
+++ b/crates/iota-tls/src/lib.rs
@@ -21,6 +21,23 @@ pub use verifier::{
 
 pub const IOTA_VALIDATOR_SERVER_NAME: &str = "iota";
 
+/// Create a TLS server config by loading PEM formatted certificate chain and
+/// private key files from the filesystem. No client authentication is required.
+pub fn create_rustls_server_config_from_pem(
+    cert_file: impl AsRef<std::path::Path>,
+    private_key_file: impl AsRef<std::path::Path>,
+) -> Result<ServerConfig, Box<dyn std::error::Error + Send + Sync>> {
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+
+    let certs = CertificateDer::pem_file_iter(cert_file)?.collect::<Result<_, _>>()?;
+    let private_key = PrivateKeyDer::from_pem_file(private_key_file)?;
+    let tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, private_key)?;
+
+    Ok(tls_config)
+}
+
 pub fn create_rustls_server_config(
     private_key: Ed25519PrivateKey,
     server_name: String,


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@3933733](https://github.com/MystenLabs/sui/commit/39337332ac84ef76f5740d641840f725e9d6fc9b)
- Description:

Provide the `tls_single_cert` convenience method for instantiating a TLS
configuration by loading PEM formatted files for the certificate chain
and private key material.

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes