### PR TITLE
feat(gRPC): simplify gas cost calculation in `simulate_transactions`

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -66,7 +66,7 @@ async fn simulate_transaction_scenarios() {
         "Effects should be present with minimal mask"
     );
 
-    // Test: insufficient gas budget returns gRPC error
+    // Test: insufficient gas budget returns InvalidArgument error
     // Gas budget validation (min/max bounds) happens upfront in
     // check_gas_balance(), so a budget of 1 (below minimum) is rejected before
     // execution begins.
@@ -83,7 +83,7 @@ async fn simulate_transaction_scenarios() {
         .build();
     let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
     let result = client.simulate_transaction(transaction, false, None).await;
-    assert_grpc_error(result, Code::Internal);
+    assert_grpc_error(result, Code::InvalidArgument);
 
     // Test: transfer exceeding balance returns Ok with failed effects
     // Transfer amount validation happens during Move VM execution, not upfront,

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -21,7 +21,7 @@ async fn simulate_transaction_scenarios() {
         let transaction = create_transaction_for_simulation(&test_cluster).await;
 
         let result = client
-            .simulate_transaction(transaction, dev_inspect, false, None)
+            .simulate_transaction(transaction, dev_inspect, None)
             .await
             .unwrap_or_else(|e| panic!("Failed to simulate transaction in {mode_name} mode: {e}"));
 
@@ -48,12 +48,7 @@ async fn simulate_transaction_scenarios() {
     // Test: minimal read mask
     let transaction = create_transaction_for_simulation(&test_cluster).await;
     let result = client
-        .simulate_transaction(
-            transaction,
-            false,
-            false,
-            Some("executed_transaction.effects"),
-        )
+        .simulate_transaction(transaction, false, Some("executed_transaction.effects"))
         .await
         .expect("Failed to simulate transaction with minimal mask");
 
@@ -87,9 +82,7 @@ async fn simulate_transaction_scenarios() {
         .with_gas_budget(1)
         .build();
     let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
-    let result = client
-        .simulate_transaction(transaction, false, false, None)
-        .await;
+    let result = client.simulate_transaction(transaction, false, None).await;
     assert_grpc_error(result, Code::Internal);
 
     // Test: transfer exceeding balance returns Ok with failed effects
@@ -108,7 +101,7 @@ async fn simulate_transaction_scenarios() {
         .build();
     let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
     let response = client
-        .simulate_transaction(transaction, false, false, None)
+        .simulate_transaction(transaction, false, None)
         .await
         .expect("Simulation should succeed at RPC level");
 

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/header.rs
@@ -75,14 +75,12 @@ async fn test_response_headers() {
             1000,          // gas price
         );
 
-        // Create the simulation request with gas estimation enabled
         let transaction = ProtoTransaction::default()
             .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap()));
 
         let item = SimulateTransactionItem::default()
             .with_transaction(transaction)
-            .with_tx_checks(vec![])
-            .with_estimate_gas_budget(true);
+            .with_tx_checks(vec![]);
 
         let request = SimulateTransactionsRequest::default().with_transactions(vec![item]);
 

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
@@ -31,16 +31,6 @@ fn build_simulate_item(transaction: ProtoTransaction) -> SimulateTransactionItem
         .with_tx_checks(vec![])
 }
 
-/// Helper to build a `SimulateTransactionItem` with gas estimation enabled.
-fn build_simulate_item_with_gas_estimation(
-    transaction: ProtoTransaction,
-) -> SimulateTransactionItem {
-    SimulateTransactionItem::default()
-        .with_transaction(transaction)
-        .with_tx_checks(vec![])
-        .with_estimate_gas_budget(true)
-}
-
 /// Extract the `SimulatedTransaction` from the first result in the response.
 fn first_simulated_transaction(response: &SimulateTransactionsResponse) -> &SimulatedTransaction {
     let result = response
@@ -136,7 +126,7 @@ async fn assert_simulate_transaction_request(
 }
 
 #[sim_test]
-async fn simulate_transaction_with_gas_estimation() {
+async fn simulate_transaction_zero_gas_budget_uses_max() {
     let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
 
     let mut exec_client = client.execution_service_client();
@@ -148,21 +138,20 @@ async fn simulate_transaction_with_gas_estimation() {
     let obj_to_send = gas.first().unwrap();
     let gas_obj = gas.last().unwrap();
 
-    // Build a simple transfer transaction with a very high gas budget
+    // Build a transfer transaction with gas budget = 0
     let tx_data = TransactionData::new_transfer(
         recipient,
         *obj_to_send,
         sender,
         *gas_obj,
-        1_000_000_000, // very high gas budget
-        1000,          // gas price
+        0,    // zero gas budget — server should replace with max_tx_gas
+        1000, // gas price
     );
 
-    // Create the simulation request with gas estimation enabled
     let transaction = ProtoTransaction::default()
         .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap()));
 
-    let item = build_simulate_item_with_gas_estimation(transaction);
+    let item = build_simulate_item(transaction);
     let request = SimulateTransactionsRequest::default().with_transactions(vec![item]);
 
     // Simulate the transaction
@@ -174,7 +163,8 @@ async fn simulate_transaction_with_gas_estimation() {
 
     let simulated = first_simulated_transaction(&response);
 
-    // Verify gas budget estimation worked correctly
+    // Verify that the returned transaction has a non-zero gas budget (replaced with
+    // max_tx_gas)
     let bcs_data = simulated
         .executed_transaction
         .as_ref()
@@ -187,16 +177,63 @@ async fn simulate_transaction_with_gas_estimation() {
         .unwrap();
 
     let returned_tx: TransactionData = bcs::from_bytes(&bcs_data.data).unwrap();
-    // The estimated budget should be much less than 1 billion
-    assert!(
-        returned_tx.gas_data().budget < 1_000_000_000,
-        "estimated budget should be less than original 1_000_000_000, got: {}",
-        returned_tx.gas_data().budget
-    );
-    // The gas data should be positive
     assert!(
         returned_tx.gas_data().budget > 0,
-        "estimated budget should be positive"
+        "gas budget should have been replaced with max_tx_gas, but was 0"
+    );
+}
+
+#[sim_test]
+async fn simulate_transaction_below_min_gas_budget_returns_error() {
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+
+    let mut exec_client = client.execution_service_client();
+
+    let recipient = iota_types::base_types::IotaAddress::random_for_testing_only();
+
+    let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
+    gas.sort_by_key(|object_ref| object_ref.0);
+    let obj_to_send = gas.first().unwrap();
+    let gas_obj = gas.last().unwrap();
+
+    // Build a transfer transaction with a gas budget below the minimum
+    // (min = base_tx_cost_fixed * gas_price = 1000 * 1000 = 1_000_000 NANOS)
+    let tx_data = TransactionData::new_transfer(
+        recipient,
+        *obj_to_send,
+        sender,
+        *gas_obj,
+        1,    // way below minimum gas budget
+        1000, // gas price
+    );
+
+    let transaction = ProtoTransaction::default()
+        .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap()));
+
+    let item = build_simulate_item(transaction);
+    let request = SimulateTransactionsRequest::default().with_transactions(vec![item]);
+
+    let response = exec_client
+        .simulate_transactions(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    // The per-item result should be an error
+    let result = response.transaction_results.first().unwrap();
+    let error = result
+        .error()
+        .expect("Expected per-item error for below-minimum gas budget");
+    assert_eq!(
+        error.code,
+        tonic::Code::InvalidArgument as i32,
+        "Expected InvalidArgument error code, got code {}",
+        error.code
+    );
+    assert!(
+        error.message.contains("below the minimum"),
+        "Error message should mention 'below the minimum', got: {}",
+        error.message
     );
 }
 

--- a/crates/iota-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-grpc-client/src/api/execution/simulate.rs
@@ -24,8 +24,6 @@ pub struct SimulateTransactionInput {
     /// Set to true for relaxed Move VM checks (useful for debugging and
     /// development).
     pub dev_inspect: bool,
-    /// Set to true to estimate the gas budget required.
-    pub estimate_gas_budget: bool,
 }
 
 impl Client {
@@ -39,7 +37,6 @@ impl Client {
     /// - `transaction`: The transaction to simulate
     /// - `dev_inspect`: Set to true for relaxed Move VM checks (useful for
     ///   debugging and development)
-    /// - `estimate_gas_budget`: Set to true to estimate the gas budget required
     /// - `read_mask`: Optional field mask to control which fields are returned
     ///
     /// Returns [`SimulatedTransaction`] which contains:
@@ -169,7 +166,7 @@ impl Client {
     /// let tx: Transaction = todo!();
     ///
     /// // Simulate transaction - returns proto type
-    /// let result = client.simulate_transaction(tx, false, false, None).await?;
+    /// let result = client.simulate_transaction(tx, false, None).await?;
     ///
     /// // Lazy conversion - only deserialize what you need
     /// let executed_tx = result.body().executed_transaction()?;
@@ -185,14 +182,12 @@ impl Client {
         &self,
         transaction: Transaction,
         dev_inspect: bool,
-        estimate_gas_budget: bool,
         read_mask: Option<&str>,
     ) -> Result<MetadataEnvelope<SimulatedTransaction>> {
         self.simulate_transactions(
             vec![SimulateTransactionInput {
                 transaction,
                 dev_inspect,
-                estimate_gas_budget,
             }],
             read_mask,
         )
@@ -230,13 +225,7 @@ impl Client {
 
         let items = transactions
             .into_iter()
-            .map(|input| {
-                build_simulate_item(
-                    input.transaction,
-                    input.dev_inspect,
-                    input.estimate_gas_budget,
-                )
-            })
+            .map(|input| build_simulate_item(input.transaction, input.dev_inspect))
             .collect::<Result<Vec<_>>>()?;
 
         let request = SimulateTransactionsRequest::default()
@@ -264,7 +253,6 @@ impl Client {
 fn build_simulate_item(
     transaction: Transaction,
     dev_inspect: bool,
-    estimate_gas_budget: bool,
 ) -> Result<SimulateTransactionItem> {
     let proto_transaction = build_proto_transaction(&transaction, transaction.digest())?;
 
@@ -276,6 +264,5 @@ fn build_simulate_item(
 
     Ok(SimulateTransactionItem::default()
         .with_transaction(proto_transaction)
-        .with_tx_checks(tx_checks)
-        .with_estimate_gas_budget(estimate_gas_budget))
+        .with_tx_checks(tx_checks))
 }

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -21,7 +21,6 @@ use iota_grpc_types::{
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     effects::TransactionEffectsAPI,
-    gas::GasCostSummary,
     transaction::TransactionDataAPI,
     transaction_executor::{
         SimulateTransactionResult as InternalSimulateResult, TransactionExecutor, VmChecks,
@@ -199,22 +198,28 @@ async fn simulate_single_transaction(
         })?;
 
     let system_state = if read_mask.contains(SimulatedTransaction::SUGGESTED_GAS_PRICE_FIELD.name)
-        || (item.estimate_gas_budget.unwrap_or(false) && vm_checks.enabled())
+        || vm_checks.enabled()
     {
         Some(reader.get_system_state_summary().map_err(|e| {
             RpcError::new(
                 tonic::Code::Internal,
-                format!("failed to get system state for suggested gas price or gas price estimation: {e}"),
+                format!("failed to get system state: {e}"),
             )
         })?)
     } else {
         None
     };
 
-    // Perform budget estimation if requested and if VmChecks are enabled
-    // (it makes no sense to do gas estimation if checks are disabled because such a
-    // transaction can't ever be committed to the chain).
-    if item.estimate_gas_budget.unwrap_or(false) && vm_checks.enabled() {
+    // If the transaction has a zero gas budget and VM checks are enabled, we'll set
+    // the gas budget in the result to the actual cost from the simulation. This
+    // allows clients to estimate the gas cost by simulating with a zero budget.
+    let set_gas_budget = vm_checks.enabled() && transaction_data.gas_data().budget == 0;
+    let mut min_gas_budget_opt = None;
+
+    // Validate and adjust gas budget when VM checks are enabled.
+    // (It makes no sense to validate gas if checks are disabled because such a
+    // transaction can't ever be committed to the chain.)
+    if vm_checks.enabled() {
         let protocol_config = ProtocolConfig::get_for_version_if_supported(
             system_state
                 .as_ref()
@@ -225,59 +230,29 @@ async fn simulate_single_transaction(
         .ok_or_else(|| {
             RpcError::new(
                 tonic::Code::Internal,
-                "failed to get protocol config for gas estimation".to_string(),
+                "failed to get protocol config for gas budget validation".to_string(),
             )
         })?;
 
-        let mut estimation_transaction = transaction_data.clone();
-        estimation_transaction.gas_data_mut().payment = Vec::new();
-        estimation_transaction.gas_data_mut().budget = protocol_config.max_tx_gas();
+        let min_gas_budget =
+            protocol_config.base_tx_cost_fixed() * transaction_data.gas_data().price;
 
-        let simulation_result = executor
-            .simulate_transaction(estimation_transaction, VmChecks::Enabled)
-            .map_err(|e| {
-                RpcError::new(
-                    tonic::Code::Internal,
-                    format!("Transaction simulation for gas estimation failed: {e}"),
-                )
-            })?;
-
-        if !simulation_result.effects.status().is_ok() {
+        let gas_budget = transaction_data.gas_data().budget;
+        if gas_budget == 0 {
+            // A zero budget signals "use maximum" — run the dry run with
+            // max_tx_gas so the actual cost shows up in the gas status.
+            transaction_data.gas_data_mut().budget = protocol_config.max_tx_gas();
+        } else if gas_budget < min_gas_budget {
             return Err(RpcError::new(
                 tonic::Code::InvalidArgument,
                 format!(
-                    "Budget estimation failed with status: {:?}.",
-                    simulation_result.effects.status()
+                    "Gas budget {gas_budget} NANOS is below the minimum required \
+                        gas budget of {min_gas_budget} NANOS"
                 ),
             ));
         }
 
-        let estimate = estimate_gas_budget_from_gas_cost(
-            simulation_result.effects.gas_cost_summary(),
-            system_state
-                .as_ref()
-                .expect("system state should be available")
-                .reference_gas_price(),
-            transaction_data.gas_data().payment.len(),
-            &protocol_config,
-        );
-
-        // We don't want to return a resolved transaction where the gas payment can't
-        // satisfy the budget, so validate that balance can actually cover the
-        // estimated budget.
-        let gas_balance = transaction_data.gas_data().budget;
-        if gas_balance < estimate {
-            return Err(RpcError::new(
-                tonic::Code::InvalidArgument,
-                format!(
-                    "Insufficient gas balance to cover estimated transaction cost. \
-                    Available gas balance: {gas_balance} NANOS. Estimated gas budget required: {estimate} NANOS"
-                ),
-            ));
-        }
-
-        // Update transaction with estimated budget
-        transaction_data.gas_data_mut().budget = estimate;
+        min_gas_budget_opt = Some(min_gas_budget);
     }
 
     // Simulate the transaction
@@ -304,6 +279,13 @@ async fn simulate_single_transaction(
     // Only include transaction if requested
     if let Some(tx_mask) = read_mask.subtree(SimulatedTransaction::EXECUTED_TRANSACTION_FIELD.name)
     {
+        if set_gas_budget {
+            transaction_data.gas_data_mut().budget = effects
+                .gas_cost_summary()
+                .gas_used()
+                .max(min_gas_budget_opt.expect("min_gas_budget_opt should exist"));
+        }
+
         let transaction: iota_sdk_types::Transaction = transaction_data.try_into()?;
 
         // Create a source for the merge
@@ -400,72 +382,4 @@ async fn simulate_single_transaction(
     }
 
     Ok(response)
-}
-
-// An amount of gas (in gas units) that is added to transactions as an overhead
-// to ensure transactions do not fail.
-const GAS_SAFE_OVERHEAD: u64 = 1000;
-const GAS_COIN_BCS_BYTES_SIZE: u64 = 40;
-
-/// Estimate the gas budget for a transaction based on simulation results.
-///
-/// The estimation includes:
-/// 1. Base cost from gas_cost_summary (computation + storage costs)
-/// 2. Cost of loading gas payment objects (which weren't loaded during
-///    simulation)
-/// 3. Rounding up to the protocol gas rounding step (typically 1000 NANOS)
-/// 4. Adding safe overhead buffer (1000 * reference_gas_price)
-/// 5. Clamping to max_tx_gas protocol limit
-pub fn estimate_gas_budget_from_gas_cost(
-    gas_cost_summary: &GasCostSummary,
-    reference_gas_price: u64,
-    num_payment_objects_on_request: usize,
-    protocol_config: &iota_protocol_config::ProtocolConfig,
-) -> u64 {
-    // Calculate base estimate from gas cost summary (in NANOS)
-    let gas_usage = gas_cost_summary.net_gas_usage();
-    let base_estimate_nanos =
-        gas_cost_summary
-            .computation_cost
-            .max(if gas_usage < 0 { 0 } else { gas_usage as u64 });
-
-    // Calculate cost of loading gas payment objects.
-    // Subtract 1 because the simulation already loaded one ephemeral gas coin.
-    let num_payment_objects_for_estimation = {
-        let total = if num_payment_objects_on_request == 0 {
-            protocol_config.max_gas_payment_objects() as u64
-        } else {
-            num_payment_objects_on_request as u64
-        };
-        total.saturating_sub(1)
-    };
-
-    // Calculate gas loading cost in gas units
-    let gas_loading_cost_units = num_payment_objects_for_estimation
-        .saturating_mul(GAS_COIN_BCS_BYTES_SIZE)
-        .saturating_mul(protocol_config.obj_access_cost_read_per_byte());
-
-    // Round up to the nearest gas rounding step (in gas units)
-    let rounded_gas_loading_cost_units =
-        if let Some(step) = protocol_config.gas_rounding_step_as_option() {
-            gas_loading_cost_units
-                .checked_next_multiple_of(step)
-                .unwrap_or(u64::MAX)
-        } else {
-            gas_loading_cost_units
-        };
-
-    // Convert gas loading cost to NANOS
-    let gas_loading_cost_nanos = rounded_gas_loading_cost_units.saturating_mul(reference_gas_price);
-
-    // Calculate safe overhead buffer in NANOS
-    let safe_overhead_nanos = GAS_SAFE_OVERHEAD.saturating_mul(reference_gas_price);
-
-    // Add all together: base (NANOS) + loading (NANOS) + overhead (NANOS)
-    let estimate_nanos = base_estimate_nanos
-        .saturating_add(gas_loading_cost_nanos)
-        .saturating_add(safe_overhead_nanos);
-
-    // Clamp to max_tx_gas to ensure we don't exceed the protocol limit
-    estimate_nanos.min(protocol_config.max_tx_gas())
 }

--- a/crates/iota-grpc-types/proto/iota/grpc/v1/transaction_execution_service.proto
+++ b/crates/iota-grpc-types/proto/iota/grpc/v1/transaction_execution_service.proto
@@ -79,9 +79,6 @@ message SimulateTransactionItem {
 
   // List of checks to disable. If empty, all checks are enabled (default).
   repeated TransactionCheckModes tx_checks = 2;
-
-  // Perform gas budget estimation and include the budget in the response.
-  optional bool estimate_gas_budget = 3;
 }
 
 message SimulateTransactionsRequest {

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.accessors.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.accessors.rs
@@ -108,11 +108,6 @@ mod _accessor_impls {
             self.tx_checks = field;
             self
         }
-        /// Sets `estimate_gas_budget` with the provided value.
-        pub fn with_estimate_gas_budget(mut self, field: bool) -> Self {
-            self.estimate_gas_budget = Some(field);
-            self
-        }
     }
     impl super::SimulateTransactionResult {
         /// Sets `simulated_transaction` with the provided value.

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.field_info.rs
@@ -249,20 +249,11 @@ mod _field_impls {
             is_map: false,
             message_fields: None,
         };
-        pub const ESTIMATE_GAS_BUDGET_FIELD: &'static MessageField = &MessageField {
-            name: "estimate_gas_budget",
-            json_name: "estimateGasBudget",
-            number: 3i32,
-            is_optional: true,
-            is_map: false,
-            message_fields: None,
-        };
     }
     impl MessageFields for SimulateTransactionItem {
         const FIELDS: &'static [&'static MessageField] = &[
             Self::TRANSACTION_FIELD,
             Self::TX_CHECKS_FIELD,
-            Self::ESTIMATE_GAS_BUDGET_FIELD,
         ];
     }
     impl SimulateTransactionItem {
@@ -291,10 +282,6 @@ mod _field_impls {
         }
         pub fn tx_checks(mut self) -> String {
             self.path.push(SimulateTransactionItem::TX_CHECKS_FIELD.name);
-            self.finish()
-        }
-        pub fn estimate_gas_budget(mut self) -> String {
-            self.path.push(SimulateTransactionItem::ESTIMATE_GAS_BUDGET_FIELD.name);
             self.finish()
         }
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.rs
@@ -66,9 +66,6 @@ pub struct SimulateTransactionItem {
         tag = "2"
     )]
     pub tx_checks: ::prost::alloc::vec::Vec<i32>,
-    /// Perform gas budget estimation and include the budget in the response.
-    #[prost(bool, optional, tag = "3")]
-    pub estimate_gas_budget: ::core::option::Option<bool>,
 }
 /// Nested message and enum types in `SimulateTransactionItem`.
 pub mod simulate_transaction_item {

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -115,7 +115,6 @@ impl WriteApi {
             .simulate_transaction(
                 transaction_data.clone().try_into()?,
                 false,
-                false,
                 Some(readmask.as_str()),
             )
             .await?
@@ -257,7 +256,6 @@ impl WriteApi {
             .simulate_transaction(
                 transaction_data.try_into()?,
                 skip_checks,
-                false,
                 Some(readmask.as_str()),
             )
             .await?


### PR DESCRIPTION
# Description of change

We don't need to estimate, before we actually do the final simulate_tx, because we don't use the gas coin selection.
The user can simply specifiy `gas_budget = 0`, the node will replace this value with the `max_tx_budget` and run a simulation, and set the `gas_budget` to the `gas_used` from the transaction effects after the execution.

## Links to any relevant issues

#10973 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes