### PR TITLE
fix(graphql-e2e-tests): Propagate pg_integration feature to iota-indexer for e2e tests

### DIFF
--- a/crates/iota-graphql-e2e-tests/Cargo.toml
+++ b/crates/iota-graphql-e2e-tests/Cargo.toml
@@ -29,7 +29,7 @@ harness = false
 
 [features]
 default = ["pg_backend"]
-pg_integration = []
+pg_integration = ["iota-graphql-rpc/pg_integration"]
 pg_backend = []
 
 [target.'cfg(msim)'.dependencies]

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -91,7 +91,7 @@ iota-test-transaction-builder.workspace = true
 simulacrum.workspace = true
 
 [features]
-pg_integration = []
+pg_integration = ["iota-indexer/pg_integration"]
 
 [package.metadata.cargo-udeps.ignore]
 development = ["serial_test", "simulacrum"]


### PR DESCRIPTION
# Description of change

Forwards the `pg_integration` feature flag through the dependency chain (`iota-graphql-e2e-tests` → `iota-graphql-rpc` → `iota-indexer`) so that test-specific constants like the 1-second pruning delay are used in e2e tests instead of the 2-hour production value.

Fixes the `prune/prune.move` e2e test timeout.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/10879

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
