### PR TITLE
feat(gRPC): add gRPC client features for `tls-native-roots` and `tls-webpki-roots`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15332,6 +15332,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 1.0.4",
  "zstd",
 ]
 

--- a/crates/iota-grpc-client/Cargo.toml
+++ b/crates/iota-grpc-client/Cargo.toml
@@ -17,8 +17,14 @@ futures.workspace = true
 http.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-tonic = { workspace = true, features = ["tls-ring"] }
+tonic.workspace = true
 
 # internal dependencies
 iota-grpc-types.workspace = true
 iota-sdk-types.workspace = true
+
+[features]
+default = ["tls-ring", "tls-native-roots"]
+tls-ring = ["tonic/tls-ring"]
+tls-native-roots = ["tonic/tls-native-roots"]
+tls-webpki-roots = ["tonic/tls-webpki-roots"]

--- a/crates/iota-grpc-client/src/client.rs
+++ b/crates/iota-grpc-client/src/client.rs
@@ -8,7 +8,7 @@ use iota_grpc_types::v0::{
     ledger_service::ledger_service_client::LedgerServiceClient,
     transaction_execution_service::transaction_execution_service_client::TransactionExecutionServiceClient,
 };
-use tonic::{codec::CompressionEncoding, transport::channel::ClientTlsConfig};
+use tonic::codec::CompressionEncoding;
 
 use crate::{api::Result, interceptors::HeadersInterceptor};
 
@@ -45,10 +45,30 @@ impl Client {
 
         let mut endpoint = tonic::transport::Endpoint::from(uri.clone());
         if uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
-            endpoint = endpoint
-                .tls_config(ClientTlsConfig::new().with_enabled_roots())
-                .map_err(Into::into)
-                .map_err(tonic::Status::from_error)?;
+            #[cfg(not(feature = "tls-ring"))]
+            return Err(tonic::Status::failed_precondition(
+                "the `tls-ring` feature must be enabled for HTTPS",
+            )
+            .into());
+
+            #[cfg(not(any(feature = "tls-native-roots", feature = "tls-webpki-roots")))]
+            return Err(tonic::Status::failed_precondition(
+                "the `tls-native-roots` or `tls-webpki-roots` feature must be enabled for HTTPS",
+            )
+            .into());
+
+            #[cfg(all(
+                feature = "tls-ring",
+                any(feature = "tls-native-roots", feature = "tls-webpki-roots")
+            ))]
+            {
+                endpoint = endpoint
+                    .tls_config(
+                        tonic::transport::channel::ClientTlsConfig::new().with_enabled_roots(),
+                    )
+                    .map_err(Into::into)
+                    .map_err(tonic::Status::from_error)?;
+            }
         }
 
         let channel = endpoint


### PR DESCRIPTION
# Description of change

Clients can choose what to use, and the default is set to `tls-native-roots`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes