### PR TITLE
fix(move): port upstream cleanups, doc fixes, and naming improvements

### DIFF
--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -2436,7 +2436,7 @@ impl Default for AdapterInitConfig {
 }
 
 static NAMED_ADDRESSES: Lazy<BTreeMap<String, NumericalAddress>> = Lazy::new(|| {
-    let mut map = move_stdlib::move_stdlib_named_addresses();
+    let mut map = move_stdlib::named_addresses();
     assert!(map.get("std").unwrap().into_inner() == MOVE_STDLIB_ADDRESS);
     // TODO fix IOTA framework constants
     map.insert(

--- a/external-crates/move/crates/language-benchmarks/src/move_vm.rs
+++ b/external-crates/move/crates/language-benchmarks/src/move_vm.rs
@@ -22,8 +22,8 @@ static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
     let program_res = move_compiler::construct_pre_compiled_lib(
         vec![PackagePaths {
             name: None,
-            paths: move_stdlib::move_stdlib_files(),
-            named_address_map: move_stdlib::move_stdlib_named_addresses(),
+            paths: move_stdlib::source_files(),
+            named_address_map: move_stdlib::named_addresses(),
         }],
         None,
         move_compiler::Flags::empty(),
@@ -60,16 +60,12 @@ pub fn compile_modules(filename: &str) -> Vec<CompiledModule> {
         edition: Edition::E2024_BETA,
         ..Default::default()
     };
-    let (_files, compiled_units) = Compiler::from_files(
-        None,
-        src_files,
-        vec![],
-        move_stdlib::move_stdlib_named_addresses(),
-    )
-    .set_pre_compiled_lib(Arc::new(PRECOMPILED_MOVE_STDLIB.clone()))
-    .set_default_config(pkg_config)
-    .build_and_report()
-    .expect("Error compiling...");
+    let (_files, compiled_units) =
+        Compiler::from_files(None, src_files, vec![], move_stdlib::named_addresses())
+            .set_pre_compiled_lib(Arc::new(PRECOMPILED_MOVE_STDLIB.clone()))
+            .set_default_config(pkg_config)
+            .build_and_report()
+            .expect("Error compiling...");
     compiled_units
         .into_iter()
         .map(|annot_unit| annot_unit.named_module.module)

--- a/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
+++ b/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
@@ -190,7 +190,7 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
     let named_address_map = default_testing_addresses(flavor);
     let deps = vec![PackagePaths {
         name: Some(("stdlib".into(), PackageConfig::default())),
-        paths: move_stdlib::move_stdlib_files(),
+        paths: move_stdlib::source_files(),
         named_address_map: named_address_map.clone(),
     }];
     let target_name = if migration_mode {

--- a/external-crates/move/crates/move-stackless-bytecode/tests/testsuite.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/tests/testsuite.rs
@@ -133,7 +133,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
         vec![PackagePaths {
             name: None,
             paths: sources,
-            named_address_map: move_stdlib::move_stdlib_named_addresses(),
+            named_address_map: move_stdlib::named_addresses(),
         }],
         vec![],
         ModelBuilderOptions::default(),

--- a/external-crates/move/crates/move-stdlib/src/lib.rs
+++ b/external-crates/move/crates/move-stdlib/src/lib.rs
@@ -20,6 +20,7 @@ pub mod utils;
 
 const MODULES_DIR: &str = "sources";
 const DOCS_DIR: &str = "docs";
+const SUMMARIES_DIR: &str = "summaries";
 
 const REFERENCES_TEMPLATE: &str = "doc_templates/references.md";
 const OVERVIEW_TEMPLATE: &str = "doc_templates/overview.md";
@@ -40,20 +41,24 @@ where
     path
 }
 
-pub fn move_stdlib_modules_full_path() -> String {
+pub fn modules_full_path() -> String {
     format!("{}/{}", env!("CARGO_MANIFEST_DIR"), MODULES_DIR)
 }
 
-pub fn move_stdlib_docs_full_path() -> String {
+pub fn docs_full_path() -> String {
     format!("{}/{}", env!("CARGO_MANIFEST_DIR"), DOCS_DIR)
 }
 
-pub fn move_stdlib_files() -> Vec<String> {
+pub fn summaries_full_path() -> String {
+    format!("{}/{}", env!("CARGO_MANIFEST_DIR"), SUMMARIES_DIR)
+}
+
+pub fn source_files() -> Vec<String> {
     let path = path_in_crate(MODULES_DIR);
     find_filenames(&[path], |p| extension_equals(p, MOVE_EXTENSION)).unwrap()
 }
 
-pub fn move_stdlib_named_addresses() -> BTreeMap<String, NumericalAddress> {
+pub fn named_addresses() -> BTreeMap<String, NumericalAddress> {
     let mapping = [("std", "0x1")];
     mapping
         .iter()
@@ -61,18 +66,10 @@ pub fn move_stdlib_named_addresses() -> BTreeMap<String, NumericalAddress> {
         .collect()
 }
 
-pub fn build_stdlib_doc(output_directory: String) -> anyhow::Result<()> {
-    let config = BuildConfig {
-        additional_named_addresses: move_stdlib_named_addresses()
-            .into_iter()
-            .map(|(k, v)| (k, v.into_inner()))
-            .collect(),
-        ..BuildConfig::default()
-    };
-    let model = config.move_model_for_package(
-        Path::new(&move_stdlib_modules_full_path()),
-        &mut std::io::stdout(),
-    )?;
+pub fn build_doc(output_directory: String) -> anyhow::Result<()> {
+    let config = build_config();
+    let model =
+        config.move_model_for_package(Path::new(&modules_full_path()), &mut std::io::stdout())?;
     let options = DocgenOptions {
         output_directory,
         doc_path: vec![String::new()],
@@ -95,4 +92,14 @@ pub fn build_stdlib_doc(output_directory: String) -> anyhow::Result<()> {
         fs::write(path.as_path(), content)?;
     }
     Ok(())
+}
+
+pub(crate) fn build_config() -> BuildConfig {
+    BuildConfig {
+        additional_named_addresses: named_addresses()
+            .into_iter()
+            .map(|(k, v)| (k, v.into_inner()))
+            .collect(),
+        ..BuildConfig::default()
+    }
 }

--- a/external-crates/move/crates/move-stdlib/src/main.rs
+++ b/external-crates/move/crates/move-stdlib/src/main.rs
@@ -9,9 +9,8 @@ fn main() {
     // Generate documentation
     {
         time_it("Generating stdlib documentation", || {
-            std::fs::remove_dir_all(move_stdlib::move_stdlib_docs_full_path()).unwrap_or(());
-            // std::fs::create_dir_all(&move_stdlib::move_stdlib_docs_full_path()).unwrap();
-            move_stdlib::build_stdlib_doc(move_stdlib::move_stdlib_docs_full_path()).unwrap();
+            std::fs::remove_dir_all(move_stdlib::docs_full_path()).unwrap_or(());
+            move_stdlib::build_doc(move_stdlib::docs_full_path()).unwrap();
         });
     }
 }

--- a/external-crates/move/crates/move-stdlib/src/tests.rs
+++ b/external-crates/move/crates/move-stdlib/src/tests.rs
@@ -13,9 +13,9 @@ use walkdir::{DirEntry, WalkDir};
 fn check_that_docs_are_updated() {
     let temp_dir = tempdir().unwrap();
 
-    crate::build_stdlib_doc(temp_dir.path().to_string_lossy().to_string()).unwrap();
+    crate::build_doc(temp_dir.path().to_string_lossy().to_string()).unwrap();
 
-    let res = check_dirs_not_diff(&temp_dir, crate::move_stdlib_docs_full_path());
+    let res = check_dirs_not_diff(&temp_dir, crate::docs_full_path());
     assert!(
         res.is_ok(),
         "Generated docs differ from the ones checked in. {}",

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -21,7 +21,7 @@ use move_core_types::{
     parsing::address::ParsedAddress,
     runtime_value::MoveValue,
 };
-use move_stdlib::move_stdlib_named_addresses;
+use move_stdlib::named_addresses as move_stdlib_named_addresses;
 use move_symbol_pool::Symbol;
 use move_vm_config::runtime::VMConfig;
 use move_vm_runtime::{
@@ -300,8 +300,8 @@ pub static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
     let program_res = move_compiler::construct_pre_compiled_lib(
         vec![PackagePaths {
             name: None,
-            paths: move_stdlib::move_stdlib_files(),
-            named_address_map: move_stdlib::move_stdlib_named_addresses(),
+            paths: move_stdlib::source_files(),
+            named_address_map: move_stdlib::named_addresses(),
         }],
         None,
         move_compiler::Flags::empty(),
@@ -320,9 +320,9 @@ pub static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
 static MOVE_STDLIB_COMPILED: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
     let (files, units_res) = move_compiler::Compiler::from_files(
         None,
-        move_stdlib::move_stdlib_files(),
+        move_stdlib::source_files(),
         vec![],
-        move_stdlib::move_stdlib_named_addresses(),
+        move_stdlib::named_addresses(),
     )
     .build()
     .unwrap();

--- a/external-crates/move/crates/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/external-crates/move/crates/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -17,10 +17,8 @@ fn run_test_impl(path: &Path) -> anyhow::Result<()> {
         num_threads: 1,
         gas_limit: Some(1000),
         source_files,
-        dep_files: move_stdlib::move_stdlib_files(),
-        named_address_values: move_stdlib::move_stdlib_named_addresses()
-            .into_iter()
-            .collect(),
+        dep_files: move_stdlib::source_files(),
+        named_address_values: move_stdlib::named_addresses().into_iter().collect(),
         report_stacktrace_on_abort: true,
         deterministic_generation: true,
 

--- a/external-crates/move/crates/move-unit-test/tests/test_deps.rs
+++ b/external-crates/move/crates/move-unit-test/tests/test_deps.rs
@@ -15,11 +15,11 @@ use move_unit_test::{self, UnitTestingConfig};
 #[test]
 fn test_deps_arent_tested() {
     let mut testing_config = UnitTestingConfig::default_with_bound(None)
-        .with_named_addresses(move_stdlib::move_stdlib_named_addresses());
+        .with_named_addresses(move_stdlib::named_addresses());
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let a_path = path.join("tests/sources/A.move");
     let b_path = path.join("tests/sources/B.move");
-    let mut deps = move_stdlib::move_stdlib_files();
+    let mut deps = move_stdlib::source_files();
     deps.push(a_path.to_string_lossy().to_string());
 
     testing_config.source_files = vec![b_path.to_str().unwrap().to_owned()];

--- a/external-crates/move/crates/move-vm-integration-tests/src/compiler.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/compiler.rs
@@ -23,7 +23,7 @@ pub fn compile_units(s: &str) -> Result<Vec<AnnotatedCompiledUnit>> {
         None,
         vec![file_path.to_str().unwrap().to_string()],
         vec![],
-        move_stdlib::move_stdlib_named_addresses(),
+        move_stdlib::named_addresses(),
     )
     .build_and_report()?;
 

--- a/external-crates/move/crates/test-generation/src/lib.rs
+++ b/external-crates/move/crates/test-generation/src/lib.rs
@@ -57,9 +57,9 @@ static STORAGE_WITH_MOVE_STDLIB: Lazy<InMemoryStorage> = Lazy::new(|| {
     let mut storage = InMemoryStorage::new();
     let (_, compiled_units) = Compiler::from_files(
         None,
-        move_stdlib::move_stdlib_files(),
+        move_stdlib::source_files(),
         vec![],
-        move_stdlib::move_stdlib_named_addresses(),
+        move_stdlib::named_addresses(),
     )
     .build_and_report()
     .unwrap();

--- a/external-crates/move/documentation/book/src/control-flow/labeled-control-flow.md
+++ b/external-crates/move/documentation/book/src/control-flow/labeled-control-flow.md
@@ -19,7 +19,7 @@ outer label to escape both loops at once:
 fun sum_until_threshold(input: &vector<vector<u64>>, threshold: u64): u64 {
     let mut sum = 0;
     let mut i = 0;
-    let input_size = vector::length(vec);
+    let input_size = vector::length(input);
 
     'outer: loop {
         // breaks to outer since it is the closest enclosing loop
@@ -37,9 +37,9 @@ fun sum_until_threshold(input: &vector<vector<u64>>, threshold: u64): u64 {
                 // the next element we saw would break the threshold,
                 // so we return the current sum
                 break 'outer sum
-            }
+            };
             j = j + 1;
-        }
+        };
         i = i + 1;
     }
 }

--- a/external-crates/move/documentation/book/src/equality.md
+++ b/external-crates/move/documentation/book/src/equality.md
@@ -126,7 +126,7 @@ reference types have the [`drop` ability](./abilities.md). For example
 
 ```move=
 module 0x42::example {
-    public struct Coin as store { value: u64 }
+    public struct Coin has store { value: u64 }
     fun swap_if_equal(c1: Coin, c2: Coin): (Coin, Coin) {
         let are_equal = &c1 == c2; // valid, note `c2` is automatically borrowed
         if (are_equal) (c2, c1) else (c1, c2)


### PR DESCRIPTION
## Description

Ports 3 upstream Sui commits as described in #10857:

### Ported commits

1. **Sui PR #22374** — Rename redundant \`move_stdlib_*\` function prefixes:
   - \`move_stdlib_files()\` → \`source_files()\`
   - \`move_stdlib_named_addresses()\` → \`named_addresses()\`
   - \`move_stdlib_modules_full_path()\` → \`modules_full_path()\`
   - \`move_stdlib_docs_full_path()\` → \`docs_full_path()\`
   - \`build_stdlib_doc()\` → \`build_doc()\`
   - Added \`summaries_full_path()\` and extracted \`build_config()\` helper
   - 12 files updated across move-stdlib, move-compiler, language-benchmarks, test runners

2. **Sui PR #22473** — Fix code errors in \`labeled-control-flow.md\`:
   - Wrong parameter name (\`vec\` → \`input\`)
   - Missing semicolons after \`break\` blocks

3. **Sui PR #22503** — Fix typo in \`equality.md\`: \`as\` → \`has\` in struct declaration

### Skipped commits (as noted in #10857)
- Sui PR #22387 (build fix) — not applicable
- Sui PR #22611 (type resolution errors) — complex protocol version changes

## Links to any relevant issues

Partial fix for #10857

## How the change has been tested

- [x] \`cargo build -p move-stdlib\` — compiles successfully
- [x] \`cargo +nightly fmt -- --check\` — formatted
- [x] Documentation fixes verified for correctness

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full Nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: Renamed \`move_stdlib::move_stdlib_*()\` functions to cleaner names (\`source_files()\`, \`named_addresses()\`, etc.)
- [ ] REST API: