### PR TITLE
feat(iota-core): [P-COOL] wire format server side implementation

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -5043,6 +5043,14 @@ impl AuthorityPerEpochStore {
             .read()
             .load_stored_object_debts_for_testing(for_randomness, object_ids)
     }
+
+    #[cfg(test)]
+    pub(crate) fn insert_dropped_digests_for_testing(
+        &self,
+        dropped: &[(TransactionDigest, IotaError)],
+    ) {
+        self.dropped_tx_status_cache.insert_and_notify(dropped);
+    }
 }
 
 impl ExecutionComponents {

--- a/crates/iota-core/src/authority_server/mod.rs
+++ b/crates/iota-core/src/authority_server/mod.rs
@@ -229,7 +229,7 @@ impl ValidatorService {
             Weight,
             Result<T, tonic::Status>,
         ) = match response {
-            Ok((result, spam_weight)) => (None, spam_weight.clone(), Ok(result)),
+            Ok((result, spam_weight)) => (None, spam_weight, Ok(result)),
             Err(status) => (
                 Some(IotaError::from(status.clone())),
                 Weight::zero(),
@@ -242,7 +242,7 @@ impl ValidatorService {
                 direct: client,
                 through_fullnode: None,
                 error_info: error.map(|e| {
-                    let error_type = String::from(e.clone().as_ref());
+                    let error_type = String::from(e.as_ref());
                     let error_weight = normalize(e);
                     (error_weight, error_type)
                 }),

--- a/crates/iota-core/src/authority_server/mod.rs
+++ b/crates/iota-core/src/authority_server/mod.rs
@@ -15,7 +15,6 @@ use std::{
     sync::Arc,
     time::SystemTime,
 };
-use tokio_stream::StreamExt;
 
 use iota_network::{
     tonic,
@@ -28,6 +27,7 @@ use iota_types::{
 pub use metrics::ValidatorServiceMetrics;
 #[cfg(test)]
 pub use test_server::{AuthorityServer, AuthorityServerHandle};
+use tokio_stream::StreamExt;
 use tonic::transport::server::TcpConnectInfo;
 use tracing::error;
 
@@ -40,9 +40,8 @@ use crate::{
 };
 type WrappedServiceResponse<T> = Result<(tonic::Response<T>, Weight), tonic::Status>;
 
-type StreamResponse<T> = std::pin::Pin<
-    Box<dyn tokio_stream::Stream<Item = Result<T, tonic::Status>> + Send>,
->;
+type StreamResponse<T> =
+    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<T, tonic::Status>> + Send>>;
 
 /// The validator service.
 #[derive(Clone)]
@@ -98,7 +97,7 @@ impl ValidatorService {
         &self.state
     }
 
-    pub fn get_client_ip_addr<T>(
+    pub(crate) fn get_client_ip_addr<T>(
         &self,
         request: &tonic::Request<T>,
         source: &ClientIdSource,
@@ -109,9 +108,7 @@ impl ValidatorService {
 
                 // We will hit this case if the IO type used does not
                 // implement Connected or when using a unix domain socket.
-                // TODO: once we have confirmed that no legitimate traffic
-                // is hitting this case, we should reject such requests that
-                // hit this case.
+                // TODO(#11095): reject requests without a peer address.
                 if let Some(socket_addr) = socket_addr {
                     Some(socket_addr.ip())
                 } else {
@@ -167,9 +164,7 @@ impl ValidatorService {
                             })
                         }
                         Err(e) => {
-                            // TODO: once we have confirmed that no legitimate traffic
-                            // is hitting this case, we should reject such requests that
-                            // hit this case.
+                            // TODO(#11095): reject requests with invalid x-forwarded-for.
                             self.metrics.forwarded_header_invalid.inc();
                             error!("Invalid UTF-8 in x-forwarded-for header: {:?}", e);
                             None
@@ -191,7 +186,7 @@ impl ValidatorService {
         }
     }
 
-    async fn handle_traffic_req(&self, client: Option<IpAddr>) -> Result<(), tonic::Status> {
+    async fn check_traffic(&self, client: Option<IpAddr>) -> Result<(), tonic::Status> {
         if let Some(traffic_controller) = &self.traffic_controller {
             if !traffic_controller.check(&client, &None).await {
                 // Entity in blocklist
@@ -204,45 +199,24 @@ impl ValidatorService {
         }
     }
 
-    fn handle_traffic_resp<T>(
+    fn extract_client_ip_and_request<DomainReq, ProtoReq>(
         &self,
-        client: Option<IpAddr>,
-        wrapped_response: WrappedServiceResponse<T>,
-    ) -> Result<tonic::Response<T>, tonic::Status> {
-        let (error, spam_weight, unwrapped_response) = match wrapped_response {
-            Ok((result, spam_weight)) => (None, spam_weight, Ok(result)),
-            Err(status) => (
-                Some(IotaError::from(status.clone())),
-                Weight::zero(),
-                Err(status),
-            ),
-        };
-
-        if let Some(traffic_controller) = self.traffic_controller.clone() {
-            traffic_controller.tally(TrafficTally {
-                direct: client,
-                through_fullnode: None,
-                error_info: error.map(|e| {
-                    let error_type = String::from(e.as_ref());
-                    let error_weight = normalize(e);
-                    (error_weight, error_type)
-                }),
-                spam_weight,
-                timestamp: SystemTime::now(),
-            })
-        }
-        unwrapped_response
-    }
-
-    fn extract_client_ip_and_request<T, MappedT>(&self, request: tonic::Request<MappedT>) -> (T, Option<IpAddr>)
-    where MappedT: Into<T>
+        request: tonic::Request<ProtoReq>,
+    ) -> Result<(DomainReq, Option<IpAddr>), tonic::Status>
+    where
+        ProtoReq: TryInto<DomainReq>,
+        ProtoReq::Error: std::fmt::Display,
     {
-        if self.client_id_source.is_none() {
-            (request.into_inner().into(), None)
-        } else {
-            let ip = self.get_client_ip_addr(&request, self.client_id_source.as_ref().unwrap());
-            (request.into_inner().into(), ip)
-        }
+        let ip = self
+            .client_id_source
+            .as_ref()
+            .and_then(|source| self.get_client_ip_addr(&request, source));
+        // TODO(#11095): move deserialization off the critical path (spawn_blocking).
+        let domain_req = request
+            .into_inner()
+            .try_into()
+            .map_err(|e| tonic::Status::internal(format!("request conversion failed: {e}")))?;
+        Ok((domain_req, ip))
     }
 
     fn tally_traffic<T>(
@@ -250,7 +224,11 @@ impl ValidatorService {
         client: Option<IpAddr>,
         response: Result<(T, Weight), tonic::Status>,
     ) -> Result<T, tonic::Status> {
-        let (error, spam_weight, unwrapped_response): (Option<IotaError>, Weight, Result<T, tonic::Status>) = match response {
+        let (error, spam_weight, unwrapped_response): (
+            Option<IotaError>,
+            Weight,
+            Result<T, tonic::Status>,
+        ) = match response {
             Ok((result, spam_weight)) => (None, spam_weight.clone(), Ok(result)),
             Err(status) => (
                 Some(IotaError::from(status.clone())),
@@ -282,10 +260,11 @@ impl ValidatorService {
         request: tonic::Request<ProtoReq>,
     ) -> Result<(DomainReq, Option<IpAddr>), tonic::Status>
     where
-        ProtoReq: Into<DomainReq>,
+        ProtoReq: TryInto<DomainReq>,
+        ProtoReq::Error: std::fmt::Display,
     {
-        let (domain_req, ip) = self.extract_client_ip_and_request(request);
-        self.handle_traffic_req(ip).await?;
+        let (domain_req, ip) = self.extract_client_ip_and_request(request)?;
+        self.check_traffic(ip).await?;
         Ok((domain_req, ip))
     }
 
@@ -309,6 +288,7 @@ impl ValidatorService {
 
     /// Tallies traffic and maps each domain stream item into its proto
     /// equivalent.
+    // TODO(#11080): tally traffic per-item, not just once at stream creation.
     fn post_handle_stream<S, DomainItem, ProtoItem>(
         &self,
         ip: Option<IpAddr>,
@@ -344,7 +324,7 @@ fn make_tonic_request_for_testing<T>(message: T) -> tonic::Request<T> {
     request
 }
 
-// TODO: refine error matching here
+// TODO(#11095): refine error-to-weight mapping.
 fn normalize(err: IotaError) -> Weight {
     match err {
         IotaError::UserInput {
@@ -373,10 +353,10 @@ macro_rules! handle_with_decoration {
         let client = $self.get_client_ip_addr(&$request, $self.client_id_source.as_ref().unwrap());
 
         // check if either IP is blocked, in which case return early
-        $self.handle_traffic_req(client.clone()).await?;
+        $self.check_traffic(client.clone()).await?;
 
         // handle traffic tallying
         let wrapped_response = $self.$func_name($request).await;
-        $self.handle_traffic_resp(client, wrapped_response)
+        $self.tally_traffic(client, wrapped_response)
     }};
 }

--- a/crates/iota-core/src/authority_server/mod.rs
+++ b/crates/iota-core/src/authority_server/mod.rs
@@ -15,6 +15,7 @@ use std::{
     sync::Arc,
     time::SystemTime,
 };
+use tokio_stream::StreamExt;
 
 use iota_network::{
     tonic,
@@ -38,6 +39,10 @@ use crate::{
     },
 };
 type WrappedServiceResponse<T> = Result<(tonic::Response<T>, Weight), tonic::Status>;
+
+type StreamResponse<T> = std::pin::Pin<
+    Box<dyn tokio_stream::Stream<Item = Result<T, tonic::Status>> + Send>,
+>;
 
 /// The validator service.
 #[derive(Clone)]
@@ -93,7 +98,7 @@ impl ValidatorService {
         &self.state
     }
 
-    fn get_client_ip_addr<T>(
+    pub fn get_client_ip_addr<T>(
         &self,
         request: &tonic::Request<T>,
         source: &ClientIdSource,
@@ -227,6 +232,103 @@ impl ValidatorService {
             })
         }
         unwrapped_response
+    }
+
+    fn extract_client_ip_and_request<T, MappedT>(&self, request: tonic::Request<MappedT>) -> (T, Option<IpAddr>)
+    where MappedT: Into<T>
+    {
+        if self.client_id_source.is_none() {
+            (request.into_inner().into(), None)
+        } else {
+            let ip = self.get_client_ip_addr(&request, self.client_id_source.as_ref().unwrap());
+            (request.into_inner().into(), ip)
+        }
+    }
+
+    fn tally_traffic<T>(
+        &self,
+        client: Option<IpAddr>,
+        response: Result<(T, Weight), tonic::Status>,
+    ) -> Result<T, tonic::Status> {
+        let (error, spam_weight, unwrapped_response): (Option<IotaError>, Weight, Result<T, tonic::Status>) = match response {
+            Ok((result, spam_weight)) => (None, spam_weight.clone(), Ok(result)),
+            Err(status) => (
+                Some(IotaError::from(status.clone())),
+                Weight::zero(),
+                Err(status),
+            ),
+        };
+
+        if let Some(traffic_controller) = self.traffic_controller.clone() {
+            traffic_controller.tally(TrafficTally {
+                direct: client,
+                through_fullnode: None,
+                error_info: error.map(|e| {
+                    let error_type = String::from(e.clone().as_ref());
+                    let error_weight = normalize(e);
+                    (error_weight, error_type)
+                }),
+                spam_weight,
+                timestamp: SystemTime::now(),
+            })
+        }
+        unwrapped_response
+    }
+
+    /// Extracts the domain request from a proto request and checks traffic
+    /// control. Shared pre-processing for both unary and streaming handlers.
+    async fn pre_handle<ProtoReq, DomainReq>(
+        &self,
+        request: tonic::Request<ProtoReq>,
+    ) -> Result<(DomainReq, Option<IpAddr>), tonic::Status>
+    where
+        ProtoReq: Into<DomainReq>,
+    {
+        let (domain_req, ip) = self.extract_client_ip_and_request(request);
+        self.handle_traffic_req(ip).await?;
+        Ok((domain_req, ip))
+    }
+
+    /// Tallies traffic and converts a single domain response into a proto
+    /// tonic response.
+    fn post_handle_unary<DomainResp, ProtoResp>(
+        &self,
+        ip: Option<IpAddr>,
+        result: Result<(DomainResp, Weight), tonic::Status>,
+    ) -> Result<tonic::Response<ProtoResp>, tonic::Status>
+    where
+        DomainResp: TryInto<ProtoResp>,
+        DomainResp::Error: std::fmt::Display,
+    {
+        let value = self.tally_traffic(ip, result)?;
+        let proto = value
+            .try_into()
+            .map_err(|e| tonic::Status::internal(format!("response conversion failed: {e}")))?;
+        Ok(tonic::Response::new(proto))
+    }
+
+    /// Tallies traffic and maps each domain stream item into its proto
+    /// equivalent.
+    fn post_handle_stream<S, DomainItem, ProtoItem>(
+        &self,
+        ip: Option<IpAddr>,
+        result: Result<(S, Weight), tonic::Status>,
+    ) -> Result<tonic::Response<StreamResponse<ProtoItem>>, tonic::Status>
+    where
+        S: tokio_stream::Stream<Item = Result<DomainItem, tonic::Status>> + Send + 'static,
+        DomainItem: TryInto<ProtoItem> + 'static,
+        DomainItem::Error: std::fmt::Display,
+        ProtoItem: 'static,
+    {
+        let stream = self.tally_traffic(ip, result)?;
+        let mapped = stream.map(|item| {
+            item.and_then(|v| {
+                v.try_into().map_err(|e| {
+                    tonic::Status::internal(format!("stream item conversion failed: {e}"))
+                })
+            })
+        });
+        Ok(tonic::Response::new(Box::pin(mapped)))
     }
 }
 

--- a/crates/iota-core/src/authority_server/validator_peer.rs
+++ b/crates/iota-core/src/authority_server/validator_peer.rs
@@ -5,15 +5,30 @@ use iota_network::{
     api::{GetCheckpointRequest, GetCheckpointResponse, ValidatorPeer},
     tonic,
 };
+use iota_types::{
+    messages_checkpoint::{CheckpointRequest, CheckpointResponse},
+    traffic_control::Weight,
+};
 
 use crate::authority_server::ValidatorService;
+
+impl ValidatorService {
+    async fn get_checkpoint_impl(
+        &self,
+        request: CheckpointRequest,
+    ) -> Result<(CheckpointResponse, Weight), tonic::Status> {
+        let response = self.state.handle_checkpoint_request(&request)?;
+        Ok((response, Weight::one()))
+    }
+}
 
 #[async_trait::async_trait]
 impl ValidatorPeer for ValidatorService {
     async fn get_checkpoint(
         &self,
-        _request: tonic::Request<GetCheckpointRequest>,
+        request: tonic::Request<GetCheckpointRequest>,
     ) -> Result<tonic::Response<GetCheckpointResponse>, tonic::Status> {
-        todo!()
+        let (req, ip) = self.pre_handle(request).await?;
+        self.post_handle_unary(ip, self.get_checkpoint_impl(req).await)
     }
 }

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use futures::future::Either;
 use iota_network::{
-    api::{GetTxStatusRequest, SubmitTxRequest, TxStatus, ValidatorV2},
+    api::{
+        GetTxStatusRequest, NotifyCapabilitiesRequest, NotifyCapabilitiesResponse, SubmitTxRequest,
+        TxStatus, ValidatorV2,
+    },
     tonic::{Request, Response, Status},
 };
 use iota_types::{
@@ -16,8 +19,9 @@ use iota_types::{
     message_envelope::Message,
     messages_consensus::ConsensusTransaction,
     messages_grpc::{
-        ExecutedData, GetTxStatusRequest as DomainGetTxStatusRequest, SubmitTransactionsRequest,
-        TxStatusUpdate,
+        ExecutedData, GetTxStatusRequest as DomainGetTxStatusRequest,
+        HandleCapabilityNotificationRequestV1, HandleCapabilityNotificationResponseV1,
+        SubmitTransactionsRequest, TxStatusUpdate,
     },
     traffic_control::Weight,
     transaction::Transaction,
@@ -35,6 +39,8 @@ const GET_TX_STATUS_TIMEOUT_SECS: u64 = 30;
 
 /// A single streamed item in a V2 RPC response.
 type TxUpdateItem = Result<(TransactionDigest, TxStatusUpdate), Status>;
+
+use iota_metrics::spawn_monitored_task;
 
 use crate::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
@@ -82,7 +88,7 @@ impl ValidatorService {
             let consensus_adapter = consensus_adapter.clone();
             let metrics = metrics.clone();
             let tx_sender = tx_sender.clone();
-            tokio::spawn(async move {
+            spawn_monitored_task!(async move {
                 let tx_digest = *transaction.digest();
                 let result = Self::submit_single_tx(
                     &state,
@@ -413,6 +419,89 @@ impl ValidatorService {
             output_objects,
         })
     }
+
+    async fn notify_capabilities_impl(
+        &self,
+        request: HandleCapabilityNotificationRequestV1,
+    ) -> Result<(HandleCapabilityNotificationResponseV1, Weight), Status> {
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+
+        fp_ensure!(
+            epoch_store
+                .protocol_config()
+                .track_non_committee_eligible_validators(),
+            IotaError::UnsupportedFeature {
+                error: "capability notification endpoint is not supported in this Protocol Version"
+                    .to_string()
+            }
+            .into()
+        );
+
+        fp_ensure!(
+            !self.state.is_fullnode(&epoch_store),
+            IotaError::FullNodeCantHandleAuthorityCapabilities.into()
+        );
+
+        let existing_capabilities = epoch_store.get_capabilities_v1()?;
+        let incoming_capability = request.message.data();
+
+        tracing::info!(
+            "Received capability notification: {:?}",
+            incoming_capability
+        );
+
+        if let Some(existing) = existing_capabilities
+            .iter()
+            .find(|cap| cap.authority == incoming_capability.authority)
+        {
+            if incoming_capability.generation <= existing.generation {
+                return Ok((
+                    HandleCapabilityNotificationResponseV1 { _unused: false },
+                    Weight::one(),
+                ));
+            }
+        }
+
+        if let Err(error) = self.consensus_adapter.check_consensus_overload() {
+            self.metrics
+                .num_rejected_capability_notifications_during_overload
+                .with_label_values(&[error.as_ref()])
+                .inc();
+            return Err(error.into());
+        }
+
+        let _metrics_guard = self
+            .metrics
+            .handle_capability_notification_latency
+            .start_timer();
+
+        let signed_authority_capabilities = request.message;
+        let verified_authority_capabilities = epoch_store
+            .verify_authority_capabilities(signed_authority_capabilities)
+            .inspect_err(|_e| {
+                self.metrics.signature_errors.inc();
+            })?;
+
+        let authority_name = verified_authority_capabilities.authority;
+        // Process the verified capabilities
+        tracing::debug!("Verified capability notification for authority {authority_name:?}");
+
+        let transaction = ConsensusTransaction::new_signed_capability_notification_v1(
+            verified_authority_capabilities.into_inner(),
+        );
+
+        self.consensus_adapter
+            .submit(transaction, None, &epoch_store)?;
+
+        tracing::debug!(
+            "Submitted capability notification to consensus for authority {authority_name:?}"
+        );
+
+        Ok((
+            HandleCapabilityNotificationResponseV1 { _unused: false },
+            Weight::one(),
+        ))
+    }
 }
 
 #[async_trait::async_trait]
@@ -435,5 +524,13 @@ impl ValidatorV2 for ValidatorService {
     ) -> Result<Response<Self::GetTxStatusStream>, Status> {
         let (req, ip) = self.pre_handle(request).await?;
         self.post_handle_stream(ip, self.get_tx_status_impl(req).await)
+    }
+
+    async fn notify_capabilities(
+        &self,
+        request: Request<NotifyCapabilitiesRequest>,
+    ) -> Result<Response<NotifyCapabilitiesResponse>, Status> {
+        let (req, ip) = self.pre_handle(request).await?;
+        self.post_handle_unary(ip, self.notify_capabilities_impl(req).await)
     }
 }

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -3,8 +3,9 @@
 
 use std::sync::Arc;
 
+use futures::future::Either;
 use iota_network::{
-    api::{SubmitTxRequest, TxDigest, TxStatus, ValidatorV2},
+    api::{GetTxStatusRequest, SubmitTxRequest, TxStatus, ValidatorV2},
     tonic::{Request, Response, Status},
 };
 use iota_types::{
@@ -14,7 +15,10 @@ use iota_types::{
     fp_ensure,
     message_envelope::Message,
     messages_consensus::ConsensusTransaction,
-    messages_grpc::{ExecutedData, SubmitTransactionResult, SubmitTransactionsRequest},
+    messages_grpc::{
+        ExecutedData, GetTxStatusRequest as DomainGetTxStatusRequest, SubmitTransactionsRequest,
+        TxStatusUpdate,
+    },
     traffic_control::Weight,
     transaction::Transaction,
 };
@@ -22,6 +26,15 @@ use tokio_stream::wrappers::ReceiverStream;
 
 /// Maximum number of transactions allowed in a single `submit_tx` request.
 const MAX_TRANSACTIONS_PER_SUBMIT: usize = 256;
+
+/// Maximum number of queries allowed in a single `get_tx_status` request.
+const MAX_QUERIES_PER_GET_TX_STATUS: usize = 256;
+
+/// Timeout for waiting on transaction execution in `get_tx_status`.
+const GET_TX_STATUS_TIMEOUT_SECS: u64 = 30;
+
+/// A single streamed item in a V2 RPC response.
+type TxUpdateItem = Result<(TransactionDigest, TxStatusUpdate), Status>;
 
 use crate::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
@@ -33,13 +46,7 @@ impl ValidatorService {
     async fn submit_tx_impl(
         &self,
         request: SubmitTransactionsRequest,
-    ) -> Result<
-        (
-            ReceiverStream<Result<(TransactionDigest, SubmitTransactionResult), Status>>,
-            Weight,
-        ),
-        Status,
-    > {
+    ) -> Result<(ReceiverStream<TxUpdateItem>, Weight), Status> {
         let state = self.state.clone();
         let epoch_store = state.load_epoch_store_one_call_per_task();
 
@@ -107,31 +114,16 @@ impl ValidatorService {
         metrics: &Arc<ValidatorServiceMetrics>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         transaction: Transaction,
-    ) -> Result<SubmitTransactionResult, Status> {
+    ) -> Result<TxStatusUpdate, Status> {
         let tx_digest = *transaction.digest();
 
-        let build_executed =
-            |effects: TransactionEffects| -> Result<SubmitTransactionResult, Status> {
-                let effects_digest = effects.digest();
-                let events = if effects.events_digest().is_some() {
-                    state
-                        .get_transaction_events(effects.transaction_digest())
-                        .ok()
-                } else {
-                    None
-                };
-                let input_objects = state.get_transaction_input_objects(&effects).ok();
-                let output_objects = state.get_transaction_output_objects(&effects).ok();
-                Ok(SubmitTransactionResult::Executed {
-                    effects_digest,
-                    details: Box::new(ExecutedData {
-                        effects,
-                        events,
-                        input_objects: input_objects.unwrap_or_default(),
-                        output_objects: output_objects.unwrap_or_default(),
-                    }),
-                })
-            };
+        let build_executed = |effects: TransactionEffects| -> Result<TxStatusUpdate, Status> {
+            let effects_digest = effects.digest();
+            Ok(TxStatusUpdate::Executed {
+                effects_digest,
+                details: Some(Self::build_executed_data(state, &effects)),
+            })
+        };
 
         // Check system overload.
         if let Err(e) = state.check_system_overload(
@@ -143,27 +135,24 @@ impl ValidatorService {
                 .num_rejected_tx_during_overload
                 .with_label_values(&[e.as_ref()])
                 .inc();
-            return Ok(SubmitTransactionResult::Rejected { error: e });
+            return Ok(TxStatusUpdate::Rejected { error: Some(e) });
         }
 
         // Validate transaction.
         if let Err(e) =
             transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())
         {
-            return Ok(SubmitTransactionResult::Rejected { error: e });
+            return Ok(TxStatusUpdate::Rejected { error: Some(e) });
         }
 
-        // Check if already executed.
-        // TODO: The `?` here causes an early error return if the cache read fails.
-        // The intent is only to short-circuit when the tx is already executed. A
-        // transient cache error should probably not abort submission — consider using
-        // `.ok().flatten()` so errors are treated as "not found" and the normal flow
-        // continues (consensus handles dedup). The same applies to the second
-        // `try_get_executed_effects` call below. V1 has the same pattern, so verify
-        // the intended semantics for both code paths.
+        // Check if already executed. Transient cache errors are treated as
+        // "not found" — consensus handles dedup, so the normal submission
+        // flow continues safely.
         if let Some(effects) = state
             .get_transaction_cache_reader()
-            .try_get_executed_effects(&tx_digest)?
+            .try_get_executed_effects(&tx_digest)
+            .ok()
+            .flatten()
         {
             return build_executed(effects);
         }
@@ -174,11 +163,12 @@ impl ValidatorService {
             Ok(verified) => verified,
             Err(e) => {
                 metrics.signature_errors.inc();
-                return Ok(SubmitTransactionResult::Rejected { error: e });
+                return Ok(TxStatusUpdate::Rejected { error: Some(e) });
             }
         };
         drop(tx_verif_guard);
 
+        // TODO(#11110): return Rejected instead of Err(Status) for consistency.
         // Early bail-out during epoch boundary.
         if !epoch_store
             .get_reconfig_state_read_lock_guard()
@@ -188,6 +178,7 @@ impl ValidatorService {
             return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
         }
 
+        // TODO(#11110): return Rejected instead of Err(Status) for consistency.
         // Content validation: deny checks + owned object version validation.
         let owned_objects = state
             .handle_transaction_validation_checks(&verified_tx, epoch_store)
@@ -200,13 +191,16 @@ impl ValidatorService {
             // Edge case: check if executed while being validated.
             if let Some(effects) = state
                 .get_transaction_cache_reader()
-                .try_get_executed_effects(&tx_digest)?
+                .try_get_executed_effects(&tx_digest)
+                .ok()
+                .flatten()
             {
                 return build_executed(effects);
             }
             return Err(Status::from(e));
         }
 
+        // TODO(#11110): return Rejected instead of Err(Status) for consistency.
         // Reconfig check.
         let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
         if !reconfiguration_lock.should_accept_user_certs() {
@@ -223,7 +217,201 @@ impl ValidatorService {
             )
             .map_err(Status::from)?;
 
-        Ok(SubmitTransactionResult::Submitted)
+        Ok(TxStatusUpdate::Submitted)
+    }
+
+    /// Waits for one or more previously submitted transactions to reach
+    /// finality and streams a terminal status per digest (Executed, Rejected,
+    /// or Expired).
+    async fn get_tx_status_impl(
+        &self,
+        request: DomainGetTxStatusRequest,
+    ) -> Result<(ReceiverStream<TxUpdateItem>, Weight), Status> {
+        let state = self.state.clone();
+        let epoch_store = state.load_epoch_store_one_call_per_task();
+
+        fp_ensure!(
+            !state.is_fullnode(&epoch_store),
+            IotaError::FullNodeCantHandleSubmitTransactions.into()
+        );
+
+        fp_ensure!(
+            epoch_store.protocol_config().enable_white_flag_flow(),
+            IotaError::UnsupportedFeature {
+                error: "White flag flow is not enabled in this protocol version".to_string()
+            }
+            .into()
+        );
+
+        // Empty queries is a valid no-op/ping (consistent with V1's
+        // SubmitTransactionsRequest and WaitForEffectsRequest).
+        fp_ensure!(
+            request.queries.len() <= MAX_QUERIES_PER_GET_TX_STATUS,
+            Status::invalid_argument(format!(
+                "too many queries: {} exceeds limit of {MAX_QUERIES_PER_GET_TX_STATUS}",
+                request.queries.len()
+            ))
+        );
+
+        // TODO(#11111): epoch_store is captured once and used for the full 30s wait.
+        // If an epoch change occurs mid-wait, notify_read_dropped_digests
+        // watches the old epoch's cache and the timeout reports a stale epoch.
+        // This matches V1's handle_wait_for_effect_impl behavior. Client retry
+        // after timeout gets a fresh epoch store. Consider listening for epoch
+        // change to return Expired early if cross-epoch awareness is needed.
+        let (tx_sender, rx) = tokio::sync::mpsc::channel(request.queries.len().max(1));
+
+        for query in request.queries {
+            let state = state.clone();
+            let epoch_store = epoch_store.clone();
+            let tx_sender = tx_sender.clone();
+            tokio::spawn(async move {
+                let update = Self::wait_for_tx_finality(
+                    &state,
+                    &epoch_store,
+                    query.transaction_digest,
+                    query.include_details,
+                )
+                .await;
+                let _ = tx_sender.send(Ok((query.transaction_digest, update))).await;
+            });
+        }
+
+        Ok((ReceiverStream::new(rx), Weight::one()))
+    }
+
+    /// Waits for a single transaction to reach finality. Returns immediately
+    /// if already executed, otherwise blocks up to the timeout.
+    async fn wait_for_tx_finality(
+        state: &Arc<AuthorityState>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        tx_digest: TransactionDigest,
+        include_details: bool,
+    ) -> TxStatusUpdate {
+        // Fast path: already executed.
+        let cache = state.get_transaction_cache_reader();
+        match cache.try_get_executed_effects(&tx_digest) {
+            Ok(Some(effects)) => {
+                return Self::build_executed_update(state, effects, include_details);
+            }
+            Err(e) => {
+                tracing::warn!(?tx_digest, "failed to read effects cache: {e}");
+                // Fall through to the wait path.
+            }
+            Ok(None) => {}
+        }
+
+        // Wait for execution, rejection, or timeout.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(GET_TX_STATUS_TIMEOUT_SECS),
+            async {
+                let digests_to_watch = [tx_digest];
+                tokio::select! {
+                    biased;
+                    effects_digests = cache.notify_read_executed_effects_digests(&digests_to_watch) => {
+                        Either::Left(effects_digests)
+                    }
+                    dropped_error = epoch_store.notify_read_dropped_digests(tx_digest) => {
+                        Either::Right(dropped_error)
+                    }
+                }
+            },
+        )
+        .await;
+
+        match result {
+            Ok(Either::Left(effects_digests)) => {
+                let Some(effects_digest) = effects_digests.into_iter().next() else {
+                    tracing::warn!(
+                        ?tx_digest,
+                        "empty effects from notify_read, returning Expired"
+                    );
+                    return TxStatusUpdate::Expired {
+                        epoch: epoch_store.epoch(),
+                    };
+                };
+                let details = if include_details {
+                    match cache.try_get_executed_effects(&tx_digest) {
+                        Ok(Some(effects)) => Some(Self::build_executed_data(state, &effects)),
+                        Ok(None) => {
+                            tracing::warn!(
+                                ?tx_digest,
+                                "effects disappeared between notification and fetch, \
+                                 returning Executed without details"
+                            );
+                            None
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                ?tx_digest,
+                                "failed to read effects: {e}, returning Executed without details"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+                TxStatusUpdate::Executed {
+                    effects_digest,
+                    details,
+                }
+            }
+            Ok(Either::Right(dropped_error)) => TxStatusUpdate::Rejected {
+                error: Some(dropped_error),
+            },
+            Err(_timeout) => TxStatusUpdate::Expired {
+                epoch: epoch_store.epoch(),
+            },
+        }
+    }
+
+    /// Builds a `TxStatusUpdate::Executed` from known effects, optionally
+    /// including full details.
+    fn build_executed_update(
+        state: &Arc<AuthorityState>,
+        effects: TransactionEffects,
+        include_details: bool,
+    ) -> TxStatusUpdate {
+        let effects_digest = effects.digest();
+        let details = if include_details {
+            Some(Self::build_executed_data(state, &effects))
+        } else {
+            None
+        };
+        TxStatusUpdate::Executed {
+            effects_digest,
+            details,
+        }
+    }
+
+    /// Fetches execution details (events, input/output objects) for a
+    /// transaction.
+    fn build_executed_data(
+        state: &Arc<AuthorityState>,
+        effects: &TransactionEffects,
+    ) -> Box<ExecutedData> {
+        let events = if effects.events_digest().is_some() {
+            state
+                .get_transaction_events(effects.transaction_digest())
+                .ok()
+        } else {
+            None
+        };
+        let input_objects = state
+            .get_transaction_input_objects(effects)
+            .ok()
+            .unwrap_or_default();
+        let output_objects = state
+            .get_transaction_output_objects(effects)
+            .ok()
+            .unwrap_or_default();
+        Box::new(ExecutedData {
+            effects: effects.clone(),
+            events,
+            input_objects,
+            output_objects,
+        })
     }
 }
 
@@ -239,12 +427,13 @@ impl ValidatorV2 for ValidatorService {
         self.post_handle_stream(ip, self.submit_tx_impl(req).await)
     }
 
-    type GetTxStatusStream = ReceiverStream<Result<TxStatus, Status>>;
+    type GetTxStatusStream = StreamResponse<TxStatus>;
 
     async fn get_tx_status(
         &self,
-        _request: Request<TxDigest>,
+        request: Request<GetTxStatusRequest>,
     ) -> Result<Response<Self::GetTxStatusStream>, Status> {
-        todo!()
+        let (req, ip) = self.pre_handle(request).await?;
+        self.post_handle_stream(ip, self.get_tx_status_impl(req).await)
     }
 }

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -1,10 +1,8 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_network::{
-    api::{SubmitTxRequest, TxDigest, TxStatus, ValidatorV2},
-    tonic::{Request, Response, Status},
-};
+
+use iota_network::{api::{SubmitTxRequest, TxDigest, TxStatus, ValidatorV2}, tonic::{Request, Response, Status}};
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::authority_server::ValidatorService;

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -1,21 +1,242 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
 
-use iota_network::{api::{SubmitTxRequest, TxDigest, TxStatus, ValidatorV2}, tonic::{Request, Response, Status}};
+use iota_network::{
+    api::{SubmitTxRequest, TxDigest, TxStatus, ValidatorV2},
+    tonic::{Request, Response, Status},
+};
+use iota_types::{
+    digests::TransactionDigest,
+    effects::{TransactionEffects, TransactionEffectsAPI},
+    error::IotaError,
+    fp_ensure,
+    message_envelope::Message,
+    messages_consensus::ConsensusTransaction,
+    messages_grpc::{ExecutedData, SubmitTransactionResult, SubmitTransactionsRequest},
+    traffic_control::Weight,
+    transaction::Transaction,
+};
 use tokio_stream::wrappers::ReceiverStream;
 
-use crate::authority_server::ValidatorService;
+/// Maximum number of transactions allowed in a single `submit_tx` request.
+const MAX_TRANSACTIONS_PER_SUBMIT: usize = 256;
+
+use crate::{
+    authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
+    authority_server::{StreamResponse, ValidatorService, ValidatorServiceMetrics},
+    consensus_adapter::ConsensusAdapter,
+};
+
+impl ValidatorService {
+    async fn submit_tx_impl(
+        &self,
+        request: SubmitTransactionsRequest,
+    ) -> Result<
+        (
+            ReceiverStream<Result<(TransactionDigest, SubmitTransactionResult), Status>>,
+            Weight,
+        ),
+        Status,
+    > {
+        let state = self.state.clone();
+        let epoch_store = state.load_epoch_store_one_call_per_task();
+
+        fp_ensure!(
+            !state.is_fullnode(&epoch_store),
+            IotaError::FullNodeCantHandleSubmitTransactions.into()
+        );
+
+        fp_ensure!(
+            epoch_store.protocol_config().enable_white_flag_flow(),
+            IotaError::UnsupportedFeature {
+                error: "White flag flow is not enabled in this protocol version".to_string()
+            }
+            .into()
+        );
+
+        fp_ensure!(
+            request.transactions.len() <= MAX_TRANSACTIONS_PER_SUBMIT,
+            Status::invalid_argument(format!(
+                "too many transactions: {} exceeds limit of {MAX_TRANSACTIONS_PER_SUBMIT}",
+                request.transactions.len()
+            ))
+        );
+
+        let (tx_sender, rx) = tokio::sync::mpsc::channel(request.transactions.len().max(1));
+        let consensus_adapter = self.consensus_adapter.clone();
+        let metrics = self.metrics.clone();
+
+        // TODO(#11109): cap in-flight work per request (e.g. buffer_unordered(N)).
+        for transaction in request.transactions {
+            let state = state.clone();
+            let epoch_store = epoch_store.clone();
+            let consensus_adapter = consensus_adapter.clone();
+            let metrics = metrics.clone();
+            let tx_sender = tx_sender.clone();
+            tokio::spawn(async move {
+                let tx_digest = *transaction.digest();
+                let result = Self::submit_single_tx(
+                    &state,
+                    &consensus_adapter,
+                    &metrics,
+                    &epoch_store,
+                    transaction,
+                )
+                .await;
+                let item = match result {
+                    Ok(submit_result) => Ok((tx_digest, submit_result)),
+                    Err(status) => Err(status),
+                };
+                // Ignore error: receiver dropped means client disconnected.
+                let _ = tx_sender.send(item).await;
+            });
+        }
+
+        // TODO(#11080): scale traffic weight with batch size.
+        Ok((ReceiverStream::new(rx), Weight::one()))
+    }
+
+    /// Handles submission of a single transaction. Validates, checks for prior
+    /// execution, verifies signature, runs deny checks, and submits to
+    /// consensus.
+    async fn submit_single_tx(
+        state: &Arc<AuthorityState>,
+        consensus_adapter: &Arc<ConsensusAdapter>,
+        metrics: &Arc<ValidatorServiceMetrics>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        transaction: Transaction,
+    ) -> Result<SubmitTransactionResult, Status> {
+        let tx_digest = *transaction.digest();
+
+        let build_executed =
+            |effects: TransactionEffects| -> Result<SubmitTransactionResult, Status> {
+                let effects_digest = effects.digest();
+                let events = if effects.events_digest().is_some() {
+                    state
+                        .get_transaction_events(effects.transaction_digest())
+                        .ok()
+                } else {
+                    None
+                };
+                let input_objects = state.get_transaction_input_objects(&effects).ok();
+                let output_objects = state.get_transaction_output_objects(&effects).ok();
+                Ok(SubmitTransactionResult::Executed {
+                    effects_digest,
+                    details: Box::new(ExecutedData {
+                        effects,
+                        events,
+                        input_objects: input_objects.unwrap_or_default(),
+                        output_objects: output_objects.unwrap_or_default(),
+                    }),
+                })
+            };
+
+        // Check system overload.
+        if let Err(e) = state.check_system_overload(
+            consensus_adapter,
+            transaction.data(),
+            state.check_system_overload_at_signing(),
+        ) {
+            metrics
+                .num_rejected_tx_during_overload
+                .with_label_values(&[e.as_ref()])
+                .inc();
+            return Ok(SubmitTransactionResult::Rejected { error: e });
+        }
+
+        // Validate transaction.
+        if let Err(e) =
+            transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())
+        {
+            return Ok(SubmitTransactionResult::Rejected { error: e });
+        }
+
+        // Check if already executed.
+        // TODO: The `?` here causes an early error return if the cache read fails.
+        // The intent is only to short-circuit when the tx is already executed. A
+        // transient cache error should probably not abort submission — consider using
+        // `.ok().flatten()` so errors are treated as "not found" and the normal flow
+        // continues (consensus handles dedup). The same applies to the second
+        // `try_get_executed_effects` call below. V1 has the same pattern, so verify
+        // the intended semantics for both code paths.
+        if let Some(effects) = state
+            .get_transaction_cache_reader()
+            .try_get_executed_effects(&tx_digest)?
+        {
+            return build_executed(effects);
+        }
+
+        // Verify user signature.
+        let tx_verif_guard = metrics.tx_verification_latency.start_timer();
+        let verified_tx = match epoch_store.verify_transaction(transaction) {
+            Ok(verified) => verified,
+            Err(e) => {
+                metrics.signature_errors.inc();
+                return Ok(SubmitTransactionResult::Rejected { error: e });
+            }
+        };
+        drop(tx_verif_guard);
+
+        // Early bail-out during epoch boundary.
+        if !epoch_store
+            .get_reconfig_state_read_lock_guard()
+            .should_accept_user_certs()
+        {
+            metrics.num_rejected_tx_in_epoch_boundary.inc();
+            return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
+        }
+
+        // Content validation: deny checks + owned object version validation.
+        let owned_objects = state
+            .handle_transaction_validation_checks(&verified_tx, epoch_store)
+            .await
+            .map_err(Status::from)?;
+        if let Err(e) = state
+            .get_cache_writer()
+            .validate_owned_object_versions(&owned_objects)
+        {
+            // Edge case: check if executed while being validated.
+            if let Some(effects) = state
+                .get_transaction_cache_reader()
+                .try_get_executed_effects(&tx_digest)?
+            {
+                return build_executed(effects);
+            }
+            return Err(Status::from(e));
+        }
+
+        // Reconfig check.
+        let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
+        if !reconfiguration_lock.should_accept_user_certs() {
+            metrics.num_rejected_tx_in_epoch_boundary.inc();
+            return Err(IotaError::ValidatorHaltedAtEpochEnd.into());
+        }
+
+        // Submit to consensus.
+        consensus_adapter
+            .submit(
+                ConsensusTransaction::new_user_transaction(verified_tx.into_inner()),
+                Some(&reconfiguration_lock),
+                epoch_store,
+            )
+            .map_err(Status::from)?;
+
+        Ok(SubmitTransactionResult::Submitted)
+    }
+}
 
 #[async_trait::async_trait]
 impl ValidatorV2 for ValidatorService {
-    type SubmitTxStream = ReceiverStream<Result<TxStatus, Status>>;
+    type SubmitTxStream = StreamResponse<TxStatus>;
 
     async fn submit_tx(
         &self,
-        _request: Request<SubmitTxRequest>,
+        request: Request<SubmitTxRequest>,
     ) -> Result<Response<Self::SubmitTxStream>, Status> {
-        todo!()
+        let (req, ip) = self.pre_handle(request).await?;
+        self.post_handle_stream(ip, self.submit_tx_impl(req).await)
     }
 
     type GetTxStatusStream = ReceiverStream<Result<TxStatus, Status>>;

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -56,6 +56,7 @@ impl IotaTxValidator {
         let mut ckpt_messages = Vec::new();
         let mut ckpt_batch = Vec::new();
         let mut authority_cap_batch = Vec::new();
+        let mut user_tx_v1_count: u64 = 0;
 
         for tx in txs.iter() {
             match tx {
@@ -111,6 +112,7 @@ impl IotaTxValidator {
                         .tap_err(|e| {
                             warn!("UserTransactionV1 signature verification failed: {}", e)
                         })?;
+                    user_tx_v1_count += 1;
                 }
 
                 ConsensusTransactionKind::EndOfPublish(_)
@@ -145,6 +147,9 @@ impl IotaTxValidator {
         self.metrics
             .authority_capabilities_verified
             .inc_by(authority_cap_count as u64);
+        self.metrics
+            .user_transaction_signatures_verified
+            .inc_by(user_tx_v1_count);
         Ok(())
 
         // todo - we should un-comment line below once we have a way to revert
@@ -209,6 +214,7 @@ pub struct IotaTxValidatorMetrics {
     certificate_signatures_verified: IntCounter,
     checkpoint_signatures_verified: IntCounter,
     authority_capabilities_verified: IntCounter,
+    user_transaction_signatures_verified: IntCounter,
 }
 
 impl IotaTxValidatorMetrics {
@@ -229,6 +235,12 @@ impl IotaTxValidatorMetrics {
             authority_capabilities_verified: register_int_counter_with_registry!(
                 "authority_capabilities_verified",
                 "Number of signed authority capabilities verified in consensus batch verifier",
+                registry
+            )
+            .unwrap(),
+            user_transaction_signatures_verified: register_int_counter_with_registry!(
+                "user_transaction_signatures_verified",
+                "Number of UserTransactionV1 signatures verified in consensus validator",
                 registry
             )
             .unwrap(),

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::traits::KeyPair;
+use iota_network::api::{GetCheckpointRequest, ValidatorPeer};
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope::AuthorityCapabilities};
 use iota_types::{
@@ -11,6 +12,7 @@ use iota_types::{
         AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature, get_authority_key_pair,
     },
     error::IotaError,
+    messages_checkpoint::CheckpointResponse,
     messages_consensus::{AuthorityCapabilitiesV1, SignedAuthorityCapabilitiesV1},
     messages_grpc::{
         LayoutGenerationOption, RawSubmitTransactionsRequest, RawSubmitTransactionsResponse,
@@ -940,6 +942,61 @@ async fn test_submit_transactions_different_gas_prices_accepted() {
             other => panic!("Expected Submitted for tx {i}, got {:?}", other),
         }
     }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_get_checkpoint_happy_path() {
+    telemetry_subscribers::init_for_testing();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .insert_genesis_checkpoint()
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state,
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    // Request the genesis checkpoint (sequence 0, certified).
+    let proto_request = GetCheckpointRequest {
+        sequence_number: Some(0),
+        request_content: true,
+        certified: true,
+    };
+
+    let response = validator_service
+        .get_checkpoint(make_tonic_request_for_testing(proto_request))
+        .await
+        .expect("get_checkpoint should succeed for genesis checkpoint");
+
+    let proto_resp = response.into_inner();
+
+    // The genesis checkpoint must be present.
+    assert!(
+        proto_resp.checkpoint.is_some(),
+        "Expected checkpoint data in response"
+    );
+
+    // Verify the proto response can be converted back to the domain type.
+    let native: CheckpointResponse = proto_resp
+        .try_into()
+        .expect("proto → native conversion should succeed");
+    assert!(native.checkpoint.is_some());
+    assert!(native.contents.is_some());
 }
 
 /// A transaction whose serialized size exceeds `max_tx_size_bytes` (128 KiB)

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::traits::KeyPair;
-use iota_network::api::{GetCheckpointRequest, ValidatorPeer};
+use iota_network::api::{GetCheckpointRequest, SubmitTxRequest, ValidatorPeer, ValidatorV2};
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope::AuthorityCapabilities};
 use iota_types::{
@@ -33,6 +33,7 @@ use iota_types::{
     utils::to_sender_signed_transaction,
 };
 use move_core_types::ident_str;
+use tokio_stream::StreamExt;
 
 use super::*;
 use crate::{
@@ -1072,5 +1073,748 @@ async fn test_submit_oversized_transaction() {
         matches!(&results[0], SubmitTransactionResult::Rejected { .. }),
         "Expected Rejected for oversized transaction, got {:?}",
         results[0]
+    );
+}
+
+// ── ValidatorV2 submit_tx (streaming) tests ──────────────────────────────────
+
+/// Helper: convert a native `SubmitTransactionsRequest` into the proto
+/// `SubmitTxRequest` and wrap it in a tonic request.
+fn make_v2_submit_request(request: SubmitTransactionsRequest) -> tonic::Request<SubmitTxRequest> {
+    let proto: SubmitTxRequest = request.try_into().expect("BCS serialization failed");
+    make_tonic_request_for_testing(proto)
+}
+
+/// Result from collecting a V2 stream item: either a successfully decoded
+/// status or a raw `tonic::Status` error.
+enum V2StreamItem {
+    Ok(
+        iota_types::digests::TransactionDigest,
+        SubmitTransactionResult,
+    ),
+    Err(tonic::Status),
+}
+
+/// Collect all items from a V2 streaming response.
+async fn collect_v2_stream_raw(
+    response: tonic::Response<crate::authority_server::StreamResponse<iota_network::api::TxStatus>>,
+) -> Vec<V2StreamItem> {
+    use iota_network::api::status_detail::Kind;
+    let mut stream = response.into_inner();
+    let mut results = Vec::new();
+    while let Some(item) = stream.next().await {
+        match item {
+            Err(status) => results.push(V2StreamItem::Err(status)),
+            Ok(status) => {
+                let digest: iota_types::digests::TransactionDigest = status
+                    .tx_digest
+                    .expect("tx_digest present")
+                    .try_into()
+                    .expect("digest conversion");
+                let detail = status.status.expect("status present");
+                let native_result = match detail.kind.expect("kind present") {
+                    Kind::Submitted(_) => SubmitTransactionResult::Submitted,
+                    Kind::Executed(exec) => {
+                        let effects_digest = bcs::from_bytes(&exec.effects_digest)
+                            .expect("effects_digest deserialization");
+                        let details = exec
+                            .details
+                            .map(|d| bcs::from_bytes(&d).expect("details deserialization"))
+                            .expect("details present");
+                        SubmitTransactionResult::Executed {
+                            effects_digest,
+                            details: Box::new(details),
+                        }
+                    }
+                    Kind::Rejected(rej) => {
+                        let error: IotaError =
+                            bcs::from_bytes(rej.error.as_deref().expect("error field present"))
+                                .expect("error deserialization");
+                        SubmitTransactionResult::Rejected { error }
+                    }
+                    Kind::Expired(_) => panic!("unexpected Expired status"),
+                };
+                results.push(V2StreamItem::Ok(digest, native_result));
+            }
+        }
+    }
+    results
+}
+
+/// Convenience wrapper: collect all items and panic on stream-level errors.
+async fn collect_v2_stream(
+    response: tonic::Response<crate::authority_server::StreamResponse<iota_network::api::TxStatus>>,
+) -> Vec<(
+    iota_types::digests::TransactionDigest,
+    SubmitTransactionResult,
+)> {
+    collect_v2_stream_raw(response)
+        .await
+        .into_iter()
+        .map(|item| match item {
+            V2StreamItem::Ok(digest, result) => (digest, result),
+            V2StreamItem::Err(status) => panic!("unexpected stream error: {status}"),
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_success() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let recipient = dbg_addr(2);
+
+    let tx_data = TransactionData::new_transfer(
+        recipient,
+        object.compute_object_reference(),
+        sender,
+        gas.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+    let expected_digest = *tx.digest();
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(
+            SubmitTransactionsRequest::new_transaction(tx),
+        ))
+        .await
+        .expect("submit_tx should succeed");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    let (digest, result) = &results[0];
+    assert_eq!(*digest, expected_digest);
+    assert!(
+        matches!(result, SubmitTransactionResult::Submitted),
+        "Expected Submitted, got {:?}",
+        result
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_invalid_signature() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, _sender_key): (_, AccountKeyPair) = get_key_pair();
+    let (_wrong_sender, wrong_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let recipient = dbg_addr(2);
+
+    let tx_data = TransactionData::new_transfer(
+        recipient,
+        object.compute_object_reference(),
+        sender,
+        gas.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &wrong_key);
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(
+            SubmitTransactionsRequest::new_transaction(tx),
+        ))
+        .await
+        .expect("submit_tx stream should open successfully");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    match &results[0].1 {
+        SubmitTransactionResult::Rejected { error } => {
+            let msg = format!("{:?}", error).to_lowercase();
+            assert!(
+                msg.contains("signature"),
+                "Error should mention signature, got: {msg}",
+            );
+        }
+        other => panic!("Expected Rejected, got {:?}", other),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_feature_flag_disabled() {
+    telemetry_subscribers::init_for_testing();
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let recipient = dbg_addr(2);
+
+    let tx_data = TransactionData::new_transfer(
+        recipient,
+        object.compute_object_reference(),
+        sender,
+        gas.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+
+    let result = validator_service
+        .submit_tx(make_v2_submit_request(
+            SubmitTransactionsRequest::new_transaction(tx),
+        ))
+        .await;
+
+    match result {
+        Err(err) => assert!(
+            err.message()
+                .contains("White flag flow is not enabled in this protocol version"),
+        ),
+        Ok(_) => panic!("Expected error when white flag is disabled"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_already_executed() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+
+    let tx_data = TransactionData::new_transfer(
+        dbg_addr(2),
+        object.compute_object_reference(),
+        sender,
+        gas.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+
+    // Execute the transaction first.
+    let cert = init_certified_transaction(tx.clone(), &authority_state);
+    let (effects, _) = authority_state.execute_for_test(&cert);
+
+    // Re-submit via V2 streaming endpoint.
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(
+            SubmitTransactionsRequest::new_transaction(tx),
+        ))
+        .await
+        .expect("submit_tx should succeed");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    match &results[0].1 {
+        SubmitTransactionResult::Executed { effects_digest, .. } => {
+            assert_eq!(effects_digest, effects.digest());
+        }
+        other => panic!("Expected Executed, got {:?}", other),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_multiple_transactions() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_id1 = ObjectID::random();
+    let gas_id2 = ObjectID::random();
+
+    let (authority_state, pkg_ref) =
+        init_state_with_ids_and_object_basics(vec![(sender, gas_id1), (sender, gas_id2)]).await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let tx1 =
+        build_shared_object_transaction(&authority_state, sender, &sender_key, gas_id1, pkg_ref)
+            .await;
+    let tx2 =
+        build_shared_object_transaction(&authority_state, sender, &sender_key, gas_id2, pkg_ref)
+            .await;
+
+    let request = SubmitTransactionsRequest {
+        transactions: vec![tx1, tx2],
+    };
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(request))
+        .await
+        .expect("submit_tx should succeed");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 2, "Expected one result per transaction");
+    for (i, (_digest, result)) in results.iter().enumerate() {
+        assert!(
+            matches!(result, SubmitTransactionResult::Submitted),
+            "Expected Submitted for tx {i}, got {:?}",
+            result
+        );
+    }
+}
+
+/// V2 mirror of `test_submit_transaction_invalid_transaction`: a PTB with an
+/// empty `SplitCoins` args list is structurally invalid and fails
+/// `validity_check`, producing a `Rejected` stream item.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_invalid_transaction() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[Object::with_id_owner_for_testing(gas_id, sender)])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+
+    let pt = ProgrammableTransaction {
+        inputs: vec![],
+        commands: vec![Command::SplitCoins(
+            iota_types::transaction::Argument::GasCoin,
+            vec![], // empty — invalid
+        )],
+    };
+    let tx_data = TransactionData::new_programmable(
+        sender,
+        vec![gas.compute_object_reference()],
+        pt,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(
+            SubmitTransactionsRequest::new_transaction(tx),
+        ))
+        .await
+        .expect("stream should open successfully");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    assert!(
+        matches!(&results[0].1, SubmitTransactionResult::Rejected { .. }),
+        "Expected Rejected for invalid transaction, got {:?}",
+        results[0].1
+    );
+}
+
+/// V2 mirror of `test_submit_transaction_gas_object_validation`: a transaction
+/// referencing a non-existent gas object fails during validation checks.
+/// In V2, per-transaction errors from `handle_transaction_validation_checks`
+/// are surfaced as stream-level `Err` items (tonic::Status).
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_gas_object_validation() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[Object::with_id_owner_for_testing(object_id, sender)])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+
+    let tx_data = TransactionData::new_transfer(
+        dbg_addr(2),
+        object.compute_object_reference(),
+        sender,
+        random_object_ref(), // non-existent gas object
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(
+            SubmitTransactionsRequest::new_transaction(tx),
+        ))
+        .await
+        .expect("stream should open successfully");
+
+    // In V2, validation errors from spawned tasks surface as stream-level errors.
+    let items = collect_v2_stream_raw(response).await;
+    assert_eq!(items.len(), 1);
+    // The non-existent gas object may surface as either a Rejected status or a
+    // stream-level error depending on which validation step catches it.
+    match &items[0] {
+        V2StreamItem::Ok(_, SubmitTransactionResult::Rejected { .. }) => {}
+        V2StreamItem::Err(_) => {}
+        other => panic!(
+            "Expected Rejected or stream error for non-existent gas, got {:?}",
+            match other {
+                V2StreamItem::Ok(_, r) => format!("Ok({:?})", r),
+                V2StreamItem::Err(s) => format!("Err({:?})", s),
+            }
+        ),
+    }
+}
+
+/// V2 mirror of `test_submit_transactions_different_gas_prices_accepted`:
+/// transactions with different gas prices are processed independently in
+/// white-flag mode.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_different_gas_prices_accepted() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_id1 = ObjectID::random();
+    let gas_id2 = ObjectID::random();
+
+    let (authority_state, pkg_ref) =
+        init_state_with_ids_and_object_basics(vec![(sender, gas_id1), (sender, gas_id2)]).await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let gas1 = authority_state.get_object(&gas_id1).await.unwrap();
+    let gas2 = authority_state.get_object(&gas_id2).await.unwrap();
+
+    let tx_data1 = TransactionData::new_move_call(
+        sender,
+        pkg_ref.0,
+        ident_str!("object_basics").to_owned(),
+        ident_str!("use_clock").to_owned(),
+        vec![],
+        gas1.compute_object_reference(),
+        vec![CallArg::CLOCK_IMM],
+        TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
+        rgp, // base price
+    )
+    .unwrap();
+    let tx1 = to_sender_signed_transaction(tx_data1, &sender_key);
+
+    let tx_data2 = TransactionData::new_move_call(
+        sender,
+        pkg_ref.0,
+        ident_str!("object_basics").to_owned(),
+        ident_str!("use_clock").to_owned(),
+        vec![],
+        gas2.compute_object_reference(),
+        vec![CallArg::CLOCK_IMM],
+        TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp * 2,
+        rgp * 2, // different price
+    )
+    .unwrap();
+    let tx2 = to_sender_signed_transaction(tx_data2, &sender_key);
+
+    let request = SubmitTransactionsRequest {
+        transactions: vec![tx1, tx2],
+    };
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(request))
+        .await
+        .expect("submit_tx should succeed");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 2, "Expected one result per transaction");
+    for (i, (_digest, result)) in results.iter().enumerate() {
+        assert!(
+            matches!(result, SubmitTransactionResult::Submitted),
+            "Expected Submitted for tx {i}, got {:?}",
+            result
+        );
+    }
+}
+
+/// V2 mirror of `test_submit_oversized_transaction`: a transaction exceeding
+/// `max_tx_size_bytes` (128 KiB) is rejected by `validity_check`.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_oversized_transaction() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[Object::with_id_owner_for_testing(gas_id, sender)])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+
+    // Build a PTB whose inputs alone total ~140 KiB > max_tx_size_bytes (128 KiB).
+    let inputs: Vec<_> = (0u8..10)
+        .map(|i| CallArg::Pure(vec![i; 14 * 1024]))
+        .collect();
+    let pt = ProgrammableTransaction {
+        inputs,
+        commands: vec![],
+    };
+    let tx_data = TransactionData::new_programmable(
+        sender,
+        vec![gas.compute_object_reference()],
+        pt,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(
+            SubmitTransactionsRequest::new_transaction(tx),
+        ))
+        .await
+        .expect("stream should open successfully");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    assert!(
+        matches!(&results[0].1, SubmitTransactionResult::Rejected { .. }),
+        "Expected Rejected for oversized transaction, got {:?}",
+        results[0].1
     );
 }

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::traits::KeyPair;
-use iota_network::api::{GetCheckpointRequest, SubmitTxRequest, ValidatorPeer, ValidatorV2};
+use iota_network::api::{
+    GetCheckpointRequest, GetTxStatusRequest, SubmitTxRequest, TxStatusQuery, ValidatorPeer,
+    ValidatorV2,
+};
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope::AuthorityCapabilities};
 use iota_types::{
@@ -24,7 +27,7 @@ use iota_types::{
 use iota_types::{
     base_types::{IotaAddress, ObjectID, random_object_ref},
     crypto::{AccountKeyPair, get_key_pair},
-    messages_grpc::SubmitTransactionResult,
+    messages_grpc::{SubmitTransactionResult, TxStatusUpdate},
     object::Object,
     transaction::{
         CallArg, Command, ProgrammableTransaction, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
@@ -1816,5 +1819,519 @@ async fn test_v2_submit_tx_oversized_transaction() {
         matches!(&results[0].1, SubmitTransactionResult::Rejected { .. }),
         "Expected Rejected for oversized transaction, got {:?}",
         results[0].1
+    );
+}
+
+// ── ValidatorV2 get_tx_status (streaming) tests ──────────────────────────────
+
+/// Helper: build a proto `GetTxStatusRequest` from digest/include_details
+/// pairs.
+fn make_v2_get_tx_status_request(
+    queries: Vec<(iota_types::digests::TransactionDigest, bool)>,
+) -> tonic::Request<GetTxStatusRequest> {
+    let proto = GetTxStatusRequest {
+        queries: queries
+            .into_iter()
+            .map(|(digest, include_details)| {
+                let tx_digest: iota_network::api::TxDigest = digest.try_into().unwrap();
+                TxStatusQuery {
+                    tx_digest: Some(tx_digest),
+                    include_details,
+                }
+            })
+            .collect(),
+    };
+    make_tonic_request_for_testing(proto)
+}
+
+/// Collect all items from a get_tx_status streaming response into
+/// `(TransactionDigest, TxStatusUpdate)` pairs.
+async fn collect_v2_status_stream(
+    response: tonic::Response<crate::authority_server::StreamResponse<iota_network::api::TxStatus>>,
+) -> Vec<(iota_types::digests::TransactionDigest, TxStatusUpdate)> {
+    use iota_network::api::status_detail::Kind;
+    let mut stream = response.into_inner();
+    let mut results = Vec::new();
+    while let Some(item) = stream.next().await {
+        let status = item.expect("stream item should be Ok");
+        let digest: iota_types::digests::TransactionDigest = status
+            .tx_digest
+            .expect("tx_digest present")
+            .try_into()
+            .expect("digest conversion");
+        let detail = status.status.expect("status present");
+        let update = match detail.kind.expect("kind present") {
+            Kind::Submitted(_) => TxStatusUpdate::Submitted,
+            Kind::Executed(exec) => {
+                let effects_digest =
+                    bcs::from_bytes(&exec.effects_digest).expect("effects_digest deserialization");
+                let details = exec
+                    .details
+                    .map(|d| Box::new(bcs::from_bytes(&d).expect("details deserialization")));
+                TxStatusUpdate::Executed {
+                    effects_digest,
+                    details,
+                }
+            }
+            Kind::Rejected(rej) => {
+                let error = rej
+                    .error
+                    .as_deref()
+                    .map(|e| bcs::from_bytes(e).expect("error deserialization"));
+                TxStatusUpdate::Rejected { error }
+            }
+            Kind::Expired(exp) => TxStatusUpdate::Expired { epoch: exp.epoch },
+        };
+        results.push((digest, update));
+    }
+    results
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_already_executed() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+
+    let tx_data = TransactionData::new_transfer(
+        dbg_addr(2),
+        object.compute_object_reference(),
+        sender,
+        gas.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+    let tx_digest = *tx.digest();
+
+    // Execute the transaction first.
+    let cert = init_certified_transaction(tx, &authority_state);
+    let (effects, _) = authority_state.execute_for_test(&cert);
+
+    // Query status — should return Executed immediately.
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![(tx_digest, false)]))
+        .await
+        .expect("get_tx_status should succeed");
+
+    let results = collect_v2_status_stream(response).await;
+    assert_eq!(results.len(), 1);
+    let (digest, update) = &results[0];
+    assert_eq!(*digest, tx_digest);
+    match update {
+        TxStatusUpdate::Executed {
+            effects_digest,
+            details,
+        } => {
+            assert_eq!(effects_digest, effects.digest());
+            assert!(
+                details.is_none(),
+                "details should be None when not requested"
+            );
+        }
+        other => panic!("Expected Executed, got {:?}", other),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_already_executed_with_details() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+
+    let tx_data = TransactionData::new_transfer(
+        dbg_addr(2),
+        object.compute_object_reference(),
+        sender,
+        gas.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+    let tx_digest = *tx.digest();
+
+    // Execute first.
+    let cert = init_certified_transaction(tx, &authority_state);
+    authority_state.execute_for_test(&cert);
+
+    // Query with include_details = true.
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![(tx_digest, true)]))
+        .await
+        .expect("get_tx_status should succeed");
+
+    let results = collect_v2_status_stream(response).await;
+    assert_eq!(results.len(), 1);
+    match &results[0].1 {
+        TxStatusUpdate::Executed { details, .. } => {
+            assert!(
+                details.is_some(),
+                "details should be present when requested"
+            );
+        }
+        other => panic!("Expected Executed, got {:?}", other),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_multiple_queries() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id1 = ObjectID::random();
+    let gas_id1 = ObjectID::random();
+    let object_id2 = ObjectID::random();
+    let gas_id2 = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id1, sender),
+            Object::with_id_owner_for_testing(gas_id1, sender),
+            Object::with_id_owner_for_testing(object_id2, sender),
+            Object::with_id_owner_for_testing(gas_id2, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let obj1 = authority_state.get_object(&object_id1).await.unwrap();
+    let gas1 = authority_state.get_object(&gas_id1).await.unwrap();
+    let obj2 = authority_state.get_object(&object_id2).await.unwrap();
+    let gas2 = authority_state.get_object(&gas_id2).await.unwrap();
+
+    // Build and execute two transactions.
+    let tx1 = to_sender_signed_transaction(
+        TransactionData::new_transfer(
+            dbg_addr(2),
+            obj1.compute_object_reference(),
+            sender,
+            gas1.compute_object_reference(),
+            rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+            rgp,
+        ),
+        &sender_key,
+    );
+    let tx2 = to_sender_signed_transaction(
+        TransactionData::new_transfer(
+            dbg_addr(3),
+            obj2.compute_object_reference(),
+            sender,
+            gas2.compute_object_reference(),
+            rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+            rgp,
+        ),
+        &sender_key,
+    );
+    let digest1 = *tx1.digest();
+    let digest2 = *tx2.digest();
+
+    let cert1 = init_certified_transaction(tx1, &authority_state);
+    let cert2 = init_certified_transaction(tx2, &authority_state);
+    authority_state.execute_for_test(&cert1);
+    authority_state.execute_for_test(&cert2);
+
+    // Query both with different include_details settings.
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![
+            (digest1, true),
+            (digest2, false),
+        ]))
+        .await
+        .expect("get_tx_status should succeed");
+
+    let results = collect_v2_status_stream(response).await;
+    assert_eq!(results.len(), 2);
+
+    // Results may arrive in any order due to concurrent spawns.
+    for (digest, update) in &results {
+        match update {
+            TxStatusUpdate::Executed { details, .. } => {
+                if *digest == digest1 {
+                    assert!(details.is_some(), "digest1 requested details");
+                } else {
+                    assert!(details.is_none(), "digest2 did not request details");
+                }
+            }
+            other => panic!("Expected Executed, got {:?}", other),
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_too_many_queries() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state,
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    // Build 257 queries (exceeds MAX_QUERIES_PER_GET_TX_STATUS = 256).
+    let queries: Vec<_> = (0..257)
+        .map(|_| (iota_types::digests::TransactionDigest::random(), false))
+        .collect();
+
+    let result = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(queries))
+        .await;
+
+    match result {
+        Err(status) => assert_eq!(status.code(), tonic::Code::InvalidArgument),
+        Ok(_) => panic!("should reject oversized request"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_empty_queries_ping() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state,
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![]))
+        .await
+        .expect("empty request should succeed (ping)");
+
+    let results = collect_v2_status_stream(response).await;
+    assert!(results.is_empty(), "ping should return empty stream");
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_dropped_digest_rejected() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let dropped_digest = iota_types::digests::TransactionDigest::random();
+    let dropped_error = IotaError::TransactionExpired;
+
+    // Simulate white-flag dropping the transaction.
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
+    epoch_store.insert_dropped_digests_for_testing(&[(dropped_digest, dropped_error.clone())]);
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state,
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![(dropped_digest, false)]))
+        .await
+        .expect("get_tx_status should succeed");
+
+    let results = collect_v2_status_stream(response).await;
+    assert_eq!(results.len(), 1);
+    let (digest, update) = &results[0];
+    assert_eq!(*digest, dropped_digest);
+    assert!(
+        matches!(update, TxStatusUpdate::Rejected { error: Some(_) }),
+        "Expected Rejected for dropped digest, got {:?}",
+        update
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_unknown_digest_expires() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state,
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let unknown_digest = iota_types::digests::TransactionDigest::random();
+
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![(unknown_digest, false)]))
+        .await
+        .expect("get_tx_status should succeed");
+
+    // With paused time, the 30s timeout fires immediately.
+    let results = collect_v2_status_stream(response).await;
+    assert_eq!(results.len(), 1);
+    let (digest, update) = &results[0];
+    assert_eq!(*digest, unknown_digest);
+    assert!(
+        matches!(update, TxStatusUpdate::Expired { .. }),
+        "Expected Expired for unknown digest, got {:?}",
+        update
     );
 }

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -4,8 +4,8 @@
 
 use fastcrypto::traits::KeyPair;
 use iota_network::api::{
-    GetCheckpointRequest, GetTxStatusRequest, SubmitTxRequest, TxStatusQuery, ValidatorPeer,
-    ValidatorV2,
+    GetCheckpointRequest, GetTxStatusRequest, NotifyCapabilitiesRequest, SubmitTxRequest,
+    TxStatusQuery, ValidatorPeer, ValidatorV2,
 };
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope::AuthorityCapabilities};
@@ -2333,5 +2333,169 @@ async fn test_v2_get_tx_status_unknown_digest_expires() {
         matches!(update, TxStatusUpdate::Expired { .. }),
         "Expected Expired for unknown digest, got {:?}",
         update
+    );
+}
+
+// ── ValidatorV2 notify_capabilities tests
+// ─────────────────────────────────────
+
+/// Helper: build a proto `NotifyCapabilitiesRequest` from a domain request.
+fn make_v2_notify_capabilities_request(
+    domain: HandleCapabilityNotificationRequestV1,
+) -> tonic::Request<NotifyCapabilitiesRequest> {
+    let proto: NotifyCapabilitiesRequest = domain.try_into().unwrap();
+    make_tonic_request_for_testing(proto)
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_notify_capabilities_reject_unauthorized() {
+    telemetry_subscribers::init_for_testing();
+
+    let (_sender, sender_key): (_, AuthorityKeyPair) = get_authority_key_pair();
+
+    let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+    protocol_config.set_select_committee_from_eligible_validators_for_testing(true);
+    protocol_config.set_track_non_committee_eligible_validators_for_testing(true);
+    protocol_config.set_select_committee_supporting_next_epoch_version(true);
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config)
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    // Request from an unknown authority — should be rejected.
+    let capabilities = AuthorityCapabilitiesV1::new(
+        AuthorityName::new(sender_key.public().pubkey.to_bytes()),
+        Chain::Mainnet,
+        SupportedProtocolVersions::new_for_testing(1, 10),
+        vec![],
+    );
+    let signature = AuthoritySignature::new_secure(
+        &IntentMessage::new(Intent::iota_app(AuthorityCapabilities), &capabilities),
+        &authority_state.current_epoch_for_testing(),
+        &sender_key,
+    );
+    let request1 = HandleCapabilityNotificationRequestV1 {
+        message: SignedAuthorityCapabilitiesV1::new_from_data_and_sig(capabilities, signature),
+    };
+
+    assert!(
+        validator_service
+            .notify_capabilities(make_v2_notify_capabilities_request(request1))
+            .await
+            .is_err(),
+        "Expected capability notification from unauthorized authority to be rejected"
+    );
+
+    // Request from the committee member itself — also rejected.
+    let authority_capabilities = AuthorityCapabilitiesV1::new(
+        authority_state.name,
+        Chain::Mainnet,
+        SupportedProtocolVersions::new_for_testing(1, 10),
+        vec![],
+    );
+    let authority_signature = AuthoritySignature::new_secure(
+        &IntentMessage::new(
+            Intent::iota_app(AuthorityCapabilities),
+            &authority_capabilities,
+        ),
+        &authority_state.current_epoch_for_testing(),
+        &*authority_state.secret,
+    );
+    let request2 = HandleCapabilityNotificationRequestV1 {
+        message: SignedAuthorityCapabilitiesV1::new_from_data_and_sig(
+            authority_capabilities,
+            authority_signature,
+        ),
+    };
+
+    assert!(
+        validator_service
+            .notify_capabilities(make_v2_notify_capabilities_request(request2))
+            .await
+            .is_err(),
+        "Expected capability notification from committee member to be rejected"
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_notify_capabilities_feature_disabled() {
+    telemetry_subscribers::init_for_testing();
+
+    let (_sender, sender_key): (_, AuthorityKeyPair) = get_authority_key_pair();
+
+    let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+    protocol_config.set_select_committee_from_eligible_validators_for_testing(false);
+    protocol_config.set_track_non_committee_eligible_validators_for_testing(false);
+    protocol_config.set_select_committee_supporting_next_epoch_version(false);
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config)
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let capabilities = AuthorityCapabilitiesV1::new(
+        AuthorityName::new(sender_key.public().pubkey.to_bytes()),
+        Chain::Mainnet,
+        SupportedProtocolVersions::new_for_testing(1, 10),
+        vec![],
+    );
+    let signature = AuthoritySignature::new_secure(
+        &IntentMessage::new(Intent::iota_app(AuthorityCapabilities), &capabilities),
+        &authority_state.current_epoch_for_testing(),
+        &sender_key,
+    );
+    let request = HandleCapabilityNotificationRequestV1 {
+        message: SignedAuthorityCapabilitiesV1::new_from_data_and_sig(capabilities, signature),
+    };
+
+    let result = validator_service
+        .notify_capabilities(make_v2_notify_capabilities_request(request))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Expected capability notification to be rejected due to feature being disabled"
+    );
+    let err_kind = IotaError::from(result.unwrap_err());
+    assert!(
+        matches!(err_kind, IotaError::UnsupportedFeature { .. }),
+        "Expected UnsupportedFeature error, but got {err_kind:?}",
     );
 }

--- a/crates/iota-network/proto/validator_v2.proto
+++ b/crates/iota-network/proto/validator_v2.proto
@@ -9,7 +9,7 @@ service ValidatorV2 {
   rpc SubmitTx(SubmitTxRequest) returns (stream TxStatus);
 
   // Stream status updates for a previously submitted transaction
-  rpc GetTxStatus(TxDigest) returns (stream TxStatus);
+  rpc GetTxStatus(GetTxStatusRequest) returns (stream TxStatus);
 }
 
 // Wraps one or more transactions (BCS-encoded payloads)
@@ -20,6 +20,20 @@ message SubmitTxRequest {
 // Digest identifying a transaction
 message TxDigest {
   bytes digest = 1;
+}
+
+// Request to query the finality status of one or more previously submitted
+// transactions. Streams one TxStatus per query.
+message GetTxStatusRequest {
+  repeated TxStatusQuery queries = 1;
+}
+
+// A single transaction status query.
+message TxStatusQuery {
+  TxDigest tx_digest = 1;
+  // When true, execution details (effects, events, objects) are included
+  // in the ExecutedStatus response for this transaction.
+  bool include_details = 2;
 }
 
 // Status update streamed back to the client

--- a/crates/iota-network/proto/validator_v2.proto
+++ b/crates/iota-network/proto/validator_v2.proto
@@ -10,6 +10,10 @@ service ValidatorV2 {
 
   // Stream status updates for a previously submitted transaction
   rpc GetTxStatus(GetTxStatusRequest) returns (stream TxStatus);
+
+  // Submit a signed capability notification from a non-committee validator.
+  rpc NotifyCapabilities(NotifyCapabilitiesRequest)
+      returns (NotifyCapabilitiesResponse);
 }
 
 // Wraps one or more transactions (BCS-encoded payloads)
@@ -74,3 +78,10 @@ message RejectedStatus {
 message ExpiredStatus {
   uint64 epoch = 1;
 }
+
+message NotifyCapabilitiesRequest {
+  // BCS-serialized SignedAuthorityCapabilitiesV1.
+  bytes capabilities = 1;
+}
+
+message NotifyCapabilitiesResponse {}

--- a/crates/iota-network/src/api.rs
+++ b/crates/iota-network/src/api.rs
@@ -16,8 +16,8 @@ mod validator_v2 {
 }
 
 pub use validator_v2::{
-    ExecutedStatus, ExpiredStatus, RejectedStatus, StatusDetail, SubmitTxRequest, SubmittedStatus,
-    TxDigest, TxStatus, status_detail,
+    ExecutedStatus, ExpiredStatus, GetTxStatusRequest, RejectedStatus, StatusDetail,
+    SubmitTxRequest, SubmittedStatus, TxDigest, TxStatus, TxStatusQuery, status_detail,
     validator_v2_client::ValidatorV2Client,
     validator_v2_server::{ValidatorV2, ValidatorV2Server},
 };

--- a/crates/iota-network/src/api.rs
+++ b/crates/iota-network/src/api.rs
@@ -16,8 +16,9 @@ mod validator_v2 {
 }
 
 pub use validator_v2::{
-    ExecutedStatus, ExpiredStatus, GetTxStatusRequest, RejectedStatus, StatusDetail,
-    SubmitTxRequest, SubmittedStatus, TxDigest, TxStatus, TxStatusQuery, status_detail,
+    ExecutedStatus, ExpiredStatus, GetTxStatusRequest, NotifyCapabilitiesRequest,
+    NotifyCapabilitiesResponse, RejectedStatus, StatusDetail, SubmitTxRequest, SubmittedStatus,
+    TxDigest, TxStatus, TxStatusQuery, status_detail,
     validator_v2_client::ValidatorV2Client,
     validator_v2_server::{ValidatorV2, ValidatorV2Server},
 };

--- a/crates/iota-network/src/convert/validator_v2.rs
+++ b/crates/iota-network/src/convert/validator_v2.rs
@@ -6,7 +6,10 @@
 use iota_types::{
     digests::TransactionDigest,
     error::IotaError,
-    messages_grpc::{ExecutedData, SubmitTransactionResult, WaitForEffectResponse},
+    messages_grpc::{
+        ExecutedData, SubmitTransactionResult, SubmitTransactionsRequest, WaitForEffectResponse,
+    },
+    transaction::Transaction,
 };
 
 use super::{bcs_deserialize, bcs_serialize};
@@ -174,6 +177,49 @@ impl TryFrom<StatusDetail> for WaitForEffectResponse {
             }
             Kind::Expired(e) => Ok(WaitForEffectResponse::Expired { epoch: e.epoch }),
         }
+    }
+}
+
+// --- SubmitTxRequest ↔ SubmitTransactionsRequest ---
+
+impl TryFrom<api::SubmitTxRequest> for SubmitTransactionsRequest {
+    type Error = IotaError;
+
+    fn try_from(value: api::SubmitTxRequest) -> Result<Self, Self::Error> {
+        let transactions = value
+            .tx
+            .iter()
+            .map(|t| bcs_deserialize::<Transaction>(t, "SubmitTxRequest.tx"))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(SubmitTransactionsRequest { transactions })
+    }
+}
+
+impl TryFrom<SubmitTransactionsRequest> for api::SubmitTxRequest {
+    type Error = IotaError;
+
+    fn try_from(value: SubmitTransactionsRequest) -> Result<Self, Self::Error> {
+        let tx = value
+            .transactions
+            .iter()
+            .map(|t| bcs_serialize(t, "SubmitTxRequest.tx"))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(api::SubmitTxRequest { tx })
+    }
+}
+
+// --- TxStatus ← (TransactionDigest, SubmitTransactionResult) ---
+
+impl TryFrom<(TransactionDigest, SubmitTransactionResult)> for api::TxStatus {
+    type Error = IotaError;
+
+    fn try_from(
+        (digest, result): (TransactionDigest, SubmitTransactionResult),
+    ) -> Result<Self, Self::Error> {
+        Ok(api::TxStatus {
+            tx_digest: Some(digest.try_into()?),
+            status: Some(result.try_into()?),
+        })
     }
 }
 

--- a/crates/iota-network/src/convert/validator_v2.rs
+++ b/crates/iota-network/src/convert/validator_v2.rs
@@ -6,7 +6,12 @@
 use iota_types::{
     digests::TransactionDigest,
     error::IotaError,
-    messages_grpc::{GetTxStatusRequest, SubmitTransactionsRequest, TxStatusQuery, TxStatusUpdate},
+    messages_consensus::SignedAuthorityCapabilitiesV1,
+    messages_grpc::{
+        GetTxStatusRequest, HandleCapabilityNotificationRequestV1,
+        HandleCapabilityNotificationResponseV1, SubmitTransactionsRequest, TxStatusQuery,
+        TxStatusUpdate,
+    },
     transaction::Transaction,
 };
 
@@ -141,6 +146,44 @@ impl TryFrom<(TransactionDigest, TxStatusUpdate)> for api::TxStatus {
             tx_digest: Some(digest.try_into()?),
             status: Some(update.try_into()?),
         })
+    }
+}
+
+// --- NotifyCapabilitiesRequest ↔ HandleCapabilityNotificationRequestV1 ---
+
+impl TryFrom<HandleCapabilityNotificationRequestV1> for api::NotifyCapabilitiesRequest {
+    type Error = IotaError;
+
+    fn try_from(value: HandleCapabilityNotificationRequestV1) -> Result<Self, Self::Error> {
+        Ok(Self {
+            capabilities: bcs_serialize(&value.message, "NotifyCapabilitiesRequest.capabilities")?,
+        })
+    }
+}
+
+impl TryFrom<api::NotifyCapabilitiesRequest> for HandleCapabilityNotificationRequestV1 {
+    type Error = IotaError;
+
+    fn try_from(value: api::NotifyCapabilitiesRequest) -> Result<Self, Self::Error> {
+        let message: SignedAuthorityCapabilitiesV1 = bcs_deserialize(
+            &value.capabilities,
+            "NotifyCapabilitiesRequest.capabilities",
+        )?;
+        Ok(Self { message })
+    }
+}
+
+// --- NotifyCapabilitiesResponse ↔ HandleCapabilityNotificationResponseV1 ---
+
+impl From<HandleCapabilityNotificationResponseV1> for api::NotifyCapabilitiesResponse {
+    fn from(_value: HandleCapabilityNotificationResponseV1) -> Self {
+        Self {}
+    }
+}
+
+impl From<api::NotifyCapabilitiesResponse> for HandleCapabilityNotificationResponseV1 {
+    fn from(_value: api::NotifyCapabilitiesResponse) -> Self {
+        Self { _unused: false }
     }
 }
 

--- a/crates/iota-network/src/convert/validator_v2.rs
+++ b/crates/iota-network/src/convert/validator_v2.rs
@@ -6,9 +6,7 @@
 use iota_types::{
     digests::TransactionDigest,
     error::IotaError,
-    messages_grpc::{
-        ExecutedData, SubmitTransactionResult, SubmitTransactionsRequest, WaitForEffectResponse,
-    },
+    messages_grpc::{GetTxStatusRequest, SubmitTransactionsRequest, TxStatusQuery, TxStatusUpdate},
     transaction::Transaction,
 };
 
@@ -42,145 +40,38 @@ impl TryFrom<api::TxDigest> for TransactionDigest {
     }
 }
 
-// --- StatusDetail ↔ SubmitTransactionResult ---
+// --- GetTxStatusRequest (proto → domain) ---
 
-impl TryFrom<SubmitTransactionResult> for StatusDetail {
+impl TryFrom<api::TxStatusQuery> for TxStatusQuery {
     type Error = IotaError;
 
-    fn try_from(value: SubmitTransactionResult) -> Result<Self, Self::Error> {
-        let kind = match value {
-            SubmitTransactionResult::Submitted => Kind::Submitted(SubmittedStatus {}),
-            SubmitTransactionResult::Executed {
-                effects_digest,
-                details,
-            } => Kind::Executed(ExecutedStatus {
-                effects_digest: bcs_serialize(&effects_digest, "ExecutedStatus.effects_digest")?,
-                details: Some(bcs_serialize(&*details, "ExecutedStatus.details")?),
-            }),
-            SubmitTransactionResult::Rejected { error } => Kind::Rejected(RejectedStatus {
-                error: Some(bcs_serialize(&error, "RejectedStatus.error")?),
-            }),
-        };
-        Ok(StatusDetail { kind: Some(kind) })
-    }
-}
-
-impl TryFrom<StatusDetail> for SubmitTransactionResult {
-    type Error = IotaError;
-
-    fn try_from(value: StatusDetail) -> Result<Self, Self::Error> {
-        let kind = value
-            .kind
+    fn try_from(value: api::TxStatusQuery) -> Result<Self, Self::Error> {
+        let tx_digest = value
+            .tx_digest
             .ok_or_else(|| IotaError::TransactionSerialization {
-                error: "StatusDetail.kind is None".to_string(),
+                error: "TxStatusQuery.tx_digest is None".to_string(),
             })?;
-        match kind {
-            Kind::Submitted(_) => Ok(SubmitTransactionResult::Submitted),
-            Kind::Executed(e) => {
-                let effects_digest =
-                    bcs_deserialize(&e.effects_digest, "ExecutedStatus.effects_digest")?;
-                let details_bytes =
-                    e.details
-                        .ok_or_else(|| IotaError::TransactionSerialization {
-                            error: "ExecutedStatus.details is None for SubmitTransactionResult"
-                                .to_string(),
-                        })?;
-                let details: ExecutedData =
-                    bcs_deserialize(&details_bytes, "ExecutedStatus.details")?;
-                Ok(SubmitTransactionResult::Executed {
-                    effects_digest,
-                    details: Box::new(details),
-                })
-            }
-            Kind::Rejected(r) => {
-                let error = r
-                    .error
-                    .as_ref()
-                    .map(|e| bcs_deserialize(e, "RejectedStatus.error"))
-                    .transpose()?
-                    .ok_or_else(|| IotaError::TransactionSerialization {
-                        error: "RejectedStatus.error is None for SubmitTransactionResult"
-                            .to_string(),
-                    })?;
-                Ok(SubmitTransactionResult::Rejected { error })
-            }
-            Kind::Expired(_) => Err(IotaError::TransactionSerialization {
-                error: "Expired status is not valid for SubmitTransactionResult".to_string(),
-            }),
-        }
+        Ok(TxStatusQuery {
+            transaction_digest: tx_digest.try_into()?,
+            include_details: value.include_details,
+        })
     }
 }
 
-// --- StatusDetail ↔ WaitForEffectResponse ---
-
-impl TryFrom<WaitForEffectResponse> for StatusDetail {
+impl TryFrom<api::GetTxStatusRequest> for GetTxStatusRequest {
     type Error = IotaError;
 
-    fn try_from(value: WaitForEffectResponse) -> Result<Self, Self::Error> {
-        let kind = match value {
-            WaitForEffectResponse::Executed {
-                effects_digest,
-                details,
-            } => Kind::Executed(ExecutedStatus {
-                effects_digest: bcs_serialize(&effects_digest, "ExecutedStatus.effects_digest")?,
-                details: details
-                    .as_ref()
-                    .map(|d| bcs_serialize(d.as_ref(), "ExecutedStatus.details"))
-                    .transpose()?,
-            }),
-            WaitForEffectResponse::Rejected { error } => Kind::Rejected(RejectedStatus {
-                error: error
-                    .as_ref()
-                    .map(|e| bcs_serialize(e, "RejectedStatus.error"))
-                    .transpose()?,
-            }),
-            WaitForEffectResponse::Expired { epoch } => Kind::Expired(ExpiredStatus { epoch }),
-        };
-        Ok(StatusDetail { kind: Some(kind) })
+    fn try_from(value: api::GetTxStatusRequest) -> Result<Self, Self::Error> {
+        let queries = value
+            .queries
+            .into_iter()
+            .map(TxStatusQuery::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(GetTxStatusRequest { queries })
     }
 }
 
-impl TryFrom<StatusDetail> for WaitForEffectResponse {
-    type Error = IotaError;
-
-    fn try_from(value: StatusDetail) -> Result<Self, Self::Error> {
-        let kind = value
-            .kind
-            .ok_or_else(|| IotaError::TransactionSerialization {
-                error: "StatusDetail.kind is None".to_string(),
-            })?;
-        match kind {
-            Kind::Submitted(_) => Err(IotaError::TransactionSerialization {
-                error: "Submitted status is not valid for WaitForEffectResponse".to_string(),
-            }),
-            Kind::Executed(e) => {
-                let effects_digest =
-                    bcs_deserialize(&e.effects_digest, "ExecutedStatus.effects_digest")?;
-                let details = e
-                    .details
-                    .as_ref()
-                    .map(|d| bcs_deserialize::<ExecutedData>(d, "ExecutedStatus.details"))
-                    .transpose()?
-                    .map(Box::new);
-                Ok(WaitForEffectResponse::Executed {
-                    effects_digest,
-                    details,
-                })
-            }
-            Kind::Rejected(r) => {
-                let error = r
-                    .error
-                    .as_ref()
-                    .map(|e| bcs_deserialize(e, "RejectedStatus.error"))
-                    .transpose()?;
-                Ok(WaitForEffectResponse::Rejected { error })
-            }
-            Kind::Expired(e) => Ok(WaitForEffectResponse::Expired { epoch: e.epoch }),
-        }
-    }
-}
-
-// --- SubmitTxRequest ↔ SubmitTransactionsRequest ---
+// --- SubmitTxRequest (proto → domain) ---
 
 impl TryFrom<api::SubmitTxRequest> for SubmitTransactionsRequest {
     type Error = IotaError;
@@ -195,6 +86,8 @@ impl TryFrom<api::SubmitTxRequest> for SubmitTransactionsRequest {
     }
 }
 
+// --- SubmitTxRequest (domain → proto, used by tests) ---
+
 impl TryFrom<SubmitTransactionsRequest> for api::SubmitTxRequest {
     type Error = IotaError;
 
@@ -208,17 +101,45 @@ impl TryFrom<SubmitTransactionsRequest> for api::SubmitTxRequest {
     }
 }
 
-// --- TxStatus ← (TransactionDigest, SubmitTransactionResult) ---
+// --- TxStatusUpdate → StatusDetail → TxStatus ---
 
-impl TryFrom<(TransactionDigest, SubmitTransactionResult)> for api::TxStatus {
+impl TryFrom<TxStatusUpdate> for StatusDetail {
+    type Error = IotaError;
+
+    fn try_from(value: TxStatusUpdate) -> Result<Self, Self::Error> {
+        let kind = match value {
+            TxStatusUpdate::Submitted => Kind::Submitted(SubmittedStatus {}),
+            TxStatusUpdate::Executed {
+                effects_digest,
+                details,
+            } => Kind::Executed(ExecutedStatus {
+                effects_digest: bcs_serialize(&effects_digest, "ExecutedStatus.effects_digest")?,
+                details: details
+                    .as_ref()
+                    .map(|d| bcs_serialize(d.as_ref(), "ExecutedStatus.details"))
+                    .transpose()?,
+            }),
+            TxStatusUpdate::Rejected { error } => Kind::Rejected(RejectedStatus {
+                error: error
+                    .as_ref()
+                    .map(|e| bcs_serialize(e, "RejectedStatus.error"))
+                    .transpose()?,
+            }),
+            TxStatusUpdate::Expired { epoch } => Kind::Expired(ExpiredStatus { epoch }),
+        };
+        Ok(StatusDetail { kind: Some(kind) })
+    }
+}
+
+impl TryFrom<(TransactionDigest, TxStatusUpdate)> for api::TxStatus {
     type Error = IotaError;
 
     fn try_from(
-        (digest, result): (TransactionDigest, SubmitTransactionResult),
+        (digest, update): (TransactionDigest, TxStatusUpdate),
     ) -> Result<Self, Self::Error> {
         Ok(api::TxStatus {
             tx_digest: Some(digest.try_into()?),
-            status: Some(result.try_into()?),
+            status: Some(update.try_into()?),
         })
     }
 }
@@ -228,10 +149,10 @@ mod tests {
     use iota_types::{
         digests::{TransactionDigest, TransactionEffectsDigest},
         error::IotaError,
-        messages_grpc::{ExecutedData, SubmitTransactionResult, WaitForEffectResponse},
+        messages_grpc::{ExecutedData, GetTxStatusRequest, TxStatusUpdate},
     };
 
-    use crate::api::{self, StatusDetail, status_detail::Kind};
+    use crate::api::{self, status_detail::Kind};
 
     // --- TxDigest round-trip ---
 
@@ -252,155 +173,126 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // --- SubmitTransactionResult round-trips ---
+    // --- GetTxStatusRequest ---
 
     #[test]
-    fn submit_submitted_round_trip() {
-        let original = SubmitTransactionResult::Submitted;
-        let proto: StatusDetail = original.try_into().unwrap();
-        assert!(matches!(proto.kind, Some(Kind::Submitted(_))));
-        let back: SubmitTransactionResult = proto.try_into().unwrap();
-        assert!(matches!(back, SubmitTransactionResult::Submitted));
+    fn get_tx_status_request_converts() {
+        let d1 = TransactionDigest::random();
+        let d2 = TransactionDigest::random();
+        let proto = api::GetTxStatusRequest {
+            queries: vec![
+                api::TxStatusQuery {
+                    tx_digest: Some(d1.try_into().unwrap()),
+                    include_details: true,
+                },
+                api::TxStatusQuery {
+                    tx_digest: Some(d2.try_into().unwrap()),
+                    include_details: false,
+                },
+            ],
+        };
+        let domain: GetTxStatusRequest = proto.try_into().unwrap();
+        assert_eq!(domain.queries.len(), 2);
+        assert_eq!(domain.queries[0].transaction_digest, d1);
+        assert!(domain.queries[0].include_details);
+        assert_eq!(domain.queries[1].transaction_digest, d2);
+        assert!(!domain.queries[1].include_details);
     }
 
     #[test]
-    fn submit_executed_round_trip() {
-        let original = SubmitTransactionResult::Executed {
-            effects_digest: TransactionEffectsDigest::random(),
-            details: Box::new(ExecutedData::default()),
+    fn get_tx_status_query_missing_digest_is_error() {
+        let proto = api::GetTxStatusRequest {
+            queries: vec![api::TxStatusQuery {
+                tx_digest: None,
+                include_details: false,
+            }],
         };
-        let proto: StatusDetail = original.try_into().unwrap();
-        assert!(matches!(proto.kind, Some(Kind::Executed(_))));
-        let back: SubmitTransactionResult = proto.try_into().unwrap();
-        assert!(matches!(back, SubmitTransactionResult::Executed { .. }));
-    }
-
-    #[test]
-    fn submit_rejected_round_trip() {
-        let error = IotaError::TransactionSerialization {
-            error: "test error".to_string(),
-        };
-        let original = SubmitTransactionResult::Rejected {
-            error: error.clone(),
-        };
-        let proto: StatusDetail = original.try_into().unwrap();
-        assert!(matches!(proto.kind, Some(Kind::Rejected(_))));
-        let back: SubmitTransactionResult = proto.try_into().unwrap();
-        match back {
-            SubmitTransactionResult::Rejected { error: e } => {
-                assert_eq!(e.to_string(), error.to_string());
-            }
-            _ => panic!("expected Rejected"),
-        }
-    }
-
-    #[test]
-    fn submit_rejects_expired_status() {
-        let proto = StatusDetail {
-            kind: Some(Kind::Expired(crate::api::ExpiredStatus { epoch: 1 })),
-        };
-        let result = SubmitTransactionResult::try_from(proto);
+        let result = GetTxStatusRequest::try_from(proto);
         assert!(result.is_err());
     }
 
-    // --- WaitForEffectResponse round-trips ---
-
     #[test]
-    fn wait_executed_round_trip() {
-        let digest = TransactionEffectsDigest::random();
-        let original = WaitForEffectResponse::Executed {
-            effects_digest: digest,
-            details: Some(Box::new(ExecutedData::default())),
-        };
-        let proto: StatusDetail = original.try_into().unwrap();
-        assert!(matches!(proto.kind, Some(Kind::Executed(_))));
-        let back: WaitForEffectResponse = proto.try_into().unwrap();
-        match back {
-            WaitForEffectResponse::Executed {
-                effects_digest,
-                details,
-            } => {
-                assert_eq!(effects_digest, digest);
-                assert!(details.is_some());
-            }
-            _ => panic!("expected Executed"),
-        }
+    fn get_tx_status_request_empty_queries() {
+        let proto = api::GetTxStatusRequest { queries: vec![] };
+        let domain: GetTxStatusRequest = proto.try_into().unwrap();
+        assert!(domain.queries.is_empty());
     }
 
-    #[test]
-    fn wait_executed_without_details_round_trip() {
-        let digest = TransactionEffectsDigest::random();
-        let original = WaitForEffectResponse::Executed {
-            effects_digest: digest,
-            details: None,
-        };
-        let proto: StatusDetail = original.try_into().unwrap();
-        let back: WaitForEffectResponse = proto.try_into().unwrap();
-        match back {
-            WaitForEffectResponse::Executed {
-                effects_digest,
-                details,
-            } => {
-                assert_eq!(effects_digest, digest);
-                assert!(details.is_none());
-            }
-            _ => panic!("expected Executed"),
-        }
-    }
+    // --- TxStatus from (TransactionDigest, TxStatusUpdate) ---
 
     #[test]
-    fn wait_rejected_with_error_round_trip() {
-        let error = IotaError::TransactionSerialization {
-            error: "conflict".to_string(),
-        };
-        let original = WaitForEffectResponse::Rejected {
-            error: Some(error.clone()),
-        };
-        let proto: StatusDetail = original.try_into().unwrap();
-        let back: WaitForEffectResponse = proto.try_into().unwrap();
-        match back {
-            WaitForEffectResponse::Rejected { error: Some(e) } => {
-                assert_eq!(e.to_string(), error.to_string());
-            }
-            _ => panic!("expected Rejected with error"),
-        }
-    }
-
-    #[test]
-    fn wait_rejected_without_error_round_trip() {
-        let original = WaitForEffectResponse::Rejected { error: None };
-        let proto: StatusDetail = original.try_into().unwrap();
-        let back: WaitForEffectResponse = proto.try_into().unwrap();
+    fn tx_status_update_submitted() {
+        let digest = TransactionDigest::random();
+        let tx_status: api::TxStatus = (digest, TxStatusUpdate::Submitted).try_into().unwrap();
+        assert!(tx_status.tx_digest.is_some());
         assert!(matches!(
-            back,
-            WaitForEffectResponse::Rejected { error: None }
+            tx_status.status.unwrap().kind,
+            Some(Kind::Submitted(_))
         ));
     }
 
     #[test]
-    fn wait_expired_round_trip() {
-        let original = WaitForEffectResponse::Expired { epoch: 42 };
-        let proto: StatusDetail = original.try_into().unwrap();
-        let back: WaitForEffectResponse = proto.try_into().unwrap();
-        match back {
-            WaitForEffectResponse::Expired { epoch } => assert_eq!(epoch, 42),
+    fn tx_status_update_executed_with_details() {
+        let digest = TransactionDigest::random();
+        let update = TxStatusUpdate::Executed {
+            effects_digest: TransactionEffectsDigest::random(),
+            details: Some(Box::new(ExecutedData::default())),
+        };
+        let tx_status: api::TxStatus = (digest, update).try_into().unwrap();
+        assert!(matches!(
+            tx_status.status.unwrap().kind,
+            Some(Kind::Executed(_))
+        ));
+    }
+
+    #[test]
+    fn tx_status_update_executed_without_details() {
+        let digest = TransactionDigest::random();
+        let update = TxStatusUpdate::Executed {
+            effects_digest: TransactionEffectsDigest::random(),
+            details: None,
+        };
+        let tx_status: api::TxStatus = (digest, update).try_into().unwrap();
+        assert!(matches!(
+            tx_status.status.unwrap().kind,
+            Some(Kind::Executed(_))
+        ));
+    }
+
+    #[test]
+    fn tx_status_update_rejected() {
+        let digest = TransactionDigest::random();
+        let update = TxStatusUpdate::Rejected {
+            error: Some(IotaError::TransactionSerialization {
+                error: "conflict".to_string(),
+            }),
+        };
+        let tx_status: api::TxStatus = (digest, update).try_into().unwrap();
+        assert!(matches!(
+            tx_status.status.unwrap().kind,
+            Some(Kind::Rejected(_))
+        ));
+    }
+
+    #[test]
+    fn tx_status_update_rejected_no_error() {
+        let digest = TransactionDigest::random();
+        let update = TxStatusUpdate::Rejected { error: None };
+        let tx_status: api::TxStatus = (digest, update).try_into().unwrap();
+        assert!(matches!(
+            tx_status.status.unwrap().kind,
+            Some(Kind::Rejected(_))
+        ));
+    }
+
+    #[test]
+    fn tx_status_update_expired() {
+        let digest = TransactionDigest::random();
+        let update = TxStatusUpdate::Expired { epoch: 42 };
+        let tx_status: api::TxStatus = (digest, update).try_into().unwrap();
+        match tx_status.status.unwrap().kind {
+            Some(Kind::Expired(e)) => assert_eq!(e.epoch, 42),
             _ => panic!("expected Expired"),
         }
-    }
-
-    #[test]
-    fn wait_rejects_submitted_status() {
-        let proto = StatusDetail {
-            kind: Some(Kind::Submitted(crate::api::SubmittedStatus {})),
-        };
-        let result = WaitForEffectResponse::try_from(proto);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn status_detail_none_kind_is_error() {
-        let proto = StatusDetail { kind: None };
-        assert!(SubmitTransactionResult::try_from(proto.clone()).is_err());
-        assert!(WaitForEffectResponse::try_from(proto).is_err());
     }
 }

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -390,6 +390,39 @@ pub struct SubmitTransactionsResponse {
     pub results: Vec<SubmitTransactionResult>,
 }
 
+/// Request to query the finality status of one or more previously submitted
+/// transactions.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetTxStatusRequest {
+    pub queries: Vec<TxStatusQuery>,
+}
+
+/// A single transaction status query.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TxStatusQuery {
+    pub transaction_digest: TransactionDigest,
+    /// When true, execution details (effects, events, objects) are included
+    /// in the response for this transaction.
+    pub include_details: bool,
+}
+
+/// Streamed status update for ValidatorV2 RPCs (`submit_tx` and
+/// `get_tx_status`). Covers every state a transaction can be in.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum TxStatusUpdate {
+    /// The transaction passed validation and was submitted to consensus.
+    Submitted,
+    /// The transaction was executed and finalized.
+    Executed {
+        effects_digest: TransactionEffectsDigest,
+        details: Option<Box<ExecutedData>>,
+    },
+    /// The transaction was rejected.
+    Rejected { error: Option<IotaError> },
+    /// Transaction status has expired from the cache or timed out.
+    Expired { epoch: EpochId },
+}
+
 /// A single wait-for-effects item within a batch request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WaitForEffectRequest {


### PR DESCRIPTION
# Description of change

Implements the server-side ValidatorV2 gRPC service for the certificate-less (P-COOL) transaction flow.

### What's new

- **`SubmitTx` RPC** — accepts up to 256 transactions, streams `TxStatusUpdate` per tx (Submitted, Executed, Rejected, Expired)
- **`GetTxStatus` RPC** — queries finality status for previously submitted transactions with optional execution details
- **`NotifyCapabilities` RPC** — accepts signed capability notifications from non-committee validators (moved from ValidatorPeer to the public ValidatorV2 service)
- **Proto + conversions** — `validator_v2.proto` with full proto ↔ domain round-trip conversions
- **Refactored authority server** — replaced `handle_with_decoration!` macro with typed `pre_handle`/`post_handle_unary`/`post_handle_stream` methods

### Key design decisions

- White-flag-only flow: no certificate APIs referenced
- Per-tx errors return `TxStatusUpdate::Rejected` (TODOs added for remaining `Err(Status)` inconsistencies)
- Traffic weight is per-request not per-tx (TODO to scale with batch size)

## Links to any relevant issues

Closes #10974.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
