### PR TITLE
upstream(core): Enable TLS by default for validator gRPC client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8293,6 +8293,7 @@ dependencies = [
  "iota-sdk",
  "iota-snapshot",
  "iota-storage",
+ "iota-tls",
  "iota-types",
  "itertools 0.13.0",
  "move-core-types",

--- a/crates/iota-core/src/authority_client.rs
+++ b/crates/iota-core/src/authority_client.rs
@@ -30,6 +30,7 @@ use iota_types::{
     multiaddr::Multiaddr,
     transaction::*,
 };
+use tap::TapFallible;
 
 use crate::authority_client::tonic::IntoRequest;
 
@@ -264,27 +265,35 @@ pub fn make_network_authority_clients_with_network_config(
 ) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
     let mut authority_clients = BTreeMap::new();
     for (name, (_state, network_metadata)) in committee.validators() {
-        let address = network_metadata.network_address.clone();
-        let address = address.rewrite_udp_to_tcp();
-        // TODO: Enable TLS on this interface with below config, once support is rolled
-        // out to validators. let tls_config =
-        // network_metadata.network_public_key.as_ref().map(|key| {
-        //     iota_tls::create_rustls_client_config(
-        //         key.clone(),
-        //         iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
-        //         None,
-        //     )
-        // });
-        // TODO: Change below code to generate a IotaError if no valid TLS config is
-        // available.
-        let maybe_channel = network_config.connect_lazy(&address, None).map_err(|e| {
-            tracing::error!(
-                address = %address,
-                name = %name,
-                "unable to create authority client: {e}"
-            );
-            e.to_string().into()
-        });
+        let address = network_metadata
+            .network_address
+            .clone()
+            .rewrite_udp_to_tcp()
+            .rewrite_http_to_https();
+        let tls_config = network_metadata
+            .network_public_key
+            .as_ref()
+            .map(|key| {
+                iota_tls::create_rustls_client_config(
+                    key.clone(),
+                    iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+                    None,
+                )
+            })
+            .ok_or(IotaError::from("network public key is not available"));
+        let maybe_channel = tls_config
+            .and_then(|tls_config| {
+                network_config
+                    .connect_lazy(&address, Some(tls_config))
+                    .map_err(|e| e.to_string().into())
+            })
+            .tap_err(|e| {
+                tracing::error!(
+                    address = %address,
+                    name = %name,
+                    "unable to create authority client: {e}"
+                )
+            });
         let client = NetworkAuthorityClient::new_lazy(maybe_channel);
         authority_clients.insert(*name, client);
     }

--- a/crates/iota-network-stack/src/client.rs
+++ b/crates/iota-network-stack/src/client.rs
@@ -128,16 +128,23 @@ impl MyEndpoint {
         });
 
         if disable_caching_resolver {
+            let mut http = HttpConnector::new();
+            http.enforce_http(false);
+            http.set_nodelay(true);
+            http.set_keepalive(None);
+            http.set_connect_timeout(None);
+
             if let Some(tls_config) = self.tls_config {
-                self.endpoint.connect_with_connector_lazy(
+                Channel::new(
                     hyper_rustls::HttpsConnectorBuilder::new()
                         .with_tls_config(tls_config)
                         .https_only()
                         .enable_http2()
-                        .build(),
+                        .wrap_connector(http),
+                    self.endpoint,
                 )
             } else {
-                self.endpoint.connect_lazy()
+                self.endpoint.connect_with_connector_lazy(http)
             }
         } else {
             let mut http = HttpConnector::new_with_resolver(CachingResolver::new());
@@ -150,9 +157,9 @@ impl MyEndpoint {
                 let https = hyper_rustls::HttpsConnectorBuilder::new()
                     .with_tls_config(tls_config)
                     .https_only()
-                    .enable_http1()
+                    .enable_http2()
                     .wrap_connector(http);
-                self.endpoint.connect_with_connector_lazy(https)
+                Channel::new(https, self.endpoint)
             } else {
                 self.endpoint.connect_with_connector_lazy(http)
             }
@@ -166,8 +173,7 @@ impl MyEndpoint {
                 .https_only()
                 .enable_http2()
                 .build();
-            self.endpoint
-                .connect_with_connector(https_connector)
+            Channel::connect(https_connector, self.endpoint)
                 .await
                 .map_err(Into::into)
         } else {

--- a/crates/iota-network-stack/src/multiaddr.rs
+++ b/crates/iota-network-stack/src/multiaddr.rs
@@ -219,6 +219,20 @@ impl Multiaddr {
         new
     }
 
+    pub fn rewrite_http_to_https(&self) -> Self {
+        let mut new = Self::empty();
+
+        for component in self.iter() {
+            if let Protocol::Http = component {
+                new.push(Protocol::Https);
+            } else {
+                new.push(component);
+            }
+        }
+
+        new
+    }
+
     /// Checks if the multiaddr contains a private/unroutable IP address or
     /// invalid DNS. Returns true if the address should is private or
     /// unroutable.

--- a/crates/iota-swarm/src/memory/node.rs
+++ b/crates/iota-swarm/src/memory/node.rs
@@ -108,7 +108,11 @@ impl Node {
         }
 
         if is_validator {
-            let network_address = self.config().network_address().clone();
+            let network_address = self
+                .config()
+                .network_address()
+                .clone()
+                .rewrite_http_to_https();
             let tls_config = iota_tls::create_rustls_client_config(
                 self.config().network_key_pair().public().to_owned(),
                 iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),

--- a/crates/iota-tool/Cargo.toml
+++ b/crates/iota-tool/Cargo.toml
@@ -57,6 +57,7 @@ iota-replay.workspace = true
 iota-sdk.workspace = true
 iota-snapshot.workspace = true
 iota-storage.workspace = true
+iota-tls.workspace = true
 iota-types.workspace = true
 move-core-types.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -115,18 +115,18 @@ async fn make_clients(
         .await?;
 
     for committee_member in state.iter_committee_members() {
-        let net_addr = Multiaddr::try_from(committee_member.net_address.clone()).unwrap();
-        // TODO: Enable TLS on this interface with below config, once support is rolled
-        // out to validators.
-        // ```
-        // let tls_config = iota_tls::create_rustls_client_config(
-        //     iota_types::crypto::NetworkPublicKey::from_bytes(&committee_member.network_pubkey_bytes)?,
-        //     iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
-        //     None,
-        // );
-        // ```
+        let net_addr = Multiaddr::try_from(committee_member.net_address.clone())
+            .unwrap()
+            .rewrite_http_to_https();
+        let tls_config = iota_tls::create_rustls_client_config(
+            iota_types::crypto::NetworkPublicKey::from_bytes(
+                &committee_member.network_pubkey_bytes,
+            )?,
+            iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+            None,
+        );
         let channel = net_config
-            .connect_lazy(&net_addr, None)
+            .connect_lazy(&net_addr, Some(tls_config))
             .map_err(|err| anyhow!(err.to_string()))?;
         let client = NetworkAuthorityClient::new(channel);
         let public_key_bytes =


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@94124a8](https://github.com/MystenLabs/sui/commit/94124a87fb4d4233de74442132fce75f340c37d2)
- Description:

Enable TLS by default for validator gRPC client 

---

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Release notes
- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] gRPC: 
  - Enables TLS on connections to validators over the gRPC
interface.
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: 
  - Enables TLS on connections to validators over the gRPC
interface.
- [ ] Rust SDK:
