### PR TITLE
refactor(gRPC): rename checkpoint endpoints and request types for consistency

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v0/ledger_service/header.rs
@@ -4,8 +4,8 @@
 use iota_grpc_types::{
     headers,
     v0::ledger_service::{
-        CheckpointDataStreamRequest, GetCheckpointDataRequest, GetEpochRequest, GetObjectsRequest,
-        GetServiceInfoRequest, GetTransactionsRequest,
+        GetCheckpointRequest, GetEpochRequest, GetObjectsRequest, GetServiceInfoRequest,
+        GetTransactionsRequest, StreamCheckpointsRequest,
     },
 };
 use iota_macros::sim_test;
@@ -107,38 +107,38 @@ async fn test_response_headers() {
         assert!(epoch >= 1, "epoch should be at least 1, got {epoch}");
     }
 
-    // Test get_checkpoint_data
+    // Test get_checkpoint
     {
-        let request = GetCheckpointDataRequest::default().with_latest(true);
+        let request = GetCheckpointRequest::default().with_latest(true);
 
         let stream = ledger_client
-            .get_checkpoint_data(request)
+            .get_checkpoint(request)
             .await
-            .expect("gRPC call to get_checkpoint_data");
+            .expect("gRPC call to get_checkpoint");
 
         // Get metadata from the response
         let metadata = stream.metadata();
-        verify_iota_headers(metadata, "get_checkpoint_data");
+        verify_iota_headers(metadata, "get_checkpoint");
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);
         assert!(epoch >= 1, "epoch should be at least 1, got {epoch}");
     }
 
-    // Test stream_checkpoint_data
+    // Test stream_checkpoints
     {
-        let request = CheckpointDataStreamRequest::default()
+        let request = StreamCheckpointsRequest::default()
             .with_start_sequence_number(1)
             .with_end_sequence_number(2);
 
         let stream = ledger_client
-            .stream_checkpoint_data(request)
+            .stream_checkpoints(request)
             .await
-            .expect("gRPC call to stream_checkpoint_data");
+            .expect("gRPC call to stream_checkpoints");
 
         // Get metadata from the response
         let metadata = stream.metadata();
-        verify_iota_headers(metadata, "stream_checkpoint_data");
+        verify_iota_headers(metadata, "stream_checkpoints");
 
         // Verify epoch value
         let epoch = parse_u64_header(metadata, headers::X_IOTA_EPOCH);

--- a/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-grpc-client/src/api/ledger/checkpoints.rs
@@ -86,8 +86,7 @@ use futures::{Stream, StreamExt};
 use iota_grpc_types::v0::{
     checkpoint, event, filter as grpc_filter,
     ledger_service::{
-        CheckpointDataStreamRequest, GetCheckpointDataRequest, checkpoint_data,
-        get_checkpoint_data_request,
+        GetCheckpointRequest, StreamCheckpointsRequest, checkpoint_data, get_checkpoint_request,
     },
     signatures::ValidatorAggregatedSignature as ProtoValidatorAggregatedSignature,
     transaction::ExecutedTransaction,
@@ -135,7 +134,7 @@ impl Client {
         events_filter: Option<grpc_filter::EventFilter>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
-            get_checkpoint_data_request::CheckpointId::Latest(true),
+            get_checkpoint_request::CheckpointId::Latest(true),
             read_mask,
             transactions_filter,
             events_filter,
@@ -179,7 +178,7 @@ impl Client {
         events_filter: Option<grpc_filter::EventFilter>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
-            get_checkpoint_data_request::CheckpointId::SequenceNumber(sequence_number),
+            get_checkpoint_request::CheckpointId::SequenceNumber(sequence_number),
             read_mask,
             transactions_filter,
             events_filter,
@@ -225,7 +224,7 @@ impl Client {
         events_filter: Option<grpc_filter::EventFilter>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
-            get_checkpoint_data_request::CheckpointId::Digest(digest.into()),
+            get_checkpoint_request::CheckpointId::Digest(digest.into()),
             read_mask,
             transactions_filter,
             events_filter,
@@ -236,20 +235,20 @@ impl Client {
     /// Internal helper to fetch checkpoint by any ID type.
     async fn get_checkpoint_internal(
         &self,
-        checkpoint_id: get_checkpoint_data_request::CheckpointId,
+        checkpoint_id: get_checkpoint_request::CheckpointId,
         read_mask: Option<&str>,
         transactions_filter: Option<grpc_filter::TransactionFilter>,
         events_filter: Option<grpc_filter::EventFilter>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         let mut request = match checkpoint_id {
-            get_checkpoint_data_request::CheckpointId::Latest(val) => {
-                GetCheckpointDataRequest::default().with_latest(val)
+            get_checkpoint_request::CheckpointId::Latest(val) => {
+                GetCheckpointRequest::default().with_latest(val)
             }
-            get_checkpoint_data_request::CheckpointId::SequenceNumber(val) => {
-                GetCheckpointDataRequest::default().with_sequence_number(val)
+            get_checkpoint_request::CheckpointId::SequenceNumber(val) => {
+                GetCheckpointRequest::default().with_sequence_number(val)
             }
-            get_checkpoint_data_request::CheckpointId::Digest(val) => {
-                GetCheckpointDataRequest::default().with_digest(val)
+            get_checkpoint_request::CheckpointId::Digest(val) => {
+                GetCheckpointRequest::default().with_digest(val)
             }
             _ => {
                 return Err(Error::Protocol("Invalid checkpoint ID type".into()));
@@ -268,7 +267,7 @@ impl Client {
         }
 
         let mut client = self.ledger_service_client();
-        let response = client.get_checkpoint_data(request).await?;
+        let response = client.get_checkpoint(request).await?;
         let (stream, metadata) = MetadataEnvelope::from(response).into_parts();
 
         let reassembled = Self::reassemble_checkpoint_data_stream(stream);
@@ -469,7 +468,7 @@ impl Client {
         progress_interval_ms: Option<u32>,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointStreamItem>> + Send>>>>
     {
-        let mut request = CheckpointDataStreamRequest::default()
+        let mut request = StreamCheckpointsRequest::default()
             .with_read_mask(field_mask_with_default(read_mask, GET_CHECKPOINT_READ_MASK));
 
         if let Some(start) = start_sequence_number {
@@ -495,7 +494,7 @@ impl Client {
         }
 
         let mut client = self.ledger_service_client();
-        let response = client.stream_checkpoint_data(request).await?;
+        let response = client.stream_checkpoints(request).await?;
         let (stream, metadata) = MetadataEnvelope::from(response).into_parts();
 
         Ok(MetadataEnvelope::new(

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implementation of the `get_checkpoint` and `stream_checkpoint_data` methods
+//! Implementation of the `get_checkpoint` and `stream_checkpoints` methods
 //! of the LedgerService.
 //!
 //! # Available Read Mask Fields
@@ -222,19 +222,17 @@ fn parse_checkpoint_read_mask(
 ///   - `sequence_number` - the sequence number of the checkpoint to fetch
 ///   - `digest` - the digest of the checkpoint to fetch
 ///   - `latest` - if set, fetches the latest checkpoint
-pub(crate) fn get_checkpoint_data(
+pub(crate) fn get_checkpoint(
     service: &LedgerGrpcService,
-    request: Request<grpc_ledger_service::GetCheckpointDataRequest>,
+    request: Request<grpc_ledger_service::GetCheckpointRequest>,
 ) -> Result<impl Stream<Item = CheckpointStreamResult> + Send, RpcError> {
     let req = request.into_inner();
 
     // determine if we need to get the checkpoint based on the sequential number,
     // digest or the latest one.
     let sequence_number = match req.checkpoint_id {
-        Some(grpc_ledger_service::get_checkpoint_data_request::CheckpointId::SequenceNumber(
-            seq,
-        )) => seq,
-        Some(grpc_ledger_service::get_checkpoint_data_request::CheckpointId::Digest(digest)) => {
+        Some(grpc_ledger_service::get_checkpoint_request::CheckpointId::SequenceNumber(seq)) => seq,
+        Some(grpc_ledger_service::get_checkpoint_request::CheckpointId::Digest(digest)) => {
             let sdk_digest: iota_sdk_types::Digest = (&digest)
                 .try_into()
                 .map_err(|e| Status::invalid_argument(format!("invalid checkpoint digest: {e}")))?;
@@ -245,7 +243,7 @@ pub(crate) fn get_checkpoint_data(
                 .map_err(|e| Status::internal(format!("failed to get checkpoint by digest: {e}")))?
                 .ok_or(Status::not_found("checkpoint not found"))?
         }
-        Some(grpc_ledger_service::get_checkpoint_data_request::CheckpointId::Latest(_)) => service
+        Some(grpc_ledger_service::get_checkpoint_request::CheckpointId::Latest(_)) => service
             .reader
             .get_latest_checkpoint_sequence_number()
             .map_err(|e| Status::internal(format!("failed to get latest checkpoint: {e}")))?
@@ -342,9 +340,9 @@ pub(crate) fn get_checkpoint_data(
 /// * `max_message_size_bytes` - Optional maximum message size in bytes that the
 ///   client can handle. The server will use this to limit the size of the
 ///   response and avoid sending messages that are too large.
-pub(crate) fn stream_checkpoint_data(
+pub(crate) fn stream_checkpoints(
     service: &LedgerGrpcService,
-    request: Request<grpc_ledger_service::CheckpointDataStreamRequest>,
+    request: Request<grpc_ledger_service::StreamCheckpointsRequest>,
 ) -> Result<impl Stream<Item = CheckpointStreamResult> + Send, RpcError> {
     let req = request.into_inner();
     let start_sequence_number = req.start_sequence_number;

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -51,8 +51,8 @@ impl LedgerGrpcService {
 impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcService {
     type GetObjectsStream = crate::types::GetObjectsStream;
     type GetTransactionsStream = crate::types::GetTransactionsStream;
-    type GetCheckpointDataStream = crate::types::GetCheckpointDataStream;
-    type StreamCheckpointDataStream = crate::types::StreamCheckpointDataStream;
+    type GetCheckpointStream = crate::types::GetCheckpointStream;
+    type StreamCheckpointsStream = crate::types::StreamCheckpointsStream;
 
     async fn get_health(
         &self,
@@ -104,22 +104,22 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
     }
 
     /// Checkpoint operations
-    async fn get_checkpoint_data(
+    async fn get_checkpoint(
         &self,
-        request: tonic::Request<grpc_ledger_service::GetCheckpointDataRequest>,
-    ) -> std::result::Result<tonic::Response<Self::GetCheckpointDataStream>, tonic::Status> {
-        let response = get_checkpoint::get_checkpoint_data(self, request)
-            .map(|stream| Response::new(Box::pin(stream) as Self::GetCheckpointDataStream))
+        request: tonic::Request<grpc_ledger_service::GetCheckpointRequest>,
+    ) -> std::result::Result<tonic::Response<Self::GetCheckpointStream>, tonic::Status> {
+        let response = get_checkpoint::get_checkpoint(self, request)
+            .map(|stream| Response::new(Box::pin(stream) as Self::GetCheckpointStream))
             .map_err(tonic::Status::from)?;
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 
-    async fn stream_checkpoint_data(
+    async fn stream_checkpoints(
         &self,
-        request: tonic::Request<grpc_ledger_service::CheckpointDataStreamRequest>,
-    ) -> std::result::Result<tonic::Response<Self::StreamCheckpointDataStream>, tonic::Status> {
-        let response = get_checkpoint::stream_checkpoint_data(self, request)
-            .map(|stream| Response::new(Box::pin(stream) as Self::StreamCheckpointDataStream))
+        request: tonic::Request<grpc_ledger_service::StreamCheckpointsRequest>,
+    ) -> std::result::Result<tonic::Response<Self::StreamCheckpointsStream>, tonic::Status> {
+        let response = get_checkpoint::stream_checkpoints(self, request)
+            .map(|stream| Response::new(Box::pin(stream) as Self::StreamCheckpointsStream))
             .map_err(tonic::Status::from)?;
         Ok(append_info_headers!(response, self.reader.clone()))
     }

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -72,12 +72,11 @@ pub type GetObjectsStream = Pin<Box<dyn futures::Stream<Item = ObjectsStreamResu
 pub type GetTransactionsStream =
     Pin<Box<dyn futures::Stream<Item = TransactionsStreamResult> + Send>>;
 
-/// Server streaming response type for the GetCheckpointData method.
-pub type GetCheckpointDataStream =
-    Pin<Box<dyn futures::Stream<Item = CheckpointStreamResult> + Send>>;
+/// Server streaming response type for the GetCheckpoint method.
+pub type GetCheckpointStream = Pin<Box<dyn futures::Stream<Item = CheckpointStreamResult> + Send>>;
 
-/// Server streaming response type for the StreamCheckpointData method.
-pub type StreamCheckpointDataStream =
+/// Server streaming response type for the StreamCheckpoints method.
+pub type StreamCheckpointsStream =
     Pin<Box<dyn futures::Stream<Item = CheckpointStreamResult> + Send>>;
 
 /// Wrapper that converts native CheckpointData to gRPC type before broadcasting

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -896,25 +896,25 @@ async fn collect_checkpoint_data_stream(
     (all_messages, tx_batch_sizes, event_batch_sizes)
 }
 
-/// Issue a `GetCheckpointData` request via the raw tonic client.
-async fn get_checkpoint_data_raw(
+/// Issue a `GetCheckpoint` request via the raw tonic client.
+async fn get_checkpoint_raw(
     client: &mut iota_grpc_types::v0::ledger_service::ledger_service_client::LedgerServiceClient<
         tonic::transport::Channel,
     >,
     read_mask: &str,
     max_message_size: u32,
 ) -> tonic::codec::Streaming<iota_grpc_types::v0::ledger_service::CheckpointData> {
-    use iota_grpc_types::{field::FieldMaskUtil, v0::ledger_service::GetCheckpointDataRequest};
+    use iota_grpc_types::{field::FieldMaskUtil, v0::ledger_service::GetCheckpointRequest};
 
-    let req = GetCheckpointDataRequest::default()
+    let req = GetCheckpointRequest::default()
         .with_sequence_number(0)
         .with_read_mask(prost_types::FieldMask::from_str(read_mask))
         .with_max_message_size_bytes(max_message_size);
 
     client
-        .get_checkpoint_data(req)
+        .get_checkpoint(req)
         .await
-        .expect("get_checkpoint_data should succeed")
+        .expect("get_checkpoint should succeed")
         .into_inner()
 }
 
@@ -956,7 +956,7 @@ async fn test_chunked_checkpoint_message_sizes_within_limit() {
     let read_mask = "checkpoint.summary,transactions";
 
     // --- Pass 1: unlimited (128 MB) → measure single-batch encoded size ---
-    let stream = get_checkpoint_data_raw(&mut client, read_mask, 128 * 1024 * 1024).await;
+    let stream = get_checkpoint_raw(&mut client, read_mask, 128 * 1024 * 1024).await;
     let (_, tx_sizes_unlimited, _) = collect_checkpoint_data_stream(stream).await;
     assert_eq!(
         tx_sizes_unlimited.len(),
@@ -971,7 +971,7 @@ async fn test_chunked_checkpoint_message_sizes_within_limit() {
     );
 
     // --- Pass 2: exact limit → should still fit in one batch ---
-    let stream = get_checkpoint_data_raw(&mut client, read_mask, exact_batch_size).await;
+    let stream = get_checkpoint_raw(&mut client, read_mask, exact_batch_size).await;
     let (_, tx_sizes_exact, _) = collect_checkpoint_data_stream(stream).await;
     assert_eq!(
         tx_sizes_exact.len(),
@@ -981,7 +981,7 @@ async fn test_chunked_checkpoint_message_sizes_within_limit() {
 
     // --- Pass 3: exact - 1 → must split ---
     let tight_limit = exact_batch_size - 1;
-    let stream = get_checkpoint_data_raw(&mut client, read_mask, tight_limit).await;
+    let stream = get_checkpoint_raw(&mut client, read_mask, tight_limit).await;
     let (all_messages, tx_sizes_split, _) = collect_checkpoint_data_stream(stream).await;
     assert!(
         tx_sizes_split.len() > 1,
@@ -1037,7 +1037,7 @@ async fn test_chunked_checkpoint_event_message_sizes_within_limit() {
     let read_mask = "checkpoint.summary,events";
 
     // --- Pass 1: unlimited (128 MB) → measure single-batch encoded size ---
-    let stream = get_checkpoint_data_raw(&mut client, read_mask, 128 * 1024 * 1024).await;
+    let stream = get_checkpoint_raw(&mut client, read_mask, 128 * 1024 * 1024).await;
     let (_, _, event_sizes_unlimited) = collect_checkpoint_data_stream(stream).await;
     assert_eq!(
         event_sizes_unlimited.len(),
@@ -1052,7 +1052,7 @@ async fn test_chunked_checkpoint_event_message_sizes_within_limit() {
     );
 
     // --- Pass 2: exact limit → should still fit in one batch ---
-    let stream = get_checkpoint_data_raw(&mut client, read_mask, exact_batch_size).await;
+    let stream = get_checkpoint_raw(&mut client, read_mask, exact_batch_size).await;
     let (_, _, event_sizes_exact) = collect_checkpoint_data_stream(stream).await;
     assert_eq!(
         event_sizes_exact.len(),
@@ -1062,7 +1062,7 @@ async fn test_chunked_checkpoint_event_message_sizes_within_limit() {
 
     // --- Pass 3: exact - 1 → must split ---
     let tight_limit = exact_batch_size - 1;
-    let stream = get_checkpoint_data_raw(&mut client, read_mask, tight_limit).await;
+    let stream = get_checkpoint_raw(&mut client, read_mask, tight_limit).await;
     let (all_messages, _, event_sizes_split) = collect_checkpoint_data_stream(stream).await;
     assert!(
         event_sizes_split.len() > 1,

--- a/crates/iota-grpc-types/proto/iota/grpc/v0/ledger_service.proto
+++ b/crates/iota-grpc-types/proto/iota/grpc/v0/ledger_service.proto
@@ -31,8 +31,8 @@ service LedgerService {
   rpc GetTransactions(GetTransactionsRequest) returns (stream GetTransactionsResponse);
 
   // Checkpoint operations
-  rpc GetCheckpointData (GetCheckpointDataRequest) returns (stream CheckpointData);
-  rpc StreamCheckpointData (CheckpointDataStreamRequest) returns (stream CheckpointData);
+  rpc GetCheckpoint (GetCheckpointRequest) returns (stream CheckpointData);
+  rpc StreamCheckpoints (StreamCheckpointsRequest) returns (stream CheckpointData);
 
   rpc GetEpoch(GetEpochRequest) returns (GetEpochResponse);
 }
@@ -187,7 +187,7 @@ message GetTransactionsResponse {
   bool has_next = 2;
 }
 
-message GetCheckpointDataRequest {
+message GetCheckpointRequest {
   option (iota.grpc.message_accessors) = "with";
 
   oneof checkpoint_id {
@@ -216,7 +216,7 @@ message GetCheckpointDataRequest {
   optional uint32 max_message_size_bytes = 7;
 }
 
-message CheckpointDataStreamRequest {
+message StreamCheckpointsRequest {
   option (iota.grpc.message_accessors) = "with";
 
   // if no start sequence number is provided, streaming starts from the latest checkpoint

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.accessors.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.accessors.rs
@@ -70,57 +70,7 @@ mod _accessor_impls {
             self
         }
     }
-    impl super::CheckpointDataStreamRequest {
-        /// Sets `start_sequence_number` with the provided value.
-        pub fn with_start_sequence_number(mut self, field: u64) -> Self {
-            self.start_sequence_number = Some(field);
-            self
-        }
-        /// Sets `end_sequence_number` with the provided value.
-        pub fn with_end_sequence_number(mut self, field: u64) -> Self {
-            self.end_sequence_number = Some(field);
-            self
-        }
-        /// Sets `read_mask` with the provided value.
-        pub fn with_read_mask<T: Into<::prost_types::FieldMask>>(
-            mut self,
-            field: T,
-        ) -> Self {
-            self.read_mask = Some(field.into());
-            self
-        }
-        /// Sets `transactions_filter` with the provided value.
-        pub fn with_transactions_filter<
-            T: Into<super::super::filter::TransactionFilter>,
-        >(mut self, field: T) -> Self {
-            self.transactions_filter = Some(field.into());
-            self
-        }
-        /// Sets `events_filter` with the provided value.
-        pub fn with_events_filter<T: Into<super::super::filter::EventFilter>>(
-            mut self,
-            field: T,
-        ) -> Self {
-            self.events_filter = Some(field.into());
-            self
-        }
-        /// Sets `filter_checkpoints` with the provided value.
-        pub fn with_filter_checkpoints(mut self, field: bool) -> Self {
-            self.filter_checkpoints = Some(field);
-            self
-        }
-        /// Sets `progress_interval_ms` with the provided value.
-        pub fn with_progress_interval_ms(mut self, field: u32) -> Self {
-            self.progress_interval_ms = Some(field);
-            self
-        }
-        /// Sets `max_message_size_bytes` with the provided value.
-        pub fn with_max_message_size_bytes(mut self, field: u32) -> Self {
-            self.max_message_size_bytes = Some(field);
-            self
-        }
-    }
-    impl super::GetCheckpointDataRequest {
+    impl super::GetCheckpointRequest {
         /// Sets `read_mask` with the provided value.
         pub fn with_read_mask<T: Into<::prost_types::FieldMask>>(
             mut self,
@@ -153,7 +103,7 @@ mod _accessor_impls {
         /// If any other oneof field in the same oneof is set, it will be cleared.
         pub fn with_latest(mut self, field: bool) -> Self {
             self.checkpoint_id = Some(
-                super::get_checkpoint_data_request::CheckpointId::Latest(field),
+                super::get_checkpoint_request::CheckpointId::Latest(field),
             );
             self
         }
@@ -161,7 +111,7 @@ mod _accessor_impls {
         /// If any other oneof field in the same oneof is set, it will be cleared.
         pub fn with_sequence_number(mut self, field: u64) -> Self {
             self.checkpoint_id = Some(
-                super::get_checkpoint_data_request::CheckpointId::SequenceNumber(field),
+                super::get_checkpoint_request::CheckpointId::SequenceNumber(field),
             );
             self
         }
@@ -172,7 +122,7 @@ mod _accessor_impls {
             field: T,
         ) -> Self {
             self.checkpoint_id = Some(
-                super::get_checkpoint_data_request::CheckpointId::Digest(field.into()),
+                super::get_checkpoint_request::CheckpointId::Digest(field.into()),
             );
             self
         }
@@ -385,6 +335,56 @@ mod _accessor_impls {
             T: Into<super::super::super::super::super::google::rpc::Status>,
         >(mut self, field: T) -> Self {
             self.result = Some(super::object_result::Result::Error(field.into()));
+            self
+        }
+    }
+    impl super::StreamCheckpointsRequest {
+        /// Sets `start_sequence_number` with the provided value.
+        pub fn with_start_sequence_number(mut self, field: u64) -> Self {
+            self.start_sequence_number = Some(field);
+            self
+        }
+        /// Sets `end_sequence_number` with the provided value.
+        pub fn with_end_sequence_number(mut self, field: u64) -> Self {
+            self.end_sequence_number = Some(field);
+            self
+        }
+        /// Sets `read_mask` with the provided value.
+        pub fn with_read_mask<T: Into<::prost_types::FieldMask>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.read_mask = Some(field.into());
+            self
+        }
+        /// Sets `transactions_filter` with the provided value.
+        pub fn with_transactions_filter<
+            T: Into<super::super::filter::TransactionFilter>,
+        >(mut self, field: T) -> Self {
+            self.transactions_filter = Some(field.into());
+            self
+        }
+        /// Sets `events_filter` with the provided value.
+        pub fn with_events_filter<T: Into<super::super::filter::EventFilter>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.events_filter = Some(field.into());
+            self
+        }
+        /// Sets `filter_checkpoints` with the provided value.
+        pub fn with_filter_checkpoints(mut self, field: bool) -> Self {
+            self.filter_checkpoints = Some(field);
+            self
+        }
+        /// Sets `progress_interval_ms` with the provided value.
+        pub fn with_progress_interval_ms(mut self, field: u32) -> Self {
+            self.progress_interval_ms = Some(field);
+            self
+        }
+        /// Sets `max_message_size_bytes` with the provided value.
+        pub fn with_max_message_size_bytes(mut self, field: u32) -> Self {
+            self.max_message_size_bytes = Some(field);
             self
         }
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.field_info.rs
@@ -903,7 +903,7 @@ mod _field_impls {
             self.finish()
         }
     }
-    impl GetCheckpointDataRequest {
+    impl GetCheckpointRequest {
         pub const LATEST_FIELD: &'static MessageField = &MessageField {
             name: "latest",
             json_name: "latest",
@@ -961,10 +961,10 @@ mod _field_impls {
             message_fields: None,
         };
     }
-    impl GetCheckpointDataRequest {
+    impl GetCheckpointRequest {
         pub const CHECKPOINT_ID_ONEOF: &'static str = "checkpoint_id";
     }
-    impl MessageFields for GetCheckpointDataRequest {
+    impl MessageFields for GetCheckpointRequest {
         const FIELDS: &'static [&'static MessageField] = &[
             Self::LATEST_FIELD,
             Self::SEQUENCE_NUMBER_FIELD,
@@ -975,15 +975,15 @@ mod _field_impls {
             Self::MAX_MESSAGE_SIZE_BYTES_FIELD,
         ];
     }
-    impl GetCheckpointDataRequest {
-        pub fn path_builder() -> GetCheckpointDataRequestFieldPathBuilder {
-            GetCheckpointDataRequestFieldPathBuilder::new()
+    impl GetCheckpointRequest {
+        pub fn path_builder() -> GetCheckpointRequestFieldPathBuilder {
+            GetCheckpointRequestFieldPathBuilder::new()
         }
     }
-    pub struct GetCheckpointDataRequestFieldPathBuilder {
+    pub struct GetCheckpointRequestFieldPathBuilder {
         path: Vec<&'static str>,
     }
-    impl GetCheckpointDataRequestFieldPathBuilder {
+    impl GetCheckpointRequestFieldPathBuilder {
         #[allow(clippy::new_without_default)]
         pub fn new() -> Self {
             Self { path: Default::default() }
@@ -996,35 +996,35 @@ mod _field_impls {
             self.path.join(".")
         }
         pub fn latest(mut self) -> String {
-            self.path.push(GetCheckpointDataRequest::LATEST_FIELD.name);
+            self.path.push(GetCheckpointRequest::LATEST_FIELD.name);
             self.finish()
         }
         pub fn sequence_number(mut self) -> String {
-            self.path.push(GetCheckpointDataRequest::SEQUENCE_NUMBER_FIELD.name);
+            self.path.push(GetCheckpointRequest::SEQUENCE_NUMBER_FIELD.name);
             self.finish()
         }
         pub fn digest(mut self) -> DigestFieldPathBuilder {
-            self.path.push(GetCheckpointDataRequest::DIGEST_FIELD.name);
+            self.path.push(GetCheckpointRequest::DIGEST_FIELD.name);
             DigestFieldPathBuilder::new_with_base(self.path)
         }
         pub fn read_mask(mut self) -> String {
-            self.path.push(GetCheckpointDataRequest::READ_MASK_FIELD.name);
+            self.path.push(GetCheckpointRequest::READ_MASK_FIELD.name);
             self.finish()
         }
         pub fn transactions_filter(mut self) -> TransactionFilterFieldPathBuilder {
-            self.path.push(GetCheckpointDataRequest::TRANSACTIONS_FILTER_FIELD.name);
+            self.path.push(GetCheckpointRequest::TRANSACTIONS_FILTER_FIELD.name);
             TransactionFilterFieldPathBuilder::new_with_base(self.path)
         }
         pub fn events_filter(mut self) -> EventFilterFieldPathBuilder {
-            self.path.push(GetCheckpointDataRequest::EVENTS_FILTER_FIELD.name);
+            self.path.push(GetCheckpointRequest::EVENTS_FILTER_FIELD.name);
             EventFilterFieldPathBuilder::new_with_base(self.path)
         }
         pub fn max_message_size_bytes(mut self) -> String {
-            self.path.push(GetCheckpointDataRequest::MAX_MESSAGE_SIZE_BYTES_FIELD.name);
+            self.path.push(GetCheckpointRequest::MAX_MESSAGE_SIZE_BYTES_FIELD.name);
             self.finish()
         }
     }
-    impl CheckpointDataStreamRequest {
+    impl StreamCheckpointsRequest {
         pub const START_SEQUENCE_NUMBER_FIELD: &'static MessageField = &MessageField {
             name: "start_sequence_number",
             json_name: "startSequenceNumber",
@@ -1090,7 +1090,7 @@ mod _field_impls {
             message_fields: None,
         };
     }
-    impl MessageFields for CheckpointDataStreamRequest {
+    impl MessageFields for StreamCheckpointsRequest {
         const FIELDS: &'static [&'static MessageField] = &[
             Self::START_SEQUENCE_NUMBER_FIELD,
             Self::END_SEQUENCE_NUMBER_FIELD,
@@ -1102,15 +1102,15 @@ mod _field_impls {
             Self::MAX_MESSAGE_SIZE_BYTES_FIELD,
         ];
     }
-    impl CheckpointDataStreamRequest {
-        pub fn path_builder() -> CheckpointDataStreamRequestFieldPathBuilder {
-            CheckpointDataStreamRequestFieldPathBuilder::new()
+    impl StreamCheckpointsRequest {
+        pub fn path_builder() -> StreamCheckpointsRequestFieldPathBuilder {
+            StreamCheckpointsRequestFieldPathBuilder::new()
         }
     }
-    pub struct CheckpointDataStreamRequestFieldPathBuilder {
+    pub struct StreamCheckpointsRequestFieldPathBuilder {
         path: Vec<&'static str>,
     }
-    impl CheckpointDataStreamRequestFieldPathBuilder {
+    impl StreamCheckpointsRequestFieldPathBuilder {
         #[allow(clippy::new_without_default)]
         pub fn new() -> Self {
             Self { path: Default::default() }
@@ -1123,37 +1123,35 @@ mod _field_impls {
             self.path.join(".")
         }
         pub fn start_sequence_number(mut self) -> String {
-            self.path
-                .push(CheckpointDataStreamRequest::START_SEQUENCE_NUMBER_FIELD.name);
+            self.path.push(StreamCheckpointsRequest::START_SEQUENCE_NUMBER_FIELD.name);
             self.finish()
         }
         pub fn end_sequence_number(mut self) -> String {
-            self.path.push(CheckpointDataStreamRequest::END_SEQUENCE_NUMBER_FIELD.name);
+            self.path.push(StreamCheckpointsRequest::END_SEQUENCE_NUMBER_FIELD.name);
             self.finish()
         }
         pub fn read_mask(mut self) -> String {
-            self.path.push(CheckpointDataStreamRequest::READ_MASK_FIELD.name);
+            self.path.push(StreamCheckpointsRequest::READ_MASK_FIELD.name);
             self.finish()
         }
         pub fn transactions_filter(mut self) -> TransactionFilterFieldPathBuilder {
-            self.path.push(CheckpointDataStreamRequest::TRANSACTIONS_FILTER_FIELD.name);
+            self.path.push(StreamCheckpointsRequest::TRANSACTIONS_FILTER_FIELD.name);
             TransactionFilterFieldPathBuilder::new_with_base(self.path)
         }
         pub fn events_filter(mut self) -> EventFilterFieldPathBuilder {
-            self.path.push(CheckpointDataStreamRequest::EVENTS_FILTER_FIELD.name);
+            self.path.push(StreamCheckpointsRequest::EVENTS_FILTER_FIELD.name);
             EventFilterFieldPathBuilder::new_with_base(self.path)
         }
         pub fn filter_checkpoints(mut self) -> String {
-            self.path.push(CheckpointDataStreamRequest::FILTER_CHECKPOINTS_FIELD.name);
+            self.path.push(StreamCheckpointsRequest::FILTER_CHECKPOINTS_FIELD.name);
             self.finish()
         }
         pub fn progress_interval_ms(mut self) -> String {
-            self.path.push(CheckpointDataStreamRequest::PROGRESS_INTERVAL_MS_FIELD.name);
+            self.path.push(StreamCheckpointsRequest::PROGRESS_INTERVAL_MS_FIELD.name);
             self.finish()
         }
         pub fn max_message_size_bytes(mut self) -> String {
-            self.path
-                .push(CheckpointDataStreamRequest::MAX_MESSAGE_SIZE_BYTES_FIELD.name);
+            self.path.push(StreamCheckpointsRequest::MAX_MESSAGE_SIZE_BYTES_FIELD.name);
             self.finish()
         }
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v0.ledger_service.rs
@@ -173,7 +173,7 @@ pub struct GetTransactionsResponse {
 }
 #[non_exhaustive]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetCheckpointDataRequest {
+pub struct GetCheckpointRequest {
     /// Mask specifying which fields to read.
     /// If no mask is specified, defaults to `summary`.
     #[prost(message, optional, tag = "4")]
@@ -188,11 +188,11 @@ pub struct GetCheckpointDataRequest {
     /// If not specified, server uses default chunking threshold (4MB)
     #[prost(uint32, optional, tag = "7")]
     pub max_message_size_bytes: ::core::option::Option<u32>,
-    #[prost(oneof = "get_checkpoint_data_request::CheckpointId", tags = "1, 2, 3")]
-    pub checkpoint_id: ::core::option::Option<get_checkpoint_data_request::CheckpointId>,
+    #[prost(oneof = "get_checkpoint_request::CheckpointId", tags = "1, 2, 3")]
+    pub checkpoint_id: ::core::option::Option<get_checkpoint_request::CheckpointId>,
 }
-/// Nested message and enum types in `GetCheckpointDataRequest`.
-pub mod get_checkpoint_data_request {
+/// Nested message and enum types in `GetCheckpointRequest`.
+pub mod get_checkpoint_request {
     #[non_exhaustive]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum CheckpointId {
@@ -209,7 +209,7 @@ pub mod get_checkpoint_data_request {
 }
 #[non_exhaustive]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CheckpointDataStreamRequest {
+pub struct StreamCheckpointsRequest {
     /// if no start sequence number is provided, streaming starts from the latest checkpoint
     #[prost(uint64, optional, tag = "1")]
     pub start_sequence_number: ::core::option::Option<u64>,
@@ -505,9 +505,9 @@ pub mod ledger_service_client {
             self.inner.server_streaming(req, path, codec).await
         }
         /// Checkpoint operations
-        pub async fn get_checkpoint_data(
+        pub async fn get_checkpoint(
             &mut self,
-            request: impl tonic::IntoRequest<super::GetCheckpointDataRequest>,
+            request: impl tonic::IntoRequest<super::GetCheckpointRequest>,
         ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::CheckpointData>>,
             tonic::Status,
@@ -522,21 +522,21 @@ pub mod ledger_service_client {
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/iota.grpc.v0.ledger_service.LedgerService/GetCheckpointData",
+                "/iota.grpc.v0.ledger_service.LedgerService/GetCheckpoint",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "iota.grpc.v0.ledger_service.LedgerService",
-                        "GetCheckpointData",
+                        "GetCheckpoint",
                     ),
                 );
             self.inner.server_streaming(req, path, codec).await
         }
-        pub async fn stream_checkpoint_data(
+        pub async fn stream_checkpoints(
             &mut self,
-            request: impl tonic::IntoRequest<super::CheckpointDataStreamRequest>,
+            request: impl tonic::IntoRequest<super::StreamCheckpointsRequest>,
         ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::CheckpointData>>,
             tonic::Status,
@@ -551,14 +551,14 @@ pub mod ledger_service_client {
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/iota.grpc.v0.ledger_service.LedgerService/StreamCheckpointData",
+                "/iota.grpc.v0.ledger_service.LedgerService/StreamCheckpoints",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "iota.grpc.v0.ledger_service.LedgerService",
-                        "StreamCheckpointData",
+                        "StreamCheckpoints",
                     ),
                 );
             self.inner.server_streaming(req, path, codec).await
@@ -646,31 +646,31 @@ pub mod ledger_service_server {
             tonic::Response<Self::GetTransactionsStream>,
             tonic::Status,
         >;
-        /// Server streaming response type for the GetCheckpointData method.
-        type GetCheckpointDataStream: tonic::codegen::tokio_stream::Stream<
+        /// Server streaming response type for the GetCheckpoint method.
+        type GetCheckpointStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::CheckpointData, tonic::Status>,
             >
             + std::marker::Send
             + 'static;
         /// Checkpoint operations
-        async fn get_checkpoint_data(
+        async fn get_checkpoint(
             &self,
-            request: tonic::Request<super::GetCheckpointDataRequest>,
+            request: tonic::Request<super::GetCheckpointRequest>,
         ) -> std::result::Result<
-            tonic::Response<Self::GetCheckpointDataStream>,
+            tonic::Response<Self::GetCheckpointStream>,
             tonic::Status,
         >;
-        /// Server streaming response type for the StreamCheckpointData method.
-        type StreamCheckpointDataStream: tonic::codegen::tokio_stream::Stream<
+        /// Server streaming response type for the StreamCheckpoints method.
+        type StreamCheckpointsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::CheckpointData, tonic::Status>,
             >
             + std::marker::Send
             + 'static;
-        async fn stream_checkpoint_data(
+        async fn stream_checkpoints(
             &self,
-            request: tonic::Request<super::CheckpointDataStreamRequest>,
+            request: tonic::Request<super::StreamCheckpointsRequest>,
         ) -> std::result::Result<
-            tonic::Response<Self::StreamCheckpointDataStream>,
+            tonic::Response<Self::StreamCheckpointsStream>,
             tonic::Status,
         >;
         async fn get_epoch(
@@ -942,28 +942,26 @@ pub mod ledger_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/iota.grpc.v0.ledger_service.LedgerService/GetCheckpointData" => {
+                "/iota.grpc.v0.ledger_service.LedgerService/GetCheckpoint" => {
                     #[allow(non_camel_case_types)]
-                    struct GetCheckpointDataSvc<T: LedgerService>(pub Arc<T>);
+                    struct GetCheckpointSvc<T: LedgerService>(pub Arc<T>);
                     impl<
                         T: LedgerService,
-                    > tonic::server::ServerStreamingService<
-                        super::GetCheckpointDataRequest,
-                    > for GetCheckpointDataSvc<T> {
+                    > tonic::server::ServerStreamingService<super::GetCheckpointRequest>
+                    for GetCheckpointSvc<T> {
                         type Response = super::CheckpointData;
-                        type ResponseStream = T::GetCheckpointDataStream;
+                        type ResponseStream = T::GetCheckpointStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::GetCheckpointDataRequest>,
+                            request: tonic::Request<super::GetCheckpointRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LedgerService>::get_checkpoint_data(&inner, request)
-                                    .await
+                                <T as LedgerService>::get_checkpoint(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -974,7 +972,7 @@ pub mod ledger_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = GetCheckpointDataSvc(inner);
+                        let method = GetCheckpointSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -990,30 +988,27 @@ pub mod ledger_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/iota.grpc.v0.ledger_service.LedgerService/StreamCheckpointData" => {
+                "/iota.grpc.v0.ledger_service.LedgerService/StreamCheckpoints" => {
                     #[allow(non_camel_case_types)]
-                    struct StreamCheckpointDataSvc<T: LedgerService>(pub Arc<T>);
+                    struct StreamCheckpointsSvc<T: LedgerService>(pub Arc<T>);
                     impl<
                         T: LedgerService,
                     > tonic::server::ServerStreamingService<
-                        super::CheckpointDataStreamRequest,
-                    > for StreamCheckpointDataSvc<T> {
+                        super::StreamCheckpointsRequest,
+                    > for StreamCheckpointsSvc<T> {
                         type Response = super::CheckpointData;
-                        type ResponseStream = T::StreamCheckpointDataStream;
+                        type ResponseStream = T::StreamCheckpointsStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::CheckpointDataStreamRequest>,
+                            request: tonic::Request<super::StreamCheckpointsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as LedgerService>::stream_checkpoint_data(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as LedgerService>::stream_checkpoints(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -1025,7 +1020,7 @@ pub mod ledger_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = StreamCheckpointDataSvc(inner);
+                        let method = StreamCheckpointsSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/iota-grpc-types/src/read_masks.rs
+++ b/crates/iota-grpc-types/src/read_masks.rs
@@ -72,7 +72,7 @@ pub const GET_TRANSACTIONS_READ_MASK: &str =
 /// Default read mask for `get_objects`.
 pub const GET_OBJECTS_READ_MASK: &str = field_mask!("reference", "bcs");
 
-/// Default read mask for `get_checkpoint` / `stream_checkpoint_data`.
+/// Default read mask for `get_checkpoint` / `stream_checkpoints`.
 pub const GET_CHECKPOINT_READ_MASK: &str = field_mask!("checkpoint.summary");
 
 /// Default read mask for `execute_transaction`.


### PR DESCRIPTION
# Description of change

Rename gRPC checkpoint RPC endpoints and message types for consistency with other service methods.

- Rename `GetCheckpointData` RPC to `GetCheckpoint` and `StreamCheckpointData` to `StreamCheckpoints` in the proto definition
  - `GetCheckpointDataRequest` → `GetCheckpointRequest`
  - `CheckpointDataStreamRequest` → `StreamCheckpointsRequest`
- Update `iota-grpc-server` implementation to match the new RPC and type names
  - Rename stream types: `GetCheckpointDataStream` → `GetCheckpointStream`, `StreamCheckpointDataStream` → `StreamCheckpointsStream`
  - Rename internal functions: `get_checkpoint_data()` → `get_checkpoint()`, `stream_checkpoint_data()` → `stream_checkpoints()`
- Update `iota-grpc-client` to use the renamed request types and client methods
- Regenerate proto accessor and field_info code to reflect the renamed messages
- Update `iota-grpc-types` read mask reference for the renamed request type
- Update all affected e2e tests and integration tests.

## Links to any relevant issues

None.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes