### PR TITLE
feat(iota-network): [P-COOL] proto file scaffolding, ValidatorV2/ValidatorPeer services, and conversion layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7536,6 +7536,7 @@ dependencies = [
  "iota-swarm-config",
  "iota-types",
  "prometheus",
+ "prost 0.14.1",
  "rand 0.8.5",
  "serde",
  "tap",
@@ -7545,6 +7546,7 @@ dependencies = [
  "tonic 0.14.2",
  "tonic-build 0.14.2",
  "tonic-prost",
+ "tonic-prost-build",
  "tower 0.4.13",
  "tracing",
 ]

--- a/crates/iota-network/Cargo.toml
+++ b/crates/iota-network/Cargo.toml
@@ -20,11 +20,11 @@ fastcrypto-tbls.workspace = true
 futures.workspace = true
 governor = "0.6.0"
 prometheus.workspace = true
+prost.workspace = true
 rand.workspace = true
 serde.workspace = true
 tap.workspace = true
 tokio = { workspace = true, features = ["full"] }
-prost.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 tower.workspace = true

--- a/crates/iota-network/Cargo.toml
+++ b/crates/iota-network/Cargo.toml
@@ -24,6 +24,7 @@ rand.workspace = true
 serde.workspace = true
 tap.workspace = true
 tokio = { workspace = true, features = ["full"] }
+prost.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 tower.workspace = true
@@ -42,6 +43,7 @@ iota-types.workspace = true
 [build-dependencies]
 anemo-build.workspace = true
 tonic-build.workspace = true
+tonic-prost-build = "0.14"
 
 [dev-dependencies]
 # external dependencies

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -144,7 +144,7 @@ fn main() -> Result<()> {
 
     build_anemo_services(&out_dir);
 
-    build_validator_v2(&out_dir)?;
+    build_proto_services(&out_dir)?;
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=proto/");
@@ -153,13 +153,16 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn build_validator_v2(out_dir: &Path) -> Result<()> {
+fn build_proto_services(out_dir: &Path) -> Result<()> {
     tonic_prost_build::configure()
         .build_client(true)
         .build_server(true)
         .bytes(".")
         .out_dir(out_dir)
-        .compile_protos(&["proto/validator_v2.proto"], &["proto/"])?;
+        .compile_protos(
+            &["proto/validator_v2.proto", "proto/validator_peer.proto"],
+            &["proto/"],
+        )?;
 
     Ok(())
 }

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -144,8 +144,22 @@ fn main() -> Result<()> {
 
     build_anemo_services(&out_dir);
 
+    build_validator_v2(&out_dir)?;
+
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=proto/");
     println!("cargo:rerun-if-env-changed=DUMP_GENERATED_GRPC");
+
+    Ok(())
+}
+
+fn build_validator_v2(out_dir: &Path) -> Result<()> {
+    tonic_prost_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .bytes(".")
+        .out_dir(out_dir)
+        .compile_protos(&["proto/validator_v2.proto"], &["proto/"])?;
 
     Ok(())
 }

--- a/crates/iota-network/proto/validator_peer.proto
+++ b/crates/iota-network/proto/validator_peer.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";

--- a/crates/iota-network/proto/validator_peer.proto
+++ b/crates/iota-network/proto/validator_peer.proto
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+package iota.validator.peer;
+
+// Authenticated validator-to-validator service for read-only queries.
+// Requires the same mutual authentication as consensus gRPC services.
+service ValidatorPeer {
+  // Fetch a checkpoint by sequence number or the latest available.
+  rpc GetCheckpoint(GetCheckpointRequest) returns (GetCheckpointResponse);
+}
+
+message GetCheckpointRequest {
+  // If set, return the checkpoint with this sequence number;
+  // otherwise return the latest checkpoint.
+  optional uint64 sequence_number = 1;
+  // When true, also include the checkpoint contents.
+  bool request_content = 2;
+  // When true, return a certified checkpoint; otherwise return a pending one.
+  bool certified = 3;
+}
+
+// BCS-encoded checkpoint data returned to the caller.
+message GetCheckpointResponse {
+  // BCS-serialized CheckpointSummaryResponse (signed or certified), if found.
+  optional bytes checkpoint = 1;
+  // BCS-serialized CheckpointContents, present when request_content was true.
+  optional bytes contents = 2;
+}

--- a/crates/iota-network/proto/validator_v2.proto
+++ b/crates/iota-network/proto/validator_v2.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";
@@ -25,11 +25,38 @@ message TxDigest {
 // Status update streamed back to the client
 message TxStatus {
   TxDigest tx_digest = 1;
-  Status status = 2;
+  StatusDetail status = 2;
 }
 
-// Transaction lifecycle statuses
-enum Status {
-  STATUS_UNSPECIFIED = 0;
-  // ... statuses TBD (e.g., PENDING, SEQUENCED, EXECUTED, REJECTED, etc.)
+// Detailed transaction status with per-variant payloads.
+message StatusDetail {
+  oneof kind {
+    SubmittedStatus submitted = 1;
+    ExecutedStatus executed = 2;
+    RejectedStatus rejected = 3;
+    ExpiredStatus expired = 4;
+  }
+}
+
+// Transaction passed pre-flight checks and was submitted to consensus.
+message SubmittedStatus {}
+
+// Transaction was executed and finalized by consensus.
+message ExecutedStatus {
+  // BCS-serialized TransactionEffectsDigest.
+  bytes effects_digest = 1;
+  // Optional BCS-serialized execution details (effects, events, objects).
+  // Present when the client requested detailed results.
+  optional bytes details = 2;
+}
+
+// Transaction was rejected during validation or by white-flag conflict resolution.
+message RejectedStatus {
+  // Optional BCS-serialized IotaError describing the rejection reason.
+  optional bytes error = 1;
+}
+
+// Transaction status has expired from the validator's cache.
+message ExpiredStatus {
+  uint64 epoch = 1;
 }

--- a/crates/iota-network/proto/validator_v2.proto
+++ b/crates/iota-network/proto/validator_v2.proto
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+package iota.validator.v2;
+
+service ValidatorV2 {
+  // Submit transaction(s) and stream all status updates until finality
+  rpc SubmitTx(SubmitTxRequest) returns (stream TxStatus);
+
+  // Stream status updates for a previously submitted transaction
+  rpc GetTxStatus(TxDigest) returns (stream TxStatus);
+}
+
+// Wraps one or more transactions (BCS-encoded payloads)
+message SubmitTxRequest {
+  repeated bytes tx = 1; // Each entry is a BCS-serialized Transaction
+}
+
+// Digest identifying a transaction
+message TxDigest {
+  bytes digest = 1;
+}
+
+// Status update streamed back to the client
+message TxStatus {
+  TxDigest tx_digest = 1;
+  Status status = 2;
+}
+
+// Transaction lifecycle statuses
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  // ... statuses TBD (e.g., PENDING, SEQUENCED, EXECUTED, REJECTED, etc.)
+}

--- a/crates/iota-network/src/api.rs
+++ b/crates/iota-network/src/api.rs
@@ -16,7 +16,8 @@ mod validator_v2 {
 }
 
 pub use validator_v2::{
-    Status, SubmitTxRequest, TxDigest, TxStatus,
+    ExecutedStatus, ExpiredStatus, RejectedStatus, StatusDetail, SubmitTxRequest, SubmittedStatus,
+    TxDigest, TxStatus, status_detail,
     validator_v2_client::ValidatorV2Client,
     validator_v2_server::{ValidatorV2, ValidatorV2Server},
 };

--- a/crates/iota-network/src/api.rs
+++ b/crates/iota-network/src/api.rs
@@ -16,6 +16,17 @@ mod validator_v2 {
 }
 
 pub use validator_v2::{
-    Status, SubmitTxRequest, TxDigest, TxStatus, validator_v2_client::ValidatorV2Client,
+    Status, SubmitTxRequest, TxDigest, TxStatus,
+    validator_v2_client::ValidatorV2Client,
     validator_v2_server::{ValidatorV2, ValidatorV2Server},
+};
+
+mod validator_peer {
+    tonic::include_proto!("iota.validator.peer");
+}
+
+pub use validator_peer::{
+    GetCheckpointRequest, GetCheckpointResponse,
+    validator_peer_client::ValidatorPeerClient,
+    validator_peer_server::{ValidatorPeer, ValidatorPeerServer},
 };

--- a/crates/iota-network/src/api.rs
+++ b/crates/iota-network/src/api.rs
@@ -10,3 +10,12 @@ pub use validator::{
     validator_client::ValidatorClient,
     validator_server::{Validator, ValidatorServer},
 };
+
+mod validator_v2 {
+    tonic::include_proto!("iota.validator.v2");
+}
+
+pub use validator_v2::{
+    Status, SubmitTxRequest, TxDigest, TxStatus, validator_v2_client::ValidatorV2Client,
+    validator_v2_server::{ValidatorV2, ValidatorV2Server},
+};

--- a/crates/iota-network/src/convert/mod.rs
+++ b/crates/iota-network/src/convert/mod.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod validator_peer;
+pub mod validator_v2;
+
+use bytes::Bytes;
+use iota_types::error::IotaError;
+use serde::{Serialize, de::DeserializeOwned};
+
+pub(crate) fn bcs_serialize<T: Serialize>(value: &T, type_info: &str) -> Result<Bytes, IotaError> {
+    bcs::to_bytes(value)
+        .map(Into::into)
+        .map_err(|e| IotaError::TransactionSerialization {
+            error: format!("{}: {}", type_info, e),
+        })
+}
+
+pub(crate) fn bcs_deserialize<T: DeserializeOwned>(
+    bytes: &[u8],
+    type_info: &str,
+) -> Result<T, IotaError> {
+    bcs::from_bytes(bytes).map_err(|e| IotaError::TransactionSerialization {
+        error: format!("{}: {}", type_info, e),
+    })
+}

--- a/crates/iota-network/src/convert/validator_peer.rs
+++ b/crates/iota-network/src/convert/validator_peer.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Conversions between `iota.validator.peer` proto types and native
+//! `iota-types`.
+
+use iota_types::{
+    error::IotaError,
+    messages_checkpoint::{CheckpointRequest, CheckpointResponse, CheckpointSummaryResponse},
+};
+
+use super::{bcs_deserialize, bcs_serialize};
+use crate::api;
+
+// --- GetCheckpointRequest ↔ CheckpointRequest ---
+
+impl From<CheckpointRequest> for api::GetCheckpointRequest {
+    fn from(value: CheckpointRequest) -> Self {
+        Self {
+            sequence_number: value.sequence_number,
+            request_content: value.request_content,
+            certified: value.certified,
+        }
+    }
+}
+
+impl From<api::GetCheckpointRequest> for CheckpointRequest {
+    fn from(value: api::GetCheckpointRequest) -> Self {
+        Self {
+            sequence_number: value.sequence_number,
+            request_content: value.request_content,
+            certified: value.certified,
+        }
+    }
+}
+
+// --- GetCheckpointResponse ↔ CheckpointResponse ---
+
+impl TryFrom<CheckpointResponse> for api::GetCheckpointResponse {
+    type Error = IotaError;
+
+    fn try_from(value: CheckpointResponse) -> Result<Self, Self::Error> {
+        let checkpoint = value
+            .checkpoint
+            .as_ref()
+            .map(|c| bcs_serialize(c, "GetCheckpointResponse.checkpoint"))
+            .transpose()?;
+        let contents = value
+            .contents
+            .as_ref()
+            .map(|c| bcs_serialize(c, "GetCheckpointResponse.contents"))
+            .transpose()?;
+        Ok(Self {
+            checkpoint,
+            contents,
+        })
+    }
+}
+
+impl TryFrom<api::GetCheckpointResponse> for CheckpointResponse {
+    type Error = IotaError;
+
+    fn try_from(value: api::GetCheckpointResponse) -> Result<Self, Self::Error> {
+        let checkpoint: Option<CheckpointSummaryResponse> = value
+            .checkpoint
+            .as_ref()
+            .map(|c| bcs_deserialize(c, "GetCheckpointResponse.checkpoint"))
+            .transpose()?;
+        let contents = value
+            .contents
+            .as_ref()
+            .map(|c| bcs_deserialize(c, "GetCheckpointResponse.contents"))
+            .transpose()?;
+        Ok(Self {
+            checkpoint,
+            contents,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
+
+    use crate::api;
+
+    // --- GetCheckpointRequest round-trips ---
+
+    #[test]
+    fn checkpoint_request_with_sequence_number_round_trip() {
+        let original = CheckpointRequest {
+            sequence_number: Some(100),
+            request_content: true,
+            certified: true,
+        };
+        let proto: api::GetCheckpointRequest = original.clone().into();
+        assert_eq!(proto.sequence_number, Some(100));
+        assert!(proto.request_content);
+        assert!(proto.certified);
+        let back: CheckpointRequest = proto.into();
+        assert_eq!(back.sequence_number, original.sequence_number);
+        assert_eq!(back.request_content, original.request_content);
+        assert_eq!(back.certified, original.certified);
+    }
+
+    #[test]
+    fn checkpoint_request_latest_round_trip() {
+        let original = CheckpointRequest {
+            sequence_number: None,
+            request_content: false,
+            certified: false,
+        };
+        let proto: api::GetCheckpointRequest = original.into();
+        assert_eq!(proto.sequence_number, None);
+        let back: CheckpointRequest = proto.into();
+        assert_eq!(back.sequence_number, None);
+        assert!(!back.request_content);
+        assert!(!back.certified);
+    }
+
+    // --- GetCheckpointResponse round-trips ---
+
+    #[test]
+    fn checkpoint_response_empty_round_trip() {
+        let original = CheckpointResponse {
+            checkpoint: None,
+            contents: None,
+        };
+        let proto: api::GetCheckpointResponse = original.try_into().unwrap();
+        assert!(proto.checkpoint.is_none());
+        assert!(proto.contents.is_none());
+        let back: CheckpointResponse = proto.try_into().unwrap();
+        assert!(back.checkpoint.is_none());
+        assert!(back.contents.is_none());
+    }
+}

--- a/crates/iota-network/src/convert/validator_v2.rs
+++ b/crates/iota-network/src/convert/validator_v2.rs
@@ -1,0 +1,360 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Conversions between `iota.validator.v2` proto types and native `iota-types`.
+
+use iota_types::{
+    digests::TransactionDigest,
+    error::IotaError,
+    messages_grpc::{ExecutedData, SubmitTransactionResult, WaitForEffectResponse},
+};
+
+use super::{bcs_deserialize, bcs_serialize};
+use crate::api::{
+    self, ExecutedStatus, ExpiredStatus, RejectedStatus, StatusDetail, SubmittedStatus,
+    status_detail::Kind,
+};
+
+// --- TxDigest ↔ TransactionDigest ---
+
+impl TryFrom<TransactionDigest> for api::TxDigest {
+    type Error = IotaError;
+
+    fn try_from(value: TransactionDigest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            digest: bytes::Bytes::copy_from_slice(value.inner()),
+        })
+    }
+}
+
+impl TryFrom<api::TxDigest> for TransactionDigest {
+    type Error = IotaError;
+
+    fn try_from(value: api::TxDigest) -> Result<Self, Self::Error> {
+        TransactionDigest::try_from(value.digest.as_ref()).map_err(|e| {
+            IotaError::TransactionSerialization {
+                error: format!("TxDigest: {}", e),
+            }
+        })
+    }
+}
+
+// --- StatusDetail ↔ SubmitTransactionResult ---
+
+impl TryFrom<SubmitTransactionResult> for StatusDetail {
+    type Error = IotaError;
+
+    fn try_from(value: SubmitTransactionResult) -> Result<Self, Self::Error> {
+        let kind = match value {
+            SubmitTransactionResult::Submitted => Kind::Submitted(SubmittedStatus {}),
+            SubmitTransactionResult::Executed {
+                effects_digest,
+                details,
+            } => Kind::Executed(ExecutedStatus {
+                effects_digest: bcs_serialize(&effects_digest, "ExecutedStatus.effects_digest")?,
+                details: Some(bcs_serialize(&*details, "ExecutedStatus.details")?),
+            }),
+            SubmitTransactionResult::Rejected { error } => Kind::Rejected(RejectedStatus {
+                error: Some(bcs_serialize(&error, "RejectedStatus.error")?),
+            }),
+        };
+        Ok(StatusDetail { kind: Some(kind) })
+    }
+}
+
+impl TryFrom<StatusDetail> for SubmitTransactionResult {
+    type Error = IotaError;
+
+    fn try_from(value: StatusDetail) -> Result<Self, Self::Error> {
+        let kind = value
+            .kind
+            .ok_or_else(|| IotaError::TransactionSerialization {
+                error: "StatusDetail.kind is None".to_string(),
+            })?;
+        match kind {
+            Kind::Submitted(_) => Ok(SubmitTransactionResult::Submitted),
+            Kind::Executed(e) => {
+                let effects_digest =
+                    bcs_deserialize(&e.effects_digest, "ExecutedStatus.effects_digest")?;
+                let details_bytes =
+                    e.details
+                        .ok_or_else(|| IotaError::TransactionSerialization {
+                            error: "ExecutedStatus.details is None for SubmitTransactionResult"
+                                .to_string(),
+                        })?;
+                let details: ExecutedData =
+                    bcs_deserialize(&details_bytes, "ExecutedStatus.details")?;
+                Ok(SubmitTransactionResult::Executed {
+                    effects_digest,
+                    details: Box::new(details),
+                })
+            }
+            Kind::Rejected(r) => {
+                let error = r
+                    .error
+                    .as_ref()
+                    .map(|e| bcs_deserialize(e, "RejectedStatus.error"))
+                    .transpose()?
+                    .ok_or_else(|| IotaError::TransactionSerialization {
+                        error: "RejectedStatus.error is None for SubmitTransactionResult"
+                            .to_string(),
+                    })?;
+                Ok(SubmitTransactionResult::Rejected { error })
+            }
+            Kind::Expired(_) => Err(IotaError::TransactionSerialization {
+                error: "Expired status is not valid for SubmitTransactionResult".to_string(),
+            }),
+        }
+    }
+}
+
+// --- StatusDetail ↔ WaitForEffectResponse ---
+
+impl TryFrom<WaitForEffectResponse> for StatusDetail {
+    type Error = IotaError;
+
+    fn try_from(value: WaitForEffectResponse) -> Result<Self, Self::Error> {
+        let kind = match value {
+            WaitForEffectResponse::Executed {
+                effects_digest,
+                details,
+            } => Kind::Executed(ExecutedStatus {
+                effects_digest: bcs_serialize(&effects_digest, "ExecutedStatus.effects_digest")?,
+                details: details
+                    .as_ref()
+                    .map(|d| bcs_serialize(d.as_ref(), "ExecutedStatus.details"))
+                    .transpose()?,
+            }),
+            WaitForEffectResponse::Rejected { error } => Kind::Rejected(RejectedStatus {
+                error: error
+                    .as_ref()
+                    .map(|e| bcs_serialize(e, "RejectedStatus.error"))
+                    .transpose()?,
+            }),
+            WaitForEffectResponse::Expired { epoch } => Kind::Expired(ExpiredStatus { epoch }),
+        };
+        Ok(StatusDetail { kind: Some(kind) })
+    }
+}
+
+impl TryFrom<StatusDetail> for WaitForEffectResponse {
+    type Error = IotaError;
+
+    fn try_from(value: StatusDetail) -> Result<Self, Self::Error> {
+        let kind = value
+            .kind
+            .ok_or_else(|| IotaError::TransactionSerialization {
+                error: "StatusDetail.kind is None".to_string(),
+            })?;
+        match kind {
+            Kind::Submitted(_) => Err(IotaError::TransactionSerialization {
+                error: "Submitted status is not valid for WaitForEffectResponse".to_string(),
+            }),
+            Kind::Executed(e) => {
+                let effects_digest =
+                    bcs_deserialize(&e.effects_digest, "ExecutedStatus.effects_digest")?;
+                let details = e
+                    .details
+                    .as_ref()
+                    .map(|d| bcs_deserialize::<ExecutedData>(d, "ExecutedStatus.details"))
+                    .transpose()?
+                    .map(Box::new);
+                Ok(WaitForEffectResponse::Executed {
+                    effects_digest,
+                    details,
+                })
+            }
+            Kind::Rejected(r) => {
+                let error = r
+                    .error
+                    .as_ref()
+                    .map(|e| bcs_deserialize(e, "RejectedStatus.error"))
+                    .transpose()?;
+                Ok(WaitForEffectResponse::Rejected { error })
+            }
+            Kind::Expired(e) => Ok(WaitForEffectResponse::Expired { epoch: e.epoch }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_types::{
+        digests::{TransactionDigest, TransactionEffectsDigest},
+        error::IotaError,
+        messages_grpc::{ExecutedData, SubmitTransactionResult, WaitForEffectResponse},
+    };
+
+    use crate::api::{self, StatusDetail, status_detail::Kind};
+
+    // --- TxDigest round-trip ---
+
+    #[test]
+    fn tx_digest_round_trip() {
+        let digest = TransactionDigest::random();
+        let proto: api::TxDigest = digest.try_into().unwrap();
+        let back: TransactionDigest = proto.try_into().unwrap();
+        assert_eq!(digest, back);
+    }
+
+    #[test]
+    fn tx_digest_invalid_length() {
+        let proto = api::TxDigest {
+            digest: bytes::Bytes::from_static(&[0u8; 5]),
+        };
+        let result = TransactionDigest::try_from(proto);
+        assert!(result.is_err());
+    }
+
+    // --- SubmitTransactionResult round-trips ---
+
+    #[test]
+    fn submit_submitted_round_trip() {
+        let original = SubmitTransactionResult::Submitted;
+        let proto: StatusDetail = original.try_into().unwrap();
+        assert!(matches!(proto.kind, Some(Kind::Submitted(_))));
+        let back: SubmitTransactionResult = proto.try_into().unwrap();
+        assert!(matches!(back, SubmitTransactionResult::Submitted));
+    }
+
+    #[test]
+    fn submit_executed_round_trip() {
+        let original = SubmitTransactionResult::Executed {
+            effects_digest: TransactionEffectsDigest::random(),
+            details: Box::new(ExecutedData::default()),
+        };
+        let proto: StatusDetail = original.try_into().unwrap();
+        assert!(matches!(proto.kind, Some(Kind::Executed(_))));
+        let back: SubmitTransactionResult = proto.try_into().unwrap();
+        assert!(matches!(back, SubmitTransactionResult::Executed { .. }));
+    }
+
+    #[test]
+    fn submit_rejected_round_trip() {
+        let error = IotaError::TransactionSerialization {
+            error: "test error".to_string(),
+        };
+        let original = SubmitTransactionResult::Rejected {
+            error: error.clone(),
+        };
+        let proto: StatusDetail = original.try_into().unwrap();
+        assert!(matches!(proto.kind, Some(Kind::Rejected(_))));
+        let back: SubmitTransactionResult = proto.try_into().unwrap();
+        match back {
+            SubmitTransactionResult::Rejected { error: e } => {
+                assert_eq!(e.to_string(), error.to_string());
+            }
+            _ => panic!("expected Rejected"),
+        }
+    }
+
+    #[test]
+    fn submit_rejects_expired_status() {
+        let proto = StatusDetail {
+            kind: Some(Kind::Expired(crate::api::ExpiredStatus { epoch: 1 })),
+        };
+        let result = SubmitTransactionResult::try_from(proto);
+        assert!(result.is_err());
+    }
+
+    // --- WaitForEffectResponse round-trips ---
+
+    #[test]
+    fn wait_executed_round_trip() {
+        let digest = TransactionEffectsDigest::random();
+        let original = WaitForEffectResponse::Executed {
+            effects_digest: digest,
+            details: Some(Box::new(ExecutedData::default())),
+        };
+        let proto: StatusDetail = original.try_into().unwrap();
+        assert!(matches!(proto.kind, Some(Kind::Executed(_))));
+        let back: WaitForEffectResponse = proto.try_into().unwrap();
+        match back {
+            WaitForEffectResponse::Executed {
+                effects_digest,
+                details,
+            } => {
+                assert_eq!(effects_digest, digest);
+                assert!(details.is_some());
+            }
+            _ => panic!("expected Executed"),
+        }
+    }
+
+    #[test]
+    fn wait_executed_without_details_round_trip() {
+        let digest = TransactionEffectsDigest::random();
+        let original = WaitForEffectResponse::Executed {
+            effects_digest: digest,
+            details: None,
+        };
+        let proto: StatusDetail = original.try_into().unwrap();
+        let back: WaitForEffectResponse = proto.try_into().unwrap();
+        match back {
+            WaitForEffectResponse::Executed {
+                effects_digest,
+                details,
+            } => {
+                assert_eq!(effects_digest, digest);
+                assert!(details.is_none());
+            }
+            _ => panic!("expected Executed"),
+        }
+    }
+
+    #[test]
+    fn wait_rejected_with_error_round_trip() {
+        let error = IotaError::TransactionSerialization {
+            error: "conflict".to_string(),
+        };
+        let original = WaitForEffectResponse::Rejected {
+            error: Some(error.clone()),
+        };
+        let proto: StatusDetail = original.try_into().unwrap();
+        let back: WaitForEffectResponse = proto.try_into().unwrap();
+        match back {
+            WaitForEffectResponse::Rejected { error: Some(e) } => {
+                assert_eq!(e.to_string(), error.to_string());
+            }
+            _ => panic!("expected Rejected with error"),
+        }
+    }
+
+    #[test]
+    fn wait_rejected_without_error_round_trip() {
+        let original = WaitForEffectResponse::Rejected { error: None };
+        let proto: StatusDetail = original.try_into().unwrap();
+        let back: WaitForEffectResponse = proto.try_into().unwrap();
+        assert!(matches!(
+            back,
+            WaitForEffectResponse::Rejected { error: None }
+        ));
+    }
+
+    #[test]
+    fn wait_expired_round_trip() {
+        let original = WaitForEffectResponse::Expired { epoch: 42 };
+        let proto: StatusDetail = original.try_into().unwrap();
+        let back: WaitForEffectResponse = proto.try_into().unwrap();
+        match back {
+            WaitForEffectResponse::Expired { epoch } => assert_eq!(epoch, 42),
+            _ => panic!("expected Expired"),
+        }
+    }
+
+    #[test]
+    fn wait_rejects_submitted_status() {
+        let proto = StatusDetail {
+            kind: Some(Kind::Submitted(crate::api::SubmittedStatus {})),
+        };
+        let result = WaitForEffectResponse::try_from(proto);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn status_detail_none_kind_is_error() {
+        let proto = StatusDetail { kind: None };
+        assert!(SubmitTransactionResult::try_from(proto.clone()).is_err());
+        assert!(WaitForEffectResponse::try_from(proto).is_err());
+    }
+}

--- a/crates/iota-network/src/lib.rs
+++ b/crates/iota-network/src/lib.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use iota_network_stack::config::Config;
 
 pub mod api;
+pub mod convert;
 pub mod discovery;
 pub mod randomness;
 pub mod state_sync;


### PR DESCRIPTION
## Description of change

Introduces `.proto` file definitions, build infrastructure, and a conversion layer for two new gRPC services in `iota-network`:

- **`ValidatorV2`** (`iota.validator.v2`) — streaming-first transaction submission API replacing the request-response pattern.
- **`ValidatorPeer`** (`iota.validator.peer`) — authenticated validator-to-validator service for read-only queries (initially `GetCheckpoint`)

## Links to any relevant issues

- Closes #10917
- Parent epic: #10747

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

16 round-trip conversion tests covering all `StatusDetail` variants, `TxDigest`, checkpoint request/response, error paths, and invalid variant crossings.
