### PR TITLE
fix(iota-data-ingestion-core): lower `GRPC_MAX_DECODING_MESSAGE_SIZE_BYTES`

### DIFF
--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -41,7 +41,7 @@ use crate::{
     },
 };
 
-const GRPC_MAX_DECODING_MESSAGE_SIZE_BYTES: usize = 128 * 1024 * 1024;
+const GRPC_MAX_DECODING_MESSAGE_SIZE_BYTES: usize = 125 * 1024 * 1024;
 
 // As an optimization, we're trying to request only the fields we actually need.
 const GRPC_CHECKPOINT_STREAM_READ_MASK: &[&str] = &[


### PR DESCRIPTION
# Description of change

Due to a bug in `iota-grpc-server`, the server-side chunking logic in `create_checkpoint_messages_stream` tracks batch size by summing `encoded_len()` of inner items but does not account for protobuf wrapper framing (field tags and length varints) added when the batch is serialized inside `CheckpointData` → `ExecutedTransactions`. 

This causes the final wire message to exceed tonic's `max_encoding_message_size` (128 MiB) by a small margin. To work around this until a proper fix is provided by the node team, we're lowering `GRPC_MAX_DECODING_MESSAGE_SIZE_BYTES` from 128 to 125 MiB, this value gets forwarded to the server as the chunking budget, leaving 3 MiB of headroom which is more than enough to cover all cases.

## Links to any relevant issues

fixes #10900 

## How the change has been tested

- Re-ran the tests on networks (alphanet & devnet) and also on staging to make sure that all was working as expected.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [x] Verification of API backward compatibility.