### PR TITLE
fix(iota-core,iota-types): fix dropped tx notification race and categorize error retryability

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -233,6 +233,7 @@ pub mod transaction_deferral;
 
 pub(crate) mod authority_store;
 pub mod backpressure;
+pub(crate) mod dropped_tx_status_cache;
 
 /// Prometheus metrics which can be displayed in Grafana, queried and alerted on
 pub struct AuthorityMetrics {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -659,10 +659,10 @@ pub struct AuthorityPerEpochStore {
 
     executed_digests_notify_read: NotifyRead<TransactionKey, TransactionDigest>,
 
-    /// Notifies waiters when a transaction is dropped by white-flag conflict
-    /// resolution. This allows `wait_for_effects` to return immediately with a
+    /// In-memory bounded cache for transactions dropped by white-flag conflict
+    /// resolution. Allows `wait_for_effects` to return immediately with a
     /// `Rejected` response instead of waiting for the gRPC deadline.
-    dropped_tx_notify_read: NotifyRead<TransactionDigest, IotaError>,
+    dropped_tx_status_cache: super::dropped_tx_status_cache::DroppedTxStatusCache,
 
     /// This is used to notify all epoch specific tasks that epoch has ended.
     epoch_alive_notify: NotifyOnce,
@@ -833,11 +833,6 @@ pub struct AuthorityEpochTables {
     /// association here
     pub(crate) executed_transactions_to_checkpoint:
         DBMap<TransactionDigest, CheckpointSequenceNumber>,
-
-    /// Transactions dropped by white-flag conflict resolution.
-    /// Stored so that late `wait_for_effects` callers can get immediate
-    /// rejection instead of hanging until timeout.
-    dropped_transactions: DBMap<TransactionDigest, IotaError>,
 
     /// JWKs that have been voted for by one or more authorities but are not yet
     /// active.
@@ -1214,7 +1209,7 @@ impl AuthorityPerEpochStore {
             checkpoint_state_notify_read: NotifyRead::new(),
             running_root_notify_read: NotifyRead::new(),
             executed_digests_notify_read: NotifyRead::new(),
-            dropped_tx_notify_read: NotifyRead::new(),
+            dropped_tx_status_cache: super::dropped_tx_status_cache::DroppedTxStatusCache::new(),
             end_of_publish: Mutex::new(end_of_publish),
             pending_consensus_certificates: RwLock::new(pending_consensus_certificates),
             mutex_table: MutexTable::new(MUTEX_TABLE_SIZE),
@@ -1745,11 +1740,9 @@ impl AuthorityPerEpochStore {
         &self,
         digest: TransactionDigest,
     ) -> IotaResult<IotaError> {
-        let registration = self.dropped_tx_notify_read.register_one(&digest);
-        if let Some(error) = self.tables()?.dropped_transactions.get(&digest)? {
-            return Ok(error);
-        }
-        Ok(registration.await)
+        self.dropped_tx_status_cache
+            .notify_read_dropped(digest)
+            .await
     }
 
     pub async fn notify_read_running_root(
@@ -3252,19 +3245,7 @@ impl AuthorityPerEpochStore {
             // TODO: possibly record dropped digests in ConsensusCommitPrologue for
             //  consistent view
             if !dropped.is_empty() {
-                let tables = self.tables()?;
-                let mut batch = tables.dropped_transactions.batch();
-                batch.insert_batch(
-                    &tables.dropped_transactions,
-                    dropped
-                        .iter()
-                        .map(|(digest, error)| (*digest, error.clone())),
-                )?;
-                batch.write()?;
-
-                for (digest, error) in &dropped {
-                    self.dropped_tx_notify_read.notify(digest, error);
-                }
+                self.dropped_tx_status_cache.insert_and_notify(&dropped);
                 authority_metrics
                     .consensus_handler_validation_dropped_transactions
                     .inc_by(dropped.len() as u64);

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1736,10 +1736,7 @@ impl AuthorityPerEpochStore {
     /// Returns the `IotaError` describing why it was dropped.
     /// Callers should race this against `notify_read_executed_effects_digests`
     /// to determine whether the transaction was executed or dropped.
-    pub async fn notify_read_dropped_digests(
-        &self,
-        digest: TransactionDigest,
-    ) -> IotaResult<IotaError> {
+    pub async fn notify_read_dropped_digests(&self, digest: TransactionDigest) -> IotaError {
         self.dropped_tx_status_cache
             .notify_read_dropped(digest)
             .await

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -834,6 +834,11 @@ pub struct AuthorityEpochTables {
     pub(crate) executed_transactions_to_checkpoint:
         DBMap<TransactionDigest, CheckpointSequenceNumber>,
 
+    /// Transactions dropped by white-flag conflict resolution.
+    /// Stored so that late `wait_for_effects` callers can get immediate
+    /// rejection instead of hanging until timeout.
+    dropped_transactions: DBMap<TransactionDigest, IotaError>,
+
     /// JWKs that have been voted for by one or more authorities but are not yet
     /// active.
     pending_jwks: DBMap<(AuthorityName, JwkId, JWK), ()>,
@@ -1736,9 +1741,15 @@ impl AuthorityPerEpochStore {
     /// Returns the `IotaError` describing why it was dropped.
     /// Callers should race this against `notify_read_executed_effects_digests`
     /// to determine whether the transaction was executed or dropped.
-    pub async fn notify_read_dropped_digests(&self, digest: TransactionDigest) -> IotaError {
+    pub async fn notify_read_dropped_digests(
+        &self,
+        digest: TransactionDigest,
+    ) -> IotaResult<IotaError> {
         let registration = self.dropped_tx_notify_read.register_one(&digest);
-        registration.await
+        if let Some(error) = self.tables()?.dropped_transactions.get(&digest)? {
+            return Ok(error);
+        }
+        Ok(registration.await)
     }
 
     pub async fn notify_read_running_root(
@@ -3241,6 +3252,16 @@ impl AuthorityPerEpochStore {
             // TODO: possibly record dropped digests in ConsensusCommitPrologue for
             //  consistent view
             if !dropped.is_empty() {
+                let tables = self.tables()?;
+                let mut batch = tables.dropped_transactions.batch();
+                batch.insert_batch(
+                    &tables.dropped_transactions,
+                    dropped
+                        .iter()
+                        .map(|(digest, error)| (*digest, error.clone())),
+                )?;
+                batch.write()?;
+
                 for (digest, error) in &dropped {
                     self.dropped_tx_notify_read.notify(digest, error);
                 }

--- a/crates/iota-core/src/authority/dropped_tx_status_cache.rs
+++ b/crates/iota-core/src/authority/dropped_tx_status_cache.rs
@@ -8,10 +8,7 @@
 use std::collections::{HashMap, VecDeque};
 
 use iota_common::sync::notify_read::NotifyRead;
-use iota_types::{
-    base_types::TransactionDigest,
-    error::{IotaError, IotaResult},
-};
+use iota_types::{base_types::TransactionDigest, error::IotaError};
 use parking_lot::RwLock;
 
 /// Maximum number of dropped transaction entries to retain.
@@ -65,9 +62,15 @@ impl DroppedTxStatusCache {
     /// Record a batch of dropped transactions and notify any waiters.
     /// When the cache is at capacity, the oldest entries are evicted first.
     pub(crate) fn insert_and_notify(&self, dropped: &[(TransactionDigest, IotaError)]) {
-        let mut inner = self.inner.write();
+        {
+            let mut inner = self.inner.write();
+            for (digest, error) in dropped {
+                inner.insert(*digest, error.clone());
+            }
+        }
+        // Notify outside the lock — entries are already visible to readers,
+        // so the register-then-check pattern in notify_read_dropped is safe.
         for (digest, error) in dropped {
-            inner.insert(*digest, error.clone());
             self.notify_read.notify(digest, error);
         }
     }
@@ -75,15 +78,12 @@ impl DroppedTxStatusCache {
     /// Wait for a transaction to be dropped, or return immediately if it was
     /// already dropped. Uses the register-then-check pattern to avoid the
     /// race where `notify()` fires before the caller registers.
-    pub(crate) async fn notify_read_dropped(
-        &self,
-        digest: TransactionDigest,
-    ) -> IotaResult<IotaError> {
+    pub(crate) async fn notify_read_dropped(&self, digest: TransactionDigest) -> IotaError {
         let registration = self.notify_read.register_one(&digest);
         if let Some(error) = self.inner.read().entries.get(&digest) {
-            return Ok(error.clone());
+            return error.clone();
         }
-        Ok(registration.await)
+        registration.await
     }
 }
 
@@ -107,8 +107,7 @@ mod tests {
 
         let result = timeout(Duration::from_secs(5), cache.notify_read_dropped(digest))
             .await
-            .expect("should not timeout")
-            .expect("should not return a storage error");
+            .expect("should not timeout");
 
         assert_eq!(result.to_string(), expected_error.to_string());
     }
@@ -122,8 +121,7 @@ mod tests {
         let expected_error = IotaError::TransactionExpired;
 
         let cache_clone = cache.clone();
-        let handle =
-            tokio::spawn(async move { cache_clone.notify_read_dropped(digest).await.unwrap() });
+        let handle = tokio::spawn(async move { cache_clone.notify_read_dropped(digest).await });
 
         // Small delay so the spawned task registers before we notify.
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/crates/iota-core/src/authority/dropped_tx_status_cache.rs
+++ b/crates/iota-core/src/authority/dropped_tx_status_cache.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! In-memory bounded cache for transactions dropped by white-flag conflict

--- a/crates/iota-core/src/authority/dropped_tx_status_cache.rs
+++ b/crates/iota-core/src/authority/dropped_tx_status_cache.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory bounded cache for transactions dropped by white-flag conflict
+//! resolution. Allows `wait_for_effects` callers to get an immediate
+//! `Rejected` response instead of hanging until timeout.
+
+use std::collections::{HashMap, VecDeque};
+
+use iota_common::sync::notify_read::NotifyRead;
+use iota_types::{
+    base_types::TransactionDigest,
+    error::{IotaError, IotaResult},
+};
+use parking_lot::RwLock;
+
+/// Maximum number of dropped transaction entries to retain.
+/// At ~200 bytes per entry (digest + error), 100k entries ≈ 20 MB.
+const MAX_DROPPED_ENTRIES: usize = 100_000;
+
+pub(crate) struct DroppedTxStatusCache {
+    inner: RwLock<Inner>,
+    notify_read: NotifyRead<TransactionDigest, IotaError>,
+}
+
+struct Inner {
+    /// Digest → error lookup for the register-then-check pattern.
+    entries: HashMap<TransactionDigest, IotaError>,
+    /// Insertion order for FIFO eviction when at capacity.
+    insertion_order: VecDeque<TransactionDigest>,
+}
+
+impl Inner {
+    fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            insertion_order: VecDeque::new(),
+        }
+    }
+
+    fn insert(&mut self, digest: TransactionDigest, error: IotaError) {
+        // If the digest is already present, skip (don't update ordering).
+        if self.entries.contains_key(&digest) {
+            return;
+        }
+        // Evict oldest entries to make room.
+        while self.entries.len() >= MAX_DROPPED_ENTRIES {
+            if let Some(oldest) = self.insertion_order.pop_front() {
+                self.entries.remove(&oldest);
+            }
+        }
+        self.entries.insert(digest, error);
+        self.insertion_order.push_back(digest);
+    }
+}
+
+impl DroppedTxStatusCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: RwLock::new(Inner::new()),
+            notify_read: NotifyRead::new(),
+        }
+    }
+
+    /// Record a batch of dropped transactions and notify any waiters.
+    /// When the cache is at capacity, the oldest entries are evicted first.
+    pub(crate) fn insert_and_notify(&self, dropped: &[(TransactionDigest, IotaError)]) {
+        let mut inner = self.inner.write();
+        for (digest, error) in dropped {
+            inner.insert(*digest, error.clone());
+            self.notify_read.notify(digest, error);
+        }
+    }
+
+    /// Wait for a transaction to be dropped, or return immediately if it was
+    /// already dropped. Uses the register-then-check pattern to avoid the
+    /// race where `notify()` fires before the caller registers.
+    pub(crate) async fn notify_read_dropped(
+        &self,
+        digest: TransactionDigest,
+    ) -> IotaResult<IotaError> {
+        let registration = self.notify_read.register_one(&digest);
+        if let Some(error) = self.inner.read().entries.get(&digest) {
+            return Ok(error.clone());
+        }
+        Ok(registration.await)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::*;
+
+    /// When a transaction is already in the cache, `notify_read_dropped`
+    /// should return immediately instead of hanging.
+    #[tokio::test]
+    async fn test_returns_persisted_error() {
+        let cache = DroppedTxStatusCache::new();
+        let digest = TransactionDigest::random();
+        let expected_error = IotaError::TransactionExpired;
+
+        cache.insert_and_notify(&[(digest, expected_error.clone())]);
+
+        let result = timeout(Duration::from_secs(5), cache.notify_read_dropped(digest))
+            .await
+            .expect("should not timeout")
+            .expect("should not return a storage error");
+
+        assert_eq!(result.to_string(), expected_error.to_string());
+    }
+
+    /// The normal path: client registers before the drop is recorded, and
+    /// the notification resolves the future.
+    #[tokio::test]
+    async fn test_waits_for_notification() {
+        let cache = std::sync::Arc::new(DroppedTxStatusCache::new());
+        let digest = TransactionDigest::random();
+        let expected_error = IotaError::TransactionExpired;
+
+        let cache_clone = cache.clone();
+        let handle =
+            tokio::spawn(async move { cache_clone.notify_read_dropped(digest).await.unwrap() });
+
+        // Small delay so the spawned task registers before we notify.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        cache.insert_and_notify(&[(digest, expected_error.clone())]);
+
+        let result = timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("should not timeout")
+            .expect("task should not panic");
+
+        assert_eq!(result.to_string(), expected_error.to_string());
+    }
+
+    /// When the cache is at capacity, the oldest entries are evicted to make
+    /// room for new ones.
+    #[tokio::test]
+    async fn test_capacity_evicts_oldest() {
+        let cache = DroppedTxStatusCache::new();
+
+        // Fill the cache to capacity.
+        let entries: Vec<_> = (0..MAX_DROPPED_ENTRIES)
+            .map(|_| (TransactionDigest::random(), IotaError::TransactionExpired))
+            .collect();
+        let first_digest = entries[0].0;
+        cache.insert_and_notify(&entries);
+
+        assert_eq!(cache.inner.read().entries.len(), MAX_DROPPED_ENTRIES);
+        assert!(cache.inner.read().entries.contains_key(&first_digest));
+
+        // Insert one more — the oldest (first) entry should be evicted.
+        let new_digest = TransactionDigest::random();
+        cache.insert_and_notify(&[(new_digest, IotaError::TransactionExpired)]);
+
+        assert_eq!(cache.inner.read().entries.len(), MAX_DROPPED_ENTRIES);
+        assert!(
+            !cache.inner.read().entries.contains_key(&first_digest),
+            "oldest entry should have been evicted"
+        );
+        assert!(
+            cache.inner.read().entries.contains_key(&new_digest),
+            "new entry should be present"
+        );
+    }
+}

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1574,6 +1574,9 @@ impl ValidatorService {
                     effects_digests = cache.notify_read_executed_effects_digests(&digests_to_watch) => {
                         Either::Left(effects_digests)
                     }
+                    // notify_read_dropped_digests returns IotaResult<IotaError>:
+                    // - Ok(error) = transaction was dropped, here's why
+                    // - Err(e) = storage failure reading the dropped_transactions table
                     dropped_result = epoch_store.notify_read_dropped_digests(tx_digest) => {
                         Either::Right(dropped_result)
                     }
@@ -1582,7 +1585,11 @@ impl ValidatorService {
         )
         .await;
 
+        // The select! produces Either<Vec<EffectsDigest>, IotaResult<IotaError>>.
+        // Unpack the four outcomes: storage error, executed, dropped, or timeout.
         match result {
+            // Storage error from the dropped-transactions DB lookup — propagate as
+            // tonic::Status so the fullnode retries on a different validator.
             Ok(Either::Right(Err(e))) => Err(e.into()),
             Ok(Either::Left(effects_digests)) => {
                 if let Some(effects_digest) = effects_digests.into_iter().next() {

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1574,23 +1574,17 @@ impl ValidatorService {
                     effects_digests = cache.notify_read_executed_effects_digests(&digests_to_watch) => {
                         Either::Left(effects_digests)
                     }
-                    // notify_read_dropped_digests returns IotaResult<IotaError>:
-                    // - Ok(error) = transaction was dropped, here's why
-                    // - Err(e) = storage failure reading the dropped_transactions table
-                    dropped_result = epoch_store.notify_read_dropped_digests(tx_digest) => {
-                        Either::Right(dropped_result)
+                    dropped_error = epoch_store.notify_read_dropped_digests(tx_digest) => {
+                        Either::Right(dropped_error)
                     }
                 }
             },
         )
         .await;
 
-        // The select! produces Either<Vec<EffectsDigest>, IotaResult<IotaError>>.
-        // Unpack the four outcomes: storage error, executed, dropped, or timeout.
+        // The select! produces Either<Vec<EffectsDigest>, IotaError>.
+        // Unpack the three outcomes: executed, dropped, or timeout.
         match result {
-            // Storage error from the dropped-transactions DB lookup — propagate as
-            // tonic::Status so the fullnode retries on a different validator.
-            Ok(Either::Right(Err(e))) => Err(e.into()),
             Ok(Either::Left(effects_digests)) => {
                 if let Some(effects_digest) = effects_digests.into_iter().next() {
                     // Fetch detailed execution data if requested.
@@ -1631,7 +1625,7 @@ impl ValidatorService {
                     }
                 }
             }
-            Ok(Either::Right(Ok(dropped_error))) => {
+            Ok(Either::Right(dropped_error)) => {
                 // Transaction was dropped by white-flag conflict resolution.
                 WaitForEffectResponse::Rejected {
                     error: Some(dropped_error),

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1574,8 +1574,8 @@ impl ValidatorService {
                     effects_digests = cache.notify_read_executed_effects_digests(&digests_to_watch) => {
                         Either::Left(effects_digests)
                     }
-                    dropped_error = epoch_store.notify_read_dropped_digests(tx_digest) => {
-                        Either::Right(dropped_error)
+                    dropped_result = epoch_store.notify_read_dropped_digests(tx_digest) => {
+                        Either::Right(dropped_result)
                     }
                 }
             },
@@ -1583,6 +1583,7 @@ impl ValidatorService {
         .await;
 
         match result {
+            Ok(Either::Right(Err(e))) => Err(e.into()),
             Ok(Either::Left(effects_digests)) => {
                 if let Some(effects_digest) = effects_digests.into_iter().next() {
                     // Fetch detailed execution data if requested.
@@ -1623,7 +1624,7 @@ impl ValidatorService {
                     }
                 }
             }
-            Ok(Either::Right(dropped_error)) => {
+            Ok(Either::Right(Ok(dropped_error))) => {
                 // Transaction was dropped by white-flag conflict resolution.
                 WaitForEffectResponse::Rejected {
                     error: Some(dropped_error),

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use iota_types::{base_types::TransactionDigest, error::IotaError};
+use iota_types::base_types::TransactionDigest;
 use tokio::time::timeout;
 
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
@@ -60,68 +60,4 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
     assert_eq!(result[0].unwrap(), checkpoint_sequence_1);
     assert_eq!(result[1].unwrap(), checkpoint_sequence_2);
     assert_eq!(result[2].unwrap(), checkpoint_sequence_2);
-}
-
-/// Tests the race condition fix: when a transaction was already dropped and
-/// cached *before* the client calls `notify_read_dropped_digests`, the method
-/// should return immediately instead of hanging until timeout.
-#[tokio::test]
-async fn test_notify_read_dropped_digests_returns_cached_error() {
-    let authority_state = TestAuthorityBuilder::new().build().await;
-    let store = authority_state.epoch_store_for_testing();
-
-    let digest = TransactionDigest::random();
-    let expected_error = IotaError::TransactionExpired;
-
-    // Simulate the consensus handler having already recorded the drop.
-    store
-        .dropped_tx_status_cache
-        .insert_and_notify(&[(digest, expected_error.clone())]);
-
-    // notify_read_dropped_digests should return immediately from the cache,
-    // not hang waiting for a notification that already fired.
-    let result = timeout(
-        Duration::from_secs(5),
-        store.notify_read_dropped_digests(digest),
-    )
-    .await
-    .expect("should not timeout — the cache lookup should return immediately")
-    .expect("should not return a storage error");
-
-    assert_eq!(result.to_string(), expected_error.to_string());
-}
-
-/// Tests the normal (non-race) path: the client registers before the drop
-/// is recorded, and the notification resolves the future.
-#[tokio::test]
-async fn test_notify_read_dropped_digests_waits_for_notification() {
-    let authority_state = TestAuthorityBuilder::new().build().await;
-    let store = authority_state.epoch_store_for_testing();
-
-    let digest = TransactionDigest::random();
-    let expected_error = IotaError::TransactionExpired;
-
-    // Spawn a task that waits for the drop notification.
-    let store_clone = store.clone();
-    let handle = tokio::spawn(async move {
-        store_clone
-            .notify_read_dropped_digests(digest)
-            .await
-            .expect("should not return a storage error")
-    });
-
-    // Small delay so the spawned task registers before we notify.
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
-    // Simulate the consensus handler: insert and notify.
-    store
-        .dropped_tx_status_cache
-        .insert_and_notify(&[(digest, expected_error.clone())]);
-
-    let result = timeout(Duration::from_secs(5), handle)
-        .await
-        .expect("should not timeout")
-        .expect("task should not panic");
-
-    assert_eq!(result.to_string(), expected_error.to_string());
 }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -4,8 +4,9 @@
 
 use std::time::Duration;
 
-use iota_types::base_types::TransactionDigest;
+use iota_types::{base_types::TransactionDigest, error::IotaError};
 use tokio::time::timeout;
+use typed_store::Map;
 
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 
@@ -60,4 +61,75 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
     assert_eq!(result[0].unwrap(), checkpoint_sequence_1);
     assert_eq!(result[1].unwrap(), checkpoint_sequence_2);
     assert_eq!(result[2].unwrap(), checkpoint_sequence_2);
+}
+
+/// Tests the race condition fix: when a transaction was already dropped and
+/// persisted to the `dropped_transactions` table *before* the client calls
+/// `notify_read_dropped_digests`, the method should return immediately
+/// instead of hanging until timeout.
+#[tokio::test]
+async fn test_notify_read_dropped_digests_returns_persisted_error() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+
+    let digest = TransactionDigest::random();
+    let expected_error = IotaError::TransactionExpired;
+
+    // Simulate the consensus handler having already persisted the drop.
+    store
+        .tables()
+        .expect("tables should be available")
+        .dropped_transactions
+        .insert(&digest, &expected_error)
+        .expect("insert should not fail");
+
+    // notify_read_dropped_digests should return immediately from the DB check,
+    // not hang waiting for a notification that already fired.
+    let result = timeout(
+        Duration::from_secs(5),
+        store.notify_read_dropped_digests(digest),
+    )
+    .await
+    .expect("should not timeout — the DB lookup should return immediately")
+    .expect("should not return a storage error");
+
+    assert_eq!(result.to_string(), expected_error.to_string());
+}
+
+/// Tests the normal (non-race) path: the client registers before the drop
+/// is persisted, and the notification resolves the future.
+#[tokio::test]
+async fn test_notify_read_dropped_digests_waits_for_notification() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+
+    let digest = TransactionDigest::random();
+    let expected_error = IotaError::TransactionExpired;
+
+    // Spawn a task that waits for the drop notification.
+    let store_clone = store.clone();
+    let expected_error_clone = expected_error.clone();
+    let handle = tokio::spawn(async move {
+        store_clone
+            .notify_read_dropped_digests(digest)
+            .await
+            .expect("should not return a storage error")
+    });
+
+    // Simulate the consensus handler: write to table, then notify.
+    let tables = store.tables().expect("tables should be available");
+    tables
+        .dropped_transactions
+        .insert(&digest, &expected_error_clone)
+        .expect("insert should not fail");
+    store
+        .dropped_tx_notify_read
+        .notify(&digest, &expected_error_clone);
+
+    let result = timeout(Duration::from_secs(5), handle)
+        .await
+        .expect("should not timeout")
+        .expect("task should not panic");
+
+    assert_eq!(result.to_string(), expected_error.to_string());
 }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use iota_types::{base_types::TransactionDigest, error::IotaError};
 use tokio::time::timeout;
-use typed_store::Map;
 
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 
@@ -64,40 +63,36 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
 }
 
 /// Tests the race condition fix: when a transaction was already dropped and
-/// persisted to the `dropped_transactions` table *before* the client calls
-/// `notify_read_dropped_digests`, the method should return immediately
-/// instead of hanging until timeout.
+/// cached *before* the client calls `notify_read_dropped_digests`, the method
+/// should return immediately instead of hanging until timeout.
 #[tokio::test]
-async fn test_notify_read_dropped_digests_returns_persisted_error() {
+async fn test_notify_read_dropped_digests_returns_cached_error() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
 
     let digest = TransactionDigest::random();
     let expected_error = IotaError::TransactionExpired;
 
-    // Simulate the consensus handler having already persisted the drop.
+    // Simulate the consensus handler having already recorded the drop.
     store
-        .tables()
-        .expect("tables should be available")
-        .dropped_transactions
-        .insert(&digest, &expected_error)
-        .expect("insert should not fail");
+        .dropped_tx_status_cache
+        .insert_and_notify(&[(digest, expected_error.clone())]);
 
-    // notify_read_dropped_digests should return immediately from the DB check,
+    // notify_read_dropped_digests should return immediately from the cache,
     // not hang waiting for a notification that already fired.
     let result = timeout(
         Duration::from_secs(5),
         store.notify_read_dropped_digests(digest),
     )
     .await
-    .expect("should not timeout — the DB lookup should return immediately")
+    .expect("should not timeout — the cache lookup should return immediately")
     .expect("should not return a storage error");
 
     assert_eq!(result.to_string(), expected_error.to_string());
 }
 
 /// Tests the normal (non-race) path: the client registers before the drop
-/// is persisted, and the notification resolves the future.
+/// is recorded, and the notification resolves the future.
 #[tokio::test]
 async fn test_notify_read_dropped_digests_waits_for_notification() {
     let authority_state = TestAuthorityBuilder::new().build().await;
@@ -108,7 +103,6 @@ async fn test_notify_read_dropped_digests_waits_for_notification() {
 
     // Spawn a task that waits for the drop notification.
     let store_clone = store.clone();
-    let expected_error_clone = expected_error.clone();
     let handle = tokio::spawn(async move {
         store_clone
             .notify_read_dropped_digests(digest)
@@ -116,15 +110,13 @@ async fn test_notify_read_dropped_digests_waits_for_notification() {
             .expect("should not return a storage error")
     });
 
-    // Simulate the consensus handler: write to table, then notify.
-    let tables = store.tables().expect("tables should be available");
-    tables
-        .dropped_transactions
-        .insert(&digest, &expected_error_clone)
-        .expect("insert should not fail");
+    // Small delay so the spawned task registers before we notify.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Simulate the consensus handler: insert and notify.
     store
-        .dropped_tx_notify_read
-        .notify(&digest, &expected_error_clone);
+        .dropped_tx_status_cache
+        .insert_and_notify(&[(digest, expected_error.clone())]);
 
     let result = timeout(Duration::from_secs(5), handle)
         .await

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -923,6 +923,9 @@ impl IotaError {
             IotaError::TooManyTransactionsPendingConsensus => true,
             IotaError::ValidatorOverloadedRetryAfter { .. } => true,
 
+            // Transient consensus failure — other validators likely unaffected
+            IotaError::FailedToSubmitToConsensus(..) => true,
+
             // Non retryable error
             IotaError::Execution(..) => false,
             IotaError::ByzantineAuthoritySuspicion { .. } => false,
@@ -935,6 +938,21 @@ impl IotaError {
             // limit / blocking of a client. It must be non-retryable otherwise
             // we will make the threat worse through automatic retries.
             IotaError::TooManyRequests => false,
+
+            // Signature errors — non-retryable, invalid input
+            IotaError::InvalidSignature { .. } => false,
+            IotaError::SignerSignatureAbsent { .. } => false,
+            IotaError::SignerSignatureNumberMismatch { .. } => false,
+            IotaError::IncorrectSigner { .. } => false,
+            IotaError::UnknownSigner { .. } => false,
+            IotaError::InvalidAuthenticator => false,
+
+            // Transaction lifecycle — non-retryable
+            IotaError::TransactionExpired => false,
+
+            // Fullnode-internal aggregation errors — non-retryable
+            IotaError::StakeAggregatorRepeatedSigner { .. } => false,
+            IotaError::CertificateRequiresQuorum => false,
 
             // For all un-categorized errors, return here with categorized = false.
             _ => return (false, false),


### PR DESCRIPTION
# Description of change

Fix two issues found during the validator error flow audit:

- **Race condition in `dropped_tx_notify_read`:** Drop notifications fired before `wait_for_effects` registers were lost, causing 30s hangs instead of immediate rejection. The fix persists dropped transactions to a new `dropped_transactions` DB table and checks it after registration, mirroring the existing `notify_read_running_root` pattern.
- **Uncategorized `IotaError` variants in `is_retryable()`:** `FailedToSubmitToConsensus` was incorrectly non-retryable (falling through catch-all). Signature errors, `TransactionExpired`, and aggregation errors now have explicit categorization, eliminating unnecessary WATCHOUT log noise.

## Links to any relevant issues

Refs #10744, #10375

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Two new tests added in `authority_per_epoch_store_tests.rs`:
- `test_notify_read_dropped_digests_returns_persisted_error` — verifies the race condition fix (late registration returns immediately from DB)
- `test_notify_read_dropped_digests_waits_for_notification` — verifies the normal notification path still works