### PR TITLE
upstream(core): Always acknowledge handled consensus commits

### DIFF
--- a/consensus/core/src/commit_consumer.rs
+++ b/consensus/core/src/commit_consumer.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 
 use iota_metrics::monitored_mpsc::UnboundedSender;
 use tokio::sync::watch;
+use tracing::{debug, info};
 
 use crate::{CommitIndex, CommittedSubDag};
 
@@ -60,6 +61,7 @@ impl CommitConsumerMonitor {
     }
 
     pub fn set_highest_handled_commit(&self, highest_handled_commit: CommitIndex) {
+        debug!("Highest handled commit set to {}", highest_handled_commit);
         self.highest_handled_commit
             .send_replace(highest_handled_commit);
     }
@@ -85,6 +87,11 @@ impl CommitConsumerMonitor {
             "highest_known_commit_at_startup can only be set once"
         );
         *commit = highest_observed_commit_at_startup;
+
+        info!(
+            "Highest observed commit at startup set to {}",
+            highest_observed_commit_at_startup
+        );
     }
 
     pub(crate) async fn replay_complete(&self) {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -490,8 +490,8 @@ impl MysticetiConsensusHandler {
                     consensus_handler
                         .handle_consensus_output(consensus_output)
                         .await;
-                    commit_consumer_monitor.set_highest_handled_commit(commit_index);
                 }
+                commit_consumer_monitor.set_highest_handled_commit(commit_index);
             }
         });
         Self {
@@ -540,8 +540,8 @@ impl StarfishConsensusHandler {
                     consensus_handler
                         .handle_consensus_output(consensus_output)
                         .await;
-                    commit_consumer_monitor.set_highest_handled_commit(commit_index);
                 }
+                commit_consumer_monitor.set_highest_handled_commit(commit_index);
             }
         });
         Self {


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@aa7696b8](https://github.com/MystenLabs/sui/commit/aa7696b8fb1870623e098b54cc943c68678cadf8)
- Description:

Otherwise, replaying commits that Iota consensus handler already observed
do not update this watermark, so waiting on `replay_complete()` never
finishes.

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes