### PR TITLE
fix(ts-sdk): Change default network in `.env.defaults` to `mainnet`

### DIFF
--- a/sdk/.env.defaults
+++ b/sdk/.env.defaults
@@ -1,4 +1,4 @@
-DEFAULT_NETWORK = 'localnet'
+DEFAULT_NETWORK = 'mainnet'
 APPS_BACKEND = 'http://localhost:3003'
 SENTRY_AUTH_TOKEN=
 


### PR DESCRIPTION
This will also make the explorer previews use mainnet (or another one if wanted) by default

