### PR TITLE
upstream(core): Export current, max supported and max configured protocol config versions as metrics

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1012,6 +1012,10 @@ impl AuthorityPerEpochStore {
     ) -> IotaResult<Arc<Self>> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
+        metrics.current_epoch.set(epoch_id as i64);
+        metrics
+            .current_voting_right
+            .set(committee.weight(&name) as i64);
 
         let tables = AuthorityEpochTables::open(epoch_id, parent_path, db_options.clone());
         let end_of_publish =
@@ -1038,12 +1042,9 @@ impl AuthorityPerEpochStore {
             epoch_start_configuration.epoch_start_state().epoch(),
             epoch_id
         );
+
         let epoch_start_configuration = Arc::new(epoch_start_configuration);
         info!("epoch flags: {:?}", epoch_start_configuration.flags());
-        metrics.current_epoch.set(epoch_id as i64);
-        metrics
-            .current_voting_right
-            .set(committee.weight(&name) as i64);
         let protocol_version = epoch_start_configuration
             .epoch_start_state()
             .protocol_version();
@@ -4648,7 +4649,6 @@ impl AuthorityPerEpochStore {
     }
 
     fn record_epoch_total_duration_metric(&self) {
-        self.metrics.current_epoch.set(self.epoch() as i64);
         self.metrics
             .epoch_total_duration
             .set(self.epoch_open_time.elapsed().as_millis() as i64);

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -100,7 +100,7 @@ use iota_network::{
     api::ValidatorServer, discovery, discovery::TrustedPeerChangeEvent, randomness, state_sync,
 };
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
-use iota_protocol_config::ProtocolConfig;
+use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use iota_rest_api::{RestMetrics, ServerVersion};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
 use iota_snapshot::uploader::StateSnapshotUploader;
@@ -876,6 +876,13 @@ impl IotaNode {
         let connection_monitor_status = Arc::new(connection_monitor_status);
         let iota_node_metrics =
             Arc::new(IotaNodeMetrics::new(&registry_service.default_registry()));
+
+        iota_node_metrics
+            .binary_max_protocol_version
+            .set(ProtocolVersion::MAX.as_u64() as i64);
+        iota_node_metrics
+            .configured_max_protocol_version
+            .set(config.supported_protocol_versions.unwrap().max.as_u64() as i64);
 
         // Convert transaction orchestrator to executor trait object for gRPC server
         // Note that the transaction_orchestrator (so as executor) will be None if it is
@@ -1802,6 +1809,11 @@ impl IotaNode {
 
             let cur_epoch_store = self.state.load_epoch_store_one_call_per_task();
 
+            // Update the current protocol version metric.
+            self.metrics
+                .current_protocol_version
+                .set(cur_epoch_store.protocol_config().version.as_u64() as i64);
+
             // Advertise capabilities to committee, if we are a validator.
             if let Some(components) = &*self.validator_components.lock().await {
                 // TODO: without this sleep, the consensus message is not delivered reliably.
@@ -2075,11 +2087,11 @@ impl IotaNode {
                 )
             {
                 self.state
-                .prune_checkpoints_for_eligible_epochs_for_testing(
-                    self.config.clone(),
-                    iota_core::authority::authority_store_pruner::AuthorityStorePruningMetrics::new_for_test(),
-                )
-                .await?;
+                    .prune_checkpoints_for_eligible_epochs_for_testing(
+                        self.config.clone(),
+                        iota_core::authority::authority_store_pruner::AuthorityStorePruningMetrics::new_for_test(),
+                    )
+                    .await?;
             }
 
             epoch_store = new_epoch_store;

--- a/crates/iota-node/src/metrics.rs
+++ b/crates/iota-node/src/metrics.rs
@@ -9,8 +9,9 @@ use iota_metrics::RegistryService;
 use iota_network::tonic::Code;
 use iota_network_stack::metrics::MetricsCallbackProvider;
 use prometheus::{
-    HistogramVec, IntCounterVec, IntGaugeVec, Registry, register_histogram_vec_with_registry,
-    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
+    HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
 };
 
 /// Starts a task to periodically push metrics to a configured endpoint if a
@@ -74,6 +75,10 @@ pub struct IotaNodeMetrics {
     pub total_jwks: IntCounterVec,
     pub invalid_jwks: IntCounterVec,
     pub unique_jwks: IntCounterVec,
+
+    pub current_protocol_version: IntGauge,
+    pub binary_max_protocol_version: IntGauge,
+    pub configured_max_protocol_version: IntGauge,
 }
 
 impl IotaNodeMetrics {
@@ -111,6 +116,24 @@ impl IotaNodeMetrics {
                 "unique_jwks",
                 "Total number of unique JWKs",
                 &["provider"],
+                registry,
+            )
+            .unwrap(),
+            current_protocol_version: register_int_gauge_with_registry!(
+                "iota_current_protocol_version",
+                "Current protocol version in this epoch",
+                registry,
+            )
+            .unwrap(),
+            binary_max_protocol_version: register_int_gauge_with_registry!(
+                "iota_binary_max_protocol_version",
+                "Max protocol version supported by this binary",
+                registry,
+            )
+            .unwrap(),
+            configured_max_protocol_version: register_int_gauge_with_registry!(
+                "iota_configured_max_protocol_version",
+                "Max protocol version configured in the node config",
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@e8f522a](https://github.com/MystenLabs/sui/commit/e8f522a3c05d0f06774e4c8b2a5ddb301c2803e5)
- Description:

Export current, max supported and max configured protocol config versions as Prometheus metrics for debugging and setting up alerts.

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes