### PR TITLE
[TEST]chore(ts-sdk): Use `indexer` instead `api` urls in the ts packages

### DIFF
--- a/sdk/.env.defaults
+++ b/sdk/.env.defaults
@@ -21,7 +21,7 @@ IOTA_NETWORKS = '
     "testnet": {
         "id": "testnet",
         "name": "Testnet",
-        "url": "https://api.testnet.iota.cafe",
+        "url": "https://indexer.testnet.iota.cafe",
         "graphql": "https://graphql.testnet.iota.cafe",
         "explorer": "https://explorer.rebased.iota.org",
         "chain": "iota:testnet",
@@ -36,7 +36,7 @@ IOTA_NETWORKS = '
     "devnet": {
         "id": "devnet",
         "name": "Devnet",
-        "url": "https://api.devnet.iota.cafe",
+        "url": "https://indexer.devnet.iota.cafe",
         "graphql": "https://graphql.devnet.iota.cafe",
         "explorer": "https://explorer.rebased.iota.org",
         "chain": "iota:devnet",

--- a/sdk/isc-sdk/README.md
+++ b/sdk/isc-sdk/README.md
@@ -26,12 +26,12 @@ import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { requestIotaFromFaucetV0 } from '@iota/iota-sdk/faucet';
 import { IotaClient } from '@iota/iota-sdk/client';
 
-const RPC_URL = 'https://api.testnet.iota.cafe';
+const RPC_URL = 'https://indexer.testnet.iota.cafe';
 const FAUCET_URL = 'https://faucet.testnet.iota.cafe';
 const DESTINATION_EVM_ADDRESS = '...';
 const L1_CONFIG = {
     networkName: 'testnet',
-    rpcUrl: 'https://api.testnet.iota.cafe',
+    rpcUrl: 'https://indexer.testnet.iota.cafe',
     faucetUrl: 'https://faucet.testnet.iota.cafe',
     chainId: '0x2f11f5ea9d3c093c9cc2e329cf92e05aa00ac052ada96c4c14a2f6869a7cbcaf',
     packageId: '0x1e6e060b87f55acc0a7632acab9cf5712ff01643f8577c9a6f99ebd1010e3f4c',


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

- [Default PR Template for External Contributors](?expand=1&template=default_external_contributors.md)
- [Default PR Template for Internal Contributors](?expand=1&template=default_internal_contributors.md)
- [Infrastructure Team](?expand=1&template=infra.md)
- [Tooling Team](?expand=1&template=tooling.md)
