### PR TITLE
upstream(core): Enable serving rpc traffic over https

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6873,6 +6873,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "iota-tls",
  "pin-project-lite",
  "reqwest",
  "socket2 0.5.7",

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -75,6 +75,19 @@ pub struct NodeConfig {
     #[serde(default = "default_json_rpc_address")]
     pub json_rpc_address: SocketAddr,
 
+    /// Configure the address to listen on for HTTPS JSON-RPC traffic.
+    ///
+    /// Defaults to `0.0.0.0:9443` if not specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_rpc_https_address: Option<SocketAddr>,
+
+    /// TLS configuration for the JSON-RPC HTTPS server.
+    ///
+    /// If not provided then the node will not create an HTTPS service for
+    /// JSON-RPC.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_rpc_tls: Option<TlsConfig>,
+
     /// Flag to enable the REST API under `/api/v1`
     /// endpoint on the same interface as `json` `rpc` server.
     #[serde(default)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2013,12 +2013,16 @@ impl AuthorityState {
                 suggested_gas_price: self
                     .congestion_tracker
                     .get_prediction_suggested_gas_price(&transaction),
-                input: IotaTransactionBlockData::try_from(transaction, &module_cache, tx_digest)
-                    .map_err(|e| IotaError::TransactionSerialization {
-                        error: format!(
-                            "Failed to convert transaction to IotaTransactionBlockData: {e}",
-                        ),
-                    })?, // TODO: replace the underlying try_from to IotaError. This one goes deep
+                input: IotaTransactionBlockData::try_from_with_module_cache(
+                    transaction,
+                    &module_cache,
+                    tx_digest,
+                )
+                .map_err(|e| IotaError::TransactionSerialization {
+                    error: format!(
+                        "Failed to convert transaction to IotaTransactionBlockData: {e}",
+                    ),
+                })?, // TODO: replace the underlying try_from to IotaError. This one goes deep
                 effects: effects.clone().try_into()?,
                 events: IotaTransactionBlockEvents::try_from(
                     inner_temp_store.events.clone(),

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -605,14 +605,14 @@ impl AuthorityStorePruner {
         delay_days: usize,
         last_processed: Arc<Mutex<HashMap<String, SystemTime>>>,
     ) -> anyhow::Result<Option<LiveFile>> {
-        let db_path = perpetual_db.objects.rocksdb.path();
+        let db_path = perpetual_db.objects.db.path_for_pruning();
         let mut state = last_processed
             .lock()
             .expect("failed to obtain a lock for last processed SST files");
         let mut sst_file_for_compaction: Option<LiveFile> = None;
         let time_threshold =
             SystemTime::now() - Duration::from_secs(delay_days as u64 * 24 * 60 * 60);
-        for sst_file in perpetual_db.objects.rocksdb.live_files()? {
+        for sst_file in perpetual_db.objects.db.live_files()? {
             let file_path = db_path.join(sst_file.name.clone().trim_matches('/'));
             let last_modified = std::fs::metadata(file_path)?.modified()?;
             if !PERIODIC_PRUNING_TABLES.contains(&sst_file.column_family_name)
@@ -1113,8 +1113,8 @@ mod tests {
         let start = ObjectKey(ObjectID::ZERO, SequenceNumber::MIN_VALID_INCL);
         let end = ObjectKey(ObjectID::MAX, SequenceNumber::MAX_VALID_EXCL);
 
-        perpetual_db.objects.rocksdb.flush()?;
-        perpetual_db.objects.compact_range_to_bottom(&start, &end)?;
+        perpetual_db.objects.db.flush()?;
+        perpetual_db.objects.compact_range(&start, &end)?;
         let before_compaction_size = get_sst_size(&db_path);
 
         let mut effects = TransactionEffects::default();
@@ -1132,8 +1132,8 @@ mod tests {
                 .await;
         info!("Total pruned keys = {:?}", total_pruned);
 
-        perpetual_db.objects.rocksdb.flush()?;
-        perpetual_db.objects.compact_range_to_bottom(&start, &end)?;
+        perpetual_db.objects.db.flush()?;
+        perpetual_db.objects.compact_range(&start, &end)?;
         let after_compaction_size = get_sst_size(&db_path);
 
         info!(

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -491,7 +491,7 @@ impl AuthorityPerpetualTables {
         self.total_iota_supply.unsafe_clear()?;
         self.expected_storage_fund_imbalance.unsafe_clear()?;
         self.object_per_epoch_marker_table.unsafe_clear()?;
-        self.objects.rocksdb.flush()?;
+        self.objects.db.flush()?;
         Ok(())
     }
 

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -882,7 +882,7 @@ impl CheckpointStore {
 
     pub fn reset_db_for_execution_since_genesis(&self) -> IotaResult {
         self.delete_highest_executed_checkpoint_test_only()?;
-        self.tables.watermarks.rocksdb.flush()?;
+        self.tables.watermarks.db.flush()?;
         Ok(())
     }
 }

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -2,16 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, str::FromStr};
-
 use iota_config::NodeConfig;
-use tap::TapFallible;
 use tokio::runtime::Runtime;
-use tracing::warn;
 
 pub struct IotaRuntimes {
     // Order in this struct is the order in which runtimes are stopped
-    pub json_rpc: Runtime,
     pub iota_node: Runtime,
     pub metrics: Runtime,
 }
@@ -30,25 +25,6 @@ impl IotaRuntimes {
             .build()
             .unwrap();
 
-        let worker_thread = env::var("RPC_WORKER_THREAD")
-            .ok()
-            .and_then(|o| {
-                usize::from_str(&o)
-                    .tap_err(|e| warn!("Cannot parse RPC_WORKER_THREAD to usize: {e}"))
-                    .ok()
-            })
-            .unwrap_or(num_cpus::get() / 2);
-
-        let json_rpc = tokio::runtime::Builder::new_multi_thread()
-            .thread_name("jsonrpc-runtime")
-            .worker_threads(worker_thread)
-            .enable_all()
-            .build()
-            .unwrap();
-        Self {
-            iota_node,
-            metrics,
-            json_rpc,
-        }
+        Self { iota_node, metrics }
     }
 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -2930,7 +2930,11 @@ async fn test_invalid_authenticator_state_parameter() {
         // type_args
         vec![],
         gas_ref,
-        vec![CallArg::AUTHENTICATOR_MUT],
+        vec![CallArg::Object(ObjectArg::SharedObject {
+            id: IOTA_AUTHENTICATOR_STATE_OBJECT_ID,
+            initial_shared_version: SequenceNumber::from(1),
+            mutable: true,
+        })],
         TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
         rgp,
     )

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -137,7 +137,7 @@ pub async fn serve_executor(
     info!("Starting executor server on {}", executor_server_url);
 
     let executor_server_handle = tokio::spawn(async move {
-        iota_rest_api::RestService::new_without_version(executor)
+        iota_rest_api::RestService::new(executor)
             .start_service(executor_server_url)
             .await;
     });

--- a/crates/iota-http/Cargo.toml
+++ b/crates/iota-http/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+# external dependencies
 bytes.workspace = true
 http.workspace = true
 http-body.workspace = true
@@ -16,11 +17,14 @@ hyper-util.workspace = true
 pin-project-lite.workspace = true
 socket2 = { version = "0.5", features = ["all"] }
 tokio = { workspace = true, features = ["macros"] }
-# TLS support
 tokio-rustls.workspace = true
 tokio-util.workspace = true
 tower.workspace = true
 tracing.workspace = true
+
+# internal dependencies
+# TLS support
+iota-tls.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/iota-http/src/lib.rs
+++ b/crates/iota-http/src/lib.rs
@@ -10,7 +10,7 @@ use http::{Request, Response};
 use hyper_util::service::TowerToHyperService;
 use io::ServerIo;
 use tokio::task::JoinSet;
-use tokio_rustls::TlsAcceptor;
+use tokio_rustls::{TlsAcceptor, rustls};
 use tower::{Service, ServiceBuilder, ServiceExt};
 use tracing::trace;
 
@@ -37,7 +37,7 @@ const ALPN_H1: &[u8] = b"http/1.1";
 #[derive(Default)]
 pub struct Builder {
     config: Config,
-    tls_config: Option<tokio_rustls::rustls::ServerConfig>,
+    tls_config: Option<rustls::ServerConfig>,
 }
 
 impl Builder {
@@ -50,7 +50,21 @@ impl Builder {
         self
     }
 
-    pub fn tls_config(mut self, tls_config: tokio_rustls::rustls::ServerConfig) -> Self {
+    // Convenience method for configuring TLS with a single server cert
+    //
+    // Attempts to load PEM formatted files for the certificate chain and private
+    // key material from the provided file system paths.
+    pub fn tls_single_cert(
+        self,
+        cert_file: impl AsRef<std::path::Path>,
+        private_key_file: impl AsRef<std::path::Path>,
+    ) -> Result<Self, BoxError> {
+        let tls_config =
+            iota_tls::create_rustls_server_config_from_pem(cert_file, private_key_file)?;
+        Ok(self.tls_config(tls_config))
+    }
+
+    pub fn tls_config(mut self, tls_config: rustls::ServerConfig) -> Self {
         self.tls_config = Some(tls_config);
         self
     }
@@ -208,7 +222,7 @@ type ConnectingOutput<Io, Addr> = Result<(ServerIo<Io>, Addr), crate::BoxError>;
 
 struct Server<L: Listener> {
     config: Config,
-    tls_config: Option<Arc<tokio_rustls::rustls::ServerConfig>>,
+    tls_config: Option<Arc<rustls::ServerConfig>>,
 
     listener: L,
     local_addr: L::Addr,

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -432,7 +432,7 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
 ) {
     let server_url = server_url.unwrap_or_else(new_local_tcp_socket_for_testing);
     let server_handle = tokio::spawn(async move {
-        iota_rest_api::RestService::new_without_version(sim)
+        iota_rest_api::RestService::new(sim)
             .start_service(server_url)
             .await;
     });

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -492,9 +492,8 @@ impl Display for IotaTransactionBlockKind {
 }
 
 impl IotaTransactionBlockKind {
-    fn try_from(
+    fn try_from_inner(
         tx: TransactionKind,
-        module_cache: &impl GetModule,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
         Ok(match tx {
@@ -518,9 +517,10 @@ impl IotaTransactionBlockKind {
                         .consensus_determined_version_assignments,
                 })
             }
-            TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
-                IotaProgrammableTransactionBlock::try_from(p, module_cache)?,
-            ),
+            TransactionKind::ProgrammableTransaction(_) => {
+                // This case is handled separately by the callers
+                unreachable!()
+            }
             TransactionKind::AuthenticatorStateUpdateV1(update) => {
                 Self::AuthenticatorStateUpdateV1(IotaAuthenticatorStateUpdateV1 {
                     epoch: update.epoch,
@@ -573,89 +573,34 @@ impl IotaTransactionBlockKind {
         })
     }
 
+    fn try_from_with_module_cache(
+        tx: TransactionKind,
+        module_cache: &impl GetModule,
+        tx_digest: TransactionDigest,
+    ) -> Result<Self, anyhow::Error> {
+        match tx {
+            TransactionKind::ProgrammableTransaction(p) => Ok(Self::ProgrammableTransaction(
+                IotaProgrammableTransactionBlock::try_from_with_module_cache(p, module_cache)?,
+            )),
+            tx => Self::try_from_inner(tx, tx_digest),
+        }
+    }
+
     async fn try_from_with_package_resolver(
         tx: TransactionKind,
         package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
-        Ok(match tx {
-            TransactionKind::Genesis(g) => Self::Genesis(IotaGenesisTransaction {
-                objects: g.objects.iter().map(GenesisObject::id).collect(),
-                events: g
-                    .events
-                    .into_iter()
-                    .enumerate()
-                    .map(|(seq, _event)| EventID::from((tx_digest, seq as u64)))
-                    .collect(),
-            }),
-            TransactionKind::ConsensusCommitPrologueV1(p) => {
-                Self::ConsensusCommitPrologueV1(IotaConsensusCommitPrologueV1 {
-                    epoch: p.epoch,
-                    round: p.round,
-                    sub_dag_index: p.sub_dag_index,
-                    commit_timestamp_ms: p.commit_timestamp_ms,
-                    consensus_commit_digest: p.consensus_commit_digest,
-                    consensus_determined_version_assignments: p
-                        .consensus_determined_version_assignments,
-                })
-            }
-            TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
+        match tx {
+            TransactionKind::ProgrammableTransaction(p) => Ok(Self::ProgrammableTransaction(
                 IotaProgrammableTransactionBlock::try_from_with_package_resolver(
                     p,
                     package_resolver,
                 )
                 .await?,
-            ),
-            TransactionKind::AuthenticatorStateUpdateV1(update) => {
-                Self::AuthenticatorStateUpdateV1(IotaAuthenticatorStateUpdateV1 {
-                    epoch: update.epoch,
-                    round: update.round,
-                    new_active_jwks: update
-                        .new_active_jwks
-                        .into_iter()
-                        .map(IotaActiveJwk::from)
-                        .collect(),
-                })
-            }
-            TransactionKind::RandomnessStateUpdate(update) => {
-                Self::RandomnessStateUpdate(IotaRandomnessStateUpdate {
-                    epoch: update.epoch,
-                    randomness_round: update.randomness_round.0,
-                    random_bytes: update.random_bytes,
-                })
-            }
-            TransactionKind::EndOfEpochTransaction(end_of_epoch_tx) => {
-                Self::EndOfEpochTransaction(IotaEndOfEpochTransaction {
-                    transactions: end_of_epoch_tx
-                        .into_iter()
-                        .map(|tx| match tx {
-                            EndOfEpochTransactionKind::ChangeEpoch(e) => {
-                                IotaEndOfEpochTransactionKind::ChangeEpoch(e.into())
-                            }
-                            EndOfEpochTransactionKind::ChangeEpochV2(e) => {
-                                IotaEndOfEpochTransactionKind::ChangeEpochV2(e.into())
-                            }
-                            EndOfEpochTransactionKind::ChangeEpochV3(e) => {
-                                IotaEndOfEpochTransactionKind::ChangeEpochV2(e.into())
-                            }
-                            EndOfEpochTransactionKind::ChangeEpochV4(e) => {
-                                IotaEndOfEpochTransactionKind::ChangeEpochV2(e.into())
-                            }
-                            EndOfEpochTransactionKind::AuthenticatorStateCreate => {
-                                IotaEndOfEpochTransactionKind::AuthenticatorStateCreate
-                            }
-                            EndOfEpochTransactionKind::AuthenticatorStateExpire(expire) => {
-                                IotaEndOfEpochTransactionKind::AuthenticatorStateExpire(
-                                    IotaAuthenticatorStateExpire {
-                                        min_epoch: expire.min_epoch,
-                                    },
-                                )
-                            }
-                        })
-                        .collect(),
-                })
-            }
-        })
+            )),
+            tx => Self::try_from_inner(tx, tx_digest),
+        }
     }
 
     pub fn transaction_count(&self) -> usize {
@@ -1700,25 +1645,10 @@ impl IotaTransactionBlockData {
             },
         }
     }
-}
 
-impl Display for IotaTransactionBlockData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::V1(data) => {
-                writeln!(f, "Sender: {}", data.sender)?;
-                writeln!(f, "{}", self.gas_data())?;
-                writeln!(f, "{}", data.transaction)
-            }
-        }
-    }
-}
-
-impl IotaTransactionBlockData {
-    pub fn try_from(
+    fn try_from_inner(
         data: TransactionData,
-        module_cache: &impl GetModule,
-        tx_digest: TransactionDigest,
+        transaction: IotaTransactionBlockKind,
     ) -> Result<Self, anyhow::Error> {
         let message_version = data.message_version();
         let sender = data.sender();
@@ -1732,8 +1662,7 @@ impl IotaTransactionBlockData {
             price: data.gas_price(),
             budget: data.gas_budget(),
         };
-        let transaction =
-            IotaTransactionBlockKind::try_from(data.into_kind(), module_cache, tx_digest)?;
+
         match message_version {
             1 => Ok(IotaTransactionBlockData::V1(IotaTransactionBlockDataV1 {
                 transaction,
@@ -1747,38 +1676,42 @@ impl IotaTransactionBlockData {
         }
     }
 
+    pub fn try_from_with_module_cache(
+        data: TransactionData,
+        module_cache: &impl GetModule,
+        tx_digest: TransactionDigest,
+    ) -> Result<Self, anyhow::Error> {
+        let transaction = IotaTransactionBlockKind::try_from_with_module_cache(
+            data.kind().clone(),
+            module_cache,
+            tx_digest,
+        )?;
+        Self::try_from_inner(data, transaction)
+    }
+
     pub async fn try_from_with_package_resolver(
         data: TransactionData,
         package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
-        let message_version = data.message_version();
-        let sender = data.sender();
-        let gas_data = IotaGasData {
-            payment: data
-                .gas()
-                .iter()
-                .map(|obj_ref| IotaObjectRef::from(*obj_ref))
-                .collect(),
-            owner: data.gas_owner(),
-            price: data.gas_price(),
-            budget: data.gas_budget(),
-        };
         let transaction = IotaTransactionBlockKind::try_from_with_package_resolver(
-            data.into_kind(),
+            data.kind().clone(),
             package_resolver,
             tx_digest,
         )
         .await?;
-        match message_version {
-            1 => Ok(IotaTransactionBlockData::V1(IotaTransactionBlockDataV1 {
-                transaction,
-                sender,
-                gas_data,
-            })),
-            _ => Err(anyhow::anyhow!(
-                "Support for TransactionData version {message_version} not implemented"
-            )),
+        Self::try_from_inner(data, transaction)
+    }
+}
+
+impl Display for IotaTransactionBlockData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V1(data) => {
+                writeln!(f, "Sender: {}", data.sender)?;
+                writeln!(f, "{}", self.gas_data())?;
+                writeln!(f, "{}", data.transaction)
+            }
         }
     }
 }
@@ -1797,7 +1730,7 @@ impl IotaTransactionBlock {
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
-            data: IotaTransactionBlockData::try_from(
+            data: IotaTransactionBlockData::try_from_with_module_cache(
                 data.intent_message().value.clone(),
                 module_cache,
                 tx_digest,
@@ -2019,7 +1952,7 @@ impl Display for IotaProgrammableTransactionBlock {
 }
 
 impl IotaProgrammableTransactionBlock {
-    fn try_from(
+    fn try_from_with_module_cache(
         value: ProgrammableTransaction,
         module_cache: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -139,7 +139,6 @@ pub use simulator::set_jwk_injector;
 use simulator::*;
 use tap::tap::TapFallible;
 use tokio::{
-    runtime::Handle,
     sync::{Mutex, broadcast, mpsc, watch},
     task::{JoinHandle, JoinSet},
 };
@@ -286,9 +285,8 @@ impl IotaNode {
     pub async fn start(
         config: NodeConfig,
         registry_service: RegistryService,
-        custom_rpc_runtime: Option<Handle>,
     ) -> Result<Arc<IotaNode>> {
-        Self::start_async(config, registry_service, custom_rpc_runtime, "unknown").await
+        Self::start_async(config, registry_service, "unknown").await
     }
 
     /// Starts the JWK (JSON Web Key) updater tasks for the specified node
@@ -433,7 +431,6 @@ impl IotaNode {
     pub async fn start_async(
         config: NodeConfig,
         registry_service: RegistryService,
-        custom_rpc_runtime: Option<Handle>,
         software_version: &'static str,
     ) -> Result<Arc<IotaNode>> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
@@ -841,7 +838,6 @@ impl IotaNode {
             &transaction_orchestrator.clone(),
             &config,
             &prometheus_registry,
-            custom_rpc_runtime,
             software_version,
         )
         .await?;
@@ -2495,7 +2491,6 @@ pub async fn build_http_server(
     transaction_orchestrator: &Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
     config: &NodeConfig,
     prometheus_registry: &Registry,
-    _custom_runtime: Option<Handle>,
     software_version: &'static str,
 ) -> Result<Option<iota_http::ServerHandle>> {
     // Validators do not expose these APIs

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -101,7 +101,7 @@ use iota_network::{
 };
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
 use iota_protocol_config::ProtocolConfig;
-use iota_rest_api::RestMetrics;
+use iota_rest_api::{RestMetrics, ServerVersion};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
 use iota_snapshot::uploader::StateSnapshotUploader;
 use iota_storage::{
@@ -286,7 +286,12 @@ impl IotaNode {
         config: NodeConfig,
         registry_service: RegistryService,
     ) -> Result<Arc<IotaNode>> {
-        Self::start_async(config, registry_service, "unknown").await
+        Self::start_async(
+            config,
+            registry_service,
+            ServerVersion::new("iota-node", "unknown"),
+        )
+        .await
     }
 
     /// Starts the JWK (JSON Web Key) updater tasks for the specified node
@@ -431,7 +436,7 @@ impl IotaNode {
     pub async fn start_async(
         config: NodeConfig,
         registry_service: RegistryService,
-        software_version: &'static str,
+        server_version: ServerVersion,
     ) -> Result<Arc<IotaNode>> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
         let mut config = config.clone();
@@ -484,7 +489,7 @@ impl IotaNode {
                 } else {
                     "fullnode"
                 },
-                software_version,
+                server_version.version,
                 &chain_identifier.to_string(),
             ))
             .expect("Failed registering uptime metric");
@@ -838,7 +843,7 @@ impl IotaNode {
             &transaction_orchestrator.clone(),
             &config,
             &prometheus_registry,
-            software_version,
+            server_version.clone(),
         )
         .await?;
 
@@ -886,6 +891,7 @@ impl IotaNode {
             state_sync_store.clone(),
             executor,
             &registry_service.default_registry(),
+            server_version,
         )
         .await?;
 
@@ -2427,6 +2433,7 @@ async fn build_grpc_server(
     state_sync_store: RocksDbStore,
     executor: Option<Arc<dyn iota_types::transaction_executor::TransactionExecutor>>,
     prometheus_registry: &Registry,
+    server_version: ServerVersion,
 ) -> Result<Option<GrpcServerHandle>> {
     // Validators do not expose gRPC APIs
     if config.consensus_config().is_some() || !config.enable_grpc_api {
@@ -2448,7 +2455,7 @@ async fn build_grpc_server(
     // Create GrpcReader
     let grpc_reader = Arc::new(GrpcReader::from_rest_state_reader(
         rest_read_store,
-        Some(env!("CARGO_PKG_VERSION").to_string()),
+        Some(server_version.to_string()),
     ));
 
     // Create gRPC server metrics
@@ -2491,7 +2498,7 @@ pub async fn build_http_server(
     transaction_orchestrator: &Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
     config: &NodeConfig,
     prometheus_registry: &Registry,
-    software_version: &'static str,
+    server_version: ServerVersion,
 ) -> Result<Option<iota_http::ServerHandle>> {
     // Validators do not expose these APIs
     if config.consensus_config().is_some() {
@@ -2560,10 +2567,9 @@ pub async fn build_http_server(
     router = router.merge(json_rpc_router);
 
     if config.enable_rest_api {
-        let mut rest_service = iota_rest_api::RestService::new(
-            Arc::new(RestReadStore::new(state.clone(), store)),
-            software_version,
-        );
+        let mut rest_service =
+            iota_rest_api::RestService::new(Arc::new(RestReadStore::new(state.clone(), store)));
+        rest_service.with_server_version(server_version);
 
         if let Some(config) = config.rest.clone() {
             rest_service.with_config(config);

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -225,9 +225,11 @@ mod simulator {
 pub struct IotaNode {
     config: NodeConfig,
     validator_components: Mutex<Option<ValidatorComponents>>,
-    /// The http server responsible for serving JSON-RPC as well as the
-    /// experimental rest service
-    _http_server: Option<iota_http::ServerHandle>,
+
+    /// The http servers responsible for serving RPC traffic (gRPC and JSON-RPC)
+    #[allow(unused)]
+    http_servers: HttpServers,
+
     state: Arc<AuthorityState>,
     transaction_orchestrator: Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
     registry_service: RegistryService,
@@ -837,7 +839,7 @@ impl IotaNode {
             None
         };
 
-        let http_server = build_http_server(
+        let http_servers = build_http_servers(
             state.clone(),
             state_sync_store.clone(),
             &transaction_orchestrator.clone(),
@@ -931,7 +933,7 @@ impl IotaNode {
         let node = Self {
             config,
             validator_components: Mutex::new(validator_components),
-            _http_server: http_server,
+            http_servers,
             state,
             transaction_orchestrator,
             registry_service,
@@ -2476,8 +2478,8 @@ async fn build_grpc_server(
     Ok(Some(handle))
 }
 
-/// Builds and starts the HTTP server for the IOTA node, exposing JSON-RPC and
-/// REST APIs based on the node's configuration.
+/// Builds and starts the HTTP server(s) for the IOTA node, exposing JSON-RPC
+/// and REST APIs based on the node's configuration.
 ///
 /// This function performs the following tasks:
 /// 1. Checks if the node is a validator by inspecting the consensus
@@ -2491,18 +2493,19 @@ async fn build_grpc_server(
 /// 4. Optionally, if the REST API is enabled, nests the REST API router under
 ///    the `/api/v1` path.
 /// 5. Binds the server to the specified JSON-RPC address and starts listening
-///    for incoming connections.
-pub async fn build_http_server(
+///    for incoming connections. If TLS is configured, also starts an HTTPS
+///    server.
+async fn build_http_servers(
     state: Arc<AuthorityState>,
     store: RocksDbStore,
     transaction_orchestrator: &Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
     config: &NodeConfig,
     prometheus_registry: &Registry,
     server_version: ServerVersion,
-) -> Result<Option<iota_http::ServerHandle>> {
+) -> Result<HttpServers> {
     // Validators do not expose these APIs
     if config.consensus_config().is_some() {
-        return Ok(None);
+        return Ok(HttpServers::default());
     }
 
     let mut router = axum::Router::new();
@@ -2602,12 +2605,41 @@ pub async fn build_http_server(
 
     router = router.layer(layers);
 
-    let handle = iota_http::Builder::new()
-        .serve(&config.json_rpc_address, router)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    info!(local_addr =? handle.local_addr(), "IOTA JSON-RPC server listening on {}", handle.local_addr());
+    let https = if let Some(tls_config) = config.json_rpc_tls.as_ref() {
+        let https_address = config
+            .json_rpc_https_address
+            .unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 9443)));
 
-    Ok(Some(handle))
+        let https = iota_http::Builder::new()
+            .tls_single_cert(tls_config.cert(), tls_config.key())
+            .and_then(|builder| builder.serve(https_address, router.clone()))
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+        info!(
+            https_address =? https.local_addr(),
+            "HTTPS rpc server listening on {}",
+            https.local_addr()
+        );
+
+        Some(https)
+    } else {
+        None
+    };
+
+    let http = iota_http::Builder::new()
+        .serve(&config.json_rpc_address, router)
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    info!(
+        http_address =? http.local_addr(),
+        "HTTP rpc server listening on {}",
+        http.local_addr()
+    );
+
+    Ok(HttpServers {
+        http: Some(http),
+        https,
+    })
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -2663,4 +2695,12 @@ fn max_tx_per_checkpoint(protocol_config: &ProtocolConfig) -> usize {
 #[cfg(test)]
 fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
     2
+}
+
+#[derive(Default)]
+struct HttpServers {
+    #[allow(unused)]
+    http: Option<iota_http::ServerHandle>,
+    #[allow(unused)]
+    https: Option<iota_http::ServerHandle>,
 }

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -112,13 +112,12 @@ fn main() {
     // work if it deadlocks.
     let node_once_cell = Arc::new(AsyncOnceCell::<Arc<IotaNode>>::new());
     let node_once_cell_clone = node_once_cell.clone();
-    let rpc_runtime = runtimes.json_rpc.handle().clone();
 
     // let iota-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
     runtimes.iota_node.spawn(async move {
-        match IotaNode::start_async(config, registry_service, Some(rpc_runtime), VERSION).await {
+        match IotaNode::start_async(config, registry_service, VERSION).await {
             Ok(iota_node) => node_once_cell_clone
                 .set(iota_node)
                 .expect("Failed to set node in AsyncOnceCell"),

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -9,6 +9,7 @@ use iota_common::sync::async_once_cell::AsyncOnceCell;
 use iota_config::{Config, NodeConfig, node::RunWithRange};
 use iota_core::runtime::IotaRuntimes;
 use iota_node::{IotaNode, metrics};
+use iota_rest_api::ServerVersion;
 use iota_types::{
     committee::EpochId, messages_checkpoint::CheckpointSequenceNumber, multiaddr::Multiaddr,
     supported_protocol_versions::SupportedProtocolVersions,
@@ -116,8 +117,9 @@ fn main() {
     // let iota-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
+    let server_version = ServerVersion::new(env!("CARGO_BIN_NAME"), VERSION);
     runtimes.iota_node.spawn(async move {
-        match IotaNode::start_async(config, registry_service, VERSION).await {
+        match IotaNode::start_async(config, registry_service, server_version).await {
             Ok(iota_node) => node_once_cell_clone
                 .set(iota_node)
                 .expect("Failed to set node in AsyncOnceCell"),

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -762,7 +762,7 @@ impl RpcExampleProvider {
             balance_changes: None,
             timestamp_ms: None,
             transaction: Some(IotaTransactionBlock {
-                data: IotaTransactionBlockData::try_from(
+                data: IotaTransactionBlockData::try_from_with_module_cache(
                     data1,
                     &&mut NoOpsModuleResolver,
                     *tx_digest,

--- a/crates/iota-rest-api/src/info.rs
+++ b/crates/iota-rest-api/src/info.rs
@@ -72,7 +72,11 @@ async fn get_node_info(State(state): State<RestService>) -> Result<Json<NodeInfo
         epoch: latest_checkpoint.epoch(),
         chain_id: Digest::new(state.chain_id().as_bytes().to_owned()),
         chain: state.chain_id().chain().as_str().into(),
-        software_version: state.software_version().into(),
+        software_version: state
+            .server_version()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+            .into(),
     }
     .pipe(Json)
     .pipe(Ok)

--- a/crates/iota-rest-api/src/lib.rs
+++ b/crates/iota-rest-api/src/lib.rs
@@ -37,6 +37,26 @@ pub use iota_types::full_checkpoint_content::{CheckpointData, CheckpointTransact
 pub use metrics::RestMetrics;
 pub use transactions::ExecuteTransactionQueryParameters;
 
+#[derive(Clone)]
+pub struct ServerVersion {
+    pub bin: &'static str,
+    pub version: &'static str,
+}
+
+impl ServerVersion {
+    pub fn new(bin: &'static str, version: &'static str) -> Self {
+        Self { bin, version }
+    }
+}
+
+impl std::fmt::Display for ServerVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.bin)?;
+        f.write_str("/")?;
+        f.write_str(self.version)
+    }
+}
+
 pub const TEXT_PLAIN_UTF_8: &str = "text/plain; charset=utf-8";
 pub const APPLICATION_BCS: &str = "application/bcs";
 pub const APPLICATION_JSON: &str = "application/json";
@@ -106,7 +126,7 @@ pub struct RestService {
     reader: StateReader,
     executor: Option<Arc<dyn TransactionExecutor>>,
     chain_id: iota_types::digests::ChainIdentifier,
-    software_version: &'static str,
+    server_version: Option<ServerVersion>,
     metrics: Option<Arc<RestMetrics>>,
     config: Config,
 }
@@ -124,20 +144,21 @@ impl axum::extract::FromRef<RestService> for Option<Arc<dyn TransactionExecutor>
 }
 
 impl RestService {
-    pub fn new(reader: Arc<dyn RestStateReader>, software_version: &'static str) -> Self {
+    pub fn new(reader: Arc<dyn RestStateReader>) -> Self {
         let chain_id = reader.get_chain_identifier().unwrap();
         Self {
             reader: StateReader::new(reader),
             executor: None,
             chain_id,
-            software_version,
+            server_version: None,
             metrics: None,
             config: Config::default(),
         }
     }
 
-    pub fn new_without_version(reader: Arc<dyn RestStateReader>) -> Self {
-        Self::new(reader, "unknown")
+    pub fn with_server_version(&mut self, server_version: ServerVersion) -> &mut Self {
+        self.server_version = Some(server_version);
+        self
     }
 
     pub fn with_config(&mut self, config: Config) {
@@ -156,14 +177,18 @@ impl RestService {
         self.chain_id
     }
 
-    pub fn software_version(&self) -> &'static str {
-        self.software_version
+    pub fn server_version(&self) -> Option<&ServerVersion> {
+        self.server_version.as_ref()
     }
 
     pub fn into_router(self) -> Router {
         let metrics = self.metrics.clone();
 
-        let mut api = openapi::Api::new(info(self.software_version()));
+        let version = self
+            .server_version()
+            .map(|v| v.version)
+            .unwrap_or("unknown");
+        let mut api = openapi::Api::new(info(version));
 
         api.register_endpoints(
             ENDPOINTS

--- a/crates/iota-rest-api/src/response.rs
+++ b/crates/iota-rest-api/src/response.rs
@@ -168,5 +168,12 @@ pub async fn append_info_headers(
         );
     }
 
+    if let Some(server_version) = state
+        .server_version()
+        .and_then(|version| version.to_string().try_into().ok())
+    {
+        headers.insert(axum::http::header::SERVER, server_version);
+    }
+
     (headers, response)
 }

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -261,6 +261,8 @@ impl ValidatorConfigBuilder {
             iota_names_config: None,
             enable_grpc_api: false,
             grpc_api_config: None,
+            json_rpc_https_address: None,
+            json_rpc_tls: None,
             chain_override_for_testing: self.chain_override,
         }
     }
@@ -620,6 +622,8 @@ impl FullnodeConfigBuilder {
             iota_names_config: self.iota_names_config,
             enable_grpc_api: self.enable_grpc_api,
             grpc_api_config,
+            json_rpc_https_address: None,
+            json_rpc_tls: None,
             chain_override_for_testing: self.chain_override,
         }
     }

--- a/crates/iota-swarm/src/memory/container-sim.rs
+++ b/crates/iota-swarm/src/memory/container-sim.rs
@@ -67,9 +67,7 @@ impl Container {
                 let startup_sender = startup_sender.clone();
                 async move {
                     let registry_service = iota_metrics::RegistryService::new(Registry::new());
-                    let server = IotaNode::start(config, registry_service, None)
-                        .await
-                        .unwrap();
+                    let server = IotaNode::start(config, registry_service).await.unwrap();
 
                     startup_sender.send(Arc::downgrade(&server)).ok();
 

--- a/crates/iota-swarm/src/memory/container.rs
+++ b/crates/iota-swarm/src/memory/container.rs
@@ -106,7 +106,7 @@ impl Container {
                     "Started Prometheus HTTP endpoint. To query metrics use\n\tcurl -s http://{}/metrics",
                     config.metrics_address
                 );
-                let server = IotaNode::start(config, registry_service, None).await.unwrap();
+                let server = IotaNode::start(config, registry_service).await.unwrap();
                 // Notify that we've successfully started the node
                 let _ = startup_sender.send(Arc::downgrade(&server));
                 // run until canceled

--- a/crates/iota-tls/src/lib.rs
+++ b/crates/iota-tls/src/lib.rs
@@ -21,6 +21,23 @@ pub use verifier::{
 
 pub const IOTA_VALIDATOR_SERVER_NAME: &str = "iota";
 
+/// Create a TLS server config by loading PEM formatted certificate chain and
+/// private key files from the filesystem. No client authentication is required.
+pub fn create_rustls_server_config_from_pem(
+    cert_file: impl AsRef<std::path::Path>,
+    private_key_file: impl AsRef<std::path::Path>,
+) -> Result<ServerConfig, Box<dyn std::error::Error + Send + Sync>> {
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+
+    let certs = CertificateDer::pem_file_iter(cert_file)?.collect::<Result<_, _>>()?;
+    let private_key = PrivateKeyDer::from_pem_file(private_key_file)?;
+    let tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, private_key)?;
+
+    Ok(tls_config)
+}
+
 pub fn create_rustls_server_config(
     private_key: Ed25519PrivateKey,
     server_name: String,

--- a/crates/iota-tool/src/db_tool/db_dump.rs
+++ b/crates/iota-tool/src/db_tool/db_dump.rs
@@ -111,22 +111,20 @@ pub fn print_table_metadata(
                 let epoch = epoch.ok_or_else(|| anyhow!("--epoch is required"))?;
                 AuthorityEpochTables::open_readonly(epoch, &db_path)
                     .next_shared_object_versions
-                    .rocksdb
+                    .db
             } else {
-                AuthorityPerpetualTables::open_readonly(&db_path)
-                    .objects
-                    .rocksdb
+                AuthorityPerpetualTables::open_readonly(&db_path).objects.db
             }
         }
         StoreName::Index => {
             IndexStoreTables::get_read_only_handle(db_path, None, None, MetricConf::default())
                 .event_by_move_module
-                .rocksdb
+                .db
         }
         StoreName::Epoch => {
             CommitteeStoreTables::get_read_only_handle(db_path, None, None, MetricConf::default())
                 .committee_map
-                .rocksdb
+                .db
         }
     };
 

--- a/crates/iota-types/src/effects/test_effects_builder.rs
+++ b/crates/iota-types/src/effects/test_effects_builder.rs
@@ -32,6 +32,8 @@ pub struct TestEffectsBuilder {
     wrapped_objects: Vec<(ObjectID, SequenceNumber)>,
     /// Objects that are unwrapped: (ID, new owner).
     unwrapped_objects: Vec<(ObjectID, Owner)>,
+    /// Immutable objects that are read.
+    frozen_objects: BTreeSet<ObjectID>,
 }
 
 impl TestEffectsBuilder {
@@ -46,6 +48,7 @@ impl TestEffectsBuilder {
             deleted_objects: vec![],
             wrapped_objects: vec![],
             unwrapped_objects: vec![],
+            frozen_objects: BTreeSet::new(),
         }
     }
 
@@ -109,6 +112,11 @@ impl TestEffectsBuilder {
         self
     }
 
+    pub fn with_frozen_objects(mut self, objects: impl IntoIterator<Item = ObjectID>) -> Self {
+        self.frozen_objects.extend(objects);
+        self
+    }
+
     pub fn build(self) -> TransactionEffects {
         let lamport_version = self.get_lamport_version();
         let status = self.status.unwrap_or(ExecutionStatus::Success);
@@ -128,6 +136,11 @@ impl TestEffectsBuilder {
             .unwrap()
             .iter()
             .filter_map(|kind| match kind {
+                InputObjectKind::ImmOrOwnedMoveObject((id, _, _))
+                    if self.frozen_objects.contains(id) =>
+                {
+                    None
+                }
                 InputObjectKind::ImmOrOwnedMoveObject(oref) => {
                     Some((
                         oref.0,

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -2,13 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
 use crate::{
-    base_types::{ObjectID, ObjectRef},
+    base_types::ObjectRef,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     iota_system_state::{IotaSystemStateTrait, get_iota_system_state},
     messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents},
@@ -53,28 +53,6 @@ impl CheckpointData {
             }
         }
         eventually_removed_object_refs.into_values().collect()
-    }
-
-    /// Returns all objects that are used as input to the transactions in the
-    /// checkpoint, and already exist prior to the checkpoint.
-    pub fn checkpoint_input_objects(&self) -> BTreeMap<ObjectID, &Object> {
-        let mut output_objects_seen = HashSet::new();
-        let mut checkpoint_input_objects = BTreeMap::new();
-        for tx in self.transactions.iter() {
-            for obj in tx.input_objects.iter() {
-                let id = obj.id();
-                if output_objects_seen.contains(&id) || checkpoint_input_objects.contains_key(&id) {
-                    continue;
-                }
-                checkpoint_input_objects.insert(id, obj);
-            }
-            for obj in tx.output_objects.iter() {
-                // We want to track input objects that are not output objects
-                // in the previous transactions.
-                output_objects_seen.insert(obj.id());
-            }
-        }
-        checkpoint_input_objects
     }
 
     pub fn all_objects(&self) -> Vec<&Object> {

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -143,7 +143,6 @@ built_in_ids! {
 
 pub const IOTA_SYSTEM_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 pub const IOTA_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
-pub const IOTA_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 
 const fn builtin_address(suffix: u16) -> AccountAddress {
     let mut addr = [0u8; AccountAddress::LENGTH];

--- a/crates/iota-types/src/signature_verification.rs
+++ b/crates/iota-types/src/signature_verification.rs
@@ -18,12 +18,12 @@ use crate::{
     transaction::{SenderSignedData, TransactionDataAPI},
 };
 
-// Cache up to 20000 verified certs. We will need to tune this number in the
+// Cache up to this many verified certs. We will need to tune this number in the
 // future - a decent guess to start with is that it should be 10-20 times larger
 // than peak transactions per second, on the assumption that we should see most
 // certs twice within about 10-20 seconds at most: Once via RPC, once via
 // consensus.
-const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 20000;
+const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 100_000;
 
 pub struct VerifiedDigestCache<D> {
     inner: RwLock<LruCache<D, ()>>,

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -506,7 +506,12 @@ impl TestCheckpointDataBuilder {
         let lamport_version = effects.lamport_version();
         let input_objects: Vec<_> = mutated_objects
             .keys()
-            .chain(shared_inputs.keys())
+            .chain(
+                shared_inputs
+                    .iter()
+                    .filter(|(_, i)| i.mutable)
+                    .map(|(id, _)| id),
+            )
             .map(|id| self.live_objects.get(id).unwrap().clone())
             .chain(deleted_objects.clone())
             .chain(wrapped_objects.clone())
@@ -518,7 +523,12 @@ impl TestCheckpointDataBuilder {
             .values()
             .cloned()
             .chain(mutated_objects.values().cloned())
-            .chain(shared_inputs.values().map(|input| input.object.clone()))
+            .chain(
+                shared_inputs
+                    .values()
+                    .filter(|i| i.mutable)
+                    .map(|i| i.object.clone()),
+            )
             .chain(unwrapped_objects.clone())
             .chain(std::iter::once(
                 self.live_objects.get(&gas.0).cloned().unwrap(),

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -30,7 +30,8 @@ use crate::{
     object::{GAS_VALUE_FOR_TESTING, MoveObject, Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
-        EndOfEpochTransactionKind, SenderSignedData, Transaction, TransactionData, TransactionKind,
+        EndOfEpochTransactionKind, ObjectArg, SenderSignedData, Transaction, TransactionData,
+        TransactionKind,
     },
 };
 
@@ -85,7 +86,14 @@ struct TransactionBuilder {
     unwrapped_objects: BTreeSet<ObjectID>,
     wrapped_objects: BTreeSet<ObjectID>,
     deleted_objects: BTreeSet<ObjectID>,
+    frozen_objects: BTreeSet<ObjectRef>,
+    shared_inputs: BTreeMap<ObjectID, Shared>,
     events: Option<Vec<Event>>,
+}
+
+struct Shared {
+    mutable: bool,
+    object: Object,
 }
 
 impl TransactionBuilder {
@@ -99,6 +107,8 @@ impl TransactionBuilder {
             unwrapped_objects: BTreeSet::new(),
             wrapped_objects: BTreeSet::new(),
             deleted_objects: BTreeSet::new(),
+            frozen_objects: BTreeSet::new(),
+            shared_inputs: BTreeMap::new(),
             events: None,
         }
     }
@@ -234,9 +244,9 @@ impl TestCheckpointDataBuilder {
         self
     }
 
-    /// Mutate an existing object in the transaction.
+    /// Mutate an existing owned object in the transaction.
     /// `object_idx` is a convenient representation of the object's ID.
-    pub fn mutate_object(mut self, object_idx: u64) -> Self {
+    pub fn mutate_owned_object(mut self, object_idx: u64) -> Self {
         let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
         let object_id = Self::derive_object_id(object_idx);
         let object = self
@@ -246,6 +256,11 @@ impl TestCheckpointDataBuilder {
             .expect("Mutating an object that doesn't exist");
         tx_builder.mutated_objects.insert(object_id, object);
         self
+    }
+
+    /// Mutate an existing shared object in the transaction.
+    pub fn mutate_shared_object(self, object_idx: u64) -> Self {
+        self.access_shared_object(object_idx, true)
     }
 
     /// Transfer an existing object to a new owner.
@@ -332,6 +347,31 @@ impl TestCheckpointDataBuilder {
         self
     }
 
+    /// Add an immutable object as an input to the transaction.
+    ///
+    /// Fails if the object is not live or if its owner is not
+    /// [Owner::Immutable]).
+    pub fn read_frozen_object(mut self, object_id: u64) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_id);
+
+        let obj = self
+            .live_objects
+            .get(&object_id)
+            .expect("Frozen object not found");
+
+        assert!(obj.owner().is_immutable());
+        tx_builder
+            .frozen_objects
+            .insert(obj.compute_object_reference());
+        self
+    }
+
+    /// Add a read to a shared object to the transaction's effects.
+    pub fn read_shared_object(self, object_idx: u64) -> Self {
+        self.access_shared_object(object_idx, false)
+    }
+
     /// Add events to the transaction.
     /// `events` is a vector of events to be added to the transaction.
     pub fn with_events(mut self, events: Vec<Event>) -> Self {
@@ -371,11 +411,15 @@ impl TestCheckpointDataBuilder {
             unwrapped_objects,
             wrapped_objects,
             deleted_objects,
+            frozen_objects,
+            shared_inputs,
             events,
         } = self.checkpoint_builder.next_transaction.take().unwrap();
+
         let sender = Self::derive_address(sender_idx);
         let events = events.map(|events| TransactionEvents { data: events });
         let events_digest = events.as_ref().map(|events| events.digest());
+
         let mut pt_builder = ProgrammableTransactionBuilder::new();
         for (package, module, function) in move_calls {
             pt_builder
@@ -388,6 +432,30 @@ impl TestCheckpointDataBuilder {
                 )
                 .unwrap();
         }
+
+        for &object_ref in &frozen_objects {
+            pt_builder
+                .obj(ObjectArg::ImmOrOwnedObject(object_ref))
+                .expect("Failed to add frozen object input");
+        }
+
+        for (id, input) in &shared_inputs {
+            let &Owner::Shared {
+                initial_shared_version,
+            } = input.object.owner()
+            else {
+                panic!("Accessing a non-shared object as shared");
+            };
+
+            pt_builder
+                .obj(ObjectArg::SharedObject {
+                    id: *id,
+                    initial_shared_version,
+                    mutable: input.mutable,
+                })
+                .expect("Failed to add shared object input");
+        }
+
         let pt = pt_builder.finish();
         let tx_data = TransactionData::new(
             TransactionKind::ProgrammableTransaction(pt),
@@ -396,7 +464,9 @@ impl TestCheckpointDataBuilder {
             1,
             1,
         );
+
         let tx = Transaction::new(SenderSignedData::new(tx_data, vec![]));
+
         let wrapped_objects: Vec<_> = wrapped_objects
             .into_iter()
             .map(|id| self.live_objects.remove(&id).unwrap())
@@ -409,6 +479,7 @@ impl TestCheckpointDataBuilder {
             .into_iter()
             .map(|id| self.wrapped_objects.remove(&id).unwrap())
             .collect();
+
         let mut effects_builder = TestEffectsBuilder::new(tx.data())
             .with_created_objects(created_objects.iter().map(|(id, o)| (*id, *o.owner())))
             .with_mutated_objects(
@@ -418,14 +489,24 @@ impl TestCheckpointDataBuilder {
             )
             .with_wrapped_objects(wrapped_objects.iter().map(|o| (o.id(), o.version())))
             .with_unwrapped_objects(unwrapped_objects.iter().map(|o| (o.id(), *o.owner())))
-            .with_deleted_objects(deleted_objects.iter().map(|o| (o.id(), o.version())));
+            .with_deleted_objects(deleted_objects.iter().map(|o| (o.id(), o.version())))
+            .with_frozen_objects(frozen_objects.into_iter().map(|(id, _, _)| id))
+            .with_shared_input_versions(
+                shared_inputs
+                    .iter()
+                    .map(|(id, input)| (*id, input.object.version()))
+                    .collect(),
+            );
+
         if let Some(events_digest) = &events_digest {
             effects_builder = effects_builder.with_events_digest(*events_digest);
         }
+
         let effects = effects_builder.build();
         let lamport_version = effects.lamport_version();
         let input_objects: Vec<_> = mutated_objects
             .keys()
+            .chain(shared_inputs.keys())
             .map(|id| self.live_objects.get(id).unwrap().clone())
             .chain(deleted_objects.clone())
             .chain(wrapped_objects.clone())
@@ -437,6 +518,7 @@ impl TestCheckpointDataBuilder {
             .values()
             .cloned()
             .chain(mutated_objects.values().cloned())
+            .chain(shared_inputs.values().map(|input| input.object.clone()))
             .chain(unwrapped_objects.clone())
             .chain(std::iter::once(
                 self.live_objects.get(&gas.0).cloned().unwrap(),
@@ -453,6 +535,7 @@ impl TestCheckpointDataBuilder {
             .extend(output_objects.iter().map(|o| (o.id(), o.clone())));
         self.wrapped_objects
             .extend(wrapped_objects.iter().map(|o| (o.id(), o.clone())));
+
         self.checkpoint_builder
             .transactions
             .push(CheckpointTransaction {
@@ -605,6 +688,22 @@ impl TestCheckpointDataBuilder {
     pub fn derive_address(address_idx: u8) -> IotaAddress {
         dbg_addr(address_idx)
     }
+
+    /// Add a shared input to the transaction, being accessed from the currently
+    /// recorded live version.
+    fn access_shared_object(mut self, object_idx: u64, mutable: bool) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        let object = self
+            .live_objects
+            .get(&object_id)
+            .cloned()
+            .expect("Accessing a shared object that doesn't exist");
+        tx_builder
+            .shared_inputs
+            .insert(object_id, Shared { mutable, object });
+        self
+    }
 }
 
 #[cfg(test)]
@@ -705,7 +804,7 @@ mod tests {
             .create_owned_object(0)
             .finish_transaction()
             .start_transaction(0)
-            .mutate_object(0)
+            .mutate_owned_object(0)
             .finish_transaction()
             .build_checkpoint();
 
@@ -975,7 +1074,7 @@ mod tests {
         let checkpoint1 = builder.build_checkpoint();
         builder = builder
             .start_transaction(0)
-            .mutate_object(0)
+            .mutate_owned_object(0)
             .finish_transaction();
         let checkpoint2 = builder.build_checkpoint();
         builder = builder

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -31,9 +31,8 @@ use tracing::{instrument, trace};
 
 use super::{base_types::*, error::*};
 use crate::{
-    IOTA_AUTHENTICATOR_STATE_OBJECT_ID, IOTA_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION,
-    IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION, IOTA_FRAMEWORK_PACKAGE_ID,
-    IOTA_RANDOMNESS_STATE_OBJECT_ID, IOTA_SYSTEM_STATE_OBJECT_ID,
+    IOTA_AUTHENTICATOR_STATE_OBJECT_ID, IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION,
+    IOTA_FRAMEWORK_PACKAGE_ID, IOTA_RANDOMNESS_STATE_OBJECT_ID, IOTA_SYSTEM_STATE_OBJECT_ID,
     IOTA_SYSTEM_STATE_OBJECT_SHARED_VERSION,
     authenticator_state::ActiveJwk,
     committee::{Committee, EpochId, ProtocolVersion},
@@ -98,11 +97,6 @@ impl CallArg {
     pub const CLOCK_MUT: Self = Self::Object(ObjectArg::SharedObject {
         id: IOTA_CLOCK_OBJECT_ID,
         initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,
-        mutable: true,
-    });
-    pub const AUTHENTICATOR_MUT: Self = Self::Object(ObjectArg::SharedObject {
-        id: IOTA_AUTHENTICATOR_STATE_OBJECT_ID,
-        initial_shared_version: IOTA_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION,
         mutable: true,
     });
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -14,7 +14,7 @@ use iota_macros::fail_point;
 use prometheus::{Histogram, HistogramTimer};
 use rocksdb::{
     DBPinnableSlice, DBWithThreadMode, Error, LiveFile, MultiThreaded, ReadOptions, WriteBatch,
-    WriteOptions, checkpoint::Checkpoint,
+    checkpoint::Checkpoint,
 };
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::oneshot;
@@ -251,13 +251,12 @@ impl Database {
         &self,
         cf: &ColumnFamily,
         key: K,
-        writeopts: &WriteOptions,
     ) -> Result<(), TypedStoreError> {
         fail_point!("delete-cf-before");
         let ret = match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
                 .underlying
-                .delete_cf_opt(&cf.rocks_cf(db), key, writeopts)
+                .delete_cf(&cf.rocks_cf(db), key)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
                 db.delete(cf_name, key.as_ref());
@@ -284,13 +283,12 @@ impl Database {
         cf: &ColumnFamily,
         key: Vec<u8>,
         value: Vec<u8>,
-        writeopts: &WriteOptions,
     ) -> Result<(), TypedStoreError> {
         fail_point!("put-cf-before");
         let ret = match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
                 .underlying
-                .put_cf_opt(&cf.rocks_cf(db), key, value, writeopts)
+                .put_cf(&cf.rocks_cf(db), key, value)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
                 db.put(cf_name, key, value);
@@ -323,16 +321,12 @@ impl Database {
         }
     }
 
-    pub fn write(
-        &self,
-        batch: StorageWriteBatch,
-        writeopts: &WriteOptions,
-    ) -> Result<(), TypedStoreError> {
+    pub fn write(&self, batch: StorageWriteBatch) -> Result<(), TypedStoreError> {
         fail_point!("batch-write-before");
         let ret = match (&self.storage, batch) {
             (Storage::Rocks(rocks), StorageWriteBatch::Rocks(batch)) => rocks
                 .underlying
-                .write_opt(batch, writeopts)
+                .write(batch)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), StorageWriteBatch::InMemory(batch)) => {
                 db.write(batch);
@@ -597,7 +591,6 @@ impl<K, V> DBMap<K, V> {
         DBBatch::new(
             &self.db,
             batch,
-            self.opts.writeopts(),
             &self.db_metrics,
             &self.write_sample_interval,
         )
@@ -925,7 +918,6 @@ impl<K, V> DBMap<K, V> {
 pub struct DBBatch {
     database: Arc<Database>,
     batch: StorageWriteBatch,
-    opts: WriteOptions,
     db_metrics: Arc<DBMetrics>,
     write_sample_interval: SamplingInterval,
 }
@@ -937,14 +929,12 @@ impl DBBatch {
     pub fn new(
         dbref: &Arc<Database>,
         batch: StorageWriteBatch,
-        opts: WriteOptions,
         db_metrics: &Arc<DBMetrics>,
         write_sample_interval: &SamplingInterval,
     ) -> Self {
         DBBatch {
             database: dbref.clone(),
             batch,
-            opts,
             db_metrics: db_metrics.clone(),
             write_sample_interval: write_sample_interval.clone(),
         }
@@ -967,7 +957,7 @@ impl DBBatch {
         } else {
             None
         };
-        self.database.write(self.batch, &self.opts)?;
+        self.database.write(self.batch)?;
         self.db_metrics
             .op_metrics
             .rocksdb_batch_commit_bytes
@@ -1195,12 +1185,7 @@ where
                 .write_perf_ctx_metrics
                 .report_metrics(self.cf_name());
         }
-        self.db.put_cf(
-            &self.column_family,
-            key_buf,
-            value_buf,
-            &self.opts.writeopts(),
-        )?;
+        self.db.put_cf(&self.column_family, key_buf, value_buf)?;
 
         let elapsed = timer.stop_and_record();
         if elapsed > 1.0 {
@@ -1234,8 +1219,7 @@ where
             None
         };
         let key_buf = be_fix_int_ser(key)?;
-        self.db
-            .delete_cf(&self.column_family, key_buf, &self.opts.writeopts())?;
+        self.db.delete_cf(&self.column_family, key_buf)?;
         self.db_metrics
             .op_metrics
             .rocksdb_deletes
@@ -1399,8 +1383,6 @@ where
 #[derive(Clone, Debug)]
 pub struct ReadWriteOptions {
     pub ignore_range_deletions: bool,
-    // Whether to sync to disk on every write.
-    sync_to_disk: bool,
 }
 
 impl ReadWriteOptions {
@@ -1408,12 +1390,6 @@ impl ReadWriteOptions {
         let mut readopts = ReadOptions::default();
         readopts.set_ignore_range_deletions(self.ignore_range_deletions);
         readopts
-    }
-
-    pub fn writeopts(&self) -> WriteOptions {
-        let mut opts = WriteOptions::default();
-        opts.set_sync(self.sync_to_disk);
-        opts
     }
 
     pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
@@ -1426,7 +1402,6 @@ impl Default for ReadWriteOptions {
     fn default() -> Self {
         Self {
             ignore_range_deletions: true,
-            sync_to_disk: std::env::var("IOTA_DB_SYNC_TO_DISK").is_ok_and(|v| v != "0"),
         }
     }
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -1,0 +1,1482 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+    ops::{Bound, Deref, RangeBounds},
+    path::Path,
+    sync::Arc,
+    time::Duration,
+};
+
+use iota_macros::fail_point;
+use prometheus::{Histogram, HistogramTimer};
+use rocksdb::{
+    DBPinnableSlice, DBWithThreadMode, Error, LiveFile, MultiThreaded, ReadOptions, WriteBatch,
+    WriteOptions, checkpoint::Checkpoint,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::oneshot;
+use tracing::{debug, error, instrument, warn};
+use typed_store_error::TypedStoreError;
+
+use crate::{
+    memstore::{InMemoryBatch, InMemoryDB},
+    metrics::{DBMetrics, RocksDBPerfContext, SamplingInterval},
+    rocks::{
+        RocksDB, be_fix_int_ser,
+        errors::{typed_store_err_from_bcs_err, typed_store_err_from_rocks_err},
+        rocks_cf,
+        safe_iter::{SafeIter, SafeRevIter},
+    },
+    traits::{Map, TableSummary},
+};
+
+#[derive(Clone)]
+pub(crate) enum ColumnFamily {
+    Rocks(String),
+    #[allow(dead_code)]
+    InMemory(String),
+}
+
+impl std::fmt::Debug for ColumnFamily {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ColumnFamily::Rocks(name) => write!(f, "RocksDB cf: {}", name),
+            ColumnFamily::InMemory(name) => write!(f, "InMemory cf: {}", name),
+        }
+    }
+}
+
+impl ColumnFamily {
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            ColumnFamily::Rocks(name) => name,
+            ColumnFamily::InMemory(name) => name,
+        }
+    }
+
+    pub(crate) fn rocks_cf<'a>(
+        &self,
+        rocks_db: &'a RocksDB,
+    ) -> Arc<rocksdb::BoundColumnFamily<'a>> {
+        match &self {
+            ColumnFamily::Rocks(name) => rocks_db
+                .underlying
+                .cf_handle(name)
+                .expect("Map-keying column family should have been checked at DB creation"),
+            _ => unreachable!("invariant is checked by the caller"),
+        }
+    }
+}
+
+pub(crate) enum Storage {
+    Rocks(RocksDB),
+    #[allow(dead_code)]
+    InMemory(InMemoryDB),
+}
+
+impl std::fmt::Debug for Storage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Storage::Rocks(db) => write!(f, "RocksDB Storage {:?}", db),
+            Storage::InMemory(db) => write!(f, "InMemoryDB Storage {:?}", db),
+        }
+    }
+}
+
+pub(crate) enum GetResult<'a> {
+    Rocks(DBPinnableSlice<'a>),
+    InMemory(Vec<u8>),
+}
+
+impl Deref for GetResult<'_> {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        match self {
+            GetResult::Rocks(d) => d.deref(),
+            GetResult::InMemory(d) => d.deref(),
+        }
+    }
+}
+
+pub enum StorageWriteBatch {
+    Rocks(rocksdb::WriteBatch),
+    InMemory(InMemoryBatch),
+}
+
+pub type RawIter<'a> = rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
+
+#[derive(Debug, Default)]
+pub struct MetricConf {
+    pub db_name: String,
+    pub read_sample_interval: SamplingInterval,
+    pub write_sample_interval: SamplingInterval,
+    pub iter_sample_interval: SamplingInterval,
+}
+
+impl MetricConf {
+    pub fn new(db_name: &str) -> Self {
+        if db_name.is_empty() {
+            error!("A meaningful db name should be used for metrics reporting.")
+        }
+        Self {
+            db_name: db_name.to_string(),
+            read_sample_interval: SamplingInterval::default(),
+            write_sample_interval: SamplingInterval::default(),
+            iter_sample_interval: SamplingInterval::default(),
+        }
+    }
+
+    pub fn with_sampling(self, read_interval: SamplingInterval) -> Self {
+        Self {
+            db_name: self.db_name,
+            read_sample_interval: read_interval,
+            write_sample_interval: SamplingInterval::default(),
+            iter_sample_interval: SamplingInterval::default(),
+        }
+    }
+}
+
+const CF_METRICS_REPORT_PERIOD_SECS: u64 = 30;
+
+#[derive(Debug)]
+pub struct Database {
+    pub(crate) storage: Storage,
+    pub(crate) metric_conf: MetricConf,
+}
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        DBMetrics::get().decrement_num_active_dbs(&self.metric_conf.db_name);
+    }
+}
+
+impl Database {
+    pub(crate) fn new(storage: Storage, metric_conf: MetricConf) -> Self {
+        DBMetrics::get().increment_num_active_dbs(&metric_conf.db_name);
+        Self {
+            storage,
+            metric_conf,
+        }
+    }
+
+    pub(crate) fn get<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        key: K,
+        readopts: &ReadOptions,
+    ) -> Result<Option<GetResult<'_>>, TypedStoreError> {
+        match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => Ok(db
+                .underlying
+                .get_pinned_cf_opt(&cf.rocks_cf(db), key, readopts)
+                .map_err(typed_store_err_from_rocks_err)?
+                .map(GetResult::Rocks)),
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
+                Ok(db.get(cf_name, key).map(GetResult::InMemory))
+            }
+
+            _ => Err(TypedStoreError::RocksDB(
+                "typed store invariant violation".to_string(),
+            )),
+        }
+    }
+
+    pub(crate) fn multi_get<I, K>(
+        &self,
+        cf: &ColumnFamily,
+        keys: I,
+        readopts: &ReadOptions,
+    ) -> Vec<Result<Option<GetResult<'_>>, TypedStoreError>>
+    where
+        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]>,
+    {
+        match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => {
+                let res = db.underlying.batched_multi_get_cf_opt(
+                    &cf.rocks_cf(db),
+                    keys,
+                    // sorted_input
+                    false,
+                    readopts,
+                );
+                res.into_iter()
+                    .map(|r| {
+                        r.map_err(typed_store_err_from_rocks_err)
+                            .map(|item| item.map(GetResult::Rocks))
+                    })
+                    .collect()
+            }
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => db
+                .multi_get(cf_name, keys)
+                .into_iter()
+                .map(|r| Ok(r.map(GetResult::InMemory)))
+                .collect(),
+            _ => unreachable!("typed store invariant violation"),
+        }
+    }
+
+    pub fn create_cf<N: AsRef<str>>(
+        &self,
+        name: N,
+        opts: &rocksdb::Options,
+    ) -> Result<(), rocksdb::Error> {
+        match &self.storage {
+            Storage::Rocks(db) => db.underlying.create_cf(name, opts),
+            Storage::InMemory(_) => Ok(()),
+        }
+    }
+
+    pub fn cf_handle(&self, name: &str) -> Option<()> {
+        match &self.storage {
+            Storage::Rocks(db) => db.underlying.cf_handle(name).map(|_| ()),
+            Storage::InMemory(db) => db.has_cf(name).then_some(()),
+        }
+    }
+
+    pub fn drop_cf(&self, name: &str) -> Result<(), rocksdb::Error> {
+        match &self.storage {
+            Storage::Rocks(db) => db.underlying.drop_cf(name),
+            Storage::InMemory(db) => {
+                db.drop_cf(name);
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn delete_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        key: K,
+        writeopts: &WriteOptions,
+    ) -> Result<(), TypedStoreError> {
+        fail_point!("delete-cf-before");
+        let ret = match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
+                .underlying
+                .delete_cf_opt(&cf.rocks_cf(db), key, writeopts)
+                .map_err(typed_store_err_from_rocks_err),
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
+                db.delete(cf_name, key.as_ref());
+                Ok(())
+            }
+            _ => Err(TypedStoreError::RocksDB(
+                "typed store invariant violation".to_string(),
+            )),
+        };
+        fail_point!("delete-cf-after");
+        #[allow(clippy::let_and_return)]
+        ret
+    }
+
+    pub fn path_for_pruning(&self) -> &Path {
+        match &self.storage {
+            Storage::Rocks(rocks) => rocks.underlying.path(),
+            _ => unimplemented!("method is only supported for rocksdb backend"),
+        }
+    }
+
+    pub(crate) fn put_cf(
+        &self,
+        cf: &ColumnFamily,
+        key: Vec<u8>,
+        value: Vec<u8>,
+        writeopts: &WriteOptions,
+    ) -> Result<(), TypedStoreError> {
+        fail_point!("put-cf-before");
+        let ret = match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
+                .underlying
+                .put_cf_opt(&cf.rocks_cf(db), key, value, writeopts)
+                .map_err(typed_store_err_from_rocks_err),
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
+                db.put(cf_name, key, value);
+                Ok(())
+            }
+            _ => Err(TypedStoreError::RocksDB(
+                "typed store invariant violation".to_string(),
+            )),
+        };
+        fail_point!("put-cf-after");
+        #[allow(clippy::let_and_return)]
+        ret
+    }
+
+    pub(crate) fn key_may_exist_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        key: K,
+        readopts: &ReadOptions,
+    ) -> bool {
+        match &self.storage {
+            // [`rocksdb::DBWithThreadMode::key_may_exist_cf`] can have false positives,
+            // but no false negatives. We use it to short-circuit the absent case
+            Storage::Rocks(rocks) => {
+                rocks
+                    .underlying
+                    .key_may_exist_cf_opt(&rocks_cf(rocks, cf.name()), key, readopts)
+            }
+            _ => true,
+        }
+    }
+
+    pub fn write(
+        &self,
+        batch: StorageWriteBatch,
+        writeopts: &WriteOptions,
+    ) -> Result<(), TypedStoreError> {
+        fail_point!("batch-write-before");
+        let ret = match (&self.storage, batch) {
+            (Storage::Rocks(rocks), StorageWriteBatch::Rocks(batch)) => rocks
+                .underlying
+                .write_opt(batch, writeopts)
+                .map_err(typed_store_err_from_rocks_err),
+            (Storage::InMemory(db), StorageWriteBatch::InMemory(batch)) => {
+                db.write(batch);
+                Ok(())
+            }
+            _ => Err(TypedStoreError::RocksDB(
+                "using invalid batch type for the database".to_string(),
+            )),
+        };
+        fail_point!("batch-write-after");
+
+        #[allow(clippy::let_and_return)]
+        ret
+    }
+
+    pub(crate) fn raw_iterator_cf<'a: 'b, 'b>(
+        &'a self,
+        cf: &ColumnFamily,
+        readopts: ReadOptions,
+    ) -> RawIter<'b> {
+        match &self.storage {
+            Storage::Rocks(rocksdb) => rocksdb
+                .underlying
+                .raw_iterator_cf_opt(&rocks_cf(rocksdb, cf.name()), readopts),
+            _ => unimplemented!("iterators not yet supported for other backends"),
+        }
+    }
+
+    pub(crate) fn compact_range_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        start: Option<K>,
+        end: Option<K>,
+    ) {
+        if let Storage::Rocks(rocksdb) = &self.storage {
+            rocksdb
+                .underlying
+                .compact_range_cf(&rocks_cf(rocksdb, cf.name()), start, end);
+        }
+    }
+
+    pub fn flush(&self) -> Result<(), TypedStoreError> {
+        match &self.storage {
+            Storage::Rocks(db) => db
+                .underlying
+                .flush()
+                .map_err(typed_store_err_from_rocks_err),
+            Storage::InMemory(_) => Ok(()),
+        }
+    }
+
+    pub fn checkpoint(&self, path: &Path) -> Result<(), TypedStoreError> {
+        // TODO: implement for other storage types
+        if let Storage::Rocks(rocks) = &self.storage {
+            let checkpoint =
+                Checkpoint::new(&rocks.underlying).map_err(typed_store_err_from_rocks_err)?;
+            checkpoint
+                .create_checkpoint(path)
+                .map_err(|e| TypedStoreError::RocksDB(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    pub fn get_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.read_sample_interval.new_from_self()
+    }
+
+    pub fn multiget_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.read_sample_interval.new_from_self()
+    }
+
+    pub fn write_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.write_sample_interval.new_from_self()
+    }
+
+    pub fn iter_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.iter_sample_interval.new_from_self()
+    }
+
+    pub(crate) fn db_name(&self) -> String {
+        let name = &self.metric_conf.db_name;
+        if name.is_empty() {
+            "default".to_string()
+        } else {
+            name.clone()
+        }
+    }
+
+    pub fn live_files(&self) -> Result<Vec<LiveFile>, Error> {
+        match &self.storage {
+            Storage::Rocks(rocks) => rocks.underlying.live_files(),
+            _ => Ok(vec![]),
+        }
+    }
+
+    pub(crate) fn try_catch_up_with_primary(&self) -> Result<(), TypedStoreError> {
+        if let Storage::Rocks(rocks) = &self.storage {
+            rocks
+                .underlying
+                .try_catch_up_with_primary()
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        Ok(())
+    }
+}
+
+fn rocks_cf_from_db<'a>(
+    db: &'a Database,
+    cf_name: &str,
+) -> Result<Arc<rocksdb::BoundColumnFamily<'a>>, TypedStoreError> {
+    match &db.storage {
+        Storage::Rocks(rocksdb) => Ok(rocksdb
+            .underlying
+            .cf_handle(cf_name)
+            .expect("Map-keying column family should have been checked at DB creation")),
+        _ => Err(TypedStoreError::RocksDB(
+            "using invalid batch type for the database".to_string(),
+        )),
+    }
+}
+
+/// An interface to a rocksDB database, keyed by a columnfamily
+#[derive(Clone, Debug)]
+pub struct DBMap<K, V> {
+    pub db: Arc<Database>,
+    _phantom: PhantomData<fn(K) -> V>,
+    column_family: ColumnFamily,
+    pub opts: ReadWriteOptions,
+    db_metrics: Arc<DBMetrics>,
+    get_sample_interval: SamplingInterval,
+    multiget_sample_interval: SamplingInterval,
+    write_sample_interval: SamplingInterval,
+    iter_sample_interval: SamplingInterval,
+    _metrics_task_cancel_handle: Arc<oneshot::Sender<()>>,
+}
+
+unsafe impl<K: Send, V: Send> Send for DBMap<K, V> {}
+
+impl<K, V> DBMap<K, V> {
+    pub(crate) fn new(
+        db: Arc<Database>,
+        opts: &ReadWriteOptions,
+        column_family: ColumnFamily,
+        is_deprecated: bool,
+    ) -> Self {
+        let db_cloned = db.clone();
+        let db_metrics = DBMetrics::get();
+        let db_metrics_cloned = db_metrics.clone();
+        let cf = column_family.name().to_string();
+
+        let (sender, mut recv) = tokio::sync::oneshot::channel();
+        if !is_deprecated && matches!(db.storage, Storage::Rocks(_)) {
+            tokio::task::spawn(async move {
+                let mut interval =
+                    tokio::time::interval(Duration::from_secs(CF_METRICS_REPORT_PERIOD_SECS));
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => {
+                            let db = db_cloned.clone();
+                            let cf = cf.clone();
+                            let db_metrics = db_metrics.clone();
+                            if let Err(e) = tokio::task::spawn_blocking(move || {
+                                Self::report_rocksdb_metrics(&db, &cf, &db_metrics);
+                            }).await {
+                                error!("Failed to log metrics with error: {}", e);
+                            }
+                        }
+                        _ = &mut recv => break,
+                    }
+                }
+                debug!("Returning the cf metric logging task for DBMap: {}", &cf);
+            });
+        }
+        DBMap {
+            db: db.clone(),
+            opts: opts.clone(),
+            _phantom: PhantomData,
+            column_family,
+            db_metrics: db_metrics_cloned,
+            _metrics_task_cancel_handle: Arc::new(sender),
+            get_sample_interval: db.get_sampling_interval(),
+            multiget_sample_interval: db.multiget_sampling_interval(),
+            write_sample_interval: db.write_sampling_interval(),
+            iter_sample_interval: db.iter_sampling_interval(),
+        }
+    }
+
+    /// Reopens an open database as a typed map operating under a specific
+    /// column family. if no column family is passed, the default column
+    /// family is used.
+    ///
+    /// ```
+    /// use core::fmt::Error;
+    /// use std::sync::Arc;
+    ///
+    /// use prometheus::Registry;
+    /// use tempfile::tempdir;
+    /// use typed_store::{metrics::DBMetrics, rocks::*};
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Error> {
+    ///     /// Open the DB with all needed column families first.
+    ///     let rocks = open_cf(
+    ///         tempdir().unwrap(),
+    ///         None,
+    ///         MetricConf::default(),
+    ///         &["First_CF", "Second_CF"],
+    ///     )
+    ///     .unwrap();
+    ///     /// Attach the column families to specific maps.
+    ///     let db_cf_1 = DBMap::<u32, u32>::reopen(
+    ///         &rocks,
+    ///         Some("First_CF"),
+    ///         &ReadWriteOptions::default(),
+    ///         false,
+    ///     )
+    ///     .expect("Failed to open storage");
+    ///     let db_cf_2 = DBMap::<u32, u32>::reopen(
+    ///         &rocks,
+    ///         Some("Second_CF"),
+    ///         &ReadWriteOptions::default(),
+    ///         false,
+    ///     )
+    ///     .expect("Failed to open storage");
+    ///     Ok(())
+    /// }
+    /// ```
+    #[instrument(level = "debug", skip(db), err)]
+    pub fn reopen(
+        db: &Arc<Database>,
+        opt_cf: Option<&str>,
+        rw_options: &ReadWriteOptions,
+        is_deprecated: bool,
+    ) -> Result<Self, TypedStoreError> {
+        let cf_key = opt_cf
+            .unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+            .to_owned();
+
+        let column_family = match &db.storage {
+            Storage::Rocks(_) => ColumnFamily::Rocks(cf_key.clone()),
+            Storage::InMemory(_) => ColumnFamily::InMemory(cf_key.clone()),
+        };
+        Ok(DBMap::new(
+            db.clone(),
+            rw_options,
+            column_family,
+            is_deprecated,
+        ))
+    }
+
+    pub fn cf_name(&self) -> &str {
+        self.column_family.name()
+    }
+
+    pub fn batch(&self) -> DBBatch {
+        let batch = match &self.db.storage {
+            Storage::Rocks(_) => StorageWriteBatch::Rocks(WriteBatch::default()),
+            Storage::InMemory(_) => StorageWriteBatch::InMemory(InMemoryBatch::default()),
+        };
+        DBBatch::new(
+            &self.db,
+            batch,
+            self.opts.writeopts(),
+            &self.db_metrics,
+            &self.write_sample_interval,
+        )
+    }
+
+    pub fn compact_range<J: Serialize>(&self, start: &J, end: &J) -> Result<(), TypedStoreError> {
+        let from_buf = be_fix_int_ser(start)?;
+        let to_buf = be_fix_int_ser(end)?;
+        self.db
+            .compact_range_cf(&self.column_family, Some(from_buf), Some(to_buf));
+        Ok(())
+    }
+
+    pub fn compact_range_raw(
+        &self,
+        cf_name: &str,
+        start: Vec<u8>,
+        end: Vec<u8>,
+    ) -> Result<(), TypedStoreError> {
+        let cf = match &self.db.storage {
+            Storage::Rocks(_) => ColumnFamily::Rocks(cf_name.to_string()),
+            Storage::InMemory(_) => ColumnFamily::InMemory(cf_name.to_string()),
+        };
+        self.db.compact_range_cf(&cf, Some(start), Some(end));
+        Ok(())
+    }
+
+    /// Returns a vector of raw values corresponding to the keys provided.
+    fn multi_get_pinned<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<Option<GetResult<'_>>>, TypedStoreError>
+    where
+        J: Borrow<K>,
+        K: Serialize,
+    {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_multiget_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let perf_ctx = if self.multiget_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let keys_bytes: Result<Vec<_>, TypedStoreError> = keys
+            .into_iter()
+            .map(|k| be_fix_int_ser(k.borrow()))
+            .collect();
+        let results: Result<Vec<_>, TypedStoreError> = self
+            .db
+            .multi_get(&self.column_family, keys_bytes?, &self.opts.readopts())
+            .into_iter()
+            .collect();
+        let entries = results?;
+        let entry_size = entries
+            .iter()
+            .flatten()
+            .map(|entry| entry.len())
+            .sum::<usize>();
+        self.db_metrics
+            .op_metrics
+            .rocksdb_multiget_bytes
+            .with_label_values(&[self.cf_name()])
+            .observe(entry_size as f64);
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(self.cf_name());
+        }
+        Ok(entries)
+    }
+
+    pub fn checkpoint_db(&self, path: &Path) -> Result<(), TypedStoreError> {
+        self.db.checkpoint(path)
+    }
+
+    pub fn table_summary(&self) -> eyre::Result<TableSummary>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let mut num_keys = 0;
+        let mut key_bytes_total = 0;
+        let mut value_bytes_total = 0;
+        let mut key_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+        let mut value_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+        for item in self.safe_iter() {
+            let (key, value) = item?;
+            num_keys += 1;
+            let key_len = be_fix_int_ser(key.borrow())?.len();
+            let value_len = bcs::to_bytes(value.borrow())?.len();
+            key_bytes_total += key_len;
+            value_bytes_total += value_len;
+            key_hist.record(key_len as u64)?;
+            value_hist.record(value_len as u64)?;
+        }
+        Ok(TableSummary {
+            num_keys,
+            key_bytes_total,
+            value_bytes_total,
+            key_hist,
+            value_hist,
+        })
+    }
+
+    // Creates metrics and context for tracking an iterator usage and performance.
+    fn create_iter_context(
+        &self,
+    ) -> (
+        Option<HistogramTimer>,
+        Option<Histogram>,
+        Option<Histogram>,
+        Option<RocksDBPerfContext>,
+    ) {
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let bytes_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_bytes
+            .with_label_values(&[self.cf_name()]);
+        let keys_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_keys
+            .with_label_values(&[self.cf_name()]);
+        let perf_ctx = if self.iter_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        (
+            Some(timer),
+            Some(bytes_scanned),
+            Some(keys_scanned),
+            perf_ctx,
+        )
+    }
+
+    // Creates a RocksDB read option with specified lower and upper bounds.
+    /// Lower bound is inclusive, and upper bound is exclusive.
+    fn create_read_options_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> ReadOptions
+    where
+        K: Serialize,
+    {
+        let mut readopts = self.opts.readopts();
+        if let Some(lower_bound) = lower_bound {
+            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
+            readopts.set_iterate_lower_bound(key_buf);
+        }
+        if let Some(upper_bound) = upper_bound {
+            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
+            readopts.set_iterate_upper_bound(key_buf);
+        }
+        readopts
+    }
+
+    /// Creates a safe reversed iterator with optional bounds.
+    /// Upper bound is included.
+    pub fn reversed_safe_iter_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Result<SafeRevIter<'_, K, V>, TypedStoreError>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
+        let readopts = self.create_read_options_with_range((
+            lower_bound
+                .as_ref()
+                .map(Bound::Included)
+                .unwrap_or(Bound::Unbounded),
+            upper_bound
+                .as_ref()
+                .map(Bound::Included)
+                .unwrap_or(Bound::Unbounded),
+        ));
+
+        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        let iter = SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        );
+        Ok(SafeRevIter::new(iter, upper_bound_key.transpose()?))
+    }
+
+    // Creates a RocksDB read option with lower and upper bounds set corresponding
+    // to `range`.
+    fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
+    where
+        K: Serialize,
+    {
+        let mut readopts = self.opts.readopts();
+
+        let lower_bound = range.start_bound();
+        let upper_bound = range.end_bound();
+
+        match lower_bound {
+            Bound::Included(lower_bound) => {
+                // Rocksdb lower bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Excluded(lower_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+
+                // Since we want exclusive, we need to increment the key to exclude the previous
+                big_endian_saturating_add_one(&mut key_buf);
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        match upper_bound {
+            Bound::Included(upper_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+
+                // If the key is already at the limit, there's nowhere else to go, so no upper
+                // bound
+                if !is_max(&key_buf) {
+                    // Since we want exclusive, we need to increment the key to get the upper bound
+                    big_endian_saturating_add_one(&mut key_buf);
+                    readopts.set_iterate_upper_bound(key_buf);
+                }
+            }
+            Bound::Excluded(upper_bound) => {
+                // Rocksdb upper bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+                readopts.set_iterate_upper_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        readopts
+    }
+}
+
+/// Provides a mutable struct to form a collection of database write operations,
+/// and execute them.
+///
+/// Batching write and delete operations is faster than performing them one by
+/// one and ensures their atomicity,  ie. they are all written or none is.
+/// This is also true of operations across column families in the same database.
+///
+/// Serializations / Deserialization, and naming of column families is performed
+/// by passing a DBMap<K,V> with each operation.
+///
+/// ```
+/// use core::fmt::Error;
+/// use std::sync::Arc;
+///
+/// use prometheus::Registry;
+/// use tempfile::tempdir;
+/// use typed_store::{Map, metrics::DBMetrics, rocks::*};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
+///     let rocks = open_cf(
+///         tempfile::tempdir().unwrap(),
+///         None,
+///         MetricConf::default(),
+///         &["First_CF", "Second_CF"],
+///     )
+///     .unwrap();
+///
+///     let db_cf_1 = DBMap::reopen(
+///         &rocks,
+///         Some("First_CF"),
+///         &ReadWriteOptions::default(),
+///         false,
+///     )
+///     .expect("Failed to open storage");
+///     let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
+///
+///     let db_cf_2 = DBMap::reopen(
+///         &rocks,
+///         Some("Second_CF"),
+///         &ReadWriteOptions::default(),
+///         false,
+///     )
+///     .expect("Failed to open storage");
+///     let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
+///
+///     let mut batch = db_cf_1.batch();
+///     batch
+///         .insert_batch(&db_cf_1, keys_vals_1.clone())
+///         .expect("Failed to batch insert")
+///         .insert_batch(&db_cf_2, keys_vals_2.clone())
+///         .expect("Failed to batch insert");
+///
+///     let _ = batch.write().expect("Failed to execute batch");
+///     for (k, v) in keys_vals_1 {
+///         let val = db_cf_1.get(&k).expect("Failed to get inserted key");
+///         assert_eq!(Some(v), val);
+///     }
+///
+///     for (k, v) in keys_vals_2 {
+///         let val = db_cf_2.get(&k).expect("Failed to get inserted key");
+///         assert_eq!(Some(v), val);
+///     }
+///     Ok(())
+/// }
+/// ```
+pub struct DBBatch {
+    database: Arc<Database>,
+    batch: StorageWriteBatch,
+    opts: WriteOptions,
+    db_metrics: Arc<DBMetrics>,
+    write_sample_interval: SamplingInterval,
+}
+
+impl DBBatch {
+    /// Create a new batch associated with a DB reference.
+    ///
+    /// Use `open_cf` to get the DB reference or an existing open database.
+    pub fn new(
+        dbref: &Arc<Database>,
+        batch: StorageWriteBatch,
+        opts: WriteOptions,
+        db_metrics: &Arc<DBMetrics>,
+        write_sample_interval: &SamplingInterval,
+    ) -> Self {
+        DBBatch {
+            database: dbref.clone(),
+            batch,
+            opts,
+            db_metrics: db_metrics.clone(),
+            write_sample_interval: write_sample_interval.clone(),
+        }
+    }
+
+    /// Consume the batch and write its operations to the database
+    #[instrument(level = "trace", skip_all, err)]
+    pub fn write(self) -> Result<(), TypedStoreError> {
+        let db_name = self.database.db_name();
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_batch_commit_latency_seconds
+            .with_label_values(&[&db_name])
+            .start_timer();
+        let batch_size = self.size_in_bytes();
+
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        self.database.write(self.batch, &self.opts)?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_batch_commit_bytes
+            .with_label_values(&[&db_name])
+            .observe(batch_size as f64);
+
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(&db_name);
+        }
+        let elapsed = timer.stop_and_record();
+        if elapsed > 1.0 {
+            warn!(?elapsed, ?db_name, "very slow batch write");
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_batch_writes_count
+                .with_label_values(&[&db_name])
+                .inc();
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_batch_writes_duration_ms
+                .with_label_values(&[&db_name])
+                .inc_by((elapsed * 1000.0) as u64);
+        }
+        Ok(())
+    }
+
+    pub fn size_in_bytes(&self) -> usize {
+        match self.batch {
+            StorageWriteBatch::Rocks(ref b) => b.size_in_bytes(),
+            StorageWriteBatch::InMemory(_) => 0,
+        }
+    }
+
+    pub fn delete_batch<J: Borrow<K>, K: Serialize, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        purged_vals: impl IntoIterator<Item = J>,
+    ) -> Result<(), TypedStoreError> {
+        if !Arc::ptr_eq(&db.db, &self.database) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+
+        purged_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                match (&mut self.batch, &db.column_family) {
+                    (StorageWriteBatch::Rocks(b), ColumnFamily::Rocks(name)) => {
+                        b.delete_cf(&rocks_cf_from_db(&self.database, name)?, k_buf)
+                    }
+                    (StorageWriteBatch::InMemory(b), ColumnFamily::InMemory(name)) => {
+                        b.delete_cf(name, k_buf)
+                    }
+                    _ => Err(TypedStoreError::RocksDB(
+                        "typed store invariant violation".to_string(),
+                    ))?,
+                }
+                Ok(())
+            })?;
+        Ok(())
+    }
+
+    /// Deletes a range of keys between `from` (inclusive) and `to`
+    /// (non-inclusive) by writing a range delete tombstone in the db map
+    /// If the DBMap is configured with ignore_range_deletions set to false,
+    /// the effect of this write will be visible immediately i.e. you won't
+    /// see old values when you do a lookup or scan. But if it is configured
+    /// with ignore_range_deletions set to true, the old value are visible until
+    /// compaction actually deletes them which will happen sometime after. By
+    /// default ignore_range_deletions is set to true on a DBMap (unless it is
+    /// overridden in the config), so please use this function with caution
+    pub fn schedule_delete_range<K: Serialize, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        from: &K,
+        to: &K,
+    ) -> Result<(), TypedStoreError> {
+        if !Arc::ptr_eq(&db.db, &self.database) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+
+        let from_buf = be_fix_int_ser(from)?;
+        let to_buf = be_fix_int_ser(to)?;
+
+        if let StorageWriteBatch::Rocks(b) = &mut self.batch {
+            b.delete_range_cf(
+                &rocks_cf_from_db(&self.database, db.cf_name())?,
+                from_buf,
+                to_buf,
+            );
+        }
+        Ok(())
+    }
+
+    /// inserts a range of (key, value) pairs given as an iterator
+    pub fn insert_batch<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
+        &mut self,
+        db: &DBMap<K, V>,
+        new_vals: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<&mut Self, TypedStoreError> {
+        if !Arc::ptr_eq(&db.db, &self.database) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+        let mut total = 0usize;
+        new_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
+                total += k_buf.len() + v_buf.len();
+                match (&mut self.batch, &db.column_family) {
+                    (StorageWriteBatch::Rocks(b), ColumnFamily::Rocks(name)) => {
+                        b.put_cf(&rocks_cf_from_db(&self.database, name)?, k_buf, v_buf)
+                    }
+                    (StorageWriteBatch::InMemory(b), ColumnFamily::InMemory(name)) => {
+                        b.put_cf(name, k_buf, v_buf)
+                    }
+                    _ => Err(TypedStoreError::RocksDB(
+                        "typed store invariant violation".to_string(),
+                    ))?,
+                }
+                Ok(())
+            })?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_batch_put_bytes
+            .with_label_values(&[db.cf_name()])
+            .observe(total as f64);
+        Ok(self)
+    }
+}
+
+impl<'a, K, V> Map<'a, K, V> for DBMap<K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    type Error = TypedStoreError;
+    type SafeIterator = SafeIter<'a, K, V>;
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
+        let key_buf = be_fix_int_ser(key)?;
+        let readopts = self.opts.readopts();
+        Ok(self
+            .db
+            .key_may_exist_cf(&self.column_family, &key_buf, &readopts)
+            && self
+                .db
+                .get(&self.column_family, &key_buf, &readopts)?
+                .is_some())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_contains_keys<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<bool>, Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        let values = self.multi_get_pinned(keys)?;
+        Ok(values.into_iter().map(|v| v.is_some()).collect())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_get_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let perf_ctx = if self.get_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        let res = self
+            .db
+            .get(&self.column_family, &key_buf, &self.opts.readopts())?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_get_bytes
+            .with_label_values(&[self.cf_name()])
+            .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(self.cf_name());
+        }
+        match res {
+            Some(data) => Ok(Some(
+                bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_put_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        let value_buf = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_put_bytes
+            .with_label_values(&[self.cf_name()])
+            .observe((key_buf.len() + value_buf.len()) as f64);
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(self.cf_name());
+        }
+        self.db.put_cf(
+            &self.column_family,
+            key_buf,
+            value_buf,
+            &self.opts.writeopts(),
+        )?;
+
+        let elapsed = timer.stop_and_record();
+        if elapsed > 1.0 {
+            warn!(?elapsed, cf = ?self.cf_name(), "very slow insert");
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_puts_count
+                .with_label_values(&[self.cf_name()])
+                .inc();
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_puts_duration_ms
+                .with_label_values(&[self.cf_name()])
+                .inc_by((elapsed * 1000.0) as u64);
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_delete_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        self.db
+            .delete_cf(&self.column_family, key_buf, &self.opts.writeopts())?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_deletes
+            .with_label_values(&[self.cf_name()])
+            .inc();
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(self.cf_name());
+        }
+        Ok(())
+    }
+
+    /// This method first drops the existing column family and then creates a
+    /// new one with the same name. The two operations are not atomic and
+    /// hence it is possible to get into a race condition where the column
+    /// family has been dropped but new one is not created yet
+    #[instrument(level = "trace", skip_all, err)]
+    fn unsafe_clear(&self) -> Result<(), TypedStoreError> {
+        let _ = self.db.drop_cf(self.cf_name());
+        self.db
+            .create_cf(self.cf_name(), &crate::rocks::default_db_options().options)
+            .map_err(typed_store_err_from_rocks_err)?;
+        Ok(())
+    }
+
+    /// Writes a range delete tombstone to delete all entries in the db map
+    /// If the DBMap is configured with ignore_range_deletions set to false,
+    /// the effect of this write will be visible immediately i.e. you won't
+    /// see old values when you do a lookup or scan. But if it is configured
+    /// with ignore_range_deletions set to true, the old value are visible until
+    /// compaction actually deletes them which will happen sometime after. By
+    /// default ignore_range_deletions is set to true on a DBMap (unless it is
+    /// overridden in the config), so please use this function with caution
+    #[instrument(level = "trace", skip_all, err)]
+    fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
+        let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);
+        let last_key = self
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+            .transpose()?
+            .map(|(k, _v)| k);
+        if let Some((first_key, last_key)) = first_key.zip(last_key) {
+            let mut batch = self.batch();
+            batch.schedule_delete_range(self, &first_key, &last_key)?;
+            batch.write()?;
+        }
+        Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.safe_iter().next().is_none()
+    }
+
+    fn safe_iter(&'a self) -> Self::SafeIterator {
+        let db_iter = self
+            .db
+            .raw_iterator_cf(&self.column_family, self.opts.readopts());
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_iter_with_bounds(
+        &'a self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Self::SafeIterator {
+        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
+        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
+        let readopts = self.create_read_options_with_range(range);
+        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    /// Returns a vector of values corresponding to the keys provided.
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_get<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<Option<V>>, TypedStoreError>
+    where
+        J: Borrow<K>,
+    {
+        let results = self.multi_get_pinned(keys)?;
+        let values_parsed: Result<Vec<_>, TypedStoreError> = results
+            .into_iter()
+            .map(|value_byte| match value_byte {
+                Some(data) => Ok(Some(
+                    bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
+                )),
+                None => Ok(None),
+            })
+            .collect();
+
+        values_parsed
+    }
+
+    /// Convenience method for batch insertion
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_insert<J, U>(
+        &self,
+        key_val_pairs: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<(), Self::Error>
+    where
+        J: Borrow<K>,
+        U: Borrow<V>,
+    {
+        let mut batch = self.batch();
+        batch.insert_batch(self, key_val_pairs)?;
+        batch.write()
+    }
+
+    /// Convenience method for batch removal
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        let mut batch = self.batch();
+        batch.delete_batch(self, keys)?;
+        batch.write()
+    }
+
+    /// Try to catch up with primary when running as secondary
+    #[instrument(level = "trace", skip_all, err)]
+    fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
+        self.db.try_catch_up_with_primary()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ReadWriteOptions {
+    pub ignore_range_deletions: bool,
+    // Whether to sync to disk on every write.
+    sync_to_disk: bool,
+}
+
+impl ReadWriteOptions {
+    pub fn readopts(&self) -> ReadOptions {
+        let mut readopts = ReadOptions::default();
+        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
+        readopts
+    }
+
+    pub fn writeopts(&self) -> WriteOptions {
+        let mut opts = WriteOptions::default();
+        opts.set_sync(self.sync_to_disk);
+        opts
+    }
+
+    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
+        self.ignore_range_deletions = ignore;
+        self
+    }
+}
+
+impl Default for ReadWriteOptions {
+    fn default() -> Self {
+        Self {
+            ignore_range_deletions: true,
+            sync_to_disk: std::env::var("IOTA_DB_SYNC_TO_DISK").is_ok_and(|v| v != "0"),
+        }
+    }
+}
+
+/// Given a `vec<u8>`, find the value which is one more than the vector
+/// if the vector was a big endian number.
+/// If the vector is already minimum, don't change it.
+pub(crate) fn big_endian_saturating_add_one(v: &mut [u8]) {
+    if is_max(v) {
+        return;
+    }
+    for i in (0..v.len()).rev() {
+        if v[i] == u8::MAX {
+            v[i] = 0;
+        } else {
+            v[i] += 1;
+            break;
+        }
+    }
+}
+
+/// Check if all the bytes in the vector are 0xFF
+pub(crate) fn is_max(v: &[u8]) -> bool {
+    v.iter().all(|&x| x == u8::MAX)
+}
+
+// `clippy::manual_div_ceil` is raised by code expanded by the
+// `uint::construct_uint!` macro so it needs to be fixed by `uint`
+#[expect(clippy::assign_op_pattern, clippy::manual_div_ceil)]
+#[test]
+fn test_helpers() {
+    let v = vec![];
+    assert!(is_max(&v));
+
+    fn check_add(v: Vec<u8>) {
+        let mut v = v;
+        let num = Num32::from_big_endian(&v);
+        big_endian_saturating_add_one(&mut v);
+        assert!(num + 1 == Num32::from_big_endian(&v));
+    }
+
+    uint::construct_uint! {
+        // 32 byte number
+        struct Num32(4);
+    }
+
+    let mut v = vec![255; 32];
+    big_endian_saturating_add_one(&mut v);
+    assert!(Num32::MAX == Num32::from_big_endian(&v));
+
+    check_add(vec![1; 32]);
+    check_add(vec![6; 32]);
+    check_add(vec![254; 32]);
+
+    // TBD: More tests coming with randomized arrays
+}

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -478,7 +478,7 @@ impl<K, V> DBMap<K, V> {
         column_family: ColumnFamily,
         is_deprecated: bool,
     ) -> Self {
-        let db_cloned = db.clone();
+        let db_cloned = Arc::downgrade(&db);
         let db_metrics = DBMetrics::get();
         let db_metrics_cloned = db_metrics.clone();
         let cf = column_family.name().to_string();
@@ -491,13 +491,16 @@ impl<K, V> DBMap<K, V> {
                 loop {
                     tokio::select! {
                         _ = interval.tick() => {
-                            let db = db_cloned.clone();
-                            let cf = cf.clone();
-                            let db_metrics = db_metrics.clone();
-                            if let Err(e) = tokio::task::spawn_blocking(move || {
-                                Self::report_rocksdb_metrics(&db, &cf, &db_metrics);
-                            }).await {
-                                error!("Failed to log metrics with error: {}", e);
+                            if let Some(db) = db_cloned.upgrade() {
+                                let cf = cf.clone();
+                                let db_metrics = db_metrics.clone();
+                                if let Err(e) = tokio::task::spawn_blocking(move || {
+                                    Self::report_rocksdb_metrics(&db, &cf, &db_metrics);
+                                }).await {
+                                    error!("Failed to log metrics with error: {}", e);
+                                }
+                            } else {
+                                break;
                             }
                         }
                         _ = &mut recv => break,

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -16,6 +16,8 @@ pub use rocksdb;
 
 pub mod traits;
 pub use traits::Map;
+pub mod database;
+pub mod memstore;
 pub mod metrics;
 pub mod rocks;
 pub mod test_db;

--- a/crates/typed-store/src/memstore.rs
+++ b/crates/typed-store/src/memstore.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::{Arc, RwLock},
+};
+
+type InMemoryStoreInternal = Arc<RwLock<HashMap<String, BTreeMap<Vec<u8>, Vec<u8>>>>>;
+
+#[derive(Clone, Debug)]
+pub struct InMemoryDB {
+    data: InMemoryStoreInternal,
+}
+
+#[derive(Clone, Debug)]
+enum InMemoryChange {
+    Delete((String, Vec<u8>)),
+    Put((String, Vec<u8>, Vec<u8>)),
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryBatch {
+    data: Vec<InMemoryChange>,
+}
+
+impl InMemoryBatch {
+    pub fn delete_cf<K: AsRef<[u8]>>(&mut self, cf_name: &str, key: K) {
+        self.data.push(InMemoryChange::Delete((
+            cf_name.to_string(),
+            key.as_ref().to_vec(),
+        )));
+    }
+
+    pub fn put_cf<K, V>(&mut self, cf_name: &str, key: K, value: V)
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        self.data.push(InMemoryChange::Put((
+            cf_name.to_string(),
+            key.as_ref().to_vec(),
+            value.as_ref().to_vec(),
+        )));
+    }
+}
+
+impl InMemoryDB {
+    pub fn get<K: AsRef<[u8]>>(&self, cf_name: &str, key: K) -> Option<Vec<u8>> {
+        let data = self.data.read().expect("can't read data");
+        match data.get(cf_name) {
+            Some(cf) => cf.get(key.as_ref()).cloned(),
+            None => None,
+        }
+    }
+
+    pub fn multi_get<I, K>(&self, cf_name: &str, keys: I) -> Vec<Option<Vec<u8>>>
+    where
+        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]>,
+    {
+        let data = self.data.read().expect("can't read data");
+        match data.get(cf_name) {
+            Some(cf) => keys
+                .into_iter()
+                .map(|k| cf.get(k.as_ref()).cloned())
+                .collect(),
+            None => vec![],
+        }
+    }
+
+    pub fn delete(&self, cf_name: &str, key: &[u8]) {
+        let mut data = self.data.write().expect("can't write data");
+        data.entry(cf_name.to_string()).or_default().remove(key);
+    }
+
+    pub fn put(&self, cf_name: &str, key: Vec<u8>, value: Vec<u8>) {
+        let mut data = self.data.write().expect("can't write data");
+        data.entry(cf_name.to_string())
+            .or_default()
+            .insert(key, value);
+    }
+
+    pub fn write(&self, batch: InMemoryBatch) {
+        for change in batch.data {
+            match change {
+                InMemoryChange::Delete((cf_name, key)) => self.delete(&cf_name, &key),
+                InMemoryChange::Put((cf_name, key, value)) => self.put(&cf_name, key, value),
+            }
+        }
+    }
+
+    pub fn has_cf(&self, name: &str) -> bool {
+        self.data
+            .read()
+            .expect("can't read data")
+            .contains_key(name)
+    }
+
+    pub fn drop_cf(&self, name: &str) {
+        self.data.write().expect("can't write data").remove(name);
+    }
+}

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -6,12 +6,9 @@ pub mod errors;
 pub(crate) mod safe_iter;
 
 use std::{
-    borrow::Borrow,
     collections::{BTreeMap, HashSet},
     env,
     ffi::CStr,
-    marker::PhantomData,
-    ops::{Bound, RangeBounds},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -19,30 +16,20 @@ use std::{
 
 use backoff::backoff::Backoff;
 use bincode::Options;
-use iota_macros::{fail_point, nondeterministic};
-use prometheus::{Histogram, HistogramTimer};
+use iota_macros::nondeterministic;
 use rocksdb::{
-    AsColumnFamilyRef, BlockBasedOptions, BottommostLevelCompaction, CStrLike, Cache,
-    ColumnFamilyDescriptor, CompactOptions, DBPinnableSlice, DBWithThreadMode, Error, LiveFile,
-    MultiThreaded, OptimisticTransactionDB, ReadOptions, SnapshotWithThreadMode, WriteBatch,
-    WriteOptions, checkpoint::Checkpoint, properties, properties::num_files_at_level,
+    AsColumnFamilyRef, BlockBasedOptions, Cache, ColumnFamilyDescriptor, Error, MultiThreaded,
+    properties, properties::num_files_at_level,
 };
-use serde::{Serialize, de::DeserializeOwned};
 use tap::TapFallible;
-use tokio::sync::oneshot;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{info, instrument, warn};
+use typed_store_error::TypedStoreError;
 
+pub use crate::database::{DBBatch, DBMap, MetricConf, ReadWriteOptions};
 use crate::{
-    TypedStoreError,
-    metrics::{DBMetrics, RocksDBPerfContext, SamplingInterval},
-    rocks::{
-        errors::{
-            typed_store_err_from_bcs_err, typed_store_err_from_bincode_err,
-            typed_store_err_from_rocks_err,
-        },
-        safe_iter::{SafeIter, SafeRevIter},
-    },
-    traits::{Map, TableSummary},
+    database::{Database, Storage},
+    metrics::DBMetrics,
+    rocks::errors::{typed_store_err_from_bincode_err, typed_store_err_from_rocks_err},
 };
 
 // Write buffer size per RocksDB instance can be set via the env var below.
@@ -76,6 +63,8 @@ const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
 // built-in. From https://github.com/facebook/rocksdb/blob/bd80433c73691031ba7baa65c16c63a83aef201a/include/rocksdb/db.h#L1169
 const ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked("rocksdb.total-blob-file-size\0".as_bytes()) };
+
+const METRICS_ERROR: i64 = -1;
 
 const DB_CORRUPTED_KEY: &[u8] = b"db_corrupted";
 
@@ -131,251 +120,24 @@ macro_rules! reopen {
 }
 
 #[derive(Debug)]
-pub struct RocksDB {
-    pub underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
-    pub metric_conf: MetricConf,
-    pub db_path: PathBuf,
+pub(crate) struct RocksDB {
+    pub(crate) underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
 }
 
 impl Drop for RocksDB {
     fn drop(&mut self) {
         self.underlying.cancel_all_background_work(/* wait */ true);
-        DBMetrics::get().decrement_num_active_dbs(&self.metric_conf.db_name);
     }
 }
 
-impl RocksDB {
-    fn new(
-        underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
-        metric_conf: MetricConf,
-        db_path: PathBuf,
-    ) -> Self {
-        DBMetrics::get().increment_num_active_dbs(&metric_conf.db_name);
-        Self {
-            underlying,
-            metric_conf,
-            db_path,
-        }
-    }
-
-    pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, rocksdb::Error> {
-        self.underlying.get(key)
-    }
-
-    pub fn multi_get_cf<'a, 'b: 'a, K, I, W>(
-        &'a self,
-        keys: I,
-        readopts: &ReadOptions,
-    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
-    where
-        K: AsRef<[u8]>,
-        I: IntoIterator<Item = (&'b W, K)>,
-        W: 'b + AsColumnFamilyRef,
-    {
-        self.underlying.multi_get_cf_opt(keys, readopts)
-    }
-
-    pub fn batched_multi_get_cf_opt<I, K>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        keys: I,
-        sorted_input: bool,
-        readopts: &ReadOptions,
-    ) -> Vec<Result<Option<DBPinnableSlice<'_>>, Error>>
-    where
-        I: IntoIterator<Item = K>,
-        K: AsRef<[u8]>,
-    {
-        self.underlying
-            .batched_multi_get_cf_opt(cf, keys, sorted_input, readopts)
-    }
-
-    pub fn property_int_value_cf(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        name: impl CStrLike,
-    ) -> Result<Option<u64>, rocksdb::Error> {
-        self.underlying.property_int_value_cf(cf, name)
-    }
-
-    pub fn get_pinned_cf_opt<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        key: K,
-        readopts: &ReadOptions,
-    ) -> Result<Option<DBPinnableSlice<'_>>, rocksdb::Error> {
-        self.underlying.get_pinned_cf_opt(cf, key, readopts)
-    }
-
-    pub fn cf_handle(&self, name: &str) -> Option<Arc<rocksdb::BoundColumnFamily<'_>>> {
-        self.underlying.cf_handle(name)
-    }
-
-    pub fn create_cf<N: AsRef<str>>(
-        &self,
-        name: N,
-        opts: &rocksdb::Options,
-    ) -> Result<(), rocksdb::Error> {
-        self.underlying.create_cf(name, opts)
-    }
-
-    pub fn drop_cf(&self, name: &str) -> Result<(), rocksdb::Error> {
-        self.underlying.drop_cf(name)
-    }
-
-    pub fn delete_cf<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        key: K,
-        writeopts: &WriteOptions,
-    ) -> Result<(), rocksdb::Error> {
-        fail_point!("delete-cf-before");
-        let ret = self.underlying.delete_cf_opt(cf, key, writeopts);
-        fail_point!("delete-cf-after");
-        #[expect(clippy::let_and_return)]
-        ret
-    }
-
-    pub fn path(&self) -> &Path {
-        self.underlying.path()
-    }
-
-    pub fn put_cf<K, V>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        key: K,
-        value: V,
-        writeopts: &WriteOptions,
-    ) -> Result<(), rocksdb::Error>
-    where
-        K: AsRef<[u8]>,
-        V: AsRef<[u8]>,
-    {
-        fail_point!("put-cf-before");
-        let ret = self.underlying.put_cf_opt(cf, key, value, writeopts);
-        fail_point!("put-cf-after");
-        #[expect(clippy::let_and_return)]
-        ret
-    }
-
-    pub fn key_may_exist_cf<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        key: K,
-        readopts: &ReadOptions,
-    ) -> bool {
-        self.underlying.key_may_exist_cf_opt(cf, key, readopts)
-    }
-
-    pub fn try_catch_up_with_primary(&self) -> Result<(), rocksdb::Error> {
-        self.underlying.try_catch_up_with_primary()
-    }
-
-    pub fn write(
-        &self,
-        batch: rocksdb::WriteBatch,
-        writeopts: &WriteOptions,
-    ) -> Result<(), TypedStoreError> {
-        fail_point!("batch-write-before");
-        self.underlying
-            .write_opt(batch, writeopts)
-            .map_err(typed_store_err_from_rocks_err)?;
-        fail_point!("batch-write-after");
-
-        Ok(())
-    }
-
-    pub fn raw_iterator_cf<'a: 'b, 'b>(
-        &'a self,
-        cf_handle: &impl AsColumnFamilyRef,
-        readopts: ReadOptions,
-    ) -> RocksDBRawIter<'b> {
-        self.underlying.raw_iterator_cf_opt(cf_handle, readopts)
-    }
-
-    pub fn compact_range_cf<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        start: Option<K>,
-        end: Option<K>,
-    ) {
-        self.underlying.compact_range_cf(cf, start, end)
-    }
-
-    pub fn compact_range_to_bottom<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        start: Option<K>,
-        end: Option<K>,
-    ) {
-        let opt = &mut CompactOptions::default();
-        opt.set_bottommost_level_compaction(BottommostLevelCompaction::ForceOptimized);
-        self.underlying.compact_range_cf_opt(cf, start, end, opt)
-    }
-
-    pub fn flush(&self) -> Result<(), TypedStoreError> {
-        self.underlying
-            .flush()
-            .map_err(|e| TypedStoreError::RocksDB(e.into_string()))
-    }
-
-    pub fn checkpoint(&self, path: &Path) -> Result<(), TypedStoreError> {
-        let checkpoint =
-            Checkpoint::new(&self.underlying).map_err(typed_store_err_from_rocks_err)?;
-        checkpoint
-            .create_checkpoint(path)
-            .map_err(|e| TypedStoreError::RocksDB(e.to_string()))?;
-        Ok(())
-    }
-
-    pub fn flush_cf(&self, cf: &impl AsColumnFamilyRef) -> Result<(), rocksdb::Error> {
-        self.underlying.flush_cf(cf)
-    }
-
-    pub fn set_options_cf(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        opts: &[(&str, &str)],
-    ) -> Result<(), rocksdb::Error> {
-        self.underlying.set_options_cf(cf, opts)
-    }
-
-    pub fn get_sampling_interval(&self) -> SamplingInterval {
-        self.metric_conf.read_sample_interval.new_from_self()
-    }
-
-    pub fn multiget_sampling_interval(&self) -> SamplingInterval {
-        self.metric_conf.read_sample_interval.new_from_self()
-    }
-
-    pub fn write_sampling_interval(&self) -> SamplingInterval {
-        self.metric_conf.write_sample_interval.new_from_self()
-    }
-
-    pub fn iter_sampling_interval(&self) -> SamplingInterval {
-        self.metric_conf.iter_sample_interval.new_from_self()
-    }
-
-    pub fn db_name(&self) -> String {
-        let name = &self.metric_conf.db_name;
-        if name.is_empty() {
-            self.default_db_name()
-        } else {
-            name.clone()
-        }
-    }
-
-    fn default_db_name(&self) -> String {
-        self.path()
-            .file_name()
-            .and_then(|f| f.to_str())
-            .unwrap_or("unknown")
-            .to_string()
-    }
-
-    pub fn live_files(&self) -> Result<Vec<LiveFile>, Error> {
-        self.underlying.live_files()
-    }
+pub(crate) fn rocks_cf<'a>(
+    rocks_db: &'a RocksDB,
+    cf_name: &str,
+) -> Arc<rocksdb::BoundColumnFamily<'a>> {
+    rocks_db
+        .underlying
+        .cf_handle(cf_name)
+        .expect("Map-keying column family should have been checked at DB creation")
 }
 
 // Check if the database is corrupted, and if so, panic.
@@ -403,1259 +165,6 @@ pub fn unmark_db_corruption(path: &Path) -> Result<(), Error> {
     rocksdb::DB::open_default(path)?.put(DB_CORRUPTED_KEY, [0])
 }
 
-pub enum RocksDBSnapshot<'a> {
-    DBWithThreadMode(rocksdb::Snapshot<'a>),
-    OptimisticTransactionDB(SnapshotWithThreadMode<'a, OptimisticTransactionDB>),
-}
-
-impl<'a> RocksDBSnapshot<'a> {
-    pub fn multi_get_cf_opt<'b: 'a, K, I, W>(
-        &'a self,
-        keys: I,
-        readopts: ReadOptions,
-    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
-    where
-        K: AsRef<[u8]>,
-        I: IntoIterator<Item = (&'b W, K)>,
-        W: 'b + AsColumnFamilyRef,
-    {
-        match self {
-            Self::DBWithThreadMode(s) => s.multi_get_cf_opt(keys, readopts),
-            Self::OptimisticTransactionDB(s) => s.multi_get_cf_opt(keys, readopts),
-        }
-    }
-    pub fn multi_get_cf<'b: 'a, K, I, W>(
-        &'a self,
-        keys: I,
-    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
-    where
-        K: AsRef<[u8]>,
-        I: IntoIterator<Item = (&'b W, K)>,
-        W: 'b + AsColumnFamilyRef,
-    {
-        match self {
-            Self::DBWithThreadMode(s) => s.multi_get_cf(keys),
-            Self::OptimisticTransactionDB(s) => s.multi_get_cf(keys),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct MetricConf {
-    pub db_name: String,
-    pub read_sample_interval: SamplingInterval,
-    pub write_sample_interval: SamplingInterval,
-    pub iter_sample_interval: SamplingInterval,
-}
-
-impl MetricConf {
-    pub fn new(db_name: &str) -> Self {
-        if db_name.is_empty() {
-            error!("A meaningful db name should be used for metrics reporting.")
-        }
-        Self {
-            db_name: db_name.to_string(),
-            read_sample_interval: SamplingInterval::default(),
-            write_sample_interval: SamplingInterval::default(),
-            iter_sample_interval: SamplingInterval::default(),
-        }
-    }
-
-    pub fn with_sampling(self, read_interval: SamplingInterval) -> Self {
-        Self {
-            db_name: self.db_name,
-            read_sample_interval: read_interval,
-            write_sample_interval: SamplingInterval::default(),
-            iter_sample_interval: SamplingInterval::default(),
-        }
-    }
-}
-const CF_METRICS_REPORT_PERIOD_SECS: u64 = 30;
-const METRICS_ERROR: i64 = -1;
-
-/// An interface to a rocksDB database, keyed by a columnfamily
-#[derive(Clone, Debug)]
-pub struct DBMap<K, V> {
-    pub rocksdb: Arc<RocksDB>,
-    _phantom: PhantomData<fn(K) -> V>,
-    // the rocksDB ColumnFamily under which the map is stored
-    cf: String,
-    pub opts: ReadWriteOptions,
-    db_metrics: Arc<DBMetrics>,
-    get_sample_interval: SamplingInterval,
-    multiget_sample_interval: SamplingInterval,
-    write_sample_interval: SamplingInterval,
-    iter_sample_interval: SamplingInterval,
-    _metrics_task_cancel_handle: Arc<oneshot::Sender<()>>,
-}
-
-unsafe impl<K: Send, V: Send> Send for DBMap<K, V> {}
-
-impl<K, V> DBMap<K, V> {
-    pub(crate) fn new(
-        db: Arc<RocksDB>,
-        opts: &ReadWriteOptions,
-        opt_cf: &str,
-        is_deprecated: bool,
-    ) -> Self {
-        let db_cloned = db.clone();
-        let db_metrics = DBMetrics::get();
-        let db_metrics_cloned = db_metrics.clone();
-        let cf = opt_cf.to_string();
-        let (sender, mut recv) = tokio::sync::oneshot::channel();
-        if !is_deprecated {
-            tokio::task::spawn(async move {
-                let mut interval =
-                    tokio::time::interval(Duration::from_secs(CF_METRICS_REPORT_PERIOD_SECS));
-                loop {
-                    tokio::select! {
-                        _ = interval.tick() => {
-                            let db = db_cloned.clone();
-                            let cf = cf.clone();
-                            let db_metrics = db_metrics.clone();
-                            if let Err(e) = tokio::task::spawn_blocking(move || {
-                                Self::report_metrics(&db, &cf, &db_metrics);
-                            }).await {
-                                error!("Failed to log metrics with error: {}", e);
-                            }
-                        }
-                        _ = &mut recv => break,
-                    }
-                }
-                debug!("Returning the cf metric logging task for DBMap: {}", &cf);
-            });
-        }
-        DBMap {
-            rocksdb: db.clone(),
-            opts: opts.clone(),
-            _phantom: PhantomData,
-            cf: opt_cf.to_string(),
-            db_metrics: db_metrics_cloned,
-            _metrics_task_cancel_handle: Arc::new(sender),
-            get_sample_interval: db.get_sampling_interval(),
-            multiget_sample_interval: db.multiget_sampling_interval(),
-            write_sample_interval: db.write_sampling_interval(),
-            iter_sample_interval: db.iter_sampling_interval(),
-        }
-    }
-
-    /// Opens a database from a path, with specific options and an optional
-    /// column family.
-    ///
-    /// This database is used to perform operations on single column family, and
-    /// parametrizes all operations in `DBBatch` when writing across column
-    /// families.
-    #[instrument(level="debug", skip_all, fields(path = ?path.as_ref(), cf = ?opt_cf), err)]
-    pub fn open<P: AsRef<Path>>(
-        path: P,
-        metric_conf: MetricConf,
-        db_options: Option<rocksdb::Options>,
-        opt_cf: Option<&str>,
-        rw_options: &ReadWriteOptions,
-    ) -> Result<Self, TypedStoreError> {
-        let cf_key = opt_cf.unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME);
-        let cfs = vec![cf_key];
-        let rocksdb = open_cf(path, db_options, metric_conf, &cfs)?;
-        Ok(DBMap::new(rocksdb, rw_options, cf_key, false))
-    }
-
-    /// Reopens an open database as a typed map operating under a specific
-    /// column family. if no column family is passed, the default column
-    /// family is used.
-    ///
-    /// ```
-    /// use core::fmt::Error;
-    /// use std::sync::Arc;
-    ///
-    /// use prometheus::Registry;
-    /// use tempfile::tempdir;
-    /// use typed_store::{metrics::DBMetrics, rocks::*};
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Error> {
-    ///     /// Open the DB with all needed column families first.
-    ///     let rocks = open_cf(
-    ///         tempdir().unwrap(),
-    ///         None,
-    ///         MetricConf::default(),
-    ///         &["First_CF", "Second_CF"],
-    ///     )
-    ///     .unwrap();
-    ///     /// Attach the column families to specific maps.
-    ///     let db_cf_1 = DBMap::<u32, u32>::reopen(
-    ///         &rocks,
-    ///         Some("First_CF"),
-    ///         &ReadWriteOptions::default(),
-    ///         false,
-    ///     )
-    ///     .expect("Failed to open storage");
-    ///     let db_cf_2 = DBMap::<u32, u32>::reopen(
-    ///         &rocks,
-    ///         Some("Second_CF"),
-    ///         &ReadWriteOptions::default(),
-    ///         false,
-    ///     )
-    ///     .expect("Failed to open storage");
-    ///     Ok(())
-    /// }
-    /// ```
-    #[instrument(level = "debug", skip(db), err)]
-    pub fn reopen(
-        db: &Arc<RocksDB>,
-        opt_cf: Option<&str>,
-        rw_options: &ReadWriteOptions,
-        is_deprecated: bool,
-    ) -> Result<Self, TypedStoreError> {
-        let cf_key = opt_cf
-            .unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
-            .to_owned();
-
-        db.cf_handle(&cf_key)
-            .ok_or_else(|| TypedStoreError::UnregisteredColumn(cf_key.clone()))?;
-
-        Ok(DBMap::new(db.clone(), rw_options, &cf_key, is_deprecated))
-    }
-
-    pub fn batch(&self) -> DBBatch {
-        let batch = WriteBatch::default();
-        DBBatch::new(
-            &self.rocksdb,
-            batch,
-            self.opts.writeopts(),
-            &self.db_metrics,
-            &self.write_sample_interval,
-        )
-    }
-
-    pub fn compact_range<J: Serialize>(&self, start: &J, end: &J) -> Result<(), TypedStoreError> {
-        let from_buf = be_fix_int_ser(start)?;
-        let to_buf = be_fix_int_ser(end)?;
-        self.rocksdb
-            .compact_range_cf(&self.cf(), Some(from_buf), Some(to_buf));
-        Ok(())
-    }
-
-    pub fn compact_range_raw(
-        &self,
-        cf_name: &str,
-        start: Vec<u8>,
-        end: Vec<u8>,
-    ) -> Result<(), TypedStoreError> {
-        let cf = self
-            .rocksdb
-            .cf_handle(cf_name)
-            .expect("compact range: column family does not exist");
-        self.rocksdb.compact_range_cf(&cf, Some(start), Some(end));
-        Ok(())
-    }
-
-    pub fn compact_range_to_bottom<J: Serialize>(
-        &self,
-        start: &J,
-        end: &J,
-    ) -> Result<(), TypedStoreError> {
-        let from_buf = be_fix_int_ser(start)?;
-        let to_buf = be_fix_int_ser(end)?;
-        self.rocksdb
-            .compact_range_to_bottom(&self.cf(), Some(from_buf), Some(to_buf));
-        Ok(())
-    }
-
-    pub fn cf(&self) -> Arc<rocksdb::BoundColumnFamily<'_>> {
-        self.rocksdb
-            .cf_handle(&self.cf)
-            .expect("Map-keying column family should have been checked at DB creation")
-    }
-
-    pub fn flush(&self) -> Result<(), TypedStoreError> {
-        self.rocksdb
-            .flush_cf(&self.cf())
-            .map_err(|e| TypedStoreError::RocksDB(e.into_string()))
-    }
-
-    pub fn set_options(&self, opts: &[(&str, &str)]) -> Result<(), rocksdb::Error> {
-        self.rocksdb.set_options_cf(&self.cf(), opts)
-    }
-
-    fn get_int_property(
-        rocksdb: &RocksDB,
-        cf: &impl AsColumnFamilyRef,
-        property_name: &std::ffi::CStr,
-    ) -> Result<i64, TypedStoreError> {
-        match rocksdb.property_int_value_cf(cf, property_name) {
-            Ok(Some(value)) => Ok(value.min(i64::MAX as u64).try_into().unwrap_or_default()),
-            Ok(None) => Ok(0),
-            Err(e) => Err(TypedStoreError::RocksDB(e.into_string())),
-        }
-    }
-
-    /// Returns a vector of raw values corresponding to the keys provided.
-    fn multi_get_pinned<J>(
-        &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<Option<DBPinnableSlice<'_>>>, TypedStoreError>
-    where
-        J: Borrow<K>,
-        K: Serialize,
-    {
-        let _timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_multiget_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let perf_ctx = if self.multiget_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        let keys_bytes: Result<Vec<_>, TypedStoreError> = keys
-            .into_iter()
-            .map(|k| be_fix_int_ser(k.borrow()))
-            .collect();
-        let results: Result<Vec<_>, TypedStoreError> = self
-            .rocksdb
-            .batched_multi_get_cf_opt(
-                &self.cf(),
-                keys_bytes?,
-                // sorted_keys=
-                false,
-                &self.opts.readopts(),
-            )
-            .into_iter()
-            .map(|r| r.map_err(|e| TypedStoreError::RocksDB(e.into_string())))
-            .collect();
-        let entries = results?;
-        let entry_size = entries
-            .iter()
-            .flatten()
-            .map(|entry| entry.len())
-            .sum::<usize>();
-        self.db_metrics
-            .op_metrics
-            .rocksdb_multiget_bytes
-            .with_label_values(&[&self.cf])
-            .observe(entry_size as f64);
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .read_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        Ok(entries)
-    }
-
-    fn report_metrics(rocksdb: &Arc<RocksDB>, cf_name: &str, db_metrics: &Arc<DBMetrics>) {
-        let Some(cf) = rocksdb.cf_handle(cf_name) else {
-            tracing::warn!(
-                "unable to report metrics for cf {cf_name:?} in db {:?}",
-                rocksdb.db_name()
-            );
-            return;
-        };
-
-        db_metrics
-            .cf_metrics
-            .rocksdb_total_sst_files_size
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::TOTAL_SST_FILES_SIZE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_total_blob_files_size
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        // 7 is the default number of levels in RocksDB. If we ever change the number of
-        // levels using `set_num_levels`, we need to update here as well. Note
-        // that there isn't an API to query the DB to get the number of levels (yet).
-        let total_num_files: i64 = (0..=6)
-            .map(|level| {
-                Self::get_int_property(rocksdb, &cf, &num_files_at_level(level))
-                    .unwrap_or(METRICS_ERROR)
-            })
-            .sum();
-        db_metrics
-            .cf_metrics
-            .rocksdb_total_num_files
-            .with_label_values(&[cf_name])
-            .set(total_num_files);
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_level0_files
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, &num_files_at_level(0))
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_current_size_active_mem_tables
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::CUR_SIZE_ACTIVE_MEM_TABLE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_size_all_mem_tables
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::SIZE_ALL_MEM_TABLES)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_snapshots
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::NUM_SNAPSHOTS)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_oldest_snapshot_time
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::OLDEST_SNAPSHOT_TIME)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_actual_delayed_write_rate
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ACTUAL_DELAYED_WRITE_RATE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_is_write_stopped
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::IS_WRITE_STOPPED)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_block_cache_capacity
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_CAPACITY)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_block_cache_usage
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_USAGE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_block_cache_pinned_usage
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_PINNED_USAGE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_estimate_table_readers_mem
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_TABLE_READERS_MEM)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_estimated_num_keys
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_NUM_KEYS)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_immutable_mem_tables
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::NUM_IMMUTABLE_MEM_TABLE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_mem_table_flush_pending
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::MEM_TABLE_FLUSH_PENDING)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_compaction_pending
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::COMPACTION_PENDING)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_estimate_pending_compaction_bytes
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_PENDING_COMPACTION_BYTES)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_running_compactions
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::NUM_RUNNING_COMPACTIONS)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_running_flushes
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::NUM_RUNNING_FLUSHES)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_estimate_oldest_key_time
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_OLDEST_KEY_TIME)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_background_errors
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BACKGROUND_ERRORS)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_base_level
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BASE_LEVEL)
-                    .unwrap_or(METRICS_ERROR),
-            );
-    }
-
-    pub fn checkpoint_db(&self, path: &Path) -> Result<(), TypedStoreError> {
-        self.rocksdb.checkpoint(path)
-    }
-
-    pub fn table_summary(&self) -> eyre::Result<TableSummary>
-    where
-        K: Serialize + DeserializeOwned,
-        V: Serialize + DeserializeOwned,
-    {
-        let mut num_keys = 0;
-        let mut key_bytes_total = 0;
-        let mut value_bytes_total = 0;
-        let mut key_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
-        let mut value_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
-        for item in self.safe_iter() {
-            let (key, value) = item?;
-            num_keys += 1;
-            let key_len = be_fix_int_ser(key.borrow())?.len();
-            let value_len = bcs::to_bytes(value.borrow())?.len();
-            key_bytes_total += key_len;
-            value_bytes_total += value_len;
-            key_hist.record(key_len as u64)?;
-            value_hist.record(value_len as u64)?;
-        }
-        Ok(TableSummary {
-            num_keys,
-            key_bytes_total,
-            value_bytes_total,
-            key_hist,
-            value_hist,
-        })
-    }
-
-    // Creates metrics and context for tracking an iterator usage and performance.
-    fn create_iter_context(
-        &self,
-    ) -> (
-        Option<HistogramTimer>,
-        Option<Histogram>,
-        Option<Histogram>,
-        Option<RocksDBPerfContext>,
-    ) {
-        let timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_iter_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let bytes_scanned = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_iter_bytes
-            .with_label_values(&[&self.cf]);
-        let keys_scanned = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_iter_keys
-            .with_label_values(&[&self.cf]);
-        let perf_ctx = if self.iter_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        (
-            Some(timer),
-            Some(bytes_scanned),
-            Some(keys_scanned),
-            perf_ctx,
-        )
-    }
-
-    // Creates a RocksDB read option with specified lower and upper bounds.
-    /// Lower bound is inclusive, and upper bound is exclusive.
-    fn create_read_options_with_bounds(
-        &self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> ReadOptions
-    where
-        K: Serialize,
-    {
-        let mut readopts = self.opts.readopts();
-        if let Some(lower_bound) = lower_bound {
-            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
-            readopts.set_iterate_lower_bound(key_buf);
-        }
-        if let Some(upper_bound) = upper_bound {
-            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
-            readopts.set_iterate_upper_bound(key_buf);
-        }
-        readopts
-    }
-
-    /// Creates a safe reversed iterator with optional bounds.
-    /// Upper bound is included.
-    pub fn reversed_safe_iter_with_bounds(
-        &self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> Result<SafeRevIter<'_, K, V>, TypedStoreError>
-    where
-        K: Serialize + DeserializeOwned,
-        V: Serialize + DeserializeOwned,
-    {
-        let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
-        let readopts = self.create_read_options_with_range((
-            lower_bound
-                .as_ref()
-                .map(Bound::Included)
-                .unwrap_or(Bound::Unbounded),
-            upper_bound
-                .as_ref()
-                .map(Bound::Included)
-                .unwrap_or(Bound::Unbounded),
-        ));
-
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        let iter = SafeIter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        );
-        Ok(SafeRevIter::new(iter, upper_bound_key.transpose()?))
-    }
-
-    // Creates a RocksDB read option with lower and upper bounds set corresponding
-    // to `range`.
-    fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
-    where
-        K: Serialize,
-    {
-        let mut readopts = self.opts.readopts();
-
-        let lower_bound = range.start_bound();
-        let upper_bound = range.end_bound();
-
-        match lower_bound {
-            Bound::Included(lower_bound) => {
-                // Rocksdb lower bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-                readopts.set_iterate_lower_bound(key_buf);
-            }
-            Bound::Excluded(lower_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-
-                // Since we want exclusive, we need to increment the key to exclude the previous
-                big_endian_saturating_add_one(&mut key_buf);
-                readopts.set_iterate_lower_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        match upper_bound {
-            Bound::Included(upper_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-
-                // If the key is already at the limit, there's nowhere else to go, so no upper
-                // bound
-                if !is_max(&key_buf) {
-                    // Since we want exclusive, we need to increment the key to get the upper bound
-                    big_endian_saturating_add_one(&mut key_buf);
-                    readopts.set_iterate_upper_bound(key_buf);
-                }
-            }
-            Bound::Excluded(upper_bound) => {
-                // Rocksdb upper bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-                readopts.set_iterate_upper_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        readopts
-    }
-}
-
-/// Provides a mutable struct to form a collection of database write operations,
-/// and execute them.
-///
-/// Batching write and delete operations is faster than performing them one by
-/// one and ensures their atomicity,  ie. they are all written or none is.
-/// This is also true of operations across column families in the same database.
-///
-/// Serializations / Deserialization, and naming of column families is performed
-/// by passing a DBMap<K,V> with each operation.
-///
-/// ```
-/// use core::fmt::Error;
-/// use std::sync::Arc;
-///
-/// use prometheus::Registry;
-/// use tempfile::tempdir;
-/// use typed_store::{Map, metrics::DBMetrics, rocks::*};
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Error> {
-///     let rocks = open_cf(
-///         tempfile::tempdir().unwrap(),
-///         None,
-///         MetricConf::default(),
-///         &["First_CF", "Second_CF"],
-///     )
-///     .unwrap();
-///
-///     let db_cf_1 = DBMap::reopen(
-///         &rocks,
-///         Some("First_CF"),
-///         &ReadWriteOptions::default(),
-///         false,
-///     )
-///     .expect("Failed to open storage");
-///     let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
-///
-///     let db_cf_2 = DBMap::reopen(
-///         &rocks,
-///         Some("Second_CF"),
-///         &ReadWriteOptions::default(),
-///         false,
-///     )
-///     .expect("Failed to open storage");
-///     let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
-///
-///     let mut batch = db_cf_1.batch();
-///     batch
-///         .insert_batch(&db_cf_1, keys_vals_1.clone())
-///         .expect("Failed to batch insert")
-///         .insert_batch(&db_cf_2, keys_vals_2.clone())
-///         .expect("Failed to batch insert");
-///
-///     let _ = batch.write().expect("Failed to execute batch");
-///     for (k, v) in keys_vals_1 {
-///         let val = db_cf_1.get(&k).expect("Failed to get inserted key");
-///         assert_eq!(Some(v), val);
-///     }
-///
-///     for (k, v) in keys_vals_2 {
-///         let val = db_cf_2.get(&k).expect("Failed to get inserted key");
-///         assert_eq!(Some(v), val);
-///     }
-///     Ok(())
-/// }
-/// ```
-pub struct DBBatch {
-    rocksdb: Arc<RocksDB>,
-    batch: rocksdb::WriteBatch,
-    opts: WriteOptions,
-    db_metrics: Arc<DBMetrics>,
-    write_sample_interval: SamplingInterval,
-}
-
-impl DBBatch {
-    /// Create a new batch associated with a DB reference.
-    ///
-    /// Use `open_cf` to get the DB reference or an existing open database.
-    pub fn new(
-        dbref: &Arc<RocksDB>,
-        batch: rocksdb::WriteBatch,
-        opts: WriteOptions,
-        db_metrics: &Arc<DBMetrics>,
-        write_sample_interval: &SamplingInterval,
-    ) -> Self {
-        DBBatch {
-            rocksdb: dbref.clone(),
-            batch,
-            opts,
-            db_metrics: db_metrics.clone(),
-            write_sample_interval: write_sample_interval.clone(),
-        }
-    }
-
-    /// Consume the batch and write its operations to the database
-    #[instrument(level = "trace", skip_all, err)]
-    pub fn write(self) -> Result<(), TypedStoreError> {
-        let db_name = self.rocksdb.db_name();
-        let timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_batch_commit_latency_seconds
-            .with_label_values(&[&db_name])
-            .start_timer();
-        let batch_size = self.batch.size_in_bytes();
-
-        let perf_ctx = if self.write_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        self.rocksdb.write(self.batch, &self.opts)?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_batch_commit_bytes
-            .with_label_values(&[&db_name])
-            .observe(batch_size as f64);
-
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .write_perf_ctx_metrics
-                .report_metrics(&db_name);
-        }
-        let elapsed = timer.stop_and_record();
-        if elapsed > 1.0 {
-            warn!(?elapsed, ?db_name, "very slow batch write");
-            self.db_metrics
-                .op_metrics
-                .rocksdb_very_slow_batch_writes_count
-                .with_label_values(&[&db_name])
-                .inc();
-            self.db_metrics
-                .op_metrics
-                .rocksdb_very_slow_batch_writes_duration_ms
-                .with_label_values(&[&db_name])
-                .inc_by((elapsed * 1000.0) as u64);
-        }
-        Ok(())
-    }
-
-    pub fn size_in_bytes(&self) -> usize {
-        self.batch.size_in_bytes()
-    }
-}
-
-impl DBBatch {
-    pub fn delete_batch<J: Borrow<K>, K: Serialize, V>(
-        &mut self,
-        db: &DBMap<K, V>,
-        purged_vals: impl IntoIterator<Item = J>,
-    ) -> Result<(), TypedStoreError> {
-        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
-            return Err(TypedStoreError::CrossDBBatch);
-        }
-
-        purged_vals
-            .into_iter()
-            .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
-                let k_buf = be_fix_int_ser(k.borrow())?;
-                self.batch.delete_cf(&db.cf(), k_buf);
-
-                Ok(())
-            })?;
-        Ok(())
-    }
-
-    /// Deletes a range of keys between `from` (inclusive) and `to`
-    /// (non-inclusive) by writing a range delete tombstone in the db map
-    /// If the DBMap is configured with ignore_range_deletions set to false,
-    /// the effect of this write will be visible immediately i.e. you won't
-    /// see old values when you do a lookup or scan. But if it is configured
-    /// with ignore_range_deletions set to true, the old value are visible until
-    /// compaction actually deletes them which will happen sometime after. By
-    /// default ignore_range_deletions is set to true on a DBMap (unless it is
-    /// overridden in the config), so please use this function with caution
-    pub fn schedule_delete_range<K: Serialize, V>(
-        &mut self,
-        db: &DBMap<K, V>,
-        from: &K,
-        to: &K,
-    ) -> Result<(), TypedStoreError> {
-        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
-            return Err(TypedStoreError::CrossDBBatch);
-        }
-
-        let from_buf = be_fix_int_ser(from)?;
-        let to_buf = be_fix_int_ser(to)?;
-
-        self.batch.delete_range_cf(&db.cf(), from_buf, to_buf);
-        Ok(())
-    }
-
-    /// inserts a range of (key, value) pairs given as an iterator
-    pub fn insert_batch<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
-        &mut self,
-        db: &DBMap<K, V>,
-        new_vals: impl IntoIterator<Item = (J, U)>,
-    ) -> Result<&mut Self, TypedStoreError> {
-        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
-            return Err(TypedStoreError::CrossDBBatch);
-        }
-        let mut total = 0usize;
-        new_vals
-            .into_iter()
-            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
-                let k_buf = be_fix_int_ser(k.borrow())?;
-                let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
-                total += k_buf.len() + v_buf.len();
-                self.batch.put_cf(&db.cf(), k_buf, v_buf);
-                Ok(())
-            })?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_batch_put_bytes
-            .with_label_values(&[&db.cf])
-            .observe(total as f64);
-        Ok(self)
-    }
-}
-
-pub type RocksDBRawIter<'a> =
-    rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
-
-impl<'a, K, V> Map<'a, K, V> for DBMap<K, V>
-where
-    K: Serialize + DeserializeOwned,
-    V: Serialize + DeserializeOwned,
-{
-    type Error = TypedStoreError;
-    type SafeIterator = SafeIter<'a, K, V>;
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
-        let key_buf = be_fix_int_ser(key)?;
-        // [`rocksdb::DBWithThreadMode::key_may_exist_cf`] can have false positives,
-        // but no false negatives. We use it to short-circuit the absent case
-        let readopts = self.opts.readopts();
-        Ok(self
-            .rocksdb
-            .key_may_exist_cf(&self.cf(), &key_buf, &readopts)
-            && self
-                .rocksdb
-                .get_pinned_cf_opt(&self.cf(), &key_buf, &readopts)
-                .map_err(typed_store_err_from_rocks_err)?
-                .is_some())
-    }
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn multi_contains_keys<J>(
-        &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<bool>, Self::Error>
-    where
-        J: Borrow<K>,
-    {
-        let values = self.multi_get_pinned(keys)?;
-        Ok(values.into_iter().map(|v| v.is_some()).collect())
-    }
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
-        let _timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_get_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let perf_ctx = if self.get_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        let key_buf = be_fix_int_ser(key)?;
-        let res = self
-            .rocksdb
-            .get_pinned_cf_opt(&self.cf(), &key_buf, &self.opts.readopts())
-            .map_err(typed_store_err_from_rocks_err)?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_get_bytes
-            .with_label_values(&[&self.cf])
-            .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .read_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        match res {
-            Some(data) => Ok(Some(
-                bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
-            )),
-            None => Ok(None),
-        }
-    }
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
-        let timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_put_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let perf_ctx = if self.write_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        let key_buf = be_fix_int_ser(key)?;
-        let value_buf = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_put_bytes
-            .with_label_values(&[&self.cf])
-            .observe((key_buf.len() + value_buf.len()) as f64);
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .write_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        self.rocksdb
-            .put_cf(&self.cf(), &key_buf, &value_buf, &self.opts.writeopts())
-            .map_err(typed_store_err_from_rocks_err)?;
-
-        let elapsed = timer.stop_and_record();
-        if elapsed > 1.0 {
-            warn!(?elapsed, cf = ?self.cf, "very slow insert");
-            self.db_metrics
-                .op_metrics
-                .rocksdb_very_slow_puts_count
-                .with_label_values(&[&self.cf])
-                .inc();
-            self.db_metrics
-                .op_metrics
-                .rocksdb_very_slow_puts_duration_ms
-                .with_label_values(&[&self.cf])
-                .inc_by((elapsed * 1000.0) as u64);
-        }
-
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
-        let _timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_delete_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let perf_ctx = if self.write_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        let key_buf = be_fix_int_ser(key)?;
-        self.rocksdb
-            .delete_cf(&self.cf(), key_buf, &self.opts.writeopts())
-            .map_err(typed_store_err_from_rocks_err)?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_deletes
-            .with_label_values(&[&self.cf])
-            .inc();
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .write_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        Ok(())
-    }
-
-    /// This method first drops the existing column family and then creates a
-    /// new one with the same name. The two operations are not atomic and
-    /// hence it is possible to get into a race condition where the column
-    /// family has been dropped but new one is not created yet
-    #[instrument(level = "trace", skip_all, err)]
-    fn unsafe_clear(&self) -> Result<(), TypedStoreError> {
-        let _ = self.rocksdb.drop_cf(&self.cf);
-        self.rocksdb
-            .create_cf(self.cf.clone(), &default_db_options().options)
-            .map_err(typed_store_err_from_rocks_err)?;
-        Ok(())
-    }
-
-    /// Writes a range delete tombstone to delete all entries in the db map
-    /// If the DBMap is configured with ignore_range_deletions set to false,
-    /// the effect of this write will be visible immediately i.e. you won't
-    /// see old values when you do a lookup or scan. But if it is configured
-    /// with ignore_range_deletions set to true, the old value are visible until
-    /// compaction actually deletes them which will happen sometime after. By
-    /// default ignore_range_deletions is set to true on a DBMap (unless it is
-    /// overridden in the config), so please use this function with caution
-    #[instrument(level = "trace", skip_all, err)]
-    fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
-        let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);
-        let last_key = self
-            .reversed_safe_iter_with_bounds(None, None)?
-            .next()
-            .transpose()?
-            .map(|(k, _v)| k);
-        if let Some((first_key, last_key)) = first_key.zip(last_key) {
-            let mut batch = self.batch();
-            batch.schedule_delete_range(self, &first_key, &last_key)?;
-            batch.write()?;
-        }
-        Ok(())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.safe_iter().next().is_none()
-    }
-
-    fn safe_iter(&'a self) -> Self::SafeIterator {
-        let db_iter = self
-            .rocksdb
-            .raw_iterator_cf(&self.cf(), self.opts.readopts());
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
-    }
-
-    fn safe_iter_with_bounds(
-        &'a self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> Self::SafeIterator {
-        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
-    }
-
-    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
-        let readopts = self.create_read_options_with_range(range);
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
-    }
-
-    /// Returns a vector of values corresponding to the keys provided.
-    #[instrument(level = "trace", skip_all, err)]
-    fn multi_get<J>(
-        &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<Option<V>>, TypedStoreError>
-    where
-        J: Borrow<K>,
-    {
-        let results = self.multi_get_pinned(keys)?;
-        let values_parsed: Result<Vec<_>, TypedStoreError> = results
-            .into_iter()
-            .map(|value_byte| match value_byte {
-                Some(data) => Ok(Some(
-                    bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
-                )),
-                None => Ok(None),
-            })
-            .collect();
-
-        values_parsed
-    }
-
-    /// Convenience method for batch insertion
-    #[instrument(level = "trace", skip_all, err)]
-    fn multi_insert<J, U>(
-        &self,
-        key_val_pairs: impl IntoIterator<Item = (J, U)>,
-    ) -> Result<(), Self::Error>
-    where
-        J: Borrow<K>,
-        U: Borrow<V>,
-    {
-        let mut batch = self.batch();
-        batch.insert_batch(self, key_val_pairs)?;
-        batch.write()
-    }
-
-    /// Convenience method for batch removal
-    #[instrument(level = "trace", skip_all, err)]
-    fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
-    where
-        J: Borrow<K>,
-    {
-        let mut batch = self.batch();
-        batch.delete_batch(self, keys)?;
-        batch.write()
-    }
-
-    /// Try to catch up with primary when running as secondary
-    #[instrument(level = "trace", skip_all, err)]
-    fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
-        self.rocksdb
-            .try_catch_up_with_primary()
-            .map_err(typed_store_err_from_rocks_err)
-    }
-}
-
 pub fn read_size_from_env(var_name: &str) -> Option<usize> {
     env::var(var_name)
         .ok()?
@@ -1669,40 +178,6 @@ pub fn read_size_from_env(var_name: &str) -> Option<usize> {
         .ok()
 }
 
-#[derive(Clone, Debug)]
-pub struct ReadWriteOptions {
-    pub ignore_range_deletions: bool,
-    // Whether to sync to disk on every write.
-    sync_to_disk: bool,
-}
-
-impl ReadWriteOptions {
-    pub fn readopts(&self) -> ReadOptions {
-        let mut readopts = ReadOptions::default();
-        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
-        readopts
-    }
-
-    pub fn writeopts(&self) -> WriteOptions {
-        let mut opts = WriteOptions::default();
-        opts.set_sync(self.sync_to_disk);
-        opts
-    }
-
-    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
-        self.ignore_range_deletions = ignore;
-        self
-    }
-}
-
-impl Default for ReadWriteOptions {
-    fn default() -> Self {
-        Self {
-            ignore_range_deletions: true,
-            sync_to_disk: std::env::var("IOTA_DB_SYNC_TO_DISK").is_ok_and(|v| v != "0"),
-        }
-    }
-}
 // TODO: refactor this into a builder pattern, where rocksdb::Options are
 // generated after a call to build().
 #[derive(Default, Clone)]
@@ -1981,7 +456,7 @@ pub fn open_cf<P: AsRef<Path>>(
     db_options: Option<rocksdb::Options>,
     metric_conf: MetricConf,
     opt_cfs: &[&str],
-) -> Result<Arc<RocksDB>, TypedStoreError> {
+) -> Result<Arc<Database>, TypedStoreError> {
     let options = db_options.unwrap_or_else(|| default_db_options().options);
     let column_descriptors: Vec<_> = opt_cfs
         .iter()
@@ -2005,13 +480,13 @@ fn prepare_db_options(db_options: Option<rocksdb::Options>) -> rocksdb::Options 
 
 /// Opens a database with options, and a number of column families with
 /// individual options that are created if they do not exist.
-#[instrument(level="debug", skip_all, fields(path = ?path.as_ref()), err)]
+#[tracing::instrument(level="debug", skip_all, fields(path = ?path.as_ref()), err)]
 pub fn open_cf_opts<P: AsRef<Path>>(
     path: P,
     db_options: Option<rocksdb::Options>,
     metric_conf: MetricConf,
     opt_cfs: &[(&str, rocksdb::Options)],
-) -> Result<Arc<RocksDB>, TypedStoreError> {
+) -> Result<Arc<Database>, TypedStoreError> {
     let path = path.as_ref();
     // In the simulator, we intercept the wall clock in the test thread only. This
     // causes problems because rocksdb uses the simulated clock when creating
@@ -2034,10 +509,11 @@ pub fn open_cf_opts<P: AsRef<Path>>(
             )
             .map_err(typed_store_err_from_rocks_err)?
         };
-        Ok(Arc::new(RocksDB::new(
-            rocksdb,
+        Ok(Arc::new(Database::new(
+            Storage::Rocks(RocksDB {
+                underlying: rocksdb,
+            }),
             metric_conf,
-            PathBuf::from(path),
         )))
     })
 }
@@ -2050,7 +526,7 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
     db_options: Option<rocksdb::Options>,
     metric_conf: MetricConf,
     opt_cfs: &[(&str, rocksdb::Options)],
-) -> Result<Arc<RocksDB>, TypedStoreError> {
+) -> Result<Arc<Database>, TypedStoreError> {
     let primary_path = primary_path.as_ref();
     let secondary_path = secondary_path.as_ref().map(|p| p.as_ref());
     // See comment above for explanation of why nondeterministic is necessary here.
@@ -2099,7 +575,12 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
                 .map_err(typed_store_err_from_rocks_err)?;
             db
         };
-        Ok(Arc::new(RocksDB::new(rocksdb, metric_conf, secondary_path)))
+        Ok(Arc::new(Database::new(
+            Storage::Rocks(RocksDB {
+                underlying: rocksdb,
+            }),
+            metric_conf,
+        )))
     })
 }
 
@@ -2123,7 +604,9 @@ pub fn list_tables(path: std::path::PathBuf) -> eyre::Result<Vec<String>> {
         })
 }
 
-/// TODO: Good description of why we're doing this : RocksDB stores keys in BE and has a seek operator on iterators, see `https://github.com/facebook/rocksdb/wiki/Iterator#introduction`
+/// Serializes keys using big-endian byte order with fixed-int encoding.
+/// RocksDB stores keys in big-endian and uses a byte-wise seek operator on
+/// iterators, see `https://github.com/facebook/rocksdb/wiki/Iterator#introduction`
 #[inline]
 pub fn be_fix_int_ser<S>(t: &S) -> Result<Vec<u8>, TypedStoreError>
 where
@@ -2194,55 +677,248 @@ fn populate_missing_cfs(
     Ok(cfs)
 }
 
-/// Given a `vec<u8>`, find the value which is one more than the vector
-/// if the vector was a big endian number.
-/// If the vector is already minimum, don't change it.
-fn big_endian_saturating_add_one(v: &mut [u8]) {
-    if is_max(v) {
-        return;
-    }
-    for i in (0..v.len()).rev() {
-        if v[i] == u8::MAX {
-            v[i] = 0;
-        } else {
-            v[i] += 1;
-            break;
+/// RocksDB-specific methods on `DBMap`. These are kept separate from the
+/// generic impl in `database.rs` because they directly access RocksDB
+/// internals and have no meaning for other storage backends.
+impl<K, V> DBMap<K, V> {
+    fn get_rocksdb_int_property(
+        rocksdb: &RocksDB,
+        cf: &impl AsColumnFamilyRef,
+        property_name: &CStr,
+    ) -> Result<i64, TypedStoreError> {
+        match rocksdb.underlying.property_int_value_cf(cf, property_name) {
+            Ok(Some(value)) => Ok(value.min(i64::MAX as u64).try_into().unwrap_or_default()),
+            Ok(None) => Ok(0),
+            Err(e) => Err(TypedStoreError::RocksDB(e.into_string())),
         }
     }
-}
 
-/// Check if all the bytes in the vector are 0xFF
-fn is_max(v: &[u8]) -> bool {
-    v.iter().all(|&x| x == u8::MAX)
-}
+    pub(crate) fn report_rocksdb_metrics(
+        database: &Arc<Database>,
+        cf_name: &str,
+        db_metrics: &Arc<DBMetrics>,
+    ) {
+        let Storage::Rocks(rocksdb) = &database.storage else {
+            return;
+        };
 
-// `clippy::manual_div_ceil` is raised by code expanded by the
-// `uint::construct_uint!` macro so it needs to be fixed by `uint`
-#[expect(clippy::assign_op_pattern, clippy::manual_div_ceil)]
-#[test]
-fn test_helpers() {
-    let v = vec![];
-    assert!(is_max(&v));
+        let Some(cf) = rocksdb.underlying.cf_handle(cf_name) else {
+            warn!(
+                "unable to report metrics for cf {cf_name:?} in db {:?}",
+                database.db_name()
+            );
+            return;
+        };
 
-    fn check_add(v: Vec<u8>) {
-        let mut v = v;
-        let num = Num32::from_big_endian(&v);
-        big_endian_saturating_add_one(&mut v);
-        assert!(num + 1 == Num32::from_big_endian(&v));
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_sst_files_size
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::TOTAL_SST_FILES_SIZE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_blob_files_size
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(
+                    rocksdb,
+                    &cf,
+                    ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE,
+                )
+                .unwrap_or(METRICS_ERROR),
+            );
+        // 7 is the default number of levels in RocksDB. If we ever change the number of
+        // levels using `set_num_levels`, we need to update here as well. Note
+        // that there isn't an API to query the DB to get the number of levels (yet).
+        let total_num_files: i64 = (0..=6)
+            .map(|level| {
+                Self::get_rocksdb_int_property(rocksdb, &cf, &num_files_at_level(level))
+                    .unwrap_or(METRICS_ERROR)
+            })
+            .sum();
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_num_files
+            .with_label_values(&[cf_name])
+            .set(total_num_files);
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_level0_files
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, &num_files_at_level(0))
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_current_size_active_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::CUR_SIZE_ACTIVE_MEM_TABLE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_size_all_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::SIZE_ALL_MEM_TABLES)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_snapshots
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::NUM_SNAPSHOTS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_oldest_snapshot_time
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::OLDEST_SNAPSHOT_TIME)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_actual_delayed_write_rate
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::ACTUAL_DELAYED_WRITE_RATE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_is_write_stopped
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::IS_WRITE_STOPPED)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_capacity
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BLOCK_CACHE_CAPACITY)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_usage
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BLOCK_CACHE_USAGE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_pinned_usage
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BLOCK_CACHE_PINNED_USAGE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_table_readers_mem
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(
+                    rocksdb,
+                    &cf,
+                    properties::ESTIMATE_TABLE_READERS_MEM,
+                )
+                .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimated_num_keys
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::ESTIMATE_NUM_KEYS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_immutable_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::NUM_IMMUTABLE_MEM_TABLE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_mem_table_flush_pending
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::MEM_TABLE_FLUSH_PENDING)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_compaction_pending
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::COMPACTION_PENDING)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_pending_compaction_bytes
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(
+                    rocksdb,
+                    &cf,
+                    properties::ESTIMATE_PENDING_COMPACTION_BYTES,
+                )
+                .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_running_compactions
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::NUM_RUNNING_COMPACTIONS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_running_flushes
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::NUM_RUNNING_FLUSHES)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_oldest_key_time
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::ESTIMATE_OLDEST_KEY_TIME)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_background_errors
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BACKGROUND_ERRORS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_base_level
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BASE_LEVEL)
+                    .unwrap_or(METRICS_ERROR),
+            );
     }
-
-    uint::construct_uint! {
-        // 32 byte number
-        struct Num32(4);
-    }
-
-    let mut v = vec![255; 32];
-    big_endian_saturating_add_one(&mut v);
-    assert!(Num32::MAX == Num32::from_big_endian(&v));
-
-    check_add(vec![1; 32]);
-    check_add(vec![6; 32]);
-    check_add(vec![254; 32]);
-
-    // TBD: More tests coming with randomized arrays
 }

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -8,14 +8,17 @@ use bincode::Options;
 use prometheus::{Histogram, HistogramTimer};
 use rocksdb::Direction;
 use serde::de::DeserializeOwned;
+use typed_store_error::TypedStoreError;
 
-use super::{RocksDBRawIter, TypedStoreError};
-use crate::metrics::{DBMetrics, RocksDBPerfContext};
+use crate::{
+    database::RawIter,
+    metrics::{DBMetrics, RocksDBPerfContext},
+};
 
 /// An iterator over all key-value pairs in a data map.
 pub struct SafeIter<'a, K, V> {
     cf_name: String,
-    db_iter: RocksDBRawIter<'a>,
+    db_iter: RawIter<'a>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
     is_initialized: bool,
@@ -29,9 +32,9 @@ pub struct SafeIter<'a, K, V> {
 }
 
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
-    pub(super) fn new(
+    pub(crate) fn new(
         cf_name: String,
-        db_iter: RocksDBRawIter<'a>,
+        db_iter: RawIter<'a>,
         _timer: Option<HistogramTimer>,
         _perf_ctx: Option<RocksDBPerfContext>,
         bytes_scanned: Option<Histogram>,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -2,12 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::RangeBounds;
+
 use rstest::rstest;
+use serde::{Serialize, de::DeserializeOwned};
 
 use super::*;
 use crate::{
     reopen,
     rocks::safe_iter::{SafeIter, SafeRevIter},
+    traits::Map,
 };
 
 fn temp_dir() -> std::path::PathBuf {
@@ -90,7 +94,7 @@ async fn test_reopen() {
             .expect("Failed to insert");
         db
     };
-    let db = DBMap::<u32, String>::reopen(&arc.rocksdb, None, &ReadWriteOptions::default(), false)
+    let db = DBMap::<u32, String>::reopen(&arc.db, None, &ReadWriteOptions::default(), false)
         .expect("Failed to re-open storage");
     assert!(
         db.contains_key(&123456789)
@@ -116,18 +120,11 @@ async fn test_reopen_macro() {
     let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
     let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
 
-    assert_eq!(db_map_1.cf, FIRST_CF);
-    assert_eq!(db_map_2.cf, SECOND_CF);
+    assert_eq!(db_map_1.cf_name(), FIRST_CF);
+    assert_eq!(db_map_2.cf_name(), SECOND_CF);
 
     assert!(db_map_1.multi_insert(keys_vals_cf1).is_ok());
     assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
-}
-
-#[tokio::test]
-async fn test_wrong_reopen() {
-    let rocks = open_rocksdb(temp_dir(), &["foo", "bar", "baz"]);
-    let db = DBMap::<u8, u8>::reopen(&rocks, Some("quux"), &ReadWriteOptions::default(), false);
-    assert!(db.is_err());
 }
 
 #[tokio::test]
@@ -395,14 +392,7 @@ async fn test_insert_batch_across_different_db() {
 
 #[tokio::test]
 async fn test_delete_batch() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        None,
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db = open_map::<_, u32, String>(temp_dir(), None);
 
     let keys_vals = (1..100).map(|i| (i, i.to_string()));
     let mut batch = db.batch();
@@ -425,14 +415,14 @@ async fn test_delete_batch() {
 
 #[tokio::test]
 async fn test_delete_range() {
-    let db: DBMap<i32, String> = DBMap::open(
-        temp_dir(),
-        MetricConf::default(),
+    let options = ReadWriteOptions::default().set_ignore_range_deletions(false);
+    let db: DBMap<i32, String> = DBMap::reopen(
+        &open_rocksdb(temp_dir(), &[rocksdb::DEFAULT_COLUMN_FAMILY_NAME]),
         None,
-        None,
-        &ReadWriteOptions::default().set_ignore_range_deletions(false),
+        &options,
+        false,
     )
-    .expect("Failed to open storage");
+    .unwrap();
 
     // Note that the last element is (100, "100".to_owned()) here
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
@@ -460,14 +450,7 @@ async fn test_delete_range() {
 
 #[tokio::test]
 async fn test_clear() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        Some("table"),
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
     // Test clear of empty map
     let _ = db.unsafe_clear();
 
@@ -599,14 +582,7 @@ async fn test_range_iter() {
 
 #[tokio::test]
 async fn test_is_empty() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        Some("table"),
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
 
     // Test empty map is truly empty
     assert!(db.is_empty());
@@ -658,7 +634,7 @@ async fn test_checkpoint() {
     db.multi_insert(keys_vals.clone())
         .expect("Failed to multi-insert");
     let checkpointed_path = path_prefix.join("checkpointed_db");
-    db.rocksdb
+    db.db
         .checkpoint(&checkpointed_path)
         .expect("Failed to create db checkpoint");
     // Create more kv pairs
@@ -719,14 +695,7 @@ async fn open_as_secondary_test() {
     let primary_path = temp_dir();
 
     // Init a DB
-    let primary_db = DBMap::<i32, String>::open(
-        primary_path.clone(),
-        MetricConf::default(),
-        None,
-        Some("table"),
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let primary_db: DBMap<i32, String> = open_map(primary_path.clone(), Some("table"));
     // Create kv pairs
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
 
@@ -736,11 +705,11 @@ async fn open_as_secondary_test() {
 
     let opt = rocksdb::Options::default();
     let secondary_store = open_cf_opts_secondary(
-        primary_path,
+        primary_path.clone(),
         None,
         None,
         MetricConf::default(),
-        &[("table", opt)],
+        &[("table", opt.clone())],
     )
     .unwrap();
     let secondary_db = DBMap::<i32, String>::reopen(
@@ -771,16 +740,16 @@ async fn open_as_secondary_test() {
 }
 
 fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> {
-    DBMap::<K, V>::open(
-        path,
-        MetricConf::default(),
-        None,
+    let cf_key = opt_cf.unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME);
+    DBMap::<K, V>::reopen(
+        &open_rocksdb(path, &[cf_key]),
         opt_cf,
         &ReadWriteOptions::default(),
+        false,
     )
     .expect("failed to open rocksdb")
 }
 
-fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<RocksDB> {
+fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<Database> {
     open_cf(path, None, MetricConf::default(), opt_cfs).expect("failed to open rocksdb")
 }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -144,6 +144,16 @@ async fn test_contains_key() {
 }
 
 #[tokio::test]
+async fn test_safe_drop_db() {
+    let path = temp_dir();
+    {
+        let db: DBMap<i32, String> = open_map(path.clone(), Some("table"));
+        db.insert(&777, &"123".to_string()).unwrap();
+    }
+    assert!(safe_drop_db(path, Duration::from_secs(5)).await.is_ok());
+}
+
+#[tokio::test]
 async fn test_multi_contain() {
     let db = open_map(temp_dir(), None);
 

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -322,7 +322,7 @@ struct TablesWithMigration {
 }
 
 fn migrate_old_to_new(
-    db: &std::sync::Arc<typed_store::rocks::RocksDB>,
+    db: &std::sync::Arc<typed_store::database::Database>,
 ) -> Result<(), typed_store::TypedStoreError> {
     use typed_store::traits::Map;
     let old = typed_store::rocks::DBMap::<String, String>::reopen(

--- a/scripts/update_all_snapshots.sh
+++ b/scripts/update_all_snapshots.sh
@@ -12,10 +12,10 @@ SCRIPT_PATH=$(realpath "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 ROOT="$SCRIPT_DIR/.."
 
+UPDATE=1 cargo test -p iota-framework --test build-system-packages
 cd "$ROOT/crates/iota-protocol-config" && cargo insta test --review
 cd "$ROOT/crates/iota-cost" && cargo insta test --review
 cd "$ROOT/crates/iota-swarm-config" && cargo insta test --review
 cd "$ROOT/crates/iota-open-rpc" && cargo run --example generate-json-rpc-spec -- record
 cd "$ROOT/crates/iota-core" && cargo -q run --example generate-format -- print > tests/staged/iota.yaml
-UPDATE=1 cargo test -p iota-framework --test build-system-packages
 UPDATE=1 cargo test -p iota-rest-api


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.46.3, v1.47.1)
- Port commit:
  - [MystenLabs/sui@0316d](https://github.com/MystenLabs/sui/commit/0316d747db35c796c5b3de099dfcedcafb0bb87d)
- Description:

Introduce the ability to serve rpc traffic over https by providing a TLS
cert and private key via config.

The relevant section of the node yaml config:

```
json-rpc-https-address: 0.0.0.0:9443 # This is the default if not provided
json-rpc-tls:
  cert: /path/to/cert.pem
  key: /path/to/key.pem
```

## Links to any relevant issues

Part of #10609

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes