### PR TITLE
feat(gRPC): add gRPC-Web support for browser clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6746,11 +6746,13 @@ dependencies = [
  "prometheus",
  "prost 0.14.1",
  "prost-types 0.14.1",
+ "reqwest",
  "serde",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.18",
  "tonic 0.14.2",
+ "tonic-web",
  "tower 0.4.13",
  "tracing",
 ]
@@ -15423,6 +15425,24 @@ dependencies = [
  "tokio-stream",
  "tonic 0.14.2",
  "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29453d84de05f4f1b573db22e6f9f6c95c189a6089a440c9a098aa9dea009299"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project",
+ "tokio-stream",
+ "tonic 0.14.2",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -382,6 +382,7 @@ tonic-build = "0.14"
 tonic-health = "0.14"
 tonic-prost = "0.14"
 tonic-rustls = "0.3.0"
+tonic-web = "0.14"
 tower = { version = "0.4.12", features = ["util", "timeout", "load-shed", "limit"] }
 tower-http = { version = "0.5", features = ["cors", "timeout", "trace", "set-header", "propagate-header"] }
 tracing = "0.1.44"

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -41,6 +41,9 @@ iota-types.workspace = true
 move-core-types.workspace = true
 
 [dev-dependencies]
+# external dependencies
+reqwest.workspace = true
+
+# internal dependencies
 iota-grpc-client.workspace = true
 iota-test-transaction-builder.workspace = true
-reqwest.workspace = true

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
 tonic = { workspace = true, features = ["tls-ring"] }
+tonic-web.workspace = true
 tower.workspace = true
 tracing.workspace = true
 
@@ -42,3 +43,4 @@ move-core-types.workspace = true
 [dev-dependencies]
 iota-grpc-client.workspace = true
 iota-test-transaction-builder.workspace = true
+reqwest.workspace = true

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -152,7 +152,7 @@ pub async fn start_grpc_server(
     // Build the server builder with TLS and optional metrics layer.
     // Server::layer() changes the builder's generic type parameter, so we use
     // a macro to avoid duplicating the service registration and spawn logic.
-    let mut server_builder = Server::builder();
+    let mut server_builder = Server::builder().accept_http1(true);
 
     // Configure TLS if enabled
     if let Some(tls_config) = config.tls_config() {
@@ -177,9 +177,14 @@ pub async fn start_grpc_server(
             .map_err(|e| anyhow::anyhow!("failed to configure TLS: {}", e))?;
     }
 
-    // Add services and spawn the server, optionally wrapping with metrics layer
+    // Add services and spawn the server, optionally wrapping with metrics layer.
+    // The GrpcWebLayer enables gRPC-Web support (HTTP/1.1-based gRPC for
+    // browser clients). It must be applied as an outer layer so it can
+    // translate between gRPC-Web and native gRPC framing.
     let server_handle = if let Some(metrics) = metrics {
-        let mut layered_builder = server_builder.layer(GrpcMetricsLayer::new(Arc::new(metrics)));
+        let mut layered_builder = server_builder
+            .layer(tonic_web::GrpcWebLayer::new())
+            .layer(GrpcMetricsLayer::new(Arc::new(metrics)));
         build_and_spawn!(
             layered_builder,
             ledger_service,
@@ -190,8 +195,9 @@ pub async fn start_grpc_server(
             shutdown_token
         )
     } else {
+        let mut layered_builder = server_builder.layer(tonic_web::GrpcWebLayer::new());
         build_and_spawn!(
-            server_builder,
+            layered_builder,
             ledger_service,
             tx_service,
             config,

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -1138,3 +1138,65 @@ async fn test_filter_checkpoints_streaming() {
         .await
         .expect("Failed to shutdown server");
 }
+
+/// Verify the gRPC server accepts gRPC-Web requests over HTTP/1.1.
+///
+/// Sends a raw HTTP/1.1 POST with `content-type: application/grpc-web` to a
+/// registered gRPC method. The `GrpcWebLayer` translates this into a native
+/// gRPC call. We assert the server responds with HTTP 200 and a grpc-web
+/// content-type (the actual gRPC status is in trailers).
+#[tokio::test]
+async fn test_grpc_web_request_accepted() {
+    let (server_handle, _client, _) = test_server_and_client_setup(0..=0, |_| {}, None, None).await;
+    let addr = server_handle.address();
+
+    // Minimal gRPC-Web frame: 1-byte compression flag + 4-byte big-endian
+    // length + protobuf payload.  An empty payload is a valid
+    // GetCheckpointRequest (all fields default).
+    let mut body = Vec::new();
+    body.push(0u8); // no compression
+    body.extend_from_slice(&0u32.to_be_bytes()); // zero-length message
+
+    let http_client = reqwest::Client::builder()
+        .http1_only()
+        .build()
+        .expect("failed to build reqwest client");
+
+    let resp = http_client
+        .post(format!(
+            "http://{addr}/iota.ledger.v0.LedgerService/GetCheckpoint"
+        ))
+        .header("content-type", "application/grpc-web")
+        .header("x-grpc-web", "1")
+        .body(body)
+        .send()
+        .await
+        .expect("HTTP request failed");
+
+    // The layer should accept the request (HTTP 200) with a grpc-web
+    // content-type. The gRPC application status may be an error (e.g.
+    // NotFound) carried in trailers — what matters is the layer didn't
+    // reject the request outright (415 / 404).
+    assert_eq!(
+        resp.status(),
+        200,
+        "expected HTTP 200 from gRPC-Web layer, got {}",
+        resp.status()
+    );
+
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .expect("missing content-type")
+        .to_str()
+        .unwrap();
+    assert!(
+        ct.contains("grpc-web"),
+        "expected grpc-web content-type, got {ct}"
+    );
+
+    server_handle
+        .shutdown()
+        .await
+        .expect("Failed to shutdown server");
+}


### PR DESCRIPTION
# Description of change

Enables gRPC-Web support on the gRPC server so browser-based clients can
communicate over HTTP/1.1 using the `application/grpc-web` content type.

Ported https://github.com/MystenLabs/sui/commit/8c91fcd8b3905aae4136d929e0cc62e1adfb4704 and added a test.

## Links to any relevant issues

None

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes