### PR TITLE
upstream(core): Process non_randomness and randomness transactions separately

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1930,8 +1930,7 @@ impl AuthorityPerEpochStore {
         let assigned_versions = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
-            certificates,
-            None,
+            certificates.iter(),
             &BTreeMap::new(),
         )?
         .assigned_versions;
@@ -2687,9 +2686,11 @@ impl AuthorityPerEpochStore {
             .expect("push_consensus_output should not fail");
     }
 
-    fn finish_consensus_certificate_process(&self, certificates: &[VerifiedExecutableTransaction]) {
+    fn process_user_signatures<'a>(
+        &self,
+        certificates: impl Iterator<Item = &'a VerifiedExecutableTransaction>,
+    ) {
         let sigs: Vec<_> = certificates
-            .iter()
             .map(|certificate| (*certificate.digest(), certificate.tx_signatures().to_vec()))
             .collect();
 
@@ -2698,7 +2699,7 @@ impl AuthorityPerEpochStore {
             .user_signatures_for_checkpoints
             .lock();
 
-        user_sigs.reserve(certificates.len());
+        user_sigs.reserve(sigs.len());
         for (digest, sigs) in sigs {
             // User signatures are written in the same batch as consensus certificate
             // processed flag, which means we won't attempt to insert this twice
@@ -3157,14 +3158,14 @@ impl AuthorityPerEpochStore {
             congestion_control_parameters,
         );
 
-        let consensus_transactions: Vec<_> = system_transactions
+        let sequenced_non_randomness_transactions: Vec<_> = system_transactions
             .into_iter()
             .chain(sequenced_transactions)
-            .chain(sequenced_randomness_transactions)
             .collect();
 
         let (
-            verified_transactions,
+            verified_non_randomness_transactions,
+            mut verified_randomness_transactions,
             notifications,
             lock,
             final_round,
@@ -3172,7 +3173,8 @@ impl AuthorityPerEpochStore {
         ) = self
             .process_consensus_transactions(
                 &mut output,
-                &consensus_transactions,
+                &sequenced_non_randomness_transactions,
+                &sequenced_randomness_transactions,
                 &end_of_publish_transactions,
                 checkpoint_service,
                 cache_reader,
@@ -3188,10 +3190,12 @@ impl AuthorityPerEpochStore {
                 shared_object_using_randomness_congestion_tracker,
             )
             .await?;
-        self.finish_consensus_certificate_process(&verified_transactions);
+        self.process_user_signatures(
+            verified_non_randomness_transactions
+                .iter()
+                .chain(verified_randomness_transactions.iter()),
+        );
         output.record_consensus_commit_stats(consensus_stats.clone());
-
-        let mut verified_transactions = verified_transactions;
 
         // Create pending checkpoints if we are still accepting tx.
         let should_accept_tx = if let Some(lock) = &lock {
@@ -3206,15 +3210,16 @@ impl AuthorityPerEpochStore {
         };
         let make_checkpoint = should_accept_tx || final_round;
         if make_checkpoint {
-            let checkpoint_height = consensus_commit_info.round * 2;
+            let checkpoint_height =
+                self.calculate_pending_checkpoint_height(consensus_commit_info.round);
 
-            let mut checkpoint_roots: Vec<TransactionKey> = Vec::with_capacity(roots.len() + 1);
+            let mut non_randomness_roots: Vec<TransactionKey> = Vec::with_capacity(roots.len() + 1);
 
             if let Some(consensus_commit_prologue_root) = consensus_commit_prologue_root {
                 // Put consensus commit prologue root at the beginning of the checkpoint roots.
-                checkpoint_roots.push(consensus_commit_prologue_root);
+                non_randomness_roots.push(consensus_commit_prologue_root);
             }
-            checkpoint_roots.extend(roots.into_iter());
+            non_randomness_roots.extend(roots.into_iter());
 
             if let Some(randomness_round) = randomness_round {
                 let key = TransactionKey::RandomnessRound(self.epoch(), randomness_round);
@@ -3230,7 +3235,7 @@ impl AuthorityPerEpochStore {
                         );
                         let tx =
                             VerifiedExecutableTransaction::new_system((*tx).clone(), self.epoch());
-                        verified_transactions.push(tx);
+                        verified_randomness_transactions.push(tx);
                     }
                 }
 
@@ -3247,7 +3252,7 @@ impl AuthorityPerEpochStore {
                 randomness_round.is_some() || (dkg_failed && !randomness_roots.is_empty());
 
             let pending_checkpoint = PendingCheckpoint::V1(PendingCheckpointContentsV1 {
-                roots: checkpoint_roots,
+                roots: non_randomness_roots,
                 details: PendingCheckpointInfo {
                     timestamp_ms: consensus_commit_info.timestamp,
                     last_of_epoch: final_round && !should_write_random_checkpoint,
@@ -3326,7 +3331,15 @@ impl AuthorityPerEpochStore {
             self.record_end_of_message_quorum_time_metric();
         }
 
-        Ok(verified_transactions)
+        Ok([
+            verified_non_randomness_transactions,
+            verified_randomness_transactions,
+        ]
+        .concat())
+    }
+
+    fn calculate_pending_checkpoint_height(&self, consensus_round: u64) -> u64 {
+        consensus_round * 2
     }
 
     // Adds the consensus commit prologue transaction to the beginning of input
@@ -3408,19 +3421,43 @@ impl AuthorityPerEpochStore {
     fn process_consensus_transaction_shared_object_versions(
         &self,
         cache_reader: &dyn ObjectCacheRead,
-        transactions: &[VerifiedExecutableTransaction],
+        non_randomness_transactions: &[VerifiedExecutableTransaction],
+        randomness_transactions: &[VerifiedExecutableTransaction],
         randomness_round: Option<RandomnessRound>,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
         output: &mut ConsensusCommitOutput,
     ) -> IotaResult {
+        // If randomness_round is set, we know that eventually there will be a
+        // randomness state update transaction. We create a placeholder
+        // transaction so that the SharedObjVerManager can update the version of
+        // the randomness state object and use that version for randomness transactions.
+        let randomness_state_update = randomness_round.map(|round| {
+            VerifiedExecutableTransaction::new_system(
+                VerifiedTransaction::new_randomness_state_update(
+                    self.epoch(),
+                    round,
+                    // This is placeholder bytes, since this transaction does not exist yet.
+                    vec![],
+                    self.epoch_start_config()
+                        .randomness_obj_initial_shared_version(),
+                ),
+                self.epoch(),
+            )
+        });
+        let all_certs = non_randomness_transactions
+            .iter()
+            // randomness_state_update must be before randomness_transactions to make sure the
+            // version of the randomness state object is updated before it is used in
+            // randomness transactions.
+            .chain(randomness_state_update.iter())
+            .chain(randomness_transactions.iter());
         let ConsensusSharedObjVerAssignment {
             shared_input_next_versions,
             assigned_versions,
         } = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
-            transactions,
-            randomness_round,
+            all_certs,
             cancelled_txns,
         )?;
 
@@ -3476,6 +3513,7 @@ impl AuthorityPerEpochStore {
         self.process_consensus_transaction_shared_object_versions(
             cache_reader,
             transactions,
+            &[],
             None,
             &BTreeMap::new(),
             &mut output,
@@ -3511,12 +3549,13 @@ impl AuthorityPerEpochStore {
     pub(crate) async fn process_consensus_transactions<C: CheckpointServiceNotify>(
         &self,
         output: &mut ConsensusCommitOutput,
-        transactions: &[VerifiedSequencedConsensusTransaction],
+        non_randomness_transactions: &[VerifiedSequencedConsensusTransaction],
+        randomness_transactions: &[VerifiedSequencedConsensusTransaction],
         end_of_publish_transactions: &[VerifiedSequencedConsensusTransaction],
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
         consensus_commit_info: &ConsensusCommitInfo,
-        roots: &mut BTreeSet<TransactionKey>,
+        non_randomness_roots: &mut BTreeSet<TransactionKey>,
         randomness_roots: &mut BTreeSet<TransactionKey>,
         previously_deferred_tx_digests: PreviouslyDeferredTransactions,
         mut randomness_manager: Option<&mut RandomnessManager>,
@@ -3526,7 +3565,8 @@ impl AuthorityPerEpochStore {
         mut shared_object_congestion_tracker: SharedObjectCongestionTracker,
         mut shared_object_using_randomness_congestion_tracker: SharedObjectCongestionTracker,
     ) -> IotaResult<(
-        Vec<VerifiedExecutableTransaction>,    // transactions to schedule
+        Vec<VerifiedExecutableTransaction>, // non-randomness transactions to schedule
+        Vec<VerifiedExecutableTransaction>, // randomness transactions to schedule
         Vec<SequencedConsensusTransactionKey>, // keys to notify as complete
         Option<RwLockWriteGuard<'_, ReconfigState>>,
         bool,                   // true if final round
@@ -3536,9 +3576,8 @@ impl AuthorityPerEpochStore {
             assert!(!dkg_failed); // invariant check
         }
 
-        let mut sequenced_transactions = Vec::with_capacity(transactions.len());
-        let mut verified_certificates = VecDeque::with_capacity(transactions.len() + 1);
-        let mut notifications = Vec::with_capacity(transactions.len());
+        let mut notifications =
+            Vec::with_capacity(non_randomness_transactions.len() + randomness_transactions.len());
 
         let mut deferred_txns: BTreeMap<DeferralKey, Vec<DeferredTransaction>> = BTreeMap::new();
         let mut cancelled_txns: BTreeMap<TransactionDigest, CancelConsensusCertificateReason> =
@@ -3580,12 +3619,27 @@ impl AuthorityPerEpochStore {
         );
 
         let mut randomness_state_updated = false;
-        for tx in transactions {
-            let key = tx.0.transaction.key();
-            let mut ignored = false;
-            let mut filter_roots = false;
-            let (congestion_tracker, sgp_calculator) = if tx.0.is_user_tx_with_randomness() {
-                (
+        let mut verified_non_randomness_certificates =
+            VecDeque::with_capacity(non_randomness_transactions.len() + 1);
+        let mut verified_randomness_certificates =
+            VecDeque::with_capacity(randomness_transactions.len());
+        let mut sequenced_non_randomness = Vec::new();
+        let mut sequenced_randomness = Vec::new();
+
+        for entry in non_randomness_transactions
+            .iter()
+            .map(Either::Left)
+            .chain(randomness_transactions.iter().map(Either::Right))
+        {
+            let (tx, congestion_tracker, sgp_calculator, sequenced_txns) = match entry {
+                Either::Left(tx) => (
+                    tx,
+                    &mut shared_object_congestion_tracker,
+                    &mut suggested_gas_price_calculator,
+                    &mut sequenced_non_randomness,
+                ),
+                Either::Right(tx) => (
+                    tx,
                     &mut shared_object_using_randomness_congestion_tracker,
                     if self
                         .protocol_config
@@ -3595,13 +3649,12 @@ impl AuthorityPerEpochStore {
                     } else {
                         &mut suggested_gas_price_calculator
                     },
-                )
-            } else {
-                (
-                    &mut shared_object_congestion_tracker,
-                    &mut suggested_gas_price_calculator,
-                )
+                    &mut sequenced_randomness,
+                ),
             };
+            let key = tx.0.transaction.key();
+            let mut ignored = false;
+            let mut filter_roots = false;
             match self
                 .process_consensus_transaction(
                     output,
@@ -3623,7 +3676,7 @@ impl AuthorityPerEpochStore {
                     start_time,
                 } => {
                     notifications.push(key.clone());
-                    sequenced_transactions.push((transaction, start_time));
+                    sequenced_txns.push((transaction, start_time));
                 }
                 ConsensusCertificateResult::Deferred {
                     deferral_key,
@@ -3645,10 +3698,7 @@ impl AuthorityPerEpochStore {
                 ConsensusCertificateResult::Cancelled((cert, reason)) => {
                     notifications.push(key.clone());
                     assert!(cancelled_txns.insert(*cert.digest(), reason).is_none());
-                    sequenced_transactions.push((
-                        cert,
-                        shared_object_congestion_tracker.max_occupied_slot_end_time(),
-                    ));
+                    sequenced_txns.push((cert, congestion_tracker.max_occupied_slot_end_time()));
                 }
                 ConsensusCertificateResult::RandomnessConsensusMessage => {
                     randomness_state_updated = true;
@@ -3674,7 +3724,7 @@ impl AuthorityPerEpochStore {
                         .executable_transaction_digest()
                         .map(TransactionKey::Digest)
                 {
-                    roots.remove(&txn_key);
+                    non_randomness_roots.remove(&txn_key);
                     randomness_roots.remove(&txn_key);
                 }
             }
@@ -3682,9 +3732,13 @@ impl AuthorityPerEpochStore {
 
         // sort the sequenced transactions based on their start_time from the
         // sequencing result and add these to the verified_certificates.
-        sequenced_transactions.sort_by_key(|(_, start_time)| *start_time);
-        for (tx, _) in sequenced_transactions {
-            verified_certificates.push_back(tx);
+        sequenced_non_randomness.sort_by_key(|(_, start_time)| *start_time);
+        for (tx, _) in sequenced_non_randomness {
+            verified_non_randomness_certificates.push_back(tx);
+        }
+        sequenced_randomness.sort_by_key(|(_, start_time)| *start_time);
+        for (tx, _) in sequenced_randomness {
+            verified_randomness_certificates.push_back(tx);
         }
         let commit_has_deferred_txns = !deferred_txns.is_empty();
         let mut total_deferred_txns = 0;
@@ -3761,19 +3815,22 @@ impl AuthorityPerEpochStore {
         }
 
         // Add the consensus commit prologue transaction to the beginning of
-        // `verified_certificates`.
+        // `verified_non_randomness_certificates`.
         let consensus_commit_prologue_root = self.add_consensus_commit_prologue_transaction(
             output,
-            &mut verified_certificates,
+            &mut verified_non_randomness_certificates,
             consensus_commit_info,
             &cancelled_txns,
         )?;
 
-        let verified_certificates: Vec<_> = verified_certificates.into();
+        let verified_non_randomness_certificates: Vec<_> =
+            verified_non_randomness_certificates.into();
+        let verified_randomness_certificates: Vec<_> = verified_randomness_certificates.into();
 
         self.process_consensus_transaction_shared_object_versions(
             cache_reader,
-            &verified_certificates,
+            &verified_non_randomness_certificates,
+            &verified_randomness_certificates,
             randomness_round,
             &cancelled_txns,
             output,
@@ -3786,7 +3843,8 @@ impl AuthorityPerEpochStore {
         )?;
 
         Ok((
-            verified_certificates,
+            verified_non_randomness_certificates,
+            verified_randomness_certificates,
             notifications,
             lock,
             final_round,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3158,10 +3158,8 @@ impl AuthorityPerEpochStore {
             congestion_control_parameters,
         );
 
-        let sequenced_non_randomness_transactions: Vec<_> = system_transactions
-            .into_iter()
-            .chain(sequenced_transactions)
-            .collect();
+        system_transactions.extend(sequenced_transactions);
+        let sequenced_non_randomness_transactions = system_transactions;
 
         let (
             verified_non_randomness_transactions,
@@ -3619,10 +3617,6 @@ impl AuthorityPerEpochStore {
         );
 
         let mut randomness_state_updated = false;
-        let mut verified_non_randomness_certificates =
-            VecDeque::with_capacity(non_randomness_transactions.len() + 1);
-        let mut verified_randomness_certificates =
-            VecDeque::with_capacity(randomness_transactions.len());
         let mut sequenced_non_randomness = Vec::new();
         let mut sequenced_randomness = Vec::new();
 
@@ -3733,13 +3727,13 @@ impl AuthorityPerEpochStore {
         // sort the sequenced transactions based on their start_time from the
         // sequencing result and add these to the verified_certificates.
         sequenced_non_randomness.sort_by_key(|(_, start_time)| *start_time);
-        for (tx, _) in sequenced_non_randomness {
-            verified_non_randomness_certificates.push_back(tx);
-        }
+        let mut verified_non_randomness_certificates: VecDeque<_> = sequenced_non_randomness
+            .into_iter()
+            .map(|(tx, _)| tx)
+            .collect();
         sequenced_randomness.sort_by_key(|(_, start_time)| *start_time);
-        for (tx, _) in sequenced_randomness {
-            verified_randomness_certificates.push_back(tx);
-        }
+        let verified_randomness_certificates: VecDeque<_> =
+            sequenced_randomness.into_iter().map(|(tx, _)| tx).collect();
         let commit_has_deferred_txns = !deferred_txns.is_empty();
         let mut total_deferred_txns = 0;
         {

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -7,7 +7,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use iota_types::{
     IOTA_RANDOMNESS_STATE_OBJECT_ID,
     base_types::{ObjectID, SequenceNumber, TransactionDigest},
-    crypto::RandomnessRound,
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::IotaResult,
     executable_transaction::VerifiedExecutableTransaction,
@@ -16,12 +15,11 @@ use iota_types::{
     },
     transaction::{SenderSignedData, SharedInputObject, TransactionKey},
 };
-use tracing::{debug, trace};
+use tracing::trace;
 
 use crate::{
     authority::{
         AuthorityPerEpochStore, authority_per_epoch_store::CancelConsensusCertificateReason,
-        epoch_start_configuration::EpochStartConfigTrait,
     },
     execution_cache::ObjectCacheRead,
 };
@@ -38,39 +36,18 @@ pub struct ConsensusSharedObjVerAssignment {
 }
 
 impl SharedObjVerManager {
-    pub fn assign_versions_from_consensus(
+    pub fn assign_versions_from_consensus<'a>(
         epoch_store: &AuthorityPerEpochStore,
         cache_reader: &dyn ObjectCacheRead,
-        certificates: &[VerifiedExecutableTransaction],
-        randomness_round: Option<RandomnessRound>,
+        certificates: impl Iterator<Item = &'a VerifiedExecutableTransaction> + Clone,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
     ) -> IotaResult<ConsensusSharedObjVerAssignment> {
         let mut shared_input_next_versions = get_or_init_versions(
-            certificates.iter().map(|cert| cert.data()),
+            certificates.clone().map(|cert| cert.data()),
             epoch_store,
             cache_reader,
-            randomness_round.is_some(),
         )?;
         let mut assigned_versions = Vec::new();
-        // We must update randomness object version first before processing any
-        // transaction, so that all reads are using the next version.
-        // TODO: Add a test that actually check this, i.e. if we change the order, some
-        // test should fail.
-        if let Some(round) = randomness_round {
-            // If we're generating randomness, update the randomness state object version.
-            let version = shared_input_next_versions
-                .get_mut(&IOTA_RANDOMNESS_STATE_OBJECT_ID)
-                .expect("randomness state object must have been added in get_or_init_versions()");
-            debug!(
-                "assigning shared object versions for randomness: epoch {}, round {round:?} -> version {version:?}",
-                epoch_store.epoch()
-            );
-            assigned_versions.push((
-                TransactionKey::RandomnessRound(epoch_store.epoch(), round),
-                vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, *version)],
-            ));
-            version.increment();
-        }
         for cert in certificates {
             if !cert.contains_shared_object() {
                 continue;
@@ -109,8 +86,8 @@ impl SharedObjVerManager {
             certs_and_effects.iter().map(|(cert, _)| cert.data()),
             epoch_store,
             cache_reader,
-            false,
         );
+
         let mut assigned_versions = Vec::new();
         for (cert, effects) in certs_and_effects {
             let cert_assigned_versions: Vec<_> = effects
@@ -264,7 +241,6 @@ fn get_or_init_versions<'a>(
     transactions: impl Iterator<Item = &'a SenderSignedData>,
     epoch_store: &AuthorityPerEpochStore,
     cache_reader: &dyn ObjectCacheRead,
-    generate_randomness: bool,
 ) -> IotaResult<HashMap<ObjectID, SequenceNumber>> {
     let mut shared_input_objects: Vec<_> = transactions
         .flat_map(|tx| {
@@ -273,15 +249,6 @@ fn get_or_init_versions<'a>(
                 .map(|so| so.into_id_and_version())
         })
         .collect();
-
-    if generate_randomness {
-        shared_input_objects.push((
-            IOTA_RANDOMNESS_STATE_OBJECT_ID,
-            epoch_store
-                .epoch_start_config()
-                .randomness_obj_initial_shared_version(),
-        ));
-    }
 
     shared_input_objects.sort();
     shared_input_objects.dedup();
@@ -305,7 +272,7 @@ mod tests {
         },
         object::{Object, Owner},
         programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::{ObjectArg, SenderSignedData, TransactionKey},
+        transaction::{ObjectArg, SenderSignedData, VerifiedTransaction},
     };
 
     use super::*;
@@ -330,7 +297,7 @@ mod tests {
             .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
             .await;
-        let certs = vec![
+        let certs = [
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, false)], 5),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 9),
@@ -343,8 +310,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
-            None,
+            certs.iter(),
             &BTreeMap::new(),
         )
         .unwrap();
@@ -383,7 +349,16 @@ mod tests {
         let randomness_obj_version = epoch_store
             .epoch_start_config()
             .randomness_obj_initial_shared_version();
-        let certs = vec![
+        let certs = [
+            VerifiedExecutableTransaction::new_system(
+                VerifiedTransaction::new_randomness_state_update(
+                    epoch_store.epoch(),
+                    RandomnessRound::new(1),
+                    vec![],
+                    randomness_obj_version,
+                ),
+                epoch_store.epoch(),
+            ),
             generate_shared_objs_tx_with_gas_version(
                 &[(
                     IOTA_RANDOMNESS_STATE_OBJECT_ID,
@@ -409,8 +384,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
-            Some(RandomnessRound::new(1)),
+            certs.iter(),
             &BTreeMap::new(),
         )
         .unwrap();
@@ -431,17 +405,17 @@ mod tests {
             assigned_versions,
             vec![
                 (
-                    TransactionKey::RandomnessRound(0, RandomnessRound::new(1)),
+                    certs[0].key(),
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, randomness_obj_version),]
                 ),
                 (
-                    certs[0].key(),
+                    certs[1].key(),
                     // It is critical that the randomness object version is updated before the
                     // assignment.
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, next_randomness_obj_version)]
                 ),
                 (
-                    certs[1].key(),
+                    certs[2].key(),
                     // It is critical that the randomness object version is updated before the
                     // assignment.
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, next_randomness_obj_version)]
@@ -496,7 +470,7 @@ mod tests {
         // lamport version = 10 due to gas object version = 9   tx5: shared
         // objects assign cancelled version, lamport version = 12 due to gas object
         // version = 11
-        let certs = vec![
+        let certs = [
             generate_shared_objs_tx_with_gas_version(
                 &[
                     (id1, init_shared_version_1, true),
@@ -565,8 +539,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
-            None,
+            certs.iter(),
             &cancelled_txns,
         )
         .unwrap();


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@90329](https://github.com/MystenLabs/sui/commit/9032975928b425cf449c373a484cb50199e6a3d4)
- Description:

This PR delays the merging of non randomness certificates and randomness
certificates when processing consensus transactions.
We keep them separated until we are done with assigning shared object
versions.
This should be a non-functional-change.

This will be necessary for supporting accumulators, because we need to
settle accumulators per pending checkpoint. In this case, if we are
generating two pending checkpoints (one for non randomness and one for
randomness), we need to assign versions for the accumulator object
twice.

To make things simpler, this PR also removes the randomness-specific
logic in the version manager, instead it generates a placeholder
randomness state update transaction, and let version manager to assign
versions automatically.

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes