### PR TITLE
fix(build-scripts): use tsc directly to fix CI build failure

### DIFF
--- a/sdk/build-scripts/src/utils/buildPackage.ts
+++ b/sdk/build-scripts/src/utils/buildPackage.ts
@@ -133,7 +133,7 @@ async function buildESM(
 }
 
 async function buildTypes(config: string) {
-    execSync(`pnpm tsc --build ${config}`, {
+    execSync(`tsc --build ${config}`, {
         stdio: 'inherit',
         cwd: process.cwd(),
     });


### PR DESCRIPTION
## Summary

- Fixes `@iota/kiosk:build` CI failure caused by pnpm 10.30.0's `loadWorkspaceState` encountering corrupted workspace state JSON in CI (with turbo caching)
- Changes `pnpm tsc --build` to `tsc --build` in `buildPackage.ts` — `node_modules/.bin` is already on PATH when running within a pnpm script context, so `tsc` resolves correctly without going through pnpm's workspace state check

## Test plan

- [ ] CI build passes for `@iota/kiosk:build` and downstream packages
- [ ] All other SDK package builds succeed

https://claude.ai/code/session_01AFiubo5gruuJdPauxqMrf7