### PR TITLE
upstream(node): Update system package before other snapshots

### DIFF
--- a/scripts/update_all_snapshots.sh
+++ b/scripts/update_all_snapshots.sh
@@ -12,10 +12,10 @@ SCRIPT_PATH=$(realpath "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 ROOT="$SCRIPT_DIR/.."
 
+UPDATE=1 cargo test -p iota-framework --test build-system-packages
 cd "$ROOT/crates/iota-protocol-config" && cargo insta test --review
 cd "$ROOT/crates/iota-cost" && cargo insta test --review
 cd "$ROOT/crates/iota-swarm-config" && cargo insta test --review
 cd "$ROOT/crates/iota-open-rpc" && cargo run --example generate-json-rpc-spec -- record
 cd "$ROOT/crates/iota-core" && cargo -q run --example generate-format -- print > tests/staged/iota.yaml
-UPDATE=1 cargo test -p iota-framework --test build-system-packages
 UPDATE=1 cargo test -p iota-rest-api


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@e897e2f](https://github.com/MystenLabs/sui/commit/e897e2f25e477daacdf8720597f3fbd10f2e8bae)
- Description:

Hash of system package is part of swarm config snapshot, so updating
system package first.

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes