### PR TITLE
upstream(core): Fix flaky get_latest_object_version

### DIFF
--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -955,7 +955,19 @@ where
                     Box::pin(async move {
                         let request =
                             ObjectInfoRequest::latest_object_info_request(object_id, /* generate_layout */ LayoutGenerationOption::None);
-                        client.handle_object_info_request(request).await
+                        let mut retry_count = 0;
+                        loop {
+                            match client.handle_object_info_request(request.clone()).await {
+                                Ok(object_info) => return Ok(object_info),
+                                Err(err) => {
+                                    retry_count += 1;
+                                    if retry_count > 3 {
+                                        return Err(err);
+                                    }
+                                    tokio::time::sleep(Duration::from_secs(1)).await;
+                                }
+                            }
+                        }
                     })
                 },
                 |mut state, name, weight, result| {


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@0ce60503](https://github.com/MystenLabs/sui/commit/0ce605031033accd6e887716046d6dd6643761c1)
- Description:

This fixes a flaky simtest.
In some simtests we crash more than a quorum of validators, and in that
case we may not be able to get the object from a quorum of validators.
Adding retry here. This function is for testing only so we don't need to
be very strict.

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes