### PR TITLE
fix(graphql): port upstream test-runner header ordering and abort code

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -4599,6 +4599,11 @@ type TransactionBlockEffects {
 	"""
 	errors: String
 	"""
+	The error code of the Move abort, populated if this transaction failed with a
+	Move abort.
+	"""
+	abortCode: BigInt
+	"""
 	Transactions whose outputs this transaction depends upon.
 	"""
 	dependencies(first: Int, after: String, last: Int, before: String): DependencyConnection!

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -11,7 +11,9 @@ use iota_json_rpc_types::IotaExecutionStatus;
 use iota_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
     event::Event as NativeEvent,
-    execution_status::ExecutionStatus as NativeExecutionStatus,
+    execution_status::{
+        ExecutionFailureStatus, ExecutionStatus as NativeExecutionStatus,
+    },
     transaction::TransactionData as NativeTransactionData,
 };
 
@@ -134,6 +136,30 @@ impl TransactionBlockEffects {
         match status {
             IotaExecutionStatus::Success => Ok(None),
             IotaExecutionStatus::Failure { error } => Ok(Some(error)),
+        }
+    }
+
+    /// The error code of the Move abort, populated if this transaction failed
+    /// with a Move abort.
+    #[graphql(complexity = 0)]
+    async fn abort_code(&self, ctx: &Context<'_>) -> Result<Option<u64>> {
+        let NativeExecutionStatus::Failure { error, command: Some(_) } = self.native().status()
+        else {
+            return Ok(None);
+        };
+
+        let ExecutionFailureStatus::MoveAbort(loc, code) = error else {
+            return Ok(None);
+        };
+
+        let resolver: &PackageResolver = ctx.data_unchecked();
+        let clever = resolver
+            .resolve_clever_error(loc.module.clone(), *code)
+            .await;
+
+        match clever.and_then(|c| c.error_code) {
+            Some(error_code) => Ok(Some(error_code as u64)),
+            None => Ok(Some(*code)),
         }
     }
 

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -4604,6 +4604,11 @@ type TransactionBlockEffects {
 	"""
 	errors: String
 	"""
+	The error code of the Move abort, populated if this transaction failed with a
+	Move abort.
+	"""
+	abortCode: BigInt
+	"""
 	Transactions whose outputs this transaction depends upon.
 	"""
 	dependencies(first: Int, after: String, last: Int, before: String): DependencyConnection!

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -1514,6 +1514,7 @@ impl IotaExecutionStatus {
                         module_id,
                         source_line_number,
                         error_info,
+                        error_code: _,
                     }) = resolver
                         .resolve_clever_error(loc.module.clone(), *code)
                         .await

--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -119,6 +119,8 @@ pub struct CleverError {
     pub error_info: ErrorConstants,
     /// The line number in the source file where the error occurred.
     pub source_line_number: u16,
+    /// The error code (from `#[error(code = N)]`), if present.
+    pub error_code: Option<u8>,
 }
 
 /// The `ErrorConstants` enum is used to represent the different kinds of error
@@ -639,11 +641,14 @@ impl<S: PackageStore> Resolver<S> {
         let source_line_number = bitset.line_number()?;
 
         // We only have a line number in our clever error, so return early.
+        let error_code = bitset.error_code();
+
         if bitset.identifier_index().is_none() && bitset.constant_index().is_none() {
             return Some(CleverError {
                 module_id,
                 error_info: ErrorConstants::None,
                 source_line_number,
+                error_code,
             });
         } else if bitset.identifier_index().is_none() || bitset.constant_index().is_none() {
             return None;
@@ -683,6 +688,7 @@ impl<S: PackageStore> Resolver<S> {
             module_id,
             error_info,
             source_line_number,
+            error_code,
         })
     }
 }

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -674,7 +674,16 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
 
                 let mut output = vec![];
                 if show_headers {
-                    output.push(format!("Headers: {:#?}", resp.http_headers.unwrap()));
+                    let headers_map: BTreeMap<_, _> = resp
+                        .http_headers
+                        .as_ref()
+                        .unwrap()
+                        .iter()
+                        .map(|(name, value)| {
+                            (name.to_string(), value.to_str().unwrap_or("").to_string())
+                        })
+                        .collect();
+                    output.push(format!("Headers: {headers_map:#?}"));
                 }
                 if show_service_version {
                     output.push(format!(


### PR DESCRIPTION
## Description of change

Port two upstream changes from Sui:

### 1. Fix header map ordering in transactional-test-runner
(upstream: MystenLabs/sui#21939)

Collect HTTP headers into a `BTreeMap` before formatting to ensure deterministic alphabetical ordering in test snapshots. Previously, header order was non-deterministic which could cause flaky test failures.

### 2. Add `abortCode` to GraphQL `TransactionBlockEffects`
(upstream: MystenLabs/sui#21941)

- Add `error_code: Option<u8>` field to `CleverError` struct, propagated from `ErrorBitset::error_code()`
- Add `abortCode: BigInt` field to the GraphQL `TransactionBlockEffects` type
- The resolver extracts the Move abort code: if a clever error with `#[error(code = N)]` exists, it returns that code; otherwise falls back to the raw abort code
- Returns `None` for non-abort failures

## Links to any relevant issues

Fixes #10835

## How the change has been tested

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes (affected crates)
- [x] `cargo +nightly fmt -- --check` passes
- [x] Schema snapshot updated to match

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [x] GraphQL: Added `abortCode` field to `TransactionBlockEffects`
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: