### PR TITLE
refactor(iota-types): rename type_ fields to tag where possible

### DIFF
--- a/crates/iota-analytics-indexer/src/handlers/event_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/event_handler.rs
@@ -118,13 +118,13 @@ impl EventHandler {
                 package_id,
                 transaction_module,
                 sender,
-                type_,
+                tag,
                 contents,
             } = event;
             let layout = state
                 .resolver
                 .type_layout(move_core_types::language_storage::TypeTag::Struct(
-                    Box::new(type_.clone()),
+                    Box::new(tag.clone()),
                 ))
                 .await?;
             let move_value = MoveValue::simple_deserialize(contents, &layout)?;
@@ -138,7 +138,7 @@ impl EventHandler {
                 sender: sender.to_string(),
                 package: package_id.to_string(),
                 module: transaction_module.to_string(),
-                event_type: type_.to_string(),
+                event_type: tag.to_string(),
                 bcs: Base64::encode(contents.clone()),
                 event_json: event_json.to_string(),
             };

--- a/crates/iota-cluster-test/src/test_case/random_beacon_test.rs
+++ b/crates/iota-cluster-test/src/test_case/random_beacon_test.rs
@@ -50,7 +50,7 @@ impl TestCaseImpl for RandomBeaconTest {
         );
         assert_eq!(
             "RandomU128Event".to_string(),
-            events.data[0].type_.name.to_string()
+            events.data[0].tag.name.to_string()
         );
 
         // Verify fullnode observes the txn

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4313,7 +4313,7 @@ impl AuthorityState {
                 tx_digest,
                 event_seq as u64,
                 Some(timestamp),
-                layout_resolver.get_annotated_layout(&e.type_)?,
+                layout_resolver.get_annotated_layout(&e.tag)?,
             )?)
         }
         Ok(events)

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -738,7 +738,7 @@ impl IndexStore {
             &self.tables.event_by_move_event,
             events.data.iter().enumerate().map(|(i, e)| {
                 (
-                    (e.type_.clone(), (sequence, i)),
+                    (e.tag.clone(), (sequence, i)),
                     (event_digest, *digest, timestamp_ms),
                 )
             }),
@@ -759,7 +759,7 @@ impl IndexStore {
             events.data.iter().enumerate().map(|(i, e)| {
                 (
                     (
-                        ModuleId::new(e.type_.address, e.type_.module.clone()),
+                        ModuleId::new(e.tag.address, e.tag.module.clone()),
                         (sequence, i),
                     ),
                     (event_digest, *digest, timestamp_ms),

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -575,7 +575,7 @@ impl RestIndexes for RestIndexStore {
                         owner,
                         object_id,
                         version,
-                        type_,
+                        tag: type_,
                     }
                 },
             )

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -143,7 +143,7 @@ impl Event {
     #[graphql(flatten)]
     async fn move_value(&self) -> Result<MoveValue> {
         Ok(MoveValue::new(
-            self.native.type_.clone().into(),
+            self.native.tag.clone().into(),
             Base64::from(self.native.contents.clone()),
         ))
     }
@@ -319,7 +319,7 @@ impl Event {
                 sender,
                 package_id,
                 transaction_module,
-                type_,
+                tag: type_,
                 contents,
             },
             checkpoint_viewed_at,

--- a/crates/iota-grpc-server/src/event_filter.rs
+++ b/crates/iota-grpc-server/src/event_filter.rs
@@ -157,10 +157,10 @@ impl EventFilter {
                         || matches!(module,  Some(m2) if m2 == &item.transaction_module))
             }
             EventFilter::MoveEventPackageAndModule { package, module } => {
-                ObjectID::from(item.type_.address) == *package
-                    && (module.is_none() || matches!(module,  Some(m2) if m2 == &item.type_.module))
+                ObjectID::from(item.tag.address) == *package
+                    && (module.is_none() || matches!(module,  Some(m2) if m2 == &item.tag.module))
             }
-            EventFilter::MoveEventType(event_type) => item.type_ == *event_type,
+            EventFilter::MoveEventType(event_type) => item.tag == *event_type,
         }
     }
 

--- a/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
@@ -175,7 +175,7 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::TransactionEvents {
                         message.json_contents = crate::utils::render_json(
                             source.reader.clone(),
                             source.config.max_json_move_value_size,
-                            &iota_types::TypeTag::Struct(Box::new(event.type_.clone())),
+                            &iota_types::TypeTag::Struct(Box::new(event.tag.clone())),
                             &event.contents,
                         );
                     }

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -555,7 +555,7 @@ impl InMemory {
                 senders: vec![Some(native.sender.to_vec())],
                 package: native.package_id.to_vec(),
                 module: native.transaction_module.to_string(),
-                event_type: native.type_.to_canonical_string(with_prefix),
+                event_type: native.tag.to_canonical_string(with_prefix),
                 timestamp_ms: tx.timestamp_ms,
                 bcs: native.contents,
             })

--- a/crates/iota-indexer/src/models/events.rs
+++ b/crates/iota-indexer/src/models/events.rs
@@ -133,7 +133,7 @@ impl StoredEvent {
             package_id,
             transaction_module: Identifier::from_str(&self.module)?,
             sender,
-            type_,
+            tag: type_,
             bcs: BcsEvent::new(self.bcs),
             parsed_json,
             timestamp_ms: Some(self.timestamp_ms as u64),

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -528,7 +528,7 @@ pub async fn tx_events_to_iota_tx_events(
         iota_event_futures.push(tokio::task::spawn(async move {
             let resolver = package_resolver_clone;
             resolver
-                .type_layout(TypeTag::Struct(Box::new(tx_event.type_.clone())))
+                .type_layout(TypeTag::Struct(Box::new(tx_event.tag.clone())))
                 .await
         }));
     }

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -185,10 +185,10 @@ impl IndexedEvent {
             senders: vec![event.sender],
             package: event.package_id,
             module: event.transaction_module.to_string(),
-            event_type: event.type_.to_canonical_string(/* with_prefix */ true),
-            event_type_package: event.type_.address.into(),
-            event_type_module: event.type_.module.to_string(),
-            event_type_name: event.type_.name.to_string(),
+            event_type: event.tag.to_canonical_string(/* with_prefix */ true),
+            event_type_package: event.tag.address.into(),
+            event_type_module: event.tag.module.to_string(),
+            event_type_name: event.tag.name.to_string(),
             bcs: event.contents.clone(),
             timestamp_ms,
         }
@@ -218,7 +218,7 @@ impl EventIndex {
         event: &iota_types::event::Event,
     ) -> Self {
         let type_instantiation = event
-            .type_
+            .tag
             .to_canonical_string(/* with_prefix */ true)
             .splitn(3, "::")
             .collect::<Vec<_>>()[2]
@@ -229,9 +229,9 @@ impl EventIndex {
             sender: event.sender,
             emit_package: event.package_id,
             emit_module: event.transaction_module.to_string(),
-            type_package: event.type_.address.into(),
-            type_module: event.type_.module.to_string(),
-            type_name: event.type_.name.to_string(),
+            type_package: event.tag.address.into(),
+            type_module: event.tag.module.to_string(),
+            type_name: event.tag.name.to_string(),
             type_instantiation,
         }
     }

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -45,9 +45,10 @@ pub struct IotaEvent {
     /// Sender's IOTA address.
     pub sender: IotaAddress,
     #[schemars(with = "String")]
+    #[serde(rename = "type")]
     #[serde_as(as = "IotaStructTag")]
     /// Move event type.
-    pub type_: StructTag,
+    pub tag: StructTag,
     /// Parsed json value of the event
     pub parsed_json: Value,
     /// Base64 encoded bcs bytes of the move event
@@ -147,7 +148,7 @@ impl From<EventEnvelope> for IotaEvent {
             package_id: ev.event.package_id,
             transaction_module: ev.event.transaction_module,
             sender: ev.event.sender,
-            type_: ev.event.type_,
+            tag: ev.event.tag,
             parsed_json: ev.parsed_json,
             bcs: BcsEvent::Base64 {
                 bcs: ev.event.contents,
@@ -163,7 +164,7 @@ impl From<IotaEvent> for Event {
             package_id: val.package_id,
             transaction_module: val.transaction_module,
             sender: val.sender,
-            type_: val.type_,
+            tag: val.tag,
             contents: val.bcs.into_bytes(),
         }
     }
@@ -181,7 +182,7 @@ impl IotaEvent {
             package_id,
             transaction_module,
             sender,
-            type_: _,
+            tag: _,
             contents,
         } = event;
 
@@ -200,7 +201,7 @@ impl IotaEvent {
             package_id,
             transaction_module,
             sender,
-            type_,
+            tag: type_,
             parsed_json: fields,
             bcs,
             timestamp_ms,
@@ -223,7 +224,7 @@ impl Display for IotaEvent {
             self.package_id,
             self.transaction_module,
             self.sender,
-            self.type_
+            self.tag
         )?;
         if let Some(ts) = self.timestamp_ms {
             writeln!(f, " │ Timestamp: {ts}\n └──")?;
@@ -249,7 +250,7 @@ impl IotaEvent {
             package_id: ObjectID::random(),
             transaction_module: Identifier::from_str("random_for_testing").unwrap(),
             sender: IotaAddress::random_for_testing_only(),
-            type_: StructTag::from_str("0x6666::random_for_testing::RandomForTesting").unwrap(),
+            tag: StructTag::from_str("0x6666::random_for_testing::RandomForTesting").unwrap(),
             parsed_json: json!({}),
             bcs: BcsEvent::new(vec![]),
             timestamp_ms: None,
@@ -354,7 +355,7 @@ pub enum EventFilter {
 impl EventFilter {
     fn try_matches(&self, item: &IotaEvent) -> IotaResult<bool> {
         Ok(match self {
-            EventFilter::MoveEventType(event_type) => &item.type_ == event_type,
+            EventFilter::MoveEventType(event_type) => &item.tag == event_type,
             EventFilter::MoveEventField { path, value } => {
                 matches!(item.parsed_json.pointer(path), Some(v) if v == value)
             }
@@ -384,7 +385,7 @@ impl EventFilter {
                 }
             }
             EventFilter::MoveEventModule { package, module } => {
-                &item.type_.module == module && &ObjectID::from(item.type_.address) == package
+                &item.tag.module == module && &ObjectID::from(item.tag.address) == package
             }
         })
     }

--- a/crates/iota-json-rpc-types/src/iota_move.rs
+++ b/crates/iota-json-rpc-types/src/iota_move.rs
@@ -497,7 +497,7 @@ impl From<MoveValue> for IotaMoveValue {
                 tag: _,
                 fields,
             }) => IotaMoveValue::Variant(IotaMoveVariant {
-                type_,
+                tag: type_,
                 variant: variant_name.to_string(),
                 fields: fields
                     .into_iter()
@@ -533,7 +533,7 @@ pub struct IotaMoveVariant {
     #[schemars(with = "String")]
     #[serde(rename = "type")]
     #[serde_as(as = "IotaStructTag")]
-    pub type_: StructTag,
+    pub tag: StructTag,
     pub variant: String,
     pub fields: BTreeMap<String, IotaMoveValue>,
 }
@@ -558,12 +558,12 @@ impl Display for IotaMoveVariant {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut writer = String::new();
         let IotaMoveVariant {
-            type_,
+            tag,
             variant,
             fields,
         } = self;
         writeln!(writer)?;
-        writeln!(writer, "  {}: {type_}", "type".bold().bright_black())?;
+        writeln!(writer, "  {}: {tag}", "type".bold().bright_black())?;
         writeln!(writer, "  {}: {variant}", "variant".bold().bright_black())?;
         for (name, value) in fields {
             let value = format!("{value}");

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -401,7 +401,7 @@ impl TryFrom<&IotaObjectData> for GasCoin {
             .ok_or_else(|| anyhow!("Expect object content to not be empty"))?
         {
             IotaParsedData::MoveObject(o) => {
-                if GasCoin::type_() == o.type_ {
+                if GasCoin::type_() == o.tag {
                     return GasCoin::try_from(&o.fields);
                 }
             }
@@ -717,7 +717,7 @@ impl IotaData for IotaRawData {
 
     fn type_(&self) -> Option<&StructTag> {
         match self {
-            Self::MoveObject(o) => Some(&o.type_),
+            Self::MoveObject(o) => Some(&o.tag),
             Self::Package(_) => None,
         }
     }
@@ -794,7 +794,7 @@ impl IotaData for IotaParsedData {
 
     fn type_(&self) -> Option<&StructTag> {
         match self {
-            Self::MoveObject(o) => Some(&o.type_),
+            Self::MoveObject(o) => Some(&o.tag),
             Self::Package(_) => None,
         }
     }
@@ -805,7 +805,7 @@ impl Display for IotaParsedData {
         let mut writer = String::new();
         match self {
             IotaParsedData::MoveObject(o) => {
-                writeln!(writer, "{}: {}", "type".bold().bright_black(), o.type_)?;
+                writeln!(writer, "{}: {}", "type".bold().bright_black(), o.tag)?;
                 write!(writer, "{}", &o.fields)?;
             }
             IotaParsedData::Package(p) => {
@@ -863,7 +863,7 @@ pub struct IotaParsedMoveObject {
     #[serde(rename = "type")]
     #[serde_as(as = "IotaStructTag")]
     #[schemars(with = "String")]
-    pub type_: StructTag,
+    pub tag: StructTag,
     pub fields: IotaMoveStruct,
 }
 
@@ -877,12 +877,12 @@ impl IotaMoveObject for IotaParsedMoveObject {
         Ok(
             if let IotaMoveStruct::WithTypes { type_, fields } = move_struct {
                 IotaParsedMoveObject {
-                    type_,
+                    tag: type_,
                     fields: IotaMoveStruct::WithFields(fields),
                 }
             } else {
                 IotaParsedMoveObject {
-                    type_: object.type_().clone().into(),
+                    tag: object.type_().clone().into(),
                     fields: move_struct,
                 }
             },
@@ -890,7 +890,7 @@ impl IotaMoveObject for IotaParsedMoveObject {
     }
 
     fn type_(&self) -> &StructTag {
-        &self.type_
+        &self.tag
     }
 }
 
@@ -924,7 +924,7 @@ pub fn type_and_fields_from_move_event_data(
                 error: "Found non-type IotaMoveStruct in MoveValue event".to_string(),
             }),
         },
-        IotaMoveValue::Variant(v) => Ok((v.type_.clone(), v.to_json_value())),
+        IotaMoveValue::Variant(v) => Ok((v.tag.clone(), v.to_json_value())),
         IotaMoveValue::Vector(_)
         | IotaMoveValue::Number(_)
         | IotaMoveValue::Bool(_)
@@ -944,7 +944,7 @@ pub struct IotaRawMoveObject {
     #[schemars(with = "String")]
     #[serde(rename = "type")]
     #[serde_as(as = "IotaStructTag")]
-    pub type_: StructTag,
+    pub tag: StructTag,
     pub version: SequenceNumber,
     #[serde_as(as = "Base64")]
     #[schemars(with = "Base64")]
@@ -954,7 +954,7 @@ pub struct IotaRawMoveObject {
 impl From<MoveObject> for IotaRawMoveObject {
     fn from(o: MoveObject) -> Self {
         Self {
-            type_: o.type_().clone().into(),
+            tag: o.type_().clone().into(),
             version: o.version(),
             bcs_bytes: o.into_contents(),
         }
@@ -967,14 +967,14 @@ impl IotaMoveObject for IotaRawMoveObject {
         _layout: MoveStructLayout,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
-            type_: object.type_().clone().into(),
+            tag: object.type_().clone().into(),
             version: object.version(),
             bcs_bytes: object.into_contents(),
         })
     }
 
     fn type_(&self) -> &StructTag {
-        &self.type_
+        &self.tag
     }
 }
 

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -1228,7 +1228,7 @@ impl IotaTransactionBlockEvents {
                 .into_iter()
                 .enumerate()
                 .map(|(seq, event)| {
-                    let layout = resolver.get_annotated_layout(&event.type_)?;
+                    let layout = resolver.get_annotated_layout(&event.tag)?;
                     IotaEvent::try_from(event, tx_digest, seq as u64, timestamp_ms, layout)
                 })
                 .collect::<Result<_, _>>()?,
@@ -1249,7 +1249,7 @@ impl IotaTransactionBlockEvents {
                 .into_iter()
                 .enumerate()
                 .map(|(seq, event)| {
-                    let layout = get_layout_from_struct_tag(event.type_.clone(), resolver)?;
+                    let layout = get_layout_from_struct_tag(event.tag.clone(), resolver)?;
                     IotaEvent::try_from(event, tx_digest, seq as u64, timestamp_ms, layout)
                 })
                 .collect::<Result<_, _>>()?,

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -970,7 +970,7 @@ impl ReadApiServer for ReadApi {
                         .into_iter()
                         .enumerate()
                         .map(|(seq, e)| {
-                            let layout = store.executor().type_layout_resolver(Box::new(&state.get_backing_package_store().as_ref())).get_annotated_layout(&e.type_)?;
+                            let layout = store.executor().type_layout_resolver(Box::new(&state.get_backing_package_store().as_ref())).get_annotated_layout(&e.tag)?;
                             IotaEvent::try_from(e, transaction_digest, seq as u64, None, layout)
                         })
                         .collect::<Result<Vec<_>, _>>()

--- a/crates/iota-light-client/src/main.rs
+++ b/crates/iota-light-client/src/main.rs
@@ -181,7 +181,7 @@ pub async fn main() -> Result<()> {
 
             if let Some(events) = &events {
                 for event in &events.data {
-                    let type_layout = resolver.type_layout(event.type_.clone().into()).await?;
+                    let type_layout = resolver.type_layout(event.tag.clone().into()).await?;
 
                     let result = BoundedVisitor::deserialize_value(&event.contents, &type_layout)
                         .context("Failed to deserialize event")?;
@@ -191,7 +191,7 @@ pub async fn main() -> Result<()> {
                         event.package_id,
                         event.transaction_module,
                         event.sender,
-                        event.type_,
+                        event.tag,
                         serde_json::to_string(&result).expect("JSON deserialization error")
                     );
                 }

--- a/crates/iota-rest-api/src/accounts.rs
+++ b/crates/iota-rest-api/src/accounts.rs
@@ -72,7 +72,7 @@ async fn list_account_objects(
                         owner: info.owner.into(),
                         object_id: info.object_id.into(),
                         version: info.version.into(),
-                        type_: struct_tag_core_to_sdk(info.type_.into())?,
+                        tag: struct_tag_core_to_sdk(info.tag.into())?,
                     }
                     .pipe(Ok)
                 })
@@ -120,5 +120,5 @@ pub struct AccountOwnedObjectInfo {
     #[schemars(with = "crate::_schemars::U64")]
     pub version: Version,
     #[serde(rename = "type")]
-    pub type_: StructTag,
+    pub tag: StructTag,
 }

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -583,7 +583,7 @@ fn select_gas(
         .ok_or_else(RestError::not_found)?
         .account_owned_objects_info_iter(owner, None)?
         .filter_map(|result| result.ok())
-        .filter(|info| info.type_.is_gas_coin())
+        .filter(|info| info.tag.is_gas_coin())
         .filter(|info| !input_objects.contains(&info.object_id))
         .filter_map(|info| {
             reader

--- a/crates/iota-types/src/display.rs
+++ b/crates/iota-types/src/display.rs
@@ -67,7 +67,7 @@ impl DisplayVersionUpdatedEvent {
     }
 
     pub fn try_from_event(event: &Event) -> Option<(&StructTag, Self)> {
-        let inner_type = Self::inner_type(&event.type_)?;
+        let inner_type = Self::inner_type(&event.tag)?;
 
         bcs::from_bytes(&event.contents)
             .ok()

--- a/crates/iota-types/src/event.rs
+++ b/crates/iota-types/src/event.rs
@@ -105,7 +105,8 @@ pub struct Event {
     pub package_id: ObjectID,
     pub transaction_module: Identifier,
     pub sender: IotaAddress,
-    pub type_: StructTag,
+    #[serde(rename = "type_")]
+    pub tag: StructTag,
     #[serde_as(as = "Bytes")]
     pub contents: Vec<u8>,
 }
@@ -115,14 +116,14 @@ impl Event {
         package_id: &AccountAddress,
         module: &IdentStr,
         sender: IotaAddress,
-        type_: StructTag,
+        tag: StructTag,
         contents: Vec<u8>,
     ) -> Self {
         Self {
             package_id: ObjectID::from(*package_id),
             transaction_module: Identifier::from(module),
             sender,
-            type_,
+            tag,
             contents,
         }
     }
@@ -138,15 +139,15 @@ impl Event {
     }
 
     pub fn is_system_epoch_info_event_v1(&self) -> bool {
-        self.type_.address == IOTA_SYSTEM_ADDRESS
-            && self.type_.module.as_ident_str() == ident_str!("iota_system_state_inner")
-            && self.type_.name.as_ident_str() == ident_str!("SystemEpochInfoEventV1")
+        self.tag.address == IOTA_SYSTEM_ADDRESS
+            && self.tag.module.as_ident_str() == ident_str!("iota_system_state_inner")
+            && self.tag.name.as_ident_str() == ident_str!("SystemEpochInfoEventV1")
     }
 
     pub fn is_system_epoch_info_event_v2(&self) -> bool {
-        self.type_.address == IOTA_SYSTEM_ADDRESS
-            && self.type_.module.as_ident_str() == ident_str!("iota_system_state_inner")
-            && self.type_.name.as_ident_str() == ident_str!("SystemEpochInfoEventV2")
+        self.tag.address == IOTA_SYSTEM_ADDRESS
+            && self.tag.module.as_ident_str() == ident_str!("iota_system_state_inner")
+            && self.tag.name.as_ident_str() == ident_str!("SystemEpochInfoEventV2")
     }
 
     pub fn is_system_epoch_info_event(&self) -> bool {
@@ -160,7 +161,7 @@ impl Event {
             package_id: ObjectID::random(),
             transaction_module: Identifier::new("test").unwrap(),
             sender: AccountAddress::random().into(),
-            type_: StructTag {
+            tag: StructTag {
                 address: AccountAddress::random(),
                 module: Identifier::new("test").unwrap(),
                 name: Identifier::new("test").unwrap(),

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -435,7 +435,7 @@ impl TryFrom<crate::transaction::TransactionKind> for TransactionKind {
                         .into_iter()
                         .map(|event| {
                             let module = Identifier::new(event.transaction_module.as_str());
-                            let type_ = struct_tag_core_to_sdk(event.type_);
+                            let type_ = struct_tag_core_to_sdk(event.tag);
 
                             match (module, type_) {
                                 (Ok(module), Ok(type_)) => Ok(Event {
@@ -569,7 +569,7 @@ impl TryFrom<TransactionKind> for crate::transaction::TransactionKind {
                                     package_id: event.package_id.into(),
                                     transaction_module,
                                     sender: event.sender.into(),
-                                    type_,
+                                    tag: type_,
                                     contents: event.contents,
                                 }),
                                 _ => Err(SdkTypeConversionError(
@@ -1865,7 +1865,7 @@ impl TryFrom<crate::event::Event> for Event {
             package_id: value.package_id.into(),
             module: Identifier::new(value.transaction_module.as_str())?,
             sender: value.sender.into(),
-            type_: struct_tag_core_to_sdk(value.type_)?,
+            type_: struct_tag_core_to_sdk(value.tag)?,
             contents: value.contents,
         }
         .pipe(Ok)
@@ -1880,7 +1880,7 @@ impl TryFrom<Event> for crate::event::Event {
             package_id: value.package_id.into(),
             transaction_module: crate::Identifier::new(value.module.as_str())?,
             sender: value.sender.into(),
-            type_: struct_tag_sdk_to_core(&value.type_)?,
+            tag: struct_tag_sdk_to_core(&value.type_)?,
             contents: value.contents,
         }
         .pipe(Ok)

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -882,7 +882,7 @@ pub struct AccountOwnedObjectInfo {
     pub owner: IotaAddress,
     pub object_id: ObjectID,
     pub version: SequenceNumber,
-    pub type_: MoveObjectType,
+    pub tag: MoveObjectType,
 }
 
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -526,8 +526,8 @@ mod checked {
         used_in_non_entry_move_call: bool,
     ) -> Result<Value, ExecutionError> {
         Ok(match value_info {
-            ValueKind::Object { type_, .. } => Value::Object(context.make_object_value(
-                type_,
+            ValueKind::Object { tag, .. } => Value::Object(context.make_object_value(
+                tag,
                 used_in_non_entry_move_call,
                 &bytes,
             )?),
@@ -1230,7 +1230,7 @@ mod checked {
     /// Used to remember type information about a type when resolving the
     /// signature
     enum ValueKind {
-        Object { type_: MoveObjectType },
+        Object { tag: MoveObjectType },
         Raw(Type, AbilitySet),
     }
 
@@ -1425,7 +1425,7 @@ mod checked {
                             invariant_violation!("Struct type make a non struct type tag")
                         };
                         ValueKind::Object {
-                            type_: MoveObjectType::from(*struct_tag),
+                            tag: MoveObjectType::from(*struct_tag),
                         }
                     }
                     Type::Datatype(_)
@@ -1588,8 +1588,8 @@ mod checked {
                         let TypeTag::Struct(struct_tag) = type_tag else {
                             invariant_violation!("Struct type make a non struct type tag")
                         };
-                        let type_ = (*struct_tag).into();
-                        ValueKind::Object { type_ }
+                        let tag = (*struct_tag).into();
+                        ValueKind::Object { tag }
                     } else {
                         let abilities = context
                             .vm


### PR DESCRIPTION
## Description of change

Rename `type_` fields to `tag` on structs where the field holds a `StructTag` or `MoveObjectType`. This improves readability and aligns field names with the semantic meaning — `tag` is the conventional name for struct tags in the Move ecosystem.

### Serialization safety

All renames preserve serialization compatibility:

| Struct | Serialization | Safety mechanism |
|--------|--------------|-----------------|
| `IotaMoveVariant` | JSON | Existing `#[serde(rename = "type")]` |
| `IotaParsedMoveObject` | JSON | Existing `#[serde(rename = "type")]` |
| `IotaRawMoveObject` | JSON | Existing `#[serde(rename = "type")]` |
| `AccountOwnedObjectInfo` (rest-api) | JSON | Existing `#[serde(rename = "type")]` |
| `IotaEvent` | JSON | Added `#[serde(rename = "type")]` (was derived via `rename_all = "camelCase"`) |
| `Event` (iota-types) | BCS | Added `#[serde(rename = "type_")]` for backwards compat |
| `AccountOwnedObjectInfo` (storage) | Internal | No serde, plain struct |
| `ValueKind::Object` (execution) | Internal | Local enum, no serialization |

### Not included (follow-up scope)

These `type_` fields were intentionally left for a follow-up:

- **`OwnerIndexInfo`** in `rest_index.rs` — serialized to persistent storage (RocksDB), renaming would require a data migration
- **`external-crates/move/` structs** (`MoveStruct`, `MoveVariant`, `MoveStructLayout`, `MoveEnumLayout`) — upstream Move types; additionally `MoveVariant` already has a `tag: u16` field which would cause a name conflict
- **Fields with non-StructTag types** (`TypeTag`, `String`, `IotaMoveNormalizedType`) — semantically `tag` only fits `StructTag`/`MoveObjectType`

## Links to any relevant issues

Fixes #10859

## How the change has been tested

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes  
- [x] `cargo +nightly fmt -- --check` passes
- [x] Verified all `#[serde(rename)]` attributes preserve JSON/BCS output

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: