### PR TITLE
feat(iota-core,iota-types): [P-COOL] batch response and multi-transaction wait-for-effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7544,6 +7544,7 @@ dependencies = [
  "tokio",
  "tonic 0.14.2",
  "tonic-build 0.14.2",
+ "tonic-prost",
  "tower 0.4.13",
  "tracing",
 ]
@@ -8533,6 +8534,7 @@ dependencies = [
  "better_any",
  "bincode",
  "byteorder",
+ "bytes",
  "consensus-config",
  "coset",
  "criterion",
@@ -8573,6 +8575,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "proptest-derive",
+ "prost 0.14.1",
  "prost-types 0.14.1",
  "rand 0.8.5",
  "roaring",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2385,24 +2385,6 @@ impl AuthorityPerEpochStore {
         }
     }
 
-    /// Check whether any user transactions were processed by consensus.
-    /// This handles multiple transactions at once (white-flag / soft-bundle
-    /// path).
-    pub fn is_any_user_tx_consensus_message_processed<'a>(
-        &self,
-        transactions: impl Iterator<Item = &'a Transaction>,
-    ) -> IotaResult<bool> {
-        let keys = transactions.map(|tx| {
-            SequencedConsensusTransactionKey::External(ConsensusTransactionKey::UserTransaction(
-                *tx.digest(),
-            ))
-        });
-        Ok(self
-            .check_consensus_messages_processed(keys)?
-            .into_iter()
-            .any(|processed| processed))
-    }
-
     /// Check whether any certificates were processed by consensus.
     /// This handles multiple certificates at once.
     pub fn is_any_tx_certs_consensus_message_processed<'a>(

--- a/crates/iota-core/src/authority_client.rs
+++ b/crates/iota-core/src/authority_client.rs
@@ -283,14 +283,18 @@ impl AuthorityAPI for NetworkAuthorityClient {
         request: SubmitTransactionsRequest,
         client_addr: Option<SocketAddr>,
     ) -> Result<SubmitTransactionsResponse, IotaError> {
-        let mut grpc_request = request.into_request();
+        use iota_types::messages_grpc::RawSubmitTransactionsRequest;
+        let raw_request: RawSubmitTransactionsRequest = request.try_into()?;
+        let mut grpc_request = raw_request.into_request();
         insert_metadata(&mut grpc_request, client_addr);
 
-        self.client()?
+        let raw_response = self
+            .client()?
             .handle_submit_transactions(grpc_request)
             .await
             .map(tonic::Response::into_inner)
-            .map_err(Into::into)
+            .map_err(IotaError::from)?;
+        raw_response.try_into()
     }
 
     async fn handle_wait_for_effects(
@@ -298,22 +302,32 @@ impl AuthorityAPI for NetworkAuthorityClient {
         request: WaitForEffectsRequest,
         _client_addr: Option<SocketAddr>,
     ) -> Result<WaitForEffectsResponse, IotaError> {
-        self.client()?
-            .handle_wait_for_effects(request.into_request())
+        use iota_types::messages_grpc::RawWaitForEffectsRequest;
+        let raw_request: RawWaitForEffectsRequest = request.try_into()?;
+
+        let raw_response = self
+            .client()?
+            .handle_wait_for_effects(raw_request.into_request())
             .await
             .map(tonic::Response::into_inner)
-            .map_err(Into::into)
+            .map_err(IotaError::from)?;
+        raw_response.try_into()
     }
 
     async fn handle_validator_health(
         &self,
         request: ValidatorHealthRequest,
     ) -> Result<ValidatorHealthResponse, IotaError> {
-        self.client()?
-            .handle_validator_health(request.into_request())
+        use iota_types::messages_grpc::RawValidatorHealthRequest;
+        let raw_request: RawValidatorHealthRequest = request.try_into()?;
+
+        let raw_response = self
+            .client()?
+            .handle_validator_health(raw_request.into_request())
             .await
             .map(tonic::Response::into_inner)
-            .map_err(Into::into)
+            .map_err(IotaError::from)?;
+        raw_response.try_into()
     }
 }
 

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -22,7 +22,6 @@ use iota_network::{
 };
 use iota_network_stack::server::IOTA_TLS_SERVER_NAME;
 use iota_types::{
-    base_types::TransactionEffectsDigest,
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::*,
     fp_ensure,
@@ -1299,26 +1298,20 @@ impl ValidatorService {
 
         let request = request.into_inner();
 
-        // Handle ping.
+        // Handle ping (empty request → empty response).
         if request.is_ping() {
-            // TODO: handle ping response better. Do we even need ping requests?
             return Ok((
-                tonic::Response::new(SubmitTransactionsResponse {
-                    results: vec![SubmitTransactionResult::Submitted],
-                }),
+                tonic::Response::new(SubmitTransactionsResponse { results: vec![] }),
                 Weight::zero(),
             ));
         }
 
         let transactions = request.transactions;
 
-        // Per-tx validity checks. For soft bundles this also accumulates total
-        // serialized size for the bundle size limit.
-        // TODO: check if size check needed?
-        let mut _total_size_bytes: u64 = 0;
+        // Per-tx validity and overload checks. These are validator-wide
+        // conditions so we short-circuit before spawning parallel futures.
         for tx in &transactions {
-            _total_size_bytes +=
-                tx.validity_check(epoch_store.protocol_config(), epoch_store.epoch())? as u64;
+            tx.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
 
             // System overload check per transaction: check_execution_overload examines
             // per-transaction input objects (shared objects, object queue depth).
@@ -1339,9 +1332,7 @@ impl ValidatorService {
         // where the timer also starts after the overload check.
         let _handle_tx_metrics_guard = metrics.handle_transaction_latency.start_timer();
 
-        // ── Single-transaction path ─────────────────────────────────────────
-        // TODO fix above
-        // NOTO: executed in parallel
+        // Process each transaction independently in parallel.
         let futures = transactions
             .into_iter()
             .map(|tx| self.handle_submit_transaction_impl(tx, &epoch_store));
@@ -1367,12 +1358,9 @@ impl ValidatorService {
         transaction: Transaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> Result<SubmitTransactionResult, tonic::Status> {
-        let Self {
-            state,
-            consensus_adapter,
-            metrics,
-            ..
-        } = self.clone();
+        let state = &self.state;
+        let consensus_adapter = &self.consensus_adapter;
+        let metrics = &self.metrics;
 
         let tx_digest = *transaction.digest();
 
@@ -1474,19 +1462,14 @@ impl ValidatorService {
         &self,
         request: tonic::Request<iota_types::messages_grpc::WaitForEffectsRequest>,
     ) -> WrappedServiceResponse<iota_types::messages_grpc::WaitForEffectsResponse> {
-        use iota_types::messages_grpc::{WaitForEffectResponse, WaitForEffectsResponse};
+        use iota_types::messages_grpc::WaitForEffectsResponse;
 
         let batch_request = request.into_inner();
 
-        // Handle ping requests (empty requests vec).
+        // Handle ping (empty request → empty response).
         if batch_request.is_ping() {
             return Ok((
-                tonic::Response::new(WaitForEffectsResponse {
-                    results: vec![WaitForEffectResponse::Executed {
-                        effects_digest: TransactionEffectsDigest::ZERO,
-                        details: None,
-                    }],
-                }),
+                tonic::Response::new(WaitForEffectsResponse { results: vec![] }),
                 Weight::one(),
             ));
         }

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1474,23 +1474,44 @@ impl ValidatorService {
         &self,
         request: tonic::Request<iota_types::messages_grpc::WaitForEffectsRequest>,
     ) -> WrappedServiceResponse<iota_types::messages_grpc::WaitForEffectsResponse> {
-        use iota_types::messages_grpc::WaitForEffectsResponse;
+        use iota_types::messages_grpc::{WaitForEffectResponse, WaitForEffectsResponse};
 
-        let wait_request = request.into_inner();
+        let batch_request = request.into_inner();
 
-        // Handle ping requests
-        if wait_request.transaction_digest.is_none() || wait_request.ping_type {
-            // For ping, return a dummy response with zeroed digest
+        // Handle ping requests (empty requests vec).
+        if batch_request.is_ping() {
             return Ok((
-                tonic::Response::new(WaitForEffectsResponse::Executed {
-                    effects_digest: TransactionEffectsDigest::ZERO,
-                    details: None,
+                tonic::Response::new(WaitForEffectsResponse {
+                    results: vec![WaitForEffectResponse::Executed {
+                        effects_digest: TransactionEffectsDigest::ZERO,
+                        details: None,
+                    }],
                 }),
                 Weight::one(),
             ));
         }
 
-        let tx_digest = wait_request.transaction_digest.unwrap();
+        let futures = batch_request
+            .requests
+            .into_iter()
+            .map(|req| self.handle_wait_for_effect_impl(req));
+        let results = join_all(futures).await;
+
+        Ok((
+            tonic::Response::new(WaitForEffectsResponse { results }),
+            Weight::one(),
+        ))
+    }
+
+    /// Handles a single wait-for-effects request. Waits for the transaction to
+    /// be executed or dropped, and returns the per-item response.
+    async fn handle_wait_for_effect_impl(
+        &self,
+        request: iota_types::messages_grpc::WaitForEffectRequest,
+    ) -> iota_types::messages_grpc::WaitForEffectResponse {
+        use iota_types::messages_grpc::WaitForEffectResponse;
+
+        let tx_digest = request.transaction_digest;
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
 
         // Wait for the transaction to be executed and get the effects digest.
@@ -1520,8 +1541,8 @@ impl ValidatorService {
         match result {
             Ok(Either::Left(effects_digests)) => {
                 if let Some(effects_digest) = effects_digests.into_iter().next() {
-                    // Fetch detailed execution data if requested
-                    let details = if wait_request.include_details {
+                    // Fetch detailed execution data if requested.
+                    let details = if request.include_details {
                         if let Some(effects) = cache.get_executed_effects(&tx_digest) {
                             let events = if effects.events_digest().is_some() {
                                 self.state
@@ -1547,40 +1568,28 @@ impl ValidatorService {
                         None
                     };
 
-                    Ok((
-                        tonic::Response::new(WaitForEffectsResponse::Executed {
-                            effects_digest,
-                            details,
-                        }),
-                        Weight::one(),
-                    ))
+                    WaitForEffectResponse::Executed {
+                        effects_digest,
+                        details,
+                    }
                 } else {
-                    // Empty effects list — should not happen, but treat as expired
-                    Ok((
-                        tonic::Response::new(WaitForEffectsResponse::Expired {
-                            epoch: epoch_store.epoch(),
-                        }),
-                        Weight::one(),
-                    ))
+                    // Empty effects list — should not happen, but treat as expired.
+                    WaitForEffectResponse::Expired {
+                        epoch: epoch_store.epoch(),
+                    }
                 }
             }
             Ok(Either::Right(dropped_error)) => {
-                // Transaction was dropped by white-flag conflict resolution
-                Ok((
-                    tonic::Response::new(WaitForEffectsResponse::Rejected {
-                        error: Some(dropped_error),
-                    }),
-                    Weight::one(),
-                ))
+                // Transaction was dropped by white-flag conflict resolution.
+                WaitForEffectResponse::Rejected {
+                    error: Some(dropped_error),
+                }
             }
             Err(_timeout) => {
-                // Timed out waiting for effects
-                Ok((
-                    tonic::Response::new(WaitForEffectsResponse::Expired {
-                        epoch: epoch_store.epoch(),
-                    }),
-                    Weight::one(),
-                ))
+                // Timed out waiting for effects.
+                WaitForEffectResponse::Expired {
+                    epoch: epoch_store.epoch(),
+                }
             }
         }
     }

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1307,14 +1307,22 @@ impl ValidatorService {
         }
 
         let transactions = request.transactions;
+        let tx_count = transactions.len();
 
-        // Per-tx validity and overload checks. These are validator-wide
-        // conditions so we short-circuit before spawning parallel futures.
-        for tx in &transactions {
-            tx.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+        // Pre-allocate a results vector aligned 1:1 with the input transactions.
+        let mut results: Vec<Option<SubmitTransactionResult>> = vec![None; tx_count];
 
-            // System overload check per transaction: check_execution_overload examines
-            // per-transaction input objects (shared objects, object queue depth).
+        // Per-tx validity and overload checks. Failures are stored per-tx
+        // rather than aborting the whole batch, so valid transactions can
+        // still proceed.
+        let mut valid_transactions: Vec<(usize, Transaction)> = Vec::with_capacity(tx_count);
+
+        for (idx, tx) in transactions.into_iter().enumerate() {
+            if let Err(e) = tx.validity_check(epoch_store.protocol_config(), epoch_store.epoch()) {
+                results[idx] = Some(SubmitTransactionResult::Rejected { error: e });
+                continue;
+            }
+
             if let Err(e) = state.check_system_overload(
                 &consensus_adapter,
                 tx.data(),
@@ -1323,25 +1331,38 @@ impl ValidatorService {
                 metrics
                     .num_rejected_tx_during_overload
                     .with_label_values(&[e.as_ref()])
-                    .inc_by(transactions.len() as u64);
-                return Err(e.into());
+                    .inc();
+                results[idx] = Some(SubmitTransactionResult::Rejected { error: e });
+                continue;
             }
+
+            valid_transactions.push((idx, tx));
         }
 
         // Latency timer starts after pre-flight checks, mirroring handle_transaction
         // where the timer also starts after the overload check.
         let _handle_tx_metrics_guard = metrics.handle_transaction_latency.start_timer();
 
-        // Process each transaction independently in parallel.
-        let futures = transactions
-            .into_iter()
-            .map(|tx| self.handle_submit_transaction_impl(tx, &epoch_store));
-        // Waits for all to finish, does not stop if any error out.
+        // Process each valid transaction independently in parallel.
+        let epoch_store_ref = &epoch_store;
+        let futures = valid_transactions.into_iter().map(|(idx, tx)| async move {
+            let result = self
+                .handle_submit_transaction_impl(tx, epoch_store_ref)
+                .await;
+            (idx, result)
+        });
         let futures_result = join_all(futures).await;
 
-        let results = futures_result
+        // Fill in results for transactions that passed pre-flight checks.
+        for (idx, result) in futures_result {
+            results[idx] = Some(
+                result.unwrap_or_else(|e| SubmitTransactionResult::Rejected { error: e.into() }),
+            );
+        }
+
+        let results = results
             .into_iter()
-            .map(|x| x.unwrap_or_else(|e| SubmitTransactionResult::Rejected { error: e.into() }))
+            .map(|r| r.expect("every transaction slot must be filled"))
             .collect::<Vec<_>>();
 
         Ok((

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -13,7 +13,7 @@ use std::{
 use anyhow::Result;
 use async_trait::async_trait;
 use fastcrypto::traits::KeyPair;
-use futures::future::Either;
+use futures::future::{Either, join_all};
 use iota_config::local_ip_utils::new_local_tcp_address_for_testing;
 use iota_metrics::spawn_monitored_task;
 use iota_network::{
@@ -1270,111 +1270,6 @@ impl ValidatorService {
         ))
     }
 
-    /// Validates a batch of transactions that arrive together as a soft bundle
-    /// (white-flag flow). Enforces the same invariants as
-    /// [`Self::soft_bundle_validity_check`] but operates on raw
-    /// [`Transaction`]s instead of [`CertifiedTransaction`]s.
-    ///
-    /// Checks (all-or-nothing — any failure rejects the entire bundle):
-    /// * Count ≤ `max_soft_bundle_size`
-    /// * Total serialized size ≤ half of
-    ///   `consensus_max_transactions_in_block_bytes`
-    /// * Every transaction accesses at least one shared object
-    /// * No transaction has already been executed
-    /// * All transactions share the same gas price
-    /// * No transaction has already been processed by consensus
-    async fn submit_transactions_bundle_validity_check(
-        &self,
-        transactions: &[Transaction],
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-        total_size_bytes: u64,
-    ) -> Result<(), tonic::Status> {
-        let protocol_config = epoch_store.protocol_config();
-
-        // Enforce these checks:
-        // - All certs must access at least one shared object.
-        // - All certs must not be already executed.
-        // - All certs must have the same gas price.
-        // - Number of certs must not exceed the max allowed.
-        // - Total size of all certs must not exceed the max allowed.
-        fp_ensure!(
-            transactions.len() as u64 <= protocol_config.max_soft_bundle_size(),
-            IotaError::UserInput {
-                error: UserInputError::TooManyTransactionsInSoftBundle {
-                    limit: protocol_config.max_soft_bundle_size(),
-                },
-            }
-            .into()
-        );
-
-        // We set the soft bundle max size to be half of the consensus max transactions
-        // in block size. We do this to account for serialization overheads and
-        // to ensure that the soft bundle is not too large when is attempted to be
-        // posted via consensus. Although half the block size is on the extreme
-        // side, it's should be good enough for now.
-        let soft_bundle_max_size_bytes =
-            protocol_config.consensus_max_transactions_in_block_bytes() / 2;
-        fp_ensure!(
-            total_size_bytes <= soft_bundle_max_size_bytes,
-            IotaError::UserInput {
-                error: UserInputError::SoftBundleTooLarge {
-                    size: total_size_bytes,
-                    limit: soft_bundle_max_size_bytes,
-                },
-            }
-            .into()
-        );
-
-        let mut gas_price: Option<u64> = None;
-        for transaction in transactions {
-            let tx_digest = *transaction.digest();
-
-            fp_ensure!(
-                transaction.contains_shared_object(),
-                IotaError::UserInput {
-                    error: UserInputError::NoSharedObject { digest: tx_digest },
-                }
-                .into()
-            );
-            fp_ensure!(
-                !self.state.try_is_tx_already_executed(&tx_digest)?,
-                IotaError::UserInput {
-                    error: UserInputError::AlreadyExecuted { digest: tx_digest },
-                }
-                .into()
-            );
-
-            if let Some(gas) = gas_price {
-                fp_ensure!(
-                    gas == transaction.gas_price(),
-                    IotaError::UserInput {
-                        error: UserInputError::GasPriceMismatch {
-                            digest: tx_digest,
-                            expected: gas,
-                            actual: transaction.gas_price(),
-                        },
-                    }
-                    .into()
-                );
-            } else {
-                gas_price = Some(transaction.gas_price());
-            }
-        }
-
-        // Reject the entire bundle if any transaction has already been sequenced by
-        // consensus. This is a best-effort check — a race is possible but
-        // harmless (consensus deduplicates).
-        fp_ensure!(
-            !epoch_store.is_any_user_tx_consensus_message_processed(transactions.iter())?,
-            IotaError::UserInput {
-                error: UserInputError::CertificateAlreadyProcessed,
-            }
-            .into()
-        );
-
-        Ok(())
-    }
-
     async fn handle_submit_transactions_impl(
         &self,
         request: tonic::Request<SubmitTransactionsRequest>,
@@ -1409,22 +1304,20 @@ impl ValidatorService {
             // TODO: handle ping response better. Do we even need ping requests?
             return Ok((
                 tonic::Response::new(SubmitTransactionsResponse {
-                    result: SubmitTransactionResult::Submitted,
+                    results: vec![SubmitTransactionResult::Submitted],
                 }),
                 Weight::zero(),
             ));
         }
 
         let transactions = request.transactions;
-        // is_ping() = len() == 0 (handled above); is_soft_bundle() = len() > 1; else =
-        // len() == 1.
-        let is_soft_bundle = transactions.len() > 1;
 
         // Per-tx validity checks. For soft bundles this also accumulates total
         // serialized size for the bundle size limit.
-        let mut total_size_bytes: u64 = 0;
+        // TODO: check if size check needed?
+        let mut _total_size_bytes: u64 = 0;
         for tx in &transactions {
-            total_size_bytes +=
+            _total_size_bytes +=
                 tx.validity_check(epoch_store.protocol_config(), epoch_store.epoch())? as u64;
 
             // System overload check per transaction: check_execution_overload examines
@@ -1446,196 +1339,135 @@ impl ValidatorService {
         // where the timer also starts after the overload check.
         let _handle_tx_metrics_guard = metrics.handle_transaction_latency.start_timer();
 
-        if is_soft_bundle {
-            // ── Soft-bundle path (all-or-nothing) ──────────────────────────────
+        // ── Single-transaction path ─────────────────────────────────────────
+        // TODO fix above
+        // NOTO: executed in parallel
+        let futures = transactions
+            .into_iter()
+            .map(|tx| self.handle_submit_transaction_impl(tx, &epoch_store));
+        // Waits for all to finish, does not stop if any error out.
+        let futures_result = join_all(futures).await;
 
-            // Bundle-level validity checks (shared-object, size, gas price, already
-            // processed).
-            self.submit_transactions_bundle_validity_check(
-                &transactions,
-                &epoch_store,
-                total_size_bytes,
-            )
-            .await?;
+        let results = futures_result
+            .into_iter()
+            .map(|x| x.unwrap_or_else(|e| SubmitTransactionResult::Rejected { error: e.into() }))
+            .collect::<Vec<_>>();
 
-            // Verify each transaction's user signature individually.
-            // TODO: switch to batch verification once a parallel helper exists.
-            let tx_verif_guard = metrics.tx_verification_latency.start_timer();
-            let mut verified_transactions = Vec::with_capacity(transactions.len());
-            for tx in &transactions {
-                match epoch_store.verify_transaction(tx.clone()) {
-                    Ok(verified) => verified_transactions.push(verified),
-                    Err(e) => {
-                        metrics.signature_errors.inc();
-                        return Err(e.into());
-                    }
-                }
-            }
-            drop(tx_verif_guard);
+        Ok((
+            tonic::Response::new(SubmitTransactionsResponse { results }),
+            Weight::one(),
+        ))
+    }
 
-            // Early bail-out during epoch boundary, before running expensive deny checks.
-            if !epoch_store
-                .get_reconfig_state_read_lock_guard()
-                .should_accept_user_certs()
-            {
-                metrics
-                    .num_rejected_tx_in_epoch_boundary
-                    .inc_by(transactions.len() as u64);
-                return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
-            }
+    /// Handles submission of a single transaction. Validates, checks for prior
+    /// execution, verifies signature, runs deny checks, and submits to
+    /// consensus. Returns the per-transaction result.
+    async fn handle_submit_transaction_impl(
+        &self,
+        transaction: Transaction,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> Result<SubmitTransactionResult, tonic::Status> {
+        let Self {
+            state,
+            consensus_adapter,
+            metrics,
+            ..
+        } = self.clone();
 
-            // Content validation: deny checks + owned object version validation.
-            for verified_tx in &verified_transactions {
-                let owned_objects = state
-                    .handle_transaction_validation_checks(verified_tx, &epoch_store)
-                    .await
-                    .map_err(tonic::Status::from)?;
-                state
-                    .get_cache_writer()
-                    .validate_owned_object_versions(&owned_objects)
-                    .map_err(tonic::Status::from)?;
-            }
+        let tx_digest = *transaction.digest();
 
-            // Acquire the reconfiguration lock once for the whole bundle so that
-            // all transactions are either accepted or rejected together.
-            let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
-            if !reconfiguration_lock.should_accept_user_certs() {
-                // NOTE: `handle_transaction` increments the same counter on the signing path.
-                // But since `handle_transaction` and `submit_transaction_impl` are mutually
-                // exclusive based on the `enable_white_flag_flow` protocol parameter,
-                // it is fine to use `num_rejected_tx_in_epoch_boundary` here.
-                metrics
-                    .num_rejected_tx_in_epoch_boundary
-                    .inc_by(transactions.len() as u64);
-                return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
-            }
-
-            // Build consensus messages and submit as an atomic batch.
-            let consensus_txs: Vec<_> = transactions
-                .into_iter()
-                .map(ConsensusTransaction::new_user_transaction)
-                .collect();
-
-            self.consensus_adapter
-                .submit_batch(&consensus_txs, Some(&reconfiguration_lock), &epoch_store)
-                .map_err(tonic::Status::from)?;
-
-            Ok((
-                tonic::Response::new(SubmitTransactionsResponse {
-                    result: SubmitTransactionResult::Submitted,
-                }),
-                Weight::one(),
-            ))
-        } else {
-            // ── Single-transaction path ─────────────────────────────────────────
-            let transaction = transactions
-                .into_iter()
-                .next()
-                .expect("single transaction expected: ping and soft-bundle cases already handled");
-            let tx_digest = *transaction.digest();
-
-            // Helper to build an Executed response from transaction effects.
-            let build_executed_response =
-                |effects: TransactionEffects| -> Result<_, tonic::Status> {
-                    let effects_digest = effects.digest();
-                    let events = if effects.events_digest().is_some() {
-                        state
-                            .get_transaction_events(effects.transaction_digest())
-                            .ok()
-                    } else {
-                        None
-                    };
-                    let input_objects = state.get_transaction_input_objects(&effects).ok();
-                    let output_objects = state.get_transaction_output_objects(&effects).ok();
-                    let details = Box::new(ExecutedData {
-                        effects,
-                        events,
-                        input_objects: input_objects.unwrap_or_default(),
-                        output_objects: output_objects.unwrap_or_default(),
-                    });
-                    Ok((
-                        tonic::Response::new(SubmitTransactionsResponse {
-                            result: SubmitTransactionResult::Executed {
-                                effects_digest,
-                                details,
-                            },
-                        }),
-                        Weight::one(),
-                    ))
+        // Helper to build an Executed result from transaction effects.
+        let build_executed_result =
+            |effects: TransactionEffects| -> Result<SubmitTransactionResult, tonic::Status> {
+                let effects_digest = effects.digest();
+                let events = if effects.events_digest().is_some() {
+                    state
+                        .get_transaction_events(effects.transaction_digest())
+                        .ok()
+                } else {
+                    None
                 };
+                let input_objects = state.get_transaction_input_objects(&effects).ok();
+                let output_objects = state.get_transaction_output_objects(&effects).ok();
+                let details = Box::new(ExecutedData {
+                    effects,
+                    events,
+                    input_objects: input_objects.unwrap_or_default(),
+                    output_objects: output_objects.unwrap_or_default(),
+                });
+                Ok(SubmitTransactionResult::Executed {
+                    effects_digest,
+                    details,
+                })
+            };
 
-            // Check if already executed.
+        // Check if already executed.
+        if let Some(effects) = state
+            .get_transaction_cache_reader()
+            .try_get_executed_effects(&tx_digest)
+            .map_err(tonic::Status::from)?
+        {
+            return build_executed_result(effects);
+        }
+
+        // Verify user signature.
+        let tx_verif_guard = metrics.tx_verification_latency.start_timer();
+        let verified_tx = match epoch_store.verify_transaction(transaction.clone()) {
+            Ok(verified) => verified,
+            Err(e) => {
+                metrics.signature_errors.inc();
+                return Err(e.into());
+            }
+        };
+        drop(tx_verif_guard);
+
+        // Early bail-out during epoch boundary, before running expensive deny checks.
+        if !epoch_store
+            .get_reconfig_state_read_lock_guard()
+            .should_accept_user_certs()
+        {
+            metrics.num_rejected_tx_in_epoch_boundary.inc();
+            return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
+        }
+
+        // Content validation: deny checks + owned object version validation.
+        let owned_objects = state
+            .handle_transaction_validation_checks(&verified_tx, epoch_store)
+            .await
+            .map_err(tonic::Status::from)?;
+        if let Err(e) = state
+            .get_cache_writer()
+            .validate_owned_object_versions(&owned_objects)
+        {
+            // Check if the transaction was executed while being validated, and that's why
+            // the owned object version validation failed. This is an edge
+            // case so checking executed effects twice is acceptable.
             if let Some(effects) = state
                 .get_transaction_cache_reader()
                 .try_get_executed_effects(&tx_digest)?
             {
-                return build_executed_response(effects);
+                return build_executed_result(effects);
             }
-
-            // Verify user signature.
-            let tx_verif_guard = metrics.tx_verification_latency.start_timer();
-            let verified_tx = match epoch_store.verify_transaction(transaction.clone()) {
-                Ok(verified) => verified,
-                Err(e) => {
-                    metrics.signature_errors.inc();
-                    return Err(e.into());
-                }
-            };
-            drop(tx_verif_guard);
-
-            // Early bail-out during epoch boundary, before running expensive deny checks.
-            if !epoch_store
-                .get_reconfig_state_read_lock_guard()
-                .should_accept_user_certs()
-            {
-                metrics.num_rejected_tx_in_epoch_boundary.inc();
-                return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
-            }
-
-            // Content validation: deny checks + owned object version validation.
-            let owned_objects = state
-                .handle_transaction_validation_checks(&verified_tx, &epoch_store)
-                .await
-                .map_err(tonic::Status::from)?;
-            if let Err(e) = state
-                .get_cache_writer()
-                .validate_owned_object_versions(&owned_objects)
-            {
-                // Check if the transaction was executed while being validated, and that's why
-                // the owned object version validation failed. This is an edge
-                // case so checking executed effects twice is acceptable.
-                if let Some(effects) = state
-                    .get_transaction_cache_reader()
-                    .try_get_executed_effects(&tx_digest)?
-                {
-                    return build_executed_response(effects);
-                }
-                return Err(tonic::Status::from(e));
-            }
-
-            // Reconfig check.
-            let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
-            if !reconfiguration_lock.should_accept_user_certs() {
-                metrics.num_rejected_tx_in_epoch_boundary.inc();
-                return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
-            }
-
-            // Submit to consensus.
-            consensus_adapter
-                .submit(
-                    ConsensusTransaction::new_user_transaction(transaction),
-                    Some(&reconfiguration_lock),
-                    &epoch_store,
-                )
-                .map_err(tonic::Status::from)?;
-
-            Ok((
-                tonic::Response::new(SubmitTransactionsResponse {
-                    result: SubmitTransactionResult::Submitted,
-                }),
-                Weight::one(),
-            ))
+            return Err(tonic::Status::from(e));
         }
+
+        // Reconfig check.
+        let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
+        if !reconfiguration_lock.should_accept_user_certs() {
+            metrics.num_rejected_tx_in_epoch_boundary.inc();
+            return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
+        }
+
+        // Submit to consensus.
+        consensus_adapter
+            .submit(
+                ConsensusTransaction::new_user_transaction(transaction),
+                Some(&reconfiguration_lock),
+                epoch_store,
+            )
+            .map_err(tonic::Status::from)?;
+
+        Ok(SubmitTransactionResult::Submitted)
     }
 
     async fn handle_wait_for_effects_impl(

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -34,8 +34,7 @@ use iota_types::{
         HandleCapabilityNotificationResponseV1, HandleCertificateRequestV1,
         HandleCertificateResponseV1, HandleSoftBundleCertificatesRequestV1,
         HandleSoftBundleCertificatesResponseV1, HandleTransactionResponse, ObjectInfoRequest,
-        ObjectInfoResponse, SubmitCertificateResponse, SubmitTransactionResult,
-        SubmitTransactionsRequest, SubmitTransactionsResponse, SystemStateRequest,
+        ObjectInfoResponse, SubmitCertificateResponse, SubmitTransactionResult, SystemStateRequest,
         TransactionInfoRequest, TransactionInfoResponse,
     },
     multiaddr::Multiaddr,
@@ -1271,8 +1270,12 @@ impl ValidatorService {
 
     async fn handle_submit_transactions_impl(
         &self,
-        request: tonic::Request<SubmitTransactionsRequest>,
-    ) -> WrappedServiceResponse<SubmitTransactionsResponse> {
+        request: tonic::Request<iota_types::messages_grpc::RawSubmitTransactionsRequest>,
+    ) -> WrappedServiceResponse<iota_types::messages_grpc::RawSubmitTransactionsResponse> {
+        use iota_types::messages_grpc::{
+            RawSubmitTransactionResult, RawSubmitTransactionsResponse,
+        };
+
         let Self {
             state,
             consensus_adapter,
@@ -1296,28 +1299,39 @@ impl ValidatorService {
             .into()
         );
 
-        let request = request.into_inner();
+        let raw_request = request.into_inner();
 
         // Handle ping (empty request → empty response).
-        if request.is_ping() {
+        if raw_request.transactions.is_empty() {
             return Ok((
-                tonic::Response::new(SubmitTransactionsResponse { results: vec![] }),
+                tonic::Response::new(RawSubmitTransactionsResponse { results: vec![] }),
                 Weight::zero(),
             ));
         }
 
-        let transactions = request.transactions;
-        let tx_count = transactions.len();
+        let tx_count = raw_request.transactions.len();
 
         // Pre-allocate a results vector aligned 1:1 with the input transactions.
         let mut results: Vec<Option<SubmitTransactionResult>> = vec![None; tx_count];
 
-        // Per-tx validity and overload checks. Failures are stored per-tx
-        // rather than aborting the whole batch, so valid transactions can
-        // still proceed.
+        // Deserialize, validate, and check overload in a single pass.
+        // Per-tx failures (BCS, validity, overload) are stored per-tx rather
+        // than aborting the whole batch, so valid transactions can still proceed.
         let mut valid_transactions: Vec<(usize, Transaction)> = Vec::with_capacity(tx_count);
 
-        for (idx, tx) in transactions.into_iter().enumerate() {
+        for (idx, tx_bytes) in raw_request.transactions.iter().enumerate() {
+            let tx: Transaction = match bcs::from_bytes(tx_bytes) {
+                Ok(tx) => tx,
+                Err(e) => {
+                    results[idx] = Some(SubmitTransactionResult::Rejected {
+                        error: IotaError::TransactionSerialization {
+                            error: e.to_string(),
+                        },
+                    });
+                    continue;
+                }
+            };
+
             if let Err(e) = tx.validity_check(epoch_store.protocol_config(), epoch_store.epoch()) {
                 results[idx] = Some(SubmitTransactionResult::Rejected { error: e });
                 continue;
@@ -1360,13 +1374,16 @@ impl ValidatorService {
             );
         }
 
-        let results = results
+        // Convert each native result to its Raw protobuf representation.
+        let results: Vec<RawSubmitTransactionResult> = results
             .into_iter()
             .map(|r| r.expect("every transaction slot must be filled"))
-            .collect::<Vec<_>>();
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<_>, IotaError>>()
+            .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
         Ok((
-            tonic::Response::new(SubmitTransactionsResponse { results }),
+            tonic::Response::new(RawSubmitTransactionsResponse { results }),
             Weight::one(),
         ))
     }
@@ -1481,28 +1498,51 @@ impl ValidatorService {
 
     async fn handle_wait_for_effects_impl(
         &self,
-        request: tonic::Request<iota_types::messages_grpc::WaitForEffectsRequest>,
-    ) -> WrappedServiceResponse<iota_types::messages_grpc::WaitForEffectsResponse> {
-        use iota_types::messages_grpc::WaitForEffectsResponse;
+        request: tonic::Request<iota_types::messages_grpc::RawWaitForEffectsRequest>,
+    ) -> WrappedServiceResponse<iota_types::messages_grpc::RawWaitForEffectsResponse> {
+        use iota_types::messages_grpc::{
+            RawWaitForEffectResponse, RawWaitForEffectsResponse, WaitForEffectRequest,
+        };
 
-        let batch_request = request.into_inner();
+        let raw_request = request.into_inner();
 
         // Handle ping (empty request → empty response).
-        if batch_request.is_ping() {
+        if raw_request.requests.is_empty() {
             return Ok((
-                tonic::Response::new(WaitForEffectsResponse { results: vec![] }),
+                tonic::Response::new(RawWaitForEffectsResponse { results: vec![] }),
                 Weight::one(),
             ));
         }
 
-        let futures = batch_request
-            .requests
+        // Deserialize each item's fields lazily and construct native requests.
+        let mut native_requests = Vec::with_capacity(raw_request.requests.len());
+        for raw_item in &raw_request.requests {
+            let transaction_digest =
+                bcs::from_bytes(&raw_item.transaction_digest).map_err(|e| {
+                    tonic::Status::invalid_argument(format!(
+                        "Failed to deserialize transaction_digest: {e}"
+                    ))
+                })?;
+            native_requests.push(WaitForEffectRequest {
+                transaction_digest,
+                include_details: raw_item.include_details,
+            });
+        }
+
+        let futures = native_requests
             .into_iter()
             .map(|req| self.handle_wait_for_effect_impl(req));
-        let results = join_all(futures).await;
+        let native_results = join_all(futures).await;
+
+        // Convert each native result to its Raw protobuf representation.
+        let results: Vec<RawWaitForEffectResponse> = native_results
+            .into_iter()
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<_>, IotaError>>()
+            .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
         Ok((
-            tonic::Response::new(WaitForEffectsResponse { results }),
+            tonic::Response::new(RawWaitForEffectsResponse { results }),
             Weight::one(),
         ))
     }
@@ -1600,8 +1640,8 @@ impl ValidatorService {
 
     async fn handle_validator_health_impl(
         &self,
-        _request: tonic::Request<iota_types::messages_grpc::ValidatorHealthRequest>,
-    ) -> WrappedServiceResponse<iota_types::messages_grpc::ValidatorHealthResponse> {
+        _request: tonic::Request<iota_types::messages_grpc::RawValidatorHealthRequest>,
+    ) -> WrappedServiceResponse<iota_types::messages_grpc::RawValidatorHealthResponse> {
         use iota_types::messages_grpc::ValidatorHealthResponse;
 
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
@@ -1613,20 +1653,20 @@ impl ValidatorService {
             .map(|(seq, _)| seq)
             .unwrap_or(0);
 
-        Ok((
-            tonic::Response::new(ValidatorHealthResponse {
-                num_inflight_execution_transactions: self
-                    .state
-                    .transaction_manager()
-                    .inflight_queue_len()
-                    as u64,
-                num_inflight_consensus_transactions: self
-                    .consensus_adapter
-                    .num_inflight_transactions(),
-                last_locally_built_checkpoint,
-            }),
-            Weight::zero(),
-        ))
+        let typed_response = ValidatorHealthResponse {
+            num_inflight_execution_transactions: self
+                .state
+                .transaction_manager()
+                .inflight_queue_len() as u64,
+            num_inflight_consensus_transactions: self.consensus_adapter.num_inflight_transactions(),
+            last_locally_built_checkpoint,
+        };
+
+        let raw_response = typed_response
+            .try_into()
+            .map_err(|e: IotaError| tonic::Status::internal(e.to_string()))?;
+
+        Ok((tonic::Response::new(raw_response), Weight::zero()))
     }
 }
 
@@ -1776,8 +1816,11 @@ impl Validator for ValidatorService {
 
     async fn handle_submit_transactions(
         &self,
-        request: tonic::Request<SubmitTransactionsRequest>,
-    ) -> Result<tonic::Response<SubmitTransactionsResponse>, tonic::Status> {
+        request: tonic::Request<iota_types::messages_grpc::RawSubmitTransactionsRequest>,
+    ) -> Result<
+        tonic::Response<iota_types::messages_grpc::RawSubmitTransactionsResponse>,
+        tonic::Status,
+    > {
         let validator_service = self.clone();
         spawn_monitored_task!(async move {
             handle_with_decoration!(validator_service, handle_submit_transactions_impl, request)
@@ -1788,8 +1831,8 @@ impl Validator for ValidatorService {
 
     async fn handle_wait_for_effects(
         &self,
-        request: tonic::Request<iota_types::messages_grpc::WaitForEffectsRequest>,
-    ) -> Result<tonic::Response<iota_types::messages_grpc::WaitForEffectsResponse>, tonic::Status>
+        request: tonic::Request<iota_types::messages_grpc::RawWaitForEffectsRequest>,
+    ) -> Result<tonic::Response<iota_types::messages_grpc::RawWaitForEffectsResponse>, tonic::Status>
     {
         let validator_service = self.clone();
         spawn_monitored_task!(async move {
@@ -1801,8 +1844,8 @@ impl Validator for ValidatorService {
 
     async fn handle_validator_health(
         &self,
-        request: tonic::Request<iota_types::messages_grpc::ValidatorHealthRequest>,
-    ) -> Result<tonic::Response<iota_types::messages_grpc::ValidatorHealthResponse>, tonic::Status>
+        request: tonic::Request<iota_types::messages_grpc::RawValidatorHealthRequest>,
+    ) -> Result<tonic::Response<iota_types::messages_grpc::RawValidatorHealthResponse>, tonic::Status>
     {
         handle_with_decoration!(self, handle_validator_health_impl, request)
     }

--- a/crates/iota-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/iota-core/src/transaction_driver/effects_certifier.rs
@@ -17,7 +17,8 @@ use iota_types::{
     effects::TransactionEffectsAPI as _,
     error::{IotaError, IotaResult},
     messages_grpc::{
-        ExecutedData, SubmitTransactionResult, WaitForEffectsRequest, WaitForEffectsResponse,
+        ExecutedData, SubmitTransactionResult, WaitForEffectRequest, WaitForEffectResponse,
+        WaitForEffectsRequest, WaitForEffectsResponse,
     },
     transaction_driver_types::{EffectsFinalityInfo, FinalizedEffects},
 };
@@ -232,11 +233,16 @@ impl EffectsCertifier {
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
-        let ping_type = tx_digest.is_none();
-        let request = WaitForEffectsRequest {
-            transaction_digest: tx_digest,
-            include_details: true,
-            ping_type,
+        let request = if let Some(digest) = tx_digest {
+            WaitForEffectsRequest {
+                requests: vec![WaitForEffectRequest {
+                    transaction_digest: digest,
+                    include_details: true,
+                }],
+            }
+        } else {
+            // Ping: empty requests vec.
+            WaitForEffectsRequest { requests: vec![] }
         };
 
         match timeout(
@@ -245,11 +251,11 @@ impl EffectsCertifier {
         )
         .await
         {
-            Ok(Ok(response)) => match response {
-                WaitForEffectsResponse::Executed {
+            Ok(Ok(response)) => match response.results.into_iter().next() {
+                Some(WaitForEffectResponse::Executed {
                     effects_digest,
                     details,
-                } => {
+                }) => {
                     if let Some(details) = details {
                         tracing::Span::current()
                             .record("ret_effects_digest", format!("{:?}", effects_digest));
@@ -261,16 +267,19 @@ impl EffectsCertifier {
                         ))
                     }
                 }
-                WaitForEffectsResponse::Rejected { error } => match error {
+                Some(WaitForEffectResponse::Rejected { error }) => match error {
                     Some(e) => Err(TransactionRequestError::RejectedAtValidator(e)),
                     // Even though this response is not an error, returning an error which is
                     // required by the function signature. This will get ignored
                     // by the caller as a retriable error.
                     None => Err(TransactionRequestError::RejectedByConsensus),
                 },
-                WaitForEffectsResponse::Expired { epoch } => {
+                Some(WaitForEffectResponse::Expired { epoch }) => {
                     Err(TransactionRequestError::StatusExpired(epoch))
                 }
+                None => Err(TransactionRequestError::ValidatorInternal(
+                    "Empty response from validator".to_string(),
+                )),
             },
             Ok(Err(e)) => Err(TransactionRequestError::Aborted(e)),
             Err(_) => Err(TransactionRequestError::TimedOutGettingFullEffectsAtValidator),
@@ -392,10 +401,15 @@ impl EffectsCertifier {
             let name = *name;
             let display_name = authority_aggregator.get_display_name(&name);
 
-            let request = WaitForEffectsRequest {
-                transaction_digest: tx_digest,
-                include_details: false,
-                ping_type,
+            let request = if let Some(digest) = tx_digest {
+                WaitForEffectsRequest {
+                    requests: vec![WaitForEffectRequest {
+                        transaction_digest: digest,
+                        include_details: false,
+                    }],
+                }
+            } else {
+                WaitForEffectsRequest { requests: vec![] }
             };
 
             let future = async move {
@@ -448,11 +462,13 @@ impl EffectsCertifier {
         let mut reason_not_found_aggregator = StatusAggregator::<()>::new(committee.clone());
         // Every validator returns at most one WaitForEffectsResponse.
         while let Some((name, response)) = futures.next().await {
-            match response {
-                Ok(WaitForEffectsResponse::Executed {
+            // Extract the first per-item result from the batch response.
+            let single_result = response.map(|r| r.results.into_iter().next());
+            match single_result {
+                Ok(Some(WaitForEffectResponse::Executed {
                     effects_digest,
                     details: _,
-                }) => {
+                })) => {
                     // Notify that this validator has successfully executed the transaction.
                     let _ = acked_validators_tx.try_send(name);
 
@@ -487,7 +503,7 @@ impl EffectsCertifier {
                         return Ok(effects_digest);
                     }
                 }
-                Ok(WaitForEffectsResponse::Rejected { error }) => {
+                Ok(Some(WaitForEffectResponse::Rejected { error })) => {
                     if let Some(e) = error {
                         tracing::trace!(name = ?name.concise(), "Rejected at validator: {:?}", e);
                         let error = TransactionRequestError::RejectedAtValidator(e);
@@ -505,7 +521,7 @@ impl EffectsCertifier {
                         .with_label_values(&[ping_label.as_str()])
                         .inc();
                 }
-                Ok(WaitForEffectsResponse::Expired { epoch }) => {
+                Ok(Some(WaitForEffectResponse::Expired { epoch })) => {
                     let error = TransactionRequestError::StatusExpired(epoch);
                     // Expired status is submission retriable.
                     retriable_errors_aggregator.insert(name, error);
@@ -513,6 +529,13 @@ impl EffectsCertifier {
                         .expiration_acks
                         .with_label_values(&[ping_label.as_str()])
                         .inc();
+                }
+                Ok(None) => {
+                    // Empty response from validator — treat as retriable error.
+                    let error = TransactionRequestError::ValidatorInternal(
+                        "Empty response from validator".to_string(),
+                    );
+                    retriable_errors_aggregator.insert(name, error);
                 }
                 Err(error) => {
                     let error = TransactionRequestError::Aborted(error);
@@ -650,7 +673,7 @@ impl EffectsCertifier {
         let effects_start = Instant::now();
         let backoff =
             ExponentialBackoff::new(Duration::from_millis(100), MAX_WAIT_FOR_EFFECTS_RETRY_DELAY);
-        let is_ping = request.ping_type;
+        let is_ping = request.is_ping();
         // This loop should only retry errors that are retriable without new submission.
         for (attempt, delay) in backoff.enumerate() {
             let result = client

--- a/crates/iota-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/iota-core/src/transaction_driver/transaction_submitter.rs
@@ -225,7 +225,13 @@ impl TransactionSubmitter {
             TransactionRequestError::RejectedAtValidator(error)
         })?;
 
-        let result = resp.result;
+        let result = resp
+            .results
+            .into_iter()
+            .next()
+            .unwrap_or(SubmitTransactionResult::Rejected {
+                error: iota_types::error::IotaError::Unknown("No result returned".to_string()),
+            });
 
         // Since only one transaction is submitted, it is ok to return error when the
         // submission is rejected.

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -390,16 +390,20 @@ async fn test_submit_transaction_invalid_signature() {
         ))
         .await;
 
-    // Signature errors now return a hard Err, consistent
-    // with the certificate flow where validity failures are fatal to the caller.
-    assert!(result.is_err(), "Should return Err for invalid signature");
-    let err = result.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::Internal);
-    assert!(
-        err.message().to_lowercase().contains("signature"),
-        "Error message should mention signature, got: {}",
-        err.message()
-    );
+    // Signature errors are reported per-transaction as Rejected results.
+    assert!(result.is_ok(), "Batch response should be Ok");
+    let response = result.unwrap().0.into_inner();
+    assert_eq!(response.results.len(), 1);
+    match &response.results[0] {
+        SubmitTransactionResult::Rejected { error } => {
+            let msg = format!("{:?}", error).to_lowercase();
+            assert!(
+                msg.contains("signature"),
+                "Error should mention signature, got: {msg}",
+            );
+        }
+        other => panic!("Expected Rejected result, got {:?}", other),
+    }
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -653,15 +657,10 @@ async fn test_submit_transaction_already_executed() {
 
     assert!(result.is_ok(), "Expected Ok for already-executed tx");
     let response = result.unwrap().0.into_inner();
-    match response
-        .results
-        .into_iter()
-        .next()
-        .unwrap_or(SubmitTransactionResult::Rejected {
-            error: iota_types::error::IotaError::Unknown("No result returned".to_string()),
-        }) {
+    assert_eq!(response.results.len(), 1, "Expected exactly one result");
+    match &response.results[0] {
         SubmitTransactionResult::Executed { effects_digest, .. } => {
-            assert_eq!(effects_digest, *effects.digest());
+            assert_eq!(effects_digest, effects.digest());
         }
         other => panic!("Expected Executed result, got {:?}", other),
     }
@@ -726,9 +725,16 @@ async fn test_submit_transaction_gas_object_validation() {
         ))
         .await;
 
-    // TODO: check for an exact error kind once we have better error handling in
-    // place for the white-flag flow. For now, just check that it's an error.
-    assert!(result.is_err(), "Expected Err for non-existent gas object");
+    // Non-existent gas object errors are reported per-transaction as Rejected
+    // results. TODO: check for a specific error kind once we have better error
+    // handling in place for the white-flag flow.
+    assert!(result.is_ok(), "Batch response should be Ok");
+    let response = result.unwrap().0.into_inner();
+    assert_eq!(response.results.len(), 1);
+    match &response.results[0] {
+        SubmitTransactionResult::Rejected { .. } => {}
+        other => panic!("Expected Rejected result, got {:?}", other),
+    }
 }
 
 /// Soft-bundle happy path: two `use_clock` (shared-object) transactions
@@ -783,17 +789,18 @@ async fn test_submit_soft_bundle_transactions() {
         .handle_submit_transactions_impl(make_tonic_request_for_testing(request))
         .await;
 
-    assert!(result.is_ok(), "Soft bundle submission should succeed");
+    assert!(result.is_ok(), "Batch submission should succeed");
     let response = result.unwrap().0.into_inner();
-    match response
-        .results
-        .into_iter()
-        .next()
-        .unwrap_or(SubmitTransactionResult::Rejected {
-            error: iota_types::error::IotaError::Unknown("No result returned".to_string()),
-        }) {
-        SubmitTransactionResult::Submitted => {}
-        other => panic!("Expected Submitted, got {:?}", other),
+    assert_eq!(
+        response.results.len(),
+        2,
+        "Expected one result per transaction"
+    );
+    for (i, result) in response.results.iter().enumerate() {
+        match result {
+            SubmitTransactionResult::Submitted => {}
+            other => panic!("Expected Submitted for tx {i}, got {:?}", other),
+        }
     }
 }
 
@@ -875,12 +882,21 @@ async fn test_submit_soft_bundle_transactions_gas_price_mismatch() {
         .handle_submit_transactions_impl(make_tonic_request_for_testing(request))
         .await;
 
-    // TODO: check for specific error once we have better error handling in place
-    // for the white-flag flow. For now, just check that it's an error.
-    assert!(
-        result.is_err(),
-        "Bundle with mismatched gas prices should be rejected"
+    // With soft-bundle checks removed, each transaction is processed independently.
+    // Different gas prices no longer cause a batch-level rejection.
+    assert!(result.is_ok(), "Batch response should be Ok");
+    let response = result.unwrap().0.into_inner();
+    assert_eq!(
+        response.results.len(),
+        2,
+        "Expected one result per transaction"
     );
+    for (i, result) in response.results.iter().enumerate() {
+        match result {
+            SubmitTransactionResult::Submitted => {}
+            other => panic!("Expected Submitted for tx {i}, got {:?}", other),
+        }
+    }
 }
 
 /// A transaction whose serialized size exceeds `max_tx_size_bytes` (128 KiB)

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -470,7 +470,7 @@ async fn test_submit_transaction_success() {
     // Should succeed with Submitted result
     assert!(result.is_ok(), "Transaction submission should succeed");
     let response = result.unwrap().0.into_inner();
-    match &response.result {
+    match &response.results[0] {
         SubmitTransactionResult::Submitted => {
             // Success - transaction was submitted to consensus
         }
@@ -653,7 +653,13 @@ async fn test_submit_transaction_already_executed() {
 
     assert!(result.is_ok(), "Expected Ok for already-executed tx");
     let response = result.unwrap().0.into_inner();
-    match response.result {
+    match response
+        .results
+        .into_iter()
+        .next()
+        .unwrap_or(SubmitTransactionResult::Rejected {
+            error: iota_types::error::IotaError::Unknown("No result returned".to_string()),
+        }) {
         SubmitTransactionResult::Executed { effects_digest, .. } => {
             assert_eq!(effects_digest, *effects.digest());
         }
@@ -779,7 +785,13 @@ async fn test_submit_soft_bundle_transactions() {
 
     assert!(result.is_ok(), "Soft bundle submission should succeed");
     let response = result.unwrap().0.into_inner();
-    match response.result {
+    match response
+        .results
+        .into_iter()
+        .next()
+        .unwrap_or(SubmitTransactionResult::Rejected {
+            error: iota_types::error::IotaError::Unknown("No result returned".to_string()),
+        }) {
         SubmitTransactionResult::Submitted => {}
         other => panic!("Expected Submitted, got {:?}", other),
     }

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -575,15 +575,20 @@ async fn test_submit_transaction_invalid_transaction() {
     );
     let tx = to_sender_signed_transaction(tx_data, &sender_key);
 
-    let result = validator_service
+    let (response, _weight) = validator_service
         .handle_submit_transactions_impl(make_tonic_request_for_testing(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
-        .await;
+        .await
+        .expect("batch call should succeed even when individual txs fail");
 
-    // TODO: check for specific error once we have better error handling in place
-    // for the white-flag flow. For now, just check that it's an error.
-    assert!(result.is_err(), "Expected Err for invalid transaction");
+    let results = response.into_inner().results;
+    assert_eq!(results.len(), 1);
+    assert!(
+        matches!(&results[0], SubmitTransactionResult::Rejected { .. }),
+        "Expected Rejected for invalid transaction, got {:?}",
+        results[0]
+    );
 }
 
 /// Re-submitting an already-executed transaction returns
@@ -958,11 +963,18 @@ async fn test_submit_oversized_transaction() {
     );
     let tx = to_sender_signed_transaction(tx_data, &sender_key);
 
-    let result = validator_service
+    let (response, _weight) = validator_service
         .handle_submit_transactions_impl(make_tonic_request_for_testing(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
-        .await;
+        .await
+        .expect("batch call should succeed even when individual txs fail");
 
-    assert!(result.is_err(), "Expected Err for oversized transaction");
+    let results = response.into_inner().results;
+    assert_eq!(results.len(), 1);
+    assert!(
+        matches!(&results[0], SubmitTransactionResult::Rejected { .. }),
+        "Expected Rejected for oversized transaction, got {:?}",
+        results[0]
+    );
 }

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -809,11 +809,11 @@ async fn test_submit_soft_bundle_transactions() {
     }
 }
 
-/// A soft bundle whose transactions have mismatched gas prices is rejected
-/// (all-or-nothing semantics). This covers the `GasPriceMismatch` path inside
-/// `submit_transactions_bundle_validity_check`.
+/// In white-flag mode, transactions with different gas prices are processed
+/// independently — there is no bundle-level gas price matching. Each
+/// transaction is submitted on its own regardless of gas price differences.
 #[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn test_submit_soft_bundle_transactions_gas_price_mismatch() {
+async fn test_submit_transactions_different_gas_prices_accepted() {
     telemetry_subscribers::init_for_testing();
 
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
@@ -846,7 +846,7 @@ async fn test_submit_soft_bundle_transactions_gas_price_mismatch() {
         Arc::new(ValidatorServiceMetrics::new_for_tests()),
     ));
 
-    // tx1 at base rgp, tx2 at 2× rgp — gas prices must match within a bundle.
+    // tx1 at base rgp, tx2 at 2× rgp — both should be accepted independently.
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let gas1 = authority_state.get_object(&gas_id1).await.unwrap();
     let gas2 = authority_state.get_object(&gas_id2).await.unwrap();
@@ -874,7 +874,7 @@ async fn test_submit_soft_bundle_transactions_gas_price_mismatch() {
         gas2.compute_object_reference(),
         vec![CallArg::CLOCK_IMM],
         TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp * 2,
-        rgp * 2, // different price — causes GasPriceMismatch
+        rgp * 2, // different price — accepted in white-flag mode
     )
     .unwrap();
     let tx2 = to_sender_signed_transaction(tx_data2, &sender_key);

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -11,7 +11,10 @@ use iota_types::{
     },
     error::IotaError,
     messages_consensus::{AuthorityCapabilitiesV1, SignedAuthorityCapabilitiesV1},
-    messages_grpc::{LayoutGenerationOption, SubmitTransactionsRequest},
+    messages_grpc::{
+        LayoutGenerationOption, RawSubmitTransactionsRequest, RawSubmitTransactionsResponse,
+        SubmitTransactionsRequest, SubmitTransactionsResponse,
+    },
     supported_protocol_versions::SupportedProtocolVersions,
 };
 // Additional imports for white flag tests
@@ -38,6 +41,27 @@ use crate::{
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
     consensus_adapter::MockConsensusClient,
 };
+
+/// Helper to make a tonic request with a native SubmitTransactionsRequest
+/// converted to Raw* for the protobuf wire format.
+fn make_raw_submit_request(
+    request: SubmitTransactionsRequest,
+) -> tonic::Request<RawSubmitTransactionsRequest> {
+    let raw: RawSubmitTransactionsRequest = request.try_into().expect("BCS serialization failed");
+    make_tonic_request_for_testing(raw)
+}
+
+/// Helper to convert a Raw submit response back to native types for assertion.
+fn into_native_submit_response(
+    result: Result<(tonic::Response<RawSubmitTransactionsResponse>, Weight), tonic::Status>,
+) -> Result<(tonic::Response<SubmitTransactionsResponse>, Weight), tonic::Status> {
+    let (response, weight) = result?;
+    let native: SubmitTransactionsResponse = response
+        .into_inner()
+        .try_into()
+        .map_err(|e: IotaError| tonic::Status::internal(e.to_string()))?;
+    Ok((tonic::Response::new(native), weight))
+}
 
 // This is the most basic example of how to test the server logic
 #[tokio::test]
@@ -308,7 +332,7 @@ async fn test_submit_transaction_v1_feature_flag_disabled() {
 
     // Call submit_transaction
     let result = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(
+        .handle_submit_transactions_impl(make_raw_submit_request(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
         .await;
@@ -385,12 +409,13 @@ async fn test_submit_transaction_invalid_signature() {
 
     // Call submit_transaction
     let result = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(
+        .handle_submit_transactions_impl(make_raw_submit_request(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
         .await;
 
     // Signature errors are reported per-transaction as Rejected results.
+    let result = into_native_submit_response(result);
     assert!(result.is_ok(), "Batch response should be Ok");
     let response = result.unwrap().0.into_inner();
     assert_eq!(response.results.len(), 1);
@@ -466,12 +491,13 @@ async fn test_submit_transaction_success() {
 
     // Call submit_transaction
     let result = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(
+        .handle_submit_transactions_impl(make_raw_submit_request(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
         .await;
 
     // Should succeed with Submitted result
+    let result = into_native_submit_response(result);
     assert!(result.is_ok(), "Transaction submission should succeed");
     let response = result.unwrap().0.into_inner();
     match &response.results[0] {
@@ -575,13 +601,14 @@ async fn test_submit_transaction_invalid_transaction() {
     );
     let tx = to_sender_signed_transaction(tx_data, &sender_key);
 
-    let (response, _weight) = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(
+    let result = validator_service
+        .handle_submit_transactions_impl(make_raw_submit_request(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
-        .await
-        .expect("batch call should succeed even when individual txs fail");
+        .await;
 
+    let (response, _weight) = into_native_submit_response(result)
+        .expect("batch call should succeed even when individual txs fail");
     let results = response.into_inner().results;
     assert_eq!(results.len(), 1);
     assert!(
@@ -655,11 +682,12 @@ async fn test_submit_transaction_already_executed() {
 
     // Re-submit the same transaction via the white-flag endpoint.
     let result = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(
+        .handle_submit_transactions_impl(make_raw_submit_request(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
         .await;
 
+    let result = into_native_submit_response(result);
     assert!(result.is_ok(), "Expected Ok for already-executed tx");
     let response = result.unwrap().0.into_inner();
     assert_eq!(response.results.len(), 1, "Expected exactly one result");
@@ -725,7 +753,7 @@ async fn test_submit_transaction_gas_object_validation() {
     let tx = to_sender_signed_transaction(tx_data, &sender_key);
 
     let result = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(
+        .handle_submit_transactions_impl(make_raw_submit_request(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
         .await;
@@ -733,6 +761,7 @@ async fn test_submit_transaction_gas_object_validation() {
     // Non-existent gas object errors are reported per-transaction as Rejected
     // results. TODO: check for a specific error kind once we have better error
     // handling in place for the white-flag flow.
+    let result = into_native_submit_response(result);
     assert!(result.is_ok(), "Batch response should be Ok");
     let response = result.unwrap().0.into_inner();
     assert_eq!(response.results.len(), 1);
@@ -791,9 +820,10 @@ async fn test_submit_soft_bundle_transactions() {
     };
 
     let result = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(request))
+        .handle_submit_transactions_impl(make_raw_submit_request(request))
         .await;
 
+    let result = into_native_submit_response(result);
     assert!(result.is_ok(), "Batch submission should succeed");
     let response = result.unwrap().0.into_inner();
     assert_eq!(
@@ -884,11 +914,12 @@ async fn test_submit_transactions_different_gas_prices_accepted() {
     };
 
     let result = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(request))
+        .handle_submit_transactions_impl(make_raw_submit_request(request))
         .await;
 
     // With soft-bundle checks removed, each transaction is processed independently.
     // Different gas prices no longer cause a batch-level rejection.
+    let result = into_native_submit_response(result);
     assert!(result.is_ok(), "Batch response should be Ok");
     let response = result.unwrap().0.into_inner();
     assert_eq!(
@@ -963,13 +994,14 @@ async fn test_submit_oversized_transaction() {
     );
     let tx = to_sender_signed_transaction(tx_data, &sender_key);
 
-    let (response, _weight) = validator_service
-        .handle_submit_transactions_impl(make_tonic_request_for_testing(
+    let result = validator_service
+        .handle_submit_transactions_impl(make_raw_submit_request(
             SubmitTransactionsRequest::new_transaction(tx),
         ))
-        .await
-        .expect("batch call should succeed even when individual txs fail");
+        .await;
 
+    let (response, _weight) = into_native_submit_response(result)
+        .expect("batch call should succeed even when individual txs fail");
     let results = response.into_inner().results;
     assert_eq!(results.len(), 1);
     assert!(

--- a/crates/iota-network/Cargo.toml
+++ b/crates/iota-network/Cargo.toml
@@ -25,6 +25,7 @@ serde.workspace = true
 tap.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tonic.workspace = true
+tonic-prost.workspace = true
 tower.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -22,6 +22,7 @@ fn main() -> Result<()> {
     };
 
     let codec_path = "iota_network_stack::codec::BcsCodec";
+    let prost_codec_path = "tonic_prost::ProstCodec";
 
     let validator_service = Service::builder()
         .name("Validator")
@@ -112,27 +113,27 @@ fn main() -> Result<()> {
             Method::builder()
                 .name("handle_submit_transactions")
                 .route_name("SubmitTransactionsV1")
-                .input_type("iota_types::messages_grpc::SubmitTransactionsRequest")
-                .output_type("iota_types::messages_grpc::SubmitTransactionsResponse")
-                .codec_path(codec_path)
+                .input_type("iota_types::messages_grpc::RawSubmitTransactionsRequest")
+                .output_type("iota_types::messages_grpc::RawSubmitTransactionsResponse")
+                .codec_path(prost_codec_path)
                 .build(),
         )
         .method(
             Method::builder()
                 .name("handle_wait_for_effects")
                 .route_name("WaitForEffectsV1")
-                .input_type("iota_types::messages_grpc::WaitForEffectsRequest")
-                .output_type("iota_types::messages_grpc::WaitForEffectsResponse")
-                .codec_path(codec_path)
+                .input_type("iota_types::messages_grpc::RawWaitForEffectsRequest")
+                .output_type("iota_types::messages_grpc::RawWaitForEffectsResponse")
+                .codec_path(prost_codec_path)
                 .build(),
         )
         .method(
             Method::builder()
                 .name("handle_validator_health")
                 .route_name("ValidatorHealthV1")
-                .input_type("iota_types::messages_grpc::ValidatorHealthRequest")
-                .output_type("iota_types::messages_grpc::ValidatorHealthResponse")
-                .codec_path(codec_path)
+                .input_type("iota_types::messages_grpc::RawValidatorHealthRequest")
+                .output_type("iota_types::messages_grpc::RawValidatorHealthResponse")
+                .codec_path(prost_codec_path)
                 .build(),
         )
         .build();

--- a/crates/iota-types/Cargo.toml
+++ b/crates/iota-types/Cargo.toml
@@ -20,6 +20,7 @@ bcs.workspace = true
 better_any.workspace = true
 bincode.workspace = true
 byteorder.workspace = true
+bytes.workspace = true
 derive_more = { workspace = true, default-features = true, features = ["as_ref", "from", "debug", "display"] }
 either.workspace = true
 enum_dispatch.workspace = true
@@ -43,6 +44,7 @@ passkey-types.workspace = true
 prometheus.workspace = true
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
+prost.workspace = true
 prost-types.workspace = true
 rand.workspace = true
 roaring.workspace = true

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -397,8 +397,7 @@ impl std::fmt::Debug for SubmitTransactionResult {
 }
 
 /// Response from the TransactionDriver submit_transaction endpoint.
-/// TODO: Remove note bellow once soft bundle support is removed.
-/// NOTE: Vector of results does not work with soft bundles.
+/// Contains one result per submitted transaction.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubmitTransactionsResponse {
     pub results: Vec<SubmitTransactionResult>,

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use bytes::Bytes;
 use move_core_types::annotated_value::MoveStructLayout;
 use serde::{Deserialize, Serialize};
 
@@ -426,4 +427,623 @@ pub enum WaitForEffectResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WaitForEffectsResponse {
     pub results: Vec<WaitForEffectResponse>,
+}
+
+// =========== Raw prost wire-format types ===========
+
+#[derive(Clone, prost::Message)]
+pub struct RawExecutedData {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub effects: Bytes,
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    pub events: Option<Bytes>,
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    pub input_objects: Vec<Bytes>,
+    #[prost(bytes = "bytes", repeated, tag = "4")]
+    pub output_objects: Vec<Bytes>,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawSubmitTransactionsRequest {
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    pub transactions: Vec<Bytes>,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawSubmitTransactionsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub results: Vec<RawSubmitTransactionResult>,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawSubmitTransactionResult {
+    #[prost(oneof = "RawSubmitStatus", tags = "1, 2, 3")]
+    pub inner: Option<RawSubmitStatus>,
+}
+
+#[derive(Clone, prost::Oneof)]
+pub enum RawSubmitStatus {
+    #[prost(message, tag = "1")]
+    Submitted(RawSubmittedStatus),
+    #[prost(message, tag = "2")]
+    Executed(RawExecutedStatus),
+    #[prost(message, tag = "3")]
+    Rejected(RawRejectedStatus),
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawSubmittedStatus {}
+
+#[derive(Clone, prost::Message)]
+pub struct RawExecutedStatus {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub effects_digest: Bytes,
+    #[prost(message, optional, tag = "2")]
+    pub details: Option<RawExecutedData>,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawRejectedStatus {
+    #[prost(bytes = "bytes", optional, tag = "1")]
+    pub error: Option<Bytes>,
+}
+
+/// A single wait-for-effect item in the raw (protobuf) batch request.
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectRequest {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub transaction_digest: Bytes,
+    #[prost(bool, tag = "2")]
+    pub include_details: bool,
+}
+
+/// Batch request: repeated items. An empty `requests` vec is treated as a ping.
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectsRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub requests: Vec<RawWaitForEffectRequest>,
+}
+
+/// Per-item response for a single wait-for-effect in the raw (protobuf) format.
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectResponse {
+    #[prost(oneof = "RawWaitForEffectsStatus", tags = "1, 2, 3")]
+    pub inner: Option<RawWaitForEffectsStatus>,
+}
+
+/// Batch response: repeated items.
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub results: Vec<RawWaitForEffectResponse>,
+}
+
+#[derive(Clone, prost::Oneof)]
+pub enum RawWaitForEffectsStatus {
+    #[prost(message, tag = "1")]
+    Executed(RawExecutedStatus),
+    #[prost(message, tag = "2")]
+    Rejected(RawRejectedStatus),
+    #[prost(message, tag = "3")]
+    Expired(RawExpiredStatus),
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawExpiredStatus {
+    #[prost(uint64, tag = "1")]
+    pub epoch: u64,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawValidatorHealthRequest {}
+
+#[derive(Clone, prost::Message)]
+pub struct RawValidatorHealthResponse {
+    #[prost(uint64, optional, tag = "1")]
+    pub num_inflight_execution_transactions: Option<u64>,
+    #[prost(uint64, optional, tag = "2")]
+    pub num_inflight_consensus_transactions: Option<u64>,
+    /// Sequence number of the last locally built checkpoint.
+    #[prost(uint64, tag = "3")]
+    pub last_locally_built_checkpoint: u64,
+}
+
+// =========== TryFrom conversions ===========
+
+fn bcs_serialize<T: Serialize>(value: &T, type_info: &str) -> Result<Bytes, IotaError> {
+    bcs::to_bytes(value)
+        .map(Into::into)
+        .map_err(|e| IotaError::TransactionSerialization {
+            error: format!("{}: {}", type_info, e),
+        })
+}
+
+fn bcs_deserialize<T: serde::de::DeserializeOwned>(
+    bytes: &[u8],
+    type_info: &str,
+) -> Result<T, IotaError> {
+    bcs::from_bytes(bytes).map_err(|e| IotaError::TransactionSerialization {
+        error: format!("{}: {}", type_info, e),
+    })
+}
+
+// --- ExecutedData ---
+
+impl TryFrom<ExecutedData> for RawExecutedData {
+    type Error = IotaError;
+
+    fn try_from(value: ExecutedData) -> Result<Self, Self::Error> {
+        let effects = bcs_serialize(&value.effects, "ExecutedData.effects")?;
+        let events = value
+            .events
+            .as_ref()
+            .map(|e| bcs_serialize(e, "ExecutedData.events"))
+            .transpose()?;
+        let input_objects = value
+            .input_objects
+            .iter()
+            .map(|o| bcs_serialize(o, "ExecutedData.input_objects"))
+            .collect::<Result<Vec<_>, _>>()?;
+        let output_objects = value
+            .output_objects
+            .iter()
+            .map(|o| bcs_serialize(o, "ExecutedData.output_objects"))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(RawExecutedData {
+            effects,
+            events,
+            input_objects,
+            output_objects,
+        })
+    }
+}
+
+impl TryFrom<RawExecutedData> for ExecutedData {
+    type Error = IotaError;
+
+    fn try_from(value: RawExecutedData) -> Result<Self, Self::Error> {
+        let effects = bcs_deserialize(&value.effects, "RawExecutedData.effects")?;
+        let events = value
+            .events
+            .as_ref()
+            .map(|e| bcs_deserialize(e, "RawExecutedData.events"))
+            .transpose()?;
+        let input_objects = value
+            .input_objects
+            .iter()
+            .map(|o| bcs_deserialize(o, "RawExecutedData.input_objects"))
+            .collect::<Result<Vec<_>, _>>()?;
+        let output_objects = value
+            .output_objects
+            .iter()
+            .map(|o| bcs_deserialize(o, "RawExecutedData.output_objects"))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ExecutedData {
+            effects,
+            events,
+            input_objects,
+            output_objects,
+        })
+    }
+}
+
+// --- Shared helpers for Executed/Rejected status ---
+
+fn try_from_response_executed_submit(
+    effects_digest: TransactionEffectsDigest,
+    details: Box<ExecutedData>,
+) -> Result<RawExecutedStatus, IotaError> {
+    let effects_digest_bytes = bcs_serialize(&effects_digest, "effects_digest")?;
+    let details = Some((*details).try_into()?);
+    Ok(RawExecutedStatus {
+        effects_digest: effects_digest_bytes,
+        details,
+    })
+}
+
+fn try_from_raw_executed_status_submit(
+    executed: RawExecutedStatus,
+) -> Result<(TransactionEffectsDigest, Box<ExecutedData>), IotaError> {
+    let effects_digest =
+        bcs_deserialize(&executed.effects_digest, "RawExecutedStatus.effects_digest")?;
+    let details = executed
+        .details
+        .ok_or_else(|| IotaError::TransactionSerialization {
+            error: "RawExecutedStatus.details is None for SubmitTransactionResult".to_string(),
+        })?
+        .try_into()
+        .map(Box::new)?;
+    Ok((effects_digest, details))
+}
+
+fn try_from_response_executed_wait(
+    effects_digest: TransactionEffectsDigest,
+    details: Option<Box<ExecutedData>>,
+) -> Result<RawExecutedStatus, IotaError> {
+    let effects_digest_bytes = bcs_serialize(&effects_digest, "effects_digest")?;
+    let details = details.map(|d| (*d).try_into()).transpose()?;
+    Ok(RawExecutedStatus {
+        effects_digest: effects_digest_bytes,
+        details,
+    })
+}
+
+fn try_from_raw_executed_status_wait(
+    executed: RawExecutedStatus,
+) -> Result<(TransactionEffectsDigest, Option<Box<ExecutedData>>), IotaError> {
+    let effects_digest =
+        bcs_deserialize(&executed.effects_digest, "RawExecutedStatus.effects_digest")?;
+    let details = executed
+        .details
+        .map(|d| d.try_into().map(Box::new))
+        .transpose()?;
+    Ok((effects_digest, details))
+}
+
+fn try_from_response_rejected(error: Option<IotaError>) -> Result<RawRejectedStatus, IotaError> {
+    let error = error
+        .map(|e| bcs_serialize(&e, "RawRejectedStatus.error"))
+        .transpose()?;
+    Ok(RawRejectedStatus { error })
+}
+
+fn try_from_raw_rejected_status(
+    rejected: RawRejectedStatus,
+) -> Result<Option<IotaError>, IotaError> {
+    rejected
+        .error
+        .as_ref()
+        .map(|e| bcs_deserialize(e, "RawRejectedStatus.error"))
+        .transpose()
+}
+
+// --- SubmitTransactions ---
+
+impl TryFrom<SubmitTransactionsRequest> for RawSubmitTransactionsRequest {
+    type Error = IotaError;
+
+    fn try_from(value: SubmitTransactionsRequest) -> Result<Self, Self::Error> {
+        let transactions = value
+            .transactions
+            .iter()
+            .map(|t| bcs_serialize(t, "SubmitTransactionsRequest.transactions"))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(RawSubmitTransactionsRequest { transactions })
+    }
+}
+
+impl TryFrom<SubmitTransactionResult> for RawSubmitTransactionResult {
+    type Error = IotaError;
+
+    fn try_from(value: SubmitTransactionResult) -> Result<Self, Self::Error> {
+        let inner = match value {
+            SubmitTransactionResult::Submitted => RawSubmitStatus::Submitted(RawSubmittedStatus {}),
+            SubmitTransactionResult::Executed {
+                effects_digest,
+                details,
+            } => RawSubmitStatus::Executed(try_from_response_executed_submit(
+                effects_digest,
+                details,
+            )?),
+            SubmitTransactionResult::Rejected { error } => {
+                RawSubmitStatus::Rejected(try_from_response_rejected(Some(error))?)
+            }
+        };
+        Ok(RawSubmitTransactionResult { inner: Some(inner) })
+    }
+}
+
+impl TryFrom<RawSubmitTransactionResult> for SubmitTransactionResult {
+    type Error = IotaError;
+
+    fn try_from(value: RawSubmitTransactionResult) -> Result<Self, Self::Error> {
+        match value.inner {
+            Some(RawSubmitStatus::Submitted(_)) => Ok(SubmitTransactionResult::Submitted),
+            Some(RawSubmitStatus::Executed(executed)) => {
+                let (effects_digest, details) = try_from_raw_executed_status_submit(executed)?;
+                Ok(SubmitTransactionResult::Executed {
+                    effects_digest,
+                    details,
+                })
+            }
+            Some(RawSubmitStatus::Rejected(rejected)) => {
+                let error = try_from_raw_rejected_status(rejected)?.unwrap_or(
+                    IotaError::TransactionSerialization {
+                        error: "RawSubmitTransactionResult rejected error is None".to_string(),
+                    },
+                );
+                Ok(SubmitTransactionResult::Rejected { error })
+            }
+            None => Err(IotaError::TransactionSerialization {
+                error: "RawSubmitTransactionResult.inner is None".to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<SubmitTransactionsResponse> for RawSubmitTransactionsResponse {
+    type Error = IotaError;
+
+    fn try_from(value: SubmitTransactionsResponse) -> Result<Self, Self::Error> {
+        let results = value
+            .results
+            .into_iter()
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(RawSubmitTransactionsResponse { results })
+    }
+}
+
+impl TryFrom<RawSubmitTransactionsResponse> for SubmitTransactionsResponse {
+    type Error = IotaError;
+
+    fn try_from(value: RawSubmitTransactionsResponse) -> Result<Self, Self::Error> {
+        let results = value
+            .results
+            .into_iter()
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(SubmitTransactionsResponse { results })
+    }
+}
+
+// --- WaitForEffects ---
+
+impl TryFrom<WaitForEffectRequest> for RawWaitForEffectRequest {
+    type Error = IotaError;
+
+    fn try_from(value: WaitForEffectRequest) -> Result<Self, Self::Error> {
+        let transaction_digest = bcs_serialize(
+            &value.transaction_digest,
+            "WaitForEffectRequest.transaction_digest",
+        )?;
+        Ok(RawWaitForEffectRequest {
+            transaction_digest,
+            include_details: value.include_details,
+        })
+    }
+}
+
+impl TryFrom<WaitForEffectsRequest> for RawWaitForEffectsRequest {
+    type Error = IotaError;
+
+    fn try_from(value: WaitForEffectsRequest) -> Result<Self, Self::Error> {
+        let requests = value
+            .requests
+            .into_iter()
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(RawWaitForEffectsRequest { requests })
+    }
+}
+
+impl TryFrom<WaitForEffectResponse> for RawWaitForEffectResponse {
+    type Error = IotaError;
+
+    fn try_from(value: WaitForEffectResponse) -> Result<Self, Self::Error> {
+        let inner = match value {
+            WaitForEffectResponse::Executed {
+                effects_digest,
+                details,
+            } => RawWaitForEffectsStatus::Executed(try_from_response_executed_wait(
+                effects_digest,
+                details,
+            )?),
+            WaitForEffectResponse::Rejected { error } => {
+                RawWaitForEffectsStatus::Rejected(try_from_response_rejected(error)?)
+            }
+            WaitForEffectResponse::Expired { epoch } => {
+                RawWaitForEffectsStatus::Expired(RawExpiredStatus { epoch })
+            }
+        };
+        Ok(RawWaitForEffectResponse { inner: Some(inner) })
+    }
+}
+
+impl TryFrom<RawWaitForEffectResponse> for WaitForEffectResponse {
+    type Error = IotaError;
+
+    fn try_from(value: RawWaitForEffectResponse) -> Result<Self, Self::Error> {
+        match value.inner {
+            Some(RawWaitForEffectsStatus::Executed(executed)) => {
+                let (effects_digest, details) = try_from_raw_executed_status_wait(executed)?;
+                Ok(WaitForEffectResponse::Executed {
+                    effects_digest,
+                    details,
+                })
+            }
+            Some(RawWaitForEffectsStatus::Rejected(rejected)) => {
+                let error = try_from_raw_rejected_status(rejected)?;
+                Ok(WaitForEffectResponse::Rejected { error })
+            }
+            Some(RawWaitForEffectsStatus::Expired(expired)) => Ok(WaitForEffectResponse::Expired {
+                epoch: expired.epoch,
+            }),
+            None => Err(IotaError::TransactionSerialization {
+                error: "RawWaitForEffectResponse.inner is None".to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<WaitForEffectsResponse> for RawWaitForEffectsResponse {
+    type Error = IotaError;
+
+    fn try_from(value: WaitForEffectsResponse) -> Result<Self, Self::Error> {
+        let results = value
+            .results
+            .into_iter()
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(RawWaitForEffectsResponse { results })
+    }
+}
+
+impl TryFrom<RawWaitForEffectsResponse> for WaitForEffectsResponse {
+    type Error = IotaError;
+
+    fn try_from(value: RawWaitForEffectsResponse) -> Result<Self, Self::Error> {
+        let results = value
+            .results
+            .into_iter()
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(WaitForEffectsResponse { results })
+    }
+}
+
+// --- ValidatorHealth ---
+
+impl TryFrom<ValidatorHealthRequest> for RawValidatorHealthRequest {
+    type Error = IotaError;
+
+    fn try_from(_value: ValidatorHealthRequest) -> Result<Self, Self::Error> {
+        Ok(Self {})
+    }
+}
+
+impl TryFrom<RawValidatorHealthRequest> for ValidatorHealthRequest {
+    type Error = IotaError;
+
+    fn try_from(_value: RawValidatorHealthRequest) -> Result<Self, Self::Error> {
+        Ok(Self {})
+    }
+}
+
+impl TryFrom<ValidatorHealthResponse> for RawValidatorHealthResponse {
+    type Error = IotaError;
+
+    fn try_from(value: ValidatorHealthResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            num_inflight_execution_transactions: Some(value.num_inflight_execution_transactions),
+            num_inflight_consensus_transactions: Some(value.num_inflight_consensus_transactions),
+            last_locally_built_checkpoint: value.last_locally_built_checkpoint,
+        })
+    }
+}
+
+impl TryFrom<RawValidatorHealthResponse> for ValidatorHealthResponse {
+    type Error = IotaError;
+
+    fn try_from(value: RawValidatorHealthResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            num_inflight_execution_transactions: value
+                .num_inflight_execution_transactions
+                .unwrap_or(0),
+            num_inflight_consensus_transactions: value
+                .num_inflight_consensus_transactions
+                .unwrap_or(0),
+            last_locally_built_checkpoint: value.last_locally_built_checkpoint,
+        })
+    }
+}
+
+// =========== Tests ===========
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_executed_data_round_trip() {
+        let data = ExecutedData::default();
+        let raw: RawExecutedData = data.clone().try_into().unwrap();
+        let back: ExecutedData = raw.try_into().unwrap();
+        assert_eq!(
+            bcs::to_bytes(&data.effects).unwrap(),
+            bcs::to_bytes(&back.effects).unwrap()
+        );
+        assert!(back.events.is_none());
+        assert!(back.input_objects.is_empty());
+        assert!(back.output_objects.is_empty());
+    }
+
+    #[test]
+    fn test_submit_transactions_request_ping_to_raw() {
+        let request = SubmitTransactionsRequest::new_ping();
+        let raw: RawSubmitTransactionsRequest = request.try_into().unwrap();
+        assert!(raw.transactions.is_empty());
+    }
+
+    #[test]
+    fn test_submit_transaction_result_submitted_round_trip() {
+        let result = SubmitTransactionResult::Submitted;
+        let raw: RawSubmitTransactionResult = result.try_into().unwrap();
+        let back: SubmitTransactionResult = raw.try_into().unwrap();
+        assert!(matches!(back, SubmitTransactionResult::Submitted));
+    }
+
+    #[test]
+    fn test_wait_for_effects_request_to_raw() {
+        let request = WaitForEffectsRequest {
+            requests: vec![WaitForEffectRequest {
+                transaction_digest: TransactionDigest::default(),
+                include_details: true,
+            }],
+        };
+        let raw: RawWaitForEffectsRequest = request.try_into().unwrap();
+        assert_eq!(raw.requests.len(), 1);
+        assert!(raw.requests[0].include_details);
+    }
+
+    #[test]
+    fn test_wait_for_effects_request_ping_to_raw() {
+        let request = WaitForEffectsRequest { requests: vec![] };
+        assert!(request.is_ping());
+        let raw: RawWaitForEffectsRequest = request.try_into().unwrap();
+        assert!(raw.requests.is_empty());
+    }
+
+    #[test]
+    fn test_wait_for_effect_response_expired_round_trip() {
+        let response = WaitForEffectResponse::Expired { epoch: 42 };
+        let raw: RawWaitForEffectResponse = response.try_into().unwrap();
+        let back: WaitForEffectResponse = raw.try_into().unwrap();
+        match back {
+            WaitForEffectResponse::Expired { epoch } => {
+                assert_eq!(epoch, 42);
+            }
+            _ => panic!("Expected Expired variant"),
+        }
+    }
+
+    #[test]
+    fn test_wait_for_effects_response_batch_round_trip() {
+        let response = WaitForEffectsResponse {
+            results: vec![
+                WaitForEffectResponse::Expired { epoch: 1 },
+                WaitForEffectResponse::Rejected { error: None },
+            ],
+        };
+        let raw: RawWaitForEffectsResponse = response.try_into().unwrap();
+        assert_eq!(raw.results.len(), 2);
+        let back: WaitForEffectsResponse = raw.try_into().unwrap();
+        assert_eq!(back.results.len(), 2);
+        assert!(matches!(
+            back.results[0],
+            WaitForEffectResponse::Expired { epoch: 1 }
+        ));
+        assert!(matches!(
+            back.results[1],
+            WaitForEffectResponse::Rejected { error: None }
+        ));
+    }
+
+    #[test]
+    fn test_validator_health_round_trip() {
+        let request = ValidatorHealthRequest {};
+        let raw_req: RawValidatorHealthRequest = request.try_into().unwrap();
+        let _back_req: ValidatorHealthRequest = raw_req.try_into().unwrap();
+
+        let response = ValidatorHealthResponse {
+            num_inflight_execution_transactions: 10,
+            num_inflight_consensus_transactions: 20,
+            last_locally_built_checkpoint: 30,
+        };
+        let raw_resp: RawValidatorHealthResponse = response.try_into().unwrap();
+        let back_resp: ValidatorHealthResponse = raw_resp.try_into().unwrap();
+        assert_eq!(back_resp.num_inflight_execution_transactions, 10);
+        assert_eq!(back_resp.num_inflight_consensus_transactions, 20);
+        assert_eq!(back_resp.last_locally_built_checkpoint, 30);
+    }
 }

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -367,10 +367,6 @@ impl SubmitTransactionsRequest {
     pub fn is_ping(&self) -> bool {
         self.transactions.is_empty()
     }
-
-    pub fn is_soft_bundle(&self) -> bool {
-        self.transactions.len() > 1
-    }
 }
 
 /// The result of submitting a transaction to a validator.
@@ -401,9 +397,11 @@ impl std::fmt::Debug for SubmitTransactionResult {
 }
 
 /// Response from the TransactionDriver submit_transaction endpoint.
+/// TODO: Remove note bellow once soft bundle support is removed.
+/// NOTE: Vector of results does not work with soft bundles.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubmitTransactionsResponse {
-    pub result: SubmitTransactionResult,
+    pub results: Vec<SubmitTransactionResult>,
 }
 
 /// Request to wait for transaction effects from a validator.

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -404,17 +404,29 @@ pub struct SubmitTransactionsResponse {
     pub results: Vec<SubmitTransactionResult>,
 }
 
-/// Request to wait for transaction effects from a validator.
+/// A single wait-for-effects item within a batch request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct WaitForEffectsRequest {
-    pub transaction_digest: Option<TransactionDigest>,
+pub struct WaitForEffectRequest {
+    pub transaction_digest: TransactionDigest,
     pub include_details: bool,
-    pub ping_type: bool,
 }
 
-/// Response from a validator to a wait for effects request.
+/// Batch request to wait for transaction effects from a validator.
+/// An empty `requests` vec is treated as a ping.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum WaitForEffectsResponse {
+pub struct WaitForEffectsRequest {
+    pub requests: Vec<WaitForEffectRequest>,
+}
+
+impl WaitForEffectsRequest {
+    pub fn is_ping(&self) -> bool {
+        self.requests.is_empty()
+    }
+}
+
+/// Per-item response for a single wait-for-effects request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum WaitForEffectResponse {
     Executed {
         effects_digest: TransactionEffectsDigest,
         details: Option<Box<ExecutedData>>,
@@ -423,4 +435,10 @@ pub enum WaitForEffectsResponse {
     Rejected { error: Option<IotaError> },
     /// Transaction status has expired from the cache.
     Expired { epoch: EpochId },
+}
+
+/// Batch response from a validator to a wait for effects request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WaitForEffectsResponse {
+    pub results: Vec<WaitForEffectResponse>,
 }

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -317,20 +317,6 @@ pub struct ExecutedData {
     pub output_objects: Vec<Object>,
 }
 
-/// Discriminates the submission mode in ['SubmitTransactionsRequest']. TODO: Is
-/// it even necessary though?
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub enum SubmitTransactionsType {
-    /// Single transaction submission (default path).
-    #[default]
-    Default,
-    /// Ping (health-check / latency measurement); no transaction data.
-    Ping,
-    /// Multiple transactions submitted together as a soft bundle for
-    /// post-consensus owned-object conflict detection.
-    SoftBundle,
-}
-
 /// Contains either a transaction or the type of Ping request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubmitTransactionsRequest {


### PR DESCRIPTION
 # Description of change

  Changed `SubmitTransactionsResponse` to return `Vec<SubmitTransactionResult>` and
  `WaitForEffectsResponse` to return `Vec<WaitForEffectResponse>`, one entry per transaction.
  Both handlers process requests in parallel via `join_all` through dedicated single-item
  methods. Removed soft-bundle code as part of deprecation.

 ## Note
 PR #10810 was merged into this PR, it defines protobuf wrappers for validator wire format.

  ## Links to any relevant issues

  closes #10748, #10719 

  ## How the change has been tested

  - [x] Basic tests (linting, compilation, formatting, unit/integration tests)
  - [ ] Patch-specific tests (correctness, functionality coverage)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] I have checked that new and existing unit tests pass locally with my changes
