### PR TITLE
upstream(core): Add advance_epoch_and_protocol_upgrade to TestCheckpointDataBuilder

### DIFF
--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -4,7 +4,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use iota_protocol_config::ProtocolConfig;
+use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use move_core_types::{
     ident_str,
     language_storage::{StructTag, TypeTag},
@@ -558,16 +558,27 @@ impl TestCheckpointDataBuilder {
         self
     }
 
+    /// Like `advance_epoch_and_protocol_upgrade`, but default the protocol
+    /// version to the maximum.
+    pub fn advance_epoch(&mut self, safe_mode: bool) -> CheckpointData {
+        self.advance_epoch_and_protocol_upgrade(safe_mode, ProtocolVersion::MAX)
+    }
+
     /// Creates a transaction that advances the epoch, adds it to the
     /// checkpoint, and then builds the checkpoint. This increments the
     /// stored checkpoint sequence number and epoch. If `safe_mode` is true,
     /// the epoch end transaction will not include the `SystemEpochInfoEvent`.
-    pub fn advance_epoch(&mut self, safe_mode: bool) -> CheckpointData {
+    /// The `protocol_version` is used to set the protocol that we are going to
+    /// follow in the subsequent epoch.
+    pub fn advance_epoch_and_protocol_upgrade(
+        &mut self,
+        safe_mode: bool,
+        protocol_version: ProtocolVersion,
+    ) -> CheckpointData {
         let (committee, _) = Committee::new_simple_test_committee();
-        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         let tx_kind = EndOfEpochTransactionKind::new_change_epoch(
             self.checkpoint_builder.epoch + 1,
-            protocol_config.version,
+            protocol_version,
             Default::default(),
             Default::default(),
             Default::default(),
@@ -592,7 +603,7 @@ impl TestCheckpointDataBuilder {
         let events = if !safe_mode {
             let system_epoch_info_event = SystemEpochInfoEventV2 {
                 epoch: self.checkpoint_builder.epoch,
-                protocol_version: protocol_config.version.as_u64(),
+                protocol_version: protocol_version.as_u64(),
                 ..Default::default()
             };
             let struct_tag = StructTag {
@@ -630,7 +641,7 @@ impl TestCheckpointDataBuilder {
         let mut checkpoint = self.build_checkpoint();
         let end_of_epoch_data = EndOfEpochData {
             next_epoch_committee: committee.voting_rights,
-            next_epoch_protocol_version: protocol_config.version,
+            next_epoch_protocol_version: protocol_version,
             epoch_commitments: vec![],
             // Do not simulate supply changes in tests.
             epoch_supply_change: 0,


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@7d89f27](https://github.com/MystenLabs/sui/commit/7d89f274f838e40c05c6f29a943231748f6b3258)
- Description:

Add `advance_epoch_and_protocol_upgrade` method to `TestCheckpointDataBuilder`, which accepts a specific `ProtocolVersion` parameter instead of always using the max version. The existing `advance_epoch` method is kept as a convenience wrapper that defaults to `ProtocolVersion::MAX`.

This is a partial port of the upstream commit. Those changes were not applied because the `iota-indexer-alt` crate does not exist in this fork.

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes