### PR TITLE
fix(indexer): add objects_owner_with_id index

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-03-26-120000_objects_owner_object_id_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-03-26-120000_objects_owner_object_id_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS objects_owner_object_id;

--- a/crates/iota-indexer/migrations/pg/2026-03-26-120000_objects_owner_object_id_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-03-26-120000_objects_owner_object_id_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-03-26-120000_objects_owner_object_id_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-03-26-120000_objects_owner_object_id_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS objects_owner_object_id ON objects (owner_type, owner_id, object_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;


### PR DESCRIPTION
# Description of change

This patch adds a new index on the `objects` table to handle skewed distributions of ownership.

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

Ran the migrations on cold database.

### Release Notes

- [x] Indexer: :warning: Maintenance required: Introducing a new migration in preparation of removing an index with the subsequent release v1.21. Operators should update their `IOTA Indexer` instances and restart the writer service.
- [x] GraphQL: :warning: Maintenance required: Introducing a new migration in IOTA Indexer requires updating GraphQL and restarting service. 
