### PR TITLE
chore(ts-sdk): Bring back sdk type header in the client

### DIFF
--- a/.changeset/moody-suits-cheer.md
+++ b/.changeset/moody-suits-cheer.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': patch
+---
+
+Bring back the sdk type header in the ts-sdk http transport client

--- a/sdk/typescript/src/client/http-transport.ts
+++ b/sdk/typescript/src/client/http-transport.ts
@@ -108,6 +108,7 @@ export class IotaHTTPTransport implements IotaTransport {
                 signal: input.signal,
                 headers: {
                     'Content-Type': 'application/json',
+                    'Client-Sdk-Type': 'typescript',
                     ...this.#options.rpc?.headers,
                 },
                 body: JSON.stringify({

--- a/sdk/typescript/test/unit/client/http-transport.test.ts
+++ b/sdk/typescript/test/unit/client/http-transport.test.ts
@@ -59,6 +59,7 @@ describe('IotaHTTPTransport', () => {
                 }),
                 headers: {
                     'Content-Type': 'application/json',
+                    'Client-Sdk-Type': 'typescript',
                 },
                 method: 'POST',
             });


### PR DESCRIPTION
Kinda reverts https://github.com/iotaledger/iota/pull/10673