### PR TITLE
fix(docs): update tokenomics and gas pricing documentation

### DIFF
--- a/docs/content/about-iota/tokenomics/gas-in-iota.mdx
+++ b/docs/content/about-iota/tokenomics/gas-in-iota.mdx
@@ -1,6 +1,6 @@
 ---
-title: Transaction Pricing
-description: An IOTA transaction must both pay for the computational cost of execution and pay a deposit for storing the objects a transaction creates or mutates.
+title: Gas Pricing and Transaction Fees
+description: How IOTA transactions are priced, including computation fees, storage deposits, gas pricing mechanisms, and gas price prediction during dry runs.
 tags: [tokenomics]
 teams:
   - iotaledger/research
@@ -9,7 +9,17 @@ teams:
 import Quiz from '@site/src/components/Quiz';
 import quizData from '../../../site/static/json/about-iota/tokenomics/gas-in-iota.json';
 
-An IOTA transaction must both pay for the computational cost of execution and pay a deposit for storing the objects a transaction creates or mutates. Specifically, [IOTA Gas Pricing](gas-pricing.mdx) is such that the computation component is given as follows:
+## Overview
+
+An IOTA transaction must both pay for the computational cost of execution and pay a deposit for storing the objects a transaction creates or mutates. The total gas fees for a transaction are:
+
+<div align="center">
+`gas_fees(t) = computation_units(t) * gas_price + storage_units(t) * storage_price`
+</div>
+
+The gas functions `computation_units(t)` and `storage_units(t)` measure the amount of computation and storage resources, respectively, required to process and store the data associated with a transaction. The prices `gas_price` and `storage_price` translate the cost of computation and storage, respectively, into IOTA units. The decoupling between gas units and gas prices is useful since the IOTA market price will fluctuate over time in accordance with supply and demand.
+
+The computation component is given as follows:
 
 <div align="center">
   `computation_fee = computation_units * gas_price = computation_units * (reference_gas_price + tip)`,
@@ -35,18 +45,48 @@ Finally, storage rebates are provided whenever a transaction deletes previously 
 
 The information on net gas fees is displayed in the [IOTA network explorer](https://explorer.iota.org/) for each transaction block.
 
-## Gas prices
+## Computation Gas Prices {#computation-gas-prices}
+
+The computation gas price `gas_price` captures the cost of one unit of computation in IOTA units. This price is set at the transaction level and submitted by the user as the transaction's gas price. Conceptually, it is useful to think about this gas price in two parts:
+
+<div align="center">
+`gas_price(t) = reference_gas_price + tip(t)`.
+</div>
+
+In the IOTA network, the `reference_gas_price` is currently fixed to a value defined by `base_gas_price` in the protocol config. All user transactions are required to pay at least `reference_gas_price`, and all fees up to this price are burned by the protocol. Any additional fee above the `reference_gas_price` adds to the validators' rewards for the epoch, and hence, in practice, when a user submits a gas price above the `reference_gas_price`, it is useful to think of the difference as a _tip_ paid to the network in order to get higher priority. During moments of regular network operations, users are not expected to pay tips and the vast majority of transactions have gas prices equal to `reference_gas_price`.
+
+More generally, the IOTA gas price mechanism makes the `reference_gas_price` a credible anchor for you to reference when submitting transactions to the network, providing reasonable confidence that all transactions are executed in a timely manner. This is achieved through two core components:
+
+### Tallying Rule
+
+Throughout each epoch, validators observe the behavior of other validators. Each validator constructs a binary score (0 or 1) for every other validator: a score of 1 indicates the validator is operating correctly, and a score of 0 indicates non-performant behavior. The default score is 1, meaning validators only need to update a score when they detect that another validator is not operating correctly.
+
+At the epoch boundary, the protocol computes a global tallying score for each validator by taking the **stake-weighted median** of all the individual scores assigned to that validator. This global score acts as a multiplier on the validator's stake rewards:
+- Validators with a global score of **1** receive their full stake rewards.
+- Validators with a global score of **0** receive slashed (reduced) stake rewards.
+
+The tallying rule creates a community-enforced mechanism for encouraging validators to honor the reference gas price and operate efficiently. Community members can launch public dashboards tracking validator performance, providing additional signal for scoring decisions. There is no limit on the number of validators that can receive a 0 tallying score in an epoch.
+
+### Incentivized Stake Reward Distribution
+
+At the end of each epoch, the distribution of stake rewards across validators is adjusted using the tallying rule scores. Since stake rewards are influenced by the amount of stake each validator holds, validators are encouraged to attract more stake by maintaining good performance and competitive gas fees. This benefits IOTA end users because the reward distribution mechanism incentivizes validators to deliver a cost-efficient network, pricing out inefficient validators over time.
+
+## Storage Gas Prices
+
+The storage gas price `storage_price` captures the costs of covering one unit of storage in perpetuity, in IOTA units. This price is set through governance proposals and is updated infrequently. The goal is to ensure IOTA users pay for their use of on-chain data storage by storage deposits. Storage prices are fixed and common for all transactions both within an epoch and across epochs until the storage price is updated.
+
+The `storage_price` is set exogenously through governance proposals with the goal of targeting the off-chain dollar cost of data storage. In the long run, as the costs of storage fall due to technological improvements and the dollar price of the IOTA token evolves, governance proposals will update the price in order to reflect the new dollar target price.
 
 During regular network operations, all IOTA users can expect to pay the reference gas price and storage price for computation and storage, respectively.
 
-## Gas units
+## Gas Units
 
-Gas units include both
+Gas units include both:
 
 - [Computation units](#computation-units)
 - [Storage units](#storage-units)
 
-### Computation units
+### Computation Units
 
 Different IOTA transactions require varying amounts of computational time for processing and execution. IOTA translates these varying operational loads into transaction fees by measuring each transaction in terms of _computation units_. In general, more complex transactions require more computation units.
 
@@ -57,13 +97,13 @@ Using bucketing accomplishes two important goals:
 - Frees users from optimizing their smart contracts to deliver marginal gains in gas costs via "gas golfing" — instead, they can focus on step-function improvements in their products and services.
 - Gives users the freedom to adjust per-instruction gas costs and experiment with new gas metering schemes without creating significant development disruption. This can happen frequently, so it is important that they do not rely on per-instruction gas costs remaining stable over time.
 
-### Storage units
+### Storage Units
 
 Similarly, IOTA transactions vary depending on the amount of new data written into on-chain storage. The variable storage units capture these differences by mapping the number of bytes held in storage into _storage units_. The current IOTA schedule is linear and maps each byte into 100 storage units. So, for example, a transaction that stores 25 bytes costs 2,500 storage units, while a transaction that stores 75 bytes costs 7,500 units.
 
-Importantly, in IOTA's storage model, users pay storage deposit fees for storing data in perpetuity but can also get a full rebate on previously stored data if that data is deleted. Hence, the amount of storage fees that users pay are 100% rebateable. This storage deposit mechanism incentivizes users to minimize the storage burden they place on all nodes by reducing their storage requirements and cleaning up unused objects. 
+Importantly, in IOTA's storage model, users pay storage deposit fees for storing data in perpetuity but can also get a full rebate on previously stored data if that data is deleted. Hence, the amount of storage fees that users pay are 100% rebateable. This storage deposit mechanism incentivizes users to minimize the storage burden they place on all nodes by reducing their storage requirements and cleaning up unused objects.
 
-### Gas budgets
+### Gas Budgets
 
 Users must submit all transactions they need together with a _gas budget_. This provides a cap to the amount of gas fees paid, especially because sometimes it might be difficult to perfectly forecast how much a transaction costs before the user submits it to the IOTA network.
 
@@ -81,7 +121,7 @@ Importantly, the minimum gas budget is 1,000,000 NANOS or 0.001 IOTA (considerin
 
 As mentioned previously, the storage rebate is 100% of the originally paid storage fees. Because the gas budget applies to the totality of gas fees, it is often the case that a transaction only goes through if the gas budget is considerably higher than the net gas fees that a user ultimately pays.
 
-### Gas budget examples
+### Gas Budget Examples
 
 The following table provides some examples of gas accounting on the IOTA network. Within the first two and last two rows, computation units are the same because transactions fall within the same bucket. However, the last two transactions are more complex than the first two, and thus, fall in a higher bucket. Finally, in the last transaction, the storage rebate is large enough to fully offset the transaction gas fees and actually pays the user back a positive amount of IOTA.
 
@@ -93,6 +133,29 @@ These examples showcase the importance of the gas budget. The minimum gas budget
 | Simple transaction storing 10 bytes and deleting data   | 500 NANOS           | 1,000             | 75 NANOS      | 1,000         | 100,000 NANOS   | 500,000 NANOS      | 475,000 NANOS   |
 | Complex transaction storing 120 bytes                   | 1,000 NANOS         | 5,000             | 200 NANOS     | 12,000        | 0 NANOS         | 7,400,000 NANOS    | 7,400,000 NANOS |
 | Complex transaction storing 120 bytes and deleting data | 500 NANOS           | 5,000             | 200 NANOS     | 12,000        | 5,000,000 NANOS | 2,500,000 NANOS    | -100,000 NANOS  |
+
+## Gas Price Prediction During Dry Run {#gas-price-prediction}
+
+When you execute a **dry run** or **dev inspect** transaction, the IOTA network provides a `suggested_gas_price` in the response. This suggested price helps users set an appropriate gas price for transactions that interact with shared objects, particularly during periods of network congestion.
+
+### How It Works
+
+The network maintains a **congestion tracker** that monitors shared object access patterns across checkpoints. For each mutable shared object, the tracker computes a _hotness_ value that reflects how congested that object is based on recent transaction history. The hotness value increases when transactions accessing a shared object are cancelled due to congestion, and decays over time when congestion subsides.
+
+During a dry run, the suggested gas price is calculated as:
+
+<div align="center">
+`suggested_gas_price = reference_gas_price + max_hotness`
+</div>
+
+where `max_hotness` is the highest hotness value among all mutable shared objects accessed by the transaction. If the transaction does not access any tracked shared objects, the suggested gas price falls back to the current `reference_gas_price`.
+
+### When to Use It
+
+- **Transactions on shared objects**: If your transaction touches popular shared objects (e.g., a DEX pool), the suggested gas price accounts for current congestion and helps ensure your transaction is not cancelled.
+- **Regular transactions**: For transactions that only use owned objects, the suggested gas price will typically equal the `reference_gas_price` and no additional tip is needed.
+
+By using the `suggested_gas_price` from a dry run response, you can dynamically adjust your gas price to current network conditions without overpaying during calm periods or underpaying during congestion.
 
 
 <Quiz questions={quizData.questions} />

--- a/docs/content/about-iota/tokenomics/gas-pricing.mdx
+++ b/docs/content/about-iota/tokenomics/gas-pricing.mdx
@@ -1,47 +1,10 @@
 ---
 title: Gas Pricing
+description: Learn about IOTA's gas pricing mechanism, including computation gas prices, storage gas prices, and the tallying rule.
 tags: [tokenomics]
 teams:
   - iotaledger/research
+redirect: /about-iota/tokenomics/gas-in-iota
 ---
 
-import Quiz from '@site/src/components/Quiz';
-import quizData from '../../../site/static/json/about-iota/tokenomics/gas-pricing.json';
-
-The IOTA gas-pricing mechanism achieves two outcomes:
-1. Delivering low, predictable transaction fees (if the transaction does not operate on a [shared object]../../developer/iota-101/objects/shared-owned.mdx#shared-objects).
-2. Preventing denial-of-service attacks.
-
-This enables you to focus on using the IOTA network to provide the best user experience without needing to forecast the current market price of gas fees. Since validators receive subsidies for doing their job correctly, they are not solely reliant on user fees to incentivize them.
-
-In the IOTA network, users pay separate fees for transaction execution and for storing the data associated with each transaction. The gas fees associated with an arbitrary transaction `t` equal:
-
-<div align="center">
-`gas_fees(t) = computation_units(t) * gas_price + storage_units(t) * storage_price.`
-</div>
-
-The gas functions `computation_units(t)` and `storage_units(t)` measure the amount of computation and storage resources, respectively, required to process and store the data associated with transaction `t`. The prices `gas_price` and `storage_price` translate the cost of computation and storage, respectively, into IOTA units. The decoupling between gas units and gas prices is useful since IOTA market price will fluctuate over time in accordance with supply and demand.
-
-## Computation gas prices
-
-The computation gas price `gas_price(t)` captures the cost of one unit of computation in IOTA units. This price is set at the transaction level and submitted by the user as the transaction's gas price. Conceptually, it is useful to think about this gas price in two parts:
-
-<div align="center">
-`gas_price(t) = reference_gas_price + tip(t)`.
-</div>
-
-In the IOTA network, the `reference_gas_price` is currently fixed to a value defined by `base_gas_price` in the protocol config. All user transactions are required to pay at least `reference_gas_price`, and all fees up to this price are burned by the protocol. Any additional fee above the `reference_gas_price` adds to the validators' rewards for the epoch, and hence, in practice, when a user submits a gas price above the `reference_gas_price`, it is useful to think of the difference as a _tip_ paid to the network in order to get higher priority. During moments of regular network operations, users are not expected to pay tips and the vast majority of transactions have gas prices equal to `reference_gas_price`.
-
-More generally, the IOTA gas price mechanism makes the `reference_gas_price` a credible anchor for you to reference when submitting transactions to the network. Providing reasonable confidence that all transactions are executed in a timely manner. This is achieved through two core steps:
-
-- **Tallying rule:** Throughout the epoch, validators obtain signals over the operations of other validators. Each validator uses these signals to build a (subjective) evaluation of the performance of every other validator. Specifically, each validator constructs a multiplier for the stake rewards of every other validator such that validators who behave well receive boosted rewards, and validators who do not — receive reduced rewards. The tallying rule goal is to create a community-enforced mechanism for encouraging validators to honor the reference gas price.
-- **Incentivized stake reward distribution rule:** At the end of the epoch, the distribution of stake rewards across validators is adjusted using information from the tallying rule. Specifically, a global multiplier is built for every validator using the median value (weighted by stake) out of the set of individual multipliers constructed during the tallying rule. All else equal, validators that operated performantly receive their regular stake rewards, whereas validators who did not operate performantly at the reference gas price receive slashed rewards. Since stake rewards are influenced by the amount of stake each validator owns, validators are encouraged to obtain more stake by lowering gas fees and pricing out inefficient validators. This benefits IOTA end users since the stake reward distribution rule incentivizes validators to deliver a more cost-efficient network.
-
-## Storage gas prices
-
-The storage gas price `storage_price` captures the costs of covering one unit of storage in perpetuity, in IOTA units. This price is set through governance proposals and is updated infrequently. The goal is to ensure IOTA users pay for their use of on-chain data storage by storage deposits. Storage prices are fixed and common for all transactions both within an epoch and across epochs until the storage price is updated.
-
-The `storage_price` is set exogenously through the governance proposal with the goal of targeting the off-chain dollar cost of data storage. In the long run, as the costs of storage fall due to technological improvements and the dollar price of the IOTA token evolves, governance proposals will update the price in order to reflect the new dollar target price.
-
-
-<Quiz questions={quizData.questions} />
+This page has been merged into [Gas Pricing and Transaction Fees](gas-in-iota.mdx).

--- a/docs/content/about-iota/tokenomics/proof-of-stake.mdx
+++ b/docs/content/about-iota/tokenomics/proof-of-stake.mdx
@@ -36,7 +36,7 @@ At the end of each epoch, the protocol distributes stake rewards to participants
 This occurs through three main steps:
 
 - The total amount of stake rewards is calculated. The stake rewards are composed of a validator subsidy, which is currently set as 767,000 IOTA tokens per epoch, plus any tips from user transactions.
-- The total amount of stake rewards is distributed across various pools, proportionally to their stake and accordingly to the [tallying rule](./gas-pricing.mdx#computation-gas-prices).
+- The total amount of stake rewards is distributed across various pools, proportionally to their stake and accordingly to the [tallying rule](./gas-in-iota.mdx#computation-gas-prices).
 - Each pool's amount of rewards is distributed between the validator and the other parties. Validators first keep a commission $$\delta_v$$ (maximum 20%) of the total pool rewards as a fee to cover their costs. The rest of the rewards (i.e., after discounting the validator's commission) is distributed among all users (including the validator) proportionally to their stake.
 
 Finally, let $$\beta_v$$ represent the share of stake managed by a validator $$v$$ that is owned by itself, while $$(1-\beta_v)$$ represents the share owned by third-party stakers.
@@ -50,7 +50,7 @@ $$
 ValidatorRewards_v \ = \ \Big(\beta_v + \delta_v \times (1-\beta_v)\Big) \times \mu_v \times \sigma_v \times TotalStakeRewards.
 $$
 
-The $$\mu_v$$ variable captures the output of the [tallying rule](./gas-pricing.mdx#computation-gas-prices) computed as part of the [gas price mechanism](./gas-pricing.mdx) and corresponds to $$\mu_v=1$$ for performant validators and $$\mu_v<1$$ for non-performant validators.
+The $$\mu_v$$ variable captures the output of the [tallying rule](./gas-in-iota.mdx#computation-gas-prices) computed as part of the [gas price mechanism](./gas-in-iota.mdx) and corresponds to $$\mu_v=1$$ for performant validators and $$\mu_v<1$$ for non-performant validators.
 This variable ensures that validators have incurred monetary risk and therefore are incentivized to operate the IOTA network efficiently.
 The $$\sigma_v$$ parameter captures each pool's share of total stake.
 

--- a/docs/content/about-iota/tokenomics/staking-unstaking.mdx
+++ b/docs/content/about-iota/tokenomics/staking-unstaking.mdx
@@ -26,7 +26,7 @@ Similar to staking, a user withdraws their stake from a validator by sending a t
 When you stake on IOTA, you have to choose a specific validator you would like to stake with. The choice of validator can potentially impact the amount of staking rewards you receive. The factors determining this amount include, but are not limited to:
 
 - _Validator commission rate_: a validator can set a non-zero commission rate specifying the percentage of staking rewards they are taking from the stakers. For example, if a validator has a commission rate of 10%, then 10% of every staker's staking rewards is given to the validator. Note that a validator can change its commission at a future moment in time without prior notice.
-- _Validator performance_: a validator with bad performance might be punished according to the [tallying rule](./gas-pricing.mdx#computation-gas-prices). Punished validators receive only a fraction of staking rewards for the epoch during which they are punished, and you also will receive a fraction of that epoch's rewards when you withdraw your stake from that validator.
+- _Validator performance_: a validator with bad performance might be punished according to the [tallying rule](./gas-in-iota.mdx#computation-gas-prices). Punished validators receive only a fraction of staking rewards for the epoch during which they are punished, and you also will receive a fraction of that epoch's rewards when you withdraw your stake from that validator.
 
 IOTA-compatible crypto wallets and explorers typically provide validator information such as commission and APY. See the respective documentation for these tools for information on how to retrieve this data.
 

--- a/docs/content/operator/validator-node/validator-tokenomics.mdx
+++ b/docs/content/operator/validator-node/validator-tokenomics.mdx
@@ -63,9 +63,11 @@ Importantly, the gas object's value persists across epochs so that a validator w
 
 ## Validator Slashing and Tallying Rule
 
-IOTA is designed to encourage and enforce community monitoring of the validator set. This is done through the Tallying Rule by which each validator monitors and scores every other validator in order to ensure that everyone is operating efficiently and in the network's best interest. Validators that receive a low score can be penalized with slashed stake rewards.
+IOTA is designed to encourage and enforce community monitoring of the validator set. This is done through the Tallying Rule by which each validator monitors and assigns a binary score (0 or 1) to every other validator in order to ensure that everyone is operating efficiently and in the network's best interest. Validators that receive a low score can be penalized with slashed stake rewards.
 
-The protocol only computes the global Tallying Rule score at the epoch boundary and so relies on validators monitoring actively and changing their individual scores whenever they detect changes in other validator behavior. In general, the Tallying Rule default option should always be a score of one for all validators and only be changed to zero upon determining bad operations. In practice, the Tallying Rule consists of a set of objects each validator owns that default to scores of one and thus a validator will generally be passive and only update the object corresponding to another validator's score whenever needed.
+At the epoch boundary, the protocol computes a global Tallying Rule score for each validator by taking the **stake-weighted median** of all individual scores assigned to that validator. A global score of 1 means the validator receives full stake rewards; a global score of 0 means slashed rewards. The protocol relies on validators actively monitoring each other and updating scores whenever they detect changes in behavior.
+
+In practice, the Tallying Rule default score is 1 for all validators and should only be changed to 0 upon determining bad operations. Each validator owns a set of score objects that default to 1, so a validator will generally be passive and only update the score for another validator when needed.
 
 For example, to report a validator whose IOTA address is `0x44840a79dd5cf1f5efeff1379f5eece04c72db13512a2e31e8750f5176285446` as bad or non-performant, run:
 
@@ -73,6 +75,8 @@ For example, to report a validator whose IOTA address is `0x44840a79dd5cf1f5efef
 iota client call --package <PACKAGE-ID> --module iota_system --function report_validator --args 0x5 0x44840a79dd5cf1f5efeff1379f5eece04c72db13512a2e31e8750f5176285446 --gas-budget <GAS-AMOUNT>
 ```
 
-The Tallying Rule should be implemented through a social equilibrium. The validator set should actively monitor itself and if one validator is clearly non-performant, then the other validators should score that validator with a 0 and slash its rewards. Community members can launch public dashboards tracking validator performance and that can be used as further signal into a validator's operations. There is no limit on the number of validators that can receive a 0 tallying score in an epoch.
+The Tallying Rule is enforced through a social equilibrium. The validator set should actively monitor itself, and if a validator is clearly non-performant, the other validators should score that validator with a 0 to slash its rewards. Community members can launch public dashboards tracking validator performance to provide additional signal for scoring decisions. There is no limit on the number of validators that can receive a 0 tallying score in an epoch.
+
+For more details on gas pricing, the tallying rule, and how transaction fees work, see the [Gas Pricing and Transaction Fees](/about-iota/tokenomics/gas-in-iota) documentation.
 
 <Quiz questions={questions} />

--- a/docs/content/sidebars/about-iota.js
+++ b/docs/content/sidebars/about-iota.js
@@ -36,7 +36,6 @@ const aboutIota = [
             'about-iota/tokenomics/validators-staking',
             'about-iota/tokenomics/staking-unstaking',
             'about-iota/tokenomics/gas-in-iota',
-            'about-iota/tokenomics/gas-pricing',
         ],
     },
     {

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -275,6 +275,10 @@ const config = {
             {
               from: '/about-iota/iota-wallet/how-to/integrate-ledger',
               to: '/users/iota-wallet/how-to/import/ledger'
+            },
+            {
+              from: '/about-iota/tokenomics/gas-pricing',
+              to: '/about-iota/tokenomics/gas-in-iota'
             }
           ];
           let paths = [];


### PR DESCRIPTION
## Description

Updates the tokenomics documentation as described in #10811:

### Changes

1. **Merged gas pricing pages**: Combined `gas-pricing.mdx` and `gas-in-iota.mdx` (Transaction Pricing) into a single comprehensive page titled "Gas Pricing and Transaction Fees". The old `gas-pricing.mdx` now redirects to the merged page.

2. **Updated tallying rule description**: Replaced the vague description of validators building "multipliers" with an accurate explanation:
   - Validators assign binary scores (0 or 1)
   - Protocol computes global score via stake-weighted median
   - Score of 1 = full rewards, score of 0 = slashed rewards

3. **Added gas price prediction section**: New "Gas Price Prediction During Dry Run" section explaining:
   - The `suggested_gas_price` field in dry run responses
   - Congestion tracker and per-object hotness values
   - Formula: `suggested_gas_price = reference_gas_price + max_hotness`
   - When to use it (shared vs owned objects)

4. **Updated cross-references**: Fixed links in `proof-of-stake.mdx`, `staking-unstaking.mdx`, and `validator-tokenomics.mdx` to point to the merged page.

## Links to any relevant issues

fixes #10811

## How the change has been tested

- [x] Documentation links verified
- [x] No code changes

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full Nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: