### PR TITLE
feat(indexer,ts-sdk): Return unwrapped objects in object changes

### DIFF
--- a/.changeset/six-lies-count.md
+++ b/.changeset/six-lies-count.md
@@ -1,0 +1,6 @@
+---
+'@iota/graphql-transport': minor
+'@iota/iota-sdk': minor
+---
+
+Add support for unwrapped objects

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -124,6 +124,11 @@ It supports following backfill options:
 This job backfills the `tx_wrapped_or_deleted_objects` table, which indexes transactions that either wrapped or deleted given objects.
 Replace `<START>` and `<END>` with the desired checkpoint range to backfill (e.g., `0` `10000`, both inclusive), and `<REMOTE_STORE_URL>` with the fullnode gRPC API URL used to fetch checkpoint data.
 
+#### Backfill job: `object-changes-unwrapped`
+
+This job backfills the information about unwrapped objects to the `transactions` table.
+Replace `<START>` and `<END>` with the desired checkpoint range to backfill (e.g., `0` `10000`, both inclusive), and `<REMOTE_STORE_URL>` with the fullnode REST API URL used to fetch checkpoint data.
+
 ```sh
 cargo run --bin iota-indexer -- --database-url <DATABASE_URL> run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects --remote-store-url <REMOTE_STORE_URL>
 ```

--- a/crates/iota-indexer/src/backfill/ingestion/adapter.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/adapter.rs
@@ -33,7 +33,7 @@ impl<T: IngestionBackfill> Worker for Adapter<T> {
         &self,
         checkpoint: Arc<CheckpointData>,
     ) -> Result<(), IndexerError> {
-        let processed = T::process_checkpoint(checkpoint.clone())?;
+        let processed = T::process_checkpoint(checkpoint.clone()).await?;
         self.ready_checkpoints
             .insert(checkpoint.checkpoint_summary.sequence_number, processed);
         self.notify.notify_waiters();

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/mod.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod object_changes_unwrapped;
 pub(crate) mod tx_wrapped_or_deleted_objects;

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use std::sync::Arc;
+
+use diesel::{ExpressionMethods, RunQueryDsl};
+use downcast::Any;
+use iota_types::{effects::TransactionEffectsAPI, full_checkpoint_content::CheckpointData};
+
+use crate::{
+    Duration, IndexerMetrics, Registry, backfill::ingestion::IngestionBackfill, db::ConnectionPool,
+    errors::IndexerError, ingestion::primary::prepare::PrimaryWorker,
+    models::transactions::StoredTransaction, schema::transactions,
+    transactional_blocking_with_retry,
+};
+
+const PG_DB_COMMIT_SLEEP_DURATION: Duration = Duration::from_secs(3600);
+
+pub(crate) struct ObjectChangesUnwrappedBackfill;
+
+#[async_trait::async_trait]
+impl IngestionBackfill for ObjectChangesUnwrappedBackfill {
+    type ProcessedType = StoredTransaction;
+
+    async fn process_checkpoint(
+        checkpoint: Arc<CheckpointData>,
+    ) -> Result<Vec<Self::ProcessedType>, IndexerError> {
+        let checkpoint_summary = &checkpoint.checkpoint_summary;
+        let checkpoint_contents = &checkpoint.checkpoint_contents;
+        let transactions = &checkpoint.transactions;
+        let checkpoint_seq = checkpoint_summary.sequence_number;
+
+        if checkpoint_contents.size() != transactions.len() {
+            return Err(IndexerError::FullNodeReading(format!(
+                "checkpoint content size mismatch at checkpoint {checkpoint_seq}: expected {}, found {}",
+                checkpoint_contents.size(),
+                transactions.len()
+            )));
+        }
+
+        let tx_seq_numbers = checkpoint_contents
+            .enumerate_transactions(checkpoint_summary)
+            .map(|(seq, digest)| (digest.transaction, seq));
+
+        let mut results = Vec::new();
+        let dummy_metrics = IndexerMetrics::new(&Registry::new());
+
+        // Only transactions with unwrapped objects need to be backfilled
+        for (tx, (expected_digest, tx_sequence_number)) in transactions
+            .iter()
+            .zip(tx_seq_numbers)
+            .filter(|(tx, _)| !tx.effects.unwrapped().is_empty())
+        {
+            let actual_digest = tx.transaction.digest();
+
+            if expected_digest != *actual_digest {
+                return Err(IndexerError::FullNodeReading(format!(
+                    "digest mismatch at checkpoint {checkpoint_seq}: expected {expected_digest}, found {actual_digest}",
+                )));
+            }
+
+            let indexed_tx = PrimaryWorker::index_transaction(
+                tx,
+                tx_sequence_number,
+                checkpoint_seq,
+                checkpoint_summary.timestamp_ms,
+                &dummy_metrics,
+            )
+            .await?;
+
+            results.push(StoredTransaction::from(&indexed_tx));
+        }
+
+        Ok(results)
+    }
+
+    async fn persist_chunk(
+        pool: ConnectionPool,
+        processed_data: Vec<Self::ProcessedType>,
+    ) -> Result<(), IndexerError> {
+        if processed_data.is_empty() {
+            return Ok(());
+        }
+
+        let (tx_sequence_numbers, object_changes): (Vec<i64>, Vec<Vec<Option<Vec<u8>>>>) =
+            processed_data
+                .into_iter()
+                .map(|tx| (tx.tx_sequence_number, tx.object_changes))
+                .unzip();
+
+        // The UPDATE only affects rows that exist in the database. Update for
+        // non-existing rows is silently skipped.
+        transactional_blocking_with_retry!(
+            &pool,
+            |conn| {
+                for (tx_seq, obj_changes) in tx_sequence_numbers.iter().zip(object_changes.iter()) {
+                    diesel::update(transactions::table)
+                        .filter(transactions::tx_sequence_number.eq(tx_seq))
+                        .set(transactions::object_changes.eq(obj_changes))
+                        .execute(conn)?;
+                }
+
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+}

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
@@ -20,7 +20,7 @@ pub(crate) struct TxWrappedOrDeletedObjectsBackfill;
 impl IngestionBackfill for TxWrappedOrDeletedObjectsBackfill {
     type ProcessedType = StoredTxWrappedOrDeletedObject;
 
-    fn process_checkpoint(
+    async fn process_checkpoint(
         checkpoint: Arc<CheckpointData>,
     ) -> Result<Vec<Self::ProcessedType>, IndexerError> {
         let checkpoint_summary = &checkpoint.checkpoint_summary;

--- a/crates/iota-indexer/src/backfill/ingestion/mod.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/mod.rs
@@ -18,7 +18,7 @@ pub(crate) trait IngestionBackfill: Send + Sync {
     type ProcessedType: Send + Sync;
 
     /// Converts a `CheckpointData` into zero-or-more items (`ProcessedType`).
-    fn process_checkpoint(
+    async fn process_checkpoint(
         checkpoint: Arc<CheckpointData>,
     ) -> Result<Vec<Self::ProcessedType>, IndexerError>;
 

--- a/crates/iota-indexer/src/backfill/ingestion/task.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/task.rs
@@ -169,7 +169,7 @@ mod tests {
     impl IngestionBackfill for BackfillDummyTable {
         type ProcessedType = usize;
 
-        fn process_checkpoint(
+        async fn process_checkpoint(
             checkpoint: Arc<CheckpointData>,
         ) -> Result<Vec<Self::ProcessedType>, IndexerError> {
             Ok(vec![checkpoint.checkpoint_summary.sequence_number as usize])

--- a/crates/iota-indexer/src/backfill/mod.rs
+++ b/crates/iota-indexer/src/backfill/mod.rs
@@ -11,7 +11,10 @@ use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use crate::{
     backfill::{
         ingestion::{
-            jobs::tx_wrapped_or_deleted_objects::TxWrappedOrDeletedObjectsBackfill,
+            jobs::{
+                object_changes_unwrapped::ObjectChangesUnwrappedBackfill,
+                tx_wrapped_or_deleted_objects::TxWrappedOrDeletedObjectsBackfill,
+            },
             task::IngestionBackfillTask,
         },
         sql::sql_backfill::SqlBackfill,
@@ -78,6 +81,7 @@ pub enum BackfillKind {
 pub enum IngestionBackfillKind {
     /// Backfills the `tx_wrapped_or_deleted_objects` table.
     TxWrappedOrDeletedObjects,
+    ObjectChangesUnwrapped,
 }
 
 pub(crate) async fn get_backfill(
@@ -89,6 +93,13 @@ pub(crate) async fn get_backfill(
         BackfillKind::Ingestion { kind, config } => match kind {
             IngestionBackfillKind::TxWrappedOrDeletedObjects => Ok(Arc::new(
                 IngestionBackfillTask::<TxWrappedOrDeletedObjectsBackfill>::new(
+                    config,
+                    range_start as CheckpointSequenceNumber,
+                )
+                .await?,
+            )),
+            IngestionBackfillKind::ObjectChangesUnwrapped => Ok(Arc::new(
+                IngestionBackfillTask::<ObjectChangesUnwrappedBackfill>::new(
                     config,
                     range_start as CheckpointSequenceNumber,
                 )

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -520,6 +520,16 @@ pub enum IndexedObjectChange {
         object_id: ObjectID,
         version: SequenceNumber,
     },
+    /// Unwrapped object
+    Unwrapped {
+        sender: IotaAddress,
+        owner: Owner,
+        #[serde_as(as = "IotaStructTag")]
+        object_type: StructTag,
+        object_id: ObjectID,
+        version: SequenceNumber,
+        digest: ObjectDigest,
+    },
     /// New object creation
     Created {
         sender: IotaAddress,
@@ -599,6 +609,21 @@ impl From<ObjectChange> for IndexedObjectChange {
                 object_type,
                 object_id,
                 version,
+            },
+            ObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => Self::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
             },
             ObjectChange::Created {
                 sender,
@@ -686,6 +711,21 @@ impl From<IndexedObjectChange> for ObjectChange {
                 object_type,
                 object_id,
                 version,
+            },
+            IndexedObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => ObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
             },
             IndexedObjectChange::Created {
                 sender,

--- a/crates/iota-indexer/tests/data/wrap_unwrap/Move.toml
+++ b/crates/iota-indexer/tests/data/wrap_unwrap/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "wrap_unwrap"
+edition = "2024.beta"
+
+[dependencies]
+Iota = { local = "../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+wrap_unwrap = "0x0"

--- a/crates/iota-indexer/tests/data/wrap_unwrap/sources/wrap_unwrap.move
+++ b/crates/iota-indexer/tests/data/wrap_unwrap/sources/wrap_unwrap.move
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Test module for wrapping and unwrapping objects
+module wrap_unwrap::wrap_unwrap {
+
+    public struct Inner has key, store {
+        id: UID,
+    }
+
+    public struct Wrapper has key, store {
+        id: UID,
+        inner: Inner,
+    }
+
+    public entry fun create_and_wrap(ctx: &mut TxContext) {
+        let inner = Inner { id: object::new(ctx) };
+        iota::transfer::public_transfer(
+            Wrapper { id: object::new(ctx), inner },
+            tx_context::sender(ctx),
+        );
+    }
+
+    public entry fun unwrap(wrapper: Wrapper, ctx: &mut TxContext) {
+        let Wrapper { id, inner } = wrapper;
+        object::delete(id);
+        iota::transfer::public_transfer(inner, tx_context::sender(ctx));
+    }
+}

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -10,13 +10,14 @@ use iota_indexer::{
     store::{PgIndexerStore, package_resolver::IndexerStorePackageResolver},
     test_utils::{TestDatabase, db_url},
 };
-use iota_json::{call_args, type_args};
+use iota_json::{IotaJsonValue, call_args, type_args};
 use iota_json_rpc_api::{IndexerApiClient, ReadApiClient, TransactionBuilderClient};
 use iota_json_rpc_types::{
     CheckpointId, IotaGetPastObjectRequest, IotaObjectDataOptions, IotaObjectRef,
     IotaObjectResponse, IotaObjectResponseQuery, IotaPastObjectResponse,
     IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    IotaTransactionBlockResponseOptions, IotaTransactionBlockResponseQueryV2, TransactionFilterV2,
+    IotaTransactionBlockResponseOptions, IotaTransactionBlockResponseQueryV2, ObjectChange,
+    TransactionFilterV2,
 };
 use iota_package_resolver::Resolver;
 use iota_protocol_config::ProtocolVersion;
@@ -26,7 +27,7 @@ use iota_test_transaction_builder::{
 };
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
-    crypto::{AccountKeyPair, get_key_pair},
+    crypto::{AccountKeyPair, IotaKeyPair, get_key_pair},
     digests::{ChainIdentifier, ObjectDigest, TransactionDigest},
     error::IotaObjectResponseError,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -40,10 +41,11 @@ use rand::{SeedableRng, rngs::StdRng};
 use serde_json::Value;
 
 use crate::{
+    coin_api::execute_move_call,
     common::{
         ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer_checkpoint,
         indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
-        indexer_wait_for_transaction, rpc_call_error_msg_matches,
+        indexer_wait_for_transaction, publish_test_move_package, rpc_call_error_msg_matches,
         start_test_cluster_with_read_write_indexer,
     },
     write_api::{create_basic_object, deploy_basics_pkg},
@@ -2577,4 +2579,106 @@ fn is_transaction_present() {
                 .unwrap()
         );
     });
+}
+
+#[test]
+fn get_transaction_block_with_unwrapped_object_changes() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+        let keypair = IotaKeyPair::Ed25519(keypair);
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000_000),
+                address,
+            )
+            .await;
+        let gas_object_id = gas.0;
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        let ((package_id, _, _), publish_tx_response) =
+            publish_test_move_package(client, address, &keypair, "wrap_unwrap").await?;
+        indexer_wait_for_transaction(publish_tx_response.digest, store, client).await;
+
+        let create_wrapped_res = execute_move_call(
+            client,
+            address,
+            &keypair,
+            package_id,
+            "wrap_unwrap".to_string(),
+            "create_and_wrap".to_string(),
+            vec![],
+            vec![],
+            Some(gas_object_id),
+        )
+        .await?;
+
+        let wrapper_object_id = create_wrapped_res
+            .effects
+            .as_ref()
+            .unwrap()
+            .created()
+            .first()
+            .expect("expected created object")
+            .reference
+            .object_id;
+
+        let unwrap_res = execute_move_call(
+            client,
+            address,
+            &keypair,
+            package_id,
+            "wrap_unwrap".to_string(),
+            "unwrap".to_string(),
+            vec![],
+            vec![IotaJsonValue::from_object_id(wrapper_object_id)],
+            Some(gas_object_id),
+        )
+        .await?;
+        indexer_wait_for_transaction(unwrap_res.digest, store, client).await;
+
+        let options = IotaTransactionBlockResponseOptions::default().with_object_changes();
+        let fullnode_tx = cluster
+            .rpc_client()
+            .get_transaction_block(unwrap_res.digest, Some(options.clone()))
+            .await
+            .unwrap();
+        let indexer_tx = client
+            .get_transaction_block(unwrap_res.digest, Some(options.clone()))
+            .await
+            .unwrap();
+
+        assert!(
+            fullnode_tx
+                .object_changes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|change| matches!(change, ObjectChange::Unwrapped { .. })),
+            "fullnode response should contain Unwrapped object change"
+        );
+        assert!(
+            indexer_tx
+                .object_changes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|change| matches!(change, ObjectChange::Unwrapped { .. })),
+            "indexer response should contain Unwrapped object change"
+        );
+
+        assert_eq!(
+            fullnode_tx, indexer_tx,
+            "fullnode and indexer responses should match"
+        );
+
+        Ok(())
+    })
 }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -331,7 +331,8 @@ impl Display for IotaTransactionBlockResponse {
                 mut published,
                 mut transferred,
                 mut wrapped,
-            ) = (vec![], vec![], vec![], vec![], vec![], vec![]);
+                mut unwrapped,
+            ) = (vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
 
             for obj in object_changes {
                 match obj {
@@ -341,6 +342,7 @@ impl Display for IotaTransactionBlockResponse {
                     ObjectChange::Published { .. } => published.push(obj),
                     ObjectChange::Transferred { .. } => transferred.push(obj),
                     ObjectChange::Wrapped { .. } => wrapped.push(obj),
+                    ObjectChange::Unwrapped { .. } => unwrapped.push(obj),
                 };
             }
 
@@ -350,6 +352,7 @@ impl Display for IotaTransactionBlockResponse {
             write_obj_changes(published, "Published", &mut builder)?;
             write_obj_changes(transferred, "Transferred", &mut builder)?;
             write_obj_changes(wrapped, "Wrapped", &mut builder)?;
+            write_obj_changes(unwrapped, "Unwrapped", &mut builder)?;
 
             let mut table = builder.build();
             table.with(TablePanel::header("Object Changes"));

--- a/crates/iota-json-rpc-types/src/object_changes.rs
+++ b/crates/iota-json-rpc-types/src/object_changes.rs
@@ -85,6 +85,20 @@ pub enum ObjectChange {
         #[serde_as(as = "AsSequenceNumber")]
         version: SequenceNumber,
     },
+    /// Unwrapped object
+    #[serde(rename_all = "camelCase")]
+    Unwrapped {
+        sender: IotaAddress,
+        owner: Owner,
+        #[schemars(with = "String")]
+        #[serde_as(as = "IotaStructTag")]
+        object_type: StructTag,
+        object_id: ObjectID,
+        #[schemars(with = "AsSequenceNumber")]
+        #[serde_as(as = "AsSequenceNumber")]
+        version: SequenceNumber,
+        digest: ObjectDigest,
+    },
     /// New object creation
     #[serde(rename_all = "camelCase")]
     Created {
@@ -109,6 +123,7 @@ impl ObjectChange {
             | ObjectChange::Mutated { object_id, .. }
             | ObjectChange::Deleted { object_id, .. }
             | ObjectChange::Wrapped { object_id, .. }
+            | ObjectChange::Unwrapped { object_id, .. }
             | ObjectChange::Created { object_id, .. } => *object_id,
         }
     }
@@ -128,6 +143,12 @@ impl ObjectChange {
                 ..
             }
             | ObjectChange::Mutated {
+                object_id,
+                version,
+                digest,
+                ..
+            }
+            | ObjectChange::Unwrapped {
                 object_id,
                 version,
                 digest,
@@ -157,6 +178,9 @@ impl ObjectChange {
                 version, digest, ..
             }
             | ObjectChange::Mutated {
+                version, digest, ..
+            }
+            | ObjectChange::Unwrapped {
                 version, digest, ..
             }
             | ObjectChange::Created {
@@ -257,6 +281,25 @@ impl Display for ObjectChange {
                     sender,
                     object_type,
                     u64::from(*version)
+                )
+            }
+            ObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => {
+                write!(
+                    f,
+                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Owner: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
+                    object_id,
+                    sender,
+                    owner,
+                    object_type,
+                    u64::from(*version),
+                    digest
                 )
             }
             ObjectChange::Created {

--- a/crates/iota-json-rpc/src/object_changes.rs
+++ b/crates/iota-json-rpc/src/object_changes.rs
@@ -52,7 +52,14 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
                     version,
                     digest,
                 }),
-                _ => {}
+                WriteKind::Unwrap => object_changes.push(ObjectChange::Unwrapped {
+                    sender,
+                    owner,
+                    object_type,
+                    object_id,
+                    version,
+                    digest,
+                }),
             }
         } else if let Some(p) = o.data.try_as_package() {
             if kind == WriteKind::Create {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -10850,6 +10850,45 @@
             }
           },
           {
+            "description": "Unwrapped object",
+            "type": "object",
+            "required": [
+              "digest",
+              "objectId",
+              "objectType",
+              "owner",
+              "sender",
+              "type",
+              "version"
+            ],
+            "properties": {
+              "digest": {
+                "$ref": "#/components/schemas/ObjectDigest"
+              },
+              "objectId": {
+                "$ref": "#/components/schemas/ObjectID"
+              },
+              "objectType": {
+                "type": "string"
+              },
+              "owner": {
+                "$ref": "#/components/schemas/Owner"
+              },
+              "sender": {
+                "$ref": "#/components/schemas/IotaAddress"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "unwrapped"
+                ]
+              },
+              "version": {
+                "$ref": "#/components/schemas/SequenceNumber2"
+              }
+            }
+          },
+          {
             "description": "New object creation",
             "type": "object",
             "required": [

--- a/crates/iota/src/displays/dry_run_tx_block.rs
+++ b/crates/iota/src/displays/dry_run_tx_block.rs
@@ -50,7 +50,8 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
                 mut published,
                 mut transferred,
                 mut wrapped,
-            ) = (vec![], vec![], vec![], vec![], vec![], vec![]);
+                mut unwrapped,
+            ) = (vec![], vec![], vec![], vec![], vec![], vec![], vec![]);
             for obj in &response.object_changes {
                 match obj {
                     ObjectChange::Created { .. } => created.push(obj),
@@ -59,6 +60,7 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
                     ObjectChange::Published { .. } => published.push(obj),
                     ObjectChange::Transferred { .. } => transferred.push(obj),
                     ObjectChange::Wrapped { .. } => wrapped.push(obj),
+                    ObjectChange::Unwrapped { .. } => unwrapped.push(obj),
                 };
             }
 
@@ -68,6 +70,7 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
             write_obj_changes(published, "Published", &mut builder)?;
             write_obj_changes(transferred, "Transferred", &mut builder)?;
             write_obj_changes(wrapped, "Wrapped", &mut builder)?;
+            write_obj_changes(unwrapped, "Unwrapped", &mut builder)?;
 
             let mut table = builder.build();
             table.with(TablePanel::header("Object Changes"));

--- a/sdk/graphql-transport/src/mappers/transaction-block.ts
+++ b/sdk/graphql-transport/src/mappers/transaction-block.ts
@@ -159,15 +159,31 @@ function mapObjectChanges(
         });
     });
 
-    effects?.unwrapped?.forEach((unwrapped) => {
+    effects?.wrapped?.forEach((wrapped) => {
         changes.push({
             type: 'wrapped',
+            objectId: wrapped.objectId,
+            objectType: toShortTypeString(
+                transactionBlock.effects?.objectChanges?.nodes.find(
+                    (change) => change.address === wrapped.objectId,
+                )?.inputState?.asMoveObject?.contents?.type.repr!,
+            ),
+            sender: transactionBlock.sender?.address!,
+            version: wrapped.version?.toString(),
+        });
+    });
+
+    effects?.unwrapped?.forEach((unwrapped) => {
+        changes.push({
+            type: 'unwrapped',
+            digest: unwrapped.reference.digest,
             objectId: unwrapped.reference.objectId,
             objectType: toShortTypeString(
                 transactionBlock.effects?.objectChanges?.nodes.find(
                     (change) => change.address === unwrapped.reference.objectId,
                 )?.outputState?.asMoveObject?.contents?.type.repr!,
             ),
+            owner: unwrapped.owner,
             sender: transactionBlock.sender?.address!,
             version: unwrapped.reference.version?.toString(),
         });

--- a/sdk/typescript/src/client/types/changes.ts
+++ b/sdk/typescript/src/client/types/changes.ts
@@ -10,3 +10,4 @@ export type IotaObjectChangeMutated = Extract<IotaObjectChange, { type: 'mutated
 export type IotaObjectChangeDeleted = Extract<IotaObjectChange, { type: 'deleted' }>;
 export type IotaObjectChangeWrapped = Extract<IotaObjectChange, { type: 'wrapped' }>;
 export type IotaObjectChangeCreated = Extract<IotaObjectChange, { type: 'created' }>;
+export type IotaObjectChangeUnwrapped = Extract<IotaObjectChange, { type: 'unwrapped' }>;

--- a/sdk/typescript/src/client/types/generated.ts
+++ b/sdk/typescript/src/client/types/generated.ts
@@ -1266,6 +1266,15 @@ export type IotaObjectChange =
           sender: string;
           type: 'wrapped';
           version: string;
+      } /** Unwrapped object */
+    | {
+          digest: string;
+          objectId: string;
+          objectType: string;
+          owner: ObjectOwner;
+          sender: string;
+          type: 'unwrapped';
+          version: string;
       } /** New object creation */
     | {
           digest: string;


### PR DESCRIPTION
# Description of change

Adds support for unwrapped objects in transaction object changes, making them visible in API responses and the TS SDK.

1. **Store unwrapped object changes** — IndexedTransactions now include unwrapped objects in `object_changes` (#9774)
2. **Backfill job** — `object-changes-unwrapped` backfill command to populate historical data (#9799)
3. **TS SDK update** — SDK updated to handle unwrapped objects (#10808)

## Links to any relevant issues

fixes #4727

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

   - [x] Indexer: Unwrapped objects are now included in transaction object changes. A `run-backfill object-changes-unwrapped` command is available to populate historical data.
   - [x] JSON-RPC: Transaction responses now include unwrapped objects in the `objectChanges` field.
 
