### PR TITLE
chore: add enum name to unimplemented!() match fallbacks

### DIFF
--- a/crates/iota-graphql-rpc/src/types/system_state_summary.rs
+++ b/crates/iota-graphql-rpc/src/types/system_state_summary.rs
@@ -169,7 +169,7 @@ impl From<NativeSystemStateSummary> for NativeStateValidatorInfo {
                 inner.validator_candidates_id,
                 inner.validator_candidates_size,
             ),
-            _ => unimplemented!(),
+            _ => unimplemented!("a new IotaSystemStateSummary variant was added and needs to be handled"),
         };
         Self {
             active_validators,

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -63,7 +63,7 @@ async fn execute_add_validator_transactions(
         match system_state {
             IotaSystemStateSummary::V1(inner) => inner.validator_candidates_size,
             IotaSystemStateSummary::V2(inner) => inner.validator_candidates_size,
-            _ => unimplemented!(),
+            _ => unimplemented!("a new IotaSystemStateSummary variant was added and needs to be handled"),
         }
     });
     let address = (&new_validator.account_key_pair.public()).into();
@@ -92,7 +92,7 @@ async fn execute_add_validator_transactions(
         let validator_candidates_size = match system_state {
             IotaSystemStateSummary::V1(inner) => inner.validator_candidates_size,
             IotaSystemStateSummary::V2(inner) => inner.validator_candidates_size,
-            _ => unimplemented!(),
+            _ => unimplemented!("a new IotaSystemStateSummary variant was added and needs to be handled"),
         };
         assert_eq!(validator_candidates_size, cur_validator_candidate_count + 1);
     });

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -254,7 +254,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         let active_validators = match system_state_summary {
             IotaSystemStateSummary::V1(inner) => inner.active_validators,
             IotaSystemStateSummary::V2(inner) => inner.active_validators,
-            _ => unimplemented!(),
+            _ => unimplemented!("a new IotaSystemStateSummary variant was added and needs to be handled"),
         };
 
         Ok(active_validators


### PR DESCRIPTION
## Description of change

Add descriptive messages to all bare `unimplemented!()` calls in wildcard match arms. This makes it easier to find and update the match when a new enum variant is added.

**Before:**
```rust
_ => unimplemented!(),
```

**After:**
```rust
_ => unimplemented!("a new IotaSystemStateSummary variant was added and needs to be handled"),
```

All 4 occurrences matched on `IotaSystemStateSummary` / `NativeSystemStateSummary`:
- `crates/iota-graphql-rpc/src/types/system_state_summary.rs`
- `crates/iota-json-rpc-tests/tests/governance_api.rs` (2 occurrences)
- `crates/iota-transactional-test-runner/src/lib.rs`

Note: The two existing `unimplemented!()` calls in `messages_checkpoint.rs` already had descriptive messages and were left unchanged.

## Links to any relevant issues

Fixes #10402

## How the change has been tested

- [x] `cargo check` passes
- [x] `cargo +nightly fmt -- --check` passes
- [x] No behavior change — only panic messages updated
