### PR TITLE
feat(gRPC): add option to wait for checkpoint inclusion

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -329,6 +329,12 @@ pub struct GrpcApiConfig {
     /// batch request.
     #[serde(default = "default_grpc_api_max_simulate_transaction_batch_size")]
     pub max_simulate_transaction_batch_size: u32,
+
+    /// Maximum allowed timeout in milliseconds for waiting for checkpoint
+    /// inclusion in ExecuteTransactions requests. Client-specified timeouts
+    /// are clamped to this value.
+    #[serde(default = "default_grpc_api_max_checkpoint_inclusion_timeout_ms")]
+    pub max_checkpoint_inclusion_timeout_ms: u64,
 }
 
 fn default_grpc_api_address() -> SocketAddr {
@@ -355,6 +361,10 @@ fn default_grpc_api_max_simulate_transaction_batch_size() -> u32 {
     20
 }
 
+fn default_grpc_api_max_checkpoint_inclusion_timeout_ms() -> u64 {
+    60_000 // 60 seconds
+}
+
 impl Default for GrpcApiConfig {
     fn default() -> Self {
         Self {
@@ -367,6 +377,8 @@ impl Default for GrpcApiConfig {
             ),
             max_simulate_transaction_batch_size:
                 default_grpc_api_max_simulate_transaction_batch_size(),
+            max_checkpoint_inclusion_timeout_ms:
+                default_grpc_api_max_checkpoint_inclusion_timeout_ms(),
         }
     }
 }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3624,6 +3624,43 @@ impl AuthorityState {
             .get_checkpoint_by_sequence_number(sequence_number)?)
     }
 
+    /// Wait for the given transactions to be included in a checkpoint.
+    ///
+    /// Returns a mapping from transaction digest to
+    /// `(checkpoint_sequence_number, checkpoint_timestamp_ms)`.
+    /// On timeout, returns partial results for any transactions that were
+    /// already checkpointed.
+    pub async fn wait_for_checkpoint_inclusion(
+        &self,
+        digests: &[TransactionDigest],
+        timeout: Duration,
+    ) -> IotaResult<BTreeMap<TransactionDigest, (CheckpointSequenceNumber, u64)>> {
+        let epoch_store = self.load_epoch_store_one_call_per_task();
+
+        // Local cache so multiple transactions in the same checkpoint only
+        // trigger a single checkpoint summary lookup.
+        let mut checkpoint_timestamp_cache = HashMap::<CheckpointSequenceNumber, u64>::new();
+
+        let results = epoch_store
+            .wait_for_transactions_in_checkpoint_with_timeout(digests, timeout, |seq| {
+                *checkpoint_timestamp_cache.entry(seq).or_insert_with(|| {
+                    self.get_checkpoint_by_sequence_number(seq)
+                        .ok()
+                        .flatten()
+                        .map(|c| c.timestamp_ms)
+                        .unwrap_or(0)
+                })
+            })
+            .await?;
+
+        Ok(digests
+            .iter()
+            .copied()
+            .zip(results)
+            .filter_map(|(digest, opt)| opt.map(|seq_and_ts| (digest, seq_and_ts)))
+            .collect())
+    }
+
     #[instrument(level = "trace", skip_all)]
     pub fn get_transaction_checkpoint_for_tests(
         &self,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -18,8 +18,9 @@ use fastcrypto_zkp::bn254::{
     zk_login_api::ZkLoginEnv,
 };
 use futures::{
-    FutureExt,
+    FutureExt, StreamExt,
     future::{Either, join_all, select},
+    stream::FuturesUnordered,
 };
 use iota_common::{
     fatal,
@@ -600,8 +601,9 @@ pub struct AuthorityPerEpochStore {
     consensus_notify_read: NotifyRead<SequencedConsensusTransactionKey, ()>,
 
     // Subscribers will get notified when a transaction is executed via checkpoint execution.
+    // The value is (checkpoint_sequence_number, checkpoint_timestamp_ms).
     executed_transactions_to_checkpoint_notify_read:
-        NotifyRead<TransactionDigest, CheckpointSequenceNumber>,
+        NotifyRead<TransactionDigest, (CheckpointSequenceNumber, u64)>,
 
     /// Batch verifier for certificates - also caches certificates and tx sigs
     /// that are known to have valid signatures. Lives in per-epoch store
@@ -1753,6 +1755,7 @@ impl AuthorityPerEpochStore {
         &self,
         digests: &[TransactionDigest],
         sequence: CheckpointSequenceNumber,
+        timestamp_ms: u64,
     ) -> IotaResult {
         let _metrics_scope =
             iota_metrics::monitored_scope("AuthorityPerEpochStore::insert_finalized_transactions");
@@ -1769,7 +1772,7 @@ impl AuthorityPerEpochStore {
         // checkpoint execution.
         for digest in digests {
             self.executed_transactions_to_checkpoint_notify_read
-                .notify(digest, &sequence);
+                .notify(digest, &(sequence, timestamp_ms));
         }
 
         Ok(())
@@ -2397,6 +2400,87 @@ impl AuthorityPerEpochStore {
 
         join_all(unprocessed_keys_registrations).await;
         Ok(())
+    }
+
+    /// Wait for the given transactions to be included in a checkpoint, with a
+    /// timeout.
+    ///
+    /// Returns a vec parallel to `digests` with `Some((seq, timestamp_ms))` for
+    /// each transaction that was checkpointed within the timeout, and `None`
+    /// for any that were not.
+    ///
+    /// For transactions not yet checkpointed, the `(seq, timestamp_ms)` comes
+    /// directly from the notification. For transactions already in the DB,
+    /// the seq comes from the DB table and `get_timestamp` is called to
+    /// resolve the timestamp for each unique checkpoint.
+    pub async fn wait_for_transactions_in_checkpoint_with_timeout(
+        &self,
+        digests: &[TransactionDigest],
+        timeout: std::time::Duration,
+        mut get_timestamp: impl FnMut(CheckpointSequenceNumber) -> u64,
+    ) -> IotaResult<Vec<Option<(CheckpointSequenceNumber, u64)>>> {
+        // First register for notifications and read the DB in afterwards, to avoid a
+        // race where a transaction gets checkpointed after we read the DB but
+        // before we register for notifications.
+        let registrations = self
+            .executed_transactions_to_checkpoint_notify_read
+            .register_all(digests);
+
+        // Now read the DB to see if any of the transactions were already checkpointed
+        // before we registered. For any that were, we can resolve the timestamp
+        // immediately via the callback. For any that weren't, we will wait for the
+        // notification to fire, which guarantees that the timestamp is included.
+        let already_checkpointed: Vec<Option<CheckpointSequenceNumber>> = self
+            .tables()?
+            .executed_transactions_to_checkpoint
+            .multi_get(digests)?;
+
+        let mut results: Vec<Option<(CheckpointSequenceNumber, u64)>> = vec![None; digests.len()];
+        let mut pending = Vec::new();
+
+        for (i, (registration, existing)) in registrations
+            .into_iter()
+            .zip(already_checkpointed)
+            .enumerate()
+        {
+            if let Some(seq) = existing {
+                // Transaction was already checkpointed before we started waiting.
+                // The notification has already fired so the registration won't
+                // resolve. Resolve the timestamp via the callback.
+                results[i] = Some((seq, get_timestamp(seq)));
+            } else {
+                pending.push((i, registration));
+            }
+        }
+
+        // Await pending notifications concurrently. Collect results as they
+        // arrive until the deadline.
+        if !pending.is_empty() {
+            let deadline = tokio::time::sleep(timeout);
+            tokio::pin!(deadline);
+
+            let mut in_flight: FuturesUnordered<_> = pending
+                .into_iter()
+                .map(|(i, reg)| async move { (i, reg.await) })
+                .collect();
+
+            loop {
+                tokio::select! {
+                    Some((i, seq_and_ts)) = in_flight.next() => {
+                        results[i] = Some(seq_and_ts);
+                    }
+                    () = &mut deadline => {
+                        break;
+                    }
+                    else => {
+                        // All futures completed before the deadline.
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(results)
     }
 
     pub fn has_sent_end_of_publish(&self, authority: &AuthorityName) -> IotaResult<bool> {

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -498,7 +498,7 @@ impl CheckpointExecutor {
         // Currently this code only runs on validators, where this method call does
         // nothing. But in the future, fullnodes may follow the mysticeti dag
         // and build their own checkpoints.
-        self.insert_finalized_transactions(&tx_digests, sequence_number);
+        self.insert_finalized_transactions(&tx_digests, sequence_number, checkpoint.timestamp_ms);
 
         pipeline_handle.skip_to(PipelineStage::BuildDbBatch).await;
 
@@ -555,7 +555,11 @@ impl CheckpointExecutor {
             );
         }
 
-        self.insert_finalized_transactions(&ckpt_state.data.tx_digests, sequence_number);
+        self.insert_finalized_transactions(
+            &ckpt_state.data.tx_digests,
+            sequence_number,
+            ckpt_state.data.checkpoint.timestamp_ms,
+        );
 
         // The early versions of the accumulator (prior to effectsv2) rely on db
         // state, so we must wait until all transactions have been executed
@@ -585,9 +589,10 @@ impl CheckpointExecutor {
         &self,
         tx_digests: &[TransactionDigest],
         sequence_number: CheckpointSequenceNumber,
+        timestamp_ms: u64,
     ) {
         self.epoch_store
-            .insert_finalized_transactions(tx_digests, sequence_number)
+            .insert_finalized_transactions(tx_digests, sequence_number, timestamp_ms)
             .expect("failed to insert finalized transactions");
 
         if self.state.is_fullnode(&self.epoch_store) {

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -6,7 +6,9 @@
 // submit transactions to validators for finality, and proactively executes
 // finalized transactions locally, when possible.
 
-use std::{net::SocketAddr, ops::Deref, path::Path, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap, net::SocketAddr, ops::Deref, path::Path, sync::Arc, time::Duration,
+};
 
 use futures::{
     FutureExt,
@@ -22,6 +24,7 @@ use iota_types::{
     base_types::TransactionDigest,
     error::{IotaError, IotaResult},
     iota_system_state::IotaSystemState,
+    messages_checkpoint::CheckpointSequenceNumber,
     quorum_driver_types::{
         ExecuteTransactionRequestType, ExecuteTransactionRequestV1, ExecuteTransactionResponseV1,
         FinalizedEffects, IsTransactionExecutedLocally, QuorumDriverEffectsQueueResult,
@@ -732,5 +735,21 @@ where
     ) -> Result<SimulateTransactionResult, IotaError> {
         self.validator_state
             .simulate_transaction(transaction, checks)
+    }
+
+    /// Wait for the given transactions to be included in a checkpoint.
+    ///
+    /// Returns a mapping from transaction digest to
+    /// `(checkpoint_sequence_number, checkpoint_timestamp_ms)`.
+    /// On timeout, returns partial results for any transactions that were
+    /// already checkpointed.
+    async fn wait_for_checkpoint_inclusion(
+        &self,
+        digests: &[TransactionDigest],
+        timeout: Duration,
+    ) -> Result<BTreeMap<TransactionDigest, (CheckpointSequenceNumber, u64)>, IotaError> {
+        self.validator_state
+            .wait_for_checkpoint_inclusion(digests, timeout)
+            .await
     }
 }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -27,6 +27,7 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
         .insert_finalized_transactions(
             vec![txes_to_be_notified[0]].as_slice(),
             checkpoint_sequence_1,
+            0,
         )
         .expect("Should not fail");
 
@@ -41,7 +42,7 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
     // Now insert the rest of the transactions
     let store = authority_state.epoch_store_for_testing();
     store
-        .insert_finalized_transactions(&txes_to_be_notified[1..], checkpoint_sequence_2)
+        .insert_finalized_transactions(&txes_to_be_notified[1..], checkpoint_sequence_2, 0)
         .expect("Should not fail");
 
     // We should get notified about all the transactions having been executed via

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -150,7 +150,11 @@ pub fn make_consensus_adapter_for_test(
                 if let Some(transaction_digest) = tx.transaction.executable_transaction_digest() {
                     if self.process_via_checkpoint.contains(&transaction_digest) {
                         epoch_store
-                            .insert_finalized_transactions(vec![transaction_digest].as_slice(), 10)
+                            .insert_finalized_transactions(
+                                vec![transaction_digest].as_slice(),
+                                10,
+                                0,
+                            )
                             .expect("Should not fail");
                         executed_via_checkpoint += 1;
                     } else {

--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -18,7 +18,7 @@ async fn execute_transaction_transfer() {
     let signed_tx = create_signed_transaction(&test_cluster).await;
 
     let result = client
-        .execute_transaction(signed_tx, None)
+        .execute_transaction(signed_tx, None, None)
         .await
         .expect("Failed to execute transaction");
 
@@ -66,7 +66,7 @@ async fn execute_transaction_transfer_outputs() {
         tx.try_into().expect("SDK type conversion failed");
 
     let result = client
-        .execute_transaction(signed_tx, None)
+        .execute_transaction(signed_tx, None, None)
         .await
         .expect("Failed to execute transaction");
 
@@ -100,7 +100,7 @@ async fn execute_transaction_minimal_mask() {
     let signed_tx = create_signed_transaction(&test_cluster).await;
 
     let result = client
-        .execute_transaction(signed_tx, Some("effects"))
+        .execute_transaction(signed_tx, Some("effects"), None)
         .await
         .expect("Failed to execute transaction");
 
@@ -151,7 +151,7 @@ async fn execute_transaction_invalid_signature() {
         bcs::from_bytes(&sig_bytes).expect("Corrupted signature should still deserialize");
     signed_tx.signatures = vec![corrupted_sig];
 
-    let result = client.execute_transaction(signed_tx, None).await;
+    let result = client.execute_transaction(signed_tx, None, None).await;
 
     // With batch semantics, per-item validation errors come back as Error::Server
     let err = result.expect_err("Expected error for invalid signature");
@@ -176,7 +176,7 @@ async fn execute_transaction_idempotency() {
     let signed_tx = create_signed_transaction(&test_cluster).await;
 
     let result1 = client
-        .execute_transaction(signed_tx.clone(), None)
+        .execute_transaction(signed_tx.clone(), None, None)
         .await
         .expect("First execution should succeed");
 
@@ -197,7 +197,7 @@ async fn execute_transaction_idempotency() {
     // The server uses TransactionOrchestrator with a NotifyRead pub-sub mechanism
     // that naturally returns cached effects for duplicates.
     let result2 = client
-        .execute_transaction(signed_tx, None)
+        .execute_transaction(signed_tx, None, None)
         .await
         .expect("Re-execution should return cached result");
 

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
@@ -399,3 +399,161 @@ async fn execute_transaction_batch_size_exceeded() {
         status.code()
     );
 }
+
+#[sim_test]
+async fn execute_transaction_with_checkpoint_inclusion() {
+    let (test_cluster, client) = setup_grpc_test(None, None).await;
+
+    let mut exec_client = client.execution_service_client();
+
+    let recipient = iota_types::base_types::IotaAddress::random_for_testing_only();
+    let amount = 9;
+
+    let txn =
+        make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(amount)).await;
+    let item = build_item(&txn);
+
+    // Execute with checkpoint inclusion timeout and request checkpoint + timestamp
+    // in the read mask
+    let response = exec_client
+        .execute_transactions(
+            ExecuteTransactionsRequest::default()
+                .with_transactions(vec![item])
+                .with_read_mask(FieldMask::from_paths([
+                    "transaction.digest",
+                    "effects",
+                    "checkpoint",
+                    "timestamp",
+                ]))
+                .with_checkpoint_inclusion_timeout_ms(30_000),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let executed_tx = first_executed_transaction(&response);
+
+    // Verify checkpoint and timestamp are populated
+    assert!(
+        executed_tx.checkpoint.is_some(),
+        "checkpoint should be populated when checkpoint_inclusion_timeout_ms is set"
+    );
+    assert!(
+        executed_tx.timestamp.is_some(),
+        "timestamp should be populated when checkpoint_inclusion_timeout_ms is set"
+    );
+
+    // Verify the checkpoint number is reasonable (> 0)
+    let checkpoint = executed_tx.checkpoint.unwrap();
+    assert!(checkpoint > 0, "checkpoint should be > 0, got {checkpoint}");
+
+    // Verify the timestamp is reasonable (> 0)
+    let timestamp = executed_tx.timestamp.as_ref().unwrap();
+    assert!(
+        timestamp.seconds > 0,
+        "timestamp seconds should be > 0, got {}",
+        timestamp.seconds
+    );
+}
+
+#[sim_test]
+async fn execute_transaction_without_checkpoint_timeout_has_no_checkpoint() {
+    let (test_cluster, client) = setup_grpc_test(None, None).await;
+
+    let mut exec_client = client.execution_service_client();
+
+    let recipient = iota_types::base_types::IotaAddress::random_for_testing_only();
+    let amount = 9;
+
+    let txn =
+        make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(amount)).await;
+    let item = build_item(&txn);
+
+    // Execute without checkpoint inclusion timeout but request checkpoint in mask
+    let response = exec_client
+        .execute_transactions(
+            ExecuteTransactionsRequest::default()
+                .with_transactions(vec![item])
+                .with_read_mask(FieldMask::from_paths([
+                    "transaction.digest",
+                    "effects",
+                    "checkpoint",
+                    "timestamp",
+                ])),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let executed_tx = first_executed_transaction(&response);
+
+    // Without checkpoint_inclusion_timeout_ms, checkpoint and timestamp should be
+    // absent
+    assert!(
+        executed_tx.checkpoint.is_none(),
+        "checkpoint should be None without checkpoint_inclusion_timeout_ms"
+    );
+    assert!(
+        executed_tx.timestamp.is_none(),
+        "timestamp should be None without checkpoint_inclusion_timeout_ms"
+    );
+}
+
+#[sim_test]
+async fn execute_transaction_batch_with_checkpoint_inclusion() {
+    let (test_cluster, client) = setup_grpc_test(None, None).await;
+
+    let mut exec_client = client.execution_service_client();
+
+    let recipient = iota_types::base_types::IotaAddress::random_for_testing_only();
+    let amount = 9;
+
+    // Create two valid transactions
+    let txn1 =
+        make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(amount)).await;
+    let txn2 =
+        make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(amount)).await;
+
+    let items = vec![build_item(&txn1), build_item(&txn2)];
+
+    let response = exec_client
+        .execute_transactions(
+            ExecuteTransactionsRequest::default()
+                .with_transactions(items)
+                .with_read_mask(FieldMask::from_paths([
+                    "transaction.digest",
+                    "effects",
+                    "checkpoint",
+                    "timestamp",
+                ]))
+                .with_checkpoint_inclusion_timeout_ms(30_000),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        response.transaction_results.len(),
+        2,
+        "Expected 2 results for batch of 2 transactions"
+    );
+
+    // Both transactions should have checkpoint and timestamp populated
+    for (i, result) in response.transaction_results.iter().enumerate() {
+        let executed = result.executed_transaction().unwrap_or_else(|| {
+            panic!(
+                "Expected success for transaction {i}, got: {:?}",
+                result.result
+            )
+        });
+
+        assert!(
+            executed.checkpoint.is_some(),
+            "transaction {i}: checkpoint should be populated"
+        );
+        assert!(
+            executed.timestamp.is_some(),
+            "transaction {i}: timestamp should be populated"
+        );
+    }
+}

--- a/crates/iota-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-grpc-client/src/api/execution/execute.rs
@@ -46,10 +46,10 @@ impl Client {
     /// - `effects` - includes all effects fields
     ///   - `effects.digest` - the effects digest
     ///   - `effects.bcs` - the full BCS-encoded effects
-    /// - `checkpoint` - the checkpoint that included the transaction (not
-    ///   available for just-executed transactions)
-    /// - `timestamp` - the timestamp of the checkpoint (not available for
-    ///   just-executed transactions)
+    /// - `checkpoint` - the checkpoint that included the transaction. Requires
+    ///   `checkpoint_inclusion_timeout_ms` to be set.
+    /// - `timestamp` - the timestamp of the checkpoint. Requires
+    ///   `checkpoint_inclusion_timeout_ms` to be set.
     ///
     /// ## Event Fields
     /// - `events` - includes all event fields (all events of the transaction)
@@ -83,6 +83,13 @@ impl Client {
     ///       object contents
     ///   - `output_objects.bcs` - the full BCS-encoded object
     ///
+    /// # Checkpoint Inclusion
+    ///
+    /// If `checkpoint_inclusion_timeout_ms` is set, the server will wait up to
+    /// the specified duration (in milliseconds) for the transaction to be
+    /// included in a checkpoint before returning. When set, include
+    /// `checkpoint` and `timestamp` in the `read_mask` to receive the data.
+    ///
     /// # Example
     ///
     /// ```no_run
@@ -94,7 +101,7 @@ impl Client {
     /// let signed_tx: SignedTransaction = todo!();
     ///
     /// // Execute transaction - returns proto type
-    /// let result = client.execute_transaction(signed_tx, None).await?;
+    /// let result = client.execute_transaction(signed_tx, None, None).await?;
     ///
     /// // Lazy conversion - only deserialize what you need
     /// let effects = result.body().effects()?.effects()?;
@@ -111,15 +118,20 @@ impl Client {
         &self,
         signed_transaction: SignedTransaction,
         read_mask: Option<&str>,
+        checkpoint_inclusion_timeout_ms: Option<u64>,
     ) -> Result<MetadataEnvelope<ExecutedTransaction>> {
-        self.execute_transactions(vec![signed_transaction], read_mask)
-            .await?
-            .try_map(|results| {
-                results
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| Error::Protocol("empty transaction_results".into()))?
-            })
+        self.execute_transactions(
+            vec![signed_transaction],
+            read_mask,
+            checkpoint_inclusion_timeout_ms,
+        )
+        .await?
+        .try_map(|results| {
+            results
+                .into_iter()
+                .next()
+                .ok_or_else(|| Error::Protocol("empty transaction_results".into()))?
+        })
     }
 
     /// Execute a batch of signed transactions.
@@ -141,6 +153,13 @@ impl Client {
     /// See [`execute_transaction`](Self::execute_transaction) for the full list
     /// of supported read mask fields.
     ///
+    /// # Checkpoint Inclusion
+    ///
+    /// If `checkpoint_inclusion_timeout_ms` is set, the server will wait up to
+    /// the specified duration (in milliseconds) for all executed transactions
+    /// to be included in a checkpoint before returning. When set, include
+    /// `checkpoint` and `timestamp` in the `read_mask` to receive the data.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::EmptyRequest`] if `transactions` is empty.
@@ -150,6 +169,7 @@ impl Client {
         &self,
         transactions: Vec<SignedTransaction>,
         read_mask: Option<&str>,
+        checkpoint_inclusion_timeout_ms: Option<u64>,
     ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
         if transactions.is_empty() {
             return Err(Error::EmptyRequest);
@@ -160,12 +180,16 @@ impl Client {
             .map(build_execute_item)
             .collect::<Result<Vec<_>>>()?;
 
-        let request = ExecuteTransactionsRequest::default()
+        let mut request = ExecuteTransactionsRequest::default()
             .with_transactions(items)
             .with_read_mask(field_mask_with_default(
                 read_mask,
                 EXECUTE_TRANSACTIONS_READ_MASK,
             ));
+
+        if let Some(timeout_ms) = checkpoint_inclusion_timeout_ms {
+            request = request.with_checkpoint_inclusion_timeout_ms(timeout_ms);
+        }
 
         let response = self
             .execution_service_client()

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -5,11 +5,12 @@
 mod simulate;
 mod transaction;
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use iota_grpc_types::{
     field::{FieldMaskTree, FieldMaskUtil, MessageFields},
     google::rpc::bad_request::FieldViolation,
+    proto::timestamp_ms_to_proto,
     read_masks::EXECUTE_TRANSACTIONS_READ_MASK,
     v1::{
         error_reason::ErrorReason,
@@ -17,11 +18,13 @@ use iota_grpc_types::{
         transaction_execution_service::{
             self as grpc_tx_service, ExecuteTransactionItem, ExecuteTransactionResult,
             ExecuteTransactionsRequest, ExecuteTransactionsResponse, SimulateTransactionsRequest,
-            SimulateTransactionsResponse,
+            SimulateTransactionsResponse, execute_transaction_result,
         },
     },
 };
 use iota_types::{
+    digests::TransactionDigest,
+    effects::TransactionEffectsAPI,
     quorum_driver_types::{ExecuteTransactionRequestV1, ExecuteTransactionResponseV1},
     transaction_executor::TransactionExecutor,
 };
@@ -179,6 +182,20 @@ fn parse_transaction_proto(
 /// Each transaction is executed independently — failure of one does not abort
 /// the rest. Results are returned in the same order as the input.
 ///
+/// ## Checkpoint Inclusion
+///
+/// If `checkpoint_inclusion_timeout_ms` is set in the request, the server will
+/// wait (after executing all transactions) for them to be included in a
+/// checkpoint. On success the `checkpoint` and `timestamp` fields of each
+/// `ExecutedTransaction` are populated. If the timeout expires, partial results
+/// are returned: transactions that were already checkpointed will have the
+/// fields set, while the rest will have them unset.
+///
+/// Note: `checkpoint` and `timestamp` must also be included in the `read_mask`
+/// for them to appear in the response.
+///
+/// ## Read Mask
+///
 /// The read mask paths apply directly to
 /// [`ExecutedTransaction`](iota_grpc_types::v1::transaction::ExecutedTransaction)
 /// fields (e.g. `"effects"`, not `"executed_transaction.effects"`).
@@ -212,11 +229,11 @@ fn parse_transaction_proto(
 ///     event
 ///   - `events.events.json_contents` - the JSON-encoded contents of the event
 ///
-/// ## Timing Fields
-/// - `checkpoint` - the checkpoint that included the transaction (not available
-///   for just-executed transactions)
-/// - `timestamp` - the timestamp of the checkpoint (not available for
-///   just-executed transactions)
+/// ## Checkpoint Fields
+/// - `checkpoint` - the checkpoint that included the transaction. Requires
+///   `checkpoint_inclusion_timeout_ms` to be set.
+/// - `timestamp` - the timestamp of the checkpoint. Requires
+///   `checkpoint_inclusion_timeout_ms` to be set.
 ///
 /// ## Object Fields
 /// - `input_objects` - includes all input object fields
@@ -247,16 +264,78 @@ pub async fn execute_transactions(
     let read_mask =
         parse_read_mask::<ExecutedTransaction>(request.read_mask, EXECUTE_TRANSACTIONS_READ_MASK)?;
 
-    // Execute each transaction sequentially, collecting per-item results
+    // Parse and clamp checkpoint inclusion timeout.
+    // If None or 0 is provided, we won't wait for checkpoint inclusion and the
+    // response will be returned immediately after execution with
+    // checkpoint/timestamp fields unset. If a positive value is provided, the
+    // server will wait up to the specified duration for the transaction to be
+    // included in a checkpoint before returning. The timeout is clamped by the
+    // server's max_checkpoint_inclusion_timeout_ms config to prevent excessively
+    // long waits.
+    let checkpoint_timeout = request
+        .checkpoint_inclusion_timeout_ms
+        .filter(|&ms| ms > 0)
+        .map(|ms| Duration::from_millis(ms.min(config.max_checkpoint_inclusion_timeout_ms)));
+
+    // Execute each transaction sequentially, collecting per-item results and
+    // digests for successful executions.
     let mut transaction_results = Vec::with_capacity(request.transactions.len());
-    for item in &request.transactions {
+    let mut successful_digests: Vec<(usize, TransactionDigest)> = Vec::new();
+    for (i, item) in request.transactions.iter().enumerate() {
         let result = match execute_single_transaction(reader, executor, config, item, &read_mask)
             .await
         {
-            Ok(tx) => ExecuteTransactionResult::default().with_executed_transaction(tx),
+            Ok((digest, tx)) => {
+                successful_digests.push((i, digest));
+                ExecuteTransactionResult::default().with_executed_transaction(tx)
+            }
             Err(error) => ExecuteTransactionResult::default().with_error(error.into_status_proto()),
         };
         transaction_results.push(result);
+    }
+
+    // Optionally wait for checkpoint inclusion and populate checkpoint/timestamp
+    // on the already-built results.
+    if let Some(timeout) = checkpoint_timeout {
+        if !successful_digests.is_empty() {
+            let digests: Vec<_> = successful_digests.iter().map(|(_, d)| *d).collect();
+            match executor
+                .wait_for_checkpoint_inclusion(&digests, timeout)
+                .await
+            {
+                Ok(checkpoint_map) => {
+                    let needs_checkpoint =
+                        read_mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name);
+                    let needs_timestamp =
+                        read_mask.contains(ExecutedTransaction::TIMESTAMP_FIELD.name);
+
+                    if !needs_checkpoint && !needs_timestamp {
+                        // No need to update results if fields aren't requested in read mask
+                        return Ok(ExecuteTransactionsResponse::default()
+                            .with_transaction_results(transaction_results));
+                    }
+
+                    for (i, digest) in &successful_digests {
+                        if let Some((seq, ts)) = checkpoint_map.get(digest) {
+                            if let Some(execute_transaction_result::Result::ExecutedTransaction(
+                                ref mut tx,
+                            )) = transaction_results[*i].result
+                            {
+                                if needs_checkpoint {
+                                    tx.checkpoint = Some(*seq);
+                                }
+                                if needs_timestamp && *ts > 0 {
+                                    tx.timestamp = Some(timestamp_ms_to_proto(*ts));
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("wait_for_checkpoint_inclusion failed: {e}");
+                }
+            }
+        }
     }
 
     Ok(ExecuteTransactionsResponse::default().with_transaction_results(transaction_results))
@@ -269,7 +348,7 @@ async fn execute_single_transaction(
     config: &iota_config::node::GrpcApiConfig,
     item: &ExecuteTransactionItem,
     read_mask: &FieldMaskTree,
-) -> Result<ExecutedTransaction, RpcError> {
+) -> Result<(TransactionDigest, ExecutedTransaction), RpcError> {
     let sdk_transaction = parse_transaction_proto(item.transaction.as_ref())?;
 
     // Extract and validate signatures
@@ -337,6 +416,8 @@ async fn execute_single_transaction(
         .await
         .map_err(RpcError::from)?;
 
+    let digest = *effects.effects.transaction_digest();
+
     // Build the merged response
     let sdk_transaction: iota_sdk_types::Transaction =
         transaction.transaction_data().clone().try_into()?;
@@ -360,6 +441,8 @@ async fn execute_single_transaction(
         output_objects,
     };
 
-    ExecutedTransaction::merge_from(&source, read_mask)
-        .map_err(|e| e.with_context("failed to merge executed transaction"))
+    let executed = ExecutedTransaction::merge_from(&source, read_mask)
+        .map_err(|e| e.with_context("failed to merge executed transaction"))?;
+
+    Ok((digest, executed))
 }

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -684,6 +684,14 @@ impl GrpcReader {
         self.state_reader.get_chain_identifier()
     }
 
+    /// Get checkpoint summary by sequence number.
+    pub fn get_checkpoint_summary(
+        &self,
+        seq: u64,
+    ) -> anyhow::Result<Option<CertifiedCheckpointSummary>> {
+        self.state_reader.get_checkpoint_summary(seq)
+    }
+
     /// Get checkpoint sequence number by digest
     pub fn get_checkpoint_sequence_number_by_digest(
         &self,

--- a/crates/iota-grpc-types/proto/iota/grpc/v1/transaction_execution_service.proto
+++ b/crates/iota-grpc-types/proto/iota/grpc/v1/transaction_execution_service.proto
@@ -43,6 +43,14 @@ message ExecuteTransactionsRequest {
   // Mask specifying which fields to read, applied to each ExecutedTransaction in the response.
   // If no mask is specified, defaults to `transaction.digest,effects,events,input_objects,output_objects`.
   optional google.protobuf.FieldMask read_mask = 2;
+
+  // Optional timeout in milliseconds for waiting for checkpoint inclusion.
+  // If set and > 0, after executing all transactions, the server waits up to
+  // this duration for them to be included in a checkpoint, populating the
+  // `checkpoint` and `timestamp` fields in the response, if specified in `read_mask`.
+  // If not set or zero, no waiting is done (default behavior).
+  // The server may clamp this to a configured maximum.
+  optional uint64 checkpoint_inclusion_timeout_ms = 3;
 }
 
 // The result of executing a single transaction: either the executed transaction or an error.

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.accessors.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.accessors.rs
@@ -63,6 +63,11 @@ mod _accessor_impls {
             self.read_mask = Some(field.into());
             self
         }
+        /// Sets `checkpoint_inclusion_timeout_ms` with the provided value.
+        pub fn with_checkpoint_inclusion_timeout_ms(mut self, field: u64) -> Self {
+            self.checkpoint_inclusion_timeout_ms = Some(field);
+            self
+        }
     }
     impl super::ExecuteTransactionsResponse {
         /// Sets `transaction_results` with the provided value.

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.field_info.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.field_info.rs
@@ -97,11 +97,20 @@ mod _field_impls {
             is_map: false,
             message_fields: None,
         };
+        pub const CHECKPOINT_INCLUSION_TIMEOUT_MS_FIELD: &'static MessageField = &MessageField {
+            name: "checkpoint_inclusion_timeout_ms",
+            json_name: "checkpointInclusionTimeoutMs",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
     }
     impl MessageFields for ExecuteTransactionsRequest {
         const FIELDS: &'static [&'static MessageField] = &[
             Self::TRANSACTIONS_FIELD,
             Self::READ_MASK_FIELD,
+            Self::CHECKPOINT_INCLUSION_TIMEOUT_MS_FIELD,
         ];
     }
     impl ExecuteTransactionsRequest {
@@ -130,6 +139,14 @@ mod _field_impls {
         }
         pub fn read_mask(mut self) -> String {
             self.path.push(ExecuteTransactionsRequest::READ_MASK_FIELD.name);
+            self.finish()
+        }
+        pub fn checkpoint_inclusion_timeout_ms(mut self) -> String {
+            self.path
+                .push(
+                    ExecuteTransactionsRequest::CHECKPOINT_INCLUSION_TIMEOUT_MS_FIELD
+                        .name,
+                );
             self.finish()
         }
     }

--- a/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.rs
+++ b/crates/iota-grpc-types/src/proto/generated/iota.grpc.v1.transaction_execution_service.rs
@@ -26,6 +26,14 @@ pub struct ExecuteTransactionsRequest {
     /// If no mask is specified, defaults to `transaction.digest,effects,events,input_objects,output_objects`.
     #[prost(message, optional, tag = "2")]
     pub read_mask: ::core::option::Option<::prost_types::FieldMask>,
+    /// Optional timeout in milliseconds for waiting for checkpoint inclusion.
+    /// If set and > 0, after executing all transactions, the server waits up to
+    /// this duration for them to be included in a checkpoint, populating the
+    /// `checkpoint` and `timestamp` fields in the response, if specified in `read_mask`.
+    /// If not set or zero, no waiting is done (default behavior).
+    /// The server may clamp this to a configured maximum.
+    #[prost(uint64, optional, tag = "3")]
+    pub checkpoint_inclusion_timeout_ms: ::core::option::Option<u64>,
 }
 /// The result of executing a single transaction: either the executed transaction or an error.
 #[non_exhaustive]

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -229,7 +229,11 @@ impl OptimisticTransactionExecutor {
 
         let response = self
             .rpc_client
-            .execute_transaction(transaction.clone().try_into()?, Some(readmask.as_str()))
+            .execute_transaction(
+                transaction.clone().try_into()?,
+                Some(readmask.as_str()),
+                None,
+            )
             .await;
 
         let executed_transaction = match response {

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -2,13 +2,15 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 use crate::{
     base_types::ObjectID,
+    digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEvents},
     error::{ExecutionError, IotaError},
     execution::ExecutionResult,
+    messages_checkpoint::CheckpointSequenceNumber,
     object::Object,
     quorum_driver_types::{
         ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, QuorumDriverError,
@@ -31,6 +33,18 @@ pub trait TransactionExecutor: Send + Sync {
         transaction: TransactionData,
         checks: VmChecks,
     ) -> Result<SimulateTransactionResult, IotaError>;
+
+    /// Wait for the given transactions to be included in a checkpoint.
+    ///
+    /// Returns a mapping from transaction digest to
+    /// `(checkpoint_sequence_number, checkpoint_timestamp_ms)`.
+    /// On timeout, returns partial results for any transactions that were
+    /// already checkpointed.
+    async fn wait_for_checkpoint_inclusion(
+        &self,
+        digests: &[TransactionDigest],
+        timeout: Duration,
+    ) -> Result<BTreeMap<TransactionDigest, (CheckpointSequenceNumber, u64)>, IotaError>;
 }
 
 pub struct SimulateTransactionResult {

--- a/crates/simulacrum/src/transaction_executor.rs
+++ b/crates/simulacrum/src/transaction_executor.rs
@@ -7,12 +7,15 @@
 //! transaction execution and simulation via gRPC without requiring quorum
 //! consensus.
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use async_trait::async_trait;
 use iota_types::{
+    digests::TransactionDigest,
     effects::TransactionEffectsAPI,
+    error::IotaError,
+    messages_checkpoint::CheckpointSequenceNumber,
     quorum_driver_types::{
         ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, FinalizedEffects,
         QuorumDriverError,
@@ -125,5 +128,21 @@ impl TransactionExecutorTrait for TransactionExecutor {
         checks: VmChecks,
     ) -> Result<SimulateTransactionResult, iota_types::error::IotaError> {
         self.simulacrum.simulate_transaction(transaction, checks)
+    }
+
+    /// Wait for the given transactions to be included in a checkpoint.
+    ///
+    /// Returns a mapping from transaction digest to
+    /// `(checkpoint_sequence_number, checkpoint_timestamp_ms)`.
+    /// On timeout, returns partial results for any transactions that were
+    /// already checkpointed.
+    async fn wait_for_checkpoint_inclusion(
+        &self,
+        _digests: &[TransactionDigest],
+        _timeout: Duration,
+    ) -> Result<BTreeMap<TransactionDigest, (CheckpointSequenceNumber, u64)>, IotaError> {
+        Err(IotaError::UnsupportedFeature {
+            error: "wait_for_checkpoint_inclusion not supported by this executor".into(),
+        })
     }
 }


### PR DESCRIPTION
# Description of change

This PR adds an option to the `execute_transactions` endpoint to wait for checkpoint inclusion with a defined timeout.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes