### PR TITLE
upstream(core): Filter out immutable shared objects in test checkpoint builder

### DIFF
--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -506,7 +506,12 @@ impl TestCheckpointDataBuilder {
         let lamport_version = effects.lamport_version();
         let input_objects: Vec<_> = mutated_objects
             .keys()
-            .chain(shared_inputs.keys())
+            .chain(
+                shared_inputs
+                    .iter()
+                    .filter(|(_, i)| i.mutable)
+                    .map(|(id, _)| id),
+            )
             .map(|id| self.live_objects.get(id).unwrap().clone())
             .chain(deleted_objects.clone())
             .chain(wrapped_objects.clone())
@@ -518,7 +523,12 @@ impl TestCheckpointDataBuilder {
             .values()
             .cloned()
             .chain(mutated_objects.values().cloned())
-            .chain(shared_inputs.values().map(|input| input.object.clone()))
+            .chain(
+                shared_inputs
+                    .values()
+                    .filter(|i| i.mutable)
+                    .map(|i| i.object.clone()),
+            )
             .chain(unwrapped_objects.clone())
             .chain(std::iter::once(
                 self.live_objects.get(&gas.0).cloned().unwrap(),


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@275fa](https://github.com/MystenLabs/sui/commit/275fa4db3336dca249ea5a807b93c7f781d663fe)
- Description:

Filter out immutable shared objects from `input_objects` and `output_objects` in the test checkpoint data builder, so that read-only shared objects are no longer incorrectly included alongside mutable shared inputs.


## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes