### PR TITLE
fix(gRPC): fixed size calculations for chunking in affected endpoints

### DIFF
--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -479,7 +479,7 @@ impl AuthorityStorePruner {
                 break;
             };
             let checkpoint = ckpt.into_inner();
-            // Skipping because  checkpoint's epoch or checkpoint number is too new.
+            // Skipping because checkpoint's epoch or checkpoint number is too new.
             // We have to respect the highest executed checkpoint watermark (including the
             // watermark itself) because there might be parts of the system that
             // still require access to old object versions (i.e. state

--- a/crates/iota-grpc-server/src/macros.rs
+++ b/crates/iota-grpc-server/src/macros.rs
@@ -34,7 +34,7 @@ macro_rules! create_batching_stream {
         async_stream::try_stream! {
             let mut requests_iter = $requests_iter;
             let mut current_batch = Vec::new();
-            let mut current_size = 0;
+            let mut current_size: usize = 0;
             let mut has_yielded = false;
 
             loop {
@@ -44,17 +44,24 @@ macro_rules! create_batching_stream {
                         // Process the item using the provided block
                         let (result_item, item_size) = $process_block;
 
+                        // Account for per-item protobuf repeated field overhead
+                        let item_size_with_overhead = item_size
+                            + $crate::utils::repeated_field_item_overhead(item_size);
+
                         // Check if a single item exceeds the message size limit
-                        if item_size > $max_message_size {
+                        // (item + has_next: true overhead for intermediate batches)
+                        if item_size_with_overhead + $crate::utils::HAS_NEXT_TRUE_OVERHEAD > $max_message_size {
                             Err($crate::error::RpcError::new(
                                 tonic::Code::InvalidArgument,
                                 format!("Single item size ({} bytes) exceeds max message size ({} bytes)",
-                                    item_size, $max_message_size)
+                                    item_size_with_overhead + $crate::utils::HAS_NEXT_TRUE_OVERHEAD, $max_message_size)
                             ))?;
                         }
 
                         // Check if adding this item would exceed the limit
-                        if current_size + item_size > $max_message_size && !current_batch.is_empty() {
+                        // (content + has_next: true for intermediate batches)
+                        let candidate_size = current_size + item_size_with_overhead;
+                        if candidate_size + $crate::utils::HAS_NEXT_TRUE_OVERHEAD > $max_message_size && !current_batch.is_empty() {
                             // Current batch is full, yield it
                             has_yielded = true;
                             yield paste::paste! {
@@ -64,11 +71,11 @@ macro_rules! create_batching_stream {
                             };
                             // Start new batch with current item
                             current_batch = vec![result_item];
-                            current_size = item_size;
+                            current_size = item_size_with_overhead;
                         } else {
                             // Item fits, add to current batch
                             current_batch.push(result_item);
-                            current_size += item_size;
+                            current_size += item_size_with_overhead;
                         }
                     }
                     None => {

--- a/crates/iota-grpc-server/src/macros.rs
+++ b/crates/iota-grpc-server/src/macros.rs
@@ -34,7 +34,7 @@ macro_rules! create_batching_stream {
         async_stream::try_stream! {
             let mut requests_iter = $requests_iter;
             let mut current_batch = Vec::new();
-            let mut current_size: usize = 0;
+            let mut current_size = 0;
             let mut has_yielded = false;
 
             loop {

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -649,6 +649,15 @@ impl GrpcReader {
                                         let event_encoded_len = grpc_event.encoded_len();
                                         let event_size = event_encoded_len + crate::utils::repeated_field_item_overhead(event_encoded_len);
 
+                                        // Check if a single event exceeds the message size limit
+                                        let event_total = event_size + crate::utils::checkpoint_data_wrapper_overhead(event_size);
+                                        if event_total > max_message_size_bytes {
+                                            yield Err(Status::invalid_argument(format!(
+                                                "Single event size ({event_total} bytes) exceeds max message size ({max_message_size_bytes} bytes)"
+                                            )));
+                                            return;
+                                        }
+
                                         // Check if adding this event would exceed limit
                                         // (batch content + wrapper overhead for CheckpointData oneof)
                                         let candidate_size = events_batch_size + event_size;
@@ -689,6 +698,15 @@ impl GrpcReader {
                                 .map_err(|e| e.with_context("failed to merge transaction"))?;
                                 let tx_encoded_len = executed_tx.encoded_len();
                                 let tx_size = tx_encoded_len + crate::utils::repeated_field_item_overhead(tx_encoded_len);
+
+                                // Check if a single transaction exceeds the message size limit
+                                let tx_total = tx_size + crate::utils::checkpoint_data_wrapper_overhead(tx_size);
+                                if tx_total > max_message_size_bytes {
+                                    yield Err(Status::invalid_argument(format!(
+                                        "Single transaction size ({tx_total} bytes) exceeds max message size ({max_message_size_bytes} bytes)"
+                                    )));
+                                    return;
+                                }
 
                                 // Check if adding this tx would exceed limit
                                 // (batch content + wrapper overhead for CheckpointData oneof)

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -646,10 +646,13 @@ impl GrpcReader {
                                             .map_err(|e| Status::internal(format!("event conversion error: {e}")))?;
                                         let grpc_event = grpc_event::Event::merge_from(&sdk_event, &events_submask)
                                             .map_err(|e| e.with_context("failed to merge event"))?;
-                                        let event_size = grpc_event.encoded_len();
+                                        let event_encoded_len = grpc_event.encoded_len();
+                                        let event_size = event_encoded_len + crate::utils::repeated_field_item_overhead(event_encoded_len);
 
                                         // Check if adding this event would exceed limit
-                                        if events_batch_size + event_size > max_message_size_bytes && !events_batch.is_empty() {
+                                        // (batch content + wrapper overhead for CheckpointData oneof)
+                                        let candidate_size = events_batch_size + event_size;
+                                        if candidate_size + crate::utils::checkpoint_data_wrapper_overhead(candidate_size) > max_message_size_bytes && !events_batch.is_empty() {
                                             // Yield current event batch
                                             yield Ok(grpc_ledger_service::CheckpointData::default()
                                                 .with_events(grpc_event::Events::default().with_events(events_batch)));
@@ -684,10 +687,13 @@ impl GrpcReader {
                                     &tx_mask,
                                 )
                                 .map_err(|e| e.with_context("failed to merge transaction"))?;
-                                let tx_size = executed_tx.encoded_len();
+                                let tx_encoded_len = executed_tx.encoded_len();
+                                let tx_size = tx_encoded_len + crate::utils::repeated_field_item_overhead(tx_encoded_len);
 
                                 // Check if adding this tx would exceed limit
-                                if current_batch_size + tx_size > max_message_size_bytes && !current_batch.is_empty() {
+                                // (batch content + wrapper overhead for CheckpointData oneof)
+                                let candidate_size = current_batch_size + tx_size;
+                                if candidate_size + crate::utils::checkpoint_data_wrapper_overhead(candidate_size) > max_message_size_bytes && !current_batch.is_empty() {
                                     // Yield current transaction batch
                                     yield Ok(grpc_ledger_service::CheckpointData::default()
                                         .with_executed_transactions(grpc_transaction::ExecutedTransactions::default().with_executed_transactions(current_batch)));

--- a/crates/iota-grpc-server/src/utils.rs
+++ b/crates/iota-grpc-server/src/utils.rs
@@ -6,7 +6,27 @@ use std::sync::Arc;
 
 use crate::GrpcReader;
 
-pub fn render_json(
+/// Per-item overhead when an item is placed in a protobuf `repeated`
+/// length-delimited field (field number 1-15):
+///   field_tag (1 byte) + length_delimiter_varint
+pub(crate) fn repeated_field_item_overhead(item_encoded_len: usize) -> usize {
+    1 + prost::length_delimiter_len(item_encoded_len)
+}
+
+/// Wrapper overhead for a `CheckpointData` oneof message wrapping an inner
+/// message (e.g. `ExecutedTransactions` or `Events`).
+///
+/// Encoding: field_tag (1 byte) + length_delimiter(inner_encoded_len).
+pub(crate) fn checkpoint_data_wrapper_overhead(inner_encoded_len: usize) -> usize {
+    1 + prost::length_delimiter_len(inner_encoded_len)
+}
+
+/// Exact overhead for `has_next: true` in `GetObjectsResponse` /
+/// `GetTransactionsResponse`. A proto3 bool field set to `true` encodes as
+/// field_tag (1 byte) + varint(1) (1 byte) = 2 bytes.
+pub(crate) const HAS_NEXT_TRUE_OVERHEAD: usize = 2;
+
+pub(crate) fn render_json(
     grpc_reader: Arc<GrpcReader>,
     max_json_move_value_size: usize,
     type_tag: &iota_types::TypeTag,

--- a/crates/iota-grpc-server/tests/batching_stream.rs
+++ b/crates/iota-grpc-server/tests/batching_stream.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for `create_batching_stream!` macro used by `get_objects` and
@@ -158,6 +158,11 @@ async fn test_get_objects_batching_within_limit() {
     // has_next=false does not include those 2 bytes, so the exact limit that
     // still fits everything in one batch is encoded_len() + 2.
     let exact_limit = u32::try_from(all_responses[0].encoded_len()).unwrap() + 2;
+    assert!(
+        exact_limit >= 1_024 * 1_024,
+        "Test prerequisite: single batch ({exact_limit}) must be >= 1 MB \
+         so the server does not reject the limit"
+    );
 
     // --- Pass 2: exact limit → should still fit in one batch ---
     let req = GetObjectsRequest::default()

--- a/crates/iota-grpc-server/tests/batching_stream.rs
+++ b/crates/iota-grpc-server/tests/batching_stream.rs
@@ -1,0 +1,395 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for `create_batching_stream!` macro used by `get_objects` and
+//! `get_transactions` endpoints.
+mod common;
+
+use std::{collections::HashMap, sync::Arc};
+
+use common::MockGrpcStateReader;
+use iota_grpc_types::{
+    field::FieldMaskUtil,
+    v0::{
+        ledger_service::{
+            GetObjectsRequest, GetTransactionsRequest, ObjectRequest, ObjectRequests,
+            TransactionRequest, TransactionRequests, ledger_service_client::LedgerServiceClient,
+        },
+        types::ObjectReference,
+    },
+};
+use iota_test_transaction_builder::TestTransactionBuilder;
+use iota_types::{
+    base_types::{ObjectID, random_object_ref},
+    crypto::{AccountKeyPair, get_key_pair},
+    digests::TransactionDigest,
+    effects::{TestEffectsBuilder, TransactionEffects},
+    gas_coin::GasCoin,
+    object::{MoveObject, OBJECT_START_VERSION, Object, Owner},
+    transaction::VerifiedTransaction,
+};
+use prost::Message;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Create a large object (~`padding_bytes` extra) so that a small number of
+/// objects exceeds the 1 MB minimum message size.
+fn create_large_object(padding_bytes_len: usize) -> (ObjectID, Object) {
+    let id = ObjectID::random();
+    let (owner, _) = get_key_pair::<AccountKeyPair>();
+    let mut contents = GasCoin::new(id, 100).to_bcs_bytes();
+    contents.extend(vec![0u8; padding_bytes_len]);
+    let move_obj = MoveObject::new_from_execution_with_limit(
+        GasCoin::type_().into(),
+        OBJECT_START_VERSION,
+        contents,
+        u64::try_from(padding_bytes_len).unwrap() + 1024,
+    )
+    .unwrap();
+    let obj = Object::new_move(
+        move_obj,
+        Owner::AddressOwner(owner),
+        TransactionDigest::genesis_marker(),
+    );
+    (id, obj)
+}
+
+/// Create a transaction and its effects so `get_transactions` can return it.
+fn create_test_transaction() -> (
+    TransactionDigest,
+    Arc<VerifiedTransaction>,
+    TransactionEffects,
+) {
+    let (sender, key): (_, AccountKeyPair) = get_key_pair();
+    let gas = random_object_ref();
+    let tx = TestTransactionBuilder::new(sender, gas, 1000)
+        .transfer(random_object_ref(), sender)
+        .build_and_sign(&key);
+    let effects = TestEffectsBuilder::new(tx.data()).build();
+    let digest = *tx.digest();
+    (
+        digest,
+        Arc::new(VerifiedTransaction::new_unchecked(tx)),
+        effects,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_get_objects_batching_within_limit() {
+    // Create 30 objects each ~50 KB so the total (~1.5 MB) exceeds the 1 MB
+    // minimum message size and forces batching.
+    const NUM_OBJECTS: usize = 30;
+    const PADDING: usize = 50_000;
+
+    let mut objects = HashMap::new();
+    let mut object_ids = Vec::with_capacity(NUM_OBJECTS);
+    for _ in 0..NUM_OBJECTS {
+        let (id, obj) = create_large_object(PADDING);
+        object_ids.push(id);
+        objects.insert(id, obj);
+    }
+
+    let state_reader = Arc::new(MockGrpcStateReader {
+        objects,
+        ..Default::default()
+    });
+
+    let (server_handle, _) = common::start_test_server(state_reader, |_| {}).await;
+    let addr = server_handle.address();
+
+    // Use the raw tonic client instead of the high-level Client so we can
+    // inspect individual streamed GetObjectsResponse messages and verify their
+    // sizes. The high-level client reassembles them into a single response.
+    let channel = tonic::transport::Channel::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .expect("connect");
+    let mut client = LedgerServiceClient::new(channel).max_decoding_message_size(128 * 1024 * 1024);
+
+    // Build proto request parts (reused across passes)
+    let requests = ObjectRequests::default().with_requests(
+        object_ids
+            .iter()
+            .map(|id| {
+                ObjectRequest::default()
+                    .with_object_ref(ObjectReference::default().with_object_id(id.to_string()))
+            })
+            .collect(),
+    );
+    let read_mask = prost_types::FieldMask::from_str("reference,bcs");
+
+    // --- Pass 1: unlimited (128 MB) → measure single-batch encoded size ---
+    let req = GetObjectsRequest::default()
+        .with_requests(requests.clone())
+        .with_read_mask(read_mask.clone())
+        .with_max_message_size_bytes(128 * 1024 * 1024);
+    let mut stream = client
+        .get_objects(req)
+        .await
+        .expect("get_objects should succeed")
+        .into_inner();
+
+    let mut all_responses = Vec::new();
+    while let Some(resp) = stream.message().await.expect("stream should not error") {
+        all_responses.push(resp);
+    }
+
+    assert_eq!(
+        all_responses.len(),
+        1,
+        "With 128 MB limit everything should fit in a single response"
+    );
+    assert!(
+        !all_responses[0].has_next,
+        "Single response should have has_next = false"
+    );
+    let total_items: usize = all_responses.iter().map(|r| r.objects.len()).sum();
+    assert_eq!(total_items, NUM_OBJECTS, "All objects should be returned");
+
+    // The macro checks `candidate_size + HAS_NEXT_TRUE_OVERHEAD > max` for each
+    // item, where HAS_NEXT_TRUE_OVERHEAD = 2 bytes. encoded_len() with
+    // has_next=false does not include those 2 bytes, so the exact limit that
+    // still fits everything in one batch is encoded_len() + 2.
+    let exact_limit = u32::try_from(all_responses[0].encoded_len()).unwrap() + 2;
+
+    // --- Pass 2: exact limit → should still fit in one batch ---
+    let req = GetObjectsRequest::default()
+        .with_requests(requests.clone())
+        .with_read_mask(read_mask.clone())
+        .with_max_message_size_bytes(exact_limit);
+    let mut stream = client
+        .get_objects(req)
+        .await
+        .expect("get_objects should succeed")
+        .into_inner();
+
+    let mut exact_responses = Vec::new();
+    while let Some(resp) = stream.message().await.expect("stream should not error") {
+        exact_responses.push(resp);
+    }
+    assert_eq!(
+        exact_responses.len(),
+        1,
+        "At exact limit ({exact_limit}) all objects should still fit in one batch"
+    );
+
+    // --- Pass 3: exact - 1 → must split ---
+    let tight_limit = exact_limit - 1;
+    let req = GetObjectsRequest::default()
+        .with_requests(requests.clone())
+        .with_read_mask(read_mask.clone())
+        .with_max_message_size_bytes(tight_limit);
+    let mut stream = client
+        .get_objects(req)
+        .await
+        .expect("get_objects should succeed")
+        .into_inner();
+
+    let mut split_responses = Vec::new();
+    while let Some(resp) = stream.message().await.expect("stream should not error") {
+        split_responses.push(resp);
+    }
+
+    assert!(
+        split_responses.len() > 1,
+        "At limit {tight_limit} (exact-1) objects must be split, got {} batch(es)",
+        split_responses.len()
+    );
+
+    // Verify has_next flags: all but last should be true
+    for (i, resp) in split_responses.iter().enumerate() {
+        let is_last = i == split_responses.len() - 1;
+        assert_eq!(
+            resp.has_next, !is_last,
+            "Response {i}: has_next should be {} (is_last={is_last})",
+            !is_last
+        );
+    }
+
+    // All items should be present
+    let split_total: usize = split_responses.iter().map(|r| r.objects.len()).sum();
+    assert_eq!(split_total, NUM_OBJECTS, "All objects must be returned");
+
+    // Every response should fit within the message size limit
+    for (i, resp) in split_responses.iter().enumerate() {
+        let size = resp.encoded_len();
+        assert!(
+            size <= usize::try_from(tight_limit).unwrap(),
+            "Response {i} has encoded_len {size} which exceeds limit {tight_limit}"
+        );
+    }
+
+    server_handle.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn test_get_transactions_batching_within_limit() {
+    // Each transaction proto (with bcs + signatures + effects) is ~1 KB.
+    // 1500 transactions comfortably exceeds the 1 MB minimum message size.
+    const NUM_TXS: usize = 1500;
+
+    let mut transactions = HashMap::new();
+    let mut effects_map = HashMap::new();
+    let mut digests = Vec::with_capacity(NUM_TXS);
+
+    for _ in 0..NUM_TXS {
+        let (digest, tx, effects) = create_test_transaction();
+        digests.push(digest);
+        transactions.insert(digest, tx);
+        effects_map.insert(digest, effects);
+    }
+
+    let state_reader = Arc::new(MockGrpcStateReader {
+        transactions,
+        effects: effects_map,
+        ..Default::default()
+    });
+
+    let (server_handle, _) = common::start_test_server(state_reader, |_| {}).await;
+    let addr = server_handle.address();
+
+    // Use the raw tonic client instead of the high-level Client so we can
+    // inspect individual streamed GetTransactionsResponse messages and verify
+    // their sizes. The high-level client reassembles them into a single response.
+    let channel = tonic::transport::Channel::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .expect("connect");
+    let mut client = LedgerServiceClient::new(channel).max_decoding_message_size(128 * 1024 * 1024);
+
+    // Build proto request parts (reused across passes)
+    let requests = TransactionRequests::default().with_requests(
+        digests
+            .iter()
+            .map(|d| {
+                TransactionRequest::default().with_digest(
+                    iota_grpc_types::v0::types::Digest::default()
+                        .with_digest(d.into_inner().to_vec()),
+                )
+            })
+            .collect(),
+    );
+    let read_mask = prost_types::FieldMask::from_str("transaction,signatures,effects");
+
+    // --- Pass 1: unlimited (128 MB) → measure single-batch encoded size ---
+    let req = GetTransactionsRequest::default()
+        .with_requests(requests.clone())
+        .with_read_mask(read_mask.clone())
+        .with_max_message_size_bytes(128 * 1024 * 1024);
+    let mut stream = client
+        .get_transactions(req)
+        .await
+        .expect("get_transactions should succeed")
+        .into_inner();
+
+    let mut all_responses = Vec::new();
+    while let Some(resp) = stream.message().await.expect("stream should not error") {
+        all_responses.push(resp);
+    }
+
+    assert_eq!(
+        all_responses.len(),
+        1,
+        "With 128 MB limit everything should fit in a single response"
+    );
+    assert!(
+        !all_responses[0].has_next,
+        "Single response should have has_next = false"
+    );
+    let total_items: usize = all_responses
+        .iter()
+        .map(|r| r.transaction_results.len())
+        .sum();
+    assert_eq!(total_items, NUM_TXS, "All transactions should be returned");
+
+    // The macro checks `candidate_size + HAS_NEXT_TRUE_OVERHEAD > max` for each
+    // item, where HAS_NEXT_TRUE_OVERHEAD = 2 bytes. encoded_len() with
+    // has_next=false does not include those 2 bytes, so the exact limit that
+    // still fits everything in one batch is encoded_len() + 2.
+    let exact_limit = u32::try_from(all_responses[0].encoded_len()).unwrap() + 2;
+    assert!(
+        exact_limit >= 1_024 * 1_024,
+        "Test prerequisite: single batch ({exact_limit}) must be >= 1 MB \
+         so the server does not reject the limit"
+    );
+
+    // --- Pass 2: exact limit → should still fit in one batch ---
+    let req = GetTransactionsRequest::default()
+        .with_requests(requests.clone())
+        .with_read_mask(read_mask.clone())
+        .with_max_message_size_bytes(exact_limit);
+    let mut stream = client
+        .get_transactions(req)
+        .await
+        .expect("get_transactions should succeed")
+        .into_inner();
+
+    let mut exact_responses = Vec::new();
+    while let Some(resp) = stream.message().await.expect("stream should not error") {
+        exact_responses.push(resp);
+    }
+    assert_eq!(
+        exact_responses.len(),
+        1,
+        "At exact limit ({exact_limit}) all transactions should still fit in one batch"
+    );
+
+    // --- Pass 3: exact - 1 → must split ---
+    let tight_limit = exact_limit - 1;
+    let req = GetTransactionsRequest::default()
+        .with_requests(requests.clone())
+        .with_read_mask(read_mask.clone())
+        .with_max_message_size_bytes(tight_limit);
+    let mut stream = client
+        .get_transactions(req)
+        .await
+        .expect("get_transactions should succeed")
+        .into_inner();
+
+    let mut split_responses = Vec::new();
+    while let Some(resp) = stream.message().await.expect("stream should not error") {
+        split_responses.push(resp);
+    }
+
+    assert!(
+        split_responses.len() > 1,
+        "At limit {tight_limit} (exact-1) transactions must be split, got {} batch(es)",
+        split_responses.len()
+    );
+
+    // Verify has_next flags
+    for (i, resp) in split_responses.iter().enumerate() {
+        let is_last = i == split_responses.len() - 1;
+        assert_eq!(
+            resp.has_next, !is_last,
+            "Response {i}: has_next should be {} (is_last={is_last})",
+            !is_last
+        );
+    }
+
+    // All items should be present
+    let split_total: usize = split_responses
+        .iter()
+        .map(|r| r.transaction_results.len())
+        .sum();
+    assert_eq!(split_total, NUM_TXS, "All transactions must be returned");
+
+    // Every response should fit within the message size limit
+    for (i, resp) in split_responses.iter().enumerate() {
+        let size = resp.encoded_len();
+        assert!(
+            size <= usize::try_from(tight_limit).unwrap(),
+            "Response {i} has encoded_len {size} which exceeds limit {tight_limit}"
+        );
+    }
+
+    server_handle.shutdown().await.expect("shutdown");
+}

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -23,6 +23,7 @@ use iota_types::{
     },
     storage::{RestIndexes, RestStateReader, error::Result as StorageResult},
 };
+use prost::Message;
 use tokio_stream::StreamExt;
 
 struct MockRestStateReader {
@@ -119,12 +120,9 @@ fn mock_checkpoint_data_with_sender(
     }
 }
 
-fn mock_large_checkpoint_data(sequence_number: u64) -> CheckpointData {
-    let summary = mock_summary(sequence_number);
-
-    // Create many dummy transactions to exceed the message size limit when chunked
-    // Each transaction will be roughly 1KB when serialized, so we need about 5000
-    // transactions to exceed 4MB when serialized
+fn build_large_checkpoint_transactions() -> Vec<CheckpointTransaction> {
+    // Create many dummy transactions to exceed the message size limit when chunked.
+    // Each transaction is roughly 500-1000 bytes when serialized as protobuf.
     let num_transactions = 50000;
     let mut transactions = Vec::with_capacity(num_transactions);
 
@@ -145,6 +143,13 @@ fn mock_large_checkpoint_data(sequence_number: u64) -> CheckpointData {
             output_objects: vec![], // Empty for simplicity
         });
     }
+
+    transactions
+}
+
+fn mock_large_checkpoint_data(sequence_number: u64) -> CheckpointData {
+    let summary = mock_summary(sequence_number);
+    let transactions = build_large_checkpoint_transactions();
 
     CheckpointData {
         checkpoint_summary: summary,
@@ -1222,4 +1227,246 @@ async fn test_stream_checkpoint_pruned_start_returns_not_found() {
         .shutdown()
         .await
         .expect("Failed to shutdown server");
+}
+
+/// A minimal GrpcStateReader that stores pre-built checkpoint transactions
+/// and directly returns them via stream_checkpoint_transactions.
+/// This avoids the ReadStore blanket impl issue with dyn RestStateReader.
+struct ChunkingTestStateReader {
+    summary: CertifiedCheckpointSummary,
+    contents: CheckpointContents,
+    transactions: Vec<CheckpointTransaction>,
+}
+
+impl iota_grpc_server::GrpcStateReader for ChunkingTestStateReader {
+    fn get_chain_identifier(&self) -> anyhow::Result<iota_types::digests::ChainIdentifier> {
+        Ok(iota_types::digests::ChainIdentifier::default())
+    }
+    fn get_latest_checkpoint_sequence_number(&self) -> anyhow::Result<Option<u64>> {
+        Ok(Some(0))
+    }
+    fn get_checkpoint_summary(
+        &self,
+        _seq: u64,
+    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>> {
+        Ok(Some(self.summary.clone()))
+    }
+    fn get_checkpoint_sequence_number_by_digest(
+        &self,
+        _digest: &iota_types::digests::CheckpointDigest,
+    ) -> anyhow::Result<Option<u64>> {
+        unimplemented!()
+    }
+    fn get_checkpoint_data(&self, _seq: u64) -> anyhow::Result<Option<CheckpointData>> {
+        unimplemented!()
+    }
+    fn get_checkpoint_summary_and_contents(
+        &self,
+        _seq: u64,
+    ) -> anyhow::Result<Option<(CertifiedCheckpointSummary, CheckpointContents)>> {
+        Ok(Some((self.summary.clone(), self.contents.clone())))
+    }
+    fn stream_checkpoint_transactions(
+        &self,
+        _checkpoint_contents: CheckpointContents,
+    ) -> std::pin::Pin<
+        Box<dyn futures::Stream<Item = anyhow::Result<CheckpointTransaction>> + Send + '_>,
+    > {
+        let transactions = self.transactions.clone();
+        Box::pin(async_stream::stream! {
+            for tx in transactions {
+                yield Ok(tx);
+            }
+        })
+    }
+    fn get_epoch_last_checkpoint(
+        &self,
+        _epoch: u64,
+    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>> {
+        Ok(None)
+    }
+    fn get_lowest_available_checkpoint(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+    fn get_lowest_available_checkpoint_objects(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+    fn get_object(
+        &self,
+        _object_id: &ObjectID,
+    ) -> anyhow::Result<Option<iota_types::object::Object>> {
+        Ok(None)
+    }
+    fn get_object_by_key(
+        &self,
+        _object_id: &ObjectID,
+        _version: iota_types::base_types::SequenceNumber,
+    ) -> anyhow::Result<Option<iota_types::object::Object>> {
+        Ok(None)
+    }
+    fn get_committee(
+        &self,
+        _epoch: u64,
+    ) -> anyhow::Result<Option<std::sync::Arc<iota_types::committee::Committee>>> {
+        Ok(None)
+    }
+    fn get_system_state(&self) -> anyhow::Result<iota_types::iota_system_state::IotaSystemState> {
+        unimplemented!()
+    }
+    fn get_epoch_info(
+        &self,
+        _epoch: u64,
+    ) -> anyhow::Result<Option<iota_types::storage::EpochInfo>> {
+        Ok(None)
+    }
+    fn get_type_layout(
+        &self,
+        _type_tag: &iota_types::TypeTag,
+    ) -> anyhow::Result<Option<move_core_types::annotated_value::MoveTypeLayout>> {
+        Ok(None)
+    }
+    fn get_transaction(
+        &self,
+        _digest: &iota_types::digests::TransactionDigest,
+    ) -> anyhow::Result<Option<std::sync::Arc<iota_types::transaction::VerifiedTransaction>>> {
+        Ok(None)
+    }
+    fn get_transaction_effects(
+        &self,
+        _digest: &iota_types::digests::TransactionDigest,
+    ) -> anyhow::Result<Option<iota_types::effects::TransactionEffects>> {
+        Ok(None)
+    }
+    fn get_transaction_events(
+        &self,
+        _digest: &iota_types::digests::TransactionDigest,
+    ) -> anyhow::Result<Option<iota_types::effects::TransactionEvents>> {
+        Ok(None)
+    }
+    fn get_transaction_checkpoint(
+        &self,
+        _digest: &iota_types::digests::TransactionDigest,
+    ) -> anyhow::Result<Option<u64>> {
+        Ok(None)
+    }
+}
+
+/// Helper: collect all CheckpointData messages from a stream, returning
+/// (all_messages, tx_batch_messages_with_encoded_len).
+async fn collect_checkpoint_stream(
+    reader: &GrpcReader,
+    max_message_size: u32,
+) -> (
+    Vec<iota_grpc_types::v0::ledger_service::CheckpointData>,
+    Vec<usize>,
+) {
+    use iota_grpc_types::{field::FieldMaskTree, v0::ledger_service::checkpoint_data};
+
+    let stream = reader.get_checkpoint_data(
+        0,
+        FieldMaskTree::new_wildcard(),
+        Some(FieldMaskTree::new_wildcard()),
+        None,
+        max_message_size,
+        None,
+        None,
+    );
+
+    let mut stream = Box::pin(stream);
+    let mut all_messages = Vec::new();
+    let mut tx_batch_sizes = Vec::new();
+
+    while let Some(result) = StreamExt::next(&mut stream).await {
+        let msg: iota_grpc_types::v0::ledger_service::CheckpointData =
+            result.expect("stream should not error");
+        if matches!(
+            msg.payload,
+            Some(checkpoint_data::Payload::ExecutedTransactions(_))
+        ) {
+            tx_batch_sizes.push(msg.encoded_len());
+        }
+        all_messages.push(msg);
+    }
+
+    (all_messages, tx_batch_sizes)
+}
+
+/// Build a small set of transactions for the chunking boundary test.
+/// Uses fewer transactions than `build_large_checkpoint_transactions` so the
+/// test runs fast while still exercising the boundary precisely.
+fn build_small_checkpoint_transactions(count: usize) -> Vec<CheckpointTransaction> {
+    let mut transactions = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (sender, key): (_, AccountKeyPair) = get_key_pair();
+        let gas = random_object_ref();
+        let transaction = TestTransactionBuilder::new(sender, gas, 1000)
+            .transfer(random_object_ref(), sender)
+            .build_and_sign(&key);
+        let effects = TestEffectsBuilder::new(transaction.data()).build();
+        transactions.push(CheckpointTransaction {
+            transaction,
+            effects,
+            events: None,
+            input_objects: vec![],
+            output_objects: vec![],
+        });
+    }
+    transactions
+}
+
+#[tokio::test]
+async fn test_chunked_checkpoint_message_sizes_within_limit() {
+    // Use a small number of transactions so the test is fast.
+    let transactions = build_small_checkpoint_transactions(20);
+    let summary = mock_summary(0);
+    let contents = MOCK_CHECKPOINT_CONTENTS.clone();
+
+    let state_reader = Arc::new(ChunkingTestStateReader {
+        summary,
+        contents,
+        transactions,
+    });
+    let reader = GrpcReader::new(state_reader, Some("test".to_string()));
+
+    // --- Pass 1: unlimited size to measure the single-batch encoded size ---
+    let (_, tx_sizes_unlimited) = collect_checkpoint_stream(&reader, u32::MAX).await;
+    assert_eq!(
+        tx_sizes_unlimited.len(),
+        1,
+        "With unlimited size all transactions should fit in a single batch"
+    );
+    let exact_batch_size = tx_sizes_unlimited[0];
+
+    // --- Pass 2: set limit to exactly the measured batch size ---
+    // All transactions must still fit in a single batch.
+    let (_, tx_sizes_exact) = collect_checkpoint_stream(&reader, exact_batch_size as u32).await;
+    assert_eq!(
+        tx_sizes_exact.len(),
+        1,
+        "At exact limit ({exact_batch_size}) all transactions should still fit in one batch"
+    );
+    assert_eq!(
+        tx_sizes_exact[0], exact_batch_size,
+        "Batch encoded_len should match the measured size"
+    );
+
+    // --- Pass 3: set limit to one byte less → must split ---
+    let tight_limit = (exact_batch_size - 1) as u32;
+    let (all_messages, tx_sizes_split) = collect_checkpoint_stream(&reader, tight_limit).await;
+    assert!(
+        tx_sizes_split.len() > 1,
+        "At limit {tight_limit} (exact-1) transactions must be split into multiple batches, \
+         got {} batch(es)",
+        tx_sizes_split.len()
+    );
+
+    // Every single message (checkpoint, tx batches, end marker) must be within the
+    // limit.
+    for (i, msg) in all_messages.iter().enumerate() {
+        let size = msg.encoded_len();
+        assert!(
+            size <= tight_limit as usize,
+            "Message {i} has encoded_len {size} which exceeds limit {tight_limit}"
+        );
+    }
 }

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -1,95 +1,36 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-
+mod common;
 use std::{
     collections::HashSet,
     sync::{Arc, LazyLock, Mutex},
     time::Duration,
 };
 
-use iota_config::{local_ip_utils, node::GrpcApiConfig};
+use common::MockGrpcStateReader;
+use iota_config::node::GrpcApiConfig;
 use iota_grpc_client::{CheckpointStreamItem, Client};
-use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
+use iota_grpc_server::GrpcServerHandle;
+use iota_grpc_types::v0::{filter, ledger_service::checkpoint_data};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
-    base_types::{IotaAddress, ObjectID, random_object_ref},
-    committee::EpochId,
-    crypto::{AccountKeyPair, AuthorityStrongQuorumSignInfo, get_key_pair},
-    effects::TestEffectsBuilder,
+    base_types::{IotaAddress, random_object_ref},
+    crypto::{AccountKeyPair, get_key_pair},
+    effects::{TestEffectsBuilder, TransactionEvents},
+    event::Event,
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
-    messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
-        CheckpointSummary, VerifiedCheckpoint,
-    },
-    storage::{RestIndexes, RestStateReader, error::Result as StorageResult},
+    messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber},
 };
+use move_core_types::{account_address::AccountAddress, ident_str, language_storage::StructTag};
 use prost::Message;
 use tokio_stream::StreamExt;
-
-struct MockRestStateReader {
-    chain_identifier: iota_types::digests::ChainIdentifier,
-    checkpoints: Arc<Mutex<HashSet<CheckpointSequenceNumber>>>,
-    large_checkpoints: Arc<Mutex<HashSet<CheckpointSequenceNumber>>>,
-    lowest_available_checkpoint: u64,
-}
-impl MockRestStateReader {
-    fn new_from_iter<I: Iterator<Item = u64>>(iter: I) -> Self {
-        Self {
-            chain_identifier: iota_types::digests::ChainIdentifier::default(),
-            checkpoints: Arc::new(Mutex::new(iter.collect())),
-            large_checkpoints: Arc::new(Mutex::new(HashSet::new())),
-            lowest_available_checkpoint: 0,
-        }
-    }
-
-    fn with_lowest_available_checkpoint(mut self, lowest: u64) -> Self {
-        self.lowest_available_checkpoint = lowest;
-        self
-    }
-
-    /// Mark a checkpoint sequence number as using large data
-    fn mark_checkpoint_as_large(&self, seq: CheckpointSequenceNumber) {
-        self.large_checkpoints.lock().unwrap().insert(seq);
-    }
-
-    /// Check if a checkpoint should use large data
-    fn is_large_checkpoint(&self, seq: CheckpointSequenceNumber) -> bool {
-        self.large_checkpoints.lock().unwrap().contains(&seq)
-    }
-}
 
 static MOCK_CHECKPOINT_CONTENTS: LazyLock<CheckpointContents> =
     LazyLock::new(|| CheckpointContents::new_with_digests_only_for_tests(vec![]));
 
-fn mock_checkpoint_summary(sequence_number: u64) -> CheckpointSummary {
-    CheckpointSummary {
-        epoch: 0,
-        sequence_number,
-        network_total_transactions: 0,
-        content_digest: *MOCK_CHECKPOINT_CONTENTS.digest(),
-        previous_digest: None,
-        epoch_rolling_gas_cost_summary: Default::default(),
-        timestamp_ms: 0,
-        checkpoint_commitments: vec![],
-        end_of_epoch_data: None,
-        version_specific_data: vec![],
-    }
-}
-
-fn mock_summary(sequence_number: u64) -> CertifiedCheckpointSummary {
-    let summary = mock_checkpoint_summary(sequence_number);
-    let sig = AuthorityStrongQuorumSignInfo {
-        epoch: 0,
-        signature: Default::default(),
-        signers_map: Default::default(),
-    };
-    CertifiedCheckpointSummary::new_from_data_and_sig(summary, sig)
-}
-
 fn mock_checkpoint_data(sequence_number: u64) -> CheckpointData {
-    let summary = mock_summary(sequence_number);
     CheckpointData {
-        checkpoint_summary: summary,
+        checkpoint_summary: common::mock_summary(sequence_number, &MOCK_CHECKPOINT_CONTENTS),
         checkpoint_contents: MOCK_CHECKPOINT_CONTENTS.clone(),
         transactions: vec![],
     }
@@ -101,14 +42,13 @@ fn mock_checkpoint_data_with_sender(
     sender: IotaAddress,
     key: &AccountKeyPair,
 ) -> CheckpointData {
-    let summary = mock_summary(sequence_number);
     let gas = random_object_ref();
     let transaction = TestTransactionBuilder::new(sender, gas, 1000)
         .transfer(random_object_ref(), sender)
         .build_and_sign(key);
     let effects = TestEffectsBuilder::new(transaction.data()).build();
     CheckpointData {
-        checkpoint_summary: summary,
+        checkpoint_summary: common::mock_summary(sequence_number, &MOCK_CHECKPOINT_CONTENTS),
         checkpoint_contents: MOCK_CHECKPOINT_CONTENTS.clone(),
         transactions: vec![CheckpointTransaction {
             transaction,
@@ -126,7 +66,7 @@ fn build_large_checkpoint_transactions() -> Vec<CheckpointTransaction> {
     let num_transactions = 50000;
     let mut transactions = Vec::with_capacity(num_transactions);
 
-    for _i in 0..num_transactions {
+    for _ in 0..num_transactions {
         let (sender, key): (_, AccountKeyPair) = get_key_pair();
         let gas = random_object_ref();
         let transaction = TestTransactionBuilder::new(sender, gas, 1000)
@@ -147,335 +87,7 @@ fn build_large_checkpoint_transactions() -> Vec<CheckpointTransaction> {
     transactions
 }
 
-fn mock_large_checkpoint_data(sequence_number: u64) -> CheckpointData {
-    let summary = mock_summary(sequence_number);
-    let transactions = build_large_checkpoint_transactions();
-
-    CheckpointData {
-        checkpoint_summary: summary,
-        checkpoint_contents: MOCK_CHECKPOINT_CONTENTS.clone(),
-        transactions,
-    }
-}
-
-// Minimal empty trait impls to satisfy RestStateReader supertraits
-impl iota_types::storage::ObjectStore for MockRestStateReader {
-    fn try_get_object(
-        &self,
-        _id: &ObjectID,
-    ) -> iota_types::storage::error::Result<Option<iota_types::object::Object>> {
-        unimplemented!()
-    }
-
-    fn try_get_object_by_key(
-        &self,
-        _id: &ObjectID,
-        _version: iota_types::base_types::SequenceNumber,
-    ) -> iota_types::storage::error::Result<Option<iota_types::object::Object>> {
-        unimplemented!()
-    }
-
-    fn get_object(&self, id: &ObjectID) -> Option<iota_types::object::Object> {
-        self.try_get_object(id).expect("storage access failed")
-    }
-
-    fn get_object_by_key(
-        &self,
-        id: &ObjectID,
-        version: iota_types::base_types::SequenceNumber,
-    ) -> Option<iota_types::object::Object> {
-        self.try_get_object_by_key(id, version)
-            .expect("storage access failed")
-    }
-}
-
-impl iota_types::storage::ReadStore for MockRestStateReader {
-    fn try_get_committee(
-        &self,
-        _epoch: EpochId,
-    ) -> iota_types::storage::error::Result<Option<std::sync::Arc<iota_types::committee::Committee>>>
-    {
-        unimplemented!()
-    }
-
-    fn get_committee(
-        &self,
-        epoch: EpochId,
-    ) -> Option<std::sync::Arc<iota_types::committee::Committee>> {
-        self.try_get_committee(epoch)
-            .expect("storage access failed")
-    }
-
-    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        // Return the checkpoint with the highest sequence number
-        let guard = self.checkpoints.lock().unwrap();
-        if let Some(max_seq) = guard.iter().max().cloned() {
-            Ok(VerifiedCheckpoint::new_unchecked(mock_summary(max_seq)))
-        } else {
-            // Use the missing error constructor
-            Err(iota_types::storage::error::Error::missing(
-                "No checkpoints available",
-            ))
-        }
-    }
-
-    fn try_get_highest_verified_checkpoint(
-        &self,
-    ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        unimplemented!()
-    }
-
-    fn get_highest_verified_checkpoint(&self) -> VerifiedCheckpoint {
-        self.try_get_highest_verified_checkpoint()
-            .expect("storage access failed")
-    }
-
-    fn try_get_highest_synced_checkpoint(
-        &self,
-    ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        let guard = self.checkpoints.lock().unwrap();
-        if let Some(max_seq) = guard.iter().max().cloned() {
-            Ok(VerifiedCheckpoint::new_unchecked(mock_summary(max_seq)))
-        } else {
-            Err(iota_types::storage::error::Error::custom(
-                "No checkpoints available",
-            ))
-        }
-    }
-
-    fn get_highest_synced_checkpoint(&self) -> VerifiedCheckpoint {
-        self.try_get_highest_synced_checkpoint()
-            .expect("storage access failed")
-    }
-
-    fn try_get_lowest_available_checkpoint(&self) -> iota_types::storage::error::Result<u64> {
-        Ok(self.lowest_available_checkpoint)
-    }
-
-    fn get_lowest_available_checkpoint(&self) -> u64 {
-        self.try_get_lowest_available_checkpoint()
-            .expect("storage access failed")
-    }
-
-    fn try_get_checkpoint_by_digest(
-        &self,
-        _digest: &iota_types::messages_checkpoint::CheckpointDigest,
-    ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
-        unimplemented!()
-    }
-
-    fn get_checkpoint_by_digest(
-        &self,
-        digest: &iota_types::messages_checkpoint::CheckpointDigest,
-    ) -> Option<VerifiedCheckpoint> {
-        self.try_get_checkpoint_by_digest(digest)
-            .expect("storage access failed")
-    }
-
-    fn try_get_checkpoint_by_sequence_number(
-        &self,
-        seq: CheckpointSequenceNumber,
-    ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
-        let guard = self.checkpoints.lock().unwrap();
-        if seq == u64::MAX {
-            // Return the highest checkpoint
-            if let Some(max_seq) = guard.iter().max().cloned() {
-                return Ok(Some(VerifiedCheckpoint::new_unchecked(mock_summary(
-                    max_seq,
-                ))));
-            } else {
-                return Ok(None);
-            }
-        }
-        Ok(guard
-            .get(&seq)
-            .map(|_| VerifiedCheckpoint::new_unchecked(mock_summary(seq))))
-    }
-
-    fn get_checkpoint_by_sequence_number(
-        &self,
-        seq: CheckpointSequenceNumber,
-    ) -> Option<VerifiedCheckpoint> {
-        self.try_get_checkpoint_by_sequence_number(seq)
-            .expect("storage access failed")
-    }
-
-    fn try_get_checkpoint_contents_by_digest(
-        &self,
-        _digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
-    ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
-        unimplemented!()
-    }
-
-    fn get_checkpoint_contents_by_digest(
-        &self,
-        digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
-    ) -> Option<CheckpointContents> {
-        self.try_get_checkpoint_contents_by_digest(digest)
-            .expect("storage access failed")
-    }
-
-    fn try_get_checkpoint_contents_by_sequence_number(
-        &self,
-        seq: CheckpointSequenceNumber,
-    ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
-        let guard = self.checkpoints.lock().unwrap();
-        Ok(guard.get(&seq).map(|_| MOCK_CHECKPOINT_CONTENTS.clone()))
-    }
-
-    fn get_checkpoint_contents_by_sequence_number(
-        &self,
-        seq: CheckpointSequenceNumber,
-    ) -> Option<CheckpointContents> {
-        self.try_get_checkpoint_contents_by_sequence_number(seq)
-            .expect("storage access failed")
-    }
-
-    fn try_get_transaction(
-        &self,
-        _digest: &iota_types::digests::TransactionDigest,
-    ) -> iota_types::storage::error::Result<
-        Option<
-            std::sync::Arc<
-                iota_types::message_envelope::VerifiedEnvelope<
-                    iota_types::transaction::SenderSignedData,
-                    iota_types::crypto::EmptySignInfo,
-                >,
-            >,
-        >,
-    > {
-        unimplemented!()
-    }
-
-    fn get_transaction(
-        &self,
-        digest: &iota_types::digests::TransactionDigest,
-    ) -> Option<
-        std::sync::Arc<
-            iota_types::message_envelope::VerifiedEnvelope<
-                iota_types::transaction::SenderSignedData,
-                iota_types::crypto::EmptySignInfo,
-            >,
-        >,
-    > {
-        self.try_get_transaction(digest)
-            .expect("storage access failed")
-    }
-
-    fn try_get_transaction_effects(
-        &self,
-        _digest: &iota_types::digests::TransactionDigest,
-    ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEffects>> {
-        unimplemented!()
-    }
-
-    fn get_transaction_effects(
-        &self,
-        digest: &iota_types::digests::TransactionDigest,
-    ) -> Option<iota_types::effects::TransactionEffects> {
-        self.try_get_transaction_effects(digest)
-            .expect("storage access failed")
-    }
-
-    fn try_get_events(
-        &self,
-        _digest: &iota_types::digests::TransactionDigest,
-    ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
-        unimplemented!()
-    }
-
-    fn get_events(
-        &self,
-        digest: &iota_types::digests::TransactionDigest,
-    ) -> Option<iota_types::effects::TransactionEvents> {
-        self.try_get_events(digest).expect("storage access failed")
-    }
-
-    fn try_get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        _seq: CheckpointSequenceNumber,
-    ) -> iota_types::storage::error::Result<
-        Option<iota_types::messages_checkpoint::FullCheckpointContents>,
-    > {
-        unimplemented!()
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        seq: CheckpointSequenceNumber,
-    ) -> Option<iota_types::messages_checkpoint::FullCheckpointContents> {
-        self.try_get_full_checkpoint_contents_by_sequence_number(seq)
-            .expect("storage access failed")
-    }
-
-    fn try_get_full_checkpoint_contents(
-        &self,
-        _digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
-    ) -> iota_types::storage::error::Result<
-        Option<iota_types::messages_checkpoint::FullCheckpointContents>,
-    > {
-        unimplemented!()
-    }
-
-    fn get_full_checkpoint_contents(
-        &self,
-        digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
-    ) -> Option<iota_types::messages_checkpoint::FullCheckpointContents> {
-        self.try_get_full_checkpoint_contents(digest)
-            .expect("storage access failed")
-    }
-
-    fn get_checkpoint_data(
-        &self,
-        checkpoint: VerifiedCheckpoint,
-        checkpoint_contents: CheckpointContents,
-    ) -> CheckpointData {
-        let seq = checkpoint.sequence_number;
-
-        // If this is a large checkpoint, return the large mock data
-        if self.is_large_checkpoint(seq) {
-            return mock_large_checkpoint_data(seq);
-        }
-
-        // Otherwise return the regular mock data
-        CheckpointData {
-            checkpoint_summary: checkpoint.into_inner(),
-            checkpoint_contents,
-            transactions: vec![], // Empty transactions for mock
-        }
-    }
-}
-
-impl RestStateReader for MockRestStateReader {
-    fn get_lowest_available_checkpoint_objects(&self) -> StorageResult<CheckpointSequenceNumber> {
-        Ok(0)
-    }
-
-    fn get_chain_identifier(&self) -> StorageResult<iota_types::digests::ChainIdentifier> {
-        Ok(self.chain_identifier)
-    }
-
-    fn get_epoch_last_checkpoint(
-        &self,
-        _: EpochId,
-    ) -> StorageResult<Option<iota_types::messages_checkpoint::VerifiedCheckpoint>> {
-        unimplemented!()
-    }
-
-    fn indexes(&self) -> Option<&dyn RestIndexes> {
-        None
-    }
-
-    fn get_struct_layout(
-        &self,
-        _: &move_core_types::language_storage::StructTag,
-    ) -> iota_types::storage::error::Result<Option<move_core_types::annotated_value::MoveTypeLayout>>
-    {
-        Ok(None)
-    }
-}
-
-/// Helper to set up test server with specific large checkpoints
+/// Helper to set up test server with specific large checkpoints.
 async fn test_server_and_client_setup_with_large_checkpoints<
     I: Iterator<Item = u64>,
     L: Iterator<Item = u64>,
@@ -489,7 +101,9 @@ async fn test_server_and_client_setup_with_large_checkpoints<
     Client,
     Arc<Mutex<HashSet<CheckpointSequenceNumber>>>,
 ) {
-    let mock = Arc::new(MockRestStateReader::new_from_iter(checkpoint_range));
+    let mut mock = MockGrpcStateReader::new_from_iter(checkpoint_range);
+    mock.large_checkpoint_transactions = build_large_checkpoint_transactions();
+    let mock = Arc::new(mock);
 
     // Mark specified checkpoints as large
     for seq in large_checkpoints {
@@ -505,45 +119,23 @@ async fn test_server_and_client_setup_with_large_checkpoints<
     .await
 }
 
+/// Set up a test server and high-level `Client` with a set of available
+/// checkpoint sequence numbers.
 async fn test_server_and_client_setup<I: Iterator<Item = u64>>(
     checkpoint_range: I,
     config_customizer: impl FnOnce(&mut GrpcApiConfig),
-    mock_state_reader: Option<Arc<MockRestStateReader>>,
+    mock_state_reader: Option<Arc<MockGrpcStateReader>>,
     client_max_message_size_bytes: Option<u32>,
 ) -> (
     GrpcServerHandle,
     Client,
     Arc<Mutex<HashSet<CheckpointSequenceNumber>>>,
 ) {
-    let mock = mock_state_reader.unwrap_or(Arc::new(MockRestStateReader::new_from_iter(
-        checkpoint_range,
-    )));
+    let mock = mock_state_reader
+        .unwrap_or_else(|| Arc::new(MockGrpcStateReader::new_from_iter(checkpoint_range)));
     let checkpoints = mock.checkpoints.clone();
-    let cancellation_token = tokio_util::sync::CancellationToken::new();
-    let grpc_reader = Arc::new(GrpcReader::from_rest_state_reader(
-        mock,
-        Some("test".to_string()),
-    ));
 
-    let localhost = local_ip_utils::localhost_for_testing();
-    let grpc_port = local_ip_utils::get_available_port(&localhost);
-
-    let mut config = GrpcApiConfig {
-        address: format!("{localhost}:{grpc_port}").parse().unwrap(),
-        ..GrpcApiConfig::default()
-    };
-    config_customizer(&mut config);
-
-    let server_handle = start_grpc_server(
-        grpc_reader,
-        None, // No transaction executor for this test
-        config,
-        cancellation_token,
-        iota_types::digests::ChainIdentifier::default(),
-        None, // No metrics for this test
-    )
-    .await
-    .expect("Failed to start gRPC server");
+    let (server_handle, _) = common::start_test_server(mock, config_customizer).await;
 
     let server_addr = server_handle.address();
     let mut client = Client::connect(&format!("http://{server_addr}"))
@@ -551,7 +143,7 @@ async fn test_server_and_client_setup<I: Iterator<Item = u64>>(
         .expect("Failed to connect to gRPC server");
 
     if let Some(max_size) = client_max_message_size_bytes {
-        client = client.with_max_decoding_message_size(max_size as usize);
+        client = client.with_max_decoding_message_size(usize::try_from(max_size).unwrap());
     }
 
     (server_handle, client, checkpoints)
@@ -991,8 +583,6 @@ async fn test_chunked_checkpoint_streaming() {
 
 #[tokio::test]
 async fn test_filter_checkpoints_validation() {
-    use iota_grpc_types::v0::filter;
-
     let (server_handle, client, _) = test_server_and_client_setup(0..=5, |_| {}, None, None).await;
 
     // filter_checkpoints=true with no filters should fail
@@ -1155,7 +745,7 @@ async fn test_filter_checkpoints_streaming() {
 async fn test_get_checkpoint_pruned_returns_not_found() {
     // Set up mock with checkpoints 0..=10 but lowest_available_checkpoint = 5
     let mock =
-        Arc::new(MockRestStateReader::new_from_iter(0..=10).with_lowest_available_checkpoint(5));
+        Arc::new(MockGrpcStateReader::new_from_iter(0..=10).with_lowest_available_checkpoint(5));
 
     let (server_handle, client, _) =
         test_server_and_client_setup(std::iter::empty(), |_| {}, Some(mock), None).await;
@@ -1196,7 +786,7 @@ async fn test_get_checkpoint_pruned_returns_not_found() {
 async fn test_stream_checkpoint_pruned_start_returns_not_found() {
     // Set up mock with checkpoints 0..=10 but lowest_available_checkpoint = 5
     let mock =
-        Arc::new(MockRestStateReader::new_from_iter(0..=10).with_lowest_available_checkpoint(5));
+        Arc::new(MockGrpcStateReader::new_from_iter(0..=10).with_lowest_available_checkpoint(5));
 
     let (server_handle, client, _) =
         test_server_and_client_setup(std::iter::empty(), |_| {}, Some(mock), None).await;
@@ -1229,172 +819,12 @@ async fn test_stream_checkpoint_pruned_start_returns_not_found() {
         .expect("Failed to shutdown server");
 }
 
-/// A minimal GrpcStateReader that stores pre-built checkpoint transactions
-/// and directly returns them via stream_checkpoint_transactions.
-/// This avoids the ReadStore blanket impl issue with dyn RestStateReader.
-struct ChunkingTestStateReader {
-    summary: CertifiedCheckpointSummary,
-    contents: CheckpointContents,
-    transactions: Vec<CheckpointTransaction>,
-}
-
-impl iota_grpc_server::GrpcStateReader for ChunkingTestStateReader {
-    fn get_chain_identifier(&self) -> anyhow::Result<iota_types::digests::ChainIdentifier> {
-        Ok(iota_types::digests::ChainIdentifier::default())
-    }
-    fn get_latest_checkpoint_sequence_number(&self) -> anyhow::Result<Option<u64>> {
-        Ok(Some(0))
-    }
-    fn get_checkpoint_summary(
-        &self,
-        _seq: u64,
-    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>> {
-        Ok(Some(self.summary.clone()))
-    }
-    fn get_checkpoint_sequence_number_by_digest(
-        &self,
-        _digest: &iota_types::digests::CheckpointDigest,
-    ) -> anyhow::Result<Option<u64>> {
-        unimplemented!()
-    }
-    fn get_checkpoint_data(&self, _seq: u64) -> anyhow::Result<Option<CheckpointData>> {
-        unimplemented!()
-    }
-    fn get_checkpoint_summary_and_contents(
-        &self,
-        _seq: u64,
-    ) -> anyhow::Result<Option<(CertifiedCheckpointSummary, CheckpointContents)>> {
-        Ok(Some((self.summary.clone(), self.contents.clone())))
-    }
-    fn stream_checkpoint_transactions(
-        &self,
-        _checkpoint_contents: CheckpointContents,
-    ) -> std::pin::Pin<
-        Box<dyn futures::Stream<Item = anyhow::Result<CheckpointTransaction>> + Send + '_>,
-    > {
-        let transactions = self.transactions.clone();
-        Box::pin(async_stream::stream! {
-            for tx in transactions {
-                yield Ok(tx);
-            }
-        })
-    }
-    fn get_epoch_last_checkpoint(
-        &self,
-        _epoch: u64,
-    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>> {
-        Ok(None)
-    }
-    fn get_lowest_available_checkpoint(&self) -> anyhow::Result<u64> {
-        Ok(0)
-    }
-    fn get_lowest_available_checkpoint_objects(&self) -> anyhow::Result<u64> {
-        Ok(0)
-    }
-    fn get_object(
-        &self,
-        _object_id: &ObjectID,
-    ) -> anyhow::Result<Option<iota_types::object::Object>> {
-        Ok(None)
-    }
-    fn get_object_by_key(
-        &self,
-        _object_id: &ObjectID,
-        _version: iota_types::base_types::SequenceNumber,
-    ) -> anyhow::Result<Option<iota_types::object::Object>> {
-        Ok(None)
-    }
-    fn get_committee(
-        &self,
-        _epoch: u64,
-    ) -> anyhow::Result<Option<std::sync::Arc<iota_types::committee::Committee>>> {
-        Ok(None)
-    }
-    fn get_system_state(&self) -> anyhow::Result<iota_types::iota_system_state::IotaSystemState> {
-        unimplemented!()
-    }
-    fn get_epoch_info(
-        &self,
-        _epoch: u64,
-    ) -> anyhow::Result<Option<iota_types::storage::EpochInfo>> {
-        Ok(None)
-    }
-    fn get_type_layout(
-        &self,
-        _type_tag: &iota_types::TypeTag,
-    ) -> anyhow::Result<Option<move_core_types::annotated_value::MoveTypeLayout>> {
-        Ok(None)
-    }
-    fn get_transaction(
-        &self,
-        _digest: &iota_types::digests::TransactionDigest,
-    ) -> anyhow::Result<Option<std::sync::Arc<iota_types::transaction::VerifiedTransaction>>> {
-        Ok(None)
-    }
-    fn get_transaction_effects(
-        &self,
-        _digest: &iota_types::digests::TransactionDigest,
-    ) -> anyhow::Result<Option<iota_types::effects::TransactionEffects>> {
-        Ok(None)
-    }
-    fn get_transaction_events(
-        &self,
-        _digest: &iota_types::digests::TransactionDigest,
-    ) -> anyhow::Result<Option<iota_types::effects::TransactionEvents>> {
-        Ok(None)
-    }
-    fn get_transaction_checkpoint(
-        &self,
-        _digest: &iota_types::digests::TransactionDigest,
-    ) -> anyhow::Result<Option<u64>> {
-        Ok(None)
-    }
-}
-
-/// Helper: collect all CheckpointData messages from a stream, returning
-/// (all_messages, tx_batch_messages_with_encoded_len).
-async fn collect_checkpoint_stream(
-    reader: &GrpcReader,
-    max_message_size: u32,
-) -> (
-    Vec<iota_grpc_types::v0::ledger_service::CheckpointData>,
-    Vec<usize>,
-) {
-    use iota_grpc_types::{field::FieldMaskTree, v0::ledger_service::checkpoint_data};
-
-    let stream = reader.get_checkpoint_data(
-        0,
-        FieldMaskTree::new_wildcard(),
-        Some(FieldMaskTree::new_wildcard()),
-        None,
-        max_message_size,
-        None,
-        None,
-    );
-
-    let mut stream = Box::pin(stream);
-    let mut all_messages = Vec::new();
-    let mut tx_batch_sizes = Vec::new();
-
-    while let Some(result) = StreamExt::next(&mut stream).await {
-        let msg: iota_grpc_types::v0::ledger_service::CheckpointData =
-            result.expect("stream should not error");
-        if matches!(
-            msg.payload,
-            Some(checkpoint_data::Payload::ExecutedTransactions(_))
-        ) {
-            tx_batch_sizes.push(msg.encoded_len());
-        }
-        all_messages.push(msg);
-    }
-
-    (all_messages, tx_batch_sizes)
-}
-
-/// Build a small set of transactions for the chunking boundary test.
-/// Uses fewer transactions than `build_large_checkpoint_transactions` so the
-/// test runs fast while still exercising the boundary precisely.
-fn build_small_checkpoint_transactions(count: usize) -> Vec<CheckpointTransaction> {
+/// Build checkpoint transactions, each optionally carrying `events_per_tx`
+/// events.
+fn build_checkpoint_transactions_with_events(
+    count: usize,
+    events_per_tx: usize,
+) -> Vec<CheckpointTransaction> {
     let mut transactions = Vec::with_capacity(count);
     for _ in 0..count {
         let (sender, key): (_, AccountKeyPair) = get_key_pair();
@@ -1403,10 +833,30 @@ fn build_small_checkpoint_transactions(count: usize) -> Vec<CheckpointTransactio
             .transfer(random_object_ref(), sender)
             .build_and_sign(&key);
         let effects = TestEffectsBuilder::new(transaction.data()).build();
+        let events = if events_per_tx > 0 {
+            let mut data = Vec::with_capacity(events_per_tx);
+            for _ in 0..events_per_tx {
+                data.push(Event::new(
+                    &AccountAddress::ZERO,
+                    ident_str!("test_module"),
+                    sender,
+                    StructTag {
+                        address: AccountAddress::ZERO,
+                        module: ident_str!("test_module").into(),
+                        name: ident_str!("TestEvent").into(),
+                        type_params: vec![],
+                    },
+                    vec![0u8; 64], // 64 bytes of dummy content
+                ));
+            }
+            Some(TransactionEvents { data })
+        } else {
+            None
+        };
         transactions.push(CheckpointTransaction {
             transaction,
             effects,
-            events: None,
+            events,
             input_objects: vec![],
             output_objects: vec![],
         });
@@ -1414,59 +864,217 @@ fn build_small_checkpoint_transactions(count: usize) -> Vec<CheckpointTransactio
     transactions
 }
 
+/// Collect all CheckpointData messages from a tonic streaming response,
+/// partitioning payload sizes by type.
+async fn collect_checkpoint_data_stream(
+    mut stream: tonic::codec::Streaming<iota_grpc_types::v0::ledger_service::CheckpointData>,
+) -> (
+    Vec<iota_grpc_types::v0::ledger_service::CheckpointData>,
+    Vec<usize>,
+    Vec<usize>,
+) {
+    let mut all_messages = Vec::new();
+    let mut tx_batch_sizes = Vec::new();
+    let mut event_batch_sizes = Vec::new();
+
+    while let Some(msg) = stream.message().await.expect("stream should not error") {
+        match &msg.payload {
+            Some(checkpoint_data::Payload::ExecutedTransactions(_)) => {
+                tx_batch_sizes.push(msg.encoded_len());
+            }
+            Some(checkpoint_data::Payload::Events(_)) => {
+                event_batch_sizes.push(msg.encoded_len());
+            }
+            _ => {}
+        }
+        all_messages.push(msg);
+    }
+
+    (all_messages, tx_batch_sizes, event_batch_sizes)
+}
+
+/// Issue a `GetCheckpointData` request via the raw tonic client.
+async fn get_checkpoint_data_raw(
+    client: &mut iota_grpc_types::v0::ledger_service::ledger_service_client::LedgerServiceClient<
+        tonic::transport::Channel,
+    >,
+    read_mask: &str,
+    max_message_size: u32,
+) -> tonic::codec::Streaming<iota_grpc_types::v0::ledger_service::CheckpointData> {
+    use iota_grpc_types::{field::FieldMaskUtil, v0::ledger_service::GetCheckpointDataRequest};
+
+    let req = GetCheckpointDataRequest::default()
+        .with_sequence_number(0)
+        .with_read_mask(prost_types::FieldMask::from_str(read_mask))
+        .with_max_message_size_bytes(max_message_size);
+
+    client
+        .get_checkpoint_data(req)
+        .await
+        .expect("get_checkpoint_data should succeed")
+        .into_inner()
+}
+
 #[tokio::test]
 async fn test_chunked_checkpoint_message_sizes_within_limit() {
-    // Use a small number of transactions so the test is fast.
-    let transactions = build_small_checkpoint_transactions(20);
-    let summary = mock_summary(0);
+    // 10 000 transactions → total payload exceeds the 4 MB minimum message size
+    // enforced by the server, which enables the splitting test.
+    let transactions = build_checkpoint_transactions_with_events(10_000, 0);
+    let summary = common::mock_summary(0, &MOCK_CHECKPOINT_CONTENTS);
     let contents = MOCK_CHECKPOINT_CONTENTS.clone();
 
-    let state_reader = Arc::new(ChunkingTestStateReader {
-        summary,
-        contents,
-        transactions,
+    let state_reader = Arc::new(MockGrpcStateReader {
+        summary: Some(summary),
+        contents: Some(contents),
+        checkpoint_transactions: transactions,
+        ..Default::default()
     });
-    let reader = GrpcReader::new(state_reader, Some("test".to_string()));
+    let (server_handle, _) = common::start_test_server(state_reader, |config| {
+        // Server max = 128 MB so the unlimited pass fits in one batch.
+        config.max_message_size_bytes = 128 * 1024 * 1024;
+    })
+    .await;
+    let addr = server_handle.address();
 
-    // --- Pass 1: unlimited size to measure the single-batch encoded size ---
-    let (_, tx_sizes_unlimited) = collect_checkpoint_stream(&reader, u32::MAX).await;
+    // Use the raw tonic client instead of the high-level Client so we can
+    // inspect individual streamed CheckpointData messages and verify their
+    // sizes. The high-level client reassembles them into a single response.
+    let channel = tonic::transport::Channel::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .expect("connect");
+    let mut client =
+        iota_grpc_types::v0::ledger_service::ledger_service_client::LedgerServiceClient::new(
+            channel,
+        )
+        .max_decoding_message_size(128 * 1024 * 1024);
+
+    let read_mask = "checkpoint.summary,transactions";
+
+    // --- Pass 1: unlimited (128 MB) → measure single-batch encoded size ---
+    let stream = get_checkpoint_data_raw(&mut client, read_mask, 128 * 1024 * 1024).await;
+    let (_, tx_sizes_unlimited, _) = collect_checkpoint_data_stream(stream).await;
     assert_eq!(
         tx_sizes_unlimited.len(),
         1,
-        "With unlimited size all transactions should fit in a single batch"
+        "With 128 MB limit all transactions should fit in a single batch"
     );
-    let exact_batch_size = tx_sizes_unlimited[0];
+    let exact_batch_size = u32::try_from(tx_sizes_unlimited[0]).unwrap();
+    assert!(
+        exact_batch_size >= 4 * 1024 * 1024,
+        "Test prerequisite: single batch ({exact_batch_size}) must be >= 4 MB \
+         so the server does not clamp the limit"
+    );
 
-    // --- Pass 2: set limit to exactly the measured batch size ---
-    // All transactions must still fit in a single batch.
-    let (_, tx_sizes_exact) = collect_checkpoint_stream(&reader, exact_batch_size as u32).await;
+    // --- Pass 2: exact limit → should still fit in one batch ---
+    let stream = get_checkpoint_data_raw(&mut client, read_mask, exact_batch_size).await;
+    let (_, tx_sizes_exact, _) = collect_checkpoint_data_stream(stream).await;
     assert_eq!(
         tx_sizes_exact.len(),
         1,
         "At exact limit ({exact_batch_size}) all transactions should still fit in one batch"
     );
-    assert_eq!(
-        tx_sizes_exact[0], exact_batch_size,
-        "Batch encoded_len should match the measured size"
-    );
 
-    // --- Pass 3: set limit to one byte less → must split ---
-    let tight_limit = (exact_batch_size - 1) as u32;
-    let (all_messages, tx_sizes_split) = collect_checkpoint_stream(&reader, tight_limit).await;
+    // --- Pass 3: exact - 1 → must split ---
+    let tight_limit = exact_batch_size - 1;
+    let stream = get_checkpoint_data_raw(&mut client, read_mask, tight_limit).await;
+    let (all_messages, tx_sizes_split, _) = collect_checkpoint_data_stream(stream).await;
     assert!(
         tx_sizes_split.len() > 1,
-        "At limit {tight_limit} (exact-1) transactions must be split into multiple batches, \
-         got {} batch(es)",
+        "At limit {tight_limit} (exact-1) transactions must be split, got {} batch(es)",
         tx_sizes_split.len()
     );
 
-    // Every single message (checkpoint, tx batches, end marker) must be within the
-    // limit.
+    // Every message must be within the limit.
     for (i, msg) in all_messages.iter().enumerate() {
         let size = msg.encoded_len();
         assert!(
-            size <= tight_limit as usize,
+            size <= usize::try_from(tight_limit).unwrap(),
             "Message {i} has encoded_len {size} which exceeds limit {tight_limit}"
         );
     }
+
+    server_handle.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn test_chunked_checkpoint_event_message_sizes_within_limit() {
+    // 2 000 transactions × 5 events each → total event payload exceeds 4 MB.
+    let transactions = build_checkpoint_transactions_with_events(2_000, 5);
+    let summary = common::mock_summary(0, &MOCK_CHECKPOINT_CONTENTS);
+    let contents = MOCK_CHECKPOINT_CONTENTS.clone();
+
+    let state_reader = Arc::new(MockGrpcStateReader {
+        summary: Some(summary),
+        contents: Some(contents),
+        checkpoint_transactions: transactions,
+        ..Default::default()
+    });
+    let (server_handle, _) = common::start_test_server(state_reader, |config| {
+        config.max_message_size_bytes = 128 * 1024 * 1024;
+    })
+    .await;
+    let addr = server_handle.address();
+
+    // Use the raw tonic client instead of the high-level Client so we can
+    // inspect individual streamed CheckpointData messages and verify their
+    // sizes. The high-level client reassembles them into a single response.
+    let channel = tonic::transport::Channel::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .expect("connect");
+    let mut client =
+        iota_grpc_types::v0::ledger_service::ledger_service_client::LedgerServiceClient::new(
+            channel,
+        )
+        .max_decoding_message_size(128 * 1024 * 1024);
+
+    let read_mask = "checkpoint.summary,events";
+
+    // --- Pass 1: unlimited (128 MB) → measure single-batch encoded size ---
+    let stream = get_checkpoint_data_raw(&mut client, read_mask, 128 * 1024 * 1024).await;
+    let (_, _, event_sizes_unlimited) = collect_checkpoint_data_stream(stream).await;
+    assert_eq!(
+        event_sizes_unlimited.len(),
+        1,
+        "With 128 MB limit all events should fit in a single batch"
+    );
+    let exact_batch_size = u32::try_from(event_sizes_unlimited[0]).unwrap();
+    assert!(
+        exact_batch_size >= 4 * 1024 * 1024,
+        "Test prerequisite: single batch ({exact_batch_size}) must be >= 4 MB \
+         so the server does not clamp the limit"
+    );
+
+    // --- Pass 2: exact limit → should still fit in one batch ---
+    let stream = get_checkpoint_data_raw(&mut client, read_mask, exact_batch_size).await;
+    let (_, _, event_sizes_exact) = collect_checkpoint_data_stream(stream).await;
+    assert_eq!(
+        event_sizes_exact.len(),
+        1,
+        "At exact limit ({exact_batch_size}) all events should still fit in one batch"
+    );
+
+    // --- Pass 3: exact - 1 → must split ---
+    let tight_limit = exact_batch_size - 1;
+    let stream = get_checkpoint_data_raw(&mut client, read_mask, tight_limit).await;
+    let (all_messages, _, event_sizes_split) = collect_checkpoint_data_stream(stream).await;
+    assert!(
+        event_sizes_split.len() > 1,
+        "At limit {tight_limit} (exact-1) events must be split, got {} batch(es)",
+        event_sizes_split.len()
+    );
+
+    // Every message must be within the limit.
+    for (i, msg) in all_messages.iter().enumerate() {
+        let size = msg.encoded_len();
+        assert!(
+            size <= usize::try_from(tight_limit).unwrap(),
+            "Message {i} has encoded_len {size} which exceeds limit {tight_limit}"
+        );
+    }
+
+    server_handle.shutdown().await.expect("shutdown");
 }

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -3,7 +3,7 @@
 mod common;
 use std::{
     collections::HashSet,
-    sync::{Arc, LazyLock, Mutex},
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -19,19 +19,19 @@ use iota_types::{
     effects::{TestEffectsBuilder, TransactionEvents},
     event::Event,
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
-    messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber},
+    messages_checkpoint::CheckpointSequenceNumber,
 };
 use move_core_types::{account_address::AccountAddress, ident_str, language_storage::StructTag};
 use prost::Message;
 use tokio_stream::StreamExt;
 
-static MOCK_CHECKPOINT_CONTENTS: LazyLock<CheckpointContents> =
-    LazyLock::new(|| CheckpointContents::new_with_digests_only_for_tests(vec![]));
-
 fn mock_checkpoint_data(sequence_number: u64) -> CheckpointData {
     CheckpointData {
-        checkpoint_summary: common::mock_summary(sequence_number, &MOCK_CHECKPOINT_CONTENTS),
-        checkpoint_contents: MOCK_CHECKPOINT_CONTENTS.clone(),
+        checkpoint_summary: common::mock_summary(
+            sequence_number,
+            &common::EMPTY_CHECKPOINT_CONTENTS,
+        ),
+        checkpoint_contents: common::EMPTY_CHECKPOINT_CONTENTS.clone(),
         transactions: vec![],
     }
 }
@@ -48,8 +48,11 @@ fn mock_checkpoint_data_with_sender(
         .build_and_sign(key);
     let effects = TestEffectsBuilder::new(transaction.data()).build();
     CheckpointData {
-        checkpoint_summary: common::mock_summary(sequence_number, &MOCK_CHECKPOINT_CONTENTS),
-        checkpoint_contents: MOCK_CHECKPOINT_CONTENTS.clone(),
+        checkpoint_summary: common::mock_summary(
+            sequence_number,
+            &common::EMPTY_CHECKPOINT_CONTENTS,
+        ),
+        checkpoint_contents: common::EMPTY_CHECKPOINT_CONTENTS.clone(),
         transactions: vec![CheckpointTransaction {
             transaction,
             effects,
@@ -920,8 +923,8 @@ async fn test_chunked_checkpoint_message_sizes_within_limit() {
     // 10 000 transactions → total payload exceeds the 4 MB minimum message size
     // enforced by the server, which enables the splitting test.
     let transactions = build_checkpoint_transactions_with_events(10_000, 0);
-    let summary = common::mock_summary(0, &MOCK_CHECKPOINT_CONTENTS);
-    let contents = MOCK_CHECKPOINT_CONTENTS.clone();
+    let summary = common::mock_summary(0, &common::EMPTY_CHECKPOINT_CONTENTS);
+    let contents = common::EMPTY_CHECKPOINT_CONTENTS.clone();
 
     let state_reader = Arc::new(MockGrpcStateReader {
         summary: Some(summary),
@@ -1002,8 +1005,8 @@ async fn test_chunked_checkpoint_message_sizes_within_limit() {
 async fn test_chunked_checkpoint_event_message_sizes_within_limit() {
     // 2 000 transactions × 5 events each → total event payload exceeds 4 MB.
     let transactions = build_checkpoint_transactions_with_events(2_000, 5);
-    let summary = common::mock_summary(0, &MOCK_CHECKPOINT_CONTENTS);
-    let contents = MOCK_CHECKPOINT_CONTENTS.clone();
+    let summary = common::mock_summary(0, &common::EMPTY_CHECKPOINT_CONTENTS);
+    let contents = common::EMPTY_CHECKPOINT_CONTENTS.clone();
 
     let state_reader = Arc::new(MockGrpcStateReader {
         summary: Some(summary),

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! Shared test utilities for iota-grpc-server integration tests.
@@ -98,7 +98,7 @@ pub struct MockGrpcStateReader {
 }
 
 /// Shared empty contents used when generating on-the-fly summaries.
-static EMPTY_CHECKPOINT_CONTENTS: std::sync::LazyLock<CheckpointContents> =
+pub(crate) static EMPTY_CHECKPOINT_CONTENTS: std::sync::LazyLock<CheckpointContents> =
     std::sync::LazyLock::new(|| CheckpointContents::new_with_digests_only_for_tests(vec![]));
 
 impl MockGrpcStateReader {

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -1,0 +1,347 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test utilities for iota-grpc-server integration tests.
+//! Not every test binary uses every item.
+#![allow(dead_code)]
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
+
+use iota_config::{local_ip_utils, node::GrpcApiConfig};
+use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
+use iota_types::{
+    base_types::{ObjectID, SequenceNumber},
+    crypto::AuthorityStrongQuorumSignInfo,
+    digests::TransactionDigest,
+    effects::{TransactionEffects, TransactionEvents},
+    full_checkpoint_content::{CheckpointData, CheckpointTransaction},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
+    },
+    object::Object,
+    transaction::VerifiedTransaction,
+};
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/// Create a mock `CertifiedCheckpointSummary` for the given sequence number.
+pub fn mock_summary(
+    sequence_number: u64,
+    contents: &CheckpointContents,
+) -> CertifiedCheckpointSummary {
+    let summary = CheckpointSummary {
+        epoch: 0,
+        sequence_number,
+        network_total_transactions: 0,
+        content_digest: *contents.digest(),
+        previous_digest: None,
+        epoch_rolling_gas_cost_summary: Default::default(),
+        timestamp_ms: 0,
+        checkpoint_commitments: vec![],
+        end_of_epoch_data: None,
+        version_specific_data: vec![],
+    };
+    let sig = AuthorityStrongQuorumSignInfo {
+        epoch: 0,
+        signature: Default::default(),
+        signers_map: Default::default(),
+    };
+    CertifiedCheckpointSummary::new_from_data_and_sig(summary, sig)
+}
+
+// ---------------------------------------------------------------------------
+// MockGrpcStateReader
+// ---------------------------------------------------------------------------
+
+/// A configurable mock `GrpcStateReader` for integration tests.
+///
+/// All fields default to empty / `None`. Tests set only the fields they need.
+///
+/// # Checkpoint modes
+///
+/// - **Fixed mode** (set `summary` + `contents` + `checkpoint_transactions`):
+///   every sequence number returns the same summary/contents/transactions. Used
+///   by the boundary-size chunking tests.
+///
+/// - **Set mode** (set `checkpoints`): only sequence numbers present in the set
+///   are "available". A mock summary is generated on the fly for each. Used by
+///   the checkpoint-streaming integration tests.
+#[derive(Default)]
+pub struct MockGrpcStateReader {
+    // -- Fixed checkpoint mode --
+    pub summary: Option<CertifiedCheckpointSummary>,
+    pub contents: Option<CheckpointContents>,
+    pub checkpoint_transactions: Vec<CheckpointTransaction>,
+
+    // -- Set-based checkpoint mode (for streaming tests) --
+    pub checkpoints: Arc<Mutex<HashSet<CheckpointSequenceNumber>>>,
+    /// Sequence numbers whose `stream_checkpoint_transactions` should return
+    /// `large_checkpoint_transactions` instead of the default empty vec.
+    pub large_checkpoints: Arc<Mutex<HashSet<CheckpointSequenceNumber>>>,
+    /// Transactions returned for "large" checkpoints.
+    pub large_checkpoint_transactions: Vec<CheckpointTransaction>,
+
+    // -- Objects --
+    pub objects: HashMap<ObjectID, Object>,
+
+    // -- Transactions --
+    pub transactions: HashMap<TransactionDigest, Arc<VerifiedTransaction>>,
+    pub effects: HashMap<TransactionDigest, TransactionEffects>,
+
+    // -- Pruning --
+    pub lowest_available_checkpoint: u64,
+}
+
+/// Shared empty contents used when generating on-the-fly summaries.
+static EMPTY_CHECKPOINT_CONTENTS: std::sync::LazyLock<CheckpointContents> =
+    std::sync::LazyLock::new(|| CheckpointContents::new_with_digests_only_for_tests(vec![]));
+
+impl MockGrpcStateReader {
+    /// Create a `MockGrpcStateReader` in set mode from a checkpoint range.
+    pub fn new_from_iter(iter: impl Iterator<Item = u64>) -> Self {
+        Self {
+            checkpoints: Arc::new(Mutex::new(iter.collect())),
+            ..Default::default()
+        }
+    }
+
+    /// Whether we are in "set mode" (at least one checkpoint in the set).
+    fn is_set_mode(&self) -> bool {
+        !self.checkpoints.lock().unwrap().is_empty()
+    }
+
+    /// Mark a checkpoint sequence number as using large data.
+    pub fn mark_checkpoint_as_large(&self, seq: CheckpointSequenceNumber) {
+        self.large_checkpoints.lock().unwrap().insert(seq);
+    }
+
+    fn is_large_checkpoint(&self, seq: CheckpointSequenceNumber) -> bool {
+        self.large_checkpoints.lock().unwrap().contains(&seq)
+    }
+
+    /// Builder: set the lowest available checkpoint (for pruning tests).
+    pub fn with_lowest_available_checkpoint(mut self, seq: u64) -> Self {
+        self.lowest_available_checkpoint = seq;
+        self
+    }
+}
+
+impl iota_grpc_server::GrpcStateReader for MockGrpcStateReader {
+    fn get_chain_identifier(&self) -> anyhow::Result<iota_types::digests::ChainIdentifier> {
+        Ok(iota_types::digests::ChainIdentifier::default())
+    }
+
+    fn get_latest_checkpoint_sequence_number(&self) -> anyhow::Result<Option<u64>> {
+        if self.is_set_mode() {
+            Ok(self.checkpoints.lock().unwrap().iter().max().copied())
+        } else {
+            // Fixed mode: assume checkpoint 0 exists if summary is set.
+            Ok(self.summary.as_ref().map(|s| s.sequence_number))
+        }
+    }
+
+    fn get_checkpoint_summary(
+        &self,
+        seq: u64,
+    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>> {
+        if self.is_set_mode() {
+            let guard = self.checkpoints.lock().unwrap();
+            if guard.contains(&seq) {
+                Ok(Some(mock_summary(seq, &EMPTY_CHECKPOINT_CONTENTS)))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(self.summary.clone())
+        }
+    }
+
+    fn get_checkpoint_sequence_number_by_digest(
+        &self,
+        _digest: &iota_types::digests::CheckpointDigest,
+    ) -> anyhow::Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn get_checkpoint_data(&self, seq: u64) -> anyhow::Result<Option<CheckpointData>> {
+        if self.is_set_mode() {
+            let guard = self.checkpoints.lock().unwrap();
+            if !guard.contains(&seq) {
+                return Ok(None);
+            }
+            drop(guard);
+
+            let transactions = if self.is_large_checkpoint(seq) {
+                self.large_checkpoint_transactions.clone()
+            } else {
+                vec![]
+            };
+            Ok(Some(CheckpointData {
+                checkpoint_summary: mock_summary(seq, &EMPTY_CHECKPOINT_CONTENTS),
+                checkpoint_contents: EMPTY_CHECKPOINT_CONTENTS.clone(),
+                transactions,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_checkpoint_summary_and_contents(
+        &self,
+        seq: u64,
+    ) -> anyhow::Result<Option<(CertifiedCheckpointSummary, CheckpointContents)>> {
+        if self.is_set_mode() {
+            let guard = self.checkpoints.lock().unwrap();
+            if guard.contains(&seq) {
+                Ok(Some((
+                    mock_summary(seq, &EMPTY_CHECKPOINT_CONTENTS),
+                    EMPTY_CHECKPOINT_CONTENTS.clone(),
+                )))
+            } else {
+                Ok(None)
+            }
+        } else {
+            match (&self.summary, &self.contents) {
+                (Some(summary), Some(contents)) => Ok(Some((summary.clone(), contents.clone()))),
+                _ => Ok(None),
+            }
+        }
+    }
+
+    fn stream_checkpoint_transactions(
+        &self,
+        _checkpoint_contents: CheckpointContents,
+    ) -> std::pin::Pin<
+        Box<dyn futures::Stream<Item = anyhow::Result<CheckpointTransaction>> + Send + '_>,
+    > {
+        // In set mode with large checkpoints, return large transactions.
+        // Otherwise return the fixed checkpoint_transactions (may be empty).
+        let transactions = self.checkpoint_transactions.clone();
+        Box::pin(async_stream::stream! {
+            for tx in transactions {
+                yield Ok(tx);
+            }
+        })
+    }
+
+    fn get_epoch_last_checkpoint(
+        &self,
+        _epoch: u64,
+    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>> {
+        Ok(None)
+    }
+
+    fn get_lowest_available_checkpoint(&self) -> anyhow::Result<u64> {
+        Ok(self.lowest_available_checkpoint)
+    }
+
+    fn get_lowest_available_checkpoint_objects(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+
+    fn get_object(&self, object_id: &ObjectID) -> anyhow::Result<Option<Object>> {
+        Ok(self.objects.get(object_id).cloned())
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        _version: SequenceNumber,
+    ) -> anyhow::Result<Option<Object>> {
+        Ok(self.objects.get(object_id).cloned())
+    }
+
+    fn get_committee(
+        &self,
+        _epoch: u64,
+    ) -> anyhow::Result<Option<Arc<iota_types::committee::Committee>>> {
+        Ok(None)
+    }
+
+    fn get_system_state(&self) -> anyhow::Result<iota_types::iota_system_state::IotaSystemState> {
+        unimplemented!()
+    }
+
+    fn get_epoch_info(
+        &self,
+        _epoch: u64,
+    ) -> anyhow::Result<Option<iota_types::storage::EpochInfo>> {
+        Ok(None)
+    }
+
+    fn get_type_layout(
+        &self,
+        _type_tag: &iota_types::TypeTag,
+    ) -> anyhow::Result<Option<move_core_types::annotated_value::MoveTypeLayout>> {
+        Ok(None)
+    }
+
+    fn get_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<Arc<VerifiedTransaction>>> {
+        Ok(self.transactions.get(digest).cloned())
+    }
+
+    fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<TransactionEffects>> {
+        Ok(self.effects.get(digest).cloned())
+    }
+
+    fn get_transaction_events(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<TransactionEvents>> {
+        Ok(None)
+    }
+
+    fn get_transaction_checkpoint(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<u64>> {
+        Ok(None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server setup helpers
+// ---------------------------------------------------------------------------
+
+/// Start a gRPC server backed by the given `MockGrpcStateReader`.
+///
+/// Returns the server handle and the `GrpcReader` (callers may need it to
+/// create different client types).
+pub async fn start_test_server(
+    state_reader: Arc<MockGrpcStateReader>,
+    config_customizer: impl FnOnce(&mut GrpcApiConfig),
+) -> (GrpcServerHandle, Arc<GrpcReader>) {
+    let grpc_reader = Arc::new(GrpcReader::new(state_reader, Some("test".to_string())));
+    let localhost = local_ip_utils::localhost_for_testing();
+    let port = local_ip_utils::get_available_port(&localhost);
+    let mut config = GrpcApiConfig {
+        address: format!("{localhost}:{port}").parse().unwrap(),
+        ..GrpcApiConfig::default()
+    };
+    config_customizer(&mut config);
+
+    let cancellation_token = tokio_util::sync::CancellationToken::new();
+    let server_handle = start_grpc_server(
+        grpc_reader.clone(),
+        None,
+        config,
+        cancellation_token,
+        iota_types::digests::ChainIdentifier::default(),
+        None,
+    )
+    .await
+    .expect("Failed to start gRPC server");
+
+    (server_handle, grpc_reader)
+}


### PR DESCRIPTION
# Description of change

This PR fixes the size calculations for endpoints that were able to chunk responses in a stream. The wrapper types that were holding the result set were not accounted for, which could result in returning a bigger response than the client can accept/process.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes