### PR TITLE
fix(gRPC): check for lowest available checkpoint

### DIFF
--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -258,6 +258,18 @@ pub(crate) fn get_checkpoint_data(
         }
     };
 
+    // Check if the requested checkpoint has been pruned
+    let lowest_available = service
+        .reader
+        .get_lowest_available_checkpoint()
+        .map_err(|e| Status::internal(format!("failed to get lowest available checkpoint: {e}")))?;
+    if sequence_number < lowest_available {
+        return Err(Status::not_found(format!(
+            "Requested checkpoint {sequence_number} is below the lowest available checkpoint {lowest_available}"
+        ))
+        .into());
+    }
+
     let client_max_message_size_bytes = req.max_message_size_bytes;
 
     debug!(

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -378,6 +378,23 @@ pub(crate) fn stream_checkpoint_data(
         events_mask.is_some()
     );
 
+    // Check if the requested checkpoint has been pruned
+    if let Some(start) = start_sequence_number {
+        let lowest_available = service
+            .reader
+            .get_lowest_available_checkpoint()
+            .map_err(|e| {
+                Status::internal(format!("failed to get lowest available checkpoint: {e}"))
+            })?;
+        if start < lowest_available {
+            return Err(Status::not_found(format!(
+                "Requested checkpoint {} is below the lowest available checkpoint {}",
+                start, lowest_available
+            ))
+            .into());
+        }
+    }
+
     // Convert proto filters to internal filters and validate complexity
     let (transaction_filter, event_filter) =
         convert_and_validate_filters(req.transactions_filter, req.events_filter)?;

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -847,6 +847,18 @@ impl GrpcReader {
             while start <= end {
                 // Try fetching historical data from the DB first
                 if start <= latest {
+                    // Check if the checkpoint has been pruned since we started
+                    // (e.g. genesis checkpoint 0 is always in DB but may be
+                    // below the pruning watermark).
+                    let lowest_available = state_reader
+                        .get_lowest_available_checkpoint()
+                        .map_err(|e| Status::internal(format!("Failed to get lowest available checkpoint: {e}")))?;
+                    if start < lowest_available {
+                        Err(Status::not_found(format!(
+                            "Checkpoint {data_type_name} {start} is below the lowest available checkpoint {lowest_available}"
+                        )))?;
+                    }
+
                     match fetch_historical(state_reader.clone(), start)? {
                         Some(item) => {
                             debug!("[profile][grpc] Fetched checkpoint {data_type_name} for index {start} from DB.");

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -29,6 +29,7 @@ struct MockRestStateReader {
     chain_identifier: iota_types::digests::ChainIdentifier,
     checkpoints: Arc<Mutex<HashSet<CheckpointSequenceNumber>>>,
     large_checkpoints: Arc<Mutex<HashSet<CheckpointSequenceNumber>>>,
+    lowest_available_checkpoint: u64,
 }
 impl MockRestStateReader {
     fn new_from_iter<I: Iterator<Item = u64>>(iter: I) -> Self {
@@ -36,7 +37,13 @@ impl MockRestStateReader {
             chain_identifier: iota_types::digests::ChainIdentifier::default(),
             checkpoints: Arc::new(Mutex::new(iter.collect())),
             large_checkpoints: Arc::new(Mutex::new(HashSet::new())),
+            lowest_available_checkpoint: 0,
         }
+    }
+
+    fn with_lowest_available_checkpoint(mut self, lowest: u64) -> Self {
+        self.lowest_available_checkpoint = lowest;
+        self
     }
 
     /// Mark a checkpoint sequence number as using large data
@@ -237,7 +244,7 @@ impl iota_types::storage::ReadStore for MockRestStateReader {
     }
 
     fn try_get_lowest_available_checkpoint(&self) -> iota_types::storage::error::Result<u64> {
-        Ok(0)
+        Ok(self.lowest_available_checkpoint)
     }
 
     fn get_lowest_available_checkpoint(&self) -> u64 {
@@ -1132,6 +1139,87 @@ async fn test_filter_checkpoints_streaming() {
     .expect("waiting for stream timed out");
     // Only checkpoint 7 should be received (all others were filtered out)
     assert_eq!(results, vec![7]);
+
+    server_handle
+        .shutdown()
+        .await
+        .expect("Failed to shutdown server");
+}
+
+#[tokio::test]
+async fn test_get_checkpoint_pruned_returns_not_found() {
+    // Set up mock with checkpoints 0..=10 but lowest_available_checkpoint = 5
+    let mock =
+        Arc::new(MockRestStateReader::new_from_iter(0..=10).with_lowest_available_checkpoint(5));
+
+    let (server_handle, client, _) =
+        test_server_and_client_setup(std::iter::empty(), |_| {}, Some(mock), None).await;
+
+    // Requesting checkpoint 0 (genesis, still in DB) should fail because it's below
+    // lowest_available_checkpoint
+    let result = client
+        .get_checkpoint_by_sequence_number(0, None, None, None)
+        .await;
+    assert!(result.is_err(), "Expected error for pruned checkpoint");
+    match result.unwrap_err() {
+        iota_grpc_client::Error::Grpc(status) => {
+            assert_eq!(status.code(), tonic::Code::NotFound);
+            assert!(
+                status
+                    .message()
+                    .contains("below the lowest available checkpoint"),
+                "Error message should mention lowest available checkpoint: {}",
+                status.message()
+            );
+        }
+        e => panic!("Expected Grpc error, got: {e:?}"),
+    }
+
+    // Requesting checkpoint 5 (at lowest_available) should succeed
+    let result = client
+        .get_checkpoint_by_sequence_number(5, None, None, None)
+        .await;
+    assert!(result.is_ok(), "Checkpoint at lowest_available should work");
+
+    server_handle
+        .shutdown()
+        .await
+        .expect("Failed to shutdown server");
+}
+
+#[tokio::test]
+async fn test_stream_checkpoint_pruned_start_returns_not_found() {
+    // Set up mock with checkpoints 0..=10 but lowest_available_checkpoint = 5
+    let mock =
+        Arc::new(MockRestStateReader::new_from_iter(0..=10).with_lowest_available_checkpoint(5));
+
+    let (server_handle, client, _) =
+        test_server_and_client_setup(std::iter::empty(), |_| {}, Some(mock), None).await;
+
+    // Streaming from checkpoint 0 should fail because it's below
+    // lowest_available_checkpoint. The error surfaces as a stream item
+    // since the pruning check happens during historical fetch.
+    let mut stream = client
+        .stream_checkpoints(Some(0), Some(10), None, None, None)
+        .await
+        .expect("stream should open successfully");
+
+    let first_item = stream.body_mut().next().await;
+    match first_item {
+        Some(Err(iota_grpc_client::Error::Grpc(status))) => {
+            assert_eq!(status.code(), tonic::Code::NotFound);
+            assert!(
+                status
+                    .message()
+                    .contains("below the lowest available checkpoint"),
+                "Error message should mention lowest available checkpoint: {}",
+                status.message()
+            );
+        }
+        Some(Err(e)) => panic!("Expected Grpc error, got: {e:?}"),
+        Some(Ok(_)) => panic!("Expected error for pruned start checkpoint"),
+        None => panic!("Stream ended without any items"),
+    }
 
     server_handle
         .shutdown()

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -1197,16 +1197,14 @@ async fn test_stream_checkpoint_pruned_start_returns_not_found() {
         test_server_and_client_setup(std::iter::empty(), |_| {}, Some(mock), None).await;
 
     // Streaming from checkpoint 0 should fail because it's below
-    // lowest_available_checkpoint. The error surfaces as a stream item
-    // since the pruning check happens during historical fetch.
-    let mut stream = client
+    // lowest_available_checkpoint. The error surfaces at the RPC level
+    // since the pruning check happens before the stream is created.
+    let result = client
         .stream_checkpoints(Some(0), Some(10), None, None, None)
-        .await
-        .expect("stream should open successfully");
+        .await;
 
-    let first_item = stream.body_mut().next().await;
-    match first_item {
-        Some(Err(iota_grpc_client::Error::Grpc(status))) => {
+    match result {
+        Err(iota_grpc_client::Error::Grpc(status)) => {
             assert_eq!(status.code(), tonic::Code::NotFound);
             assert!(
                 status
@@ -1216,9 +1214,8 @@ async fn test_stream_checkpoint_pruned_start_returns_not_found() {
                 status.message()
             );
         }
-        Some(Err(e)) => panic!("Expected Grpc error, got: {e:?}"),
-        Some(Ok(_)) => panic!("Expected error for pruned start checkpoint"),
-        None => panic!("Stream ended without any items"),
+        Err(e) => panic!("Expected Grpc error, got: {e:?}"),
+        Ok(_) => panic!("Expected error for pruned start checkpoint"),
     }
 
     server_handle


### PR DESCRIPTION
# Description of change

The genesis checkpoint is never pruned, so without a check if the requested checkpoint is below the lowest available checkpoint, that causes some inconsistencies. The REST API also does exactly this check, so it's better to add it. 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes