### PR TITLE
upstream: Porting core-protocol related upstream changes in range mainnet-1.46.3 to mainnet-1.47.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6779,6 +6779,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "iota-tls",
  "pin-project-lite",
  "reqwest",
  "socket2 0.5.7",

--- a/crates/iota-analytics-indexer/src/package_store.rs
+++ b/crates/iota-analytics-indexer/src/package_store.rs
@@ -15,7 +15,6 @@ use thiserror::Error;
 use typed_store::{
     DBMapUtils, Map, TypedStoreError,
     rocks::{DBMap, MetricConf},
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 const STORE: &str = "RocksDB";

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2012,12 +2012,16 @@ impl AuthorityState {
                 suggested_gas_price: self
                     .congestion_tracker
                     .get_prediction_suggested_gas_price(&transaction),
-                input: IotaTransactionBlockData::try_from(transaction, &module_cache, tx_digest)
-                    .map_err(|e| IotaError::TransactionSerialization {
-                        error: format!(
-                            "Failed to convert transaction to IotaTransactionBlockData: {e}",
-                        ),
-                    })?, // TODO: replace the underlying try_from to IotaError. This one goes deep
+                input: IotaTransactionBlockData::try_from_with_module_cache(
+                    transaction,
+                    &module_cache,
+                    tx_digest,
+                )
+                .map_err(|e| IotaError::TransactionSerialization {
+                    error: format!(
+                        "Failed to convert transaction to IotaTransactionBlockData: {e}",
+                    ),
+                })?, // TODO: replace the underlying try_from to IotaError. This one goes deep
                 effects: effects.clone().try_into()?,
                 events: IotaTransactionBlockEvents::try_from(
                     inner_temp_store.events.clone(),

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1929,8 +1929,7 @@ impl AuthorityPerEpochStore {
         let assigned_versions = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
-            certificates,
-            None,
+            certificates.iter(),
             &BTreeMap::new(),
         )?
         .assigned_versions;
@@ -2686,9 +2685,11 @@ impl AuthorityPerEpochStore {
             .expect("push_consensus_output should not fail");
     }
 
-    fn finish_consensus_certificate_process(&self, certificates: &[VerifiedExecutableTransaction]) {
+    fn process_user_signatures<'a>(
+        &self,
+        certificates: impl Iterator<Item = &'a VerifiedExecutableTransaction>,
+    ) {
         let sigs: Vec<_> = certificates
-            .iter()
             .map(|certificate| (*certificate.digest(), certificate.tx_signatures().to_vec()))
             .collect();
 
@@ -2697,7 +2698,7 @@ impl AuthorityPerEpochStore {
             .user_signatures_for_checkpoints
             .lock();
 
-        user_sigs.reserve(certificates.len());
+        user_sigs.reserve(sigs.len());
         for (digest, sigs) in sigs {
             // User signatures are written in the same batch as consensus certificate
             // processed flag, which means we won't attempt to insert this twice
@@ -3156,14 +3157,12 @@ impl AuthorityPerEpochStore {
             congestion_control_parameters,
         );
 
-        let consensus_transactions: Vec<_> = system_transactions
-            .into_iter()
-            .chain(sequenced_transactions)
-            .chain(sequenced_randomness_transactions)
-            .collect();
+        system_transactions.extend(sequenced_transactions);
+        let sequenced_non_randomness_transactions = system_transactions;
 
         let (
-            verified_transactions,
+            verified_non_randomness_transactions,
+            mut verified_randomness_transactions,
             notifications,
             lock,
             final_round,
@@ -3171,7 +3170,8 @@ impl AuthorityPerEpochStore {
         ) = self
             .process_consensus_transactions(
                 &mut output,
-                &consensus_transactions,
+                &sequenced_non_randomness_transactions,
+                &sequenced_randomness_transactions,
                 &end_of_publish_transactions,
                 checkpoint_service,
                 cache_reader,
@@ -3187,10 +3187,12 @@ impl AuthorityPerEpochStore {
                 shared_object_using_randomness_congestion_tracker,
             )
             .await?;
-        self.finish_consensus_certificate_process(&verified_transactions);
+        self.process_user_signatures(
+            verified_non_randomness_transactions
+                .iter()
+                .chain(verified_randomness_transactions.iter()),
+        );
         output.record_consensus_commit_stats(consensus_stats.clone());
-
-        let mut verified_transactions = verified_transactions;
 
         // Create pending checkpoints if we are still accepting tx.
         let should_accept_tx = if let Some(lock) = &lock {
@@ -3205,15 +3207,16 @@ impl AuthorityPerEpochStore {
         };
         let make_checkpoint = should_accept_tx || final_round;
         if make_checkpoint {
-            let checkpoint_height = consensus_commit_info.round * 2;
+            let checkpoint_height =
+                self.calculate_pending_checkpoint_height(consensus_commit_info.round);
 
-            let mut checkpoint_roots: Vec<TransactionKey> = Vec::with_capacity(roots.len() + 1);
+            let mut non_randomness_roots: Vec<TransactionKey> = Vec::with_capacity(roots.len() + 1);
 
             if let Some(consensus_commit_prologue_root) = consensus_commit_prologue_root {
                 // Put consensus commit prologue root at the beginning of the checkpoint roots.
-                checkpoint_roots.push(consensus_commit_prologue_root);
+                non_randomness_roots.push(consensus_commit_prologue_root);
             }
-            checkpoint_roots.extend(roots.into_iter());
+            non_randomness_roots.extend(roots.into_iter());
 
             if let Some(randomness_round) = randomness_round {
                 let key = TransactionKey::RandomnessRound(self.epoch(), randomness_round);
@@ -3229,7 +3232,7 @@ impl AuthorityPerEpochStore {
                         );
                         let tx =
                             VerifiedExecutableTransaction::new_system((*tx).clone(), self.epoch());
-                        verified_transactions.push(tx);
+                        verified_randomness_transactions.push(tx);
                     }
                 }
 
@@ -3246,7 +3249,7 @@ impl AuthorityPerEpochStore {
                 randomness_round.is_some() || (dkg_failed && !randomness_roots.is_empty());
 
             let pending_checkpoint = PendingCheckpoint::V1(PendingCheckpointContentsV1 {
-                roots: checkpoint_roots,
+                roots: non_randomness_roots,
                 details: PendingCheckpointInfo {
                     timestamp_ms: consensus_commit_info.timestamp,
                     last_of_epoch: final_round && !should_write_random_checkpoint,
@@ -3325,7 +3328,15 @@ impl AuthorityPerEpochStore {
             self.record_end_of_message_quorum_time_metric();
         }
 
-        Ok(verified_transactions)
+        Ok([
+            verified_non_randomness_transactions,
+            verified_randomness_transactions,
+        ]
+        .concat())
+    }
+
+    fn calculate_pending_checkpoint_height(&self, consensus_round: u64) -> u64 {
+        consensus_round * 2
     }
 
     // Adds the consensus commit prologue transaction to the beginning of input
@@ -3407,19 +3418,43 @@ impl AuthorityPerEpochStore {
     fn process_consensus_transaction_shared_object_versions(
         &self,
         cache_reader: &dyn ObjectCacheRead,
-        transactions: &[VerifiedExecutableTransaction],
+        non_randomness_transactions: &[VerifiedExecutableTransaction],
+        randomness_transactions: &[VerifiedExecutableTransaction],
         randomness_round: Option<RandomnessRound>,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
         output: &mut ConsensusCommitOutput,
     ) -> IotaResult {
+        // If randomness_round is set, we know that eventually there will be a
+        // randomness state update transaction. We create a placeholder
+        // transaction so that the SharedObjVerManager can update the version of
+        // the randomness state object and use that version for randomness transactions.
+        let randomness_state_update = randomness_round.map(|round| {
+            VerifiedExecutableTransaction::new_system(
+                VerifiedTransaction::new_randomness_state_update(
+                    self.epoch(),
+                    round,
+                    // This is placeholder bytes, since this transaction does not exist yet.
+                    vec![],
+                    self.epoch_start_config()
+                        .randomness_obj_initial_shared_version(),
+                ),
+                self.epoch(),
+            )
+        });
+        let all_certs = non_randomness_transactions
+            .iter()
+            // randomness_state_update must be before randomness_transactions to make sure the
+            // version of the randomness state object is updated before it is used in
+            // randomness transactions.
+            .chain(randomness_state_update.iter())
+            .chain(randomness_transactions.iter());
         let ConsensusSharedObjVerAssignment {
             shared_input_next_versions,
             assigned_versions,
         } = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
-            transactions,
-            randomness_round,
+            all_certs,
             cancelled_txns,
         )?;
 
@@ -3475,6 +3510,7 @@ impl AuthorityPerEpochStore {
         self.process_consensus_transaction_shared_object_versions(
             cache_reader,
             transactions,
+            &[],
             None,
             &BTreeMap::new(),
             &mut output,
@@ -3510,12 +3546,13 @@ impl AuthorityPerEpochStore {
     pub(crate) async fn process_consensus_transactions<C: CheckpointServiceNotify>(
         &self,
         output: &mut ConsensusCommitOutput,
-        transactions: &[VerifiedSequencedConsensusTransaction],
+        non_randomness_transactions: &[VerifiedSequencedConsensusTransaction],
+        randomness_transactions: &[VerifiedSequencedConsensusTransaction],
         end_of_publish_transactions: &[VerifiedSequencedConsensusTransaction],
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
         consensus_commit_info: &ConsensusCommitInfo,
-        roots: &mut BTreeSet<TransactionKey>,
+        non_randomness_roots: &mut BTreeSet<TransactionKey>,
         randomness_roots: &mut BTreeSet<TransactionKey>,
         previously_deferred_tx_digests: PreviouslyDeferredTransactions,
         mut randomness_manager: Option<&mut RandomnessManager>,
@@ -3525,7 +3562,8 @@ impl AuthorityPerEpochStore {
         mut shared_object_congestion_tracker: SharedObjectCongestionTracker,
         mut shared_object_using_randomness_congestion_tracker: SharedObjectCongestionTracker,
     ) -> IotaResult<(
-        Vec<VerifiedExecutableTransaction>,    // transactions to schedule
+        Vec<VerifiedExecutableTransaction>, // non-randomness transactions to schedule
+        Vec<VerifiedExecutableTransaction>, // randomness transactions to schedule
         Vec<SequencedConsensusTransactionKey>, // keys to notify as complete
         Option<RwLockWriteGuard<'_, ReconfigState>>,
         bool,                   // true if final round
@@ -3535,9 +3573,8 @@ impl AuthorityPerEpochStore {
             assert!(!dkg_failed); // invariant check
         }
 
-        let mut sequenced_transactions = Vec::with_capacity(transactions.len());
-        let mut verified_certificates = VecDeque::with_capacity(transactions.len() + 1);
-        let mut notifications = Vec::with_capacity(transactions.len());
+        let mut notifications =
+            Vec::with_capacity(non_randomness_transactions.len() + randomness_transactions.len());
 
         let mut deferred_txns: BTreeMap<DeferralKey, Vec<DeferredTransaction>> = BTreeMap::new();
         let mut cancelled_txns: BTreeMap<TransactionDigest, CancelConsensusCertificateReason> =
@@ -3579,12 +3616,23 @@ impl AuthorityPerEpochStore {
         );
 
         let mut randomness_state_updated = false;
-        for tx in transactions {
-            let key = tx.0.transaction.key();
-            let mut ignored = false;
-            let mut filter_roots = false;
-            let (congestion_tracker, sgp_calculator) = if tx.0.is_user_tx_with_randomness() {
-                (
+        let mut sequenced_non_randomness = Vec::new();
+        let mut sequenced_randomness = Vec::new();
+
+        for entry in non_randomness_transactions
+            .iter()
+            .map(Either::Left)
+            .chain(randomness_transactions.iter().map(Either::Right))
+        {
+            let (tx, congestion_tracker, sgp_calculator, sequenced_txns) = match entry {
+                Either::Left(tx) => (
+                    tx,
+                    &mut shared_object_congestion_tracker,
+                    &mut suggested_gas_price_calculator,
+                    &mut sequenced_non_randomness,
+                ),
+                Either::Right(tx) => (
+                    tx,
                     &mut shared_object_using_randomness_congestion_tracker,
                     if self
                         .protocol_config
@@ -3594,13 +3642,12 @@ impl AuthorityPerEpochStore {
                     } else {
                         &mut suggested_gas_price_calculator
                     },
-                )
-            } else {
-                (
-                    &mut shared_object_congestion_tracker,
-                    &mut suggested_gas_price_calculator,
-                )
+                    &mut sequenced_randomness,
+                ),
             };
+            let key = tx.0.transaction.key();
+            let mut ignored = false;
+            let mut filter_roots = false;
             match self
                 .process_consensus_transaction(
                     output,
@@ -3622,7 +3669,7 @@ impl AuthorityPerEpochStore {
                     start_time,
                 } => {
                     notifications.push(key.clone());
-                    sequenced_transactions.push((transaction, start_time));
+                    sequenced_txns.push((transaction, start_time));
                 }
                 ConsensusCertificateResult::Deferred {
                     deferral_key,
@@ -3644,10 +3691,7 @@ impl AuthorityPerEpochStore {
                 ConsensusCertificateResult::Cancelled((cert, reason)) => {
                     notifications.push(key.clone());
                     assert!(cancelled_txns.insert(*cert.digest(), reason).is_none());
-                    sequenced_transactions.push((
-                        cert,
-                        shared_object_congestion_tracker.max_occupied_slot_end_time(),
-                    ));
+                    sequenced_txns.push((cert, congestion_tracker.max_occupied_slot_end_time()));
                 }
                 ConsensusCertificateResult::RandomnessConsensusMessage => {
                     randomness_state_updated = true;
@@ -3673,7 +3717,7 @@ impl AuthorityPerEpochStore {
                         .executable_transaction_digest()
                         .map(TransactionKey::Digest)
                 {
-                    roots.remove(&txn_key);
+                    non_randomness_roots.remove(&txn_key);
                     randomness_roots.remove(&txn_key);
                 }
             }
@@ -3681,10 +3725,14 @@ impl AuthorityPerEpochStore {
 
         // sort the sequenced transactions based on their start_time from the
         // sequencing result and add these to the verified_certificates.
-        sequenced_transactions.sort_by_key(|(_, start_time)| *start_time);
-        for (tx, _) in sequenced_transactions {
-            verified_certificates.push_back(tx);
-        }
+        sequenced_non_randomness.sort_by_key(|(_, start_time)| *start_time);
+        let mut verified_non_randomness_certificates: VecDeque<_> = sequenced_non_randomness
+            .into_iter()
+            .map(|(tx, _)| tx)
+            .collect();
+        sequenced_randomness.sort_by_key(|(_, start_time)| *start_time);
+        let verified_randomness_certificates: VecDeque<_> =
+            sequenced_randomness.into_iter().map(|(tx, _)| tx).collect();
         let commit_has_deferred_txns = !deferred_txns.is_empty();
         let mut total_deferred_txns = 0;
         {
@@ -3760,19 +3808,22 @@ impl AuthorityPerEpochStore {
         }
 
         // Add the consensus commit prologue transaction to the beginning of
-        // `verified_certificates`.
+        // `verified_non_randomness_certificates`.
         let consensus_commit_prologue_root = self.add_consensus_commit_prologue_transaction(
             output,
-            &mut verified_certificates,
+            &mut verified_non_randomness_certificates,
             consensus_commit_info,
             &cancelled_txns,
         )?;
 
-        let verified_certificates: Vec<_> = verified_certificates.into();
+        let verified_non_randomness_certificates: Vec<_> =
+            verified_non_randomness_certificates.into();
+        let verified_randomness_certificates: Vec<_> = verified_randomness_certificates.into();
 
         self.process_consensus_transaction_shared_object_versions(
             cache_reader,
-            &verified_certificates,
+            &verified_non_randomness_certificates,
+            &verified_randomness_certificates,
             randomness_round,
             &cancelled_txns,
             output,
@@ -3785,7 +3836,8 @@ impl AuthorityPerEpochStore {
         )?;
 
         Ok((
-            verified_certificates,
+            verified_non_randomness_certificates,
+            verified_randomness_certificates,
             notifications,
             lock,
             final_round,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -82,7 +82,6 @@ use typed_store::{
         read_size_from_env,
     },
     rocksdb::Options,
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 use super::{

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -911,7 +911,7 @@ mod tests {
     use tracing::info;
     use typed_store::{
         Map,
-        rocks::{DBMap, MetricConf, ReadWriteOptions},
+        rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options},
     };
 
     use super::AuthorityStorePruner;
@@ -924,8 +924,11 @@ mod tests {
     fn get_keys_after_pruning(path: &Path) -> anyhow::Result<HashSet<ObjectKey>> {
         let perpetual_db_path = path.join(Path::new("perpetual"));
         let cf_names = AuthorityPerpetualTables::describe_tables();
-        let cfs: Vec<&str> = cf_names.keys().map(|x| x.as_str()).collect();
-        let perpetual_db = typed_store::rocks::open_cf(
+        let cfs: Vec<_> = cf_names
+            .keys()
+            .map(|x| (x.as_str(), default_db_options().options))
+            .collect();
+        let perpetual_db = typed_store::rocks::open_cf_opts(
             perpetual_db_path,
             None,
             MetricConf::new("perpetual_pruning"),

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -605,14 +605,14 @@ impl AuthorityStorePruner {
         delay_days: usize,
         last_processed: Arc<Mutex<HashMap<String, SystemTime>>>,
     ) -> anyhow::Result<Option<LiveFile>> {
-        let db_path = perpetual_db.objects.rocksdb.path();
+        let db_path = perpetual_db.objects.db.path_for_pruning();
         let mut state = last_processed
             .lock()
             .expect("failed to obtain a lock for last processed SST files");
         let mut sst_file_for_compaction: Option<LiveFile> = None;
         let time_threshold =
             SystemTime::now() - Duration::from_secs(delay_days as u64 * 24 * 60 * 60);
-        for sst_file in perpetual_db.objects.rocksdb.live_files()? {
+        for sst_file in perpetual_db.objects.db.live_files()? {
             let file_path = db_path.join(sst_file.name.clone().trim_matches('/'));
             let last_modified = std::fs::metadata(file_path)?.modified()?;
             if !PERIODIC_PRUNING_TABLES.contains(&sst_file.column_family_name)
@@ -1113,8 +1113,8 @@ mod tests {
         let start = ObjectKey(ObjectID::ZERO, SequenceNumber::MIN_VALID_INCL);
         let end = ObjectKey(ObjectID::MAX, SequenceNumber::MAX_VALID_EXCL);
 
-        perpetual_db.objects.rocksdb.flush()?;
-        perpetual_db.objects.compact_range_to_bottom(&start, &end)?;
+        perpetual_db.objects.db.flush()?;
+        perpetual_db.objects.compact_range(&start, &end)?;
         let before_compaction_size = get_sst_size(&db_path);
 
         let mut effects = TransactionEffects::default();
@@ -1132,8 +1132,8 @@ mod tests {
                 .await;
         info!("Total pruned keys = {:?}", total_pruned);
 
-        perpetual_db.objects.rocksdb.flush()?;
-        perpetual_db.objects.compact_range_to_bottom(&start, &end)?;
+        perpetual_db.objects.db.flush()?;
+        perpetual_db.objects.compact_range(&start, &end)?;
         let after_compaction_size = get_sst_size(&db_path);
 
         info!(

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -21,7 +21,7 @@ use typed_store::{
         read_size_from_env,
     },
     rocksdb::compaction_filter::Decision,
-    traits::{Map, TableSummary, TypedStoreDebug},
+    traits::Map,
 };
 
 use super::*;

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -14,7 +14,7 @@ use iota_types::{
 use serde::{Deserialize, Serialize};
 use tracing::error;
 use typed_store::{
-    DBMapUtils,
+    DBMapUtils, DbIterator,
     metrics::SamplingInterval,
     rocks::{
         DBBatch, DBMap, DBMapTableConfigMap, DBOptions, MetricConf, default_db_options,
@@ -451,7 +451,7 @@ impl AuthorityPerpetualTables {
 
     pub fn iter_live_object_set(&self) -> LiveSetIter<'_> {
         LiveSetIter {
-            iter: self.objects.safe_iter(),
+            iter: Box::new(self.objects.safe_iter()),
             tables: self,
             prev: None,
         }
@@ -466,7 +466,7 @@ impl AuthorityPerpetualTables {
         let upper_bound = upper_bound.as_ref().map(ObjectKey::max_for_id);
 
         LiveSetIter {
-            iter: self.objects.safe_iter_with_bounds(lower_bound, upper_bound),
+            iter: Box::new(self.objects.safe_iter_with_bounds(lower_bound, upper_bound)),
             tables: self,
             prev: None,
         }
@@ -563,8 +563,7 @@ impl ObjectStore for AuthorityPerpetualTables {
 }
 
 pub struct LiveSetIter<'a> {
-    iter:
-        <DBMap<ObjectKey, StoreObjectWrapper> as Map<'a, ObjectKey, StoreObjectWrapper>>::SafeIterator,
+    iter: DbIterator<'a, (ObjectKey, StoreObjectWrapper)>,
     tables: &'a AuthorityPerpetualTables,
     prev: Option<(ObjectKey, StoreObjectWrapper)>,
 }

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -491,7 +491,7 @@ impl AuthorityPerpetualTables {
         self.total_iota_supply.unsafe_clear()?;
         self.expected_storage_fund_imbalance.unsafe_clear()?;
         self.object_per_epoch_marker_table.unsafe_clear()?;
-        self.objects.rocksdb.flush()?;
+        self.objects.db.flush()?;
         Ok(())
     }
 

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -7,7 +7,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use iota_types::{
     IOTA_RANDOMNESS_STATE_OBJECT_ID,
     base_types::{ObjectID, SequenceNumber, TransactionDigest},
-    crypto::RandomnessRound,
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::IotaResult,
     executable_transaction::VerifiedExecutableTransaction,
@@ -16,12 +15,11 @@ use iota_types::{
     },
     transaction::{SenderSignedData, SharedInputObject, TransactionKey},
 };
-use tracing::{debug, trace};
+use tracing::trace;
 
 use crate::{
     authority::{
         AuthorityPerEpochStore, authority_per_epoch_store::CancelConsensusCertificateReason,
-        epoch_start_configuration::EpochStartConfigTrait,
     },
     execution_cache::ObjectCacheRead,
 };
@@ -38,39 +36,18 @@ pub struct ConsensusSharedObjVerAssignment {
 }
 
 impl SharedObjVerManager {
-    pub fn assign_versions_from_consensus(
+    pub fn assign_versions_from_consensus<'a>(
         epoch_store: &AuthorityPerEpochStore,
         cache_reader: &dyn ObjectCacheRead,
-        certificates: &[VerifiedExecutableTransaction],
-        randomness_round: Option<RandomnessRound>,
+        certificates: impl Iterator<Item = &'a VerifiedExecutableTransaction> + Clone,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
     ) -> IotaResult<ConsensusSharedObjVerAssignment> {
         let mut shared_input_next_versions = get_or_init_versions(
-            certificates.iter().map(|cert| cert.data()),
+            certificates.clone().map(|cert| cert.data()),
             epoch_store,
             cache_reader,
-            randomness_round.is_some(),
         )?;
         let mut assigned_versions = Vec::new();
-        // We must update randomness object version first before processing any
-        // transaction, so that all reads are using the next version.
-        // TODO: Add a test that actually check this, i.e. if we change the order, some
-        // test should fail.
-        if let Some(round) = randomness_round {
-            // If we're generating randomness, update the randomness state object version.
-            let version = shared_input_next_versions
-                .get_mut(&IOTA_RANDOMNESS_STATE_OBJECT_ID)
-                .expect("randomness state object must have been added in get_or_init_versions()");
-            debug!(
-                "assigning shared object versions for randomness: epoch {}, round {round:?} -> version {version:?}",
-                epoch_store.epoch()
-            );
-            assigned_versions.push((
-                TransactionKey::RandomnessRound(epoch_store.epoch(), round),
-                vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, *version)],
-            ));
-            version.increment();
-        }
         for cert in certificates {
             if !cert.contains_shared_object() {
                 continue;
@@ -109,8 +86,8 @@ impl SharedObjVerManager {
             certs_and_effects.iter().map(|(cert, _)| cert.data()),
             epoch_store,
             cache_reader,
-            false,
         );
+
         let mut assigned_versions = Vec::new();
         for (cert, effects) in certs_and_effects {
             let cert_assigned_versions: Vec<_> = effects
@@ -264,7 +241,6 @@ fn get_or_init_versions<'a>(
     transactions: impl Iterator<Item = &'a SenderSignedData>,
     epoch_store: &AuthorityPerEpochStore,
     cache_reader: &dyn ObjectCacheRead,
-    generate_randomness: bool,
 ) -> IotaResult<HashMap<ObjectID, SequenceNumber>> {
     let mut shared_input_objects: Vec<_> = transactions
         .flat_map(|tx| {
@@ -273,15 +249,6 @@ fn get_or_init_versions<'a>(
                 .map(|so| so.into_id_and_version())
         })
         .collect();
-
-    if generate_randomness {
-        shared_input_objects.push((
-            IOTA_RANDOMNESS_STATE_OBJECT_ID,
-            epoch_store
-                .epoch_start_config()
-                .randomness_obj_initial_shared_version(),
-        ));
-    }
 
     shared_input_objects.sort();
     shared_input_objects.dedup();
@@ -305,7 +272,7 @@ mod tests {
         },
         object::{Object, Owner},
         programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::{ObjectArg, SenderSignedData, TransactionKey},
+        transaction::{ObjectArg, SenderSignedData, VerifiedTransaction},
     };
 
     use super::*;
@@ -330,7 +297,7 @@ mod tests {
             .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
             .await;
-        let certs = vec![
+        let certs = [
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, false)], 5),
             generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 9),
@@ -343,8 +310,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
-            None,
+            certs.iter(),
             &BTreeMap::new(),
         )
         .unwrap();
@@ -383,7 +349,16 @@ mod tests {
         let randomness_obj_version = epoch_store
             .epoch_start_config()
             .randomness_obj_initial_shared_version();
-        let certs = vec![
+        let certs = [
+            VerifiedExecutableTransaction::new_system(
+                VerifiedTransaction::new_randomness_state_update(
+                    epoch_store.epoch(),
+                    RandomnessRound::new(1),
+                    vec![],
+                    randomness_obj_version,
+                ),
+                epoch_store.epoch(),
+            ),
             generate_shared_objs_tx_with_gas_version(
                 &[(
                     IOTA_RANDOMNESS_STATE_OBJECT_ID,
@@ -409,8 +384,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
-            Some(RandomnessRound::new(1)),
+            certs.iter(),
             &BTreeMap::new(),
         )
         .unwrap();
@@ -431,17 +405,17 @@ mod tests {
             assigned_versions,
             vec![
                 (
-                    TransactionKey::RandomnessRound(0, RandomnessRound::new(1)),
+                    certs[0].key(),
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, randomness_obj_version),]
                 ),
                 (
-                    certs[0].key(),
+                    certs[1].key(),
                     // It is critical that the randomness object version is updated before the
                     // assignment.
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, next_randomness_obj_version)]
                 ),
                 (
-                    certs[1].key(),
+                    certs[2].key(),
                     // It is critical that the randomness object version is updated before the
                     // assignment.
                     vec![(IOTA_RANDOMNESS_STATE_OBJECT_ID, next_randomness_obj_version)]
@@ -496,7 +470,7 @@ mod tests {
         // lamport version = 10 due to gas object version = 9   tx5: shared
         // objects assign cancelled version, lamport version = 12 due to gas object
         // version = 11
-        let certs = vec![
+        let certs = [
             generate_shared_objs_tx_with_gas_version(
                 &[
                     (id1, init_shared_version_1, true),
@@ -565,8 +539,7 @@ mod tests {
         } = SharedObjVerManager::assign_versions_from_consensus(
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-            &certs,
-            None,
+            certs.iter(),
             &cancelled_txns,
         )
         .unwrap();

--- a/crates/iota-core/src/authority/transaction_deferral.rs
+++ b/crates/iota-core/src/authority/transaction_deferral.rs
@@ -108,7 +108,6 @@ mod object_cost_tests {
     use typed_store::{
         DBMapUtils, Map,
         rocks::{DBMap, MetricConf},
-        traits::{TableSummary, TypedStoreDebug},
     };
 
     use super::*;

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -61,7 +61,6 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::{
     DBMapUtils, Map, TypedStoreError,
     rocks::{DBMap, MetricConf},
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 pub use crate::checkpoints::{

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -882,7 +882,7 @@ impl CheckpointStore {
 
     pub fn reset_db_for_execution_since_genesis(&self) -> IotaResult {
         self.delete_highest_executed_checkpoint_test_only()?;
-        self.tables.watermarks.rocksdb.flush()?;
+        self.tables.watermarks.db.flush()?;
         Ok(())
     }
 }

--- a/crates/iota-core/src/epoch/committee_store.rs
+++ b/crates/iota-core/src/epoch/committee_store.rs
@@ -19,7 +19,6 @@ use typed_store::{
     DBMapUtils, Map,
     rocks::{DBMap, DBOptions, MetricConf, default_db_options},
     rocksdb::Options,
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 pub struct CommitteeStore {

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -49,7 +49,7 @@ use typed_store::{
         read_size_from_env,
     },
     rocksdb::compaction_filter::Decision,
-    traits::{Map, TableSummary, TypedStoreDebug},
+    traits::Map,
 };
 
 type OwnedMutexGuard<T> = ArcMutexGuard<parking_lot::RawMutex, T>;

--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -32,7 +32,7 @@ use tracing::{debug, info};
 use typed_store::{
     DBMapUtils, TypedStoreError,
     rocks::{DBMap, MetricConf},
-    traits::{Map, TableSummary, TypedStoreDebug},
+    traits::Map,
 };
 
 use crate::{

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -2,16 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, str::FromStr};
-
 use iota_config::NodeConfig;
-use tap::TapFallible;
 use tokio::runtime::Runtime;
-use tracing::warn;
 
 pub struct IotaRuntimes {
     // Order in this struct is the order in which runtimes are stopped
-    pub json_rpc: Runtime,
     pub iota_node: Runtime,
     pub metrics: Runtime,
 }
@@ -30,25 +25,6 @@ impl IotaRuntimes {
             .build()
             .unwrap();
 
-        let worker_thread = env::var("RPC_WORKER_THREAD")
-            .ok()
-            .and_then(|o| {
-                usize::from_str(&o)
-                    .tap_err(|e| warn!("Cannot parse RPC_WORKER_THREAD to usize: {e}"))
-                    .ok()
-            })
-            .unwrap_or(num_cpus::get() / 2);
-
-        let json_rpc = tokio::runtime::Builder::new_multi_thread()
-            .thread_name("jsonrpc-runtime")
-            .worker_threads(worker_thread)
-            .enable_all()
-            .build()
-            .unwrap();
-        Self {
-            iota_node,
-            metrics,
-            json_rpc,
-        }
+        Self { iota_node, metrics }
     }
 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -2952,7 +2952,11 @@ async fn test_invalid_authenticator_state_parameter() {
         // type_args
         vec![],
         gas_ref,
-        vec![CallArg::AUTHENTICATOR_MUT],
+        vec![CallArg::Object(ObjectArg::SharedObject {
+            id: IOTA_AUTHENTICATOR_STATE_OBJECT_ID,
+            initial_shared_version: SequenceNumber::from(1),
+            mutable: true,
+        })],
         TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
         rgp,
     )

--- a/crates/iota-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/iota-faucet/src/faucet/write_ahead_log.rs
@@ -10,11 +10,7 @@ use iota_types::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::info;
-use typed_store::{
-    DBMapUtils, Map, TypedStoreError,
-    rocks::DBMap,
-    traits::{TableSummary, TypedStoreDebug},
-};
+use typed_store::{DBMapUtils, Map, TypedStoreError, rocks::DBMap};
 use uuid::Uuid;
 
 /// Persistent log of transactions paying out iota from the faucet, keyed by the

--- a/crates/iota-http/Cargo.toml
+++ b/crates/iota-http/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+# external dependencies
 bytes.workspace = true
 http.workspace = true
 http-body.workspace = true
@@ -16,11 +17,14 @@ hyper-util.workspace = true
 pin-project-lite.workspace = true
 socket2 = { version = "0.5", features = ["all"] }
 tokio = { workspace = true, features = ["macros"] }
-# TLS support
 tokio-rustls.workspace = true
 tokio-util.workspace = true
 tower.workspace = true
 tracing.workspace = true
+
+# internal dependencies
+# TLS support
+iota-tls.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/iota-http/src/lib.rs
+++ b/crates/iota-http/src/lib.rs
@@ -10,7 +10,7 @@ use http::{Request, Response};
 use hyper_util::service::TowerToHyperService;
 use io::ServerIo;
 use tokio::task::JoinSet;
-use tokio_rustls::TlsAcceptor;
+use tokio_rustls::{TlsAcceptor, rustls};
 use tower::{Service, ServiceBuilder, ServiceExt};
 use tracing::trace;
 
@@ -37,7 +37,7 @@ const ALPN_H1: &[u8] = b"http/1.1";
 #[derive(Default)]
 pub struct Builder {
     config: Config,
-    tls_config: Option<tokio_rustls::rustls::ServerConfig>,
+    tls_config: Option<rustls::ServerConfig>,
 }
 
 impl Builder {
@@ -50,7 +50,21 @@ impl Builder {
         self
     }
 
-    pub fn tls_config(mut self, tls_config: tokio_rustls::rustls::ServerConfig) -> Self {
+    // Convenience method for configuring TLS with a single server cert
+    //
+    // Attempts to load PEM formatted files for the certificate chain and private
+    // key material from the provided file system paths.
+    pub fn tls_single_cert(
+        self,
+        cert_file: impl AsRef<std::path::Path>,
+        private_key_file: impl AsRef<std::path::Path>,
+    ) -> Result<Self, BoxError> {
+        let tls_config =
+            iota_tls::create_rustls_server_config_from_pem(cert_file, private_key_file)?;
+        Ok(self.tls_config(tls_config))
+    }
+
+    pub fn tls_config(mut self, tls_config: rustls::ServerConfig) -> Self {
         self.tls_config = Some(tls_config);
         self
     }
@@ -208,7 +222,7 @@ type ConnectingOutput<Io, Addr> = Result<(ServerIo<Io>, Addr), crate::BoxError>;
 
 struct Server<L: Listener> {
     config: Config,
-    tls_config: Option<Arc<tokio_rustls::rustls::ServerConfig>>,
+    tls_config: Option<Arc<rustls::ServerConfig>>,
 
     listener: L,
     local_addr: L::Addr,

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -492,9 +492,8 @@ impl Display for IotaTransactionBlockKind {
 }
 
 impl IotaTransactionBlockKind {
-    fn try_from(
+    fn try_from_inner(
         tx: TransactionKind,
-        module_cache: &impl GetModule,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
         Ok(match tx {
@@ -518,9 +517,10 @@ impl IotaTransactionBlockKind {
                         .consensus_determined_version_assignments,
                 })
             }
-            TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
-                IotaProgrammableTransactionBlock::try_from(p, module_cache)?,
-            ),
+            TransactionKind::ProgrammableTransaction(_) => {
+                // This case is handled separately by the callers
+                unreachable!()
+            }
             TransactionKind::AuthenticatorStateUpdateV1(update) => {
                 Self::AuthenticatorStateUpdateV1(IotaAuthenticatorStateUpdateV1 {
                     epoch: update.epoch,
@@ -573,89 +573,34 @@ impl IotaTransactionBlockKind {
         })
     }
 
+    fn try_from_with_module_cache(
+        tx: TransactionKind,
+        module_cache: &impl GetModule,
+        tx_digest: TransactionDigest,
+    ) -> Result<Self, anyhow::Error> {
+        match tx {
+            TransactionKind::ProgrammableTransaction(p) => Ok(Self::ProgrammableTransaction(
+                IotaProgrammableTransactionBlock::try_from_with_module_cache(p, module_cache)?,
+            )),
+            tx => Self::try_from_inner(tx, tx_digest),
+        }
+    }
+
     async fn try_from_with_package_resolver(
         tx: TransactionKind,
         package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
-        Ok(match tx {
-            TransactionKind::Genesis(g) => Self::Genesis(IotaGenesisTransaction {
-                objects: g.objects.iter().map(GenesisObject::id).collect(),
-                events: g
-                    .events
-                    .into_iter()
-                    .enumerate()
-                    .map(|(seq, _event)| EventID::from((tx_digest, seq as u64)))
-                    .collect(),
-            }),
-            TransactionKind::ConsensusCommitPrologueV1(p) => {
-                Self::ConsensusCommitPrologueV1(IotaConsensusCommitPrologueV1 {
-                    epoch: p.epoch,
-                    round: p.round,
-                    sub_dag_index: p.sub_dag_index,
-                    commit_timestamp_ms: p.commit_timestamp_ms,
-                    consensus_commit_digest: p.consensus_commit_digest,
-                    consensus_determined_version_assignments: p
-                        .consensus_determined_version_assignments,
-                })
-            }
-            TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
+        match tx {
+            TransactionKind::ProgrammableTransaction(p) => Ok(Self::ProgrammableTransaction(
                 IotaProgrammableTransactionBlock::try_from_with_package_resolver(
                     p,
                     package_resolver,
                 )
                 .await?,
-            ),
-            TransactionKind::AuthenticatorStateUpdateV1(update) => {
-                Self::AuthenticatorStateUpdateV1(IotaAuthenticatorStateUpdateV1 {
-                    epoch: update.epoch,
-                    round: update.round,
-                    new_active_jwks: update
-                        .new_active_jwks
-                        .into_iter()
-                        .map(IotaActiveJwk::from)
-                        .collect(),
-                })
-            }
-            TransactionKind::RandomnessStateUpdate(update) => {
-                Self::RandomnessStateUpdate(IotaRandomnessStateUpdate {
-                    epoch: update.epoch,
-                    randomness_round: update.randomness_round.0,
-                    random_bytes: update.random_bytes,
-                })
-            }
-            TransactionKind::EndOfEpochTransaction(end_of_epoch_tx) => {
-                Self::EndOfEpochTransaction(IotaEndOfEpochTransaction {
-                    transactions: end_of_epoch_tx
-                        .into_iter()
-                        .map(|tx| match tx {
-                            EndOfEpochTransactionKind::ChangeEpoch(e) => {
-                                IotaEndOfEpochTransactionKind::ChangeEpoch(e.into())
-                            }
-                            EndOfEpochTransactionKind::ChangeEpochV2(e) => {
-                                IotaEndOfEpochTransactionKind::ChangeEpochV2(e.into())
-                            }
-                            EndOfEpochTransactionKind::ChangeEpochV3(e) => {
-                                IotaEndOfEpochTransactionKind::ChangeEpochV2(e.into())
-                            }
-                            EndOfEpochTransactionKind::ChangeEpochV4(e) => {
-                                IotaEndOfEpochTransactionKind::ChangeEpochV2(e.into())
-                            }
-                            EndOfEpochTransactionKind::AuthenticatorStateCreate => {
-                                IotaEndOfEpochTransactionKind::AuthenticatorStateCreate
-                            }
-                            EndOfEpochTransactionKind::AuthenticatorStateExpire(expire) => {
-                                IotaEndOfEpochTransactionKind::AuthenticatorStateExpire(
-                                    IotaAuthenticatorStateExpire {
-                                        min_epoch: expire.min_epoch,
-                                    },
-                                )
-                            }
-                        })
-                        .collect(),
-                })
-            }
-        })
+            )),
+            tx => Self::try_from_inner(tx, tx_digest),
+        }
     }
 
     pub fn transaction_count(&self) -> usize {
@@ -1700,25 +1645,10 @@ impl IotaTransactionBlockData {
             },
         }
     }
-}
 
-impl Display for IotaTransactionBlockData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::V1(data) => {
-                writeln!(f, "Sender: {}", data.sender)?;
-                writeln!(f, "{}", self.gas_data())?;
-                writeln!(f, "{}", data.transaction)
-            }
-        }
-    }
-}
-
-impl IotaTransactionBlockData {
-    pub fn try_from(
+    fn try_from_inner(
         data: TransactionData,
-        module_cache: &impl GetModule,
-        tx_digest: TransactionDigest,
+        transaction: IotaTransactionBlockKind,
     ) -> Result<Self, anyhow::Error> {
         let message_version = data.message_version();
         let sender = data.sender();
@@ -1732,8 +1662,7 @@ impl IotaTransactionBlockData {
             price: data.gas_price(),
             budget: data.gas_budget(),
         };
-        let transaction =
-            IotaTransactionBlockKind::try_from(data.into_kind(), module_cache, tx_digest)?;
+
         match message_version {
             1 => Ok(IotaTransactionBlockData::V1(IotaTransactionBlockDataV1 {
                 transaction,
@@ -1747,38 +1676,42 @@ impl IotaTransactionBlockData {
         }
     }
 
+    pub fn try_from_with_module_cache(
+        data: TransactionData,
+        module_cache: &impl GetModule,
+        tx_digest: TransactionDigest,
+    ) -> Result<Self, anyhow::Error> {
+        let transaction = IotaTransactionBlockKind::try_from_with_module_cache(
+            data.kind().clone(),
+            module_cache,
+            tx_digest,
+        )?;
+        Self::try_from_inner(data, transaction)
+    }
+
     pub async fn try_from_with_package_resolver(
         data: TransactionData,
         package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
-        let message_version = data.message_version();
-        let sender = data.sender();
-        let gas_data = IotaGasData {
-            payment: data
-                .gas()
-                .iter()
-                .map(|obj_ref| IotaObjectRef::from(*obj_ref))
-                .collect(),
-            owner: data.gas_owner(),
-            price: data.gas_price(),
-            budget: data.gas_budget(),
-        };
         let transaction = IotaTransactionBlockKind::try_from_with_package_resolver(
-            data.into_kind(),
+            data.kind().clone(),
             package_resolver,
             tx_digest,
         )
         .await?;
-        match message_version {
-            1 => Ok(IotaTransactionBlockData::V1(IotaTransactionBlockDataV1 {
-                transaction,
-                sender,
-                gas_data,
-            })),
-            _ => Err(anyhow::anyhow!(
-                "Support for TransactionData version {message_version} not implemented"
-            )),
+        Self::try_from_inner(data, transaction)
+    }
+}
+
+impl Display for IotaTransactionBlockData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V1(data) => {
+                writeln!(f, "Sender: {}", data.sender)?;
+                writeln!(f, "{}", self.gas_data())?;
+                writeln!(f, "{}", data.transaction)
+            }
         }
     }
 }
@@ -1797,7 +1730,7 @@ impl IotaTransactionBlock {
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
-            data: IotaTransactionBlockData::try_from(
+            data: IotaTransactionBlockData::try_from_with_module_cache(
                 data.intent_message().value.clone(),
                 module_cache,
                 tx_digest,
@@ -2019,7 +1952,7 @@ impl Display for IotaProgrammableTransactionBlock {
 }
 
 impl IotaProgrammableTransactionBlock {
-    fn try_from(
+    fn try_from_with_module_cache(
         value: ProgrammableTransaction,
         module_cache: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -139,7 +139,6 @@ pub use simulator::set_jwk_injector;
 use simulator::*;
 use tap::tap::TapFallible;
 use tokio::{
-    runtime::Handle,
     sync::{Mutex, broadcast, mpsc, watch},
     task::{JoinHandle, JoinSet},
 };
@@ -286,9 +285,8 @@ impl IotaNode {
     pub async fn start(
         config: NodeConfig,
         registry_service: RegistryService,
-        custom_rpc_runtime: Option<Handle>,
     ) -> Result<Arc<IotaNode>> {
-        Self::start_async(config, registry_service, custom_rpc_runtime, "unknown").await
+        Self::start_async(config, registry_service, "unknown").await
     }
 
     /// Starts the JWK (JSON Web Key) updater tasks for the specified node
@@ -433,7 +431,6 @@ impl IotaNode {
     pub async fn start_async(
         config: NodeConfig,
         registry_service: RegistryService,
-        custom_rpc_runtime: Option<Handle>,
         software_version: &'static str,
     ) -> Result<Arc<IotaNode>> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
@@ -841,7 +838,6 @@ impl IotaNode {
             &transaction_orchestrator.clone(),
             &config,
             &prometheus_registry,
-            custom_rpc_runtime,
             software_version,
         )
         .await?;
@@ -2495,7 +2491,6 @@ pub async fn build_http_server(
     transaction_orchestrator: &Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
     config: &NodeConfig,
     prometheus_registry: &Registry,
-    _custom_runtime: Option<Handle>,
     software_version: &'static str,
 ) -> Result<Option<iota_http::ServerHandle>> {
     // Validators do not expose these APIs

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -101,7 +101,7 @@ use iota_network::{
 };
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
 use iota_protocol_config::ProtocolConfig;
-use iota_rest_api::RestMetrics;
+use iota_rest_api::{RestMetrics, ServerVersion};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
 use iota_snapshot::uploader::StateSnapshotUploader;
 use iota_storage::{
@@ -286,7 +286,12 @@ impl IotaNode {
         config: NodeConfig,
         registry_service: RegistryService,
     ) -> Result<Arc<IotaNode>> {
-        Self::start_async(config, registry_service, "unknown").await
+        Self::start_async(
+            config,
+            registry_service,
+            ServerVersion::new("iota-node", "unknown"),
+        )
+        .await
     }
 
     /// Starts the JWK (JSON Web Key) updater tasks for the specified node
@@ -431,7 +436,7 @@ impl IotaNode {
     pub async fn start_async(
         config: NodeConfig,
         registry_service: RegistryService,
-        software_version: &'static str,
+        server_version: ServerVersion,
     ) -> Result<Arc<IotaNode>> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
         let mut config = config.clone();
@@ -484,7 +489,7 @@ impl IotaNode {
                 } else {
                     "fullnode"
                 },
-                software_version,
+                server_version.version,
                 &chain_identifier.to_string(),
             ))
             .expect("Failed registering uptime metric");
@@ -838,7 +843,7 @@ impl IotaNode {
             &transaction_orchestrator.clone(),
             &config,
             &prometheus_registry,
-            software_version,
+            server_version.clone(),
         )
         .await?;
 
@@ -886,6 +891,7 @@ impl IotaNode {
             state_sync_store.clone(),
             executor,
             &registry_service.default_registry(),
+            server_version,
         )
         .await?;
 
@@ -2427,6 +2433,7 @@ async fn build_grpc_server(
     state_sync_store: RocksDbStore,
     executor: Option<Arc<dyn iota_types::transaction_executor::TransactionExecutor>>,
     prometheus_registry: &Registry,
+    server_version: ServerVersion,
 ) -> Result<Option<GrpcServerHandle>> {
     // Validators do not expose gRPC APIs
     if config.consensus_config().is_some() || !config.enable_grpc_api {
@@ -2448,7 +2455,7 @@ async fn build_grpc_server(
     // Create GrpcReader
     let grpc_reader = Arc::new(GrpcReader::from_rest_state_reader(
         rest_read_store,
-        Some(env!("CARGO_PKG_VERSION").to_string()),
+        Some(server_version.to_string()),
     ));
 
     // Create gRPC server metrics
@@ -2491,7 +2498,7 @@ pub async fn build_http_server(
     transaction_orchestrator: &Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>>,
     config: &NodeConfig,
     prometheus_registry: &Registry,
-    software_version: &'static str,
+    server_version: ServerVersion,
 ) -> Result<Option<iota_http::ServerHandle>> {
     // Validators do not expose these APIs
     if config.consensus_config().is_some() {
@@ -2560,10 +2567,9 @@ pub async fn build_http_server(
     router = router.merge(json_rpc_router);
 
     if config.enable_rest_api {
-        let mut rest_service = iota_rest_api::RestService::new(
-            Arc::new(RestReadStore::new(state.clone(), store)),
-            software_version,
-        );
+        let mut rest_service =
+            iota_rest_api::RestService::new(Arc::new(RestReadStore::new(state.clone(), store)));
+        rest_service.with_server_version(server_version);
 
         if let Some(config) = config.rest.clone() {
             rest_service.with_config(config);

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -112,13 +112,12 @@ fn main() {
     // work if it deadlocks.
     let node_once_cell = Arc::new(AsyncOnceCell::<Arc<IotaNode>>::new());
     let node_once_cell_clone = node_once_cell.clone();
-    let rpc_runtime = runtimes.json_rpc.handle().clone();
 
     // let iota-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
     runtimes.iota_node.spawn(async move {
-        match IotaNode::start_async(config, registry_service, Some(rpc_runtime), VERSION).await {
+        match IotaNode::start_async(config, registry_service, VERSION).await {
             Ok(iota_node) => node_once_cell_clone
                 .set(iota_node)
                 .expect("Failed to set node in AsyncOnceCell"),

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -9,6 +9,7 @@ use iota_common::sync::async_once_cell::AsyncOnceCell;
 use iota_config::{Config, NodeConfig, node::RunWithRange};
 use iota_core::runtime::IotaRuntimes;
 use iota_node::{IotaNode, metrics};
+use iota_rest_api::ServerVersion;
 use iota_types::{
     committee::EpochId, messages_checkpoint::CheckpointSequenceNumber, multiaddr::Multiaddr,
     supported_protocol_versions::SupportedProtocolVersions,
@@ -116,8 +117,9 @@ fn main() {
     // let iota-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
+    let server_version = ServerVersion::new(env!("CARGO_BIN_NAME"), VERSION);
     runtimes.iota_node.spawn(async move {
-        match IotaNode::start_async(config, registry_service, VERSION).await {
+        match IotaNode::start_async(config, registry_service, server_version).await {
             Ok(iota_node) => node_once_cell_clone
                 .set(iota_node)
                 .expect("Failed to set node in AsyncOnceCell"),

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -762,7 +762,7 @@ impl RpcExampleProvider {
             balance_changes: None,
             timestamp_ms: None,
             transaction: Some(IotaTransactionBlock {
-                data: IotaTransactionBlockData::try_from(
+                data: IotaTransactionBlockData::try_from_with_module_cache(
                     data1,
                     &&mut NoOpsModuleResolver,
                     *tx_digest,

--- a/crates/iota-rest-api/src/info.rs
+++ b/crates/iota-rest-api/src/info.rs
@@ -72,7 +72,11 @@ async fn get_node_info(State(state): State<RestService>) -> Result<Json<NodeInfo
         epoch: latest_checkpoint.epoch(),
         chain_id: Digest::new(state.chain_id().as_bytes().to_owned()),
         chain: state.chain_id().chain().as_str().into(),
-        software_version: state.software_version().into(),
+        software_version: state
+            .server_version()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+            .into(),
     }
     .pipe(Json)
     .pipe(Ok)

--- a/crates/iota-rest-api/src/lib.rs
+++ b/crates/iota-rest-api/src/lib.rs
@@ -35,6 +35,26 @@ pub use iota_types::full_checkpoint_content::{CheckpointData, CheckpointTransact
 pub use metrics::RestMetrics;
 pub use transactions::ExecuteTransactionQueryParameters;
 
+#[derive(Clone)]
+pub struct ServerVersion {
+    pub bin: &'static str,
+    pub version: &'static str,
+}
+
+impl ServerVersion {
+    pub fn new(bin: &'static str, version: &'static str) -> Self {
+        Self { bin, version }
+    }
+}
+
+impl std::fmt::Display for ServerVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.bin)?;
+        f.write_str("/")?;
+        f.write_str(self.version)
+    }
+}
+
 pub const TEXT_PLAIN_UTF_8: &str = "text/plain; charset=utf-8";
 pub const APPLICATION_BCS: &str = "application/bcs";
 pub const APPLICATION_JSON: &str = "application/json";
@@ -104,7 +124,7 @@ pub struct RestService {
     reader: StateReader,
     executor: Option<Arc<dyn TransactionExecutor>>,
     chain_id: iota_types::digests::ChainIdentifier,
-    software_version: &'static str,
+    server_version: Option<ServerVersion>,
     metrics: Option<Arc<RestMetrics>>,
     config: Config,
 }
@@ -122,20 +142,21 @@ impl axum::extract::FromRef<RestService> for Option<Arc<dyn TransactionExecutor>
 }
 
 impl RestService {
-    pub fn new(reader: Arc<dyn RestStateReader>, software_version: &'static str) -> Self {
+    pub fn new(reader: Arc<dyn RestStateReader>) -> Self {
         let chain_id = reader.get_chain_identifier().unwrap();
         Self {
             reader: StateReader::new(reader),
             executor: None,
             chain_id,
-            software_version,
+            server_version: None,
             metrics: None,
             config: Config::default(),
         }
     }
 
-    pub fn new_without_version(reader: Arc<dyn RestStateReader>) -> Self {
-        Self::new(reader, "unknown")
+    pub fn with_server_version(&mut self, server_version: ServerVersion) -> &mut Self {
+        self.server_version = Some(server_version);
+        self
     }
 
     pub fn with_config(&mut self, config: Config) {
@@ -154,14 +175,18 @@ impl RestService {
         self.chain_id
     }
 
-    pub fn software_version(&self) -> &'static str {
-        self.software_version
+    pub fn server_version(&self) -> Option<&ServerVersion> {
+        self.server_version.as_ref()
     }
 
     pub fn into_router(self) -> Router {
         let metrics = self.metrics.clone();
 
-        let mut api = openapi::Api::new(info(self.software_version()));
+        let version = self
+            .server_version()
+            .map(|v| v.version)
+            .unwrap_or("unknown");
+        let mut api = openapi::Api::new(info(version));
 
         api.register_endpoints(
             ENDPOINTS

--- a/crates/iota-rest-api/src/response.rs
+++ b/crates/iota-rest-api/src/response.rs
@@ -168,5 +168,12 @@ pub async fn append_info_headers(
         );
     }
 
+    if let Some(server_version) = state
+        .server_version()
+        .and_then(|version| version.to_string().try_into().ok())
+    {
+        headers.insert(axum::http::header::SERVER, server_version);
+    }
+
     (headers, response)
 }

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -319,7 +319,7 @@ mod tests {
     use tempfile::TempDir;
     use typed_store::{
         Map, reopen,
-        rocks::{DBMap, MetricConf, ReadWriteOptions, open_cf},
+        rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options, open_cf_opts},
     };
 
     use crate::hard_link;
@@ -335,11 +335,14 @@ mod tests {
         const FIRST_CF: &str = "First_CF";
         const SECOND_CF: &str = "Second_CF";
 
-        let db_a = open_cf(
+        let db_a = open_cf_opts(
             input_path,
             None,
             MetricConf::new("test_db_hard_link_1"),
-            &[FIRST_CF, SECOND_CF],
+            &[
+                (FIRST_CF, default_db_options().options),
+                (SECOND_CF, default_db_options().options),
+            ],
         )
         .unwrap();
 
@@ -353,11 +356,14 @@ mod tests {
 
         // set up db hard link
         hard_link(input_path, output_path)?;
-        let db_b = open_cf(
+        let db_b = open_cf_opts(
             output_path,
             None,
             MetricConf::new("test_db_hard_link_2"),
-            &[FIRST_CF, SECOND_CF],
+            &[
+                (FIRST_CF, default_db_options().options),
+                (SECOND_CF, default_db_options().options),
+            ],
         )
         .unwrap();
 

--- a/crates/iota-storage/src/write_path_pending_tx_log.rs
+++ b/crates/iota-storage/src/write_path_pending_tx_log.rs
@@ -22,7 +22,7 @@ use tracing::instrument;
 use typed_store::{
     DBMapUtils,
     rocks::{DBMap, MetricConf},
-    traits::{Map, TableSummary, TypedStoreDebug},
+    traits::Map,
 };
 
 use crate::mutex_table::MutexTable;

--- a/crates/iota-swarm/src/memory/container-sim.rs
+++ b/crates/iota-swarm/src/memory/container-sim.rs
@@ -67,9 +67,7 @@ impl Container {
                 let startup_sender = startup_sender.clone();
                 async move {
                     let registry_service = iota_metrics::RegistryService::new(Registry::new());
-                    let server = IotaNode::start(config, registry_service, None)
-                        .await
-                        .unwrap();
+                    let server = IotaNode::start(config, registry_service).await.unwrap();
 
                     startup_sender.send(Arc::downgrade(&server)).ok();
 

--- a/crates/iota-swarm/src/memory/container.rs
+++ b/crates/iota-swarm/src/memory/container.rs
@@ -106,7 +106,7 @@ impl Container {
                     "Started Prometheus HTTP endpoint. To query metrics use\n\tcurl -s http://{}/metrics",
                     config.metrics_address
                 );
-                let server = IotaNode::start(config, registry_service, None).await.unwrap();
+                let server = IotaNode::start(config, registry_service).await.unwrap();
                 // Notify that we've successfully started the node
                 let _ = startup_sender.send(Arc::downgrade(&server));
                 // run until canceled

--- a/crates/iota-tls/src/lib.rs
+++ b/crates/iota-tls/src/lib.rs
@@ -21,6 +21,23 @@ pub use verifier::{
 
 pub const IOTA_VALIDATOR_SERVER_NAME: &str = "iota";
 
+/// Create a TLS server config by loading PEM formatted certificate chain and
+/// private key files from the filesystem. No client authentication is required.
+pub fn create_rustls_server_config_from_pem(
+    cert_file: impl AsRef<std::path::Path>,
+    private_key_file: impl AsRef<std::path::Path>,
+) -> Result<ServerConfig, Box<dyn std::error::Error + Send + Sync>> {
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+
+    let certs = CertificateDer::pem_file_iter(cert_file)?.collect::<Result<_, _>>()?;
+    let private_key = PrivateKeyDer::from_pem_file(private_key_file)?;
+    let tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, private_key)?;
+
+    Ok(tls_config)
+}
+
 pub fn create_rustls_server_config(
     private_key: Ed25519PrivateKey,
     server_name: String,

--- a/crates/iota-tool/src/db_tool/db_dump.rs
+++ b/crates/iota-tool/src/db_tool/db_dump.rs
@@ -111,22 +111,20 @@ pub fn print_table_metadata(
                 let epoch = epoch.ok_or_else(|| anyhow!("--epoch is required"))?;
                 AuthorityEpochTables::open_readonly(epoch, &db_path)
                     .next_shared_object_versions
-                    .rocksdb
+                    .db
             } else {
-                AuthorityPerpetualTables::open_readonly(&db_path)
-                    .objects
-                    .rocksdb
+                AuthorityPerpetualTables::open_readonly(&db_path).objects.db
             }
         }
         StoreName::Index => {
             IndexStoreTables::get_read_only_handle(db_path, None, None, MetricConf::default())
                 .event_by_move_module
-                .rocksdb
+                .db
         }
         StoreName::Epoch => {
             CommitteeStoreTables::get_read_only_handle(db_path, None, None, MetricConf::default())
                 .committee_map
-                .rocksdb
+                .db
         }
     };
 

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -34,7 +34,6 @@ use typed_store::{
     DBMapUtils, Map,
     metrics::SamplingInterval,
     rocks::{DBMap, MetricConf},
-    traits::{TableSummary, TypedStoreDebug},
 };
 
 use super::SimulatorStore;

--- a/crates/iota-types/src/effects/test_effects_builder.rs
+++ b/crates/iota-types/src/effects/test_effects_builder.rs
@@ -32,6 +32,8 @@ pub struct TestEffectsBuilder {
     wrapped_objects: Vec<(ObjectID, SequenceNumber)>,
     /// Objects that are unwrapped: (ID, new owner).
     unwrapped_objects: Vec<(ObjectID, Owner)>,
+    /// Immutable objects that are read.
+    frozen_objects: BTreeSet<ObjectID>,
 }
 
 impl TestEffectsBuilder {
@@ -46,6 +48,7 @@ impl TestEffectsBuilder {
             deleted_objects: vec![],
             wrapped_objects: vec![],
             unwrapped_objects: vec![],
+            frozen_objects: BTreeSet::new(),
         }
     }
 
@@ -109,6 +112,11 @@ impl TestEffectsBuilder {
         self
     }
 
+    pub fn with_frozen_objects(mut self, objects: impl IntoIterator<Item = ObjectID>) -> Self {
+        self.frozen_objects.extend(objects);
+        self
+    }
+
     pub fn build(self) -> TransactionEffects {
         let lamport_version = self.get_lamport_version();
         let status = self.status.unwrap_or(ExecutionStatus::Success);
@@ -128,6 +136,11 @@ impl TestEffectsBuilder {
             .unwrap()
             .iter()
             .filter_map(|kind| match kind {
+                InputObjectKind::ImmOrOwnedMoveObject((id, _, _))
+                    if self.frozen_objects.contains(id) =>
+                {
+                    None
+                }
                 InputObjectKind::ImmOrOwnedMoveObject(oref) => {
                     Some((
                         oref.0,

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -2,13 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
 use crate::{
-    base_types::{ObjectID, ObjectRef},
+    base_types::ObjectRef,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     iota_system_state::{IotaSystemStateTrait, get_iota_system_state},
     messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents},
@@ -53,28 +53,6 @@ impl CheckpointData {
             }
         }
         eventually_removed_object_refs.into_values().collect()
-    }
-
-    /// Returns all objects that are used as input to the transactions in the
-    /// checkpoint, and already exist prior to the checkpoint.
-    pub fn checkpoint_input_objects(&self) -> BTreeMap<ObjectID, &Object> {
-        let mut output_objects_seen = HashSet::new();
-        let mut checkpoint_input_objects = BTreeMap::new();
-        for tx in self.transactions.iter() {
-            for obj in tx.input_objects.iter() {
-                let id = obj.id();
-                if output_objects_seen.contains(&id) || checkpoint_input_objects.contains_key(&id) {
-                    continue;
-                }
-                checkpoint_input_objects.insert(id, obj);
-            }
-            for obj in tx.output_objects.iter() {
-                // We want to track input objects that are not output objects
-                // in the previous transactions.
-                output_objects_seen.insert(obj.id());
-            }
-        }
-        checkpoint_input_objects
     }
 
     pub fn all_objects(&self) -> Vec<&Object> {

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -143,7 +143,6 @@ built_in_ids! {
 
 pub const IOTA_SYSTEM_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 pub const IOTA_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
-pub const IOTA_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 
 const fn builtin_address(suffix: u16) -> AccountAddress {
     let mut addr = [0u8; AccountAddress::LENGTH];

--- a/crates/iota-types/src/signature_verification.rs
+++ b/crates/iota-types/src/signature_verification.rs
@@ -18,12 +18,12 @@ use crate::{
     transaction::{SenderSignedData, TransactionDataAPI},
 };
 
-// Cache up to 20000 verified certs. We will need to tune this number in the
+// Cache up to this many verified certs. We will need to tune this number in the
 // future - a decent guess to start with is that it should be 10-20 times larger
 // than peak transactions per second, on the assumption that we should see most
 // certs twice within about 10-20 seconds at most: Once via RPC, once via
 // consensus.
-const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 20000;
+const VERIFIED_CERTIFICATE_CACHE_SIZE: usize = 100_000;
 
 pub struct VerifiedDigestCache<D> {
     inner: RwLock<LruCache<D, ()>>,

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -30,7 +30,8 @@ use crate::{
     object::{GAS_VALUE_FOR_TESTING, MoveObject, Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
-        EndOfEpochTransactionKind, SenderSignedData, Transaction, TransactionData, TransactionKind,
+        EndOfEpochTransactionKind, ObjectArg, SenderSignedData, Transaction, TransactionData,
+        TransactionKind,
     },
 };
 
@@ -85,7 +86,14 @@ struct TransactionBuilder {
     unwrapped_objects: BTreeSet<ObjectID>,
     wrapped_objects: BTreeSet<ObjectID>,
     deleted_objects: BTreeSet<ObjectID>,
+    frozen_objects: BTreeSet<ObjectRef>,
+    shared_inputs: BTreeMap<ObjectID, Shared>,
     events: Option<Vec<Event>>,
+}
+
+struct Shared {
+    mutable: bool,
+    object: Object,
 }
 
 impl TransactionBuilder {
@@ -99,6 +107,8 @@ impl TransactionBuilder {
             unwrapped_objects: BTreeSet::new(),
             wrapped_objects: BTreeSet::new(),
             deleted_objects: BTreeSet::new(),
+            frozen_objects: BTreeSet::new(),
+            shared_inputs: BTreeMap::new(),
             events: None,
         }
     }
@@ -234,9 +244,9 @@ impl TestCheckpointDataBuilder {
         self
     }
 
-    /// Mutate an existing object in the transaction.
+    /// Mutate an existing owned object in the transaction.
     /// `object_idx` is a convenient representation of the object's ID.
-    pub fn mutate_object(mut self, object_idx: u64) -> Self {
+    pub fn mutate_owned_object(mut self, object_idx: u64) -> Self {
         let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
         let object_id = Self::derive_object_id(object_idx);
         let object = self
@@ -246,6 +256,11 @@ impl TestCheckpointDataBuilder {
             .expect("Mutating an object that doesn't exist");
         tx_builder.mutated_objects.insert(object_id, object);
         self
+    }
+
+    /// Mutate an existing shared object in the transaction.
+    pub fn mutate_shared_object(self, object_idx: u64) -> Self {
+        self.access_shared_object(object_idx, true)
     }
 
     /// Transfer an existing object to a new owner.
@@ -332,6 +347,31 @@ impl TestCheckpointDataBuilder {
         self
     }
 
+    /// Add an immutable object as an input to the transaction.
+    ///
+    /// Fails if the object is not live or if its owner is not
+    /// [Owner::Immutable]).
+    pub fn read_frozen_object(mut self, object_id: u64) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_id);
+
+        let obj = self
+            .live_objects
+            .get(&object_id)
+            .expect("Frozen object not found");
+
+        assert!(obj.owner().is_immutable());
+        tx_builder
+            .frozen_objects
+            .insert(obj.compute_object_reference());
+        self
+    }
+
+    /// Add a read to a shared object to the transaction's effects.
+    pub fn read_shared_object(self, object_idx: u64) -> Self {
+        self.access_shared_object(object_idx, false)
+    }
+
     /// Add events to the transaction.
     /// `events` is a vector of events to be added to the transaction.
     pub fn with_events(mut self, events: Vec<Event>) -> Self {
@@ -371,11 +411,15 @@ impl TestCheckpointDataBuilder {
             unwrapped_objects,
             wrapped_objects,
             deleted_objects,
+            frozen_objects,
+            shared_inputs,
             events,
         } = self.checkpoint_builder.next_transaction.take().unwrap();
+
         let sender = Self::derive_address(sender_idx);
         let events = events.map(|events| TransactionEvents { data: events });
         let events_digest = events.as_ref().map(|events| events.digest());
+
         let mut pt_builder = ProgrammableTransactionBuilder::new();
         for (package, module, function) in move_calls {
             pt_builder
@@ -388,6 +432,30 @@ impl TestCheckpointDataBuilder {
                 )
                 .unwrap();
         }
+
+        for &object_ref in &frozen_objects {
+            pt_builder
+                .obj(ObjectArg::ImmOrOwnedObject(object_ref))
+                .expect("Failed to add frozen object input");
+        }
+
+        for (id, input) in &shared_inputs {
+            let &Owner::Shared {
+                initial_shared_version,
+            } = input.object.owner()
+            else {
+                panic!("Accessing a non-shared object as shared");
+            };
+
+            pt_builder
+                .obj(ObjectArg::SharedObject {
+                    id: *id,
+                    initial_shared_version,
+                    mutable: input.mutable,
+                })
+                .expect("Failed to add shared object input");
+        }
+
         let pt = pt_builder.finish();
         let tx_data = TransactionData::new(
             TransactionKind::ProgrammableTransaction(pt),
@@ -396,7 +464,9 @@ impl TestCheckpointDataBuilder {
             1,
             1,
         );
+
         let tx = Transaction::new(SenderSignedData::new(tx_data, vec![]));
+
         let wrapped_objects: Vec<_> = wrapped_objects
             .into_iter()
             .map(|id| self.live_objects.remove(&id).unwrap())
@@ -409,6 +479,7 @@ impl TestCheckpointDataBuilder {
             .into_iter()
             .map(|id| self.wrapped_objects.remove(&id).unwrap())
             .collect();
+
         let mut effects_builder = TestEffectsBuilder::new(tx.data())
             .with_created_objects(created_objects.iter().map(|(id, o)| (*id, *o.owner())))
             .with_mutated_objects(
@@ -418,14 +489,24 @@ impl TestCheckpointDataBuilder {
             )
             .with_wrapped_objects(wrapped_objects.iter().map(|o| (o.id(), o.version())))
             .with_unwrapped_objects(unwrapped_objects.iter().map(|o| (o.id(), *o.owner())))
-            .with_deleted_objects(deleted_objects.iter().map(|o| (o.id(), o.version())));
+            .with_deleted_objects(deleted_objects.iter().map(|o| (o.id(), o.version())))
+            .with_frozen_objects(frozen_objects.into_iter().map(|(id, _, _)| id))
+            .with_shared_input_versions(
+                shared_inputs
+                    .iter()
+                    .map(|(id, input)| (*id, input.object.version()))
+                    .collect(),
+            );
+
         if let Some(events_digest) = &events_digest {
             effects_builder = effects_builder.with_events_digest(*events_digest);
         }
+
         let effects = effects_builder.build();
         let lamport_version = effects.lamport_version();
         let input_objects: Vec<_> = mutated_objects
             .keys()
+            .chain(shared_inputs.keys())
             .map(|id| self.live_objects.get(id).unwrap().clone())
             .chain(deleted_objects)
             .chain(wrapped_objects.clone())
@@ -437,6 +518,7 @@ impl TestCheckpointDataBuilder {
             .values()
             .cloned()
             .chain(mutated_objects.values().cloned())
+            .chain(shared_inputs.values().map(|input| input.object.clone()))
             .chain(unwrapped_objects)
             .chain(std::iter::once(
                 self.live_objects.get(&gas.0).cloned().unwrap(),
@@ -453,6 +535,7 @@ impl TestCheckpointDataBuilder {
             .extend(output_objects.iter().map(|o| (o.id(), o.clone())));
         self.wrapped_objects
             .extend(wrapped_objects.iter().map(|o| (o.id(), o.clone())));
+
         self.checkpoint_builder
             .transactions
             .push(CheckpointTransaction {
@@ -605,6 +688,22 @@ impl TestCheckpointDataBuilder {
     pub fn derive_address(address_idx: u8) -> IotaAddress {
         dbg_addr(address_idx)
     }
+
+    /// Add a shared input to the transaction, being accessed from the currently
+    /// recorded live version.
+    fn access_shared_object(mut self, object_idx: u64, mutable: bool) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        let object = self
+            .live_objects
+            .get(&object_id)
+            .cloned()
+            .expect("Accessing a shared object that doesn't exist");
+        tx_builder
+            .shared_inputs
+            .insert(object_id, Shared { mutable, object });
+        self
+    }
 }
 
 #[cfg(test)]
@@ -705,7 +804,7 @@ mod tests {
             .create_owned_object(0)
             .finish_transaction()
             .start_transaction(0)
-            .mutate_object(0)
+            .mutate_owned_object(0)
             .finish_transaction()
             .build_checkpoint();
 
@@ -975,7 +1074,7 @@ mod tests {
         let checkpoint1 = builder.build_checkpoint();
         builder = builder
             .start_transaction(0)
-            .mutate_object(0)
+            .mutate_owned_object(0)
             .finish_transaction();
         let checkpoint2 = builder.build_checkpoint();
         builder = builder

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -506,7 +506,12 @@ impl TestCheckpointDataBuilder {
         let lamport_version = effects.lamport_version();
         let input_objects: Vec<_> = mutated_objects
             .keys()
-            .chain(shared_inputs.keys())
+            .chain(
+                shared_inputs
+                    .iter()
+                    .filter(|(_, i)| i.mutable)
+                    .map(|(id, _)| id),
+            )
             .map(|id| self.live_objects.get(id).unwrap().clone())
             .chain(deleted_objects)
             .chain(wrapped_objects.clone())
@@ -518,7 +523,12 @@ impl TestCheckpointDataBuilder {
             .values()
             .cloned()
             .chain(mutated_objects.values().cloned())
-            .chain(shared_inputs.values().map(|input| input.object.clone()))
+            .chain(
+                shared_inputs
+                    .values()
+                    .filter(|i| i.mutable)
+                    .map(|i| i.object.clone()),
+            )
             .chain(unwrapped_objects)
             .chain(std::iter::once(
                 self.live_objects.get(&gas.0).cloned().unwrap(),

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -31,9 +31,8 @@ use tracing::{instrument, trace};
 
 use super::{base_types::*, error::*};
 use crate::{
-    IOTA_AUTHENTICATOR_STATE_OBJECT_ID, IOTA_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION,
-    IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION, IOTA_FRAMEWORK_PACKAGE_ID,
-    IOTA_RANDOMNESS_STATE_OBJECT_ID, IOTA_SYSTEM_STATE_OBJECT_ID,
+    IOTA_AUTHENTICATOR_STATE_OBJECT_ID, IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION,
+    IOTA_FRAMEWORK_PACKAGE_ID, IOTA_RANDOMNESS_STATE_OBJECT_ID, IOTA_SYSTEM_STATE_OBJECT_ID,
     IOTA_SYSTEM_STATE_OBJECT_SHARED_VERSION,
     authenticator_state::ActiveJwk,
     committee::{Committee, EpochId, ProtocolVersion},
@@ -98,11 +97,6 @@ impl CallArg {
     pub const CLOCK_MUT: Self = Self::Object(ObjectArg::SharedObject {
         id: IOTA_CLOCK_OBJECT_ID,
         initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,
-        mutable: true,
-    });
-    pub const AUTHENTICATOR_MUT: Self = Self::Object(ObjectArg::SharedObject {
-        id: IOTA_AUTHENTICATOR_STATE_OBJECT_ID,
-        initial_shared_version: IOTA_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION,
         mutable: true,
     });
 }

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -311,9 +311,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
         "std::fmt::Debug + serde::Serialize + for<'de> serde::de::Deserialize<'de>";
     let generics_bounds_token: proc_macro2::TokenStream = generics_bounds.parse().unwrap();
 
-    let config_struct_name_str = format!("{name}Configurator");
-    let config_struct_name: proc_macro2::TokenStream = config_struct_name_str.parse().unwrap();
-
     let intermediate_db_map_struct_name_str = format!("{name}IntermediateDBMapStructPrimary");
     let intermediate_db_map_struct_name: proc_macro2::TokenStream =
         intermediate_db_map_struct_name_str.parse().unwrap();
@@ -345,47 +342,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
 
-        // <----------- This section generates the configurator struct -------------->
-
-        /// Create config structs for configuring DBMap tables.
-        /// Only active (non-deprecated) tables are configurable.
-        pub struct #config_struct_name {
-            #(
-                pub #active_field_names : typed_store::rocks::DBOptions,
-            )*
-        }
-
-        impl #config_struct_name {
-            /// Initialize to defaults
-            pub fn init() -> Self {
-                Self {
-                    #(
-                        #active_field_names : typed_store::rocks::default_db_options(),
-                    )*
-                }
-            }
-
-            /// Build a config
-            pub fn build(&self) -> typed_store::rocks::DBMapTableConfigMap {
-                typed_store::rocks::DBMapTableConfigMap::new([
-                    #(
-                        (stringify!(#active_field_names).to_owned(), self.#active_field_names.clone()),
-                    )*
-                ].into_iter().collect())
-            }
-        }
-
-        impl <
-                #(
-                    #generics_names: #generics_bounds_token,
-                )*
-            > #name #generics {
-
-                pub fn configurator() -> #config_struct_name {
-                    #config_struct_name::init()
-                }
-        }
-
         // <----------- This section generates the core open logic for opening DBMaps -------------->
 
         /// Create an intermediate struct used to open the DBMap tables in primary mode
@@ -398,7 +354,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     pub #deprecated_field_names : Option<DBMap #deprecated_inner_types>,
                 )*
         }
-
 
         impl <
                 #(
@@ -619,23 +574,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 }
             }
 
-            /// Count the keys in this table
-            /// Tables must be opened in read only mode using `open_tables_read_only`
-            pub fn count_keys(&self, table_name: &str) -> eyre::Result<usize> {
-                Ok(match table_name {
-                    #(
-                        stringify!(#active_field_names) => {
-                            typed_store::traits::Map::try_catch_up_with_primary(&self.#active_field_names)?;
-                            typed_store::traits::Map::safe_iter(&self.#active_field_names)
-                                .collect::<Result<Vec<_>, _>>()?
-                                .len()
-                        }
-                    )*
-
-                    _ => eyre::bail!("No such table name: {}", table_name),
-                })
-            }
-
             pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
                 vec![#(
                     (stringify!(#active_field_names).to_owned(), (stringify!(#active_key_names).to_owned(), stringify!(#active_value_names).to_owned())),
@@ -650,37 +588,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 )*
                 Ok(())
             }
-        }
-
-        impl <
-                #(
-                    #generics_names: #generics_bounds_token,
-                )*
-            > TypedStoreDebug for #secondary_db_map_struct_name #generics {
-                fn dump_table(
-                    &self,
-                    table_name: String,
-                    page_size: u16,
-                    page_number: usize,
-                ) -> eyre::Result<std::collections::BTreeMap<String, String>> {
-                    self.dump(table_name.as_str(), page_size, page_number)
-                }
-
-                fn primary_db_name(&self) -> String {
-                    stringify!(#name).to_owned()
-                }
-
-                fn describe_all_tables(&self) -> std::collections::BTreeMap<String, (String, String)> {
-                    Self::describe_tables()
-                }
-
-                fn count_table_keys(&self, table_name: String) -> eyre::Result<usize> {
-                    self.count_keys(table_name.as_str())
-                }
-
-                fn table_summary(&self, table_name: String) -> eyre::Result<TableSummary> {
-                    self.table_summary(table_name.as_str())
-                }
         }
     })
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -14,7 +14,7 @@ use iota_macros::fail_point;
 use prometheus::{Histogram, HistogramTimer};
 use rocksdb::{
     DBPinnableSlice, DBWithThreadMode, Error, LiveFile, MultiThreaded, ReadOptions, WriteBatch,
-    WriteOptions, checkpoint::Checkpoint,
+    checkpoint::Checkpoint,
 };
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::oneshot;
@@ -251,13 +251,12 @@ impl Database {
         &self,
         cf: &ColumnFamily,
         key: K,
-        writeopts: &WriteOptions,
     ) -> Result<(), TypedStoreError> {
         fail_point!("delete-cf-before");
         let ret = match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
                 .underlying
-                .delete_cf_opt(&cf.rocks_cf(db), key, writeopts)
+                .delete_cf(&cf.rocks_cf(db), key)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
                 db.delete(cf_name, key.as_ref());
@@ -284,13 +283,12 @@ impl Database {
         cf: &ColumnFamily,
         key: Vec<u8>,
         value: Vec<u8>,
-        writeopts: &WriteOptions,
     ) -> Result<(), TypedStoreError> {
         fail_point!("put-cf-before");
         let ret = match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
                 .underlying
-                .put_cf_opt(&cf.rocks_cf(db), key, value, writeopts)
+                .put_cf(&cf.rocks_cf(db), key, value)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
                 db.put(cf_name, key, value);
@@ -323,16 +321,12 @@ impl Database {
         }
     }
 
-    pub fn write(
-        &self,
-        batch: StorageWriteBatch,
-        writeopts: &WriteOptions,
-    ) -> Result<(), TypedStoreError> {
+    pub fn write(&self, batch: StorageWriteBatch) -> Result<(), TypedStoreError> {
         fail_point!("batch-write-before");
         let ret = match (&self.storage, batch) {
             (Storage::Rocks(rocks), StorageWriteBatch::Rocks(batch)) => rocks
                 .underlying
-                .write_opt(batch, writeopts)
+                .write(batch)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), StorageWriteBatch::InMemory(batch)) => {
                 db.write(batch);
@@ -597,7 +591,6 @@ impl<K, V> DBMap<K, V> {
         DBBatch::new(
             &self.db,
             batch,
-            self.opts.writeopts(),
             &self.db_metrics,
             &self.write_sample_interval,
         )
@@ -925,7 +918,6 @@ impl<K, V> DBMap<K, V> {
 pub struct DBBatch {
     database: Arc<Database>,
     batch: StorageWriteBatch,
-    opts: WriteOptions,
     db_metrics: Arc<DBMetrics>,
     write_sample_interval: SamplingInterval,
 }
@@ -937,14 +929,12 @@ impl DBBatch {
     pub fn new(
         dbref: &Arc<Database>,
         batch: StorageWriteBatch,
-        opts: WriteOptions,
         db_metrics: &Arc<DBMetrics>,
         write_sample_interval: &SamplingInterval,
     ) -> Self {
         DBBatch {
             database: dbref.clone(),
             batch,
-            opts,
             db_metrics: db_metrics.clone(),
             write_sample_interval: write_sample_interval.clone(),
         }
@@ -967,7 +957,7 @@ impl DBBatch {
         } else {
             None
         };
-        self.database.write(self.batch, &self.opts)?;
+        self.database.write(self.batch)?;
         self.db_metrics
             .op_metrics
             .rocksdb_batch_commit_bytes
@@ -1195,12 +1185,7 @@ where
                 .write_perf_ctx_metrics
                 .report_metrics(self.cf_name());
         }
-        self.db.put_cf(
-            &self.column_family,
-            key_buf,
-            value_buf,
-            &self.opts.writeopts(),
-        )?;
+        self.db.put_cf(&self.column_family, key_buf, value_buf)?;
 
         let elapsed = timer.stop_and_record();
         if elapsed > 1.0 {
@@ -1234,8 +1219,7 @@ where
             None
         };
         let key_buf = be_fix_int_ser(key)?;
-        self.db
-            .delete_cf(&self.column_family, key_buf, &self.opts.writeopts())?;
+        self.db.delete_cf(&self.column_family, key_buf)?;
         self.db_metrics
             .op_metrics
             .rocksdb_deletes
@@ -1399,8 +1383,6 @@ where
 #[derive(Clone, Debug)]
 pub struct ReadWriteOptions {
     pub ignore_range_deletions: bool,
-    // Whether to sync to disk on every write.
-    sync_to_disk: bool,
 }
 
 impl ReadWriteOptions {
@@ -1408,12 +1390,6 @@ impl ReadWriteOptions {
         let mut readopts = ReadOptions::default();
         readopts.set_ignore_range_deletions(self.ignore_range_deletions);
         readopts
-    }
-
-    pub fn writeopts(&self) -> WriteOptions {
-        let mut opts = WriteOptions::default();
-        opts.set_sync(self.sync_to_disk);
-        opts
     }
 
     pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
@@ -1426,7 +1402,6 @@ impl Default for ReadWriteOptions {
     fn default() -> Self {
         Self {
             ignore_range_deletions: true,
-            sync_to_disk: std::env::var("IOTA_DB_SYNC_TO_DISK").is_ok_and(|v| v != "0"),
         }
     }
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -12,25 +12,24 @@ use std::{
 
 use iota_macros::fail_point;
 use prometheus::{Histogram, HistogramTimer};
-use rocksdb::{
-    DBPinnableSlice, DBWithThreadMode, Error, LiveFile, MultiThreaded, ReadOptions, WriteBatch,
-    checkpoint::Checkpoint,
-};
+use rocksdb::{DBPinnableSlice, Error, LiveFile, ReadOptions, WriteBatch, checkpoint::Checkpoint};
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::oneshot;
 use tracing::{debug, error, instrument, warn};
 use typed_store_error::TypedStoreError;
 
 use crate::{
+    DbIterator,
     memstore::{InMemoryBatch, InMemoryDB},
     metrics::{DBMetrics, RocksDBPerfContext, SamplingInterval},
     rocks::{
-        RocksDB, be_fix_int_ser,
+        RocksDB,
         errors::{typed_store_err_from_bcs_err, typed_store_err_from_rocks_err},
-        rocks_cf,
+        rocks_cf, rocks_util,
         safe_iter::{SafeIter, SafeRevIter},
     },
     traits::{Map, TableSummary},
+    util::{be_fix_int_ser, iterator_bounds, iterator_bounds_with_range},
 };
 
 #[derive(Clone)]
@@ -105,8 +104,6 @@ pub enum StorageWriteBatch {
     Rocks(rocksdb::WriteBatch),
     InMemory(InMemoryBatch),
 }
-
-pub type RawIter<'a> = rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
 
 #[derive(Debug, Default)]
 pub struct MetricConf {
@@ -340,19 +337,6 @@ impl Database {
 
         #[allow(clippy::let_and_return)]
         ret
-    }
-
-    pub(crate) fn raw_iterator_cf<'a: 'b, 'b>(
-        &'a self,
-        cf: &ColumnFamily,
-        readopts: ReadOptions,
-    ) -> RawIter<'b> {
-        match &self.storage {
-            Storage::Rocks(rocksdb) => rocksdb
-                .underlying
-                .raw_iterator_cf_opt(&rocks_cf(rocksdb, cf.name()), readopts),
-            _ => unimplemented!("iterators not yet supported for other backends"),
-        }
     }
 
     pub(crate) fn compact_range_cf<K: AsRef<[u8]>>(
@@ -597,8 +581,8 @@ impl<K, V> DBMap<K, V> {
     }
 
     pub fn compact_range<J: Serialize>(&self, start: &J, end: &J) -> Result<(), TypedStoreError> {
-        let from_buf = be_fix_int_ser(start)?;
-        let to_buf = be_fix_int_ser(end)?;
+        let from_buf = be_fix_int_ser(start);
+        let to_buf = be_fix_int_ser(end);
         self.db
             .compact_range_cf(&self.column_family, Some(from_buf), Some(to_buf));
         Ok(())
@@ -638,13 +622,10 @@ impl<K, V> DBMap<K, V> {
         } else {
             None
         };
-        let keys_bytes: Result<Vec<_>, TypedStoreError> = keys
-            .into_iter()
-            .map(|k| be_fix_int_ser(k.borrow()))
-            .collect();
+        let keys_bytes = keys.into_iter().map(|k| be_fix_int_ser(k.borrow()));
         let results: Result<Vec<_>, TypedStoreError> = self
             .db
-            .multi_get(&self.column_family, keys_bytes?, &self.opts.readopts())
+            .multi_get(&self.column_family, keys_bytes, &self.opts.readopts())
             .into_iter()
             .collect();
         let entries = results?;
@@ -683,7 +664,7 @@ impl<K, V> DBMap<K, V> {
         for item in self.safe_iter() {
             let (key, value) = item?;
             num_keys += 1;
-            let key_len = be_fix_int_ser(key.borrow())?.len();
+            let key_len = be_fix_int_ser(key.borrow()).len();
             let value_len = bcs::to_bytes(value.borrow())?.len();
             key_bytes_total += key_len;
             value_bytes_total += value_len;
@@ -737,41 +718,19 @@ impl<K, V> DBMap<K, V> {
         )
     }
 
-    // Creates a RocksDB read option with specified lower and upper bounds.
-    /// Lower bound is inclusive, and upper bound is exclusive.
-    fn create_read_options_with_bounds(
-        &self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> ReadOptions
-    where
-        K: Serialize,
-    {
-        let mut readopts = self.opts.readopts();
-        if let Some(lower_bound) = lower_bound {
-            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
-            readopts.set_iterate_lower_bound(key_buf);
-        }
-        if let Some(upper_bound) = upper_bound {
-            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
-            readopts.set_iterate_upper_bound(key_buf);
-        }
-        readopts
-    }
-
     /// Creates a safe reversed iterator with optional bounds.
-    /// Upper bound is included.
+    /// Both upper bound and lower bound are included.
+    #[allow(clippy::complexity)]
     pub fn reversed_safe_iter_with_bounds(
         &self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
-    ) -> Result<SafeRevIter<'_, K, V>, TypedStoreError>
+    ) -> Result<DbIterator<'_, (K, V)>, TypedStoreError>
     where
         K: Serialize + DeserializeOwned,
         V: Serialize + DeserializeOwned,
     {
-        let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
-        let readopts = self.create_read_options_with_range((
+        let (it_lower_bound, it_upper_bound) = iterator_bounds_with_range::<K>((
             lower_bound
                 .as_ref()
                 .map(Bound::Included)
@@ -781,71 +740,36 @@ impl<K, V> DBMap<K, V> {
                 .map(Bound::Included)
                 .unwrap_or(Bound::Unbounded),
         ));
-
-        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        let iter = SafeIter::new(
-            self.cf_name().to_string(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        );
-        Ok(SafeRevIter::new(iter, upper_bound_key.transpose()?))
-    }
-
-    // Creates a RocksDB read option with lower and upper bounds set corresponding
-    // to `range`.
-    fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
-    where
-        K: Serialize,
-    {
-        let mut readopts = self.opts.readopts();
-
-        let lower_bound = range.start_bound();
-        let upper_bound = range.end_bound();
-
-        match lower_bound {
-            Bound::Included(lower_bound) => {
-                // Rocksdb lower bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-                readopts.set_iterate_lower_bound(key_buf);
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let readopts = rocks_util::apply_range_bounds(
+                    self.opts.readopts(),
+                    it_lower_bound,
+                    it_upper_bound,
+                );
+                let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
+                let db_iter = db
+                    .underlying
+                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
+                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+                let iter = SafeIter::new(
+                    self.cf_name().to_string(),
+                    db_iter,
+                    _timer,
+                    _perf_ctx,
+                    bytes_scanned,
+                    keys_scanned,
+                    Some(self.db_metrics.clone()),
+                );
+                Ok(Box::new(SafeRevIter::new(iter, upper_bound_key)))
             }
-            Bound::Excluded(lower_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-
-                // Since we want exclusive, we need to increment the key to exclude the previous
-                big_endian_saturating_add_one(&mut key_buf);
-                readopts.set_iterate_lower_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        match upper_bound {
-            Bound::Included(upper_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-
-                // If the key is already at the limit, there's nowhere else to go, so no upper
-                // bound
-                if !is_max(&key_buf) {
-                    // Since we want exclusive, we need to increment the key to get the upper bound
-                    big_endian_saturating_add_one(&mut key_buf);
-                    readopts.set_iterate_upper_bound(key_buf);
-                }
-            }
-            Bound::Excluded(upper_bound) => {
-                // Rocksdb upper bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-                readopts.set_iterate_upper_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        readopts
+            Storage::InMemory(db) => Ok(db.iterator(
+                self.column_family.name(),
+                it_lower_bound,
+                it_upper_bound,
+                true,
+            )),
+        }
     }
 }
 
@@ -1005,7 +929,7 @@ impl DBBatch {
         purged_vals
             .into_iter()
             .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
-                let k_buf = be_fix_int_ser(k.borrow())?;
+                let k_buf = be_fix_int_ser(k.borrow());
                 match (&mut self.batch, &db.column_family) {
                     (StorageWriteBatch::Rocks(b), ColumnFamily::Rocks(name)) => {
                         b.delete_cf(&rocks_cf_from_db(&self.database, name)?, k_buf)
@@ -1041,8 +965,8 @@ impl DBBatch {
             return Err(TypedStoreError::CrossDBBatch);
         }
 
-        let from_buf = be_fix_int_ser(from)?;
-        let to_buf = be_fix_int_ser(to)?;
+        let from_buf = be_fix_int_ser(from);
+        let to_buf = be_fix_int_ser(to);
 
         if let StorageWriteBatch::Rocks(b) = &mut self.batch {
             b.delete_range_cf(
@@ -1067,7 +991,7 @@ impl DBBatch {
         new_vals
             .into_iter()
             .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
-                let k_buf = be_fix_int_ser(k.borrow())?;
+                let k_buf = be_fix_int_ser(k.borrow());
                 let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
                 total += k_buf.len() + v_buf.len();
                 match (&mut self.batch, &db.column_family) {
@@ -1098,11 +1022,10 @@ where
     V: Serialize + DeserializeOwned,
 {
     type Error = TypedStoreError;
-    type SafeIterator = SafeIter<'a, K, V>;
 
     #[instrument(level = "trace", skip_all, err)]
     fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
-        let key_buf = be_fix_int_ser(key)?;
+        let key_buf = be_fix_int_ser(key);
         let readopts = self.opts.readopts();
         Ok(self
             .db
@@ -1138,7 +1061,7 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key)?;
+        let key_buf = be_fix_int_ser(key);
         let res = self
             .db
             .get(&self.column_family, &key_buf, &self.opts.readopts())?;
@@ -1173,7 +1096,7 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key)?;
+        let key_buf = be_fix_int_ser(key);
         let value_buf = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
         self.db_metrics
             .op_metrics
@@ -1218,7 +1141,7 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key)?;
+        let key_buf = be_fix_int_ser(key);
         self.db.delete_cf(&self.column_family, key_buf)?;
         self.db_metrics
             .op_metrics
@@ -1274,54 +1197,82 @@ where
         self.safe_iter().next().is_none()
     }
 
-    fn safe_iter(&'a self) -> Self::SafeIterator {
-        let db_iter = self
-            .db
-            .raw_iterator_cf(&self.column_family, self.opts.readopts());
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf_name().to_string(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
+    fn safe_iter(&'a self) -> DbIterator<'a, (K, V)> {
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let db_iter = db.underlying.raw_iterator_cf_opt(
+                    &rocks_cf(db, self.column_family.name()),
+                    self.opts.readopts(),
+                );
+                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+                Box::new(SafeIter::new(
+                    self.cf_name().to_string(),
+                    db_iter,
+                    _timer,
+                    _perf_ctx,
+                    bytes_scanned,
+                    keys_scanned,
+                    Some(self.db_metrics.clone()),
+                ))
+            }
+            Storage::InMemory(db) => db.iterator(self.column_family.name(), None, None, false),
+        }
     }
 
     fn safe_iter_with_bounds(
         &'a self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
-    ) -> Self::SafeIterator {
-        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
-        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf_name().to_string(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
+    ) -> DbIterator<'a, (K, V)> {
+        let (lower_bound, upper_bound) = iterator_bounds(lower_bound, upper_bound);
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let readopts =
+                    rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, upper_bound);
+                let db_iter = db
+                    .underlying
+                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
+                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+                Box::new(SafeIter::new(
+                    self.cf_name().to_string(),
+                    db_iter,
+                    _timer,
+                    _perf_ctx,
+                    bytes_scanned,
+                    keys_scanned,
+                    Some(self.db_metrics.clone()),
+                ))
+            }
+            Storage::InMemory(db) => {
+                db.iterator(self.column_family.name(), lower_bound, upper_bound, false)
+            }
+        }
     }
 
-    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
-        let readopts = self.create_read_options_with_range(range);
-        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf_name().to_string(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
+        let (lower_bound, upper_bound) = iterator_bounds_with_range(range);
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let readopts =
+                    rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, upper_bound);
+                let db_iter = db
+                    .underlying
+                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
+                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+                Box::new(SafeIter::new(
+                    self.cf_name().to_string(),
+                    db_iter,
+                    _timer,
+                    _perf_ctx,
+                    bytes_scanned,
+                    keys_scanned,
+                    Some(self.db_metrics.clone()),
+                ))
+            }
+            Storage::InMemory(db) => {
+                db.iterator(self.column_family.name(), lower_bound, upper_bound, false)
+            }
+        }
     }
 
     /// Returns a vector of values corresponding to the keys provided.
@@ -1404,57 +1355,4 @@ impl Default for ReadWriteOptions {
             ignore_range_deletions: true,
         }
     }
-}
-
-/// Given a `vec<u8>`, find the value which is one more than the vector
-/// if the vector was a big endian number.
-/// If the vector is already minimum, don't change it.
-pub(crate) fn big_endian_saturating_add_one(v: &mut [u8]) {
-    if is_max(v) {
-        return;
-    }
-    for i in (0..v.len()).rev() {
-        if v[i] == u8::MAX {
-            v[i] = 0;
-        } else {
-            v[i] += 1;
-            break;
-        }
-    }
-}
-
-/// Check if all the bytes in the vector are 0xFF
-pub(crate) fn is_max(v: &[u8]) -> bool {
-    v.iter().all(|&x| x == u8::MAX)
-}
-
-// `clippy::manual_div_ceil` is raised by code expanded by the
-// `uint::construct_uint!` macro so it needs to be fixed by `uint`
-#[expect(clippy::assign_op_pattern, clippy::manual_div_ceil)]
-#[test]
-fn test_helpers() {
-    let v = vec![];
-    assert!(is_max(&v));
-
-    fn check_add(v: Vec<u8>) {
-        let mut v = v;
-        let num = Num32::from_big_endian(&v);
-        big_endian_saturating_add_one(&mut v);
-        assert!(num + 1 == Num32::from_big_endian(&v));
-    }
-
-    uint::construct_uint! {
-        // 32 byte number
-        struct Num32(4);
-    }
-
-    let mut v = vec![255; 32];
-    big_endian_saturating_add_one(&mut v);
-    assert!(Num32::MAX == Num32::from_big_endian(&v));
-
-    check_add(vec![1; 32]);
-    check_add(vec![6; 32]);
-    check_add(vec![254; 32]);
-
-    // TBD: More tests coming with randomized arrays
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -25,6 +25,7 @@ use crate::{
     rocks::{
         RocksDB,
         errors::{typed_store_err_from_bcs_err, typed_store_err_from_rocks_err},
+        options::ReadWriteOptions,
         rocks_cf, rocks_util,
         safe_iter::{SafeIter, SafeRevIter},
     },
@@ -504,42 +505,6 @@ impl<K, V> DBMap<K, V> {
     /// Reopens an open database as a typed map operating under a specific
     /// column family. if no column family is passed, the default column
     /// family is used.
-    ///
-    /// ```
-    /// use core::fmt::Error;
-    /// use std::sync::Arc;
-    ///
-    /// use prometheus::Registry;
-    /// use tempfile::tempdir;
-    /// use typed_store::{metrics::DBMetrics, rocks::*};
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Error> {
-    ///     /// Open the DB with all needed column families first.
-    ///     let rocks = open_cf(
-    ///         tempdir().unwrap(),
-    ///         None,
-    ///         MetricConf::default(),
-    ///         &["First_CF", "Second_CF"],
-    ///     )
-    ///     .unwrap();
-    ///     /// Attach the column families to specific maps.
-    ///     let db_cf_1 = DBMap::<u32, u32>::reopen(
-    ///         &rocks,
-    ///         Some("First_CF"),
-    ///         &ReadWriteOptions::default(),
-    ///         false,
-    ///     )
-    ///     .expect("Failed to open storage");
-    ///     let db_cf_2 = DBMap::<u32, u32>::reopen(
-    ///         &rocks,
-    ///         Some("Second_CF"),
-    ///         &ReadWriteOptions::default(),
-    ///         false,
-    ///     )
-    ///     .expect("Failed to open storage");
-    ///     Ok(())
-    /// }
-    /// ```
     #[instrument(level = "debug", skip(db), err)]
     pub fn reopen(
         db: &Arc<Database>,
@@ -552,8 +517,8 @@ impl<K, V> DBMap<K, V> {
             .to_owned();
 
         let column_family = match &db.storage {
-            Storage::Rocks(_) => ColumnFamily::Rocks(cf_key.clone()),
-            Storage::InMemory(_) => ColumnFamily::InMemory(cf_key.clone()),
+            Storage::Rocks(_) => ColumnFamily::Rocks(cf_key),
+            Storage::InMemory(_) => ColumnFamily::InMemory(cf_key),
         };
         Ok(DBMap::new(
             db.clone(),
@@ -793,11 +758,14 @@ impl<K, V> DBMap<K, V> {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Error> {
-///     let rocks = open_cf(
+///     let rocks = open_cf_opts(
 ///         tempfile::tempdir().unwrap(),
 ///         None,
 ///         MetricConf::default(),
-///         &["First_CF", "Second_CF"],
+///         &[
+///             ("First_CF", rocksdb::Options::default()),
+///             ("Second_CF", rocksdb::Options::default()),
+///         ],
 ///     )
 ///     .unwrap();
 ///
@@ -1328,31 +1296,5 @@ where
     #[instrument(level = "trace", skip_all, err)]
     fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
         self.db.try_catch_up_with_primary()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ReadWriteOptions {
-    pub ignore_range_deletions: bool,
-}
-
-impl ReadWriteOptions {
-    pub fn readopts(&self) -> ReadOptions {
-        let mut readopts = ReadOptions::default();
-        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
-        readopts
-    }
-
-    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
-        self.ignore_range_deletions = ignore;
-        self
-    }
-}
-
-impl Default for ReadWriteOptions {
-    fn default() -> Self {
-        Self {
-            ignore_range_deletions: true,
-        }
     }
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -1,0 +1,1482 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+    ops::{Bound, Deref, RangeBounds},
+    path::Path,
+    sync::Arc,
+    time::Duration,
+};
+
+use iota_macros::fail_point;
+use prometheus::{Histogram, HistogramTimer};
+use rocksdb::{
+    DBPinnableSlice, DBWithThreadMode, Error, LiveFile, MultiThreaded, ReadOptions, WriteBatch,
+    WriteOptions, checkpoint::Checkpoint,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::oneshot;
+use tracing::{debug, error, instrument, warn};
+use typed_store_error::TypedStoreError;
+
+use crate::{
+    memstore::{InMemoryBatch, InMemoryDB},
+    metrics::{DBMetrics, RocksDBPerfContext, SamplingInterval},
+    rocks::{
+        RocksDB, be_fix_int_ser,
+        errors::{typed_store_err_from_bcs_err, typed_store_err_from_rocks_err},
+        rocks_cf,
+        safe_iter::{SafeIter, SafeRevIter},
+    },
+    traits::{Map, TableSummary},
+};
+
+#[derive(Clone)]
+pub(crate) enum ColumnFamily {
+    Rocks(String),
+    #[allow(dead_code)]
+    InMemory(String),
+}
+
+impl std::fmt::Debug for ColumnFamily {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ColumnFamily::Rocks(name) => write!(f, "RocksDB cf: {}", name),
+            ColumnFamily::InMemory(name) => write!(f, "InMemory cf: {}", name),
+        }
+    }
+}
+
+impl ColumnFamily {
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            ColumnFamily::Rocks(name) => name,
+            ColumnFamily::InMemory(name) => name,
+        }
+    }
+
+    pub(crate) fn rocks_cf<'a>(
+        &self,
+        rocks_db: &'a RocksDB,
+    ) -> Arc<rocksdb::BoundColumnFamily<'a>> {
+        match &self {
+            ColumnFamily::Rocks(name) => rocks_db
+                .underlying
+                .cf_handle(name)
+                .expect("Map-keying column family should have been checked at DB creation"),
+            _ => unreachable!("invariant is checked by the caller"),
+        }
+    }
+}
+
+pub(crate) enum Storage {
+    Rocks(RocksDB),
+    #[allow(dead_code)]
+    InMemory(InMemoryDB),
+}
+
+impl std::fmt::Debug for Storage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Storage::Rocks(db) => write!(f, "RocksDB Storage {:?}", db),
+            Storage::InMemory(db) => write!(f, "InMemoryDB Storage {:?}", db),
+        }
+    }
+}
+
+pub(crate) enum GetResult<'a> {
+    Rocks(DBPinnableSlice<'a>),
+    InMemory(Vec<u8>),
+}
+
+impl Deref for GetResult<'_> {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        match self {
+            GetResult::Rocks(d) => d.deref(),
+            GetResult::InMemory(d) => d.deref(),
+        }
+    }
+}
+
+pub enum StorageWriteBatch {
+    Rocks(rocksdb::WriteBatch),
+    InMemory(InMemoryBatch),
+}
+
+pub type RawIter<'a> = rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
+
+#[derive(Debug, Default)]
+pub struct MetricConf {
+    pub db_name: String,
+    pub read_sample_interval: SamplingInterval,
+    pub write_sample_interval: SamplingInterval,
+    pub iter_sample_interval: SamplingInterval,
+}
+
+impl MetricConf {
+    pub fn new(db_name: &str) -> Self {
+        if db_name.is_empty() {
+            error!("A meaningful db name should be used for metrics reporting.")
+        }
+        Self {
+            db_name: db_name.to_string(),
+            read_sample_interval: SamplingInterval::default(),
+            write_sample_interval: SamplingInterval::default(),
+            iter_sample_interval: SamplingInterval::default(),
+        }
+    }
+
+    pub fn with_sampling(self, read_interval: SamplingInterval) -> Self {
+        Self {
+            db_name: self.db_name,
+            read_sample_interval: read_interval,
+            write_sample_interval: SamplingInterval::default(),
+            iter_sample_interval: SamplingInterval::default(),
+        }
+    }
+}
+
+const CF_METRICS_REPORT_PERIOD_SECS: u64 = 30;
+
+#[derive(Debug)]
+pub struct Database {
+    pub(crate) storage: Storage,
+    pub(crate) metric_conf: MetricConf,
+}
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        DBMetrics::get().decrement_num_active_dbs(&self.metric_conf.db_name);
+    }
+}
+
+impl Database {
+    pub(crate) fn new(storage: Storage, metric_conf: MetricConf) -> Self {
+        DBMetrics::get().increment_num_active_dbs(&metric_conf.db_name);
+        Self {
+            storage,
+            metric_conf,
+        }
+    }
+
+    pub(crate) fn get<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        key: K,
+        readopts: &ReadOptions,
+    ) -> Result<Option<GetResult<'_>>, TypedStoreError> {
+        match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => Ok(db
+                .underlying
+                .get_pinned_cf_opt(&cf.rocks_cf(db), key, readopts)
+                .map_err(typed_store_err_from_rocks_err)?
+                .map(GetResult::Rocks)),
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
+                Ok(db.get(cf_name, key).map(GetResult::InMemory))
+            }
+
+            _ => Err(TypedStoreError::RocksDB(
+                "typed store invariant violation".to_string(),
+            )),
+        }
+    }
+
+    pub(crate) fn multi_get<I, K>(
+        &self,
+        cf: &ColumnFamily,
+        keys: I,
+        readopts: &ReadOptions,
+    ) -> Vec<Result<Option<GetResult<'_>>, TypedStoreError>>
+    where
+        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]>,
+    {
+        match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => {
+                let res = db.underlying.batched_multi_get_cf_opt(
+                    &cf.rocks_cf(db),
+                    keys,
+                    // sorted_input
+                    false,
+                    readopts,
+                );
+                res.into_iter()
+                    .map(|r| {
+                        r.map_err(typed_store_err_from_rocks_err)
+                            .map(|item| item.map(GetResult::Rocks))
+                    })
+                    .collect()
+            }
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => db
+                .multi_get(cf_name, keys)
+                .into_iter()
+                .map(|r| Ok(r.map(GetResult::InMemory)))
+                .collect(),
+            _ => unreachable!("typed store invariant violation"),
+        }
+    }
+
+    pub fn create_cf<N: AsRef<str>>(
+        &self,
+        name: N,
+        opts: &rocksdb::Options,
+    ) -> Result<(), rocksdb::Error> {
+        match &self.storage {
+            Storage::Rocks(db) => db.underlying.create_cf(name, opts),
+            Storage::InMemory(_) => Ok(()),
+        }
+    }
+
+    pub fn cf_handle(&self, name: &str) -> Option<()> {
+        match &self.storage {
+            Storage::Rocks(db) => db.underlying.cf_handle(name).map(|_| ()),
+            Storage::InMemory(db) => db.has_cf(name).then_some(()),
+        }
+    }
+
+    pub fn drop_cf(&self, name: &str) -> Result<(), rocksdb::Error> {
+        match &self.storage {
+            Storage::Rocks(db) => db.underlying.drop_cf(name),
+            Storage::InMemory(db) => {
+                db.drop_cf(name);
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn delete_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        key: K,
+        writeopts: &WriteOptions,
+    ) -> Result<(), TypedStoreError> {
+        fail_point!("delete-cf-before");
+        let ret = match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
+                .underlying
+                .delete_cf_opt(&cf.rocks_cf(db), key, writeopts)
+                .map_err(typed_store_err_from_rocks_err),
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
+                db.delete(cf_name, key.as_ref());
+                Ok(())
+            }
+            _ => Err(TypedStoreError::RocksDB(
+                "typed store invariant violation".to_string(),
+            )),
+        };
+        fail_point!("delete-cf-after");
+        #[allow(clippy::let_and_return)]
+        ret
+    }
+
+    pub fn path_for_pruning(&self) -> &Path {
+        match &self.storage {
+            Storage::Rocks(rocks) => rocks.underlying.path(),
+            _ => unimplemented!("method is only supported for rocksdb backend"),
+        }
+    }
+
+    pub(crate) fn put_cf(
+        &self,
+        cf: &ColumnFamily,
+        key: Vec<u8>,
+        value: Vec<u8>,
+        writeopts: &WriteOptions,
+    ) -> Result<(), TypedStoreError> {
+        fail_point!("put-cf-before");
+        let ret = match (&self.storage, cf) {
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
+                .underlying
+                .put_cf_opt(&cf.rocks_cf(db), key, value, writeopts)
+                .map_err(typed_store_err_from_rocks_err),
+            (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
+                db.put(cf_name, key, value);
+                Ok(())
+            }
+            _ => Err(TypedStoreError::RocksDB(
+                "typed store invariant violation".to_string(),
+            )),
+        };
+        fail_point!("put-cf-after");
+        #[allow(clippy::let_and_return)]
+        ret
+    }
+
+    pub(crate) fn key_may_exist_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        key: K,
+        readopts: &ReadOptions,
+    ) -> bool {
+        match &self.storage {
+            // [`rocksdb::DBWithThreadMode::key_may_exist_cf`] can have false positives,
+            // but no false negatives. We use it to short-circuit the absent case
+            Storage::Rocks(rocks) => {
+                rocks
+                    .underlying
+                    .key_may_exist_cf_opt(&rocks_cf(rocks, cf.name()), key, readopts)
+            }
+            _ => true,
+        }
+    }
+
+    pub fn write(
+        &self,
+        batch: StorageWriteBatch,
+        writeopts: &WriteOptions,
+    ) -> Result<(), TypedStoreError> {
+        fail_point!("batch-write-before");
+        let ret = match (&self.storage, batch) {
+            (Storage::Rocks(rocks), StorageWriteBatch::Rocks(batch)) => rocks
+                .underlying
+                .write_opt(batch, writeopts)
+                .map_err(typed_store_err_from_rocks_err),
+            (Storage::InMemory(db), StorageWriteBatch::InMemory(batch)) => {
+                db.write(batch);
+                Ok(())
+            }
+            _ => Err(TypedStoreError::RocksDB(
+                "using invalid batch type for the database".to_string(),
+            )),
+        };
+        fail_point!("batch-write-after");
+
+        #[allow(clippy::let_and_return)]
+        ret
+    }
+
+    pub(crate) fn raw_iterator_cf<'a: 'b, 'b>(
+        &'a self,
+        cf: &ColumnFamily,
+        readopts: ReadOptions,
+    ) -> RawIter<'b> {
+        match &self.storage {
+            Storage::Rocks(rocksdb) => rocksdb
+                .underlying
+                .raw_iterator_cf_opt(&rocks_cf(rocksdb, cf.name()), readopts),
+            _ => unimplemented!("iterators not yet supported for other backends"),
+        }
+    }
+
+    pub(crate) fn compact_range_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        start: Option<K>,
+        end: Option<K>,
+    ) {
+        if let Storage::Rocks(rocksdb) = &self.storage {
+            rocksdb
+                .underlying
+                .compact_range_cf(&rocks_cf(rocksdb, cf.name()), start, end);
+        }
+    }
+
+    pub fn flush(&self) -> Result<(), TypedStoreError> {
+        match &self.storage {
+            Storage::Rocks(db) => db
+                .underlying
+                .flush()
+                .map_err(typed_store_err_from_rocks_err),
+            Storage::InMemory(_) => Ok(()),
+        }
+    }
+
+    pub fn checkpoint(&self, path: &Path) -> Result<(), TypedStoreError> {
+        // TODO: implement for other storage types
+        if let Storage::Rocks(rocks) = &self.storage {
+            let checkpoint =
+                Checkpoint::new(&rocks.underlying).map_err(typed_store_err_from_rocks_err)?;
+            checkpoint
+                .create_checkpoint(path)
+                .map_err(|e| TypedStoreError::RocksDB(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    pub fn get_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.read_sample_interval.new_from_self()
+    }
+
+    pub fn multiget_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.read_sample_interval.new_from_self()
+    }
+
+    pub fn write_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.write_sample_interval.new_from_self()
+    }
+
+    pub fn iter_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.iter_sample_interval.new_from_self()
+    }
+
+    pub(crate) fn db_name(&self) -> String {
+        let name = &self.metric_conf.db_name;
+        if name.is_empty() {
+            "default".to_string()
+        } else {
+            name.clone()
+        }
+    }
+
+    pub fn live_files(&self) -> Result<Vec<LiveFile>, Error> {
+        match &self.storage {
+            Storage::Rocks(rocks) => rocks.underlying.live_files(),
+            _ => Ok(vec![]),
+        }
+    }
+
+    pub(crate) fn try_catch_up_with_primary(&self) -> Result<(), TypedStoreError> {
+        if let Storage::Rocks(rocks) = &self.storage {
+            rocks
+                .underlying
+                .try_catch_up_with_primary()
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        Ok(())
+    }
+}
+
+fn rocks_cf_from_db<'a>(
+    db: &'a Database,
+    cf_name: &str,
+) -> Result<Arc<rocksdb::BoundColumnFamily<'a>>, TypedStoreError> {
+    match &db.storage {
+        Storage::Rocks(rocksdb) => Ok(rocksdb
+            .underlying
+            .cf_handle(cf_name)
+            .expect("Map-keying column family should have been checked at DB creation")),
+        _ => Err(TypedStoreError::RocksDB(
+            "using invalid batch type for the database".to_string(),
+        )),
+    }
+}
+
+/// An interface to a rocksDB database, keyed by a columnfamily
+#[derive(Clone, Debug)]
+pub struct DBMap<K, V> {
+    pub db: Arc<Database>,
+    _phantom: PhantomData<fn(K) -> V>,
+    column_family: ColumnFamily,
+    pub opts: ReadWriteOptions,
+    db_metrics: Arc<DBMetrics>,
+    get_sample_interval: SamplingInterval,
+    multiget_sample_interval: SamplingInterval,
+    write_sample_interval: SamplingInterval,
+    iter_sample_interval: SamplingInterval,
+    _metrics_task_cancel_handle: Arc<oneshot::Sender<()>>,
+}
+
+unsafe impl<K: Send, V: Send> Send for DBMap<K, V> {}
+
+impl<K, V> DBMap<K, V> {
+    pub(crate) fn new(
+        db: Arc<Database>,
+        opts: &ReadWriteOptions,
+        column_family: ColumnFamily,
+        is_deprecated: bool,
+    ) -> Self {
+        let db_cloned = db.clone();
+        let db_metrics = DBMetrics::get();
+        let db_metrics_cloned = db_metrics.clone();
+        let cf = column_family.name().to_string();
+
+        let (sender, mut recv) = tokio::sync::oneshot::channel();
+        if !is_deprecated && matches!(db.storage, Storage::Rocks(_)) {
+            tokio::task::spawn(async move {
+                let mut interval =
+                    tokio::time::interval(Duration::from_secs(CF_METRICS_REPORT_PERIOD_SECS));
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => {
+                            let db = db_cloned.clone();
+                            let cf = cf.clone();
+                            let db_metrics = db_metrics.clone();
+                            if let Err(e) = tokio::task::spawn_blocking(move || {
+                                Self::report_rocksdb_metrics(&db, &cf, &db_metrics);
+                            }).await {
+                                error!("Failed to log metrics with error: {}", e);
+                            }
+                        }
+                        _ = &mut recv => break,
+                    }
+                }
+                debug!("Returning the cf metric logging task for DBMap: {}", &cf);
+            });
+        }
+        DBMap {
+            db: db.clone(),
+            opts: opts.clone(),
+            _phantom: PhantomData,
+            column_family,
+            db_metrics: db_metrics_cloned,
+            _metrics_task_cancel_handle: Arc::new(sender),
+            get_sample_interval: db.get_sampling_interval(),
+            multiget_sample_interval: db.multiget_sampling_interval(),
+            write_sample_interval: db.write_sampling_interval(),
+            iter_sample_interval: db.iter_sampling_interval(),
+        }
+    }
+
+    /// Reopens an open database as a typed map operating under a specific
+    /// column family. if no column family is passed, the default column
+    /// family is used.
+    ///
+    /// ```
+    /// use core::fmt::Error;
+    /// use std::sync::Arc;
+    ///
+    /// use prometheus::Registry;
+    /// use tempfile::tempdir;
+    /// use typed_store::{metrics::DBMetrics, rocks::*};
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Error> {
+    ///     /// Open the DB with all needed column families first.
+    ///     let rocks = open_cf(
+    ///         tempdir().unwrap(),
+    ///         None,
+    ///         MetricConf::default(),
+    ///         &["First_CF", "Second_CF"],
+    ///     )
+    ///     .unwrap();
+    ///     /// Attach the column families to specific maps.
+    ///     let db_cf_1 = DBMap::<u32, u32>::reopen(
+    ///         &rocks,
+    ///         Some("First_CF"),
+    ///         &ReadWriteOptions::default(),
+    ///         false,
+    ///     )
+    ///     .expect("Failed to open storage");
+    ///     let db_cf_2 = DBMap::<u32, u32>::reopen(
+    ///         &rocks,
+    ///         Some("Second_CF"),
+    ///         &ReadWriteOptions::default(),
+    ///         false,
+    ///     )
+    ///     .expect("Failed to open storage");
+    ///     Ok(())
+    /// }
+    /// ```
+    #[instrument(level = "debug", skip(db), err)]
+    pub fn reopen(
+        db: &Arc<Database>,
+        opt_cf: Option<&str>,
+        rw_options: &ReadWriteOptions,
+        is_deprecated: bool,
+    ) -> Result<Self, TypedStoreError> {
+        let cf_key = opt_cf
+            .unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+            .to_owned();
+
+        let column_family = match &db.storage {
+            Storage::Rocks(_) => ColumnFamily::Rocks(cf_key.clone()),
+            Storage::InMemory(_) => ColumnFamily::InMemory(cf_key.clone()),
+        };
+        Ok(DBMap::new(
+            db.clone(),
+            rw_options,
+            column_family,
+            is_deprecated,
+        ))
+    }
+
+    pub fn cf_name(&self) -> &str {
+        self.column_family.name()
+    }
+
+    pub fn batch(&self) -> DBBatch {
+        let batch = match &self.db.storage {
+            Storage::Rocks(_) => StorageWriteBatch::Rocks(WriteBatch::default()),
+            Storage::InMemory(_) => StorageWriteBatch::InMemory(InMemoryBatch::default()),
+        };
+        DBBatch::new(
+            &self.db,
+            batch,
+            self.opts.writeopts(),
+            &self.db_metrics,
+            &self.write_sample_interval,
+        )
+    }
+
+    pub fn compact_range<J: Serialize>(&self, start: &J, end: &J) -> Result<(), TypedStoreError> {
+        let from_buf = be_fix_int_ser(start)?;
+        let to_buf = be_fix_int_ser(end)?;
+        self.db
+            .compact_range_cf(&self.column_family, Some(from_buf), Some(to_buf));
+        Ok(())
+    }
+
+    pub fn compact_range_raw(
+        &self,
+        cf_name: &str,
+        start: Vec<u8>,
+        end: Vec<u8>,
+    ) -> Result<(), TypedStoreError> {
+        let cf = match &self.db.storage {
+            Storage::Rocks(_) => ColumnFamily::Rocks(cf_name.to_string()),
+            Storage::InMemory(_) => ColumnFamily::InMemory(cf_name.to_string()),
+        };
+        self.db.compact_range_cf(&cf, Some(start), Some(end));
+        Ok(())
+    }
+
+    /// Returns a vector of raw values corresponding to the keys provided.
+    fn multi_get_pinned<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<Option<GetResult<'_>>>, TypedStoreError>
+    where
+        J: Borrow<K>,
+        K: Serialize,
+    {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_multiget_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let perf_ctx = if self.multiget_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let keys_bytes: Result<Vec<_>, TypedStoreError> = keys
+            .into_iter()
+            .map(|k| be_fix_int_ser(k.borrow()))
+            .collect();
+        let results: Result<Vec<_>, TypedStoreError> = self
+            .db
+            .multi_get(&self.column_family, keys_bytes?, &self.opts.readopts())
+            .into_iter()
+            .collect();
+        let entries = results?;
+        let entry_size = entries
+            .iter()
+            .flatten()
+            .map(|entry| entry.len())
+            .sum::<usize>();
+        self.db_metrics
+            .op_metrics
+            .rocksdb_multiget_bytes
+            .with_label_values(&[self.cf_name()])
+            .observe(entry_size as f64);
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(self.cf_name());
+        }
+        Ok(entries)
+    }
+
+    pub fn checkpoint_db(&self, path: &Path) -> Result<(), TypedStoreError> {
+        self.db.checkpoint(path)
+    }
+
+    pub fn table_summary(&self) -> eyre::Result<TableSummary>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let mut num_keys = 0;
+        let mut key_bytes_total = 0;
+        let mut value_bytes_total = 0;
+        let mut key_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+        let mut value_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+        for item in self.safe_iter() {
+            let (key, value) = item?;
+            num_keys += 1;
+            let key_len = be_fix_int_ser(key.borrow())?.len();
+            let value_len = bcs::to_bytes(value.borrow())?.len();
+            key_bytes_total += key_len;
+            value_bytes_total += value_len;
+            key_hist.record(key_len as u64)?;
+            value_hist.record(value_len as u64)?;
+        }
+        Ok(TableSummary {
+            num_keys,
+            key_bytes_total,
+            value_bytes_total,
+            key_hist,
+            value_hist,
+        })
+    }
+
+    // Creates metrics and context for tracking an iterator usage and performance.
+    fn create_iter_context(
+        &self,
+    ) -> (
+        Option<HistogramTimer>,
+        Option<Histogram>,
+        Option<Histogram>,
+        Option<RocksDBPerfContext>,
+    ) {
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let bytes_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_bytes
+            .with_label_values(&[self.cf_name()]);
+        let keys_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_keys
+            .with_label_values(&[self.cf_name()]);
+        let perf_ctx = if self.iter_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        (
+            Some(timer),
+            Some(bytes_scanned),
+            Some(keys_scanned),
+            perf_ctx,
+        )
+    }
+
+    // Creates a RocksDB read option with specified lower and upper bounds.
+    /// Lower bound is inclusive, and upper bound is exclusive.
+    fn create_read_options_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> ReadOptions
+    where
+        K: Serialize,
+    {
+        let mut readopts = self.opts.readopts();
+        if let Some(lower_bound) = lower_bound {
+            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
+            readopts.set_iterate_lower_bound(key_buf);
+        }
+        if let Some(upper_bound) = upper_bound {
+            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
+            readopts.set_iterate_upper_bound(key_buf);
+        }
+        readopts
+    }
+
+    /// Creates a safe reversed iterator with optional bounds.
+    /// Upper bound is included.
+    pub fn reversed_safe_iter_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Result<SafeRevIter<'_, K, V>, TypedStoreError>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
+        let readopts = self.create_read_options_with_range((
+            lower_bound
+                .as_ref()
+                .map(Bound::Included)
+                .unwrap_or(Bound::Unbounded),
+            upper_bound
+                .as_ref()
+                .map(Bound::Included)
+                .unwrap_or(Bound::Unbounded),
+        ));
+
+        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        let iter = SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        );
+        Ok(SafeRevIter::new(iter, upper_bound_key.transpose()?))
+    }
+
+    // Creates a RocksDB read option with lower and upper bounds set corresponding
+    // to `range`.
+    fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
+    where
+        K: Serialize,
+    {
+        let mut readopts = self.opts.readopts();
+
+        let lower_bound = range.start_bound();
+        let upper_bound = range.end_bound();
+
+        match lower_bound {
+            Bound::Included(lower_bound) => {
+                // Rocksdb lower bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Excluded(lower_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+
+                // Since we want exclusive, we need to increment the key to exclude the previous
+                big_endian_saturating_add_one(&mut key_buf);
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        match upper_bound {
+            Bound::Included(upper_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+
+                // If the key is already at the limit, there's nowhere else to go, so no upper
+                // bound
+                if !is_max(&key_buf) {
+                    // Since we want exclusive, we need to increment the key to get the upper bound
+                    big_endian_saturating_add_one(&mut key_buf);
+                    readopts.set_iterate_upper_bound(key_buf);
+                }
+            }
+            Bound::Excluded(upper_bound) => {
+                // Rocksdb upper bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+                readopts.set_iterate_upper_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        readopts
+    }
+}
+
+/// Provides a mutable struct to form a collection of database write operations,
+/// and execute them.
+///
+/// Batching write and delete operations is faster than performing them one by
+/// one and ensures their atomicity,  ie. they are all written or none is.
+/// This is also true of operations across column families in the same database.
+///
+/// Serializations / Deserialization, and naming of column families is performed
+/// by passing a DBMap<K,V> with each operation.
+///
+/// ```
+/// use core::fmt::Error;
+/// use std::sync::Arc;
+///
+/// use prometheus::Registry;
+/// use tempfile::tempdir;
+/// use typed_store::{Map, metrics::DBMetrics, rocks::*};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
+///     let rocks = open_cf(
+///         tempfile::tempdir().unwrap(),
+///         None,
+///         MetricConf::default(),
+///         &["First_CF", "Second_CF"],
+///     )
+///     .unwrap();
+///
+///     let db_cf_1 = DBMap::reopen(
+///         &rocks,
+///         Some("First_CF"),
+///         &ReadWriteOptions::default(),
+///         false,
+///     )
+///     .expect("Failed to open storage");
+///     let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
+///
+///     let db_cf_2 = DBMap::reopen(
+///         &rocks,
+///         Some("Second_CF"),
+///         &ReadWriteOptions::default(),
+///         false,
+///     )
+///     .expect("Failed to open storage");
+///     let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
+///
+///     let mut batch = db_cf_1.batch();
+///     batch
+///         .insert_batch(&db_cf_1, keys_vals_1.clone())
+///         .expect("Failed to batch insert")
+///         .insert_batch(&db_cf_2, keys_vals_2.clone())
+///         .expect("Failed to batch insert");
+///
+///     let _ = batch.write().expect("Failed to execute batch");
+///     for (k, v) in keys_vals_1 {
+///         let val = db_cf_1.get(&k).expect("Failed to get inserted key");
+///         assert_eq!(Some(v), val);
+///     }
+///
+///     for (k, v) in keys_vals_2 {
+///         let val = db_cf_2.get(&k).expect("Failed to get inserted key");
+///         assert_eq!(Some(v), val);
+///     }
+///     Ok(())
+/// }
+/// ```
+pub struct DBBatch {
+    database: Arc<Database>,
+    batch: StorageWriteBatch,
+    opts: WriteOptions,
+    db_metrics: Arc<DBMetrics>,
+    write_sample_interval: SamplingInterval,
+}
+
+impl DBBatch {
+    /// Create a new batch associated with a DB reference.
+    ///
+    /// Use `open_cf` to get the DB reference or an existing open database.
+    pub fn new(
+        dbref: &Arc<Database>,
+        batch: StorageWriteBatch,
+        opts: WriteOptions,
+        db_metrics: &Arc<DBMetrics>,
+        write_sample_interval: &SamplingInterval,
+    ) -> Self {
+        DBBatch {
+            database: dbref.clone(),
+            batch,
+            opts,
+            db_metrics: db_metrics.clone(),
+            write_sample_interval: write_sample_interval.clone(),
+        }
+    }
+
+    /// Consume the batch and write its operations to the database
+    #[instrument(level = "trace", skip_all, err)]
+    pub fn write(self) -> Result<(), TypedStoreError> {
+        let db_name = self.database.db_name();
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_batch_commit_latency_seconds
+            .with_label_values(&[&db_name])
+            .start_timer();
+        let batch_size = self.size_in_bytes();
+
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        self.database.write(self.batch, &self.opts)?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_batch_commit_bytes
+            .with_label_values(&[&db_name])
+            .observe(batch_size as f64);
+
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(&db_name);
+        }
+        let elapsed = timer.stop_and_record();
+        if elapsed > 1.0 {
+            warn!(?elapsed, ?db_name, "very slow batch write");
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_batch_writes_count
+                .with_label_values(&[&db_name])
+                .inc();
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_batch_writes_duration_ms
+                .with_label_values(&[&db_name])
+                .inc_by((elapsed * 1000.0) as u64);
+        }
+        Ok(())
+    }
+
+    pub fn size_in_bytes(&self) -> usize {
+        match self.batch {
+            StorageWriteBatch::Rocks(ref b) => b.size_in_bytes(),
+            StorageWriteBatch::InMemory(_) => 0,
+        }
+    }
+
+    pub fn delete_batch<J: Borrow<K>, K: Serialize, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        purged_vals: impl IntoIterator<Item = J>,
+    ) -> Result<(), TypedStoreError> {
+        if !Arc::ptr_eq(&db.db, &self.database) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+
+        purged_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                match (&mut self.batch, &db.column_family) {
+                    (StorageWriteBatch::Rocks(b), ColumnFamily::Rocks(name)) => {
+                        b.delete_cf(&rocks_cf_from_db(&self.database, name)?, k_buf)
+                    }
+                    (StorageWriteBatch::InMemory(b), ColumnFamily::InMemory(name)) => {
+                        b.delete_cf(name, k_buf)
+                    }
+                    _ => Err(TypedStoreError::RocksDB(
+                        "typed store invariant violation".to_string(),
+                    ))?,
+                }
+                Ok(())
+            })?;
+        Ok(())
+    }
+
+    /// Deletes a range of keys between `from` (inclusive) and `to`
+    /// (non-inclusive) by writing a range delete tombstone in the db map
+    /// If the DBMap is configured with ignore_range_deletions set to false,
+    /// the effect of this write will be visible immediately i.e. you won't
+    /// see old values when you do a lookup or scan. But if it is configured
+    /// with ignore_range_deletions set to true, the old value are visible until
+    /// compaction actually deletes them which will happen sometime after. By
+    /// default ignore_range_deletions is set to true on a DBMap (unless it is
+    /// overridden in the config), so please use this function with caution
+    pub fn schedule_delete_range<K: Serialize, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        from: &K,
+        to: &K,
+    ) -> Result<(), TypedStoreError> {
+        if !Arc::ptr_eq(&db.db, &self.database) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+
+        let from_buf = be_fix_int_ser(from)?;
+        let to_buf = be_fix_int_ser(to)?;
+
+        if let StorageWriteBatch::Rocks(b) = &mut self.batch {
+            b.delete_range_cf(
+                &rocks_cf_from_db(&self.database, db.cf_name())?,
+                from_buf,
+                to_buf,
+            );
+        }
+        Ok(())
+    }
+
+    /// inserts a range of (key, value) pairs given as an iterator
+    pub fn insert_batch<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
+        &mut self,
+        db: &DBMap<K, V>,
+        new_vals: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<&mut Self, TypedStoreError> {
+        if !Arc::ptr_eq(&db.db, &self.database) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+        let mut total = 0usize;
+        new_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
+                total += k_buf.len() + v_buf.len();
+                match (&mut self.batch, &db.column_family) {
+                    (StorageWriteBatch::Rocks(b), ColumnFamily::Rocks(name)) => {
+                        b.put_cf(&rocks_cf_from_db(&self.database, name)?, k_buf, v_buf)
+                    }
+                    (StorageWriteBatch::InMemory(b), ColumnFamily::InMemory(name)) => {
+                        b.put_cf(name, k_buf, v_buf)
+                    }
+                    _ => Err(TypedStoreError::RocksDB(
+                        "typed store invariant violation".to_string(),
+                    ))?,
+                }
+                Ok(())
+            })?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_batch_put_bytes
+            .with_label_values(&[db.cf_name()])
+            .observe(total as f64);
+        Ok(self)
+    }
+}
+
+impl<'a, K, V> Map<'a, K, V> for DBMap<K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    type Error = TypedStoreError;
+    type SafeIterator = SafeIter<'a, K, V>;
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
+        let key_buf = be_fix_int_ser(key)?;
+        let readopts = self.opts.readopts();
+        Ok(self
+            .db
+            .key_may_exist_cf(&self.column_family, &key_buf, &readopts)
+            && self
+                .db
+                .get(&self.column_family, &key_buf, &readopts)?
+                .is_some())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_contains_keys<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<bool>, Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        let values = self.multi_get_pinned(keys)?;
+        Ok(values.into_iter().map(|v| v.is_some()).collect())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_get_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let perf_ctx = if self.get_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        let res = self
+            .db
+            .get(&self.column_family, &key_buf, &self.opts.readopts())?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_get_bytes
+            .with_label_values(&[self.cf_name()])
+            .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(self.cf_name());
+        }
+        match res {
+            Some(data) => Ok(Some(
+                bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_put_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        let value_buf = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_put_bytes
+            .with_label_values(&[self.cf_name()])
+            .observe((key_buf.len() + value_buf.len()) as f64);
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(self.cf_name());
+        }
+        self.db.put_cf(
+            &self.column_family,
+            key_buf,
+            value_buf,
+            &self.opts.writeopts(),
+        )?;
+
+        let elapsed = timer.stop_and_record();
+        if elapsed > 1.0 {
+            warn!(?elapsed, cf = ?self.cf_name(), "very slow insert");
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_puts_count
+                .with_label_values(&[self.cf_name()])
+                .inc();
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_puts_duration_ms
+                .with_label_values(&[self.cf_name()])
+                .inc_by((elapsed * 1000.0) as u64);
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_delete_latency_seconds
+            .with_label_values(&[self.cf_name()])
+            .start_timer();
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        self.db
+            .delete_cf(&self.column_family, key_buf, &self.opts.writeopts())?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_deletes
+            .with_label_values(&[self.cf_name()])
+            .inc();
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(self.cf_name());
+        }
+        Ok(())
+    }
+
+    /// This method first drops the existing column family and then creates a
+    /// new one with the same name. The two operations are not atomic and
+    /// hence it is possible to get into a race condition where the column
+    /// family has been dropped but new one is not created yet
+    #[instrument(level = "trace", skip_all, err)]
+    fn unsafe_clear(&self) -> Result<(), TypedStoreError> {
+        let _ = self.db.drop_cf(self.cf_name());
+        self.db
+            .create_cf(self.cf_name(), &crate::rocks::default_db_options().options)
+            .map_err(typed_store_err_from_rocks_err)?;
+        Ok(())
+    }
+
+    /// Writes a range delete tombstone to delete all entries in the db map
+    /// If the DBMap is configured with ignore_range_deletions set to false,
+    /// the effect of this write will be visible immediately i.e. you won't
+    /// see old values when you do a lookup or scan. But if it is configured
+    /// with ignore_range_deletions set to true, the old value are visible until
+    /// compaction actually deletes them which will happen sometime after. By
+    /// default ignore_range_deletions is set to true on a DBMap (unless it is
+    /// overridden in the config), so please use this function with caution
+    #[instrument(level = "trace", skip_all, err)]
+    fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
+        let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);
+        let last_key = self
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+            .transpose()?
+            .map(|(k, _v)| k);
+        if let Some((first_key, last_key)) = first_key.zip(last_key) {
+            let mut batch = self.batch();
+            batch.schedule_delete_range(self, &first_key, &last_key)?;
+            batch.write()?;
+        }
+        Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.safe_iter().next().is_none()
+    }
+
+    fn safe_iter(&'a self) -> Self::SafeIterator {
+        let db_iter = self
+            .db
+            .raw_iterator_cf(&self.column_family, self.opts.readopts());
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_iter_with_bounds(
+        &'a self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Self::SafeIterator {
+        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
+        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
+        let readopts = self.create_read_options_with_range(range);
+        let db_iter = self.db.raw_iterator_cf(&self.column_family, readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    /// Returns a vector of values corresponding to the keys provided.
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_get<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<Option<V>>, TypedStoreError>
+    where
+        J: Borrow<K>,
+    {
+        let results = self.multi_get_pinned(keys)?;
+        let values_parsed: Result<Vec<_>, TypedStoreError> = results
+            .into_iter()
+            .map(|value_byte| match value_byte {
+                Some(data) => Ok(Some(
+                    bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
+                )),
+                None => Ok(None),
+            })
+            .collect();
+
+        values_parsed
+    }
+
+    /// Convenience method for batch insertion
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_insert<J, U>(
+        &self,
+        key_val_pairs: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<(), Self::Error>
+    where
+        J: Borrow<K>,
+        U: Borrow<V>,
+    {
+        let mut batch = self.batch();
+        batch.insert_batch(self, key_val_pairs)?;
+        batch.write()
+    }
+
+    /// Convenience method for batch removal
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        let mut batch = self.batch();
+        batch.delete_batch(self, keys)?;
+        batch.write()
+    }
+
+    /// Try to catch up with primary when running as secondary
+    #[instrument(level = "trace", skip_all, err)]
+    fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
+        self.db.try_catch_up_with_primary()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ReadWriteOptions {
+    pub ignore_range_deletions: bool,
+    // Whether to sync to disk on every write.
+    sync_to_disk: bool,
+}
+
+impl ReadWriteOptions {
+    pub fn readopts(&self) -> ReadOptions {
+        let mut readopts = ReadOptions::default();
+        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
+        readopts
+    }
+
+    pub fn writeopts(&self) -> WriteOptions {
+        let mut opts = WriteOptions::default();
+        opts.set_sync(self.sync_to_disk);
+        opts
+    }
+
+    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
+        self.ignore_range_deletions = ignore;
+        self
+    }
+}
+
+impl Default for ReadWriteOptions {
+    fn default() -> Self {
+        Self {
+            ignore_range_deletions: true,
+            sync_to_disk: std::env::var("IOTA_DB_SYNC_TO_DISK").is_ok_and(|v| v != "0"),
+        }
+    }
+}
+
+/// Given a `vec<u8>`, find the value which is one more than the vector
+/// if the vector was a big endian number.
+/// If the vector is already minimum, don't change it.
+pub(crate) fn big_endian_saturating_add_one(v: &mut [u8]) {
+    if is_max(v) {
+        return;
+    }
+    for i in (0..v.len()).rev() {
+        if v[i] == u8::MAX {
+            v[i] = 0;
+        } else {
+            v[i] += 1;
+            break;
+        }
+    }
+}
+
+/// Check if all the bytes in the vector are 0xFF
+pub(crate) fn is_max(v: &[u8]) -> bool {
+    v.iter().all(|&x| x == u8::MAX)
+}
+
+// `clippy::manual_div_ceil` is raised by code expanded by the
+// `uint::construct_uint!` macro so it needs to be fixed by `uint`
+#[expect(clippy::assign_op_pattern, clippy::manual_div_ceil)]
+#[test]
+fn test_helpers() {
+    let v = vec![];
+    assert!(is_max(&v));
+
+    fn check_add(v: Vec<u8>) {
+        let mut v = v;
+        let num = Num32::from_big_endian(&v);
+        big_endian_saturating_add_one(&mut v);
+        assert!(num + 1 == Num32::from_big_endian(&v));
+    }
+
+    uint::construct_uint! {
+        // 32 byte number
+        struct Num32(4);
+    }
+
+    let mut v = vec![255; 32];
+    big_endian_saturating_add_one(&mut v);
+    assert!(Num32::MAX == Num32::from_big_endian(&v));
+
+    check_add(vec![1; 32]);
+    check_add(vec![6; 32]);
+    check_add(vec![254; 32]);
+
+    // TBD: More tests coming with randomized arrays
+}

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -478,7 +478,7 @@ impl<K, V> DBMap<K, V> {
         column_family: ColumnFamily,
         is_deprecated: bool,
     ) -> Self {
-        let db_cloned = db.clone();
+        let db_cloned = Arc::downgrade(&db);
         let db_metrics = DBMetrics::get();
         let db_metrics_cloned = db_metrics.clone();
         let cf = column_family.name().to_string();
@@ -491,13 +491,16 @@ impl<K, V> DBMap<K, V> {
                 loop {
                     tokio::select! {
                         _ = interval.tick() => {
-                            let db = db_cloned.clone();
-                            let cf = cf.clone();
-                            let db_metrics = db_metrics.clone();
-                            if let Err(e) = tokio::task::spawn_blocking(move || {
-                                Self::report_rocksdb_metrics(&db, &cf, &db_metrics);
-                            }).await {
-                                error!("Failed to log metrics with error: {}", e);
+                            if let Some(db) = db_cloned.upgrade() {
+                                let cf = cf.clone();
+                                let db_metrics = db_metrics.clone();
+                                if let Err(e) = tokio::task::spawn_blocking(move || {
+                                    Self::report_rocksdb_metrics(&db, &cf, &db_metrics);
+                                }).await {
+                                    error!("Failed to log metrics with error: {}", e);
+                                }
+                            } else {
+                                break;
                             }
                         }
                         _ = &mut recv => break,

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -16,6 +16,8 @@ pub use rocksdb;
 
 pub mod traits;
 pub use traits::Map;
+pub mod database;
+pub mod memstore;
 pub mod metrics;
 pub mod rocks;
 pub mod test_db;

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -30,8 +30,7 @@ pub type StoreError = typed_store_error::TypedStoreError;
 
 /// A helper macro to simplify common operations for opening and debugging
 /// TypedStore (currently internally structs of DBMaps) It operates on a struct
-/// where all the members are of Store<K, V> or DBMap<K, V> `TypedStoreDebug`
-/// traits are then derived The main features are:
+/// where all the members are DBMap<K, V> The main features are:
 /// 1. Flexible configuration of each table (column family) via defaults and
 ///    overrides
 /// 2. Auto-generated `open` routine
@@ -52,7 +51,6 @@ pub type StoreError = typed_store_error::TypedStoreError;
 /// use typed_store::{
 ///     DBMapUtils,
 ///     rocks::{DBMap, DBOptions, MetricConf},
-///     traits::{TableSummary, TypedStoreDebug},
 /// };
 /// /// Define a struct with all members having type DBMap<K, V>
 ///
@@ -76,38 +74,6 @@ pub type StoreError = typed_store_error::TypedStoreError;
 ///     #[default_options_override_fn = "custom_fn_name1"]
 ///     table4: DBMap<i32, String>,
 /// }
-///
-/// // b. Options specified by DB opener
-/// // For finer control, we also allow the opener of the DB to specify their
-/// // own options which override the defaults set by the definer
-/// // This is done via a configurator which gives one a struct with field
-/// // similarly named as that of the DB, but of type Options
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Error> {
-///     // Get a configurator for this table
-///     let mut config = Tables::configurator();
-///     // Config table 1
-///     config.table1 = DBOptions::default();
-///     config.table1.options.create_if_missing(true);
-///     config.table1.options.set_write_buffer_size(123456);
-///
-///     let primary_path = tempfile::tempdir()
-///         .expect(
-///             "Failed to open temporary
-/// directory",
-///         )
-///         .keep();
-///
-///     // We can then open the DB with the configs
-///     let _ = Tables::open_tables_read_write(
-///         primary_path,
-///         MetricConf::default(),
-///         None,
-///         Some(config.build()),
-///     );
-///     Ok(())
-/// }
 /// ```
 ///
 /// 2. Auto-generated `open` routine The function `open_tables_read_write` is
@@ -126,7 +92,6 @@ pub type StoreError = typed_store_error::TypedStoreError;
 /// use typed_store::{
 ///     DBMapUtils,
 ///     rocks::{DBMap, DBOptions},
-///     traits::{TableSummary, TypedStoreDebug},
 /// };
 /// /// Define a struct with all members having type DBMap<K, V>
 ///
@@ -168,7 +133,6 @@ pub type StoreError = typed_store_error::TypedStoreError;
 ///         Tables::get_read_only_handle(primary_path, None, None, MetricConf::default());
 ///     // Use this handle for dumping
 ///     let ret = read_only_handle.dump("table2", 100, 0).unwrap();
-///     let key_count = read_only_handle.count_keys("table1").unwrap();
 ///     Ok(())
 /// }
 /// ```

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -14,15 +14,17 @@
 // typed-store
 pub use rocksdb;
 
-pub mod traits;
-pub use traits::Map;
 pub mod database;
+pub mod traits;
+pub use traits::{DbIterator, Map};
 pub mod memstore;
 pub mod metrics;
 pub mod rocks;
 pub mod test_db;
+mod util;
 pub use metrics::DBMetrics;
 pub use typed_store_error::TypedStoreError;
+pub use util::be_fix_int_ser;
 
 pub type StoreError = typed_store_error::TypedStoreError;
 

--- a/crates/typed-store/src/memstore.rs
+++ b/crates/typed-store/src/memstore.rs
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, Bound, HashMap},
     sync::{Arc, RwLock},
 };
+
+use bincode::Options;
+use serde::de::DeserializeOwned;
+use typed_store_error::TypedStoreError;
 
 type InMemoryStoreInternal = Arc<RwLock<HashMap<String, BTreeMap<Vec<u8>, Vec<u8>>>>>;
 
@@ -100,5 +104,42 @@ impl InMemoryDB {
 
     pub fn drop_cf(&self, name: &str) {
         self.data.write().expect("can't write data").remove(name);
+    }
+
+    pub fn iterator<K, V>(
+        &self,
+        cf_name: &str,
+        lower_bound: Option<Vec<u8>>,
+        upper_bound: Option<Vec<u8>>,
+        reverse: bool,
+    ) -> Box<dyn Iterator<Item = Result<(K, V), TypedStoreError>> + '_>
+    where
+        K: DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        let config = bincode::DefaultOptions::new()
+            .with_big_endian()
+            .with_fixint_encoding();
+        let lower_bound = lower_bound.map(Bound::Included).unwrap_or(Bound::Unbounded);
+        let upper_bound = upper_bound.map(Bound::Excluded).unwrap_or(Bound::Unbounded);
+
+        let data = self.data.read().expect("can't read data");
+        let mut section: Vec<_> = data
+            .get(cf_name)
+            .unwrap_or(&BTreeMap::new())
+            .range((lower_bound, upper_bound))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        if reverse {
+            section.reverse();
+        }
+        Box::new(section.into_iter().map(move |(raw_key, raw_value)| {
+            let key = config
+                .deserialize(&raw_key)
+                .map_err(|e| TypedStoreError::Serialization(e.to_string()))?;
+            let value = bcs::from_bytes(&raw_value)
+                .map_err(|e| TypedStoreError::Serialization(e.to_string()))?;
+            Ok((key, value))
+        }))
     }
 }

--- a/crates/typed-store/src/memstore.rs
+++ b/crates/typed-store/src/memstore.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::{Arc, RwLock},
+};
+
+type InMemoryStoreInternal = Arc<RwLock<HashMap<String, BTreeMap<Vec<u8>, Vec<u8>>>>>;
+
+#[derive(Clone, Debug)]
+pub struct InMemoryDB {
+    data: InMemoryStoreInternal,
+}
+
+#[derive(Clone, Debug)]
+enum InMemoryChange {
+    Delete((String, Vec<u8>)),
+    Put((String, Vec<u8>, Vec<u8>)),
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryBatch {
+    data: Vec<InMemoryChange>,
+}
+
+impl InMemoryBatch {
+    pub fn delete_cf<K: AsRef<[u8]>>(&mut self, cf_name: &str, key: K) {
+        self.data.push(InMemoryChange::Delete((
+            cf_name.to_string(),
+            key.as_ref().to_vec(),
+        )));
+    }
+
+    pub fn put_cf<K, V>(&mut self, cf_name: &str, key: K, value: V)
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        self.data.push(InMemoryChange::Put((
+            cf_name.to_string(),
+            key.as_ref().to_vec(),
+            value.as_ref().to_vec(),
+        )));
+    }
+}
+
+impl InMemoryDB {
+    pub fn get<K: AsRef<[u8]>>(&self, cf_name: &str, key: K) -> Option<Vec<u8>> {
+        let data = self.data.read().expect("can't read data");
+        match data.get(cf_name) {
+            Some(cf) => cf.get(key.as_ref()).cloned(),
+            None => None,
+        }
+    }
+
+    pub fn multi_get<I, K>(&self, cf_name: &str, keys: I) -> Vec<Option<Vec<u8>>>
+    where
+        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]>,
+    {
+        let data = self.data.read().expect("can't read data");
+        match data.get(cf_name) {
+            Some(cf) => keys
+                .into_iter()
+                .map(|k| cf.get(k.as_ref()).cloned())
+                .collect(),
+            None => vec![],
+        }
+    }
+
+    pub fn delete(&self, cf_name: &str, key: &[u8]) {
+        let mut data = self.data.write().expect("can't write data");
+        data.entry(cf_name.to_string()).or_default().remove(key);
+    }
+
+    pub fn put(&self, cf_name: &str, key: Vec<u8>, value: Vec<u8>) {
+        let mut data = self.data.write().expect("can't write data");
+        data.entry(cf_name.to_string())
+            .or_default()
+            .insert(key, value);
+    }
+
+    pub fn write(&self, batch: InMemoryBatch) {
+        for change in batch.data {
+            match change {
+                InMemoryChange::Delete((cf_name, key)) => self.delete(&cf_name, &key),
+                InMemoryChange::Put((cf_name, key, value)) => self.put(&cf_name, key, value),
+            }
+        }
+    }
+
+    pub fn has_cf(&self, name: &str) -> bool {
+        self.data
+            .read()
+            .expect("can't read data")
+            .contains_key(name)
+    }
+
+    pub fn drop_cf(&self, name: &str) {
+        self.data.write().expect("can't write data").remove(name);
+    }
+}

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod errors;
+pub(crate) mod options;
 pub(crate) mod rocks_util;
 pub(crate) mod safe_iter;
 
 use std::{
-    collections::{BTreeMap, HashSet},
-    env,
+    collections::HashSet,
     ffi::CStr,
     path::{Path, PathBuf},
     sync::Arc,
@@ -16,49 +16,26 @@ use std::{
 };
 
 use backoff::backoff::Backoff;
-use bincode::Options;
 use iota_macros::nondeterministic;
 use rocksdb::{
-    AsColumnFamilyRef, BlockBasedOptions, Cache, ColumnFamilyDescriptor, Error, MultiThreaded,
-    properties, properties::num_files_at_level,
+    AsColumnFamilyRef, ColumnFamilyDescriptor, Error, MultiThreaded, properties,
+    properties::num_files_at_level,
 };
-use tap::TapFallible;
-use tracing::{info, instrument, warn};
+use tracing::warn;
 use typed_store_error::TypedStoreError;
 
-pub use crate::database::{DBBatch, DBMap, MetricConf, ReadWriteOptions};
+pub use crate::{
+    database::{DBBatch, DBMap, MetricConf},
+    rocks::options::{
+        DBMapTableConfigMap, DBOptions, ReadWriteOptions, default_db_options, list_tables,
+        read_size_from_env,
+    },
+};
 use crate::{
     database::{Database, Storage},
     metrics::DBMetrics,
-    rocks::errors::{typed_store_err_from_bincode_err, typed_store_err_from_rocks_err},
+    rocks::errors::typed_store_err_from_rocks_err,
 };
-
-// Write buffer size per RocksDB instance can be set via the env var below.
-// If the env var is not set, use the default value in MiB.
-const ENV_VAR_DB_WRITE_BUFFER_SIZE: &str = "DB_WRITE_BUFFER_SIZE_MB";
-const DEFAULT_DB_WRITE_BUFFER_SIZE: usize = 1024;
-
-// Write ahead log size per RocksDB instance can be set via the env var below.
-// If the env var is not set, use the default value in MiB.
-const ENV_VAR_DB_WAL_SIZE: &str = "DB_WAL_SIZE_MB";
-const DEFAULT_DB_WAL_SIZE: usize = 1024;
-
-// Environment variable to control behavior of write throughput optimized
-// tables.
-const ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER: &str = "L0_NUM_FILES_COMPACTION_TRIGGER";
-const DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 4;
-const DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 80;
-const ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB: &str = "MAX_WRITE_BUFFER_SIZE_MB";
-const DEFAULT_MAX_WRITE_BUFFER_SIZE_MB: usize = 256;
-const ENV_VAR_MAX_WRITE_BUFFER_NUMBER: &str = "MAX_WRITE_BUFFER_NUMBER";
-const DEFAULT_MAX_WRITE_BUFFER_NUMBER: usize = 6;
-const ENV_VAR_TARGET_FILE_SIZE_BASE_MB: &str = "TARGET_FILE_SIZE_BASE_MB";
-const DEFAULT_TARGET_FILE_SIZE_BASE_MB: usize = 128;
-
-// Set to 1 to disable blob storage for transactions and effects.
-const ENV_VAR_DISABLE_BLOB_STORAGE: &str = "DISABLE_BLOB_STORAGE";
-
-const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
 
 // TODO: remove this after Rust rocksdb has the TOTAL_BLOB_FILES_SIZE property
 // built-in. From https://github.com/facebook/rocksdb/blob/bd80433c73691031ba7baa65c16c63a83aef201a/include/rocksdb/db.h#L1169
@@ -72,43 +49,7 @@ const DB_CORRUPTED_KEY: &[u8] = b"db_corrupted";
 #[cfg(test)]
 mod tests;
 
-/// A helper macro to reopen multiple column families. The macro returns
-/// a tuple of DBMap structs in the same order that the column families
-/// are defined.
-///
-/// # Arguments
-///
-/// * `db` - a reference to a rocks DB object
-/// * `cf;<ty,ty>` - a comma separated list of column families to open. For each
-///   column family a concatenation of column family name (cf) and Key-Value
-///   <ty, ty> should be provided.
-///
-/// # Examples
-///
-/// We successfully open two different column families.
-/// ```
-/// use typed_store::reopen;
-/// use typed_store::rocks::*;
-/// use tempfile::tempdir;
-/// use prometheus::Registry;
-/// use std::sync::Arc;
-/// use typed_store::metrics::DBMetrics;
-/// use core::fmt::Error;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Error> {
-/// const FIRST_CF: &str = "First_CF";
-/// const SECOND_CF: &str = "Second_CF";
-///
-///
-/// /// Create the rocks database reference for the desired column families
-/// let rocks = open_cf(tempdir().unwrap(), None, MetricConf::default(), &[FIRST_CF, SECOND_CF]).unwrap();
-///
-/// /// Now simply open all the column families for their expected Key-Value types
-/// let (db_map_1, db_map_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-/// Ok(())
-/// }
-/// ```
+// TODO: deprecate macros use
 #[macro_export]
 macro_rules! reopen {
     ( $db:expr, $($cf:expr;<$K:ty, $V:ty>),*) => {
@@ -166,319 +107,6 @@ pub fn unmark_db_corruption(path: &Path) -> Result<(), Error> {
     rocksdb::DB::open_default(path)?.put(DB_CORRUPTED_KEY, [0])
 }
 
-pub fn read_size_from_env(var_name: &str) -> Option<usize> {
-    env::var(var_name)
-        .ok()?
-        .parse::<usize>()
-        .tap_err(|e| {
-            warn!(
-                "Env var {} does not contain valid usize integer: {}",
-                var_name, e
-            )
-        })
-        .ok()
-}
-
-// TODO: refactor this into a builder pattern, where rocksdb::Options are
-// generated after a call to build().
-#[derive(Default, Clone)]
-pub struct DBOptions {
-    pub options: rocksdb::Options,
-    pub rw_options: ReadWriteOptions,
-}
-
-impl DBOptions {
-    // Optimize lookup perf for tables where no scans are performed.
-    // If non-trivial number of values can be > 512B in size, it is beneficial to
-    // also specify optimize_for_large_values_no_scan().
-    pub fn optimize_for_point_lookup(mut self, block_cache_size_mb: usize) -> DBOptions {
-        // NOTE: this overwrites the block options.
-        self.options
-            .optimize_for_point_lookup(block_cache_size_mb as u64);
-        self
-    }
-
-    // Optimize write and lookup perf for tables which are rarely scanned, and have
-    // large values. https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html
-    pub fn optimize_for_large_values_no_scan(mut self, min_blob_size: u64) -> DBOptions {
-        if env::var(ENV_VAR_DISABLE_BLOB_STORAGE).is_ok() {
-            info!("Large value blob storage optimization is disabled via env var.");
-            return self;
-        }
-
-        // Blob settings.
-        self.options.set_enable_blob_files(true);
-        self.options
-            .set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
-        self.options.set_enable_blob_gc(true);
-        // Since each blob can have non-trivial size overhead, and compression does not
-        // work across blobs, set a min blob size in bytes to so small
-        // transactions and effects are kept in sst files.
-        self.options.set_min_blob_size(min_blob_size);
-
-        // Increase write buffer size to 256MiB.
-        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
-            * 1024
-            * 1024;
-        self.options.set_write_buffer_size(write_buffer_size);
-        // Since large blobs are not in sst files, reduce the target file size and base
-        // level target size.
-        let target_file_size_base = 64 << 20;
-        self.options
-            .set_target_file_size_base(target_file_size_base);
-        // Level 1 default to 64MiB * 4 ~ 256MiB.
-        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
-            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
-        self.options
-            .set_max_bytes_for_level_base(target_file_size_base * max_level_zero_file_num as u64);
-
-        self
-    }
-
-    // Optimize tables with a mix of lookup and scan workloads.
-    pub fn optimize_for_read(mut self, block_cache_size_mb: usize) -> DBOptions {
-        self.options
-            .set_block_based_table_factory(&get_block_options(block_cache_size_mb, 16 << 10));
-        self
-    }
-
-    // Optimize DB receiving significant insertions.
-    pub fn optimize_db_for_write_throughput(mut self, db_max_write_buffer_gb: u64) -> DBOptions {
-        self.options
-            .set_db_write_buffer_size(db_max_write_buffer_gb as usize * 1024 * 1024 * 1024);
-        self.options
-            .set_max_total_wal_size(db_max_write_buffer_gb * 1024 * 1024 * 1024);
-        self
-    }
-
-    // Optimize tables receiving significant insertions.
-    pub fn optimize_for_write_throughput(mut self) -> DBOptions {
-        // Increase write buffer size to 256MiB.
-        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
-            * 1024
-            * 1024;
-        self.options.set_write_buffer_size(write_buffer_size);
-        // Increase write buffers to keep to 6 before slowing down writes.
-        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
-        self.options
-            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
-        // Keep 1 write buffer so recent writes can be read from memory.
-        self.options
-            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
-
-        // Increase compaction trigger for level 0 to 6.
-        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
-            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
-        self.options.set_level_zero_file_num_compaction_trigger(
-            max_level_zero_file_num.try_into().unwrap(),
-        );
-        self.options.set_level_zero_slowdown_writes_trigger(
-            (max_level_zero_file_num * 12).try_into().unwrap(),
-        );
-        self.options
-            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
-
-        // Increase sst file size to 128MiB.
-        self.options.set_target_file_size_base(
-            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
-                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
-                * 1024
-                * 1024,
-        );
-
-        // Increase level 1 target size to 256MiB * 6 ~ 1.5GiB.
-        self.options
-            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
-
-        self
-    }
-
-    // Optimize tables receiving significant insertions, without any deletions.
-    // TODO: merge this function with optimize_for_write_throughput(), and use a
-    // flag to indicate if deletion is received.
-    pub fn optimize_for_write_throughput_no_deletion(mut self) -> DBOptions {
-        // Increase write buffer size to 256MiB.
-        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
-            * 1024
-            * 1024;
-        self.options.set_write_buffer_size(write_buffer_size);
-        // Increase write buffers to keep to 6 before slowing down writes.
-        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
-            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
-        self.options
-            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
-        // Keep 1 write buffer so recent writes can be read from memory.
-        self.options
-            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
-
-        // Switch to universal compactions.
-        self.options
-            .set_compaction_style(rocksdb::DBCompactionStyle::Universal);
-        let mut compaction_options = rocksdb::UniversalCompactOptions::default();
-        compaction_options.set_max_size_amplification_percent(10000);
-        compaction_options.set_stop_style(rocksdb::UniversalCompactionStopStyle::Similar);
-        self.options
-            .set_universal_compaction_options(&compaction_options);
-
-        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
-            .unwrap_or(DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER);
-        self.options.set_level_zero_file_num_compaction_trigger(
-            max_level_zero_file_num.try_into().unwrap(),
-        );
-        self.options.set_level_zero_slowdown_writes_trigger(
-            (max_level_zero_file_num * 12).try_into().unwrap(),
-        );
-        self.options
-            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
-
-        // Increase sst file size to 128MiB.
-        self.options.set_target_file_size_base(
-            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
-                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
-                * 1024
-                * 1024,
-        );
-
-        // This should be a no-op for universal compaction but increasing it to be safe.
-        self.options
-            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
-
-        self
-    }
-
-    // Overrides the block options with different block cache size and block size.
-    pub fn set_block_options(
-        mut self,
-        block_cache_size_mb: usize,
-        block_size_bytes: usize,
-    ) -> DBOptions {
-        self.options
-            .set_block_based_table_factory(&get_block_options(
-                block_cache_size_mb,
-                block_size_bytes,
-            ));
-        self
-    }
-
-    // Disables write stalling and stopping based on pending compaction bytes.
-    pub fn disable_write_throttling(mut self) -> DBOptions {
-        self.options.set_soft_pending_compaction_bytes_limit(0);
-        self.options.set_hard_pending_compaction_bytes_limit(0);
-        self
-    }
-}
-
-/// Creates a default RocksDB option, to be used when RocksDB option is
-/// unspecified.
-pub fn default_db_options() -> DBOptions {
-    let mut opt = rocksdb::Options::default();
-
-    // One common issue when running tests on Mac is that the default ulimit is too
-    // low, leading to I/O errors such as "Too many open files". Raising fdlimit
-    // to bypass it.
-    if let Some(limit) = fdlimit::raise_fd_limit() {
-        // on windows raise_fd_limit return None
-        opt.set_max_open_files((limit / 8) as i32);
-    }
-
-    // The table cache is locked for updates and this determines the number
-    // of shards, ie 2^10. Increase in case of lock contentions.
-    opt.set_table_cache_num_shard_bits(10);
-
-    // LSM compression settings
-    opt.set_compression_type(rocksdb::DBCompressionType::Lz4);
-    opt.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
-    opt.set_bottommost_zstd_max_train_bytes(1024 * 1024, true);
-
-    // IOTA uses multiple RocksDB in a node, so total sizes of write buffers and WAL
-    // can be higher than the limits below.
-    //
-    // RocksDB also exposes the option to configure total write buffer size across
-    // multiple instances via `write_buffer_manager`. But the write buffer flush
-    // policy (flushing the buffer receiving the next write) may not work well.
-    // So sticking to per-db write buffer size limit for now.
-    //
-    // The environment variables are only meant to be emergency overrides. They may
-    // go away in future. It is preferable to update the default value, or
-    // override the option in code.
-    opt.set_db_write_buffer_size(
-        read_size_from_env(ENV_VAR_DB_WRITE_BUFFER_SIZE).unwrap_or(DEFAULT_DB_WRITE_BUFFER_SIZE)
-            * 1024
-            * 1024,
-    );
-    opt.set_max_total_wal_size(
-        read_size_from_env(ENV_VAR_DB_WAL_SIZE).unwrap_or(DEFAULT_DB_WAL_SIZE) as u64 * 1024 * 1024,
-    );
-
-    // Num threads for compactions and memtable flushes.
-    opt.increase_parallelism(read_size_from_env(ENV_VAR_DB_PARALLELISM).unwrap_or(8) as i32);
-
-    opt.set_enable_pipelined_write(true);
-
-    // Increase block size to 16KiB.
-    // https://github.com/EighteenZi/rocksdb_wiki/blob/master/Memory-usage-in-RocksDB.md#indexes-and-filter-blocks
-    opt.set_block_based_table_factory(&get_block_options(128, 16 << 10));
-
-    // Set memtable bloomfilter.
-    opt.set_memtable_prefix_bloom_ratio(0.02);
-
-    DBOptions {
-        options: opt,
-        rw_options: ReadWriteOptions::default(),
-    }
-}
-
-fn get_block_options(block_cache_size_mb: usize, block_size_bytes: usize) -> BlockBasedOptions {
-    // Set options mostly similar to those used in optimize_for_point_lookup(),
-    // except non-default binary and hash index, to hopefully reduce lookup
-    // latencies without causing any regression for scanning, with slightly more
-    // memory usages. https://github.com/facebook/rocksdb/blob/11cb6af6e5009c51794641905ca40ce5beec7fee/options/options.cc#L611-L621
-    let mut block_options = BlockBasedOptions::default();
-    // Overrides block size.
-    block_options.set_block_size(block_size_bytes);
-    // Configure a block cache.
-    block_options.set_block_cache(&Cache::new_lru_cache(block_cache_size_mb << 20));
-    // Set a bloomfilter with 1% false positive rate.
-    block_options.set_bloom_filter(10.0, false);
-    // From https://github.com/EighteenZi/rocksdb_wiki/blob/master/Block-Cache.md#caching-index-and-filter-blocks
-    block_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
-    block_options
-}
-
-/// Opens a database with options, and a number of column families that are
-/// created if they do not exist.
-#[instrument(level="debug", skip_all, fields(path = ?path.as_ref(), cf = ?opt_cfs), err)]
-pub fn open_cf<P: AsRef<Path>>(
-    path: P,
-    db_options: Option<rocksdb::Options>,
-    metric_conf: MetricConf,
-    opt_cfs: &[&str],
-) -> Result<Arc<Database>, TypedStoreError> {
-    let options = db_options.unwrap_or_else(|| default_db_options().options);
-    let column_descriptors: Vec<_> = opt_cfs
-        .iter()
-        .map(|name| (*name, options.clone()))
-        .collect();
-    open_cf_opts(
-        path,
-        Some(options.clone()),
-        metric_conf,
-        &column_descriptors[..],
-    )
-}
-
-fn prepare_db_options(db_options: Option<rocksdb::Options>) -> rocksdb::Options {
-    // Customize database options
-    let mut options = db_options.unwrap_or_else(|| default_db_options().options);
-    options.create_if_missing(true);
-    options.create_missing_column_families(true);
-    options
-}
-
 /// Opens a database with options, and a number of column families with
 /// individual options that are created if they do not exist.
 #[tracing::instrument(level="debug", skip_all, fields(path = ?path.as_ref()), err)]
@@ -500,7 +128,9 @@ pub fn open_cf_opts<P: AsRef<Path>>(
 
     let cfs = populate_missing_cfs(opt_cfs, path).map_err(typed_store_err_from_rocks_err)?;
     nondeterministic!({
-        let options = prepare_db_options(db_options);
+        let mut options = db_options.unwrap_or_else(|| default_db_options().options);
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
         let rocksdb = {
             rocksdb::DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
                 &options,
@@ -583,53 +213,6 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
             metric_conf,
         )))
     })
-}
-
-pub fn list_tables(path: std::path::PathBuf) -> eyre::Result<Vec<String>> {
-    const DB_DEFAULT_CF_NAME: &str = "default";
-
-    let opts = rocksdb::Options::default();
-    rocksdb::DBWithThreadMode::<rocksdb::MultiThreaded>::list_cf(&opts, path)
-        .map_err(|e| e.into())
-        .map(|q| {
-            q.iter()
-                .filter_map(|s| {
-                    // The `default` table is not used
-                    if s != DB_DEFAULT_CF_NAME {
-                        Some(s.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        })
-}
-
-/// Serializes keys using big-endian byte order with fixed-int encoding.
-/// RocksDB stores keys in big-endian and uses a byte-wise seek operator on
-/// iterators, see `https://github.com/facebook/rocksdb/wiki/Iterator#introduction`
-#[inline]
-pub fn be_fix_int_ser<S>(t: &S) -> Result<Vec<u8>, TypedStoreError>
-where
-    S: ?Sized + serde::Serialize,
-{
-    bincode::DefaultOptions::new()
-        .with_big_endian()
-        .with_fixint_encoding()
-        .serialize(t)
-        .map_err(typed_store_err_from_bincode_err)
-}
-
-#[derive(Clone)]
-pub struct DBMapTableConfigMap(BTreeMap<String, DBOptions>);
-impl DBMapTableConfigMap {
-    pub fn new(map: BTreeMap<String, DBOptions>) -> Self {
-        Self(map)
-    }
-
-    pub fn to_map(&self) -> BTreeMap<String, DBOptions> {
-        self.0.clone()
-    }
 }
 
 // Drops a database if there is no other handle to it, with retries and timeout.

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod errors;
+pub(crate) mod rocks_util;
 pub(crate) mod safe_iter;
 
 use std::{
@@ -629,11 +630,6 @@ impl DBMapTableConfigMap {
     pub fn to_map(&self) -> BTreeMap<String, DBOptions> {
         self.0.clone()
     }
-}
-
-pub enum RocksDBAccessType {
-    Primary,
-    Secondary(Option<PathBuf>),
 }
 
 // Drops a database if there is no other handle to it, with retries and timeout.

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -6,12 +6,9 @@ pub mod errors;
 pub(crate) mod safe_iter;
 
 use std::{
-    borrow::Borrow,
     collections::{BTreeMap, HashSet},
     env,
     ffi::CStr,
-    marker::PhantomData,
-    ops::{Bound, RangeBounds},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -19,30 +16,20 @@ use std::{
 
 use backoff::backoff::Backoff;
 use bincode::Options;
-use iota_macros::{fail_point, nondeterministic};
-use prometheus::{Histogram, HistogramTimer};
+use iota_macros::nondeterministic;
 use rocksdb::{
-    AsColumnFamilyRef, BlockBasedOptions, BottommostLevelCompaction, CStrLike, Cache,
-    ColumnFamilyDescriptor, CompactOptions, DBPinnableSlice, DBWithThreadMode, Error, LiveFile,
-    MultiThreaded, OptimisticTransactionDB, ReadOptions, SnapshotWithThreadMode, WriteBatch,
-    WriteOptions, checkpoint::Checkpoint, properties, properties::num_files_at_level,
+    AsColumnFamilyRef, BlockBasedOptions, Cache, ColumnFamilyDescriptor, Error, MultiThreaded,
+    properties, properties::num_files_at_level,
 };
-use serde::{Serialize, de::DeserializeOwned};
 use tap::TapFallible;
-use tokio::sync::oneshot;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{info, instrument, warn};
+use typed_store_error::TypedStoreError;
 
+pub use crate::database::{DBBatch, DBMap, MetricConf, ReadWriteOptions};
 use crate::{
-    TypedStoreError,
-    metrics::{DBMetrics, RocksDBPerfContext, SamplingInterval},
-    rocks::{
-        errors::{
-            typed_store_err_from_bcs_err, typed_store_err_from_bincode_err,
-            typed_store_err_from_rocks_err,
-        },
-        safe_iter::{SafeIter, SafeRevIter},
-    },
-    traits::{Map, TableSummary},
+    database::{Database, Storage},
+    metrics::DBMetrics,
+    rocks::errors::{typed_store_err_from_bincode_err, typed_store_err_from_rocks_err},
 };
 
 // Write buffer size per RocksDB instance can be set via the env var below.
@@ -76,6 +63,8 @@ const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
 // built-in. From https://github.com/facebook/rocksdb/blob/bd80433c73691031ba7baa65c16c63a83aef201a/include/rocksdb/db.h#L1169
 const ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked("rocksdb.total-blob-file-size\0".as_bytes()) };
+
+const METRICS_ERROR: i64 = -1;
 
 const DB_CORRUPTED_KEY: &[u8] = b"db_corrupted";
 
@@ -131,251 +120,24 @@ macro_rules! reopen {
 }
 
 #[derive(Debug)]
-pub struct RocksDB {
-    pub underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
-    pub metric_conf: MetricConf,
-    pub db_path: PathBuf,
+pub(crate) struct RocksDB {
+    pub(crate) underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
 }
 
 impl Drop for RocksDB {
     fn drop(&mut self) {
         self.underlying.cancel_all_background_work(/* wait */ true);
-        DBMetrics::get().decrement_num_active_dbs(&self.metric_conf.db_name);
     }
 }
 
-impl RocksDB {
-    fn new(
-        underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
-        metric_conf: MetricConf,
-        db_path: PathBuf,
-    ) -> Self {
-        DBMetrics::get().increment_num_active_dbs(&metric_conf.db_name);
-        Self {
-            underlying,
-            metric_conf,
-            db_path,
-        }
-    }
-
-    pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, rocksdb::Error> {
-        self.underlying.get(key)
-    }
-
-    pub fn multi_get_cf<'a, 'b: 'a, K, I, W>(
-        &'a self,
-        keys: I,
-        readopts: &ReadOptions,
-    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
-    where
-        K: AsRef<[u8]>,
-        I: IntoIterator<Item = (&'b W, K)>,
-        W: 'b + AsColumnFamilyRef,
-    {
-        self.underlying.multi_get_cf_opt(keys, readopts)
-    }
-
-    pub fn batched_multi_get_cf_opt<I, K>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        keys: I,
-        sorted_input: bool,
-        readopts: &ReadOptions,
-    ) -> Vec<Result<Option<DBPinnableSlice<'_>>, Error>>
-    where
-        I: IntoIterator<Item = K>,
-        K: AsRef<[u8]>,
-    {
-        self.underlying
-            .batched_multi_get_cf_opt(cf, keys, sorted_input, readopts)
-    }
-
-    pub fn property_int_value_cf(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        name: impl CStrLike,
-    ) -> Result<Option<u64>, rocksdb::Error> {
-        self.underlying.property_int_value_cf(cf, name)
-    }
-
-    pub fn get_pinned_cf_opt<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        key: K,
-        readopts: &ReadOptions,
-    ) -> Result<Option<DBPinnableSlice<'_>>, rocksdb::Error> {
-        self.underlying.get_pinned_cf_opt(cf, key, readopts)
-    }
-
-    pub fn cf_handle(&self, name: &str) -> Option<Arc<rocksdb::BoundColumnFamily<'_>>> {
-        self.underlying.cf_handle(name)
-    }
-
-    pub fn create_cf<N: AsRef<str>>(
-        &self,
-        name: N,
-        opts: &rocksdb::Options,
-    ) -> Result<(), rocksdb::Error> {
-        self.underlying.create_cf(name, opts)
-    }
-
-    pub fn drop_cf(&self, name: &str) -> Result<(), rocksdb::Error> {
-        self.underlying.drop_cf(name)
-    }
-
-    pub fn delete_cf<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        key: K,
-        writeopts: &WriteOptions,
-    ) -> Result<(), rocksdb::Error> {
-        fail_point!("delete-cf-before");
-        let ret = self.underlying.delete_cf_opt(cf, key, writeopts);
-        fail_point!("delete-cf-after");
-        #[expect(clippy::let_and_return)]
-        ret
-    }
-
-    pub fn path(&self) -> &Path {
-        self.underlying.path()
-    }
-
-    pub fn put_cf<K, V>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        key: K,
-        value: V,
-        writeopts: &WriteOptions,
-    ) -> Result<(), rocksdb::Error>
-    where
-        K: AsRef<[u8]>,
-        V: AsRef<[u8]>,
-    {
-        fail_point!("put-cf-before");
-        let ret = self.underlying.put_cf_opt(cf, key, value, writeopts);
-        fail_point!("put-cf-after");
-        #[expect(clippy::let_and_return)]
-        ret
-    }
-
-    pub fn key_may_exist_cf<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        key: K,
-        readopts: &ReadOptions,
-    ) -> bool {
-        self.underlying.key_may_exist_cf_opt(cf, key, readopts)
-    }
-
-    pub fn try_catch_up_with_primary(&self) -> Result<(), rocksdb::Error> {
-        self.underlying.try_catch_up_with_primary()
-    }
-
-    pub fn write(
-        &self,
-        batch: rocksdb::WriteBatch,
-        writeopts: &WriteOptions,
-    ) -> Result<(), TypedStoreError> {
-        fail_point!("batch-write-before");
-        self.underlying
-            .write_opt(batch, writeopts)
-            .map_err(typed_store_err_from_rocks_err)?;
-        fail_point!("batch-write-after");
-
-        Ok(())
-    }
-
-    pub fn raw_iterator_cf<'a: 'b, 'b>(
-        &'a self,
-        cf_handle: &impl AsColumnFamilyRef,
-        readopts: ReadOptions,
-    ) -> RocksDBRawIter<'b> {
-        self.underlying.raw_iterator_cf_opt(cf_handle, readopts)
-    }
-
-    pub fn compact_range_cf<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        start: Option<K>,
-        end: Option<K>,
-    ) {
-        self.underlying.compact_range_cf(cf, start, end)
-    }
-
-    pub fn compact_range_to_bottom<K: AsRef<[u8]>>(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        start: Option<K>,
-        end: Option<K>,
-    ) {
-        let opt = &mut CompactOptions::default();
-        opt.set_bottommost_level_compaction(BottommostLevelCompaction::ForceOptimized);
-        self.underlying.compact_range_cf_opt(cf, start, end, opt)
-    }
-
-    pub fn flush(&self) -> Result<(), TypedStoreError> {
-        self.underlying
-            .flush()
-            .map_err(|e| TypedStoreError::RocksDB(e.into_string()))
-    }
-
-    pub fn checkpoint(&self, path: &Path) -> Result<(), TypedStoreError> {
-        let checkpoint =
-            Checkpoint::new(&self.underlying).map_err(typed_store_err_from_rocks_err)?;
-        checkpoint
-            .create_checkpoint(path)
-            .map_err(|e| TypedStoreError::RocksDB(e.to_string()))?;
-        Ok(())
-    }
-
-    pub fn flush_cf(&self, cf: &impl AsColumnFamilyRef) -> Result<(), rocksdb::Error> {
-        self.underlying.flush_cf(cf)
-    }
-
-    pub fn set_options_cf(
-        &self,
-        cf: &impl AsColumnFamilyRef,
-        opts: &[(&str, &str)],
-    ) -> Result<(), rocksdb::Error> {
-        self.underlying.set_options_cf(cf, opts)
-    }
-
-    pub fn get_sampling_interval(&self) -> SamplingInterval {
-        self.metric_conf.read_sample_interval.new_from_self()
-    }
-
-    pub fn multiget_sampling_interval(&self) -> SamplingInterval {
-        self.metric_conf.read_sample_interval.new_from_self()
-    }
-
-    pub fn write_sampling_interval(&self) -> SamplingInterval {
-        self.metric_conf.write_sample_interval.new_from_self()
-    }
-
-    pub fn iter_sampling_interval(&self) -> SamplingInterval {
-        self.metric_conf.iter_sample_interval.new_from_self()
-    }
-
-    pub fn db_name(&self) -> String {
-        let name = &self.metric_conf.db_name;
-        if name.is_empty() {
-            self.default_db_name()
-        } else {
-            name.clone()
-        }
-    }
-
-    fn default_db_name(&self) -> String {
-        self.path()
-            .file_name()
-            .and_then(|f| f.to_str())
-            .unwrap_or("unknown")
-            .to_string()
-    }
-
-    pub fn live_files(&self) -> Result<Vec<LiveFile>, Error> {
-        self.underlying.live_files()
-    }
+pub(crate) fn rocks_cf<'a>(
+    rocks_db: &'a RocksDB,
+    cf_name: &str,
+) -> Arc<rocksdb::BoundColumnFamily<'a>> {
+    rocks_db
+        .underlying
+        .cf_handle(cf_name)
+        .expect("Map-keying column family should have been checked at DB creation")
 }
 
 // Check if the database is corrupted, and if so, panic.
@@ -403,1259 +165,6 @@ pub fn unmark_db_corruption(path: &Path) -> Result<(), Error> {
     rocksdb::DB::open_default(path)?.put(DB_CORRUPTED_KEY, [0])
 }
 
-pub enum RocksDBSnapshot<'a> {
-    DBWithThreadMode(rocksdb::Snapshot<'a>),
-    OptimisticTransactionDB(SnapshotWithThreadMode<'a, OptimisticTransactionDB>),
-}
-
-impl<'a> RocksDBSnapshot<'a> {
-    pub fn multi_get_cf_opt<'b: 'a, K, I, W>(
-        &'a self,
-        keys: I,
-        readopts: ReadOptions,
-    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
-    where
-        K: AsRef<[u8]>,
-        I: IntoIterator<Item = (&'b W, K)>,
-        W: 'b + AsColumnFamilyRef,
-    {
-        match self {
-            Self::DBWithThreadMode(s) => s.multi_get_cf_opt(keys, readopts),
-            Self::OptimisticTransactionDB(s) => s.multi_get_cf_opt(keys, readopts),
-        }
-    }
-    pub fn multi_get_cf<'b: 'a, K, I, W>(
-        &'a self,
-        keys: I,
-    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
-    where
-        K: AsRef<[u8]>,
-        I: IntoIterator<Item = (&'b W, K)>,
-        W: 'b + AsColumnFamilyRef,
-    {
-        match self {
-            Self::DBWithThreadMode(s) => s.multi_get_cf(keys),
-            Self::OptimisticTransactionDB(s) => s.multi_get_cf(keys),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct MetricConf {
-    pub db_name: String,
-    pub read_sample_interval: SamplingInterval,
-    pub write_sample_interval: SamplingInterval,
-    pub iter_sample_interval: SamplingInterval,
-}
-
-impl MetricConf {
-    pub fn new(db_name: &str) -> Self {
-        if db_name.is_empty() {
-            error!("A meaningful db name should be used for metrics reporting.")
-        }
-        Self {
-            db_name: db_name.to_string(),
-            read_sample_interval: SamplingInterval::default(),
-            write_sample_interval: SamplingInterval::default(),
-            iter_sample_interval: SamplingInterval::default(),
-        }
-    }
-
-    pub fn with_sampling(self, read_interval: SamplingInterval) -> Self {
-        Self {
-            db_name: self.db_name,
-            read_sample_interval: read_interval,
-            write_sample_interval: SamplingInterval::default(),
-            iter_sample_interval: SamplingInterval::default(),
-        }
-    }
-}
-const CF_METRICS_REPORT_PERIOD_SECS: u64 = 30;
-const METRICS_ERROR: i64 = -1;
-
-/// An interface to a rocksDB database, keyed by a columnfamily
-#[derive(Clone, Debug)]
-pub struct DBMap<K, V> {
-    pub rocksdb: Arc<RocksDB>,
-    _phantom: PhantomData<fn(K) -> V>,
-    // the rocksDB ColumnFamily under which the map is stored
-    cf: String,
-    pub opts: ReadWriteOptions,
-    db_metrics: Arc<DBMetrics>,
-    get_sample_interval: SamplingInterval,
-    multiget_sample_interval: SamplingInterval,
-    write_sample_interval: SamplingInterval,
-    iter_sample_interval: SamplingInterval,
-    _metrics_task_cancel_handle: Arc<oneshot::Sender<()>>,
-}
-
-unsafe impl<K: Send, V: Send> Send for DBMap<K, V> {}
-
-impl<K, V> DBMap<K, V> {
-    pub(crate) fn new(
-        db: Arc<RocksDB>,
-        opts: &ReadWriteOptions,
-        opt_cf: &str,
-        is_deprecated: bool,
-    ) -> Self {
-        let db_cloned = db.clone();
-        let db_metrics = DBMetrics::get();
-        let db_metrics_cloned = db_metrics.clone();
-        let cf = opt_cf.to_string();
-        let (sender, mut recv) = tokio::sync::oneshot::channel();
-        if !is_deprecated {
-            tokio::task::spawn(async move {
-                let mut interval =
-                    tokio::time::interval(Duration::from_secs(CF_METRICS_REPORT_PERIOD_SECS));
-                loop {
-                    tokio::select! {
-                        _ = interval.tick() => {
-                            let db = db_cloned.clone();
-                            let cf = cf.clone();
-                            let db_metrics = db_metrics.clone();
-                            if let Err(e) = tokio::task::spawn_blocking(move || {
-                                Self::report_metrics(&db, &cf, &db_metrics);
-                            }).await {
-                                error!("Failed to log metrics with error: {}", e);
-                            }
-                        }
-                        _ = &mut recv => break,
-                    }
-                }
-                debug!("Returning the cf metric logging task for DBMap: {}", &cf);
-            });
-        }
-        DBMap {
-            rocksdb: db.clone(),
-            opts: opts.clone(),
-            _phantom: PhantomData,
-            cf: opt_cf.to_string(),
-            db_metrics: db_metrics_cloned,
-            _metrics_task_cancel_handle: Arc::new(sender),
-            get_sample_interval: db.get_sampling_interval(),
-            multiget_sample_interval: db.multiget_sampling_interval(),
-            write_sample_interval: db.write_sampling_interval(),
-            iter_sample_interval: db.iter_sampling_interval(),
-        }
-    }
-
-    /// Opens a database from a path, with specific options and an optional
-    /// column family.
-    ///
-    /// This database is used to perform operations on single column family, and
-    /// parametrizes all operations in `DBBatch` when writing across column
-    /// families.
-    #[instrument(level="debug", skip_all, fields(path = ?path.as_ref(), cf = ?opt_cf), err)]
-    pub fn open<P: AsRef<Path>>(
-        path: P,
-        metric_conf: MetricConf,
-        db_options: Option<rocksdb::Options>,
-        opt_cf: Option<&str>,
-        rw_options: &ReadWriteOptions,
-    ) -> Result<Self, TypedStoreError> {
-        let cf_key = opt_cf.unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME);
-        let cfs = vec![cf_key];
-        let rocksdb = open_cf(path, db_options, metric_conf, &cfs)?;
-        Ok(DBMap::new(rocksdb, rw_options, cf_key, false))
-    }
-
-    /// Reopens an open database as a typed map operating under a specific
-    /// column family. if no column family is passed, the default column
-    /// family is used.
-    ///
-    /// ```
-    /// use core::fmt::Error;
-    /// use std::sync::Arc;
-    ///
-    /// use prometheus::Registry;
-    /// use tempfile::tempdir;
-    /// use typed_store::{metrics::DBMetrics, rocks::*};
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Error> {
-    ///     /// Open the DB with all needed column families first.
-    ///     let rocks = open_cf(
-    ///         tempdir().unwrap(),
-    ///         None,
-    ///         MetricConf::default(),
-    ///         &["First_CF", "Second_CF"],
-    ///     )
-    ///     .unwrap();
-    ///     /// Attach the column families to specific maps.
-    ///     let db_cf_1 = DBMap::<u32, u32>::reopen(
-    ///         &rocks,
-    ///         Some("First_CF"),
-    ///         &ReadWriteOptions::default(),
-    ///         false,
-    ///     )
-    ///     .expect("Failed to open storage");
-    ///     let db_cf_2 = DBMap::<u32, u32>::reopen(
-    ///         &rocks,
-    ///         Some("Second_CF"),
-    ///         &ReadWriteOptions::default(),
-    ///         false,
-    ///     )
-    ///     .expect("Failed to open storage");
-    ///     Ok(())
-    /// }
-    /// ```
-    #[instrument(level = "debug", skip(db), err)]
-    pub fn reopen(
-        db: &Arc<RocksDB>,
-        opt_cf: Option<&str>,
-        rw_options: &ReadWriteOptions,
-        is_deprecated: bool,
-    ) -> Result<Self, TypedStoreError> {
-        let cf_key = opt_cf
-            .unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
-            .to_owned();
-
-        db.cf_handle(&cf_key)
-            .ok_or_else(|| TypedStoreError::UnregisteredColumn(cf_key.clone()))?;
-
-        Ok(DBMap::new(db.clone(), rw_options, &cf_key, is_deprecated))
-    }
-
-    pub fn batch(&self) -> DBBatch {
-        let batch = WriteBatch::default();
-        DBBatch::new(
-            &self.rocksdb,
-            batch,
-            self.opts.writeopts(),
-            &self.db_metrics,
-            &self.write_sample_interval,
-        )
-    }
-
-    pub fn compact_range<J: Serialize>(&self, start: &J, end: &J) -> Result<(), TypedStoreError> {
-        let from_buf = be_fix_int_ser(start)?;
-        let to_buf = be_fix_int_ser(end)?;
-        self.rocksdb
-            .compact_range_cf(&self.cf(), Some(from_buf), Some(to_buf));
-        Ok(())
-    }
-
-    pub fn compact_range_raw(
-        &self,
-        cf_name: &str,
-        start: Vec<u8>,
-        end: Vec<u8>,
-    ) -> Result<(), TypedStoreError> {
-        let cf = self
-            .rocksdb
-            .cf_handle(cf_name)
-            .expect("compact range: column family does not exist");
-        self.rocksdb.compact_range_cf(&cf, Some(start), Some(end));
-        Ok(())
-    }
-
-    pub fn compact_range_to_bottom<J: Serialize>(
-        &self,
-        start: &J,
-        end: &J,
-    ) -> Result<(), TypedStoreError> {
-        let from_buf = be_fix_int_ser(start)?;
-        let to_buf = be_fix_int_ser(end)?;
-        self.rocksdb
-            .compact_range_to_bottom(&self.cf(), Some(from_buf), Some(to_buf));
-        Ok(())
-    }
-
-    pub fn cf(&self) -> Arc<rocksdb::BoundColumnFamily<'_>> {
-        self.rocksdb
-            .cf_handle(&self.cf)
-            .expect("Map-keying column family should have been checked at DB creation")
-    }
-
-    pub fn flush(&self) -> Result<(), TypedStoreError> {
-        self.rocksdb
-            .flush_cf(&self.cf())
-            .map_err(|e| TypedStoreError::RocksDB(e.into_string()))
-    }
-
-    pub fn set_options(&self, opts: &[(&str, &str)]) -> Result<(), rocksdb::Error> {
-        self.rocksdb.set_options_cf(&self.cf(), opts)
-    }
-
-    fn get_int_property(
-        rocksdb: &RocksDB,
-        cf: &impl AsColumnFamilyRef,
-        property_name: &std::ffi::CStr,
-    ) -> Result<i64, TypedStoreError> {
-        match rocksdb.property_int_value_cf(cf, property_name) {
-            Ok(Some(value)) => Ok(value.min(i64::MAX as u64).try_into().unwrap_or_default()),
-            Ok(None) => Ok(0),
-            Err(e) => Err(TypedStoreError::RocksDB(e.into_string())),
-        }
-    }
-
-    /// Returns a vector of raw values corresponding to the keys provided.
-    fn multi_get_pinned<J>(
-        &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<Option<DBPinnableSlice<'_>>>, TypedStoreError>
-    where
-        J: Borrow<K>,
-        K: Serialize,
-    {
-        let _timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_multiget_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let perf_ctx = if self.multiget_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        let keys_bytes: Result<Vec<_>, TypedStoreError> = keys
-            .into_iter()
-            .map(|k| be_fix_int_ser(k.borrow()))
-            .collect();
-        let results: Result<Vec<_>, TypedStoreError> = self
-            .rocksdb
-            .batched_multi_get_cf_opt(
-                &self.cf(),
-                keys_bytes?,
-                // sorted_keys=
-                false,
-                &self.opts.readopts(),
-            )
-            .into_iter()
-            .map(|r| r.map_err(|e| TypedStoreError::RocksDB(e.into_string())))
-            .collect();
-        let entries = results?;
-        let entry_size = entries
-            .iter()
-            .flatten()
-            .map(|entry| entry.len())
-            .sum::<usize>();
-        self.db_metrics
-            .op_metrics
-            .rocksdb_multiget_bytes
-            .with_label_values(&[&self.cf])
-            .observe(entry_size as f64);
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .read_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        Ok(entries)
-    }
-
-    fn report_metrics(rocksdb: &Arc<RocksDB>, cf_name: &str, db_metrics: &Arc<DBMetrics>) {
-        let Some(cf) = rocksdb.cf_handle(cf_name) else {
-            tracing::warn!(
-                "unable to report metrics for cf {cf_name:?} in db {:?}",
-                rocksdb.db_name()
-            );
-            return;
-        };
-
-        db_metrics
-            .cf_metrics
-            .rocksdb_total_sst_files_size
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::TOTAL_SST_FILES_SIZE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_total_blob_files_size
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        // 7 is the default number of levels in RocksDB. If we ever change the number of
-        // levels using `set_num_levels`, we need to update here as well. Note
-        // that there isn't an API to query the DB to get the number of levels (yet).
-        let total_num_files: i64 = (0..=6)
-            .map(|level| {
-                Self::get_int_property(rocksdb, &cf, &num_files_at_level(level))
-                    .unwrap_or(METRICS_ERROR)
-            })
-            .sum();
-        db_metrics
-            .cf_metrics
-            .rocksdb_total_num_files
-            .with_label_values(&[cf_name])
-            .set(total_num_files);
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_level0_files
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, &num_files_at_level(0))
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_current_size_active_mem_tables
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::CUR_SIZE_ACTIVE_MEM_TABLE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_size_all_mem_tables
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::SIZE_ALL_MEM_TABLES)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_snapshots
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::NUM_SNAPSHOTS)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_oldest_snapshot_time
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::OLDEST_SNAPSHOT_TIME)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_actual_delayed_write_rate
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ACTUAL_DELAYED_WRITE_RATE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_is_write_stopped
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::IS_WRITE_STOPPED)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_block_cache_capacity
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_CAPACITY)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_block_cache_usage
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_USAGE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_block_cache_pinned_usage
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_PINNED_USAGE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_estimate_table_readers_mem
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_TABLE_READERS_MEM)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_estimated_num_keys
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_NUM_KEYS)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_immutable_mem_tables
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::NUM_IMMUTABLE_MEM_TABLE)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_mem_table_flush_pending
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::MEM_TABLE_FLUSH_PENDING)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_compaction_pending
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::COMPACTION_PENDING)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_estimate_pending_compaction_bytes
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_PENDING_COMPACTION_BYTES)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_running_compactions
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::NUM_RUNNING_COMPACTIONS)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_num_running_flushes
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::NUM_RUNNING_FLUSHES)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_estimate_oldest_key_time
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_OLDEST_KEY_TIME)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_background_errors
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BACKGROUND_ERRORS)
-                    .unwrap_or(METRICS_ERROR),
-            );
-        db_metrics
-            .cf_metrics
-            .rocksdb_base_level
-            .with_label_values(&[cf_name])
-            .set(
-                Self::get_int_property(rocksdb, &cf, properties::BASE_LEVEL)
-                    .unwrap_or(METRICS_ERROR),
-            );
-    }
-
-    pub fn checkpoint_db(&self, path: &Path) -> Result<(), TypedStoreError> {
-        self.rocksdb.checkpoint(path)
-    }
-
-    pub fn table_summary(&self) -> eyre::Result<TableSummary>
-    where
-        K: Serialize + DeserializeOwned,
-        V: Serialize + DeserializeOwned,
-    {
-        let mut num_keys = 0;
-        let mut key_bytes_total = 0;
-        let mut value_bytes_total = 0;
-        let mut key_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
-        let mut value_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
-        for item in self.safe_iter() {
-            let (key, value) = item?;
-            num_keys += 1;
-            let key_len = be_fix_int_ser(key.borrow())?.len();
-            let value_len = bcs::to_bytes(value.borrow())?.len();
-            key_bytes_total += key_len;
-            value_bytes_total += value_len;
-            key_hist.record(key_len as u64)?;
-            value_hist.record(value_len as u64)?;
-        }
-        Ok(TableSummary {
-            num_keys,
-            key_bytes_total,
-            value_bytes_total,
-            key_hist,
-            value_hist,
-        })
-    }
-
-    // Creates metrics and context for tracking an iterator usage and performance.
-    fn create_iter_context(
-        &self,
-    ) -> (
-        Option<HistogramTimer>,
-        Option<Histogram>,
-        Option<Histogram>,
-        Option<RocksDBPerfContext>,
-    ) {
-        let timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_iter_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let bytes_scanned = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_iter_bytes
-            .with_label_values(&[&self.cf]);
-        let keys_scanned = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_iter_keys
-            .with_label_values(&[&self.cf]);
-        let perf_ctx = if self.iter_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        (
-            Some(timer),
-            Some(bytes_scanned),
-            Some(keys_scanned),
-            perf_ctx,
-        )
-    }
-
-    // Creates a RocksDB read option with specified lower and upper bounds.
-    /// Lower bound is inclusive, and upper bound is exclusive.
-    fn create_read_options_with_bounds(
-        &self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> ReadOptions
-    where
-        K: Serialize,
-    {
-        let mut readopts = self.opts.readopts();
-        if let Some(lower_bound) = lower_bound {
-            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
-            readopts.set_iterate_lower_bound(key_buf);
-        }
-        if let Some(upper_bound) = upper_bound {
-            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
-            readopts.set_iterate_upper_bound(key_buf);
-        }
-        readopts
-    }
-
-    /// Creates a safe reversed iterator with optional bounds.
-    /// Upper bound is included.
-    pub fn reversed_safe_iter_with_bounds(
-        &self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> Result<SafeRevIter<'_, K, V>, TypedStoreError>
-    where
-        K: Serialize + DeserializeOwned,
-        V: Serialize + DeserializeOwned,
-    {
-        let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
-        let readopts = self.create_read_options_with_range((
-            lower_bound
-                .as_ref()
-                .map(Bound::Included)
-                .unwrap_or(Bound::Unbounded),
-            upper_bound
-                .as_ref()
-                .map(Bound::Included)
-                .unwrap_or(Bound::Unbounded),
-        ));
-
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        let iter = SafeIter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        );
-        Ok(SafeRevIter::new(iter, upper_bound_key.transpose()?))
-    }
-
-    // Creates a RocksDB read option with lower and upper bounds set corresponding
-    // to `range`.
-    fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
-    where
-        K: Serialize,
-    {
-        let mut readopts = self.opts.readopts();
-
-        let lower_bound = range.start_bound();
-        let upper_bound = range.end_bound();
-
-        match lower_bound {
-            Bound::Included(lower_bound) => {
-                // Rocksdb lower bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-                readopts.set_iterate_lower_bound(key_buf);
-            }
-            Bound::Excluded(lower_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
-
-                // Since we want exclusive, we need to increment the key to exclude the previous
-                big_endian_saturating_add_one(&mut key_buf);
-                readopts.set_iterate_lower_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        match upper_bound {
-            Bound::Included(upper_bound) => {
-                let mut key_buf =
-                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-
-                // If the key is already at the limit, there's nowhere else to go, so no upper
-                // bound
-                if !is_max(&key_buf) {
-                    // Since we want exclusive, we need to increment the key to get the upper bound
-                    big_endian_saturating_add_one(&mut key_buf);
-                    readopts.set_iterate_upper_bound(key_buf);
-                }
-            }
-            Bound::Excluded(upper_bound) => {
-                // Rocksdb upper bound is inclusive by default so nothing to do
-                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
-                readopts.set_iterate_upper_bound(key_buf);
-            }
-            Bound::Unbounded => (),
-        };
-
-        readopts
-    }
-}
-
-/// Provides a mutable struct to form a collection of database write operations,
-/// and execute them.
-///
-/// Batching write and delete operations is faster than performing them one by
-/// one and ensures their atomicity,  ie. they are all written or none is.
-/// This is also true of operations across column families in the same database.
-///
-/// Serializations / Deserialization, and naming of column families is performed
-/// by passing a DBMap<K,V> with each operation.
-///
-/// ```
-/// use core::fmt::Error;
-/// use std::sync::Arc;
-///
-/// use prometheus::Registry;
-/// use tempfile::tempdir;
-/// use typed_store::{Map, metrics::DBMetrics, rocks::*};
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Error> {
-///     let rocks = open_cf(
-///         tempfile::tempdir().unwrap(),
-///         None,
-///         MetricConf::default(),
-///         &["First_CF", "Second_CF"],
-///     )
-///     .unwrap();
-///
-///     let db_cf_1 = DBMap::reopen(
-///         &rocks,
-///         Some("First_CF"),
-///         &ReadWriteOptions::default(),
-///         false,
-///     )
-///     .expect("Failed to open storage");
-///     let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
-///
-///     let db_cf_2 = DBMap::reopen(
-///         &rocks,
-///         Some("Second_CF"),
-///         &ReadWriteOptions::default(),
-///         false,
-///     )
-///     .expect("Failed to open storage");
-///     let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
-///
-///     let mut batch = db_cf_1.batch();
-///     batch
-///         .insert_batch(&db_cf_1, keys_vals_1.clone())
-///         .expect("Failed to batch insert")
-///         .insert_batch(&db_cf_2, keys_vals_2.clone())
-///         .expect("Failed to batch insert");
-///
-///     let _ = batch.write().expect("Failed to execute batch");
-///     for (k, v) in keys_vals_1 {
-///         let val = db_cf_1.get(&k).expect("Failed to get inserted key");
-///         assert_eq!(Some(v), val);
-///     }
-///
-///     for (k, v) in keys_vals_2 {
-///         let val = db_cf_2.get(&k).expect("Failed to get inserted key");
-///         assert_eq!(Some(v), val);
-///     }
-///     Ok(())
-/// }
-/// ```
-pub struct DBBatch {
-    rocksdb: Arc<RocksDB>,
-    batch: rocksdb::WriteBatch,
-    opts: WriteOptions,
-    db_metrics: Arc<DBMetrics>,
-    write_sample_interval: SamplingInterval,
-}
-
-impl DBBatch {
-    /// Create a new batch associated with a DB reference.
-    ///
-    /// Use `open_cf` to get the DB reference or an existing open database.
-    pub fn new(
-        dbref: &Arc<RocksDB>,
-        batch: rocksdb::WriteBatch,
-        opts: WriteOptions,
-        db_metrics: &Arc<DBMetrics>,
-        write_sample_interval: &SamplingInterval,
-    ) -> Self {
-        DBBatch {
-            rocksdb: dbref.clone(),
-            batch,
-            opts,
-            db_metrics: db_metrics.clone(),
-            write_sample_interval: write_sample_interval.clone(),
-        }
-    }
-
-    /// Consume the batch and write its operations to the database
-    #[instrument(level = "trace", skip_all, err)]
-    pub fn write(self) -> Result<(), TypedStoreError> {
-        let db_name = self.rocksdb.db_name();
-        let timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_batch_commit_latency_seconds
-            .with_label_values(&[&db_name])
-            .start_timer();
-        let batch_size = self.batch.size_in_bytes();
-
-        let perf_ctx = if self.write_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        self.rocksdb.write(self.batch, &self.opts)?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_batch_commit_bytes
-            .with_label_values(&[&db_name])
-            .observe(batch_size as f64);
-
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .write_perf_ctx_metrics
-                .report_metrics(&db_name);
-        }
-        let elapsed = timer.stop_and_record();
-        if elapsed > 1.0 {
-            warn!(?elapsed, ?db_name, "very slow batch write");
-            self.db_metrics
-                .op_metrics
-                .rocksdb_very_slow_batch_writes_count
-                .with_label_values(&[&db_name])
-                .inc();
-            self.db_metrics
-                .op_metrics
-                .rocksdb_very_slow_batch_writes_duration_ms
-                .with_label_values(&[&db_name])
-                .inc_by((elapsed * 1000.0) as u64);
-        }
-        Ok(())
-    }
-
-    pub fn size_in_bytes(&self) -> usize {
-        self.batch.size_in_bytes()
-    }
-}
-
-impl DBBatch {
-    pub fn delete_batch<J: Borrow<K>, K: Serialize, V>(
-        &mut self,
-        db: &DBMap<K, V>,
-        purged_vals: impl IntoIterator<Item = J>,
-    ) -> Result<(), TypedStoreError> {
-        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
-            return Err(TypedStoreError::CrossDBBatch);
-        }
-
-        purged_vals
-            .into_iter()
-            .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
-                let k_buf = be_fix_int_ser(k.borrow())?;
-                self.batch.delete_cf(&db.cf(), k_buf);
-
-                Ok(())
-            })?;
-        Ok(())
-    }
-
-    /// Deletes a range of keys between `from` (inclusive) and `to`
-    /// (non-inclusive) by writing a range delete tombstone in the db map
-    /// If the DBMap is configured with ignore_range_deletions set to false,
-    /// the effect of this write will be visible immediately i.e. you won't
-    /// see old values when you do a lookup or scan. But if it is configured
-    /// with ignore_range_deletions set to true, the old value are visible until
-    /// compaction actually deletes them which will happen sometime after. By
-    /// default ignore_range_deletions is set to true on a DBMap (unless it is
-    /// overridden in the config), so please use this function with caution
-    pub fn schedule_delete_range<K: Serialize, V>(
-        &mut self,
-        db: &DBMap<K, V>,
-        from: &K,
-        to: &K,
-    ) -> Result<(), TypedStoreError> {
-        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
-            return Err(TypedStoreError::CrossDBBatch);
-        }
-
-        let from_buf = be_fix_int_ser(from)?;
-        let to_buf = be_fix_int_ser(to)?;
-
-        self.batch.delete_range_cf(&db.cf(), from_buf, to_buf);
-        Ok(())
-    }
-
-    /// inserts a range of (key, value) pairs given as an iterator
-    pub fn insert_batch<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
-        &mut self,
-        db: &DBMap<K, V>,
-        new_vals: impl IntoIterator<Item = (J, U)>,
-    ) -> Result<&mut Self, TypedStoreError> {
-        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
-            return Err(TypedStoreError::CrossDBBatch);
-        }
-        let mut total = 0usize;
-        new_vals
-            .into_iter()
-            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
-                let k_buf = be_fix_int_ser(k.borrow())?;
-                let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
-                total += k_buf.len() + v_buf.len();
-                self.batch.put_cf(&db.cf(), k_buf, v_buf);
-                Ok(())
-            })?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_batch_put_bytes
-            .with_label_values(&[&db.cf])
-            .observe(total as f64);
-        Ok(self)
-    }
-}
-
-pub type RocksDBRawIter<'a> =
-    rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
-
-impl<'a, K, V> Map<'a, K, V> for DBMap<K, V>
-where
-    K: Serialize + DeserializeOwned,
-    V: Serialize + DeserializeOwned,
-{
-    type Error = TypedStoreError;
-    type SafeIterator = SafeIter<'a, K, V>;
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
-        let key_buf = be_fix_int_ser(key)?;
-        // [`rocksdb::DBWithThreadMode::key_may_exist_cf`] can have false positives,
-        // but no false negatives. We use it to short-circuit the absent case
-        let readopts = self.opts.readopts();
-        Ok(self
-            .rocksdb
-            .key_may_exist_cf(&self.cf(), &key_buf, &readopts)
-            && self
-                .rocksdb
-                .get_pinned_cf_opt(&self.cf(), &key_buf, &readopts)
-                .map_err(typed_store_err_from_rocks_err)?
-                .is_some())
-    }
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn multi_contains_keys<J>(
-        &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<bool>, Self::Error>
-    where
-        J: Borrow<K>,
-    {
-        let values = self.multi_get_pinned(keys)?;
-        Ok(values.into_iter().map(|v| v.is_some()).collect())
-    }
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
-        let _timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_get_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let perf_ctx = if self.get_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        let key_buf = be_fix_int_ser(key)?;
-        let res = self
-            .rocksdb
-            .get_pinned_cf_opt(&self.cf(), &key_buf, &self.opts.readopts())
-            .map_err(typed_store_err_from_rocks_err)?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_get_bytes
-            .with_label_values(&[&self.cf])
-            .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .read_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        match res {
-            Some(data) => Ok(Some(
-                bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
-            )),
-            None => Ok(None),
-        }
-    }
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
-        let timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_put_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let perf_ctx = if self.write_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        let key_buf = be_fix_int_ser(key)?;
-        let value_buf = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_put_bytes
-            .with_label_values(&[&self.cf])
-            .observe((key_buf.len() + value_buf.len()) as f64);
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .write_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        self.rocksdb
-            .put_cf(&self.cf(), &key_buf, &value_buf, &self.opts.writeopts())
-            .map_err(typed_store_err_from_rocks_err)?;
-
-        let elapsed = timer.stop_and_record();
-        if elapsed > 1.0 {
-            warn!(?elapsed, cf = ?self.cf, "very slow insert");
-            self.db_metrics
-                .op_metrics
-                .rocksdb_very_slow_puts_count
-                .with_label_values(&[&self.cf])
-                .inc();
-            self.db_metrics
-                .op_metrics
-                .rocksdb_very_slow_puts_duration_ms
-                .with_label_values(&[&self.cf])
-                .inc_by((elapsed * 1000.0) as u64);
-        }
-
-        Ok(())
-    }
-
-    #[instrument(level = "trace", skip_all, err)]
-    fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
-        let _timer = self
-            .db_metrics
-            .op_metrics
-            .rocksdb_delete_latency_seconds
-            .with_label_values(&[&self.cf])
-            .start_timer();
-        let perf_ctx = if self.write_sample_interval.sample() {
-            Some(RocksDBPerfContext)
-        } else {
-            None
-        };
-        let key_buf = be_fix_int_ser(key)?;
-        self.rocksdb
-            .delete_cf(&self.cf(), key_buf, &self.opts.writeopts())
-            .map_err(typed_store_err_from_rocks_err)?;
-        self.db_metrics
-            .op_metrics
-            .rocksdb_deletes
-            .with_label_values(&[&self.cf])
-            .inc();
-        if perf_ctx.is_some() {
-            self.db_metrics
-                .write_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        Ok(())
-    }
-
-    /// This method first drops the existing column family and then creates a
-    /// new one with the same name. The two operations are not atomic and
-    /// hence it is possible to get into a race condition where the column
-    /// family has been dropped but new one is not created yet
-    #[instrument(level = "trace", skip_all, err)]
-    fn unsafe_clear(&self) -> Result<(), TypedStoreError> {
-        let _ = self.rocksdb.drop_cf(&self.cf);
-        self.rocksdb
-            .create_cf(self.cf.clone(), &default_db_options().options)
-            .map_err(typed_store_err_from_rocks_err)?;
-        Ok(())
-    }
-
-    /// Writes a range delete tombstone to delete all entries in the db map
-    /// If the DBMap is configured with ignore_range_deletions set to false,
-    /// the effect of this write will be visible immediately i.e. you won't
-    /// see old values when you do a lookup or scan. But if it is configured
-    /// with ignore_range_deletions set to true, the old value are visible until
-    /// compaction actually deletes them which will happen sometime after. By
-    /// default ignore_range_deletions is set to true on a DBMap (unless it is
-    /// overridden in the config), so please use this function with caution
-    #[instrument(level = "trace", skip_all, err)]
-    fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
-        let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);
-        let last_key = self
-            .reversed_safe_iter_with_bounds(None, None)?
-            .next()
-            .transpose()?
-            .map(|(k, _v)| k);
-        if let Some((first_key, last_key)) = first_key.zip(last_key) {
-            let mut batch = self.batch();
-            batch.schedule_delete_range(self, &first_key, &last_key)?;
-            batch.write()?;
-        }
-        Ok(())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.safe_iter().next().is_none()
-    }
-
-    fn safe_iter(&'a self) -> Self::SafeIterator {
-        let db_iter = self
-            .rocksdb
-            .raw_iterator_cf(&self.cf(), self.opts.readopts());
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
-    }
-
-    fn safe_iter_with_bounds(
-        &'a self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> Self::SafeIterator {
-        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
-    }
-
-    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
-        let readopts = self.create_read_options_with_range(range);
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
-        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
-            self.cf.clone(),
-            db_iter,
-            _timer,
-            _perf_ctx,
-            bytes_scanned,
-            keys_scanned,
-            Some(self.db_metrics.clone()),
-        )
-    }
-
-    /// Returns a vector of values corresponding to the keys provided.
-    #[instrument(level = "trace", skip_all, err)]
-    fn multi_get<J>(
-        &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<Option<V>>, TypedStoreError>
-    where
-        J: Borrow<K>,
-    {
-        let results = self.multi_get_pinned(keys)?;
-        let values_parsed: Result<Vec<_>, TypedStoreError> = results
-            .into_iter()
-            .map(|value_byte| match value_byte {
-                Some(data) => Ok(Some(
-                    bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
-                )),
-                None => Ok(None),
-            })
-            .collect();
-
-        values_parsed
-    }
-
-    /// Convenience method for batch insertion
-    #[instrument(level = "trace", skip_all, err)]
-    fn multi_insert<J, U>(
-        &self,
-        key_val_pairs: impl IntoIterator<Item = (J, U)>,
-    ) -> Result<(), Self::Error>
-    where
-        J: Borrow<K>,
-        U: Borrow<V>,
-    {
-        let mut batch = self.batch();
-        batch.insert_batch(self, key_val_pairs)?;
-        batch.write()
-    }
-
-    /// Convenience method for batch removal
-    #[instrument(level = "trace", skip_all, err)]
-    fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
-    where
-        J: Borrow<K>,
-    {
-        let mut batch = self.batch();
-        batch.delete_batch(self, keys)?;
-        batch.write()
-    }
-
-    /// Try to catch up with primary when running as secondary
-    #[instrument(level = "trace", skip_all, err)]
-    fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
-        self.rocksdb
-            .try_catch_up_with_primary()
-            .map_err(typed_store_err_from_rocks_err)
-    }
-}
-
 pub fn read_size_from_env(var_name: &str) -> Option<usize> {
     env::var(var_name)
         .ok()?
@@ -1669,40 +178,6 @@ pub fn read_size_from_env(var_name: &str) -> Option<usize> {
         .ok()
 }
 
-#[derive(Clone, Debug)]
-pub struct ReadWriteOptions {
-    pub ignore_range_deletions: bool,
-    // Whether to sync to disk on every write.
-    sync_to_disk: bool,
-}
-
-impl ReadWriteOptions {
-    pub fn readopts(&self) -> ReadOptions {
-        let mut readopts = ReadOptions::default();
-        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
-        readopts
-    }
-
-    pub fn writeopts(&self) -> WriteOptions {
-        let mut opts = WriteOptions::default();
-        opts.set_sync(self.sync_to_disk);
-        opts
-    }
-
-    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
-        self.ignore_range_deletions = ignore;
-        self
-    }
-}
-
-impl Default for ReadWriteOptions {
-    fn default() -> Self {
-        Self {
-            ignore_range_deletions: true,
-            sync_to_disk: std::env::var("IOTA_DB_SYNC_TO_DISK").is_ok_and(|v| v != "0"),
-        }
-    }
-}
 // TODO: refactor this into a builder pattern, where rocksdb::Options are
 // generated after a call to build().
 #[derive(Default, Clone)]
@@ -1981,7 +456,7 @@ pub fn open_cf<P: AsRef<Path>>(
     db_options: Option<rocksdb::Options>,
     metric_conf: MetricConf,
     opt_cfs: &[&str],
-) -> Result<Arc<RocksDB>, TypedStoreError> {
+) -> Result<Arc<Database>, TypedStoreError> {
     let options = db_options.unwrap_or_else(|| default_db_options().options);
     let column_descriptors: Vec<_> = opt_cfs
         .iter()
@@ -2005,13 +480,13 @@ fn prepare_db_options(db_options: Option<rocksdb::Options>) -> rocksdb::Options 
 
 /// Opens a database with options, and a number of column families with
 /// individual options that are created if they do not exist.
-#[instrument(level="debug", skip_all, fields(path = ?path.as_ref()), err)]
+#[tracing::instrument(level="debug", skip_all, fields(path = ?path.as_ref()), err)]
 pub fn open_cf_opts<P: AsRef<Path>>(
     path: P,
     db_options: Option<rocksdb::Options>,
     metric_conf: MetricConf,
     opt_cfs: &[(&str, rocksdb::Options)],
-) -> Result<Arc<RocksDB>, TypedStoreError> {
+) -> Result<Arc<Database>, TypedStoreError> {
     let path = path.as_ref();
     // In the simulator, we intercept the wall clock in the test thread only. This
     // causes problems because rocksdb uses the simulated clock when creating
@@ -2034,10 +509,11 @@ pub fn open_cf_opts<P: AsRef<Path>>(
             )
             .map_err(typed_store_err_from_rocks_err)?
         };
-        Ok(Arc::new(RocksDB::new(
-            rocksdb,
+        Ok(Arc::new(Database::new(
+            Storage::Rocks(RocksDB {
+                underlying: rocksdb,
+            }),
             metric_conf,
-            PathBuf::from(path),
         )))
     })
 }
@@ -2050,7 +526,7 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
     db_options: Option<rocksdb::Options>,
     metric_conf: MetricConf,
     opt_cfs: &[(&str, rocksdb::Options)],
-) -> Result<Arc<RocksDB>, TypedStoreError> {
+) -> Result<Arc<Database>, TypedStoreError> {
     let primary_path = primary_path.as_ref();
     let secondary_path = secondary_path.as_ref().map(|p| p.as_ref());
     // See comment above for explanation of why nondeterministic is necessary here.
@@ -2099,7 +575,12 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
                 .map_err(typed_store_err_from_rocks_err)?;
             db
         };
-        Ok(Arc::new(RocksDB::new(rocksdb, metric_conf, secondary_path)))
+        Ok(Arc::new(Database::new(
+            Storage::Rocks(RocksDB {
+                underlying: rocksdb,
+            }),
+            metric_conf,
+        )))
     })
 }
 
@@ -2123,7 +604,9 @@ pub fn list_tables(path: std::path::PathBuf) -> eyre::Result<Vec<String>> {
         })
 }
 
-/// TODO: Good description of why we're doing this : RocksDB stores keys in BE and has a seek operator on iterators, see `https://github.com/facebook/rocksdb/wiki/Iterator#introduction`
+/// Serializes keys using big-endian byte order with fixed-int encoding.
+/// RocksDB stores keys in big-endian and uses a byte-wise seek operator on
+/// iterators, see `https://github.com/facebook/rocksdb/wiki/Iterator#introduction`
 #[inline]
 pub fn be_fix_int_ser<S>(t: &S) -> Result<Vec<u8>, TypedStoreError>
 where
@@ -2194,55 +677,248 @@ fn populate_missing_cfs(
     Ok(cfs)
 }
 
-/// Given a `vec<u8>`, find the value which is one more than the vector
-/// if the vector was a big endian number.
-/// If the vector is already minimum, don't change it.
-fn big_endian_saturating_add_one(v: &mut [u8]) {
-    if is_max(v) {
-        return;
-    }
-    for i in (0..v.len()).rev() {
-        if v[i] == u8::MAX {
-            v[i] = 0;
-        } else {
-            v[i] += 1;
-            break;
+/// RocksDB-specific methods on `DBMap`. These are kept separate from the
+/// generic impl in `database.rs` because they directly access RocksDB
+/// internals and have no meaning for other storage backends.
+impl<K, V> DBMap<K, V> {
+    fn get_rocksdb_int_property(
+        rocksdb: &RocksDB,
+        cf: &impl AsColumnFamilyRef,
+        property_name: &CStr,
+    ) -> Result<i64, TypedStoreError> {
+        match rocksdb.underlying.property_int_value_cf(cf, property_name) {
+            Ok(Some(value)) => Ok(value.min(i64::MAX as u64).try_into().unwrap_or_default()),
+            Ok(None) => Ok(0),
+            Err(e) => Err(TypedStoreError::RocksDB(e.into_string())),
         }
     }
-}
 
-/// Check if all the bytes in the vector are 0xFF
-fn is_max(v: &[u8]) -> bool {
-    v.iter().all(|&x| x == u8::MAX)
-}
+    pub(crate) fn report_rocksdb_metrics(
+        database: &Arc<Database>,
+        cf_name: &str,
+        db_metrics: &Arc<DBMetrics>,
+    ) {
+        let Storage::Rocks(rocksdb) = &database.storage else {
+            return;
+        };
 
-// `clippy::manual_div_ceil` is raised by code expanded by the
-// `uint::construct_uint!` macro so it needs to be fixed by `uint`
-#[expect(clippy::assign_op_pattern, clippy::manual_div_ceil)]
-#[test]
-fn test_helpers() {
-    let v = vec![];
-    assert!(is_max(&v));
+        let Some(cf) = rocksdb.underlying.cf_handle(cf_name) else {
+            warn!(
+                "unable to report metrics for cf {cf_name:?} in db {:?}",
+                database.db_name()
+            );
+            return;
+        };
 
-    fn check_add(v: Vec<u8>) {
-        let mut v = v;
-        let num = Num32::from_big_endian(&v);
-        big_endian_saturating_add_one(&mut v);
-        assert!(num + 1 == Num32::from_big_endian(&v));
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_sst_files_size
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::TOTAL_SST_FILES_SIZE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_blob_files_size
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(
+                    rocksdb,
+                    &cf,
+                    ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE,
+                )
+                .unwrap_or(METRICS_ERROR),
+            );
+        // 7 is the default number of levels in RocksDB. If we ever change the number of
+        // levels using `set_num_levels`, we need to update here as well. Note
+        // that there isn't an API to query the DB to get the number of levels (yet).
+        let total_num_files: i64 = (0..=6)
+            .map(|level| {
+                Self::get_rocksdb_int_property(rocksdb, &cf, &num_files_at_level(level))
+                    .unwrap_or(METRICS_ERROR)
+            })
+            .sum();
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_num_files
+            .with_label_values(&[cf_name])
+            .set(total_num_files);
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_level0_files
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, &num_files_at_level(0))
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_current_size_active_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::CUR_SIZE_ACTIVE_MEM_TABLE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_size_all_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::SIZE_ALL_MEM_TABLES)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_snapshots
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::NUM_SNAPSHOTS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_oldest_snapshot_time
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::OLDEST_SNAPSHOT_TIME)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_actual_delayed_write_rate
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::ACTUAL_DELAYED_WRITE_RATE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_is_write_stopped
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::IS_WRITE_STOPPED)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_capacity
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BLOCK_CACHE_CAPACITY)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_usage
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BLOCK_CACHE_USAGE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_pinned_usage
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BLOCK_CACHE_PINNED_USAGE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_table_readers_mem
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(
+                    rocksdb,
+                    &cf,
+                    properties::ESTIMATE_TABLE_READERS_MEM,
+                )
+                .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimated_num_keys
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::ESTIMATE_NUM_KEYS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_immutable_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::NUM_IMMUTABLE_MEM_TABLE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_mem_table_flush_pending
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::MEM_TABLE_FLUSH_PENDING)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_compaction_pending
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::COMPACTION_PENDING)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_pending_compaction_bytes
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(
+                    rocksdb,
+                    &cf,
+                    properties::ESTIMATE_PENDING_COMPACTION_BYTES,
+                )
+                .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_running_compactions
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::NUM_RUNNING_COMPACTIONS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_running_flushes
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::NUM_RUNNING_FLUSHES)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_oldest_key_time
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::ESTIMATE_OLDEST_KEY_TIME)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_background_errors
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BACKGROUND_ERRORS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_base_level
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_rocksdb_int_property(rocksdb, &cf, properties::BASE_LEVEL)
+                    .unwrap_or(METRICS_ERROR),
+            );
     }
-
-    uint::construct_uint! {
-        // 32 byte number
-        struct Num32(4);
-    }
-
-    let mut v = vec![255; 32];
-    big_endian_saturating_add_one(&mut v);
-    assert!(Num32::MAX == Num32::from_big_endian(&v));
-
-    check_add(vec![1; 32]);
-    check_add(vec![6; 32]);
-    check_add(vec![254; 32]);
-
-    // TBD: More tests coming with randomized arrays
 }

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -1,0 +1,374 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, env};
+
+use rocksdb::{BlockBasedOptions, Cache, ReadOptions};
+use tap::TapFallible;
+use tracing::{info, warn};
+
+// Write buffer size per RocksDB instance can be set via the env var below.
+// If the env var is not set, use the default value in MiB.
+const ENV_VAR_DB_WRITE_BUFFER_SIZE: &str = "DB_WRITE_BUFFER_SIZE_MB";
+const DEFAULT_DB_WRITE_BUFFER_SIZE: usize = 1024;
+
+// Write ahead log size per RocksDB instance can be set via the env var below.
+// If the env var is not set, use the default value in MiB.
+const ENV_VAR_DB_WAL_SIZE: &str = "DB_WAL_SIZE_MB";
+const DEFAULT_DB_WAL_SIZE: usize = 1024;
+
+// Environment variable to control behavior of write throughput optimized
+// tables.
+const ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER: &str = "L0_NUM_FILES_COMPACTION_TRIGGER";
+const DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 4;
+const DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 80;
+const ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB: &str = "MAX_WRITE_BUFFER_SIZE_MB";
+const DEFAULT_MAX_WRITE_BUFFER_SIZE_MB: usize = 256;
+const ENV_VAR_MAX_WRITE_BUFFER_NUMBER: &str = "MAX_WRITE_BUFFER_NUMBER";
+const DEFAULT_MAX_WRITE_BUFFER_NUMBER: usize = 6;
+const ENV_VAR_TARGET_FILE_SIZE_BASE_MB: &str = "TARGET_FILE_SIZE_BASE_MB";
+const DEFAULT_TARGET_FILE_SIZE_BASE_MB: usize = 128;
+
+// Set to 1 to disable blob storage for transactions and effects.
+const ENV_VAR_DISABLE_BLOB_STORAGE: &str = "DISABLE_BLOB_STORAGE";
+const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
+
+#[derive(Clone, Debug)]
+pub struct ReadWriteOptions {
+    pub ignore_range_deletions: bool,
+}
+
+impl ReadWriteOptions {
+    pub fn readopts(&self) -> ReadOptions {
+        let mut readopts = ReadOptions::default();
+        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
+        readopts
+    }
+
+    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
+        self.ignore_range_deletions = ignore;
+        self
+    }
+}
+
+impl Default for ReadWriteOptions {
+    fn default() -> Self {
+        Self {
+            ignore_range_deletions: true,
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct DBOptions {
+    pub options: rocksdb::Options,
+    pub rw_options: ReadWriteOptions,
+}
+
+#[derive(Clone)]
+pub struct DBMapTableConfigMap(BTreeMap<String, DBOptions>);
+impl DBMapTableConfigMap {
+    pub fn new(map: BTreeMap<String, DBOptions>) -> Self {
+        Self(map)
+    }
+
+    pub fn to_map(&self) -> BTreeMap<String, DBOptions> {
+        self.0.clone()
+    }
+}
+
+impl DBOptions {
+    // Optimize lookup perf for tables where no scans are performed.
+    // If non-trivial number of values can be > 512B in size, it is beneficial to
+    // also specify optimize_for_large_values_no_scan().
+    pub fn optimize_for_point_lookup(mut self, block_cache_size_mb: usize) -> DBOptions {
+        // NOTE: this overwrites the block options.
+        self.options
+            .optimize_for_point_lookup(block_cache_size_mb as u64);
+        self
+    }
+
+    // Optimize write and lookup perf for tables which are rarely scanned, and have
+    // large values. https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html
+    pub fn optimize_for_large_values_no_scan(mut self, min_blob_size: u64) -> DBOptions {
+        if env::var(ENV_VAR_DISABLE_BLOB_STORAGE).is_ok() {
+            info!("Large value blob storage optimization is disabled via env var.");
+            return self;
+        }
+
+        // Blob settings.
+        self.options.set_enable_blob_files(true);
+        self.options
+            .set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
+        self.options.set_enable_blob_gc(true);
+        // Since each blob can have non-trivial size overhead, and compression does not
+        // work across blobs, set a min blob size in bytes to so small
+        // transactions and effects are kept in sst files.
+        self.options.set_min_blob_size(min_blob_size);
+
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Since large blobs are not in sst files, reduce the target file size and base
+        // level target size.
+        let target_file_size_base = 64 << 20;
+        self.options
+            .set_target_file_size_base(target_file_size_base);
+        // Level 1 default to 64MiB * 4 ~ 256MiB.
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options
+            .set_max_bytes_for_level_base(target_file_size_base * max_level_zero_file_num as u64);
+
+        self
+    }
+
+    // Optimize tables with a mix of lookup and scan workloads.
+    pub fn optimize_for_read(mut self, block_cache_size_mb: usize) -> DBOptions {
+        self.options
+            .set_block_based_table_factory(&get_block_options(block_cache_size_mb, 16 << 10));
+        self
+    }
+
+    // Optimize DB receiving significant insertions.
+    pub fn optimize_db_for_write_throughput(mut self, db_max_write_buffer_gb: u64) -> DBOptions {
+        self.options
+            .set_db_write_buffer_size(db_max_write_buffer_gb as usize * 1024 * 1024 * 1024);
+        self.options
+            .set_max_total_wal_size(db_max_write_buffer_gb * 1024 * 1024 * 1024);
+        self
+    }
+
+    // Optimize tables receiving significant insertions.
+    pub fn optimize_for_write_throughput(mut self) -> DBOptions {
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Increase write buffers to keep to 6 before slowing down writes.
+        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        self.options
+            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
+        // Keep 1 write buffer so recent writes can be read from memory.
+        self.options
+            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
+
+        // Increase compaction trigger for level 0 to 6.
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options.set_level_zero_file_num_compaction_trigger(
+            max_level_zero_file_num.try_into().unwrap(),
+        );
+        self.options.set_level_zero_slowdown_writes_trigger(
+            (max_level_zero_file_num * 12).try_into().unwrap(),
+        );
+        self.options
+            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
+
+        // Increase sst file size to 128MiB.
+        self.options.set_target_file_size_base(
+            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
+                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
+                * 1024
+                * 1024,
+        );
+
+        // Increase level 1 target size to 256MiB * 6 ~ 1.5GiB.
+        self.options
+            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
+
+        self
+    }
+
+    // Optimize tables receiving significant insertions, without any deletions.
+    // TODO: merge this function with optimize_for_write_throughput(), and use a
+    // flag to indicate if deletion is received.
+    pub fn optimize_for_write_throughput_no_deletion(mut self) -> DBOptions {
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Increase write buffers to keep to 6 before slowing down writes.
+        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        self.options
+            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
+        // Keep 1 write buffer so recent writes can be read from memory.
+        self.options
+            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
+
+        // Switch to universal compactions.
+        self.options
+            .set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+        let mut compaction_options = rocksdb::UniversalCompactOptions::default();
+        compaction_options.set_max_size_amplification_percent(10000);
+        compaction_options.set_stop_style(rocksdb::UniversalCompactionStopStyle::Similar);
+        self.options
+            .set_universal_compaction_options(&compaction_options);
+
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options.set_level_zero_file_num_compaction_trigger(
+            max_level_zero_file_num.try_into().unwrap(),
+        );
+        self.options.set_level_zero_slowdown_writes_trigger(
+            (max_level_zero_file_num * 12).try_into().unwrap(),
+        );
+        self.options
+            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
+
+        // Increase sst file size to 128MiB.
+        self.options.set_target_file_size_base(
+            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
+                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
+                * 1024
+                * 1024,
+        );
+
+        // This should be a no-op for universal compaction but increasing it to be safe.
+        self.options
+            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
+
+        self
+    }
+
+    // Overrides the block options with different block cache size and block size.
+    pub fn set_block_options(
+        mut self,
+        block_cache_size_mb: usize,
+        block_size_bytes: usize,
+    ) -> DBOptions {
+        self.options
+            .set_block_based_table_factory(&get_block_options(
+                block_cache_size_mb,
+                block_size_bytes,
+            ));
+        self
+    }
+
+    // Disables write stalling and stopping based on pending compaction bytes.
+    pub fn disable_write_throttling(mut self) -> DBOptions {
+        self.options.set_soft_pending_compaction_bytes_limit(0);
+        self.options.set_hard_pending_compaction_bytes_limit(0);
+        self
+    }
+}
+
+/// Creates a default RocksDB option, to be used when RocksDB option is
+/// unspecified.
+pub fn default_db_options() -> DBOptions {
+    let mut opt = rocksdb::Options::default();
+
+    // One common issue when running tests on Mac is that the default ulimit is too
+    // low, leading to I/O errors such as "Too many open files". Raising fdlimit
+    // to bypass it.
+    if let Some(limit) = fdlimit::raise_fd_limit() {
+        // on windows raise_fd_limit return None
+        opt.set_max_open_files((limit / 8) as i32);
+    }
+
+    // The table cache is locked for updates and this determines the number
+    // of shards, ie 2^10. Increase in case of lock contentions.
+    opt.set_table_cache_num_shard_bits(10);
+
+    // LSM compression settings
+    opt.set_compression_type(rocksdb::DBCompressionType::Lz4);
+    opt.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
+    opt.set_bottommost_zstd_max_train_bytes(1024 * 1024, true);
+
+    // IOTA uses multiple RocksDB in a node, so total sizes of write buffers and WAL
+    // can be higher than the limits below.
+    //
+    // RocksDB also exposes the option to configure total write buffer size across
+    // multiple instances via `write_buffer_manager`. But the write buffer flush
+    // policy (flushing the buffer receiving the next write) may not work well.
+    // So sticking to per-db write buffer size limit for now.
+    //
+    // The environment variables are only meant to be emergency overrides. They may
+    // go away in future. It is preferable to update the default value, or
+    // override the option in code.
+    opt.set_db_write_buffer_size(
+        read_size_from_env(ENV_VAR_DB_WRITE_BUFFER_SIZE).unwrap_or(DEFAULT_DB_WRITE_BUFFER_SIZE)
+            * 1024
+            * 1024,
+    );
+    opt.set_max_total_wal_size(
+        read_size_from_env(ENV_VAR_DB_WAL_SIZE).unwrap_or(DEFAULT_DB_WAL_SIZE) as u64 * 1024 * 1024,
+    );
+
+    // Num threads for compactions and memtable flushes.
+    opt.increase_parallelism(read_size_from_env(ENV_VAR_DB_PARALLELISM).unwrap_or(8) as i32);
+
+    opt.set_enable_pipelined_write(true);
+
+    // Increase block size to 16KiB.
+    // https://github.com/EighteenZi/rocksdb_wiki/blob/master/Memory-usage-in-RocksDB.md#indexes-and-filter-blocks
+    opt.set_block_based_table_factory(&get_block_options(128, 16 << 10));
+
+    // Set memtable bloomfilter.
+    opt.set_memtable_prefix_bloom_ratio(0.02);
+
+    DBOptions {
+        options: opt,
+        rw_options: ReadWriteOptions::default(),
+    }
+}
+
+fn get_block_options(block_cache_size_mb: usize, block_size_bytes: usize) -> BlockBasedOptions {
+    // Set options mostly similar to those used in optimize_for_point_lookup(),
+    // except non-default binary and hash index, to hopefully reduce lookup
+    // latencies without causing any regression for scanning, with slightly more
+    // memory usages. https://github.com/facebook/rocksdb/blob/11cb6af6e5009c51794641905ca40ce5beec7fee/options/options.cc#L611-L621
+    let mut block_options = BlockBasedOptions::default();
+    // Overrides block size.
+    block_options.set_block_size(block_size_bytes);
+    // Configure a block cache.
+    block_options.set_block_cache(&Cache::new_lru_cache(block_cache_size_mb << 20));
+    // Set a bloomfilter with 1% false positive rate.
+    block_options.set_bloom_filter(10.0, false);
+    // From https://github.com/EighteenZi/rocksdb_wiki/blob/master/Block-Cache.md#caching-index-and-filter-blocks
+    block_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+    block_options
+}
+
+pub fn list_tables(path: std::path::PathBuf) -> eyre::Result<Vec<String>> {
+    const DB_DEFAULT_CF_NAME: &str = "default";
+
+    let opts = rocksdb::Options::default();
+    rocksdb::DBWithThreadMode::<rocksdb::MultiThreaded>::list_cf(&opts, path)
+        .map_err(|e| e.into())
+        .map(|q| {
+            q.iter()
+                .filter_map(|s| {
+                    // The `default` table is not used
+                    if s != DB_DEFAULT_CF_NAME {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+}
+
+pub fn read_size_from_env(var_name: &str) -> Option<usize> {
+    env::var(var_name)
+        .ok()?
+        .parse::<usize>()
+        .tap_err(|e| {
+            warn!(
+                "Env var {} does not contain valid usize integer: {}",
+                var_name, e
+            )
+        })
+        .ok()
+}

--- a/crates/typed-store/src/rocks/rocks_util.rs
+++ b/crates/typed-store/src/rocks/rocks_util.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) fn apply_range_bounds(
+    mut read_options: rocksdb::ReadOptions,
+    lower_bound: Option<Vec<u8>>,
+    upper_bound: Option<Vec<u8>>,
+) -> rocksdb::ReadOptions {
+    if let Some(lower_bound) = lower_bound {
+        read_options.set_iterate_lower_bound(lower_bound);
+    }
+    if let Some(upper_bound) = upper_bound {
+        read_options.set_iterate_upper_bound(upper_bound);
+    }
+    read_options
+}

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -8,14 +8,17 @@ use bincode::Options;
 use prometheus::{Histogram, HistogramTimer};
 use rocksdb::Direction;
 use serde::de::DeserializeOwned;
+use typed_store_error::TypedStoreError;
 
-use super::{RocksDBRawIter, TypedStoreError};
-use crate::metrics::{DBMetrics, RocksDBPerfContext};
+use crate::{
+    database::RawIter,
+    metrics::{DBMetrics, RocksDBPerfContext},
+};
 
 /// An iterator over all key-value pairs in a data map.
 pub struct SafeIter<'a, K, V> {
     cf_name: String,
-    db_iter: RocksDBRawIter<'a>,
+    db_iter: RawIter<'a>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
     is_initialized: bool,
@@ -29,9 +32,9 @@ pub struct SafeIter<'a, K, V> {
 }
 
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
-    pub(super) fn new(
+    pub(crate) fn new(
         cf_name: String,
-        db_iter: RocksDBRawIter<'a>,
+        db_iter: RawIter<'a>,
         _timer: Option<HistogramTimer>,
         _perf_ctx: Option<RocksDBPerfContext>,
         bytes_scanned: Option<Histogram>,

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -6,19 +6,16 @@ use std::{marker::PhantomData, sync::Arc};
 
 use bincode::Options;
 use prometheus::{Histogram, HistogramTimer};
-use rocksdb::Direction;
+use rocksdb::{DBWithThreadMode, Direction, MultiThreaded};
 use serde::de::DeserializeOwned;
 use typed_store_error::TypedStoreError;
 
-use crate::{
-    database::RawIter,
-    metrics::{DBMetrics, RocksDBPerfContext},
-};
+use crate::metrics::{DBMetrics, RocksDBPerfContext};
 
 /// An iterator over all key-value pairs in a data map.
 pub struct SafeIter<'a, K, V> {
     cf_name: String,
-    db_iter: RawIter<'a>,
+    db_iter: rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
     is_initialized: bool,
@@ -34,7 +31,7 @@ pub struct SafeIter<'a, K, V> {
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
     pub(crate) fn new(
         cf_name: String,
-        db_iter: RawIter<'a>,
+        db_iter: rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>,
         _timer: Option<HistogramTimer>,
         _perf_ctx: Option<RocksDBPerfContext>,
         bytes_scanned: Option<Histogram>,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -2,12 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::RangeBounds;
+
 use rstest::rstest;
+use serde::{Serialize, de::DeserializeOwned};
 
 use super::*;
 use crate::{
     reopen,
     rocks::safe_iter::{SafeIter, SafeRevIter},
+    traits::Map,
 };
 
 fn temp_dir() -> std::path::PathBuf {
@@ -90,7 +94,7 @@ async fn test_reopen() {
             .expect("Failed to insert");
         db
     };
-    let db = DBMap::<u32, String>::reopen(&arc.rocksdb, None, &ReadWriteOptions::default(), false)
+    let db = DBMap::<u32, String>::reopen(&arc.db, None, &ReadWriteOptions::default(), false)
         .expect("Failed to re-open storage");
     assert!(
         db.contains_key(&123456789)
@@ -116,18 +120,11 @@ async fn test_reopen_macro() {
     let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
     let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
 
-    assert_eq!(db_map_1.cf, FIRST_CF);
-    assert_eq!(db_map_2.cf, SECOND_CF);
+    assert_eq!(db_map_1.cf_name(), FIRST_CF);
+    assert_eq!(db_map_2.cf_name(), SECOND_CF);
 
     assert!(db_map_1.multi_insert(keys_vals_cf1).is_ok());
     assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
-}
-
-#[tokio::test]
-async fn test_wrong_reopen() {
-    let rocks = open_rocksdb(temp_dir(), &["foo", "bar", "baz"]);
-    let db = DBMap::<u8, u8>::reopen(&rocks, Some("quux"), &ReadWriteOptions::default(), false);
-    assert!(db.is_err());
 }
 
 #[tokio::test]
@@ -395,14 +392,7 @@ async fn test_insert_batch_across_different_db() {
 
 #[tokio::test]
 async fn test_delete_batch() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        None,
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db = open_map::<_, u32, String>(temp_dir(), None);
 
     let keys_vals = (1..100).map(|i| (i, i.to_string()));
     let mut batch = db.batch();
@@ -425,14 +415,14 @@ async fn test_delete_batch() {
 
 #[tokio::test]
 async fn test_delete_range() {
-    let db: DBMap<i32, String> = DBMap::open(
-        temp_dir(),
-        MetricConf::default(),
+    let options = ReadWriteOptions::default().set_ignore_range_deletions(false);
+    let db: DBMap<i32, String> = DBMap::reopen(
+        &open_rocksdb(temp_dir(), &[rocksdb::DEFAULT_COLUMN_FAMILY_NAME]),
         None,
-        None,
-        &ReadWriteOptions::default().set_ignore_range_deletions(false),
+        &options,
+        false,
     )
-    .expect("Failed to open storage");
+    .unwrap();
 
     // Note that the last element is (100, "100".to_owned()) here
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
@@ -460,14 +450,7 @@ async fn test_delete_range() {
 
 #[tokio::test]
 async fn test_clear() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        Some("table"),
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
     // Test clear of empty map
     let _ = db.unsafe_clear();
 
@@ -599,14 +582,7 @@ async fn test_range_iter() {
 
 #[tokio::test]
 async fn test_is_empty() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        Some("table"),
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
 
     // Test empty map is truly empty
     assert!(db.is_empty());
@@ -658,7 +634,7 @@ async fn test_checkpoint() {
     db.multi_insert(keys_vals.clone())
         .expect("Failed to multi-insert");
     let checkpointed_path = path_prefix.join("checkpointed_db");
-    db.rocksdb
+    db.db
         .checkpoint(&checkpointed_path)
         .expect("Failed to create db checkpoint");
     // Create more kv pairs
@@ -719,14 +695,7 @@ async fn open_as_secondary_test() {
     let primary_path = temp_dir();
 
     // Init a DB
-    let primary_db = DBMap::<i32, String>::open(
-        primary_path.clone(),
-        MetricConf::default(),
-        None,
-        Some("table"),
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let primary_db: DBMap<i32, String> = open_map(primary_path.clone(), Some("table"));
     // Create kv pairs
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
 
@@ -736,11 +705,11 @@ async fn open_as_secondary_test() {
 
     let opt = rocksdb::Options::default();
     let secondary_store = open_cf_opts_secondary(
-        primary_path,
+        primary_path.clone(),
         None,
         None,
         MetricConf::default(),
-        &[("table", opt)],
+        &[("table", opt.clone())],
     )
     .unwrap();
     let secondary_db = DBMap::<i32, String>::reopen(
@@ -771,16 +740,16 @@ async fn open_as_secondary_test() {
 }
 
 fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> {
-    DBMap::<K, V>::open(
-        path,
-        MetricConf::default(),
-        None,
+    let cf_key = opt_cf.unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME);
+    DBMap::<K, V>::reopen(
+        &open_rocksdb(path, &[cf_key]),
         opt_cf,
         &ReadWriteOptions::default(),
+        false,
     )
     .expect("failed to open rocksdb")
 }
 
-fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<RocksDB> {
+fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<Database> {
     open_cf(path, None, MetricConf::default(), opt_cfs).expect("failed to open rocksdb")
 }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -87,11 +87,14 @@ async fn test_reopen_macro() {
     const FIRST_CF: &str = "First_CF";
     const SECOND_CF: &str = "Second_CF";
 
-    let rocks = open_cf(
+    let rocks = open_cf_opts(
         temp_dir(),
         None,
         MetricConf::default(),
-        &[FIRST_CF, SECOND_CF],
+        &[
+            (FIRST_CF, rocksdb::Options::default()),
+            (SECOND_CF, rocksdb::Options::default()),
+        ],
     )
     .unwrap();
 
@@ -695,11 +698,11 @@ async fn open_as_secondary_test() {
 
     let opt = rocksdb::Options::default();
     let secondary_store = open_cf_opts_secondary(
-        primary_path.clone(),
+        primary_path,
         None,
         None,
         MetricConf::default(),
-        &[("table", opt.clone())],
+        &[("table", opt)],
     )
     .unwrap();
     let secondary_db = DBMap::<i32, String>::reopen(
@@ -741,5 +744,15 @@ fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> 
 }
 
 fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<Database> {
-    open_cf(path, None, MetricConf::default(), opt_cfs).expect("failed to open rocksdb")
+    let opts = rocksdb::Options::default();
+    open_cf_opts(
+        path,
+        None,
+        MetricConf::default(),
+        &opt_cfs
+            .iter()
+            .map(|cf| (*cf, opts.clone()))
+            .collect::<Vec<_>>(),
+    )
+    .expect("failed to open rocksdb")
 }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -144,6 +144,16 @@ async fn test_contains_key() {
 }
 
 #[tokio::test]
+async fn test_safe_drop_db() {
+    let path = temp_dir();
+    {
+        let db: DBMap<i32, String> = open_map(path.clone(), Some("table"));
+        db.insert(&777, &"123".to_string()).unwrap();
+    }
+    assert!(safe_drop_db(path, Duration::from_secs(5)).await.is_ok());
+}
+
+#[tokio::test]
 async fn test_multi_contain() {
     let db = open_map(temp_dir(), None);
 

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -8,11 +8,7 @@ use rstest::rstest;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::*;
-use crate::{
-    reopen,
-    rocks::safe_iter::{SafeIter, SafeRevIter},
-    traits::Map,
-};
+use crate::{reopen, traits::Map};
 
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
@@ -20,36 +16,19 @@ fn temp_dir() -> std::path::PathBuf {
         .keep()
 }
 
-enum TestIteratorWrapper<'a, K, V> {
-    SafeIter(SafeIter<'a, K, V>),
-}
-
-// Implement Iterator for TestIteratorWrapper that returns the same type result
-// for different types of Iterator. For non-safe Iterator, it returns the key
-// value pair. For SafeIterator, it consumes the result (assuming no error), and
-// return they key value pairs.
-impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for TestIteratorWrapper<'_, K, V> {
-    type Item = (K, V);
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            TestIteratorWrapper::SafeIter(iter) => iter.next().map(|result| result.unwrap()),
-        }
-    }
-}
-
-fn get_iter<K, V>(db: &DBMap<K, V>) -> TestIteratorWrapper<'_, K, V>
+fn get_iter<K, V>(db: &DBMap<K, V>) -> impl Iterator<Item = (K, V)> + use<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    TestIteratorWrapper::SafeIter(db.safe_iter())
+    db.safe_iter().map(|item| item.unwrap())
 }
 
 fn get_reverse_iter<K, V>(
     db: &DBMap<K, V>,
     lower_bound: Option<K>,
     upper_bound: Option<K>,
-) -> SafeRevIter<'_, K, V>
+) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + use<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
@@ -62,23 +41,24 @@ fn get_iter_with_bounds<K, V>(
     db: &DBMap<K, V>,
     lower_bound: Option<K>,
     upper_bound: Option<K>,
-) -> TestIteratorWrapper<'_, K, V>
+) -> impl Iterator<Item = (K, V)> + use<'_, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    TestIteratorWrapper::SafeIter(db.safe_iter_with_bounds(lower_bound, upper_bound))
+    db.safe_iter_with_bounds(lower_bound, upper_bound)
+        .map(|item| item.unwrap())
 }
 
-fn get_range_iter<K, V>(
-    db: &DBMap<K, V>,
-    range: impl RangeBounds<K>,
-) -> TestIteratorWrapper<'_, K, V>
+fn get_range_iter<'a, K, V>(
+    db: &'a DBMap<K, V>,
+    range: impl RangeBounds<K> + 'a,
+) -> impl Iterator<Item = (K, V)> + 'a
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    TestIteratorWrapper::SafeIter(db.safe_range_iter(range))
+    db.safe_range_iter(range).map(|item| item.unwrap())
 }
 
 #[tokio::test]

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -20,8 +20,7 @@ use rocksdb::Direction;
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
-    Map, TypedStoreError,
-    rocks::{be_fix_int_ser, errors::typed_store_err_from_bcs_err},
+    DbIterator, Map, TypedStoreError, be_fix_int_ser, rocks::errors::typed_store_err_from_bcs_err,
 };
 
 /// An interface to a btree map backed sally database. This is mainly intended
@@ -103,11 +102,11 @@ impl<'a, K: Serialize, V> TestDBIter<'a, K, V> {
     /// the key.
     pub fn skip_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
         self.with_mut(|fields| {
-            let serialized_key = be_fix_int_ser(key).expect("serialization failed");
+            let serialized_key = be_fix_int_ser(key);
             let mut peekable = fields.iter.peekable();
             let mut peeked = peekable.peek();
             while peeked.is_some() {
-                let serialized = be_fix_int_ser(peeked.unwrap()).expect("serialization failed");
+                let serialized = be_fix_int_ser(peeked.unwrap());
                 if serialized >= serialized_key {
                     break;
                 } else {
@@ -124,11 +123,11 @@ impl<'a, K: Serialize, V> TestDBIter<'a, K, V> {
     /// no element prior to it, it returns an empty iterator.
     pub fn skip_prior_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
         self.with_mut(|fields| {
-            let serialized_key = be_fix_int_ser(key).expect("serialization failed");
+            let serialized_key = be_fix_int_ser(key);
             let mut peekable = fields.iter.peekable();
             let mut peeked = peekable.peek();
             while peeked.is_some() {
-                let serialized = be_fix_int_ser(peeked.unwrap()).expect("serialization failed");
+                let serialized = be_fix_int_ser(peeked.unwrap());
                 if serialized > serialized_key {
                     break;
                 } else {
@@ -222,23 +221,22 @@ where
     V: Serialize + DeserializeOwned,
 {
     type Error = TypedStoreError;
-    type SafeIterator = TestDBIter<'a, K, V>;
 
     fn contains_key(&self, key: &K) -> Result<bool, Self::Error> {
-        let raw_key = be_fix_int_ser(key)?;
+        let raw_key = be_fix_int_ser(key);
         let locked = self.rows.read().unwrap();
         Ok(locked.contains_key(&raw_key))
     }
 
     fn get(&self, key: &K) -> Result<Option<V>, Self::Error> {
-        let raw_key = be_fix_int_ser(key)?;
+        let raw_key = be_fix_int_ser(key);
         let locked = self.rows.read().unwrap();
         let res = locked.get(&raw_key);
         Ok(res.map(|raw_value| bcs::from_bytes(raw_value).ok().unwrap()))
     }
 
     fn insert(&self, key: &K, value: &V) -> Result<(), Self::Error> {
-        let raw_key = be_fix_int_ser(key)?;
+        let raw_key = be_fix_int_ser(key);
         let raw_value = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
         let mut locked = self.rows.write().unwrap();
         locked.insert(raw_key, raw_value);
@@ -246,7 +244,7 @@ where
     }
 
     fn remove(&self, key: &K) -> Result<(), Self::Error> {
-        let raw_key = be_fix_int_ser(key)?;
+        let raw_key = be_fix_int_ser(key);
         let mut locked = self.rows.write().unwrap();
         locked.remove(&raw_key);
         Ok(())
@@ -269,25 +267,29 @@ where
         locked.is_empty()
     }
 
-    fn safe_iter(&'a self) -> Self::SafeIterator {
-        TestDBIterBuilder {
-            rows: self.rows.read().unwrap(),
-            iter_builder: |rows: &mut RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>| rows.iter(),
-            phantom: PhantomData,
-            direction: Direction::Forward,
-        }
-        .build()
+    fn safe_iter(&'a self) -> DbIterator<'a, (K, V)> {
+        Box::new(
+            TestDBIterBuilder {
+                rows: self.rows.read().unwrap(),
+                iter_builder: |rows: &mut RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>| {
+                    rows.iter()
+                },
+                phantom: PhantomData,
+                direction: Direction::Forward,
+            }
+            .build(),
+        )
     }
 
     fn safe_iter_with_bounds(
         &'a self,
         _lower_bound: Option<K>,
         _upper_bound: Option<K>,
-    ) -> Self::SafeIterator {
+    ) -> DbIterator<'a, (K, V)> {
         unimplemented!("unimplemented API");
     }
 
-    fn safe_range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::SafeIterator {
+    fn safe_range_iter(&'a self, _range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
         unimplemented!("unimplemented API");
     }
 
@@ -430,7 +432,7 @@ impl TestDBWriteBatch {
             db.name.clone(),
             purged_vals
                 .into_iter()
-                .map(|key| be_fix_int_ser(&key.borrow()).unwrap())
+                .map(|key| be_fix_int_ser(&key.borrow()))
                 .collect(),
         )));
         Ok(())
@@ -443,8 +445,8 @@ impl TestDBWriteBatch {
         from: &K,
         to: &K,
     ) -> Result<(), TypedStoreError> {
-        let raw_from = be_fix_int_ser(from).unwrap();
-        let raw_to = be_fix_int_ser(to).unwrap();
+        let raw_from = be_fix_int_ser(from);
+        let raw_to = be_fix_int_ser(to);
         self.ops.push_back(WriteBatchOp::DeleteRange((
             db.rows.clone(),
             db.name.clone(),
@@ -465,7 +467,7 @@ impl TestDBWriteBatch {
                 .into_iter()
                 .map(|(key, value)| {
                     (
-                        be_fix_int_ser(&key.borrow()).unwrap(),
+                        be_fix_int_ser(&key.borrow()),
                         bcs::to_bytes(&value.borrow()).unwrap(),
                     )
                 })

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -8,13 +8,14 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::TypedStoreError;
 
+pub type DbIterator<'a, T> = Box<dyn Iterator<Item = Result<T, TypedStoreError>> + 'a>;
+
 pub trait Map<'a, K, V>
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
     type Error: Error;
-    type SafeIterator: Iterator<Item = Result<(K, V), TypedStoreError>>;
 
     /// Returns true if the map contains a value for the specified key.
     fn contains_key(&self, key: &K) -> Result<bool, Self::Error>;
@@ -51,17 +52,17 @@ where
     fn is_empty(&self) -> bool;
 
     /// Same as `iter` but performs status check.
-    fn safe_iter(&'a self) -> Self::SafeIterator;
+    fn safe_iter(&'a self) -> DbIterator<'a, (K, V)>;
 
     // Same as `iter_with_bounds` but performs status check.
     fn safe_iter_with_bounds(
         &'a self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
-    ) -> Self::SafeIterator;
+    ) -> DbIterator<'a, (K, V)>;
 
     // Same as `range_iter` but performs status check.
-    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator;
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)>;
 
     /// Returns a vector of values corresponding to the keys provided,
     /// non-atomically.

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Borrow, collections::BTreeMap, error::Error, ops::RangeBounds};
+use std::{borrow::Borrow, error::Error, ops::RangeBounds};
 
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -106,26 +106,4 @@ pub struct TableSummary {
     pub value_bytes_total: usize,
     pub key_hist: hdrhistogram::Histogram<u64>,
     pub value_hist: hdrhistogram::Histogram<u64>,
-}
-
-pub trait TypedStoreDebug {
-    /// Dump a DB table with pagination
-    fn dump_table(
-        &self,
-        table_name: String,
-        page_size: u16,
-        page_number: usize,
-    ) -> eyre::Result<BTreeMap<String, String>>;
-
-    /// Get the name of the DB. This is simply the name of the struct
-    fn primary_db_name(&self) -> String;
-
-    /// Get a map of table names to key-value types
-    fn describe_all_tables(&self) -> BTreeMap<String, (String, String)>;
-
-    /// Count the entries in the table
-    fn count_table_keys(&self, table_name: String) -> eyre::Result<usize>;
-
-    /// Return table summary of the input table
-    fn table_summary(&self, table_name: String) -> eyre::Result<TableSummary>;
 }

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::{Bound, RangeBounds};
+
+use bincode::Options;
+use serde::Serialize;
+
+#[inline]
+pub fn be_fix_int_ser<S>(t: &S) -> Vec<u8>
+where
+    S: ?Sized + serde::Serialize,
+{
+    bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_fixint_encoding()
+        .serialize(t)
+        .expect("failed to serialize via be_fix_int_ser method")
+}
+
+pub(crate) fn iterator_bounds<K>(
+    lower_bound: Option<K>,
+    upper_bound: Option<K>,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>)
+where
+    K: Serialize,
+{
+    (
+        lower_bound.map(|b| be_fix_int_ser(&b)),
+        upper_bound.map(|b| be_fix_int_ser(&b)),
+    )
+}
+
+pub(crate) fn iterator_bounds_with_range<K>(
+    range: impl RangeBounds<K>,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>)
+where
+    K: Serialize,
+{
+    let iterator_lower_bound = match range.start_bound() {
+        Bound::Included(lower_bound) => {
+            // Rocksdb lower bound is inclusive by default so nothing to do
+            Some(be_fix_int_ser(&lower_bound))
+        }
+        Bound::Excluded(lower_bound) => {
+            let mut key_buf = be_fix_int_ser(&lower_bound);
+
+            // Since we want exclusive, we need to increment the key to exclude the previous
+            big_endian_saturating_add_one(&mut key_buf);
+            Some(key_buf)
+        }
+        Bound::Unbounded => None,
+    };
+    let iterator_upper_bound = match range.end_bound() {
+        Bound::Included(upper_bound) => {
+            let mut key_buf = be_fix_int_ser(&upper_bound);
+
+            // If the key is already at the limit, there's nowhere else to go, so no upper
+            // bound
+            if !is_max(&key_buf) {
+                // Since we want exclusive, we need to increment the key to get the upper bound
+                big_endian_saturating_add_one(&mut key_buf);
+                Some(key_buf)
+            } else {
+                None
+            }
+        }
+        Bound::Excluded(upper_bound) => {
+            // Rocksdb upper bound is exclusive by default so nothing to do
+            Some(be_fix_int_ser(&upper_bound))
+        }
+        Bound::Unbounded => None,
+    };
+    (iterator_lower_bound, iterator_upper_bound)
+}
+
+/// Given a vec<u8>, find the value which is one more than the vector
+/// if the vector was a big endian number.
+/// If the vector is already minimum, don't change it.
+fn big_endian_saturating_add_one(v: &mut [u8]) {
+    if is_max(v) {
+        return;
+    }
+    for i in (0..v.len()).rev() {
+        if v[i] == u8::MAX {
+            v[i] = 0;
+        } else {
+            v[i] += 1;
+            break;
+        }
+    }
+}
+
+/// Check if all the bytes in the vector are 0xFF
+fn is_max(v: &[u8]) -> bool {
+    v.iter().all(|&x| x == u8::MAX)
+}
+
+#[expect(clippy::assign_op_pattern, clippy::manual_div_ceil)]
+#[test]
+fn test_helpers() {
+    let v = vec![];
+    assert!(is_max(&v));
+
+    fn check_add(v: Vec<u8>) {
+        let mut v = v;
+        let num = Num32::from_big_endian(&v);
+        big_endian_saturating_add_one(&mut v);
+        assert!(num + 1 == Num32::from_big_endian(&v));
+    }
+
+    uint::construct_uint! {
+        // 32 byte number
+        struct Num32(4);
+    }
+
+    let mut v = vec![255; 32];
+    big_endian_saturating_add_one(&mut v);
+    assert!(Num32::MAX == Num32::from_big_endian(&v));
+
+    check_add(vec![1; 32]);
+    check_add(vec![6; 32]);
+    check_add(vec![254; 32]);
+
+    // TBD: More tests coming with randomized arrays
+}

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 use typed_store::{
     DBMapUtils, be_fix_int_ser,
     metrics::SamplingInterval,
-    rocks::{DBMap, MetricConf, list_tables},
-    traits::{Map, TableSummary, TypedStoreDebug},
+    rocks::{DBMap, MetricConf},
+    traits::Map,
 };
 
 fn temp_dir() -> std::path::PathBuf {
@@ -106,10 +106,9 @@ async fn macro_test() {
 
     // Open in secondary mode
     let tbls_secondary =
-        Tables::get_read_only_handle(primary_path.clone(), None, None, MetricConf::default());
+        Tables::get_read_only_handle(primary_path, None, None, MetricConf::default());
 
     // Check all the tables can be listed
-    let actual_table_names: HashSet<_> = list_tables(primary_path).unwrap().into_iter().collect();
     let observed_table_names: HashSet<_> = Tables::describe_tables()
         .iter()
         .map(|q| q.0.clone())
@@ -117,12 +116,7 @@ async fn macro_test() {
 
     let exp: HashSet<String> =
         HashSet::from_iter(vec!["table1", "table2"].into_iter().map(|s| s.to_owned()));
-    assert_eq!(HashSet::from_iter(actual_table_names), exp);
     assert_eq!(HashSet::from_iter(observed_table_names), exp);
-
-    // Check the counts
-    assert_eq!(9, tbls_secondary.count_keys("table1").unwrap());
-    assert_eq!(7, tbls_secondary.count_keys("table2").unwrap());
 
     // check raw byte sizes of key and values
     let summary1 = tbls_secondary.table_summary("table1").unwrap();
@@ -151,8 +145,6 @@ async fn macro_test() {
         .table1
         .multi_insert(keys_vals_1)
         .expect("Failed to multi-insert");
-    // New entries should be present in secondary
-    assert_eq!(19, tbls_secondary.count_keys("table1").unwrap());
 
     // Test pagination
     let m = tbls_secondary.dump("table1", 2, 0).unwrap();
@@ -541,49 +533,6 @@ fn another_custom_fn_name() -> typed_store::rocks::DBOptions {
     TABLE2_OPTIONS_SET_FLAG.lock().unwrap().push(false);
     TABLE2_OPTIONS_SET_FLAG.lock().unwrap().push(false);
     typed_store::rocks::DBOptions::default()
-}
-
-#[tokio::test]
-async fn macro_test_configure() {
-    let primary_path = temp_dir();
-
-    // Get a configurator for this table
-    let mut config = Tables::configurator();
-    // Config table 1
-    config.table1 = typed_store::rocks::DBOptions::default();
-    config.table1.options.create_if_missing(true);
-    config.table1.options.set_write_buffer_size(123456);
-
-    // Config table 2
-    config.table2 = config.table1.clone();
-
-    config.table2.options.create_if_missing(false);
-
-    // Build and open with new config
-    let _ = Tables::open_tables_read_write(
-        primary_path,
-        MetricConf::default(),
-        None,
-        Some(config.build()),
-    );
-
-    // Test the static config options
-    let primary_path = temp_dir();
-
-    assert_eq!(TABLE1_OPTIONS_SET_FLAG.lock().unwrap().len(), 0);
-
-    let _ = TablesCustomOptions::open_tables_read_write(
-        primary_path,
-        MetricConf::default(),
-        None,
-        None,
-    );
-
-    // Ensures that the function to set options was called
-    assert_eq!(TABLE1_OPTIONS_SET_FLAG.lock().unwrap().len(), 1);
-
-    // `another_custom_fn_name` is called twice, so 6 items in vec
-    assert_eq!(TABLE2_OPTIONS_SET_FLAG.lock().unwrap().len(), 6);
 }
 
 /// We show that custom functions can be applied

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -9,9 +9,9 @@ use std::{borrow::Borrow, collections::HashSet, fmt::Debug, sync::Mutex, time::D
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use typed_store::{
-    DBMapUtils,
+    DBMapUtils, be_fix_int_ser,
     metrics::SamplingInterval,
-    rocks::{DBMap, MetricConf, be_fix_int_ser, list_tables},
+    rocks::{DBMap, MetricConf, list_tables},
     traits::{Map, TableSummary, TypedStoreDebug},
 };
 
@@ -76,7 +76,7 @@ async fn macro_test() {
     for i in kv_range.clone() {
         let key = i.to_string();
         let value = i.to_string();
-        let k_buf = be_fix_int_ser::<String>(&key).unwrap();
+        let k_buf = be_fix_int_ser::<String>(&key);
         let value_buf = bcs::to_bytes::<String>(&value).unwrap();
         raw_key_bytes1 += k_buf.len();
         raw_value_bytes1 += value_buf.len();
@@ -93,7 +93,7 @@ async fn macro_test() {
     for i in kv_range.clone() {
         let key = i;
         let value = i.to_string();
-        let k_buf = be_fix_int_ser(key.borrow()).unwrap();
+        let k_buf = be_fix_int_ser(key.borrow());
         let value_buf = bcs::to_bytes::<String>(&value).unwrap();
         raw_key_bytes2 += k_buf.len();
         raw_value_bytes2 += value_buf.len();

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -322,7 +322,7 @@ struct TablesWithMigration {
 }
 
 fn migrate_old_to_new(
-    db: &std::sync::Arc<typed_store::rocks::RocksDB>,
+    db: &std::sync::Arc<typed_store::database::Database>,
 ) -> Result<(), typed_store::TypedStoreError> {
     use typed_store::traits::Map;
     let old = typed_store::rocks::DBMap::<String, String>::reopen(

--- a/scripts/update_all_snapshots.sh
+++ b/scripts/update_all_snapshots.sh
@@ -12,10 +12,10 @@ SCRIPT_PATH=$(realpath "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 ROOT="$SCRIPT_DIR/.."
 
+UPDATE=1 cargo test -p iota-framework --test build-system-packages
 cd "$ROOT/crates/iota-protocol-config" && cargo insta test --review
 cd "$ROOT/crates/iota-cost" && cargo insta test --review
 cd "$ROOT/crates/iota-swarm-config" && cargo insta test --review
 cd "$ROOT/crates/iota-open-rpc" && cargo run --example generate-json-rpc-spec -- record
 cd "$ROOT/crates/iota-core" && cargo -q run --example generate-format -- print > tests/staged/iota.yaml
-UPDATE=1 cargo test -p iota-framework --test build-system-packages
 UPDATE=1 cargo test -p iota-rest-api


### PR DESCRIPTION
# Description of change

This PR contains a batch of core-protocol related upstream changes. The changes have been individually reviewed before squash-merging. None of them modify protocol parameters, so a new protocol version is not necessary.

This PR should be rebased on top of develop without squashing as it already contains squashed PRs.

## Links to any relevant issues

List of included PRs:
- #10636 
- #10612 
- #10610
- #10638 
- #10646 
- #10647 
- #10793 
- #10657 
- #10874 
- #10792 
- #10782 
- #10886 
- #10887 
- #10780 
- #10881 
- #10885 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)