### PR TITLE
feat(indexer): Bail early from dependency wait when objects are superseded

### DIFF
--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -36,7 +36,7 @@ use crate::{
         display::StoredDisplay,
         transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
     },
-    read::IndexerReader,
+    read::{IndexerReader, InputObjectsStatus},
     store::{IndexerStore, PgIndexerStore},
     transactional_blocking_with_retry_with_conditional_abort,
     types::{
@@ -88,7 +88,6 @@ impl OptimisticTransactionExecutor {
         &self,
         input_obj_keys: Vec<(ObjectID, SequenceNumber)>,
     ) -> Result<(), IndexerError> {
-        let expected_count = input_obj_keys.len();
         let backoff = backoff::ExponentialBackoff {
             initial_interval: Duration::from_millis(100),
             max_elapsed_time: Some(WAIT_FOR_DEPS_MAX_ELAPSED_TIME),
@@ -96,24 +95,19 @@ impl OptimisticTransactionExecutor {
         };
 
         backoff::future::retry(backoff, async || {
-            let count = self
+            match self
                 .read
-                .count_existing_object_keys_in_blocking_task(input_obj_keys.clone())
-                .await?;
-            if count as usize == expected_count {
-                return Ok(());
-            }
-            // If any dependency object already has a newer version - stop retrying.
-            if self
-                .read
-                .has_superseded_objects_in_blocking_task(input_obj_keys.clone())
+                .check_input_objects_in_blocking_task(input_obj_keys.clone())
                 .await?
             {
-                return Err(backoff::Error::permanent(
+                InputObjectsStatus::Ready => Ok(()),
+                InputObjectsStatus::Superseded => Err(backoff::Error::permanent(
                     IndexerError::TransactionDependenciesNotIndexed,
-                ));
+                )),
+                InputObjectsStatus::Pending => {
+                    Err(IndexerError::TransactionDependenciesNotIndexed)?
+                }
             }
-            Err(IndexerError::TransactionDependenciesNotIndexed)?
         })
         .await
         .or(Err(IndexerError::TransactionDependenciesNotIndexed))

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -100,10 +100,20 @@ impl OptimisticTransactionExecutor {
                 .read
                 .count_existing_object_keys_in_blocking_task(input_obj_keys.clone())
                 .await?;
-            if count as usize != expected_count {
-                return Err(IndexerError::TransactionDependenciesNotIndexed)?;
+            if count as usize == expected_count {
+                return Ok(());
             }
-            Ok(())
+            // If any dependency object already has a newer version - stop retrying.
+            if self
+                .read
+                .has_superseded_objects_in_blocking_task(input_obj_keys.clone())
+                .await?
+            {
+                return Err(backoff::Error::permanent(
+                    IndexerError::TransactionDependenciesNotIndexed,
+                ));
+            }
+            Err(IndexerError::TransactionDependenciesNotIndexed)?
         })
         .await
         .or(Err(IndexerError::TransactionDependenciesNotIndexed))

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1099,6 +1099,60 @@ impl IndexerReader {
         })
     }
 
+    /// Returns `true` if any of the requested objects exist in the DB at a
+    /// version greater than the one requested. Such check is useful when
+    /// waiting for exact object versions, as it indicates that further waiting
+    /// is futile.
+    pub async fn has_superseded_objects_in_blocking_task(
+        &self,
+        object_keys: Vec<(ObjectID, SequenceNumber)>,
+    ) -> Result<bool, IndexerError> {
+        self.spawn_blocking(move |this| this.has_superseded_objects(object_keys))
+            .await
+    }
+
+    fn has_superseded_objects(
+        &self,
+        object_keys: Vec<(ObjectID, SequenceNumber)>,
+    ) -> Result<bool, IndexerError> {
+        if object_keys.is_empty() {
+            return Ok(false);
+        }
+
+        let values_clause = object_keys
+            .iter()
+            .map(|(id, version)| {
+                format!(
+                    "('\\x{}'::bytea, {}::bigint)",
+                    Hex::encode(id.to_vec()),
+                    version.value()
+                )
+            })
+            .join(", ");
+
+        let query = format!(
+            "SELECT EXISTS(\
+               SELECT 1 FROM objects \
+               JOIN (VALUES {}) AS v(object_id, object_version) \
+                 ON objects.object_id = v.object_id \
+               WHERE objects.object_version > v.object_version\
+             ) as result",
+            values_clause
+        );
+
+        #[derive(QueryableByName)]
+        struct Exists {
+            #[diesel(sql_type = diesel::sql_types::Bool)]
+            result: bool,
+        }
+
+        run_query!(&self.pool, |conn| {
+            diesel::sql_query(query)
+                .get_result::<Exists>(conn)
+                .map(|r| r.result)
+        })
+    }
+
     pub async fn query_transaction_blocks_in_blocking_task(
         &self,
         filter: Option<TransactionFilter>,

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -96,6 +96,18 @@ pub const OPTIMISTIC_SEQUENCE_NUMBER_STR: &str = "optimistic_sequence_number";
 pub const TX_DIGEST_STR: &str = "tx_digest";
 pub const EVENT_SEQUENCE_NUMBER_STR: &str = "event_sequence_number";
 
+/// Result of checking input object dependencies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputObjectsStatus {
+    /// All objects exist at the requested versions and are finalized.
+    Ready,
+    /// At least one object has a newer version — waiting will never succeed.
+    Superseded,
+    /// Not all objects are ready yet (missing, older version, or not yet
+    /// finalized by checkpoint indexing).
+    Pending,
+}
+
 /// Encapsulates the logic for reading from the database.
 ///
 /// Provides a set of methods to perform read operations,
@@ -1050,20 +1062,22 @@ impl IndexerReader {
         })
     }
 
-    pub async fn count_existing_object_keys_in_blocking_task(
+    /// Checks whether all input objects exist at the requested versions and
+    /// are finalized.
+    pub async fn check_input_objects_in_blocking_task(
         &self,
         object_keys: Vec<(ObjectID, SequenceNumber)>,
-    ) -> Result<i64, IndexerError> {
-        self.spawn_blocking(move |this| this.count_existing_object_keys(object_keys))
+    ) -> Result<InputObjectsStatus, IndexerError> {
+        self.spawn_blocking(move |this| this.check_input_objects(object_keys))
             .await
     }
 
-    fn count_existing_object_keys(
+    fn check_input_objects(
         &self,
         object_keys: Vec<(ObjectID, SequenceNumber)>,
-    ) -> Result<i64, IndexerError> {
+    ) -> Result<InputObjectsStatus, IndexerError> {
         if object_keys.is_empty() {
-            return Ok(0);
+            return Ok(InputObjectsStatus::Ready);
         }
 
         let values_clause = object_keys
@@ -1077,79 +1091,47 @@ impl IndexerReader {
             })
             .join(", ");
 
+        // Single query that returns a tri-state:
+        // TRUE  — all objects match exact versions and are finalized
+        // FALSE — at least one object has been superseded (newer version)
+        // NULL  — not ready yet (missing, older version, or not finalized)
         let query = format!(
-            "WITH max_chk AS (SELECT COALESCE(MAX(sequence_number), -1) AS max_sn FROM checkpoints) \
-             SELECT COUNT(*) as count FROM objects \
-             WHERE (object_id, object_version) IN (VALUES {}) \
-             AND (finalized_in_cp IS NULL \
-                  OR finalized_in_cp <= (SELECT max_sn FROM max_chk))",
+            "WITH \
+               input_objects(id, version) AS (VALUES {}), \
+               max_chk AS (SELECT COALESCE(MAX(sequence_number), -1) AS max_sn FROM checkpoints), \
+               matches AS ( \
+                 SELECT \
+                   i.version AS input_version, \
+                   o.object_version AS actual_version, \
+                   o.finalized_in_cp \
+                 FROM input_objects i \
+                 LEFT JOIN objects o ON o.object_id = i.id \
+               ) \
+             SELECT CASE \
+               WHEN COUNT(*) FILTER (WHERE actual_version > input_version) > 0 THEN FALSE \
+               WHEN COUNT(*) FILTER (WHERE actual_version IS NULL) > 0 THEN NULL \
+               WHEN COUNT(*) FILTER (WHERE actual_version < input_version) > 0 THEN NULL \
+               WHEN COUNT(*) FILTER (WHERE finalized_in_cp IS NOT NULL \
+                 AND finalized_in_cp > (SELECT max_sn FROM max_chk)) > 0 THEN NULL \
+               ELSE TRUE \
+             END AS result FROM matches",
             values_clause
         );
 
         #[derive(QueryableByName)]
-        struct Count {
-            #[diesel(sql_type = BigInt)]
-            count: i64,
+        struct TriState {
+            #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Bool>)]
+            result: Option<bool>,
         }
 
         run_query!(&self.pool, |conn| {
             diesel::sql_query(query)
-                .get_result::<Count>(conn)
-                .map(|result| result.count)
-        })
-    }
-
-    /// Returns `true` if any of the requested objects exist in the DB at a
-    /// version greater than the one requested. Such check is useful when
-    /// waiting for exact object versions, as it indicates that further waiting
-    /// is futile.
-    pub async fn has_superseded_objects_in_blocking_task(
-        &self,
-        object_keys: Vec<(ObjectID, SequenceNumber)>,
-    ) -> Result<bool, IndexerError> {
-        self.spawn_blocking(move |this| this.has_superseded_objects(object_keys))
-            .await
-    }
-
-    fn has_superseded_objects(
-        &self,
-        object_keys: Vec<(ObjectID, SequenceNumber)>,
-    ) -> Result<bool, IndexerError> {
-        if object_keys.is_empty() {
-            return Ok(false);
-        }
-
-        let values_clause = object_keys
-            .iter()
-            .map(|(id, version)| {
-                format!(
-                    "('\\x{}'::bytea, {}::bigint)",
-                    Hex::encode(id.to_vec()),
-                    version.value()
-                )
-            })
-            .join(", ");
-
-        let query = format!(
-            "SELECT EXISTS(\
-               SELECT 1 FROM objects \
-               JOIN (VALUES {}) AS v(object_id, object_version) \
-                 ON objects.object_id = v.object_id \
-               WHERE objects.object_version > v.object_version\
-             ) as result",
-            values_clause
-        );
-
-        #[derive(QueryableByName)]
-        struct Exists {
-            #[diesel(sql_type = diesel::sql_types::Bool)]
-            result: bool,
-        }
-
-        run_query!(&self.pool, |conn| {
-            diesel::sql_query(query)
-                .get_result::<Exists>(conn)
-                .map(|r| r.result)
+                .get_result::<TriState>(conn)
+                .map(|r| match r.result {
+                    Some(true) => InputObjectsStatus::Ready,
+                    Some(false) => InputObjectsStatus::Superseded,
+                    None => InputObjectsStatus::Pending,
+                })
         })
     }
 


### PR DESCRIPTION
# Description of change

When optimistic indexing waits for input object dependencies, it retries with exponential backoff until all objects exist at exact versions. If checkpoint indexing (or another optimistic tx) has already advanced an object past the requested version, the exact match will never succeed, but the retry
loop continues for the full timeout (~3s).

This adds a cheap `SELECT EXISTS(...)` check on the retry path: if any dependency object already has a newer version in the DB, stop retrying immediately and fall back to checkpoint-indexed data.

## Links to any relevant issues

fixes #10742

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
