### PR TITLE
refactor(iota-core, iota-e2e-tests, iota-tool): [P-COOL] split iota-core authority_client and authority_server into per-service modules

### DIFF
--- a/crates/iota-core/src/authority_client/mod.rs
+++ b/crates/iota-core/src/authority_client/mod.rs
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, net::SocketAddr, time::Duration};
+
+use anyhow::anyhow;
+use iota_network::{
+    api::ValidatorClient,
+    tonic,
+    tonic::{metadata::KeyAndValueRef, transport::Channel},
+};
+use iota_network_stack::config::Config;
+use iota_types::{
+    base_types::AuthorityName, committee::CommitteeWithNetworkMetadata, crypto::NetworkPublicKey,
+    error::IotaResult, multiaddr::Multiaddr,
+};
+
+use crate::authority_client::{
+    validator::ValidatorAPI, validator_peer::ValidatorPeerAPI, validator_v2::ValidatorV2API,
+};
+
+pub mod validator;
+pub mod validator_peer;
+pub mod validator_v2;
+
+/// A client for the network authority.
+#[derive(Clone)]
+pub struct NetworkAuthorityClient {
+    client: IotaResult<ValidatorClient<Channel>>,
+}
+
+impl NetworkAuthorityClient {
+    pub async fn connect(
+        address: &Multiaddr,
+        tls_target: Option<NetworkPublicKey>,
+    ) -> anyhow::Result<Self> {
+        let tls_config = tls_target.map(|tls_target| {
+            iota_tls::create_rustls_client_config(
+                tls_target,
+                iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+                None,
+            )
+        });
+        let channel = iota_network_stack::client::connect(address, tls_config)
+            .await
+            .map_err(|err| anyhow!(err.to_string()))?;
+        Ok(Self::new(channel))
+    }
+
+    pub fn connect_lazy(address: &Multiaddr, tls_target: Option<NetworkPublicKey>) -> Self {
+        let tls_config = tls_target.map(|tls_target| {
+            iota_tls::create_rustls_client_config(
+                tls_target,
+                iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+                None,
+            )
+        });
+        let client: IotaResult<_> = iota_network_stack::client::connect_lazy(address, tls_config)
+            .map(ValidatorClient::new)
+            .map_err(|err| err.to_string().into());
+        Self { client }
+    }
+
+    /// Creates a new client with a `transport` channel.
+    pub fn new(channel: Channel) -> Self {
+        Self {
+            client: Ok(ValidatorClient::new(channel)),
+        }
+    }
+
+    /// Creates a new client with a lazy `transport` channel.
+    fn new_lazy(client: IotaResult<Channel>) -> Self {
+        Self {
+            client: client.map(ValidatorClient::new),
+        }
+    }
+
+    fn client(&self) -> IotaResult<ValidatorClient<Channel>> {
+        self.client.clone()
+    }
+}
+
+pub trait AuthorityAPI: ValidatorAPI + ValidatorPeerAPI + ValidatorV2API {}
+
+impl<T> AuthorityAPI for T where T: ValidatorAPI + ValidatorPeerAPI + ValidatorV2API {}
+
+/// Creates authority clients with network configuration.
+pub fn make_network_authority_clients_with_network_config(
+    committee: &CommitteeWithNetworkMetadata,
+    network_config: &Config,
+) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
+    let mut authority_clients = BTreeMap::new();
+    for (name, (_state, network_metadata)) in committee.validators() {
+        let address = network_metadata.network_address.clone();
+        let address = address.rewrite_udp_to_tcp();
+        // TODO: Enable TLS on this interface with below config, once support is rolled
+        // out to validators. let tls_config =
+        // network_metadata.network_public_key.as_ref().map(|key| {
+        //     iota_tls::create_rustls_client_config(
+        //         key.clone(),
+        //         iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+        //         None,
+        //     )
+        // });
+        // TODO: Change below code to generate a IotaError if no valid TLS config is
+        // available.
+        let maybe_channel = network_config.connect_lazy(&address, None).map_err(|e| {
+            tracing::error!(
+                address = %address,
+                name = %name,
+                "unable to create authority client: {e}"
+            );
+            e.to_string().into()
+        });
+        let client = NetworkAuthorityClient::new_lazy(maybe_channel);
+        authority_clients.insert(*name, client);
+    }
+    authority_clients
+}
+
+/// Creates authority clients with a timeout configuration.
+pub fn make_authority_clients_with_timeout_config(
+    committee: &CommitteeWithNetworkMetadata,
+    connect_timeout: Duration,
+    request_timeout: Duration,
+) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
+    let mut network_config = iota_network_stack::config::Config::new();
+    network_config.connect_timeout = Some(connect_timeout);
+    network_config.request_timeout = Some(request_timeout);
+    make_network_authority_clients_with_network_config(committee, &network_config)
+}
+
+fn insert_metadata<T>(request: &mut tonic::Request<T>, client_addr: Option<SocketAddr>) {
+    if let Some(client_addr) = client_addr {
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        metadata.insert("x-forwarded-for", client_addr.to_string().parse().unwrap());
+        metadata
+            .iter()
+            .for_each(|key_and_value| match key_and_value {
+                KeyAndValueRef::Ascii(key, value) => {
+                    request.metadata_mut().insert(key, value.clone());
+                }
+                KeyAndValueRef::Binary(key, value) => {
+                    request.metadata_mut().insert_bin(key, value.clone());
+                }
+            });
+    }
+}

--- a/crates/iota-core/src/authority_client/validator.rs
+++ b/crates/iota-core/src/authority_client/validator.rs
@@ -3,21 +3,12 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, net::SocketAddr, time::Duration};
+use std::net::SocketAddr;
 
-use anyhow::anyhow;
 use async_trait::async_trait;
-use iota_network::{
-    api::ValidatorClient,
-    tonic,
-    tonic::{metadata::KeyAndValueRef, transport::Channel},
-};
-use iota_network_stack::config::Config;
+use iota_network::tonic;
 use iota_types::{
-    base_types::AuthorityName,
-    committee::CommitteeWithNetworkMetadata,
-    crypto::NetworkPublicKey,
-    error::{IotaError, IotaResult},
+    error::IotaError,
     iota_system_state::IotaSystemState,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_grpc::{
@@ -29,15 +20,14 @@ use iota_types::{
         TransactionInfoRequest, TransactionInfoResponse, ValidatorHealthRequest,
         ValidatorHealthResponse, WaitForEffectsRequest, WaitForEffectsResponse,
     },
-    multiaddr::Multiaddr,
     transaction::*,
 };
 
-use crate::authority_client::tonic::IntoRequest;
+use crate::authority_client::{NetworkAuthorityClient, insert_metadata, tonic::IntoRequest};
 
 #[async_trait]
-pub trait AuthorityAPI {
-    /// Handles a `Transaction` for this account.
+pub trait ValidatorAPI {
+    /// Handles a `Transaction`.
     async fn handle_transaction(
         &self,
         transaction: Transaction,
@@ -58,19 +48,19 @@ pub trait AuthorityAPI {
         client_addr: Option<SocketAddr>,
     ) -> Result<HandleSoftBundleCertificatesResponseV1, IotaError>;
 
-    /// Handle Object information requests for this account.
+    /// Handle Object information requests.
     async fn handle_object_info_request(
         &self,
         request: ObjectInfoRequest,
     ) -> Result<ObjectInfoResponse, IotaError>;
 
-    /// Handles a `TransactionInfoRequest` for this account.
+    /// Handles a `TransactionInfoRequest`.
     async fn handle_transaction_info_request(
         &self,
         request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, IotaError>;
 
-    /// Handles a `CheckpointRequest` for this account.
+    /// Handles a `CheckpointRequest`.
     async fn handle_checkpoint(
         &self,
         request: CheckpointRequest,
@@ -110,66 +100,9 @@ pub trait AuthorityAPI {
     ) -> Result<ValidatorHealthResponse, IotaError>;
 }
 
-/// A client for the network authority.
-#[derive(Clone)]
-pub struct NetworkAuthorityClient {
-    client: IotaResult<ValidatorClient<Channel>>,
-}
-
-impl NetworkAuthorityClient {
-    pub async fn connect(
-        address: &Multiaddr,
-        tls_target: Option<NetworkPublicKey>,
-    ) -> anyhow::Result<Self> {
-        let tls_config = tls_target.map(|tls_target| {
-            iota_tls::create_rustls_client_config(
-                tls_target,
-                iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
-                None,
-            )
-        });
-        let channel = iota_network_stack::client::connect(address, tls_config)
-            .await
-            .map_err(|err| anyhow!(err.to_string()))?;
-        Ok(Self::new(channel))
-    }
-
-    pub fn connect_lazy(address: &Multiaddr, tls_target: Option<NetworkPublicKey>) -> Self {
-        let tls_config = tls_target.map(|tls_target| {
-            iota_tls::create_rustls_client_config(
-                tls_target,
-                iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
-                None,
-            )
-        });
-        let client: IotaResult<_> = iota_network_stack::client::connect_lazy(address, tls_config)
-            .map(ValidatorClient::new)
-            .map_err(|err| err.to_string().into());
-        Self { client }
-    }
-
-    /// Creates a new client with a `transport` channel.
-    pub fn new(channel: Channel) -> Self {
-        Self {
-            client: Ok(ValidatorClient::new(channel)),
-        }
-    }
-
-    /// Creates a new client with a lazy `transport` channel.
-    fn new_lazy(client: IotaResult<Channel>) -> Self {
-        Self {
-            client: client.map(ValidatorClient::new),
-        }
-    }
-
-    fn client(&self) -> IotaResult<ValidatorClient<Channel>> {
-        self.client.clone()
-    }
-}
-
 #[async_trait]
-impl AuthorityAPI for NetworkAuthorityClient {
-    /// Handles a `Transaction` for this account.
+impl ValidatorAPI for NetworkAuthorityClient {
+    /// Handles a `Transaction` .
     async fn handle_transaction(
         &self,
         transaction: Transaction,
@@ -219,7 +152,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
         response.map_err(Into::into)
     }
 
-    /// Handles a `ObjectInfoRequest` for this account.
+    /// Handles a `ObjectInfoRequest` .
     async fn handle_object_info_request(
         &self,
         request: ObjectInfoRequest,
@@ -231,7 +164,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
             .map_err(Into::into)
     }
 
-    /// Handles a `TransactionInfoRequest` for this account.
+    /// Handles a `TransactionInfoRequest` .
     async fn handle_transaction_info_request(
         &self,
         request: TransactionInfoRequest,
@@ -243,7 +176,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
             .map_err(Into::into)
     }
 
-    /// Handles a `CheckpointRequest` for this account.
+    /// Handles a `CheckpointRequest` .
     async fn handle_checkpoint(
         &self,
         request: CheckpointRequest,
@@ -328,68 +261,5 @@ impl AuthorityAPI for NetworkAuthorityClient {
             .map(tonic::Response::into_inner)
             .map_err(IotaError::from)?;
         raw_response.try_into()
-    }
-}
-
-/// Creates authority clients with network configuration.
-pub fn make_network_authority_clients_with_network_config(
-    committee: &CommitteeWithNetworkMetadata,
-    network_config: &Config,
-) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
-    let mut authority_clients = BTreeMap::new();
-    for (name, (_state, network_metadata)) in committee.validators() {
-        let address = network_metadata.network_address.clone();
-        let address = address.rewrite_udp_to_tcp();
-        // TODO: Enable TLS on this interface with below config, once support is rolled
-        // out to validators. let tls_config =
-        // network_metadata.network_public_key.as_ref().map(|key| {
-        //     iota_tls::create_rustls_client_config(
-        //         key.clone(),
-        //         iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
-        //         None,
-        //     )
-        // });
-        // TODO: Change below code to generate a IotaError if no valid TLS config is
-        // available.
-        let maybe_channel = network_config.connect_lazy(&address, None).map_err(|e| {
-            tracing::error!(
-                address = %address,
-                name = %name,
-                "unable to create authority client: {e}"
-            );
-            e.to_string().into()
-        });
-        let client = NetworkAuthorityClient::new_lazy(maybe_channel);
-        authority_clients.insert(*name, client);
-    }
-    authority_clients
-}
-
-/// Creates authority clients with a timeout configuration.
-pub fn make_authority_clients_with_timeout_config(
-    committee: &CommitteeWithNetworkMetadata,
-    connect_timeout: Duration,
-    request_timeout: Duration,
-) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
-    let mut network_config = iota_network_stack::config::Config::new();
-    network_config.connect_timeout = Some(connect_timeout);
-    network_config.request_timeout = Some(request_timeout);
-    make_network_authority_clients_with_network_config(committee, &network_config)
-}
-
-fn insert_metadata<T>(request: &mut tonic::Request<T>, client_addr: Option<SocketAddr>) {
-    if let Some(client_addr) = client_addr {
-        let mut metadata = tonic::metadata::MetadataMap::new();
-        metadata.insert("x-forwarded-for", client_addr.to_string().parse().unwrap());
-        metadata
-            .iter()
-            .for_each(|key_and_value| match key_and_value {
-                KeyAndValueRef::Ascii(key, value) => {
-                    request.metadata_mut().insert(key, value.clone());
-                }
-                KeyAndValueRef::Binary(key, value) => {
-                    request.metadata_mut().insert_bin(key, value.clone());
-                }
-            });
     }
 }

--- a/crates/iota-core/src/authority_client/validator_peer.rs
+++ b/crates/iota-core/src/authority_client/validator_peer.rs
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority_client::NetworkAuthorityClient;
+
+pub trait ValidatorPeerAPI {}
+
+impl ValidatorPeerAPI for NetworkAuthorityClient {}

--- a/crates/iota-core/src/authority_client/validator_v2.rs
+++ b/crates/iota-core/src/authority_client/validator_v2.rs
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority_client::NetworkAuthorityClient;
+
+pub trait ValidatorV2API {}
+
+impl ValidatorV2API for NetworkAuthorityClient {}

--- a/crates/iota-core/src/authority_server/metrics.rs
+++ b/crates/iota-core/src/authority_server/metrics.rs
@@ -1,0 +1,196 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::{
+    Histogram, IntCounter, IntCounterVec, Registry, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+};
+
+/// Metrics for the validator service.
+pub struct ValidatorServiceMetrics {
+    pub signature_errors: IntCounter,
+    pub tx_verification_latency: Histogram,
+    pub cert_verification_latency: Histogram,
+    pub consensus_latency: Histogram,
+    pub handle_transaction_latency: Histogram,
+    pub submit_certificate_consensus_latency: Histogram,
+    pub handle_certificate_consensus_latency: Histogram,
+    pub handle_certificate_non_consensus_latency: Histogram,
+    pub handle_soft_bundle_certificates_consensus_latency: Histogram,
+    pub handle_soft_bundle_certificates_count: Histogram,
+    pub handle_soft_bundle_certificates_size_bytes: Histogram,
+    pub handle_capability_notification_latency: Histogram,
+
+    pub num_rejected_tx_in_epoch_boundary: IntCounter,
+    pub num_rejected_cert_in_epoch_boundary: IntCounter,
+    pub num_rejected_tx_during_overload: IntCounterVec,
+    pub num_rejected_cert_during_overload: IntCounterVec,
+    pub num_rejected_capability_notifications_during_overload: IntCounterVec,
+    pub connection_ip_not_found: IntCounter,
+    pub forwarded_header_parse_error: IntCounter,
+    pub forwarded_header_invalid: IntCounter,
+    pub forwarded_header_not_included: IntCounter,
+    pub client_id_source_config_mismatch: IntCounter,
+}
+
+impl ValidatorServiceMetrics {
+    /// Creates a new `ValidatorServiceMetrics` with Prometheus registry.
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            signature_errors: register_int_counter_with_registry!(
+                "total_signature_errors",
+                "Number of transaction signature errors",
+                registry,
+            )
+                .unwrap(),
+            tx_verification_latency: register_histogram_with_registry!(
+                "validator_service_tx_verification_latency",
+                "Latency of verifying a transaction",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            cert_verification_latency: register_histogram_with_registry!(
+                "validator_service_cert_verification_latency",
+                "Latency of verifying a certificate",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            consensus_latency: register_histogram_with_registry!(
+                "validator_service_consensus_latency",
+                "Time spent between submitting a shared obj txn to consensus and getting result",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_transaction_latency: register_histogram_with_registry!(
+                "validator_service_handle_transaction_latency",
+                "Latency of handling a transaction",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_certificate_consensus_latency: register_histogram_with_registry!(
+                "validator_service_handle_certificate_consensus_latency",
+                "Latency of handling a consensus transaction certificate",
+                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            submit_certificate_consensus_latency: register_histogram_with_registry!(
+                "validator_service_submit_certificate_consensus_latency",
+                "Latency of submit_certificate RPC handler",
+                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_certificate_non_consensus_latency: register_histogram_with_registry!(
+                "validator_service_handle_certificate_non_consensus_latency",
+                "Latency of handling a non-consensus transaction certificate",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_soft_bundle_certificates_consensus_latency: register_histogram_with_registry!(
+                "validator_service_handle_soft_bundle_certificates_consensus_latency",
+                "Latency of handling a consensus soft bundle",
+                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_soft_bundle_certificates_count: register_histogram_with_registry!(
+                "validator_service_handle_soft_bundle_certificates_count",
+                "The number of certificates included in a soft bundle",
+                iota_metrics::COUNT_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_soft_bundle_certificates_size_bytes: register_histogram_with_registry!(
+                "validator_service_handle_soft_bundle_certificates_size_bytes",
+                "The size of soft bundle in bytes",
+                iota_metrics::BYTES_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_capability_notification_latency: register_histogram_with_registry!(
+                "validator_service_handle_capability_notification_latency",
+                "Latency of handling a capability notification",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            num_rejected_tx_in_epoch_boundary: register_int_counter_with_registry!(
+                "validator_service_num_rejected_tx_in_epoch_boundary",
+                "Number of rejected transaction during epoch transitioning",
+                registry,
+            )
+                .unwrap(),
+            num_rejected_cert_in_epoch_boundary: register_int_counter_with_registry!(
+                "validator_service_num_rejected_cert_in_epoch_boundary",
+                "Number of rejected transaction certificate during epoch transitioning",
+                registry,
+            )
+                .unwrap(),
+            num_rejected_tx_during_overload: register_int_counter_vec_with_registry!(
+                "validator_service_num_rejected_tx_during_overload",
+                "Number of rejected transaction due to system overload",
+                &["error_type"],
+                registry,
+            )
+                .unwrap(),
+            num_rejected_cert_during_overload: register_int_counter_vec_with_registry!(
+                "validator_service_num_rejected_cert_during_overload",
+                "Number of rejected transaction certificate due to system overload",
+                &["error_type"],
+                registry,
+            )
+                .unwrap(),
+            num_rejected_capability_notifications_during_overload: register_int_counter_vec_with_registry!(
+                "num_rejected_capability_notifications_during_overload",
+                "Number of rejected capability notifications from non-committee active validators due to system overload",
+                &["error_type"],
+                registry,
+            )
+                .unwrap(),
+            connection_ip_not_found: register_int_counter_with_registry!(
+                "validator_service_connection_ip_not_found",
+                "Number of times connection IP was not extractable from request",
+                registry,
+            )
+                .unwrap(),
+            forwarded_header_parse_error: register_int_counter_with_registry!(
+                "validator_service_forwarded_header_parse_error",
+                "Number of times x-forwarded-for header could not be parsed",
+                registry,
+            )
+                .unwrap(),
+            forwarded_header_invalid: register_int_counter_with_registry!(
+                "validator_service_forwarded_header_invalid",
+                "Number of times x-forwarded-for header was invalid",
+                registry,
+            )
+                .unwrap(),
+            forwarded_header_not_included: register_int_counter_with_registry!(
+                "validator_service_forwarded_header_not_included",
+                "Number of times x-forwarded-for header was (unexpectedly) not included in request",
+                registry,
+            )
+                .unwrap(),
+            client_id_source_config_mismatch: register_int_counter_with_registry!(
+                "validator_service_client_id_source_config_mismatch",
+                "Number of times detected that client id source config doesn't agree with x-forwarded-for header",
+                registry,
+            )
+                .unwrap(),
+        }
+    }
+
+    /// Creates a new `ValidatorServiceMetrics` for testing.
+    pub fn new_for_tests() -> Self {
+        let registry = Registry::new();
+        Self::new(&registry)
+    }
+}

--- a/crates/iota-core/src/authority_server/mod.rs
+++ b/crates/iota-core/src/authority_server/mod.rs
@@ -6,6 +6,7 @@ mod validator;
 mod validator_peer;
 mod validator_v2;
 
+pub mod metrics;
 #[cfg(test)]
 mod test_server;
 
@@ -23,10 +24,7 @@ use iota_types::{
     error::*,
     traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight},
 };
-use prometheus::{
-    Histogram, IntCounter, IntCounterVec, Registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-};
+pub use metrics::ValidatorServiceMetrics;
 #[cfg(test)]
 pub use test_server::{AuthorityServer, AuthorityServerHandle};
 use tonic::transport::server::TcpConnectInfo;
@@ -39,193 +37,6 @@ use crate::{
         TrafficController, metrics::TrafficControllerMetrics, parse_ip, policies::TrafficTally,
     },
 };
-
-/// Metrics for the validator service.
-pub struct ValidatorServiceMetrics {
-    pub signature_errors: IntCounter,
-    pub tx_verification_latency: Histogram,
-    pub cert_verification_latency: Histogram,
-    pub consensus_latency: Histogram,
-    pub handle_transaction_latency: Histogram,
-    pub submit_certificate_consensus_latency: Histogram,
-    pub handle_certificate_consensus_latency: Histogram,
-    pub handle_certificate_non_consensus_latency: Histogram,
-    pub handle_soft_bundle_certificates_consensus_latency: Histogram,
-    pub handle_soft_bundle_certificates_count: Histogram,
-    pub handle_soft_bundle_certificates_size_bytes: Histogram,
-    pub handle_capability_notification_latency: Histogram,
-
-    num_rejected_tx_in_epoch_boundary: IntCounter,
-    num_rejected_cert_in_epoch_boundary: IntCounter,
-    num_rejected_tx_during_overload: IntCounterVec,
-    num_rejected_cert_during_overload: IntCounterVec,
-    num_rejected_capability_notifications_during_overload: IntCounterVec,
-    connection_ip_not_found: IntCounter,
-    forwarded_header_parse_error: IntCounter,
-    forwarded_header_invalid: IntCounter,
-    forwarded_header_not_included: IntCounter,
-    client_id_source_config_mismatch: IntCounter,
-}
-
-impl ValidatorServiceMetrics {
-    /// Creates a new `ValidatorServiceMetrics` with Prometheus registry.
-    pub fn new(registry: &Registry) -> Self {
-        Self {
-            signature_errors: register_int_counter_with_registry!(
-                "total_signature_errors",
-                "Number of transaction signature errors",
-                registry,
-            )
-                .unwrap(),
-            tx_verification_latency: register_histogram_with_registry!(
-                "validator_service_tx_verification_latency",
-                "Latency of verifying a transaction",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            cert_verification_latency: register_histogram_with_registry!(
-                "validator_service_cert_verification_latency",
-                "Latency of verifying a certificate",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            consensus_latency: register_histogram_with_registry!(
-                "validator_service_consensus_latency",
-                "Time spent between submitting a shared obj txn to consensus and getting result",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            handle_transaction_latency: register_histogram_with_registry!(
-                "validator_service_handle_transaction_latency",
-                "Latency of handling a transaction",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            handle_certificate_consensus_latency: register_histogram_with_registry!(
-                "validator_service_handle_certificate_consensus_latency",
-                "Latency of handling a consensus transaction certificate",
-                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            submit_certificate_consensus_latency: register_histogram_with_registry!(
-                "validator_service_submit_certificate_consensus_latency",
-                "Latency of submit_certificate RPC handler",
-                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            handle_certificate_non_consensus_latency: register_histogram_with_registry!(
-                "validator_service_handle_certificate_non_consensus_latency",
-                "Latency of handling a non-consensus transaction certificate",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            handle_soft_bundle_certificates_consensus_latency: register_histogram_with_registry!(
-                "validator_service_handle_soft_bundle_certificates_consensus_latency",
-                "Latency of handling a consensus soft bundle",
-                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            handle_soft_bundle_certificates_count: register_histogram_with_registry!(
-                "validator_service_handle_soft_bundle_certificates_count",
-                "The number of certificates included in a soft bundle",
-                iota_metrics::COUNT_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            handle_soft_bundle_certificates_size_bytes: register_histogram_with_registry!(
-                "validator_service_handle_soft_bundle_certificates_size_bytes",
-                "The size of soft bundle in bytes",
-                iota_metrics::BYTES_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            handle_capability_notification_latency: register_histogram_with_registry!(
-                "validator_service_handle_capability_notification_latency",
-                "Latency of handling a capability notification",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-                .unwrap(),
-            num_rejected_tx_in_epoch_boundary: register_int_counter_with_registry!(
-                "validator_service_num_rejected_tx_in_epoch_boundary",
-                "Number of rejected transaction during epoch transitioning",
-                registry,
-            )
-                .unwrap(),
-            num_rejected_cert_in_epoch_boundary: register_int_counter_with_registry!(
-                "validator_service_num_rejected_cert_in_epoch_boundary",
-                "Number of rejected transaction certificate during epoch transitioning",
-                registry,
-            )
-                .unwrap(),
-            num_rejected_tx_during_overload: register_int_counter_vec_with_registry!(
-                "validator_service_num_rejected_tx_during_overload",
-                "Number of rejected transaction due to system overload",
-                &["error_type"],
-                registry,
-            )
-                .unwrap(),
-            num_rejected_cert_during_overload: register_int_counter_vec_with_registry!(
-                "validator_service_num_rejected_cert_during_overload",
-                "Number of rejected transaction certificate due to system overload",
-                &["error_type"],
-                registry,
-            )
-                .unwrap(),
-            num_rejected_capability_notifications_during_overload: register_int_counter_vec_with_registry!(
-                "num_rejected_capability_notifications_during_overload",
-                "Number of rejected capability notifications from non-committee active validators due to system overload",
-                &["error_type"],
-                registry,
-            )
-                .unwrap(),
-            connection_ip_not_found: register_int_counter_with_registry!(
-                "validator_service_connection_ip_not_found",
-                "Number of times connection IP was not extractable from request",
-                registry,
-            )
-                .unwrap(),
-            forwarded_header_parse_error: register_int_counter_with_registry!(
-                "validator_service_forwarded_header_parse_error",
-                "Number of times x-forwarded-for header could not be parsed",
-                registry,
-            )
-                .unwrap(),
-            forwarded_header_invalid: register_int_counter_with_registry!(
-                "validator_service_forwarded_header_invalid",
-                "Number of times x-forwarded-for header was invalid",
-                registry,
-            )
-                .unwrap(),
-            forwarded_header_not_included: register_int_counter_with_registry!(
-                "validator_service_forwarded_header_not_included",
-                "Number of times x-forwarded-for header was (unexpectedly) not included in request",
-                registry,
-            )
-                .unwrap(),
-            client_id_source_config_mismatch: register_int_counter_with_registry!(
-                "validator_service_client_id_source_config_mismatch",
-                "Number of times detected that client id source config doesn't agree with x-forwarded-for header",
-                registry,
-            )
-                .unwrap(),
-        }
-    }
-
-    /// Creates a new `ValidatorServiceMetrics` for testing.
-    pub fn new_for_tests() -> Self {
-        let registry = Registry::new();
-        Self::new(&registry)
-    }
-}
 type WrappedServiceResponse<T> = Result<(tonic::Response<T>, Weight), tonic::Status>;
 
 /// The validator service.

--- a/crates/iota-core/src/authority_server/mod.rs
+++ b/crates/iota-core/src/authority_server/mod.rs
@@ -6,144 +6,39 @@ mod validator;
 mod validator_peer;
 mod validator_v2;
 
+#[cfg(test)]
+mod test_server;
+
 use std::{
-    io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
     time::SystemTime,
 };
 
-use anyhow::Result;
-use fastcrypto::traits::KeyPair;
-use iota_config::local_ip_utils::new_local_tcp_address_for_testing;
 use iota_network::{
-    api::ValidatorServer,
     tonic,
     tonic::metadata::{Ascii, MetadataValue},
 };
-use iota_network_stack::server::IOTA_TLS_SERVER_NAME;
 use iota_types::{
     error::*,
-    multiaddr::Multiaddr,
     traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight},
 };
 use prometheus::{
     Histogram, IntCounter, IntCounterVec, Registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
 };
+#[cfg(test)]
+pub use test_server::{AuthorityServer, AuthorityServerHandle};
 use tonic::transport::server::TcpConnectInfo;
-use tracing::{error, info};
+use tracing::error;
 
 use crate::{
     authority::AuthorityState,
-    checkpoints::CheckpointStore,
-    consensus_adapter::{
-        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
-    },
-    mysticeti_adapter::LazyMysticetiClient,
+    consensus_adapter::ConsensusAdapter,
     traffic_controller::{
         TrafficController, metrics::TrafficControllerMetrics, parse_ip, policies::TrafficTally,
     },
 };
-
-/// A handle to the authority server.
-pub struct AuthorityServerHandle {
-    server_handle: iota_network_stack::server::Server,
-}
-
-impl AuthorityServerHandle {
-    /// Waits for the server to complete.
-    pub async fn join(self) -> Result<(), io::Error> {
-        self.server_handle.handle().wait_for_shutdown().await;
-        Ok(())
-    }
-
-    /// Kills the server.
-    pub async fn kill(self) -> Result<(), io::Error> {
-        self.server_handle.handle().shutdown().await;
-        Ok(())
-    }
-
-    /// Returns the address of the server.
-    pub fn address(&self) -> &Multiaddr {
-        self.server_handle.local_addr()
-    }
-}
-
-/// An authority server that is used for testing.
-pub struct AuthorityServer {
-    address: Multiaddr,
-    pub state: Arc<AuthorityState>,
-    consensus_adapter: Arc<ConsensusAdapter>,
-    pub metrics: Arc<ValidatorServiceMetrics>,
-}
-
-impl AuthorityServer {
-    /// Creates a new `AuthorityServer` for testing with a consensus adapter.
-    pub fn new_for_test_with_consensus_adapter(
-        state: Arc<AuthorityState>,
-        consensus_adapter: Arc<ConsensusAdapter>,
-    ) -> Self {
-        let address = new_local_tcp_address_for_testing();
-        let metrics = Arc::new(ValidatorServiceMetrics::new_for_tests());
-
-        Self {
-            address,
-            state,
-            consensus_adapter,
-            metrics,
-        }
-    }
-
-    /// Creates a new `AuthorityServer` for testing.
-    pub fn new_for_test(state: Arc<AuthorityState>) -> Self {
-        let consensus_adapter = Arc::new(ConsensusAdapter::new(
-            Arc::new(LazyMysticetiClient::new()),
-            CheckpointStore::new_for_tests(),
-            state.name,
-            Arc::new(ConnectionMonitorStatusForTests {}),
-            100_000,
-            100_000,
-            None,
-            None,
-            ConsensusAdapterMetrics::new_test(),
-        ));
-        Self::new_for_test_with_consensus_adapter(state, consensus_adapter)
-    }
-
-    /// Spawns the server.
-    pub async fn spawn_for_test(self) -> Result<AuthorityServerHandle, io::Error> {
-        let address = self.address.clone();
-        self.spawn_with_bind_address_for_test(address).await
-    }
-
-    /// Spawns the server with a bind address.
-    pub async fn spawn_with_bind_address_for_test(
-        self,
-        address: Multiaddr,
-    ) -> Result<AuthorityServerHandle, io::Error> {
-        let tls_config = iota_tls::create_rustls_server_config(
-            self.state.config.network_key_pair().copy().private(),
-            IOTA_TLS_SERVER_NAME.to_string(),
-        );
-        let server = iota_network_stack::config::Config::new()
-            .server_builder()
-            .add_service(ValidatorServer::new(ValidatorService::new_for_tests(
-                self.state,
-                self.consensus_adapter,
-                self.metrics,
-            )))
-            .bind(&address, Some(tls_config))
-            .await
-            .unwrap();
-        let local_addr = server.local_addr().to_owned();
-        info!("Listening to traffic on {local_addr}");
-        let handle = AuthorityServerHandle {
-            server_handle: server,
-        };
-        Ok(handle)
-    }
-}
 
 /// Metrics for the validator service.
 pub struct ValidatorServiceMetrics {

--- a/crates/iota-core/src/authority_server/mod.rs
+++ b/crates/iota-core/src/authority_server/mod.rs
@@ -1,0 +1,574 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+mod validator;
+mod validator_peer;
+mod validator_v2;
+
+use std::{
+    io,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::SystemTime,
+};
+
+use anyhow::Result;
+use fastcrypto::traits::KeyPair;
+use iota_config::local_ip_utils::new_local_tcp_address_for_testing;
+use iota_network::{
+    api::ValidatorServer,
+    tonic,
+    tonic::metadata::{Ascii, MetadataValue},
+};
+use iota_network_stack::server::IOTA_TLS_SERVER_NAME;
+use iota_types::{
+    error::*,
+    multiaddr::Multiaddr,
+    traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight},
+};
+use prometheus::{
+    Histogram, IntCounter, IntCounterVec, Registry, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+};
+use tonic::transport::server::TcpConnectInfo;
+use tracing::{error, info};
+
+use crate::{
+    authority::AuthorityState,
+    checkpoints::CheckpointStore,
+    consensus_adapter::{
+        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
+    },
+    mysticeti_adapter::LazyMysticetiClient,
+    traffic_controller::{
+        TrafficController, metrics::TrafficControllerMetrics, parse_ip, policies::TrafficTally,
+    },
+};
+
+/// A handle to the authority server.
+pub struct AuthorityServerHandle {
+    server_handle: iota_network_stack::server::Server,
+}
+
+impl AuthorityServerHandle {
+    /// Waits for the server to complete.
+    pub async fn join(self) -> Result<(), io::Error> {
+        self.server_handle.handle().wait_for_shutdown().await;
+        Ok(())
+    }
+
+    /// Kills the server.
+    pub async fn kill(self) -> Result<(), io::Error> {
+        self.server_handle.handle().shutdown().await;
+        Ok(())
+    }
+
+    /// Returns the address of the server.
+    pub fn address(&self) -> &Multiaddr {
+        self.server_handle.local_addr()
+    }
+}
+
+/// An authority server that is used for testing.
+pub struct AuthorityServer {
+    address: Multiaddr,
+    pub state: Arc<AuthorityState>,
+    consensus_adapter: Arc<ConsensusAdapter>,
+    pub metrics: Arc<ValidatorServiceMetrics>,
+}
+
+impl AuthorityServer {
+    /// Creates a new `AuthorityServer` for testing with a consensus adapter.
+    pub fn new_for_test_with_consensus_adapter(
+        state: Arc<AuthorityState>,
+        consensus_adapter: Arc<ConsensusAdapter>,
+    ) -> Self {
+        let address = new_local_tcp_address_for_testing();
+        let metrics = Arc::new(ValidatorServiceMetrics::new_for_tests());
+
+        Self {
+            address,
+            state,
+            consensus_adapter,
+            metrics,
+        }
+    }
+
+    /// Creates a new `AuthorityServer` for testing.
+    pub fn new_for_test(state: Arc<AuthorityState>) -> Self {
+        let consensus_adapter = Arc::new(ConsensusAdapter::new(
+            Arc::new(LazyMysticetiClient::new()),
+            CheckpointStore::new_for_tests(),
+            state.name,
+            Arc::new(ConnectionMonitorStatusForTests {}),
+            100_000,
+            100_000,
+            None,
+            None,
+            ConsensusAdapterMetrics::new_test(),
+        ));
+        Self::new_for_test_with_consensus_adapter(state, consensus_adapter)
+    }
+
+    /// Spawns the server.
+    pub async fn spawn_for_test(self) -> Result<AuthorityServerHandle, io::Error> {
+        let address = self.address.clone();
+        self.spawn_with_bind_address_for_test(address).await
+    }
+
+    /// Spawns the server with a bind address.
+    pub async fn spawn_with_bind_address_for_test(
+        self,
+        address: Multiaddr,
+    ) -> Result<AuthorityServerHandle, io::Error> {
+        let tls_config = iota_tls::create_rustls_server_config(
+            self.state.config.network_key_pair().copy().private(),
+            IOTA_TLS_SERVER_NAME.to_string(),
+        );
+        let server = iota_network_stack::config::Config::new()
+            .server_builder()
+            .add_service(ValidatorServer::new(ValidatorService::new_for_tests(
+                self.state,
+                self.consensus_adapter,
+                self.metrics,
+            )))
+            .bind(&address, Some(tls_config))
+            .await
+            .unwrap();
+        let local_addr = server.local_addr().to_owned();
+        info!("Listening to traffic on {local_addr}");
+        let handle = AuthorityServerHandle {
+            server_handle: server,
+        };
+        Ok(handle)
+    }
+}
+
+/// Metrics for the validator service.
+pub struct ValidatorServiceMetrics {
+    pub signature_errors: IntCounter,
+    pub tx_verification_latency: Histogram,
+    pub cert_verification_latency: Histogram,
+    pub consensus_latency: Histogram,
+    pub handle_transaction_latency: Histogram,
+    pub submit_certificate_consensus_latency: Histogram,
+    pub handle_certificate_consensus_latency: Histogram,
+    pub handle_certificate_non_consensus_latency: Histogram,
+    pub handle_soft_bundle_certificates_consensus_latency: Histogram,
+    pub handle_soft_bundle_certificates_count: Histogram,
+    pub handle_soft_bundle_certificates_size_bytes: Histogram,
+    pub handle_capability_notification_latency: Histogram,
+
+    num_rejected_tx_in_epoch_boundary: IntCounter,
+    num_rejected_cert_in_epoch_boundary: IntCounter,
+    num_rejected_tx_during_overload: IntCounterVec,
+    num_rejected_cert_during_overload: IntCounterVec,
+    num_rejected_capability_notifications_during_overload: IntCounterVec,
+    connection_ip_not_found: IntCounter,
+    forwarded_header_parse_error: IntCounter,
+    forwarded_header_invalid: IntCounter,
+    forwarded_header_not_included: IntCounter,
+    client_id_source_config_mismatch: IntCounter,
+}
+
+impl ValidatorServiceMetrics {
+    /// Creates a new `ValidatorServiceMetrics` with Prometheus registry.
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            signature_errors: register_int_counter_with_registry!(
+                "total_signature_errors",
+                "Number of transaction signature errors",
+                registry,
+            )
+                .unwrap(),
+            tx_verification_latency: register_histogram_with_registry!(
+                "validator_service_tx_verification_latency",
+                "Latency of verifying a transaction",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            cert_verification_latency: register_histogram_with_registry!(
+                "validator_service_cert_verification_latency",
+                "Latency of verifying a certificate",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            consensus_latency: register_histogram_with_registry!(
+                "validator_service_consensus_latency",
+                "Time spent between submitting a shared obj txn to consensus and getting result",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_transaction_latency: register_histogram_with_registry!(
+                "validator_service_handle_transaction_latency",
+                "Latency of handling a transaction",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_certificate_consensus_latency: register_histogram_with_registry!(
+                "validator_service_handle_certificate_consensus_latency",
+                "Latency of handling a consensus transaction certificate",
+                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            submit_certificate_consensus_latency: register_histogram_with_registry!(
+                "validator_service_submit_certificate_consensus_latency",
+                "Latency of submit_certificate RPC handler",
+                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_certificate_non_consensus_latency: register_histogram_with_registry!(
+                "validator_service_handle_certificate_non_consensus_latency",
+                "Latency of handling a non-consensus transaction certificate",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_soft_bundle_certificates_consensus_latency: register_histogram_with_registry!(
+                "validator_service_handle_soft_bundle_certificates_consensus_latency",
+                "Latency of handling a consensus soft bundle",
+                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_soft_bundle_certificates_count: register_histogram_with_registry!(
+                "validator_service_handle_soft_bundle_certificates_count",
+                "The number of certificates included in a soft bundle",
+                iota_metrics::COUNT_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_soft_bundle_certificates_size_bytes: register_histogram_with_registry!(
+                "validator_service_handle_soft_bundle_certificates_size_bytes",
+                "The size of soft bundle in bytes",
+                iota_metrics::BYTES_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            handle_capability_notification_latency: register_histogram_with_registry!(
+                "validator_service_handle_capability_notification_latency",
+                "Latency of handling a capability notification",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+                .unwrap(),
+            num_rejected_tx_in_epoch_boundary: register_int_counter_with_registry!(
+                "validator_service_num_rejected_tx_in_epoch_boundary",
+                "Number of rejected transaction during epoch transitioning",
+                registry,
+            )
+                .unwrap(),
+            num_rejected_cert_in_epoch_boundary: register_int_counter_with_registry!(
+                "validator_service_num_rejected_cert_in_epoch_boundary",
+                "Number of rejected transaction certificate during epoch transitioning",
+                registry,
+            )
+                .unwrap(),
+            num_rejected_tx_during_overload: register_int_counter_vec_with_registry!(
+                "validator_service_num_rejected_tx_during_overload",
+                "Number of rejected transaction due to system overload",
+                &["error_type"],
+                registry,
+            )
+                .unwrap(),
+            num_rejected_cert_during_overload: register_int_counter_vec_with_registry!(
+                "validator_service_num_rejected_cert_during_overload",
+                "Number of rejected transaction certificate due to system overload",
+                &["error_type"],
+                registry,
+            )
+                .unwrap(),
+            num_rejected_capability_notifications_during_overload: register_int_counter_vec_with_registry!(
+                "num_rejected_capability_notifications_during_overload",
+                "Number of rejected capability notifications from non-committee active validators due to system overload",
+                &["error_type"],
+                registry,
+            )
+                .unwrap(),
+            connection_ip_not_found: register_int_counter_with_registry!(
+                "validator_service_connection_ip_not_found",
+                "Number of times connection IP was not extractable from request",
+                registry,
+            )
+                .unwrap(),
+            forwarded_header_parse_error: register_int_counter_with_registry!(
+                "validator_service_forwarded_header_parse_error",
+                "Number of times x-forwarded-for header could not be parsed",
+                registry,
+            )
+                .unwrap(),
+            forwarded_header_invalid: register_int_counter_with_registry!(
+                "validator_service_forwarded_header_invalid",
+                "Number of times x-forwarded-for header was invalid",
+                registry,
+            )
+                .unwrap(),
+            forwarded_header_not_included: register_int_counter_with_registry!(
+                "validator_service_forwarded_header_not_included",
+                "Number of times x-forwarded-for header was (unexpectedly) not included in request",
+                registry,
+            )
+                .unwrap(),
+            client_id_source_config_mismatch: register_int_counter_with_registry!(
+                "validator_service_client_id_source_config_mismatch",
+                "Number of times detected that client id source config doesn't agree with x-forwarded-for header",
+                registry,
+            )
+                .unwrap(),
+        }
+    }
+
+    /// Creates a new `ValidatorServiceMetrics` for testing.
+    pub fn new_for_tests() -> Self {
+        let registry = Registry::new();
+        Self::new(&registry)
+    }
+}
+type WrappedServiceResponse<T> = Result<(tonic::Response<T>, Weight), tonic::Status>;
+
+/// The validator service.
+#[derive(Clone)]
+pub struct ValidatorService {
+    state: Arc<AuthorityState>,
+    consensus_adapter: Arc<ConsensusAdapter>,
+    metrics: Arc<ValidatorServiceMetrics>,
+    traffic_controller: Option<Arc<TrafficController>>,
+    client_id_source: Option<ClientIdSource>,
+}
+
+impl ValidatorService {
+    /// Creates a new `ValidatorService`.
+    pub fn new(
+        state: Arc<AuthorityState>,
+        consensus_adapter: Arc<ConsensusAdapter>,
+        validator_metrics: Arc<ValidatorServiceMetrics>,
+        traffic_controller_metrics: TrafficControllerMetrics,
+        policy_config: Option<PolicyConfig>,
+        firewall_config: Option<RemoteFirewallConfig>,
+    ) -> Self {
+        Self {
+            state,
+            consensus_adapter,
+            metrics: validator_metrics,
+            traffic_controller: policy_config.clone().map(|policy| {
+                Arc::new(TrafficController::init(
+                    policy,
+                    traffic_controller_metrics,
+                    firewall_config,
+                ))
+            }),
+            client_id_source: policy_config.map(|policy| policy.client_id_source),
+        }
+    }
+
+    pub fn new_for_tests(
+        state: Arc<AuthorityState>,
+        consensus_adapter: Arc<ConsensusAdapter>,
+        metrics: Arc<ValidatorServiceMetrics>,
+    ) -> Self {
+        Self {
+            state,
+            consensus_adapter,
+            metrics,
+            traffic_controller: None,
+            client_id_source: None,
+        }
+    }
+
+    /// Returns the validator state.
+    pub fn validator_state(&self) -> &Arc<AuthorityState> {
+        &self.state
+    }
+
+    fn get_client_ip_addr<T>(
+        &self,
+        request: &tonic::Request<T>,
+        source: &ClientIdSource,
+    ) -> Option<IpAddr> {
+        match source {
+            ClientIdSource::SocketAddr => {
+                let socket_addr: Option<SocketAddr> = request.remote_addr();
+
+                // We will hit this case if the IO type used does not
+                // implement Connected or when using a unix domain socket.
+                // TODO: once we have confirmed that no legitimate traffic
+                // is hitting this case, we should reject such requests that
+                // hit this case.
+                if let Some(socket_addr) = socket_addr {
+                    Some(socket_addr.ip())
+                } else {
+                    if cfg!(msim) {
+                        // Ignore the error from simtests.
+                    } else if cfg!(test) {
+                        panic!("Failed to get remote address from request");
+                    } else {
+                        self.metrics.connection_ip_not_found.inc();
+                        error!("Failed to get remote address from request");
+                    }
+                    None
+                }
+            }
+            ClientIdSource::XForwardedFor(num_hops) => {
+                let do_header_parse = |op: &MetadataValue<Ascii>| {
+                    match op.to_str() {
+                        Ok(header_val) => {
+                            let header_contents =
+                                header_val.split(',').map(str::trim).collect::<Vec<_>>();
+                            if *num_hops == 0 {
+                                error!(
+                                    "x-forwarded-for: 0 specified. x-forwarded-for contents: {:?}. Please assign nonzero value for \
+                                    number of hops here, or use `socket-addr` client-id-source type if requests are not being proxied \
+                                    to this node. Skipping traffic controller request handling.",
+                                    header_contents,
+                                );
+                                return None;
+                            }
+                            let contents_len = header_contents.len();
+                            if contents_len < *num_hops {
+                                error!(
+                                    "x-forwarded-for header value of {:?} contains {} values, but {} hops were specified. \
+                                    Expected at least {} values. Please correctly set the `x-forwarded-for` value under \
+                                    `client-id-source` in the node config.",
+                                    header_contents, contents_len, num_hops, contents_len,
+                                );
+                                self.metrics.client_id_source_config_mismatch.inc();
+                                return None;
+                            }
+                            let Some(client_ip) = header_contents.get(contents_len - num_hops)
+                            else {
+                                error!(
+                                    "x-forwarded-for header value of {:?} contains {} values, but {} hops were specified. \
+                                    Expected at least {} values. Skipping traffic controller request handling.",
+                                    header_contents, contents_len, num_hops, contents_len,
+                                );
+                                return None;
+                            };
+                            parse_ip(client_ip).or_else(|| {
+                                self.metrics.forwarded_header_parse_error.inc();
+                                None
+                            })
+                        }
+                        Err(e) => {
+                            // TODO: once we have confirmed that no legitimate traffic
+                            // is hitting this case, we should reject such requests that
+                            // hit this case.
+                            self.metrics.forwarded_header_invalid.inc();
+                            error!("Invalid UTF-8 in x-forwarded-for header: {:?}", e);
+                            None
+                        }
+                    }
+                };
+                if let Some(op) = request.metadata().get("x-forwarded-for") {
+                    do_header_parse(op)
+                } else if let Some(op) = request.metadata().get("X-Forwarded-For") {
+                    do_header_parse(op)
+                } else {
+                    self.metrics.forwarded_header_not_included.inc();
+                    error!(
+                        "x-forwarded-for header not present for request despite node configuring x-forwarded-for tracking type"
+                    );
+                    None
+                }
+            }
+        }
+    }
+
+    async fn handle_traffic_req(&self, client: Option<IpAddr>) -> Result<(), tonic::Status> {
+        if let Some(traffic_controller) = &self.traffic_controller {
+            if !traffic_controller.check(&client, &None).await {
+                // Entity in blocklist
+                Err(tonic::Status::from_error(IotaError::TooManyRequests.into()))
+            } else {
+                Ok(())
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    fn handle_traffic_resp<T>(
+        &self,
+        client: Option<IpAddr>,
+        wrapped_response: WrappedServiceResponse<T>,
+    ) -> Result<tonic::Response<T>, tonic::Status> {
+        let (error, spam_weight, unwrapped_response) = match wrapped_response {
+            Ok((result, spam_weight)) => (None, spam_weight.clone(), Ok(result)),
+            Err(status) => (
+                Some(IotaError::from(status.clone())),
+                Weight::zero(),
+                Err(status.clone()),
+            ),
+        };
+
+        if let Some(traffic_controller) = self.traffic_controller.clone() {
+            traffic_controller.tally(TrafficTally {
+                direct: client,
+                through_fullnode: None,
+                error_info: error.map(|e| {
+                    let error_type = String::from(e.clone().as_ref());
+                    let error_weight = normalize(e);
+                    (error_weight, error_type)
+                }),
+                spam_weight,
+                timestamp: SystemTime::now(),
+            })
+        }
+        unwrapped_response
+    }
+}
+
+fn make_tonic_request_for_testing<T>(message: T) -> tonic::Request<T> {
+    // simulate a TCP connection, which would have added extensions to
+    // the request object that would be used downstream
+    let mut request = tonic::Request::new(message);
+    let tcp_connect_info = TcpConnectInfo {
+        local_addr: None,
+        remote_addr: Some(SocketAddr::new([127, 0, 0, 1].into(), 0)),
+    };
+    request.extensions_mut().insert(tcp_connect_info);
+    request
+}
+
+// TODO: refine error matching here
+fn normalize(err: IotaError) -> Weight {
+    match err {
+        IotaError::UserInput {
+            error: UserInputError::IncorrectUserSignature { .. },
+        } => Weight::one(),
+        IotaError::InvalidSignature { .. }
+        | IotaError::SignerSignatureAbsent { .. }
+        | IotaError::SignerSignatureNumberMismatch { .. }
+        | IotaError::IncorrectSigner { .. }
+        | IotaError::UnknownSigner { .. }
+        | IotaError::WrongEpoch { .. } => Weight::one(),
+        _ => Weight::zero(),
+    }
+}
+
+/// Implements generic pre- and post-processing. Since this is on the critical
+/// path, any heavy lifting should be done in a separate non-blocking task
+/// unless it is necessary to override the return value.
+#[macro_export]
+macro_rules! handle_with_decoration {
+    ($self:ident, $func_name:ident, $request:ident) => {{
+        if $self.client_id_source.is_none() {
+            return $self.$func_name($request).await.map(|(result, _)| result);
+        }
+
+        let client = $self.get_client_ip_addr(&$request, $self.client_id_source.as_ref().unwrap());
+
+        // check if either IP is blocked, in which case return early
+        $self.handle_traffic_req(client.clone()).await?;
+
+        // handle traffic tallying
+        let wrapped_response = $self.$func_name($request).await;
+        $self.handle_traffic_resp(client, wrapped_response)
+    }};
+}

--- a/crates/iota-core/src/authority_server/test_server.rs
+++ b/crates/iota-core/src/authority_server/test_server.rs
@@ -1,0 +1,118 @@
+use std::{io, sync::Arc};
+
+use anyhow::Result;
+use fastcrypto::traits::KeyPair;
+use iota_config::local_ip_utils::new_local_tcp_address_for_testing;
+use iota_network::api::ValidatorServer;
+use iota_network_stack::server::IOTA_TLS_SERVER_NAME;
+use iota_types::multiaddr::Multiaddr;
+use tracing::info;
+
+use crate::{
+    authority::AuthorityState,
+    authority_server::{ValidatorService, ValidatorServiceMetrics},
+    checkpoints::CheckpointStore,
+    consensus_adapter::{
+        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
+    },
+    mysticeti_adapter::LazyMysticetiClient,
+};
+
+/// A handle to the authority server.
+pub struct AuthorityServerHandle {
+    server_handle: iota_network_stack::server::Server,
+}
+
+impl AuthorityServerHandle {
+    /// Waits for the server to complete.
+    pub async fn join(self) -> Result<(), io::Error> {
+        self.server_handle.handle().wait_for_shutdown().await;
+        Ok(())
+    }
+
+    /// Kills the server.
+    pub async fn kill(self) -> Result<(), io::Error> {
+        self.server_handle.handle().shutdown().await;
+        Ok(())
+    }
+
+    /// Returns the address of the server.
+    pub fn address(&self) -> &Multiaddr {
+        self.server_handle.local_addr()
+    }
+}
+
+/// An authority server that is used for testing.
+pub struct AuthorityServer {
+    address: Multiaddr,
+    pub state: Arc<AuthorityState>,
+    consensus_adapter: Arc<ConsensusAdapter>,
+    pub metrics: Arc<ValidatorServiceMetrics>,
+}
+
+impl AuthorityServer {
+    /// Creates a new `AuthorityServer` for testing with a consensus adapter.
+    pub fn new_for_test_with_consensus_adapter(
+        state: Arc<AuthorityState>,
+        consensus_adapter: Arc<ConsensusAdapter>,
+    ) -> Self {
+        let address = new_local_tcp_address_for_testing();
+        let metrics = Arc::new(ValidatorServiceMetrics::new_for_tests());
+
+        Self {
+            address,
+            state,
+            consensus_adapter,
+            metrics,
+        }
+    }
+
+    /// Creates a new `AuthorityServer` for testing.
+    pub fn new_for_test(state: Arc<AuthorityState>) -> Self {
+        let consensus_adapter = Arc::new(ConsensusAdapter::new(
+            Arc::new(LazyMysticetiClient::new()),
+            CheckpointStore::new_for_tests(),
+            state.name,
+            Arc::new(ConnectionMonitorStatusForTests {}),
+            100_000,
+            100_000,
+            None,
+            None,
+            ConsensusAdapterMetrics::new_test(),
+        ));
+        Self::new_for_test_with_consensus_adapter(state, consensus_adapter)
+    }
+
+    /// Spawns the server.
+    pub async fn spawn_for_test(self) -> Result<AuthorityServerHandle, io::Error> {
+        let address = self.address.clone();
+        self.spawn_with_bind_address_for_test(address).await
+    }
+
+    /// Spawns the server with a bind address.
+    pub async fn spawn_with_bind_address_for_test(
+        self,
+        address: Multiaddr,
+    ) -> Result<AuthorityServerHandle, io::Error> {
+        let tls_config = iota_tls::create_rustls_server_config(
+            self.state.config.network_key_pair().copy().private(),
+            IOTA_TLS_SERVER_NAME.to_string(),
+        );
+        let server = iota_network_stack::config::Config::new()
+            .server_builder()
+            .add_service(ValidatorServer::new(ValidatorService::new_for_tests(
+                self.state,
+                self.consensus_adapter,
+                self.metrics,
+            )))
+            .bind(&address, Some(tls_config))
+            .await
+            .unwrap();
+        let local_addr = server.local_addr().to_owned();
+        info!("Listening to traffic on {local_addr}");
+        let handle = AuthorityServerHandle {
+            server_handle: server,
+        };
+        Ok(handle)
+    }
+}

--- a/crates/iota-core/src/authority_server/test_server.rs
+++ b/crates/iota-core/src/authority_server/test_server.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{io, sync::Arc};
 
 use anyhow::Result;

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -688,8 +688,8 @@ impl ValidatorService {
             }
             .into()
         );
-        // Validate if cert can be executed
-        // Fullnode does not serve handle_certificate call.
+        // Validate if the capability notification can be handled.
+        // Fullnode does not serve capability notification requests.
         fp_ensure!(
             !self.state.is_fullnode(&epoch_store),
             IotaError::FullNodeCantHandleAuthorityCapabilities.into()

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -3,27 +3,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    io,
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-    time::SystemTime,
-};
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use fastcrypto::traits::KeyPair;
 use futures::future::{Either, join_all};
-use iota_config::local_ip_utils::new_local_tcp_address_for_testing;
 use iota_metrics::spawn_monitored_task;
-use iota_network::{
-    api::{Validator, ValidatorServer},
-    tonic,
-};
-use iota_network_stack::server::IOTA_TLS_SERVER_NAME;
+use iota_network::{api::Validator, tonic};
 use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI},
-    error::*,
+    error::{IotaError, UserInputError},
     fp_ensure,
     iota_system_state::IotaSystemState,
     message_envelope::Message,
@@ -37,378 +26,24 @@ use iota_types::{
         ObjectInfoResponse, SubmitCertificateResponse, SubmitTransactionResult, SystemStateRequest,
         TransactionInfoRequest, TransactionInfoResponse,
     },
-    multiaddr::Multiaddr,
-    traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight},
+    traffic_control::{ClientIdSource, Weight},
     transaction::*,
 };
 use nonempty::{NonEmpty, nonempty};
-use prometheus::{
-    Histogram, IntCounter, IntCounterVec, Registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-};
 use tap::TapFallible;
-use tonic::{
-    metadata::{Ascii, MetadataValue},
-    transport::server::TcpConnectInfo,
-};
-use tracing::{Instrument, debug, error, error_span, info, trace_span};
+use tracing::{Instrument, debug, error_span, info, trace_span};
 
 use crate::{
-    authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
-    checkpoints::CheckpointStore,
-    consensus_adapter::{
-        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
-    },
-    mysticeti_adapter::LazyMysticetiClient,
-    traffic_controller::{
-        TrafficController, metrics::TrafficControllerMetrics, parse_ip, policies::TrafficTally,
-    },
+    authority::authority_per_epoch_store::AuthorityPerEpochStore,
+    authority_server::{ValidatorService, WrappedServiceResponse, make_tonic_request_for_testing},
+    handle_with_decoration,
 };
 
 #[cfg(test)]
-#[path = "unit_tests/server_tests.rs"]
+#[path = "../unit_tests/server_tests.rs"]
 mod server_tests;
 
-/// A handle to the authority server.
-pub struct AuthorityServerHandle {
-    server_handle: iota_network_stack::server::Server,
-}
-
-impl AuthorityServerHandle {
-    /// Waits for the server to complete.
-    pub async fn join(self) -> Result<(), io::Error> {
-        self.server_handle.handle().wait_for_shutdown().await;
-        Ok(())
-    }
-
-    /// Kills the server.
-    pub async fn kill(self) -> Result<(), io::Error> {
-        self.server_handle.handle().shutdown().await;
-        Ok(())
-    }
-
-    /// Returns the address of the server.
-    pub fn address(&self) -> &Multiaddr {
-        self.server_handle.local_addr()
-    }
-}
-
-/// An authority server that is used for testing.
-pub struct AuthorityServer {
-    address: Multiaddr,
-    pub state: Arc<AuthorityState>,
-    consensus_adapter: Arc<ConsensusAdapter>,
-    pub metrics: Arc<ValidatorServiceMetrics>,
-}
-
-impl AuthorityServer {
-    /// Creates a new `AuthorityServer` for testing with a consensus adapter.
-    pub fn new_for_test_with_consensus_adapter(
-        state: Arc<AuthorityState>,
-        consensus_adapter: Arc<ConsensusAdapter>,
-    ) -> Self {
-        let address = new_local_tcp_address_for_testing();
-        let metrics = Arc::new(ValidatorServiceMetrics::new_for_tests());
-
-        Self {
-            address,
-            state,
-            consensus_adapter,
-            metrics,
-        }
-    }
-
-    /// Creates a new `AuthorityServer` for testing.
-    pub fn new_for_test(state: Arc<AuthorityState>) -> Self {
-        let consensus_adapter = Arc::new(ConsensusAdapter::new(
-            Arc::new(LazyMysticetiClient::new()),
-            CheckpointStore::new_for_tests(),
-            state.name,
-            Arc::new(ConnectionMonitorStatusForTests {}),
-            100_000,
-            100_000,
-            None,
-            None,
-            ConsensusAdapterMetrics::new_test(),
-        ));
-        Self::new_for_test_with_consensus_adapter(state, consensus_adapter)
-    }
-
-    /// Spawns the server.
-    pub async fn spawn_for_test(self) -> Result<AuthorityServerHandle, io::Error> {
-        let address = self.address.clone();
-        self.spawn_with_bind_address_for_test(address).await
-    }
-
-    /// Spawns the server with a bind address.
-    pub async fn spawn_with_bind_address_for_test(
-        self,
-        address: Multiaddr,
-    ) -> Result<AuthorityServerHandle, io::Error> {
-        let tls_config = iota_tls::create_rustls_server_config(
-            self.state.config.network_key_pair().copy().private(),
-            IOTA_TLS_SERVER_NAME.to_string(),
-        );
-        let server = iota_network_stack::config::Config::new()
-            .server_builder()
-            .add_service(ValidatorServer::new(ValidatorService::new_for_tests(
-                self.state,
-                self.consensus_adapter,
-                self.metrics,
-            )))
-            .bind(&address, Some(tls_config))
-            .await
-            .unwrap();
-        let local_addr = server.local_addr().to_owned();
-        info!("Listening to traffic on {local_addr}");
-        let handle = AuthorityServerHandle {
-            server_handle: server,
-        };
-        Ok(handle)
-    }
-}
-
-/// Metrics for the validator service.
-pub struct ValidatorServiceMetrics {
-    pub signature_errors: IntCounter,
-    pub tx_verification_latency: Histogram,
-    pub cert_verification_latency: Histogram,
-    pub consensus_latency: Histogram,
-    pub handle_transaction_latency: Histogram,
-    pub submit_certificate_consensus_latency: Histogram,
-    pub handle_certificate_consensus_latency: Histogram,
-    pub handle_certificate_non_consensus_latency: Histogram,
-    pub handle_soft_bundle_certificates_consensus_latency: Histogram,
-    pub handle_soft_bundle_certificates_count: Histogram,
-    pub handle_soft_bundle_certificates_size_bytes: Histogram,
-    pub handle_capability_notification_latency: Histogram,
-
-    num_rejected_tx_in_epoch_boundary: IntCounter,
-    num_rejected_cert_in_epoch_boundary: IntCounter,
-    num_rejected_tx_during_overload: IntCounterVec,
-    num_rejected_cert_during_overload: IntCounterVec,
-    num_rejected_capability_notifications_during_overload: IntCounterVec,
-    connection_ip_not_found: IntCounter,
-    forwarded_header_parse_error: IntCounter,
-    forwarded_header_invalid: IntCounter,
-    forwarded_header_not_included: IntCounter,
-    client_id_source_config_mismatch: IntCounter,
-}
-
-impl ValidatorServiceMetrics {
-    /// Creates a new `ValidatorServiceMetrics` with Prometheus registry.
-    pub fn new(registry: &Registry) -> Self {
-        Self {
-            signature_errors: register_int_counter_with_registry!(
-                "total_signature_errors",
-                "Number of transaction signature errors",
-                registry,
-            )
-            .unwrap(),
-            tx_verification_latency: register_histogram_with_registry!(
-                "validator_service_tx_verification_latency",
-                "Latency of verifying a transaction",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            cert_verification_latency: register_histogram_with_registry!(
-                "validator_service_cert_verification_latency",
-                "Latency of verifying a certificate",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            consensus_latency: register_histogram_with_registry!(
-                "validator_service_consensus_latency",
-                "Time spent between submitting a shared obj txn to consensus and getting result",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_transaction_latency: register_histogram_with_registry!(
-                "validator_service_handle_transaction_latency",
-                "Latency of handling a transaction",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_certificate_consensus_latency: register_histogram_with_registry!(
-                "validator_service_handle_certificate_consensus_latency",
-                "Latency of handling a consensus transaction certificate",
-                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            submit_certificate_consensus_latency: register_histogram_with_registry!(
-                "validator_service_submit_certificate_consensus_latency",
-                "Latency of submit_certificate RPC handler",
-                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_certificate_non_consensus_latency: register_histogram_with_registry!(
-                "validator_service_handle_certificate_non_consensus_latency",
-                "Latency of handling a non-consensus transaction certificate",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_soft_bundle_certificates_consensus_latency: register_histogram_with_registry!(
-                "validator_service_handle_soft_bundle_certificates_consensus_latency",
-                "Latency of handling a consensus soft bundle",
-                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_soft_bundle_certificates_count: register_histogram_with_registry!(
-                "validator_service_handle_soft_bundle_certificates_count",
-                "The number of certificates included in a soft bundle",
-                iota_metrics::COUNT_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_soft_bundle_certificates_size_bytes: register_histogram_with_registry!(
-                "validator_service_handle_soft_bundle_certificates_size_bytes",
-                "The size of soft bundle in bytes",
-                iota_metrics::BYTES_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_capability_notification_latency: register_histogram_with_registry!(
-                "validator_service_handle_capability_notification_latency",
-                "Latency of handling a capability notification",
-                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            num_rejected_tx_in_epoch_boundary: register_int_counter_with_registry!(
-                "validator_service_num_rejected_tx_in_epoch_boundary",
-                "Number of rejected transaction during epoch transitioning",
-                registry,
-            )
-            .unwrap(),
-            num_rejected_cert_in_epoch_boundary: register_int_counter_with_registry!(
-                "validator_service_num_rejected_cert_in_epoch_boundary",
-                "Number of rejected transaction certificate during epoch transitioning",
-                registry,
-            )
-            .unwrap(),
-            num_rejected_tx_during_overload: register_int_counter_vec_with_registry!(
-                "validator_service_num_rejected_tx_during_overload",
-                "Number of rejected transaction due to system overload",
-                &["error_type"],
-                registry,
-            )
-            .unwrap(),
-            num_rejected_cert_during_overload: register_int_counter_vec_with_registry!(
-                "validator_service_num_rejected_cert_during_overload",
-                "Number of rejected transaction certificate due to system overload",
-                &["error_type"],
-                registry,
-            )
-            .unwrap(),
-            num_rejected_capability_notifications_during_overload: register_int_counter_vec_with_registry!(
-                "num_rejected_capability_notifications_during_overload",
-                "Number of rejected capability notifications from non-committee active validators due to system overload",
-                &["error_type"],
-                registry,
-            )
-            .unwrap(),
-            connection_ip_not_found: register_int_counter_with_registry!(
-                "validator_service_connection_ip_not_found",
-                "Number of times connection IP was not extractable from request",
-                registry,
-            )
-            .unwrap(),
-            forwarded_header_parse_error: register_int_counter_with_registry!(
-                "validator_service_forwarded_header_parse_error",
-                "Number of times x-forwarded-for header could not be parsed",
-                registry,
-            )
-            .unwrap(),
-            forwarded_header_invalid: register_int_counter_with_registry!(
-                "validator_service_forwarded_header_invalid",
-                "Number of times x-forwarded-for header was invalid",
-                registry,
-            )
-            .unwrap(),
-            forwarded_header_not_included: register_int_counter_with_registry!(
-                "validator_service_forwarded_header_not_included",
-                "Number of times x-forwarded-for header was (unexpectedly) not included in request",
-                registry,
-            )
-            .unwrap(),
-            client_id_source_config_mismatch: register_int_counter_with_registry!(
-                "validator_service_client_id_source_config_mismatch",
-                "Number of times detected that client id source config doesn't agree with x-forwarded-for header",
-                registry,
-            )
-            .unwrap(),
-        }
-    }
-
-    /// Creates a new `ValidatorServiceMetrics` for testing.
-    pub fn new_for_tests() -> Self {
-        let registry = Registry::new();
-        Self::new(&registry)
-    }
-}
-
-/// The validator service.
-#[derive(Clone)]
-pub struct ValidatorService {
-    state: Arc<AuthorityState>,
-    consensus_adapter: Arc<ConsensusAdapter>,
-    metrics: Arc<ValidatorServiceMetrics>,
-    traffic_controller: Option<Arc<TrafficController>>,
-    client_id_source: Option<ClientIdSource>,
-}
-
 impl ValidatorService {
-    /// Creates a new `ValidatorService`.
-    pub fn new(
-        state: Arc<AuthorityState>,
-        consensus_adapter: Arc<ConsensusAdapter>,
-        validator_metrics: Arc<ValidatorServiceMetrics>,
-        traffic_controller_metrics: TrafficControllerMetrics,
-        policy_config: Option<PolicyConfig>,
-        firewall_config: Option<RemoteFirewallConfig>,
-    ) -> Self {
-        Self {
-            state,
-            consensus_adapter,
-            metrics: validator_metrics,
-            traffic_controller: policy_config.clone().map(|policy| {
-                Arc::new(TrafficController::init(
-                    policy,
-                    traffic_controller_metrics,
-                    firewall_config,
-                ))
-            }),
-            client_id_source: policy_config.map(|policy| policy.client_id_source),
-        }
-    }
-
-    pub fn new_for_tests(
-        state: Arc<AuthorityState>,
-        consensus_adapter: Arc<ConsensusAdapter>,
-        metrics: Arc<ValidatorServiceMetrics>,
-    ) -> Self {
-        Self {
-            state,
-            consensus_adapter,
-            metrics,
-            traffic_controller: None,
-            client_id_source: None,
-        }
-    }
-
-    /// Returns the validator state.
-    pub fn validator_state(&self) -> &Arc<AuthorityState> {
-        &self.state
-    }
-
     /// Executes a `CertifiedTransaction` for testing.
     pub async fn execute_certificate_for_testing(
         &self,
@@ -729,11 +364,7 @@ impl ValidatorService {
 
         Ok((Some(responses), Weight::zero()))
     }
-}
 
-type WrappedServiceResponse<T> = Result<(tonic::Response<T>, Weight), tonic::Status>;
-
-impl ValidatorService {
     async fn transaction_impl(
         &self,
         request: tonic::Request<Transaction>,
@@ -1039,142 +670,6 @@ impl ValidatorService {
             .get_object_cache_reader()
             .try_get_iota_system_state_object_unsafe()?;
         Ok((tonic::Response::new(response), Weight::one()))
-    }
-
-    fn get_client_ip_addr<T>(
-        &self,
-        request: &tonic::Request<T>,
-        source: &ClientIdSource,
-    ) -> Option<IpAddr> {
-        match source {
-            ClientIdSource::SocketAddr => {
-                let socket_addr: Option<SocketAddr> = request.remote_addr();
-
-                // We will hit this case if the IO type used does not
-                // implement Connected or when using a unix domain socket.
-                // TODO: once we have confirmed that no legitimate traffic
-                // is hitting this case, we should reject such requests that
-                // hit this case.
-                if let Some(socket_addr) = socket_addr {
-                    Some(socket_addr.ip())
-                } else {
-                    if cfg!(msim) {
-                        // Ignore the error from simtests.
-                    } else if cfg!(test) {
-                        panic!("Failed to get remote address from request");
-                    } else {
-                        self.metrics.connection_ip_not_found.inc();
-                        error!("Failed to get remote address from request");
-                    }
-                    None
-                }
-            }
-            ClientIdSource::XForwardedFor(num_hops) => {
-                let do_header_parse = |op: &MetadataValue<Ascii>| {
-                    match op.to_str() {
-                        Ok(header_val) => {
-                            let header_contents =
-                                header_val.split(',').map(str::trim).collect::<Vec<_>>();
-                            if *num_hops == 0 {
-                                error!(
-                                    "x-forwarded-for: 0 specified. x-forwarded-for contents: {:?}. Please assign nonzero value for \
-                                    number of hops here, or use `socket-addr` client-id-source type if requests are not being proxied \
-                                    to this node. Skipping traffic controller request handling.",
-                                    header_contents,
-                                );
-                                return None;
-                            }
-                            let contents_len = header_contents.len();
-                            if contents_len < *num_hops {
-                                error!(
-                                    "x-forwarded-for header value of {:?} contains {} values, but {} hops were specified. \
-                                    Expected at least {} values. Please correctly set the `x-forwarded-for` value under \
-                                    `client-id-source` in the node config.",
-                                    header_contents, contents_len, num_hops, contents_len,
-                                );
-                                self.metrics.client_id_source_config_mismatch.inc();
-                                return None;
-                            }
-                            let Some(client_ip) = header_contents.get(contents_len - num_hops)
-                            else {
-                                error!(
-                                    "x-forwarded-for header value of {:?} contains {} values, but {} hops were specified. \
-                                    Expected at least {} values. Skipping traffic controller request handling.",
-                                    header_contents, contents_len, num_hops, contents_len,
-                                );
-                                return None;
-                            };
-                            parse_ip(client_ip).or_else(|| {
-                                self.metrics.forwarded_header_parse_error.inc();
-                                None
-                            })
-                        }
-                        Err(e) => {
-                            // TODO: once we have confirmed that no legitimate traffic
-                            // is hitting this case, we should reject such requests that
-                            // hit this case.
-                            self.metrics.forwarded_header_invalid.inc();
-                            error!("Invalid UTF-8 in x-forwarded-for header: {:?}", e);
-                            None
-                        }
-                    }
-                };
-                if let Some(op) = request.metadata().get("x-forwarded-for") {
-                    do_header_parse(op)
-                } else if let Some(op) = request.metadata().get("X-Forwarded-For") {
-                    do_header_parse(op)
-                } else {
-                    self.metrics.forwarded_header_not_included.inc();
-                    error!(
-                        "x-forwarded-for header not present for request despite node configuring x-forwarded-for tracking type"
-                    );
-                    None
-                }
-            }
-        }
-    }
-
-    async fn handle_traffic_req(&self, client: Option<IpAddr>) -> Result<(), tonic::Status> {
-        if let Some(traffic_controller) = &self.traffic_controller {
-            if !traffic_controller.check(&client, &None).await {
-                // Entity in blocklist
-                Err(tonic::Status::from_error(IotaError::TooManyRequests.into()))
-            } else {
-                Ok(())
-            }
-        } else {
-            Ok(())
-        }
-    }
-
-    fn handle_traffic_resp<T>(
-        &self,
-        client: Option<IpAddr>,
-        wrapped_response: WrappedServiceResponse<T>,
-    ) -> Result<tonic::Response<T>, tonic::Status> {
-        let (error, spam_weight, unwrapped_response) = match wrapped_response {
-            Ok((result, spam_weight)) => (None, spam_weight.clone(), Ok(result)),
-            Err(status) => (
-                Some(IotaError::from(status.clone())),
-                Weight::zero(),
-                Err(status.clone()),
-            ),
-        };
-
-        if let Some(traffic_controller) = self.traffic_controller.clone() {
-            traffic_controller.tally(TrafficTally {
-                direct: client,
-                through_fullnode: None,
-                error_info: error.map(|e| {
-                    let error_type = String::from(e.clone().as_ref());
-                    let error_weight = normalize(e);
-                    (error_weight, error_type)
-                }),
-                spam_weight,
-                timestamp: SystemTime::now(),
-            })
-        }
-        unwrapped_response
     }
 
     async fn handle_capability_notification_v1_impl(
@@ -1580,7 +1075,7 @@ impl ValidatorService {
                 }
             },
         )
-        .await;
+            .await;
 
         // The select! produces Either<Vec<EffectsDigest>, IotaError>.
         // Unpack the three outcomes: executed, dropped, or timeout.
@@ -1672,55 +1167,6 @@ impl ValidatorService {
     }
 }
 
-fn make_tonic_request_for_testing<T>(message: T) -> tonic::Request<T> {
-    // simulate a TCP connection, which would have added extensions to
-    // the request object that would be used downstream
-    let mut request = tonic::Request::new(message);
-    let tcp_connect_info = TcpConnectInfo {
-        local_addr: None,
-        remote_addr: Some(SocketAddr::new([127, 0, 0, 1].into(), 0)),
-    };
-    request.extensions_mut().insert(tcp_connect_info);
-    request
-}
-
-// TODO: refine error matching here
-fn normalize(err: IotaError) -> Weight {
-    match err {
-        IotaError::UserInput {
-            error: UserInputError::IncorrectUserSignature { .. },
-        } => Weight::one(),
-        IotaError::InvalidSignature { .. }
-        | IotaError::SignerSignatureAbsent { .. }
-        | IotaError::SignerSignatureNumberMismatch { .. }
-        | IotaError::IncorrectSigner { .. }
-        | IotaError::UnknownSigner { .. }
-        | IotaError::WrongEpoch { .. } => Weight::one(),
-        _ => Weight::zero(),
-    }
-}
-
-/// Implements generic pre- and post-processing. Since this is on the critical
-/// path, any heavy lifting should be done in a separate non-blocking task
-/// unless it is necessary to override the return value.
-#[macro_export]
-macro_rules! handle_with_decoration {
-    ($self:ident, $func_name:ident, $request:ident) => {{
-        if $self.client_id_source.is_none() {
-            return $self.$func_name($request).await.map(|(result, _)| result);
-        }
-
-        let client = $self.get_client_ip_addr(&$request, $self.client_id_source.as_ref().unwrap());
-
-        // check if either IP is blocked, in which case return early
-        $self.handle_traffic_req(client.clone()).await?;
-
-        // handle traffic tallying
-        let wrapped_response = $self.$func_name($request).await;
-        $self.handle_traffic_resp(client, wrapped_response)
-    }};
-}
-
 #[async_trait]
 impl Validator for ValidatorService {
     /// Handles a `Transaction` request.
@@ -1743,6 +1189,20 @@ impl Validator for ValidatorService {
         .unwrap()
     }
 
+    async fn handle_certificate_v1(
+        &self,
+        request: tonic::Request<HandleCertificateRequestV1>,
+    ) -> Result<tonic::Response<HandleCertificateResponseV1>, tonic::Status> {
+        handle_with_decoration!(self, handle_certificate_v1_impl, request)
+    }
+
+    async fn handle_soft_bundle_certificates_v1(
+        &self,
+        request: tonic::Request<HandleSoftBundleCertificatesRequestV1>,
+    ) -> Result<tonic::Response<HandleSoftBundleCertificatesResponseV1>, tonic::Status> {
+        handle_with_decoration!(self, handle_soft_bundle_certificates_v1_impl, request)
+    }
+
     /// Submits a `CertifiedTransaction` request.
     async fn submit_certificate(
         &self,
@@ -1761,20 +1221,6 @@ impl Validator for ValidatorService {
         })
         .await
         .unwrap()
-    }
-
-    async fn handle_certificate_v1(
-        &self,
-        request: tonic::Request<HandleCertificateRequestV1>,
-    ) -> Result<tonic::Response<HandleCertificateResponseV1>, tonic::Status> {
-        handle_with_decoration!(self, handle_certificate_v1_impl, request)
-    }
-
-    async fn handle_soft_bundle_certificates_v1(
-        &self,
-        request: tonic::Request<HandleSoftBundleCertificatesRequestV1>,
-    ) -> Result<tonic::Response<HandleSoftBundleCertificatesResponseV1>, tonic::Status> {
-        handle_with_decoration!(self, handle_soft_bundle_certificates_v1_impl, request)
     }
 
     /// Handles an `ObjectInfoRequest` request.

--- a/crates/iota-core/src/authority_server/validator_peer.rs
+++ b/crates/iota-core/src/authority_server/validator_peer.rs
@@ -1,0 +1,19 @@
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_network::{
+    api::{GetCheckpointRequest, GetCheckpointResponse, ValidatorPeer},
+    tonic,
+};
+
+use crate::authority_server::ValidatorService;
+
+#[async_trait::async_trait]
+impl ValidatorPeer for ValidatorService {
+    async fn get_checkpoint(
+        &self,
+        _request: tonic::Request<GetCheckpointRequest>,
+    ) -> Result<tonic::Response<GetCheckpointResponse>, tonic::Status> {
+        todo!()
+    }
+}

--- a/crates/iota-core/src/authority_server/validator_peer.rs
+++ b/crates/iota-core/src/authority_server/validator_peer.rs
@@ -1,4 +1,4 @@
-// Modifications Copyright (c) 2026 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_network::{

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -1,0 +1,31 @@
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_network::{
+    api::{SubmitTxRequest, TxDigest, TxStatus, ValidatorV2},
+    tonic::{Request, Response, Status},
+};
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::authority_server::ValidatorService;
+
+#[async_trait::async_trait]
+impl ValidatorV2 for ValidatorService {
+    type SubmitTxStream = ReceiverStream<Result<TxStatus, Status>>;
+
+    async fn submit_tx(
+        &self,
+        _request: Request<SubmitTxRequest>,
+    ) -> Result<Response<Self::SubmitTxStream>, Status> {
+        todo!()
+    }
+
+    type GetTxStatusStream = ReceiverStream<Result<TxStatus, Status>>;
+
+    async fn get_tx_status(
+        &self,
+        _request: Request<TxDigest>,
+    ) -> Result<Response<Self::GetTxStatusStream>, Status> {
+        todo!()
+    }
+}

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -1,4 +1,4 @@
-// Modifications Copyright (c) 2026 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_network::{

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -75,7 +75,9 @@ use crate::{
         AuthorityState,
         authority_per_epoch_store::{AuthorityPerEpochStore, scorer::MAX_SCORE},
     },
-    authority_client::{AuthorityAPI, make_network_authority_clients_with_network_config},
+    authority_client::{
+        make_network_authority_clients_with_network_config, validator::ValidatorAPI,
+    },
     checkpoints::{
         causal_order::CausalOrder,
         checkpoint_output::{CertifiedCheckpointOutput, CheckpointOutput},

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -33,7 +33,9 @@ use tracing::info;
 
 use crate::{
     authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder},
-    authority_client::AuthorityAPI,
+    authority_client::{
+        validator::ValidatorAPI, validator_peer::ValidatorPeerAPI, validator_v2::ValidatorV2API,
+    },
 };
 
 #[derive(Clone, Copy, Default)]
@@ -57,8 +59,10 @@ pub struct LocalAuthorityClient {
     pub fault_config: LocalAuthorityClientFaultConfig,
 }
 
+impl ValidatorPeerAPI for LocalAuthorityClient {}
+impl ValidatorV2API for LocalAuthorityClient {}
 #[async_trait]
-impl AuthorityAPI for LocalAuthorityClient {
+impl ValidatorAPI for LocalAuthorityClient {
     async fn handle_transaction(
         &self,
         transaction: Transaction,
@@ -115,7 +119,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         state.handle_object_info_request(request).await
     }
 
-    /// Handle Object information requests for this account.
+    /// Handle Object information requests .
     async fn handle_transaction_info_request(
         &self,
         request: TransactionInfoRequest,
@@ -308,8 +312,10 @@ impl MockAuthorityApi {
     }
 }
 
+impl ValidatorPeerAPI for MockAuthorityApi {}
+impl ValidatorV2API for MockAuthorityApi {}
 #[async_trait]
-impl AuthorityAPI for MockAuthorityApi {
+impl ValidatorAPI for MockAuthorityApi {
     /// Initiate a new transaction to an IOTA or Primary account.
     async fn handle_transaction(
         &self,
@@ -335,7 +341,7 @@ impl AuthorityAPI for MockAuthorityApi {
         unimplemented!()
     }
 
-    /// Handle Object information requests for this account.
+    /// Handle Object information requests .
     async fn handle_object_info_request(
         &self,
         _request: ObjectInfoRequest,
@@ -343,7 +349,7 @@ impl AuthorityAPI for MockAuthorityApi {
         self.handle_object_info_request_result.clone().unwrap()
     }
 
-    /// Handle Object information requests for this account.
+    /// Handle Object information requests .
     async fn handle_transaction_info_request(
         &self,
         request: TransactionInfoRequest,
@@ -423,8 +429,11 @@ pub struct HandleTransactionTestAuthorityClient {
     pub sleep_duration_before_responding: Option<Duration>,
 }
 
+impl ValidatorPeerAPI for HandleTransactionTestAuthorityClient {}
+impl ValidatorV2API for HandleTransactionTestAuthorityClient {}
+
 #[async_trait]
-impl AuthorityAPI for HandleTransactionTestAuthorityClient {
+impl ValidatorAPI for HandleTransactionTestAuthorityClient {
     async fn handle_transaction(
         &self,
         _transaction: Transaction,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -69,7 +69,7 @@ use crate::{
         move_integration_tests::build_and_publish_test_package_with_upgrade_cap,
         test_authority_builder::TestAuthorityBuilder, transaction_deferral::DeferralKey,
     },
-    authority_client::{AuthorityAPI, NetworkAuthorityClient},
+    authority_client::{NetworkAuthorityClient, validator::ValidatorAPI},
     authority_server::AuthorityServer,
     checkpoints::CheckpointServiceNoop,
     consensus_handler::SequencedConsensusTransaction,

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::traits::KeyPair;
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope::AuthorityCapabilities};
 use iota_types::{
@@ -34,12 +35,18 @@ use move_core_types::ident_str;
 use super::*;
 use crate::{
     authority::{
+        AuthorityState,
         authority_test_utils::init_certified_transaction,
         authority_tests::{init_state_with_ids_and_object_basics, init_state_with_object_id},
         test_authority_builder::TestAuthorityBuilder,
     },
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
-    consensus_adapter::MockConsensusClient,
+    authority_server::{AuthorityServer, ValidatorServiceMetrics, make_tonic_request_for_testing},
+    checkpoints::CheckpointStore,
+    consensus_adapter::{
+        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
+        MockConsensusClient,
+    },
 };
 
 /// Helper to make a tonic request with a native SubmitTransactionsRequest

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -40,7 +40,7 @@ use crate::{
         authority_tests::{init_state_with_ids_and_object_basics, init_state_with_object_id},
         test_authority_builder::TestAuthorityBuilder,
     },
-    authority_client::{AuthorityAPI, NetworkAuthorityClient},
+    authority_client::{NetworkAuthorityClient, validator::ValidatorAPI},
     authority_server::{AuthorityServer, ValidatorServiceMetrics, make_tonic_request_for_testing},
     checkpoints::CheckpointStore,
     consensus_adapter::{

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -43,6 +43,7 @@ use crate::{
         authority_tests::{call_move_, create_gas_objects, publish_object_basics},
         test_authority_builder::TestAuthorityBuilder,
     },
+    authority_client::validator::ValidatorAPI,
     consensus_adapter::consensus_tests::make_consensus_adapter_for_test,
     mock_consensus::with_block_status,
 };
@@ -70,7 +71,7 @@ use iota_types::{
 use super::*;
 pub use crate::authority::authority_test_utils::init_state_with_ids;
 use crate::{
-    authority_client::{AuthorityAPI, NetworkAuthorityClient},
+    authority_client::NetworkAuthorityClient,
     authority_server::{AuthorityServer, AuthorityServerHandle},
     stake_aggregator::{InsertResult, StakeAggregator},
 };

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -324,7 +324,9 @@ mod tests {
     use crate::{
         authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder},
         authority_aggregator::{AuthorityAggregator, AuthorityAggregatorBuilder},
-        authority_client::AuthorityAPI,
+        authority_client::{
+            validator::ValidatorAPI, validator_peer::ValidatorPeerAPI, validator_v2::ValidatorV2API,
+        },
         validator_tx_finalizer::ValidatorTxFinalizer,
     };
 
@@ -334,8 +336,11 @@ mod tests {
         inject_fault: Arc<AtomicBool>,
     }
 
+    impl ValidatorPeerAPI for MockAuthorityClient {}
+    impl ValidatorV2API for MockAuthorityClient {}
+
     #[async_trait]
-    impl AuthorityAPI for MockAuthorityClient {
+    impl ValidatorAPI for MockAuthorityClient {
         async fn handle_transaction(
             &self,
             transaction: Transaction,

--- a/crates/iota-e2e-tests/tests/multisig_tests.rs
+++ b/crates/iota-e2e-tests/tests/multisig_tests.rs
@@ -5,7 +5,7 @@
 use std::net::SocketAddr;
 
 use fastcrypto::traits::EncodeDecodeBase64;
-use iota_core::authority_client::AuthorityAPI;
+use iota_core::authority_client::validator::ValidatorAPI;
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::crypto::{Intent, IntentMessage};

--- a/crates/iota-e2e-tests/tests/passkey_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/passkey_e2e_tests.rs
@@ -5,7 +5,7 @@
 use std::net::SocketAddr;
 
 use fastcrypto::traits::ToFromBytes;
-use iota_core::authority_client::AuthorityAPI;
+use iota_core::authority_client::validator::ValidatorAPI;
 use iota_macros::sim_test;
 use iota_sdk_types::crypto::{Intent, IntentMessage};
 use iota_test_transaction_builder::TestTransactionBuilder;

--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -11,7 +11,9 @@ use std::{fs::File, num::NonZeroUsize, time::Duration};
 
 use fastcrypto::encoding::Base64;
 use iota_core::{
-    authority_client::{AuthorityAPI, make_network_authority_clients_with_network_config},
+    authority_client::{
+        make_network_authority_clients_with_network_config, validator::ValidatorAPI,
+    },
     traffic_controller::{TrafficController, TrafficSim, nodefw_test_server::NodeFwTestServer},
 };
 use iota_json_rpc_types::{

--- a/crates/iota-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/iota-e2e-tests/tests/zklogin_tests.rs
@@ -5,7 +5,7 @@
 
 use std::net::SocketAddr;
 
-use iota_core::authority_client::AuthorityAPI;
+use iota_core::authority_client::validator::ValidatorAPI;
 use iota_macros::sim_test;
 use iota_sdk_types::crypto::{Intent, IntentMessage};
 use iota_test_transaction_builder::TestTransactionBuilder;

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -14,7 +14,9 @@ use iota_config::{
     genesis::Genesis,
     object_storage_config::{ObjectStoreConfig, ObjectStoreType},
 };
-use iota_core::{authority_aggregator::AuthorityAggregatorBuilder, authority_client::AuthorityAPI};
+use iota_core::{
+    authority_aggregator::AuthorityAggregatorBuilder, authority_client::validator::ValidatorAPI,
+};
 use iota_protocol_config::Chain;
 use iota_replay::{ReplayToolCommand, execute_replay_command};
 use iota_sdk::{IotaClient, IotaClientBuilder, rpc_types::IotaTransactionBlockResponseOptions};

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -38,7 +38,7 @@ use iota_config::{
 };
 use iota_core::{
     authority::{AuthorityStore, authority_store_tables::AuthorityPerpetualTables},
-    authority_client::{AuthorityAPI, NetworkAuthorityClient},
+    authority_client::{NetworkAuthorityClient, validator::ValidatorAPI},
     checkpoints::CheckpointStore,
     epoch::committee_store::CommitteeStore,
     execution_cache::build_execution_cache_from_env,


### PR DESCRIPTION
# Description of change

Splits the monolithic authority_server.rs and authority_client.rs into module directories with separate files per gRPC service (validator, validator_peer, validator_v2). Shared infrastructure (server handle, metrics, traffic control,  client struct, connection helpers) lives in mod.rs, while each service's  trait impl gets its own file.
## Links to any relevant issues

closes #10945.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes