### PR TITLE
upstream(core): Add frozen/shared objects support to test checkpoint builder

### DIFF
--- a/crates/iota-types/src/effects/test_effects_builder.rs
+++ b/crates/iota-types/src/effects/test_effects_builder.rs
@@ -32,6 +32,8 @@ pub struct TestEffectsBuilder {
     wrapped_objects: Vec<(ObjectID, SequenceNumber)>,
     /// Objects that are unwrapped: (ID, new owner).
     unwrapped_objects: Vec<(ObjectID, Owner)>,
+    /// Immutable objects that are read.
+    frozen_objects: BTreeSet<ObjectID>,
 }
 
 impl TestEffectsBuilder {
@@ -46,6 +48,7 @@ impl TestEffectsBuilder {
             deleted_objects: vec![],
             wrapped_objects: vec![],
             unwrapped_objects: vec![],
+            frozen_objects: BTreeSet::new(),
         }
     }
 
@@ -109,6 +112,11 @@ impl TestEffectsBuilder {
         self
     }
 
+    pub fn with_frozen_objects(mut self, objects: impl IntoIterator<Item = ObjectID>) -> Self {
+        self.frozen_objects.extend(objects);
+        self
+    }
+
     pub fn build(self) -> TransactionEffects {
         let lamport_version = self.get_lamport_version();
         let status = self.status.unwrap_or(ExecutionStatus::Success);
@@ -128,6 +136,11 @@ impl TestEffectsBuilder {
             .unwrap()
             .iter()
             .filter_map(|kind| match kind {
+                InputObjectKind::ImmOrOwnedMoveObject((id, _, _))
+                    if self.frozen_objects.contains(id) =>
+                {
+                    None
+                }
                 InputObjectKind::ImmOrOwnedMoveObject(oref) => {
                     Some((
                         oref.0,

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -30,7 +30,8 @@ use crate::{
     object::{GAS_VALUE_FOR_TESTING, MoveObject, Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
-        EndOfEpochTransactionKind, SenderSignedData, Transaction, TransactionData, TransactionKind,
+        EndOfEpochTransactionKind, ObjectArg, SenderSignedData, Transaction, TransactionData,
+        TransactionKind,
     },
 };
 
@@ -85,7 +86,14 @@ struct TransactionBuilder {
     unwrapped_objects: BTreeSet<ObjectID>,
     wrapped_objects: BTreeSet<ObjectID>,
     deleted_objects: BTreeSet<ObjectID>,
+    frozen_objects: BTreeSet<ObjectRef>,
+    shared_inputs: BTreeMap<ObjectID, Shared>,
     events: Option<Vec<Event>>,
+}
+
+struct Shared {
+    mutable: bool,
+    object: Object,
 }
 
 impl TransactionBuilder {
@@ -99,6 +107,8 @@ impl TransactionBuilder {
             unwrapped_objects: BTreeSet::new(),
             wrapped_objects: BTreeSet::new(),
             deleted_objects: BTreeSet::new(),
+            frozen_objects: BTreeSet::new(),
+            shared_inputs: BTreeMap::new(),
             events: None,
         }
     }
@@ -234,9 +244,9 @@ impl TestCheckpointDataBuilder {
         self
     }
 
-    /// Mutate an existing object in the transaction.
+    /// Mutate an existing owned object in the transaction.
     /// `object_idx` is a convenient representation of the object's ID.
-    pub fn mutate_object(mut self, object_idx: u64) -> Self {
+    pub fn mutate_owned_object(mut self, object_idx: u64) -> Self {
         let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
         let object_id = Self::derive_object_id(object_idx);
         let object = self
@@ -246,6 +256,11 @@ impl TestCheckpointDataBuilder {
             .expect("Mutating an object that doesn't exist");
         tx_builder.mutated_objects.insert(object_id, object);
         self
+    }
+
+    /// Mutate an existing shared object in the transaction.
+    pub fn mutate_shared_object(self, object_idx: u64) -> Self {
+        self.access_shared_object(object_idx, true)
     }
 
     /// Transfer an existing object to a new owner.
@@ -332,6 +347,30 @@ impl TestCheckpointDataBuilder {
         self
     }
 
+    /// Add an immutable object as an input to the transaction.
+    ///
+    /// Fails if the object is not live or if its owner is not
+    /// [Owner::Immutable]).
+    pub fn read_frozen_object(mut self, object_id: u64) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_id);
+
+        let Some(obj) = self.live_objects.get(&object_id) else {
+            panic!("Frozen object not found");
+        };
+
+        assert!(obj.owner().is_immutable());
+        tx_builder
+            .frozen_objects
+            .insert(obj.compute_object_reference());
+        self
+    }
+
+    /// Add a read to a shared object to the transaction's effects.
+    pub fn read_shared_object(self, object_idx: u64) -> Self {
+        self.access_shared_object(object_idx, false)
+    }
+
     /// Add events to the transaction.
     /// `events` is a vector of events to be added to the transaction.
     pub fn with_events(mut self, events: Vec<Event>) -> Self {
@@ -371,11 +410,15 @@ impl TestCheckpointDataBuilder {
             unwrapped_objects,
             wrapped_objects,
             deleted_objects,
+            frozen_objects,
+            shared_inputs,
             events,
         } = self.checkpoint_builder.next_transaction.take().unwrap();
+
         let sender = Self::derive_address(sender_idx);
         let events = events.map(|events| TransactionEvents { data: events });
         let events_digest = events.as_ref().map(|events| events.digest());
+
         let mut pt_builder = ProgrammableTransactionBuilder::new();
         for (package, module, function) in move_calls {
             pt_builder
@@ -388,6 +431,30 @@ impl TestCheckpointDataBuilder {
                 )
                 .unwrap();
         }
+
+        for &object_ref in &frozen_objects {
+            pt_builder
+                .obj(ObjectArg::ImmOrOwnedObject(object_ref))
+                .expect("Failed to add frozen object input");
+        }
+
+        for (id, input) in &shared_inputs {
+            let &Owner::Shared {
+                initial_shared_version,
+            } = input.object.owner()
+            else {
+                panic!("Accessing a non-shared object as shared");
+            };
+
+            pt_builder
+                .obj(ObjectArg::SharedObject {
+                    id: *id,
+                    initial_shared_version,
+                    mutable: input.mutable,
+                })
+                .expect("Failed to add shared object input");
+        }
+
         let pt = pt_builder.finish();
         let tx_data = TransactionData::new(
             TransactionKind::ProgrammableTransaction(pt),
@@ -396,7 +463,9 @@ impl TestCheckpointDataBuilder {
             1,
             1,
         );
+
         let tx = Transaction::new(SenderSignedData::new(tx_data, vec![]));
+
         let wrapped_objects: Vec<_> = wrapped_objects
             .into_iter()
             .map(|id| self.live_objects.remove(&id).unwrap())
@@ -409,6 +478,7 @@ impl TestCheckpointDataBuilder {
             .into_iter()
             .map(|id| self.wrapped_objects.remove(&id).unwrap())
             .collect();
+
         let mut effects_builder = TestEffectsBuilder::new(tx.data())
             .with_created_objects(created_objects.iter().map(|(id, o)| (*id, *o.owner())))
             .with_mutated_objects(
@@ -418,14 +488,24 @@ impl TestCheckpointDataBuilder {
             )
             .with_wrapped_objects(wrapped_objects.iter().map(|o| (o.id(), o.version())))
             .with_unwrapped_objects(unwrapped_objects.iter().map(|o| (o.id(), *o.owner())))
-            .with_deleted_objects(deleted_objects.iter().map(|o| (o.id(), o.version())));
+            .with_deleted_objects(deleted_objects.iter().map(|o| (o.id(), o.version())))
+            .with_frozen_objects(frozen_objects.into_iter().map(|(id, _, _)| id))
+            .with_shared_input_versions(
+                shared_inputs
+                    .iter()
+                    .map(|(id, input)| (*id, input.object.version()))
+                    .collect(),
+            );
+
         if let Some(events_digest) = &events_digest {
             effects_builder = effects_builder.with_events_digest(*events_digest);
         }
+
         let effects = effects_builder.build();
         let lamport_version = effects.lamport_version();
         let input_objects: Vec<_> = mutated_objects
             .keys()
+            .chain(shared_inputs.keys())
             .map(|id| self.live_objects.get(id).unwrap().clone())
             .chain(deleted_objects.clone())
             .chain(wrapped_objects.clone())
@@ -437,6 +517,7 @@ impl TestCheckpointDataBuilder {
             .values()
             .cloned()
             .chain(mutated_objects.values().cloned())
+            .chain(shared_inputs.values().map(|input| input.object.clone()))
             .chain(unwrapped_objects.clone())
             .chain(std::iter::once(
                 self.live_objects.get(&gas.0).cloned().unwrap(),
@@ -453,6 +534,7 @@ impl TestCheckpointDataBuilder {
             .extend(output_objects.iter().map(|o| (o.id(), o.clone())));
         self.wrapped_objects
             .extend(wrapped_objects.iter().map(|o| (o.id(), o.clone())));
+
         self.checkpoint_builder
             .transactions
             .push(CheckpointTransaction {
@@ -605,6 +687,22 @@ impl TestCheckpointDataBuilder {
     pub fn derive_address(address_idx: u8) -> IotaAddress {
         dbg_addr(address_idx)
     }
+
+    /// Add a shared input to the transaction, being accessed from the currently
+    /// recorded live version.
+    fn access_shared_object(mut self, object_idx: u64, mutable: bool) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        let object = self
+            .live_objects
+            .get(&object_id)
+            .cloned()
+            .expect("Accessing a shared object that doesn't exist");
+        tx_builder
+            .shared_inputs
+            .insert(object_id, Shared { mutable, object });
+        self
+    }
 }
 
 #[cfg(test)]
@@ -705,7 +803,7 @@ mod tests {
             .create_owned_object(0)
             .finish_transaction()
             .start_transaction(0)
-            .mutate_object(0)
+            .mutate_owned_object(0)
             .finish_transaction()
             .build_checkpoint();
 
@@ -975,7 +1073,7 @@ mod tests {
         let checkpoint1 = builder.build_checkpoint();
         builder = builder
             .start_transaction(0)
-            .mutate_object(0)
+            .mutate_owned_object(0)
             .finish_transaction();
         let checkpoint2 = builder.build_checkpoint();
         builder = builder

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -355,9 +355,10 @@ impl TestCheckpointDataBuilder {
         let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
         let object_id = Self::derive_object_id(object_id);
 
-        let Some(obj) = self.live_objects.get(&object_id) else {
-            panic!("Frozen object not found");
-        };
+        let obj = self
+            .live_objects
+            .get(&object_id)
+            .expect("Frozen object not found");
 
         assert!(obj.owner().is_immutable());
         tx_builder


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@c9f63c6](https://github.com/MystenLabs/sui/commit/c9f63c6fbf09e50f6120b6a0d42edf3f21c99030)
- Description:

Add support for frozen objects, shared object modification and reading
shared objects to the test checkpoint builder, and use that to write a
test just for `checkpoint_input_objects`.

Only the `iota-types` changes were ported (test effects builder and test checkpoint data builder).

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes