### PR TITLE
upstream(core): Cleanup of typed store macros crate

### DIFF
--- a/crates/iota-analytics-indexer/src/package_store.rs
+++ b/crates/iota-analytics-indexer/src/package_store.rs
@@ -15,7 +15,6 @@ use thiserror::Error;
 use typed_store::{
     DBMapUtils, Map, TypedStoreError,
     rocks::{DBMap, MetricConf},
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 const STORE: &str = "RocksDB";

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -82,7 +82,6 @@ use typed_store::{
         read_size_from_env,
     },
     rocksdb::Options,
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 use super::{

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -911,7 +911,7 @@ mod tests {
     use tracing::info;
     use typed_store::{
         Map,
-        rocks::{DBMap, MetricConf, ReadWriteOptions},
+        rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options},
     };
 
     use super::AuthorityStorePruner;
@@ -924,8 +924,11 @@ mod tests {
     fn get_keys_after_pruning(path: &Path) -> anyhow::Result<HashSet<ObjectKey>> {
         let perpetual_db_path = path.join(Path::new("perpetual"));
         let cf_names = AuthorityPerpetualTables::describe_tables();
-        let cfs: Vec<&str> = cf_names.keys().map(|x| x.as_str()).collect();
-        let perpetual_db = typed_store::rocks::open_cf(
+        let cfs: Vec<_> = cf_names
+            .keys()
+            .map(|x| (x.as_str(), default_db_options().options))
+            .collect();
+        let perpetual_db = typed_store::rocks::open_cf_opts(
             perpetual_db_path,
             None,
             MetricConf::new("perpetual_pruning"),

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -21,7 +21,7 @@ use typed_store::{
         read_size_from_env,
     },
     rocksdb::compaction_filter::Decision,
-    traits::{Map, TableSummary, TypedStoreDebug},
+    traits::Map,
 };
 
 use super::*;

--- a/crates/iota-core/src/authority/transaction_deferral.rs
+++ b/crates/iota-core/src/authority/transaction_deferral.rs
@@ -108,7 +108,6 @@ mod object_cost_tests {
     use typed_store::{
         DBMapUtils, Map,
         rocks::{DBMap, MetricConf},
-        traits::{TableSummary, TypedStoreDebug},
     };
 
     use super::*;

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -61,7 +61,6 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::{
     DBMapUtils, Map, TypedStoreError,
     rocks::{DBMap, MetricConf},
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 pub use crate::checkpoints::{

--- a/crates/iota-core/src/epoch/committee_store.rs
+++ b/crates/iota-core/src/epoch/committee_store.rs
@@ -19,7 +19,6 @@ use typed_store::{
     DBMapUtils, Map,
     rocks::{DBMap, DBOptions, MetricConf, default_db_options},
     rocksdb::Options,
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 pub struct CommitteeStore {

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -49,7 +49,7 @@ use typed_store::{
         read_size_from_env,
     },
     rocksdb::compaction_filter::Decision,
-    traits::{Map, TableSummary, TypedStoreDebug},
+    traits::Map,
 };
 
 type OwnedMutexGuard<T> = ArcMutexGuard<parking_lot::RawMutex, T>;

--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -32,7 +32,7 @@ use tracing::{debug, info};
 use typed_store::{
     DBMapUtils, TypedStoreError,
     rocks::{DBMap, MetricConf},
-    traits::{Map, TableSummary, TypedStoreDebug},
+    traits::Map,
 };
 
 use crate::{

--- a/crates/iota-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/iota-faucet/src/faucet/write_ahead_log.rs
@@ -10,11 +10,7 @@ use iota_types::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::info;
-use typed_store::{
-    DBMapUtils, Map, TypedStoreError,
-    rocks::DBMap,
-    traits::{TableSummary, TypedStoreDebug},
-};
+use typed_store::{DBMapUtils, Map, TypedStoreError, rocks::DBMap};
 use uuid::Uuid;
 
 /// Persistent log of transactions paying out iota from the faucet, keyed by the

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -319,7 +319,7 @@ mod tests {
     use tempfile::TempDir;
     use typed_store::{
         Map, reopen,
-        rocks::{DBMap, MetricConf, ReadWriteOptions, open_cf},
+        rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options, open_cf_opts},
     };
 
     use crate::hard_link;
@@ -335,11 +335,14 @@ mod tests {
         const FIRST_CF: &str = "First_CF";
         const SECOND_CF: &str = "Second_CF";
 
-        let db_a = open_cf(
+        let db_a = open_cf_opts(
             input_path,
             None,
             MetricConf::new("test_db_hard_link_1"),
-            &[FIRST_CF, SECOND_CF],
+            &[
+                (FIRST_CF, default_db_options().options),
+                (SECOND_CF, default_db_options().options),
+            ],
         )
         .unwrap();
 
@@ -353,11 +356,14 @@ mod tests {
 
         // set up db hard link
         hard_link(input_path, output_path)?;
-        let db_b = open_cf(
+        let db_b = open_cf_opts(
             output_path,
             None,
             MetricConf::new("test_db_hard_link_2"),
-            &[FIRST_CF, SECOND_CF],
+            &[
+                (FIRST_CF, default_db_options().options),
+                (SECOND_CF, default_db_options().options),
+            ],
         )
         .unwrap();
 

--- a/crates/iota-storage/src/write_path_pending_tx_log.rs
+++ b/crates/iota-storage/src/write_path_pending_tx_log.rs
@@ -22,7 +22,7 @@ use tracing::instrument;
 use typed_store::{
     DBMapUtils,
     rocks::{DBMap, MetricConf},
-    traits::{Map, TableSummary, TypedStoreDebug},
+    traits::Map,
 };
 
 use crate::mutex_table::MutexTable;

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -34,7 +34,6 @@ use typed_store::{
     DBMapUtils, Map,
     metrics::SamplingInterval,
     rocks::{DBMap, MetricConf},
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 use super::SimulatorStore;

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -311,9 +311,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
         "std::fmt::Debug + serde::Serialize + for<'de> serde::de::Deserialize<'de>";
     let generics_bounds_token: proc_macro2::TokenStream = generics_bounds.parse().unwrap();
 
-    let config_struct_name_str = format!("{name}Configurator");
-    let config_struct_name: proc_macro2::TokenStream = config_struct_name_str.parse().unwrap();
-
     let intermediate_db_map_struct_name_str = format!("{name}IntermediateDBMapStructPrimary");
     let intermediate_db_map_struct_name: proc_macro2::TokenStream =
         intermediate_db_map_struct_name_str.parse().unwrap();
@@ -345,47 +342,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
 
-        // <----------- This section generates the configurator struct -------------->
-
-        /// Create config structs for configuring DBMap tables.
-        /// Only active (non-deprecated) tables are configurable.
-        pub struct #config_struct_name {
-            #(
-                pub #active_field_names : typed_store::rocks::DBOptions,
-            )*
-        }
-
-        impl #config_struct_name {
-            /// Initialize to defaults
-            pub fn init() -> Self {
-                Self {
-                    #(
-                        #active_field_names : typed_store::rocks::default_db_options(),
-                    )*
-                }
-            }
-
-            /// Build a config
-            pub fn build(&self) -> typed_store::rocks::DBMapTableConfigMap {
-                typed_store::rocks::DBMapTableConfigMap::new([
-                    #(
-                        (stringify!(#active_field_names).to_owned(), self.#active_field_names.clone()),
-                    )*
-                ].into_iter().collect())
-            }
-        }
-
-        impl <
-                #(
-                    #generics_names: #generics_bounds_token,
-                )*
-            > #name #generics {
-
-                pub fn configurator() -> #config_struct_name {
-                    #config_struct_name::init()
-                }
-        }
-
         // <----------- This section generates the core open logic for opening DBMaps -------------->
 
         /// Create an intermediate struct used to open the DBMap tables in primary mode
@@ -398,7 +354,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     pub #deprecated_field_names : Option<DBMap #deprecated_inner_types>,
                 )*
         }
-
 
         impl <
                 #(
@@ -619,23 +574,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 }
             }
 
-            /// Count the keys in this table
-            /// Tables must be opened in read only mode using `open_tables_read_only`
-            pub fn count_keys(&self, table_name: &str) -> eyre::Result<usize> {
-                Ok(match table_name {
-                    #(
-                        stringify!(#active_field_names) => {
-                            typed_store::traits::Map::try_catch_up_with_primary(&self.#active_field_names)?;
-                            typed_store::traits::Map::safe_iter(&self.#active_field_names)
-                                .collect::<Result<Vec<_>, _>>()?
-                                .len()
-                        }
-                    )*
-
-                    _ => eyre::bail!("No such table name: {}", table_name),
-                })
-            }
-
             pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
                 vec![#(
                     (stringify!(#active_field_names).to_owned(), (stringify!(#active_key_names).to_owned(), stringify!(#active_value_names).to_owned())),
@@ -650,37 +588,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 )*
                 Ok(())
             }
-        }
-
-        impl <
-                #(
-                    #generics_names: #generics_bounds_token,
-                )*
-            > TypedStoreDebug for #secondary_db_map_struct_name #generics {
-                fn dump_table(
-                    &self,
-                    table_name: String,
-                    page_size: u16,
-                    page_number: usize,
-                ) -> eyre::Result<std::collections::BTreeMap<String, String>> {
-                    self.dump(table_name.as_str(), page_size, page_number)
-                }
-
-                fn primary_db_name(&self) -> String {
-                    stringify!(#name).to_owned()
-                }
-
-                fn describe_all_tables(&self) -> std::collections::BTreeMap<String, (String, String)> {
-                    Self::describe_tables()
-                }
-
-                fn count_table_keys(&self, table_name: String) -> eyre::Result<usize> {
-                    self.count_keys(table_name.as_str())
-                }
-
-                fn table_summary(&self, table_name: String) -> eyre::Result<TableSummary> {
-                    self.table_summary(table_name.as_str())
-                }
         }
     })
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -25,6 +25,7 @@ use crate::{
     rocks::{
         RocksDB,
         errors::{typed_store_err_from_bcs_err, typed_store_err_from_rocks_err},
+        options::ReadWriteOptions,
         rocks_cf, rocks_util,
         safe_iter::{SafeIter, SafeRevIter},
     },
@@ -504,42 +505,6 @@ impl<K, V> DBMap<K, V> {
     /// Reopens an open database as a typed map operating under a specific
     /// column family. if no column family is passed, the default column
     /// family is used.
-    ///
-    /// ```
-    /// use core::fmt::Error;
-    /// use std::sync::Arc;
-    ///
-    /// use prometheus::Registry;
-    /// use tempfile::tempdir;
-    /// use typed_store::{metrics::DBMetrics, rocks::*};
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Error> {
-    ///     /// Open the DB with all needed column families first.
-    ///     let rocks = open_cf(
-    ///         tempdir().unwrap(),
-    ///         None,
-    ///         MetricConf::default(),
-    ///         &["First_CF", "Second_CF"],
-    ///     )
-    ///     .unwrap();
-    ///     /// Attach the column families to specific maps.
-    ///     let db_cf_1 = DBMap::<u32, u32>::reopen(
-    ///         &rocks,
-    ///         Some("First_CF"),
-    ///         &ReadWriteOptions::default(),
-    ///         false,
-    ///     )
-    ///     .expect("Failed to open storage");
-    ///     let db_cf_2 = DBMap::<u32, u32>::reopen(
-    ///         &rocks,
-    ///         Some("Second_CF"),
-    ///         &ReadWriteOptions::default(),
-    ///         false,
-    ///     )
-    ///     .expect("Failed to open storage");
-    ///     Ok(())
-    /// }
-    /// ```
     #[instrument(level = "debug", skip(db), err)]
     pub fn reopen(
         db: &Arc<Database>,
@@ -793,11 +758,14 @@ impl<K, V> DBMap<K, V> {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Error> {
-///     let rocks = open_cf(
+///     let rocks = open_cf_opts(
 ///         tempfile::tempdir().unwrap(),
 ///         None,
 ///         MetricConf::default(),
-///         &["First_CF", "Second_CF"],
+///         &[
+///             ("First_CF", rocksdb::Options::default()),
+///             ("Second_CF", rocksdb::Options::default()),
+///         ],
 ///     )
 ///     .unwrap();
 ///
@@ -1328,31 +1296,5 @@ where
     #[instrument(level = "trace", skip_all, err)]
     fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
         self.db.try_catch_up_with_primary()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ReadWriteOptions {
-    pub ignore_range_deletions: bool,
-}
-
-impl ReadWriteOptions {
-    pub fn readopts(&self) -> ReadOptions {
-        let mut readopts = ReadOptions::default();
-        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
-        readopts
-    }
-
-    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
-        self.ignore_range_deletions = ignore;
-        self
-    }
-}
-
-impl Default for ReadWriteOptions {
-    fn default() -> Self {
-        Self {
-            ignore_range_deletions: true,
-        }
     }
 }

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -30,8 +30,7 @@ pub type StoreError = typed_store_error::TypedStoreError;
 
 /// A helper macro to simplify common operations for opening and debugging
 /// TypedStore (currently internally structs of DBMaps) It operates on a struct
-/// where all the members are of Store<K, V> or DBMap<K, V> `TypedStoreDebug`
-/// traits are then derived The main features are:
+/// where all the members are DBMap<K, V> The main features are:
 /// 1. Flexible configuration of each table (column family) via defaults and
 ///    overrides
 /// 2. Auto-generated `open` routine
@@ -52,7 +51,6 @@ pub type StoreError = typed_store_error::TypedStoreError;
 /// use typed_store::{
 ///     DBMapUtils,
 ///     rocks::{DBMap, DBOptions, MetricConf},
-///     traits::{TableSummary, TypedStoreDebug},
 /// };
 /// /// Define a struct with all members having type DBMap<K, V>
 ///
@@ -76,38 +74,6 @@ pub type StoreError = typed_store_error::TypedStoreError;
 ///     #[default_options_override_fn = "custom_fn_name1"]
 ///     table4: DBMap<i32, String>,
 /// }
-///
-/// // b. Options specified by DB opener
-/// // For finer control, we also allow the opener of the DB to specify their
-/// // own options which override the defaults set by the definer
-/// // This is done via a configurator which gives one a struct with field
-/// // similarly named as that of the DB, but of type Options
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Error> {
-///     // Get a configurator for this table
-///     let mut config = Tables::configurator();
-///     // Config table 1
-///     config.table1 = DBOptions::default();
-///     config.table1.options.create_if_missing(true);
-///     config.table1.options.set_write_buffer_size(123456);
-///
-///     let primary_path = tempfile::tempdir()
-///         .expect(
-///             "Failed to open temporary
-/// directory",
-///         )
-///         .keep();
-///
-///     // We can then open the DB with the configs
-///     let _ = Tables::open_tables_read_write(
-///         primary_path,
-///         MetricConf::default(),
-///         None,
-///         Some(config.build()),
-///     );
-///     Ok(())
-/// }
 /// ```
 ///
 /// 2. Auto-generated `open` routine The function `open_tables_read_write` is
@@ -126,7 +92,6 @@ pub type StoreError = typed_store_error::TypedStoreError;
 /// use typed_store::{
 ///     DBMapUtils,
 ///     rocks::{DBMap, DBOptions},
-///     traits::{TableSummary, TypedStoreDebug},
 /// };
 /// /// Define a struct with all members having type DBMap<K, V>
 ///
@@ -168,7 +133,6 @@ pub type StoreError = typed_store_error::TypedStoreError;
 ///         Tables::get_read_only_handle(primary_path, None, None, MetricConf::default());
 ///     // Use this handle for dumping
 ///     let ret = read_only_handle.dump("table2", 100, 0).unwrap();
-///     let key_count = read_only_handle.count_keys("table1").unwrap();
 ///     Ok(())
 /// }
 /// ```

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod errors;
+pub(crate) mod options;
 pub(crate) mod rocks_util;
 pub(crate) mod safe_iter;
 
 use std::{
-    collections::{BTreeMap, HashSet},
-    env,
+    collections::HashSet,
     ffi::CStr,
     path::{Path, PathBuf},
     sync::Arc,
@@ -16,49 +16,26 @@ use std::{
 };
 
 use backoff::backoff::Backoff;
-use bincode::Options;
 use iota_macros::nondeterministic;
 use rocksdb::{
-    AsColumnFamilyRef, BlockBasedOptions, Cache, ColumnFamilyDescriptor, Error, MultiThreaded,
-    properties, properties::num_files_at_level,
+    AsColumnFamilyRef, ColumnFamilyDescriptor, Error, MultiThreaded, properties,
+    properties::num_files_at_level,
 };
-use tap::TapFallible;
-use tracing::{info, instrument, warn};
+use tracing::warn;
 use typed_store_error::TypedStoreError;
 
-pub use crate::database::{DBBatch, DBMap, MetricConf, ReadWriteOptions};
+pub use crate::{
+    database::{DBBatch, DBMap, MetricConf},
+    rocks::options::{
+        DBMapTableConfigMap, DBOptions, ReadWriteOptions, default_db_options, list_tables,
+        read_size_from_env,
+    },
+};
 use crate::{
     database::{Database, Storage},
     metrics::DBMetrics,
-    rocks::errors::{typed_store_err_from_bincode_err, typed_store_err_from_rocks_err},
+    rocks::errors::typed_store_err_from_rocks_err,
 };
-
-// Write buffer size per RocksDB instance can be set via the env var below.
-// If the env var is not set, use the default value in MiB.
-const ENV_VAR_DB_WRITE_BUFFER_SIZE: &str = "DB_WRITE_BUFFER_SIZE_MB";
-const DEFAULT_DB_WRITE_BUFFER_SIZE: usize = 1024;
-
-// Write ahead log size per RocksDB instance can be set via the env var below.
-// If the env var is not set, use the default value in MiB.
-const ENV_VAR_DB_WAL_SIZE: &str = "DB_WAL_SIZE_MB";
-const DEFAULT_DB_WAL_SIZE: usize = 1024;
-
-// Environment variable to control behavior of write throughput optimized
-// tables.
-const ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER: &str = "L0_NUM_FILES_COMPACTION_TRIGGER";
-const DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 4;
-const DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 80;
-const ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB: &str = "MAX_WRITE_BUFFER_SIZE_MB";
-const DEFAULT_MAX_WRITE_BUFFER_SIZE_MB: usize = 256;
-const ENV_VAR_MAX_WRITE_BUFFER_NUMBER: &str = "MAX_WRITE_BUFFER_NUMBER";
-const DEFAULT_MAX_WRITE_BUFFER_NUMBER: usize = 6;
-const ENV_VAR_TARGET_FILE_SIZE_BASE_MB: &str = "TARGET_FILE_SIZE_BASE_MB";
-const DEFAULT_TARGET_FILE_SIZE_BASE_MB: usize = 128;
-
-// Set to 1 to disable blob storage for transactions and effects.
-const ENV_VAR_DISABLE_BLOB_STORAGE: &str = "DISABLE_BLOB_STORAGE";
-
-const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
 
 // TODO: remove this after Rust rocksdb has the TOTAL_BLOB_FILES_SIZE property
 // built-in. From https://github.com/facebook/rocksdb/blob/bd80433c73691031ba7baa65c16c63a83aef201a/include/rocksdb/db.h#L1169
@@ -72,43 +49,7 @@ const DB_CORRUPTED_KEY: &[u8] = b"db_corrupted";
 #[cfg(test)]
 mod tests;
 
-/// A helper macro to reopen multiple column families. The macro returns
-/// a tuple of DBMap structs in the same order that the column families
-/// are defined.
-///
-/// # Arguments
-///
-/// * `db` - a reference to a rocks DB object
-/// * `cf;<ty,ty>` - a comma separated list of column families to open. For each
-///   column family a concatenation of column family name (cf) and Key-Value
-///   <ty, ty> should be provided.
-///
-/// # Examples
-///
-/// We successfully open two different column families.
-/// ```
-/// use typed_store::reopen;
-/// use typed_store::rocks::*;
-/// use tempfile::tempdir;
-/// use prometheus::Registry;
-/// use std::sync::Arc;
-/// use typed_store::metrics::DBMetrics;
-/// use core::fmt::Error;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Error> {
-/// const FIRST_CF: &str = "First_CF";
-/// const SECOND_CF: &str = "Second_CF";
-///
-///
-/// /// Create the rocks database reference for the desired column families
-/// let rocks = open_cf(tempdir().unwrap(), None, MetricConf::default(), &[FIRST_CF, SECOND_CF]).unwrap();
-///
-/// /// Now simply open all the column families for their expected Key-Value types
-/// let (db_map_1, db_map_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-/// Ok(())
-/// }
-/// ```
+// TODO: deprecate macros use
 #[macro_export]
 macro_rules! reopen {
     ( $db:expr, $($cf:expr;<$K:ty, $V:ty>),*) => {
@@ -166,319 +107,6 @@ pub fn unmark_db_corruption(path: &Path) -> Result<(), Error> {
     rocksdb::DB::open_default(path)?.put(DB_CORRUPTED_KEY, [0])
 }
 
-pub fn read_size_from_env(var_name: &str) -> Option<usize> {
-    env::var(var_name)
-        .ok()?
-        .parse::<usize>()
-        .tap_err(|e| {
-            warn!(
-                "Env var {} does not contain valid usize integer: {}",
-                var_name, e
-            )
-        })
-        .ok()
-}
-
-// TODO: refactor this into a builder pattern, where rocksdb::Options are
-// generated after a call to build().
-#[derive(Default, Clone)]
-pub struct DBOptions {
-    pub options: rocksdb::Options,
-    pub rw_options: ReadWriteOptions,
-}
-
-impl DBOptions {
-    // Optimize lookup perf for tables where no scans are performed.
-    // If non-trivial number of values can be > 512B in size, it is beneficial to
-    // also specify optimize_for_large_values_no_scan().
-    pub fn optimize_for_point_lookup(mut self, block_cache_size_mb: usize) -> DBOptions {
-        // NOTE: this overwrites the block options.
-        self.options
-            .optimize_for_point_lookup(block_cache_size_mb as u64);
-        self
-    }
-
-    // Optimize write and lookup perf for tables which are rarely scanned, and have
-    // large values. https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html
-    pub fn optimize_for_large_values_no_scan(mut self, min_blob_size: u64) -> DBOptions {
-        if env::var(ENV_VAR_DISABLE_BLOB_STORAGE).is_ok() {
-            info!("Large value blob storage optimization is disabled via env var.");
-            return self;
-        }
-
-        // Blob settings.
-        self.options.set_enable_blob_files(true);
-        self.options
-            .set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
-        self.options.set_enable_blob_gc(true);
-        // Since each blob can have non-trivial size overhead, and compression does not
-        // work across blobs, set a min blob size in bytes to so small
-        // transactions and effects are kept in sst files.
-        self.options.set_min_blob_size(min_blob_size);
-
-        // Increase write buffer size to 256MiB.
-        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
-            * 1024
-            * 1024;
-        self.options.set_write_buffer_size(write_buffer_size);
-        // Since large blobs are not in sst files, reduce the target file size and base
-        // level target size.
-        let target_file_size_base = 64 << 20;
-        self.options
-            .set_target_file_size_base(target_file_size_base);
-        // Level 1 default to 64MiB * 4 ~ 256MiB.
-        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
-            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
-        self.options
-            .set_max_bytes_for_level_base(target_file_size_base * max_level_zero_file_num as u64);
-
-        self
-    }
-
-    // Optimize tables with a mix of lookup and scan workloads.
-    pub fn optimize_for_read(mut self, block_cache_size_mb: usize) -> DBOptions {
-        self.options
-            .set_block_based_table_factory(&get_block_options(block_cache_size_mb, 16 << 10));
-        self
-    }
-
-    // Optimize DB receiving significant insertions.
-    pub fn optimize_db_for_write_throughput(mut self, db_max_write_buffer_gb: u64) -> DBOptions {
-        self.options
-            .set_db_write_buffer_size(db_max_write_buffer_gb as usize * 1024 * 1024 * 1024);
-        self.options
-            .set_max_total_wal_size(db_max_write_buffer_gb * 1024 * 1024 * 1024);
-        self
-    }
-
-    // Optimize tables receiving significant insertions.
-    pub fn optimize_for_write_throughput(mut self) -> DBOptions {
-        // Increase write buffer size to 256MiB.
-        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
-            * 1024
-            * 1024;
-        self.options.set_write_buffer_size(write_buffer_size);
-        // Increase write buffers to keep to 6 before slowing down writes.
-        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
-        self.options
-            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
-        // Keep 1 write buffer so recent writes can be read from memory.
-        self.options
-            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
-
-        // Increase compaction trigger for level 0 to 6.
-        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
-            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
-        self.options.set_level_zero_file_num_compaction_trigger(
-            max_level_zero_file_num.try_into().unwrap(),
-        );
-        self.options.set_level_zero_slowdown_writes_trigger(
-            (max_level_zero_file_num * 12).try_into().unwrap(),
-        );
-        self.options
-            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
-
-        // Increase sst file size to 128MiB.
-        self.options.set_target_file_size_base(
-            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
-                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
-                * 1024
-                * 1024,
-        );
-
-        // Increase level 1 target size to 256MiB * 6 ~ 1.5GiB.
-        self.options
-            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
-
-        self
-    }
-
-    // Optimize tables receiving significant insertions, without any deletions.
-    // TODO: merge this function with optimize_for_write_throughput(), and use a
-    // flag to indicate if deletion is received.
-    pub fn optimize_for_write_throughput_no_deletion(mut self) -> DBOptions {
-        // Increase write buffer size to 256MiB.
-        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
-            * 1024
-            * 1024;
-        self.options.set_write_buffer_size(write_buffer_size);
-        // Increase write buffers to keep to 6 before slowing down writes.
-        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
-        self.options
-            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
-        // Keep 1 write buffer so recent writes can be read from memory.
-        self.options
-            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
-
-        // Switch to universal compactions.
-        self.options
-            .set_compaction_style(rocksdb::DBCompactionStyle::Universal);
-        let mut compaction_options = rocksdb::UniversalCompactOptions::default();
-        compaction_options.set_max_size_amplification_percent(10000);
-        compaction_options.set_stop_style(rocksdb::UniversalCompactionStopStyle::Similar);
-        self.options
-            .set_universal_compaction_options(&compaction_options);
-
-        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
-            .unwrap_or(DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER);
-        self.options.set_level_zero_file_num_compaction_trigger(
-            max_level_zero_file_num.try_into().unwrap(),
-        );
-        self.options.set_level_zero_slowdown_writes_trigger(
-            (max_level_zero_file_num * 12).try_into().unwrap(),
-        );
-        self.options
-            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
-
-        // Increase sst file size to 128MiB.
-        self.options.set_target_file_size_base(
-            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
-                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
-                * 1024
-                * 1024,
-        );
-
-        // This should be a no-op for universal compaction but increasing it to be safe.
-        self.options
-            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
-
-        self
-    }
-
-    // Overrides the block options with different block cache size and block size.
-    pub fn set_block_options(
-        mut self,
-        block_cache_size_mb: usize,
-        block_size_bytes: usize,
-    ) -> DBOptions {
-        self.options
-            .set_block_based_table_factory(&get_block_options(
-                block_cache_size_mb,
-                block_size_bytes,
-            ));
-        self
-    }
-
-    // Disables write stalling and stopping based on pending compaction bytes.
-    pub fn disable_write_throttling(mut self) -> DBOptions {
-        self.options.set_soft_pending_compaction_bytes_limit(0);
-        self.options.set_hard_pending_compaction_bytes_limit(0);
-        self
-    }
-}
-
-/// Creates a default RocksDB option, to be used when RocksDB option is
-/// unspecified.
-pub fn default_db_options() -> DBOptions {
-    let mut opt = rocksdb::Options::default();
-
-    // One common issue when running tests on Mac is that the default ulimit is too
-    // low, leading to I/O errors such as "Too many open files". Raising fdlimit
-    // to bypass it.
-    if let Some(limit) = fdlimit::raise_fd_limit() {
-        // on windows raise_fd_limit return None
-        opt.set_max_open_files((limit / 8) as i32);
-    }
-
-    // The table cache is locked for updates and this determines the number
-    // of shards, ie 2^10. Increase in case of lock contentions.
-    opt.set_table_cache_num_shard_bits(10);
-
-    // LSM compression settings
-    opt.set_compression_type(rocksdb::DBCompressionType::Lz4);
-    opt.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
-    opt.set_bottommost_zstd_max_train_bytes(1024 * 1024, true);
-
-    // IOTA uses multiple RocksDB in a node, so total sizes of write buffers and WAL
-    // can be higher than the limits below.
-    //
-    // RocksDB also exposes the option to configure total write buffer size across
-    // multiple instances via `write_buffer_manager`. But the write buffer flush
-    // policy (flushing the buffer receiving the next write) may not work well.
-    // So sticking to per-db write buffer size limit for now.
-    //
-    // The environment variables are only meant to be emergency overrides. They may
-    // go away in future. It is preferable to update the default value, or
-    // override the option in code.
-    opt.set_db_write_buffer_size(
-        read_size_from_env(ENV_VAR_DB_WRITE_BUFFER_SIZE).unwrap_or(DEFAULT_DB_WRITE_BUFFER_SIZE)
-            * 1024
-            * 1024,
-    );
-    opt.set_max_total_wal_size(
-        read_size_from_env(ENV_VAR_DB_WAL_SIZE).unwrap_or(DEFAULT_DB_WAL_SIZE) as u64 * 1024 * 1024,
-    );
-
-    // Num threads for compactions and memtable flushes.
-    opt.increase_parallelism(read_size_from_env(ENV_VAR_DB_PARALLELISM).unwrap_or(8) as i32);
-
-    opt.set_enable_pipelined_write(true);
-
-    // Increase block size to 16KiB.
-    // https://github.com/EighteenZi/rocksdb_wiki/blob/master/Memory-usage-in-RocksDB.md#indexes-and-filter-blocks
-    opt.set_block_based_table_factory(&get_block_options(128, 16 << 10));
-
-    // Set memtable bloomfilter.
-    opt.set_memtable_prefix_bloom_ratio(0.02);
-
-    DBOptions {
-        options: opt,
-        rw_options: ReadWriteOptions::default(),
-    }
-}
-
-fn get_block_options(block_cache_size_mb: usize, block_size_bytes: usize) -> BlockBasedOptions {
-    // Set options mostly similar to those used in optimize_for_point_lookup(),
-    // except non-default binary and hash index, to hopefully reduce lookup
-    // latencies without causing any regression for scanning, with slightly more
-    // memory usages. https://github.com/facebook/rocksdb/blob/11cb6af6e5009c51794641905ca40ce5beec7fee/options/options.cc#L611-L621
-    let mut block_options = BlockBasedOptions::default();
-    // Overrides block size.
-    block_options.set_block_size(block_size_bytes);
-    // Configure a block cache.
-    block_options.set_block_cache(&Cache::new_lru_cache(block_cache_size_mb << 20));
-    // Set a bloomfilter with 1% false positive rate.
-    block_options.set_bloom_filter(10.0, false);
-    // From https://github.com/EighteenZi/rocksdb_wiki/blob/master/Block-Cache.md#caching-index-and-filter-blocks
-    block_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
-    block_options
-}
-
-/// Opens a database with options, and a number of column families that are
-/// created if they do not exist.
-#[instrument(level="debug", skip_all, fields(path = ?path.as_ref(), cf = ?opt_cfs), err)]
-pub fn open_cf<P: AsRef<Path>>(
-    path: P,
-    db_options: Option<rocksdb::Options>,
-    metric_conf: MetricConf,
-    opt_cfs: &[&str],
-) -> Result<Arc<Database>, TypedStoreError> {
-    let options = db_options.unwrap_or_else(|| default_db_options().options);
-    let column_descriptors: Vec<_> = opt_cfs
-        .iter()
-        .map(|name| (*name, options.clone()))
-        .collect();
-    open_cf_opts(
-        path,
-        Some(options.clone()),
-        metric_conf,
-        &column_descriptors[..],
-    )
-}
-
-fn prepare_db_options(db_options: Option<rocksdb::Options>) -> rocksdb::Options {
-    // Customize database options
-    let mut options = db_options.unwrap_or_else(|| default_db_options().options);
-    options.create_if_missing(true);
-    options.create_missing_column_families(true);
-    options
-}
-
 /// Opens a database with options, and a number of column families with
 /// individual options that are created if they do not exist.
 #[tracing::instrument(level="debug", skip_all, fields(path = ?path.as_ref()), err)]
@@ -500,7 +128,9 @@ pub fn open_cf_opts<P: AsRef<Path>>(
 
     let cfs = populate_missing_cfs(opt_cfs, path).map_err(typed_store_err_from_rocks_err)?;
     nondeterministic!({
-        let options = prepare_db_options(db_options);
+        let mut options = db_options.unwrap_or_else(|| default_db_options().options);
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
         let rocksdb = {
             rocksdb::DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
                 &options,
@@ -583,53 +213,6 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
             metric_conf,
         )))
     })
-}
-
-pub fn list_tables(path: std::path::PathBuf) -> eyre::Result<Vec<String>> {
-    const DB_DEFAULT_CF_NAME: &str = "default";
-
-    let opts = rocksdb::Options::default();
-    rocksdb::DBWithThreadMode::<rocksdb::MultiThreaded>::list_cf(&opts, path)
-        .map_err(|e| e.into())
-        .map(|q| {
-            q.iter()
-                .filter_map(|s| {
-                    // The `default` table is not used
-                    if s != DB_DEFAULT_CF_NAME {
-                        Some(s.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        })
-}
-
-/// Serializes keys using big-endian byte order with fixed-int encoding.
-/// RocksDB stores keys in big-endian and uses a byte-wise seek operator on
-/// iterators, see `https://github.com/facebook/rocksdb/wiki/Iterator#introduction`
-#[inline]
-pub fn be_fix_int_ser<S>(t: &S) -> Result<Vec<u8>, TypedStoreError>
-where
-    S: ?Sized + serde::Serialize,
-{
-    bincode::DefaultOptions::new()
-        .with_big_endian()
-        .with_fixint_encoding()
-        .serialize(t)
-        .map_err(typed_store_err_from_bincode_err)
-}
-
-#[derive(Clone)]
-pub struct DBMapTableConfigMap(BTreeMap<String, DBOptions>);
-impl DBMapTableConfigMap {
-    pub fn new(map: BTreeMap<String, DBOptions>) -> Self {
-        Self(map)
-    }
-
-    pub fn to_map(&self) -> BTreeMap<String, DBOptions> {
-        self.0.clone()
-    }
 }
 
 // Drops a database if there is no other handle to it, with retries and timeout.

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -1,0 +1,374 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, env};
+
+use rocksdb::{BlockBasedOptions, Cache, ReadOptions};
+use tap::TapFallible;
+use tracing::{info, warn};
+
+// Write buffer size per RocksDB instance can be set via the env var below.
+// If the env var is not set, use the default value in MiB.
+const ENV_VAR_DB_WRITE_BUFFER_SIZE: &str = "DB_WRITE_BUFFER_SIZE_MB";
+const DEFAULT_DB_WRITE_BUFFER_SIZE: usize = 1024;
+
+// Write ahead log size per RocksDB instance can be set via the env var below.
+// If the env var is not set, use the default value in MiB.
+const ENV_VAR_DB_WAL_SIZE: &str = "DB_WAL_SIZE_MB";
+const DEFAULT_DB_WAL_SIZE: usize = 1024;
+
+// Environment variable to control behavior of write throughput optimized
+// tables.
+const ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER: &str = "L0_NUM_FILES_COMPACTION_TRIGGER";
+const DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 4;
+const DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 80;
+const ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB: &str = "MAX_WRITE_BUFFER_SIZE_MB";
+const DEFAULT_MAX_WRITE_BUFFER_SIZE_MB: usize = 256;
+const ENV_VAR_MAX_WRITE_BUFFER_NUMBER: &str = "MAX_WRITE_BUFFER_NUMBER";
+const DEFAULT_MAX_WRITE_BUFFER_NUMBER: usize = 6;
+const ENV_VAR_TARGET_FILE_SIZE_BASE_MB: &str = "TARGET_FILE_SIZE_BASE_MB";
+const DEFAULT_TARGET_FILE_SIZE_BASE_MB: usize = 128;
+
+// Set to 1 to disable blob storage for transactions and effects.
+const ENV_VAR_DISABLE_BLOB_STORAGE: &str = "DISABLE_BLOB_STORAGE";
+const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
+
+#[derive(Clone, Debug)]
+pub struct ReadWriteOptions {
+    pub ignore_range_deletions: bool,
+}
+
+impl ReadWriteOptions {
+    pub fn readopts(&self) -> ReadOptions {
+        let mut readopts = ReadOptions::default();
+        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
+        readopts
+    }
+
+    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
+        self.ignore_range_deletions = ignore;
+        self
+    }
+}
+
+impl Default for ReadWriteOptions {
+    fn default() -> Self {
+        Self {
+            ignore_range_deletions: true,
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct DBOptions {
+    pub options: rocksdb::Options,
+    pub rw_options: ReadWriteOptions,
+}
+
+#[derive(Clone)]
+pub struct DBMapTableConfigMap(BTreeMap<String, DBOptions>);
+impl DBMapTableConfigMap {
+    pub fn new(map: BTreeMap<String, DBOptions>) -> Self {
+        Self(map)
+    }
+
+    pub fn to_map(&self) -> BTreeMap<String, DBOptions> {
+        self.0.clone()
+    }
+}
+
+impl DBOptions {
+    // Optimize lookup perf for tables where no scans are performed.
+    // If non-trivial number of values can be > 512B in size, it is beneficial to
+    // also specify optimize_for_large_values_no_scan().
+    pub fn optimize_for_point_lookup(mut self, block_cache_size_mb: usize) -> DBOptions {
+        // NOTE: this overwrites the block options.
+        self.options
+            .optimize_for_point_lookup(block_cache_size_mb as u64);
+        self
+    }
+
+    // Optimize write and lookup perf for tables which are rarely scanned, and have
+    // large values. https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html
+    pub fn optimize_for_large_values_no_scan(mut self, min_blob_size: u64) -> DBOptions {
+        if env::var(ENV_VAR_DISABLE_BLOB_STORAGE).is_ok() {
+            info!("Large value blob storage optimization is disabled via env var.");
+            return self;
+        }
+
+        // Blob settings.
+        self.options.set_enable_blob_files(true);
+        self.options
+            .set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
+        self.options.set_enable_blob_gc(true);
+        // Since each blob can have non-trivial size overhead, and compression does not
+        // work across blobs, set a min blob size in bytes to so small
+        // transactions and effects are kept in sst files.
+        self.options.set_min_blob_size(min_blob_size);
+
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Since large blobs are not in sst files, reduce the target file size and base
+        // level target size.
+        let target_file_size_base = 64 << 20;
+        self.options
+            .set_target_file_size_base(target_file_size_base);
+        // Level 1 default to 64MiB * 4 ~ 256MiB.
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options
+            .set_max_bytes_for_level_base(target_file_size_base * max_level_zero_file_num as u64);
+
+        self
+    }
+
+    // Optimize tables with a mix of lookup and scan workloads.
+    pub fn optimize_for_read(mut self, block_cache_size_mb: usize) -> DBOptions {
+        self.options
+            .set_block_based_table_factory(&get_block_options(block_cache_size_mb, 16 << 10));
+        self
+    }
+
+    // Optimize DB receiving significant insertions.
+    pub fn optimize_db_for_write_throughput(mut self, db_max_write_buffer_gb: u64) -> DBOptions {
+        self.options
+            .set_db_write_buffer_size(db_max_write_buffer_gb as usize * 1024 * 1024 * 1024);
+        self.options
+            .set_max_total_wal_size(db_max_write_buffer_gb * 1024 * 1024 * 1024);
+        self
+    }
+
+    // Optimize tables receiving significant insertions.
+    pub fn optimize_for_write_throughput(mut self) -> DBOptions {
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Increase write buffers to keep to 6 before slowing down writes.
+        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        self.options
+            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
+        // Keep 1 write buffer so recent writes can be read from memory.
+        self.options
+            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
+
+        // Increase compaction trigger for level 0 to 6.
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options.set_level_zero_file_num_compaction_trigger(
+            max_level_zero_file_num.try_into().unwrap(),
+        );
+        self.options.set_level_zero_slowdown_writes_trigger(
+            (max_level_zero_file_num * 12).try_into().unwrap(),
+        );
+        self.options
+            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
+
+        // Increase sst file size to 128MiB.
+        self.options.set_target_file_size_base(
+            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
+                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
+                * 1024
+                * 1024,
+        );
+
+        // Increase level 1 target size to 256MiB * 6 ~ 1.5GiB.
+        self.options
+            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
+
+        self
+    }
+
+    // Optimize tables receiving significant insertions, without any deletions.
+    // TODO: merge this function with optimize_for_write_throughput(), and use a
+    // flag to indicate if deletion is received.
+    pub fn optimize_for_write_throughput_no_deletion(mut self) -> DBOptions {
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Increase write buffers to keep to 6 before slowing down writes.
+        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        self.options
+            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
+        // Keep 1 write buffer so recent writes can be read from memory.
+        self.options
+            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
+
+        // Switch to universal compactions.
+        self.options
+            .set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+        let mut compaction_options = rocksdb::UniversalCompactOptions::default();
+        compaction_options.set_max_size_amplification_percent(10000);
+        compaction_options.set_stop_style(rocksdb::UniversalCompactionStopStyle::Similar);
+        self.options
+            .set_universal_compaction_options(&compaction_options);
+
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options.set_level_zero_file_num_compaction_trigger(
+            max_level_zero_file_num.try_into().unwrap(),
+        );
+        self.options.set_level_zero_slowdown_writes_trigger(
+            (max_level_zero_file_num * 12).try_into().unwrap(),
+        );
+        self.options
+            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
+
+        // Increase sst file size to 128MiB.
+        self.options.set_target_file_size_base(
+            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
+                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
+                * 1024
+                * 1024,
+        );
+
+        // This should be a no-op for universal compaction but increasing it to be safe.
+        self.options
+            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
+
+        self
+    }
+
+    // Overrides the block options with different block cache size and block size.
+    pub fn set_block_options(
+        mut self,
+        block_cache_size_mb: usize,
+        block_size_bytes: usize,
+    ) -> DBOptions {
+        self.options
+            .set_block_based_table_factory(&get_block_options(
+                block_cache_size_mb,
+                block_size_bytes,
+            ));
+        self
+    }
+
+    // Disables write stalling and stopping based on pending compaction bytes.
+    pub fn disable_write_throttling(mut self) -> DBOptions {
+        self.options.set_soft_pending_compaction_bytes_limit(0);
+        self.options.set_hard_pending_compaction_bytes_limit(0);
+        self
+    }
+}
+
+/// Creates a default RocksDB option, to be used when RocksDB option is
+/// unspecified.
+pub fn default_db_options() -> DBOptions {
+    let mut opt = rocksdb::Options::default();
+
+    // One common issue when running tests on Mac is that the default ulimit is too
+    // low, leading to I/O errors such as "Too many open files". Raising fdlimit
+    // to bypass it.
+    if let Some(limit) = fdlimit::raise_fd_limit() {
+        // on windows raise_fd_limit return None
+        opt.set_max_open_files((limit / 8) as i32);
+    }
+
+    // The table cache is locked for updates and this determines the number
+    // of shards, ie 2^10. Increase in case of lock contentions.
+    opt.set_table_cache_num_shard_bits(10);
+
+    // LSM compression settings
+    opt.set_compression_type(rocksdb::DBCompressionType::Lz4);
+    opt.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
+    opt.set_bottommost_zstd_max_train_bytes(1024 * 1024, true);
+
+    // IOTA uses multiple RocksDB in a node, so total sizes of write buffers and WAL
+    // can be higher than the limits below.
+    //
+    // RocksDB also exposes the option to configure total write buffer size across
+    // multiple instances via `write_buffer_manager`. But the write buffer flush
+    // policy (flushing the buffer receiving the next write) may not work well.
+    // So sticking to per-db write buffer size limit for now.
+    //
+    // The environment variables are only meant to be emergency overrides. They may
+    // go away in future. It is preferable to update the default value, or
+    // override the option in code.
+    opt.set_db_write_buffer_size(
+        read_size_from_env(ENV_VAR_DB_WRITE_BUFFER_SIZE).unwrap_or(DEFAULT_DB_WRITE_BUFFER_SIZE)
+            * 1024
+            * 1024,
+    );
+    opt.set_max_total_wal_size(
+        read_size_from_env(ENV_VAR_DB_WAL_SIZE).unwrap_or(DEFAULT_DB_WAL_SIZE) as u64 * 1024 * 1024,
+    );
+
+    // Num threads for compactions and memtable flushes.
+    opt.increase_parallelism(read_size_from_env(ENV_VAR_DB_PARALLELISM).unwrap_or(8) as i32);
+
+    opt.set_enable_pipelined_write(true);
+
+    // Increase block size to 16KiB.
+    // https://github.com/EighteenZi/rocksdb_wiki/blob/master/Memory-usage-in-RocksDB.md#indexes-and-filter-blocks
+    opt.set_block_based_table_factory(&get_block_options(128, 16 << 10));
+
+    // Set memtable bloomfilter.
+    opt.set_memtable_prefix_bloom_ratio(0.02);
+
+    DBOptions {
+        options: opt,
+        rw_options: ReadWriteOptions::default(),
+    }
+}
+
+fn get_block_options(block_cache_size_mb: usize, block_size_bytes: usize) -> BlockBasedOptions {
+    // Set options mostly similar to those used in optimize_for_point_lookup(),
+    // except non-default binary and hash index, to hopefully reduce lookup
+    // latencies without causing any regression for scanning, with slightly more
+    // memory usages. https://github.com/facebook/rocksdb/blob/11cb6af6e5009c51794641905ca40ce5beec7fee/options/options.cc#L611-L621
+    let mut block_options = BlockBasedOptions::default();
+    // Overrides block size.
+    block_options.set_block_size(block_size_bytes);
+    // Configure a block cache.
+    block_options.set_block_cache(&Cache::new_lru_cache(block_cache_size_mb << 20));
+    // Set a bloomfilter with 1% false positive rate.
+    block_options.set_bloom_filter(10.0, false);
+    // From https://github.com/EighteenZi/rocksdb_wiki/blob/master/Block-Cache.md#caching-index-and-filter-blocks
+    block_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+    block_options
+}
+
+pub fn list_tables(path: std::path::PathBuf) -> eyre::Result<Vec<String>> {
+    const DB_DEFAULT_CF_NAME: &str = "default";
+
+    let opts = rocksdb::Options::default();
+    rocksdb::DBWithThreadMode::<rocksdb::MultiThreaded>::list_cf(&opts, path)
+        .map_err(|e| e.into())
+        .map(|q| {
+            q.iter()
+                .filter_map(|s| {
+                    // The `default` table is not used
+                    if s != DB_DEFAULT_CF_NAME {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+}
+
+pub fn read_size_from_env(var_name: &str) -> Option<usize> {
+    env::var(var_name)
+        .ok()?
+        .parse::<usize>()
+        .tap_err(|e| {
+            warn!(
+                "Env var {} does not contain valid usize integer: {}",
+                var_name, e
+            )
+        })
+        .ok()
+}

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -87,11 +87,14 @@ async fn test_reopen_macro() {
     const FIRST_CF: &str = "First_CF";
     const SECOND_CF: &str = "Second_CF";
 
-    let rocks = open_cf(
+    let rocks = open_cf_opts(
         temp_dir(),
         None,
         MetricConf::default(),
-        &[FIRST_CF, SECOND_CF],
+        &[
+            (FIRST_CF, rocksdb::Options::default()),
+            (SECOND_CF, rocksdb::Options::default()),
+        ],
     )
     .unwrap();
 
@@ -741,5 +744,15 @@ fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> 
 }
 
 fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<Database> {
-    open_cf(path, None, MetricConf::default(), opt_cfs).expect("failed to open rocksdb")
+    let opts = rocksdb::Options::default();
+    open_cf_opts(
+        path,
+        None,
+        MetricConf::default(),
+        &opt_cfs
+            .iter()
+            .map(|cf| (*cf, opts.clone()))
+            .collect::<Vec<_>>(),
+    )
+    .expect("failed to open rocksdb")
 }

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Borrow, collections::BTreeMap, error::Error, ops::RangeBounds};
+use std::{borrow::Borrow, error::Error, ops::RangeBounds};
 
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -106,26 +106,4 @@ pub struct TableSummary {
     pub value_bytes_total: usize,
     pub key_hist: hdrhistogram::Histogram<u64>,
     pub value_hist: hdrhistogram::Histogram<u64>,
-}
-
-pub trait TypedStoreDebug {
-    /// Dump a DB table with pagination
-    fn dump_table(
-        &self,
-        table_name: String,
-        page_size: u16,
-        page_number: usize,
-    ) -> eyre::Result<BTreeMap<String, String>>;
-
-    /// Get the name of the DB. This is simply the name of the struct
-    fn primary_db_name(&self) -> String;
-
-    /// Get a map of table names to key-value types
-    fn describe_all_tables(&self) -> BTreeMap<String, (String, String)>;
-
-    /// Count the entries in the table
-    fn count_table_keys(&self, table_name: String) -> eyre::Result<usize>;
-
-    /// Return table summary of the input table
-    fn table_summary(&self, table_name: String) -> eyre::Result<TableSummary>;
 }

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 use typed_store::{
     DBMapUtils, be_fix_int_ser,
     metrics::SamplingInterval,
-    rocks::{DBMap, MetricConf, list_tables},
-    traits::{Map, TableSummary, TypedStoreDebug},
+    rocks::{DBMap, MetricConf},
+    traits::Map,
 };
 
 fn temp_dir() -> std::path::PathBuf {
@@ -109,7 +109,6 @@ async fn macro_test() {
         Tables::get_read_only_handle(primary_path.clone(), None, None, MetricConf::default());
 
     // Check all the tables can be listed
-    let actual_table_names: HashSet<_> = list_tables(primary_path).unwrap().into_iter().collect();
     let observed_table_names: HashSet<_> = Tables::describe_tables()
         .iter()
         .map(|q| q.0.clone())
@@ -117,12 +116,7 @@ async fn macro_test() {
 
     let exp: HashSet<String> =
         HashSet::from_iter(vec!["table1", "table2"].into_iter().map(|s| s.to_owned()));
-    assert_eq!(HashSet::from_iter(actual_table_names), exp);
     assert_eq!(HashSet::from_iter(observed_table_names), exp);
-
-    // Check the counts
-    assert_eq!(9, tbls_secondary.count_keys("table1").unwrap());
-    assert_eq!(7, tbls_secondary.count_keys("table2").unwrap());
 
     // check raw byte sizes of key and values
     let summary1 = tbls_secondary.table_summary("table1").unwrap();
@@ -151,8 +145,6 @@ async fn macro_test() {
         .table1
         .multi_insert(keys_vals_1)
         .expect("Failed to multi-insert");
-    // New entries should be present in secondary
-    assert_eq!(19, tbls_secondary.count_keys("table1").unwrap());
 
     // Test pagination
     let m = tbls_secondary.dump("table1", 2, 0).unwrap();
@@ -541,49 +533,6 @@ fn another_custom_fn_name() -> typed_store::rocks::DBOptions {
     TABLE2_OPTIONS_SET_FLAG.lock().unwrap().push(false);
     TABLE2_OPTIONS_SET_FLAG.lock().unwrap().push(false);
     typed_store::rocks::DBOptions::default()
-}
-
-#[tokio::test]
-async fn macro_test_configure() {
-    let primary_path = temp_dir();
-
-    // Get a configurator for this table
-    let mut config = Tables::configurator();
-    // Config table 1
-    config.table1 = typed_store::rocks::DBOptions::default();
-    config.table1.options.create_if_missing(true);
-    config.table1.options.set_write_buffer_size(123456);
-
-    // Config table 2
-    config.table2 = config.table1.clone();
-
-    config.table2.options.create_if_missing(false);
-
-    // Build and open with new config
-    let _ = Tables::open_tables_read_write(
-        primary_path,
-        MetricConf::default(),
-        None,
-        Some(config.build()),
-    );
-
-    // Test the static config options
-    let primary_path = temp_dir();
-
-    assert_eq!(TABLE1_OPTIONS_SET_FLAG.lock().unwrap().len(), 0);
-
-    let _ = TablesCustomOptions::open_tables_read_write(
-        primary_path,
-        MetricConf::default(),
-        None,
-        None,
-    );
-
-    // Ensures that the function to set options was called
-    assert_eq!(TABLE1_OPTIONS_SET_FLAG.lock().unwrap().len(), 1);
-
-    // `another_custom_fn_name` is called twice, so 6 items in vec
-    assert_eq!(TABLE2_OPTIONS_SET_FLAG.lock().unwrap().len(), 6);
 }
 
 /// We show that custom functions can be applied


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@b1d755d](https://github.com/MystenLabs/sui/commit/b1d755d0239946a9522ac4a0af0bf10b8fe65a56)
- Description:
  - removes few methods from typed store macros crate (configurator struct, `count_keys`)
  - deprecates `TypedStoreDebug` trait
  - moves rocksdb options construction into a separate `rocks/options.rs` module


## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes