### PR TITLE
upstream(core): Remove unsafe_clear/create_cf/flush methods from typed-store

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -905,12 +905,6 @@ impl AuthorityEpochTables {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    pub fn reset_db_for_execution_since_genesis(&self) -> IotaResult {
-        // TODO: Add new tables that get added to the db automatically
-        self.executed_transactions_to_checkpoint.unsafe_clear()?;
-        Ok(())
-    }
-
     pub fn get_transaction_checkpoint(
         &self,
         digest: &TransactionDigest,

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -1115,7 +1115,6 @@ mod tests {
         let start = ObjectKey(ObjectID::ZERO, SequenceNumber::MIN_VALID_INCL);
         let end = ObjectKey(ObjectID::MAX, SequenceNumber::MAX_VALID_EXCL);
 
-        perpetual_db.objects.db.flush()?;
         perpetual_db.objects.compact_range(&start, &end)?;
         let before_compaction_size = get_sst_size(&db_path);
 
@@ -1134,7 +1133,6 @@ mod tests {
                 .await;
         info!("Total pruned keys = {:?}", total_pruned);
 
-        perpetual_db.objects.db.flush()?;
         perpetual_db.objects.compact_range(&start, &end)?;
         let after_compaction_size = get_sst_size(&db_path);
 

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -477,24 +477,6 @@ impl AuthorityPerpetualTables {
         self.objects.checkpoint_db(path).map_err(Into::into)
     }
 
-    pub fn reset_db_for_execution_since_genesis(&self) -> IotaResult {
-        // TODO: Add new tables that get added to the db automatically
-        self.objects.unsafe_clear()?;
-        self.live_owned_object_markers.unsafe_clear()?;
-        self.executed_effects.unsafe_clear()?;
-        self.events_2.unsafe_clear()?;
-        self.events.unsafe_clear()?;
-        self.executed_transactions_to_checkpoint.unsafe_clear()?;
-        self.root_state_hash_by_epoch.unsafe_clear()?;
-        self.epoch_start_configuration.unsafe_clear()?;
-        self.pruned_checkpoint.unsafe_clear()?;
-        self.total_iota_supply.unsafe_clear()?;
-        self.expected_storage_fund_imbalance.unsafe_clear()?;
-        self.object_per_epoch_marker_table.unsafe_clear()?;
-        self.objects.db.flush()?;
-        Ok(())
-    }
-
     pub fn get_root_state_hash(
         &self,
         epoch: EpochId,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -881,7 +881,6 @@ impl CheckpointStore {
 
     pub fn reset_db_for_execution_since_genesis(&self) -> IotaResult {
         self.delete_highest_executed_checkpoint_test_only()?;
-        self.tables.watermarks.db.flush()?;
         Ok(())
     }
 }

--- a/crates/iota-tool/src/db_tool/mod.rs
+++ b/crates/iota-tool/src/db_tool/mod.rs
@@ -20,7 +20,7 @@ use iota_types::{
     messages_checkpoint::{CheckpointDigest, CheckpointSequenceNumber},
     storage::ObjectStore,
 };
-use typed_store::rocks::MetricConf;
+use typed_store::rocks::{MetricConf, safe_drop_db};
 
 use self::{
     db_dump::{StoreName, dump_table, duplicate_objects_summary, list_tables, table_summary},
@@ -191,7 +191,7 @@ pub async fn execute_db_tool_command(db_path: PathBuf, cmd: DbToolCommand) -> an
         DbToolCommand::PrintObject(o) => print_object(&db_path, o),
         DbToolCommand::PrintCheckpoint(d) => print_checkpoint(&db_path, d),
         DbToolCommand::PrintCheckpointContent(d) => print_checkpoint_content(&db_path, d),
-        DbToolCommand::ResetDB => reset_db_to_genesis(&db_path),
+        DbToolCommand::ResetDB => reset_db_to_genesis(&db_path).await,
         DbToolCommand::RewindCheckpointExecution(d) => {
             rewind_checkpoint_execution(&db_path, d.epoch, d.checkpoint_sequence_number)
         }
@@ -323,7 +323,7 @@ pub fn print_checkpoint_content(
     Ok(())
 }
 
-pub fn reset_db_to_genesis(path: &Path) -> anyhow::Result<()> {
+pub async fn reset_db_to_genesis(path: &Path) -> anyhow::Result<()> {
     // Follow the below steps to test:
     //
     // Get a db snapshot. Either generate one by running stress locally and enabling
@@ -360,24 +360,14 @@ pub fn reset_db_to_genesis(path: &Path) -> anyhow::Result<()> {
     //   num-epochs-to-retain: 18446744073709551615
     //   max-checkpoints-in-batch: 10
     //   max-transactions-in-batch: 1000
-    let perpetual_db = AuthorityPerpetualTables::open_tables_read_write(
+    safe_drop_db(
         path.join("store").join("perpetual"),
-        MetricConf::default(),
-        None,
-        None,
-    );
-    perpetual_db.reset_db_for_execution_since_genesis()?;
+        std::time::Duration::from_secs(60),
+    )
+    .await?;
 
     let checkpoint_db = CheckpointStore::new(&path.join("checkpoints"));
     checkpoint_db.reset_db_for_execution_since_genesis()?;
-
-    let epoch_db = AuthorityEpochTables::open_tables_read_write(
-        path.join("store"),
-        MetricConf::default(),
-        None,
-        None,
-    );
-    epoch_db.reset_db_for_execution_since_genesis()?;
 
     Ok(())
 }

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -807,13 +807,13 @@ impl RocksDBStore {
         use typed_store::Map as _;
 
         self.transactions
-            .unsafe_clear()
+            .schedule_delete_all()
             .map_err(ConsensusError::RocksDBFailure)?;
         self.transactions_by_tx_refs
-            .unsafe_clear()
+            .schedule_delete_all()
             .map_err(ConsensusError::RocksDBFailure)?;
         self.transaction_commitments_by_authorities
-            .unsafe_clear()
+            .schedule_delete_all()
             .map_err(ConsensusError::RocksDBFailure)?;
 
         debug!("Deleted all transactions from store");

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -217,17 +217,6 @@ impl Database {
         }
     }
 
-    pub fn create_cf<N: AsRef<str>>(
-        &self,
-        name: N,
-        opts: &rocksdb::Options,
-    ) -> Result<(), rocksdb::Error> {
-        match &self.storage {
-            Storage::Rocks(db) => db.underlying.create_cf(name, opts),
-            Storage::InMemory(_) => Ok(()),
-        }
-    }
-
     pub fn cf_handle(&self, name: &str) -> Option<()> {
         match &self.storage {
             Storage::Rocks(db) => db.underlying.cf_handle(name).map(|_| ()),
@@ -350,16 +339,6 @@ impl Database {
             rocksdb
                 .underlying
                 .compact_range_cf(&rocks_cf(rocksdb, cf.name()), start, end);
-        }
-    }
-
-    pub fn flush(&self) -> Result<(), TypedStoreError> {
-        match &self.storage {
-            Storage::Rocks(db) => db
-                .underlying
-                .flush()
-                .map_err(typed_store_err_from_rocks_err),
-            Storage::InMemory(_) => Ok(()),
         }
     }
 
@@ -1121,19 +1100,6 @@ where
                 .write_perf_ctx_metrics
                 .report_metrics(self.cf_name());
         }
-        Ok(())
-    }
-
-    /// This method first drops the existing column family and then creates a
-    /// new one with the same name. The two operations are not atomic and
-    /// hence it is possible to get into a race condition where the column
-    /// family has been dropped but new one is not created yet
-    #[instrument(level = "trace", skip_all, err)]
-    fn unsafe_clear(&self) -> Result<(), TypedStoreError> {
-        let _ = self.db.drop_cf(self.cf_name());
-        self.db
-            .create_cf(self.cf_name(), &crate::rocks::default_db_options().options)
-            .map_err(typed_store_err_from_rocks_err)?;
         Ok(())
     }
 

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -442,34 +442,6 @@ async fn test_delete_range() {
 }
 
 #[tokio::test]
-async fn test_clear() {
-    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
-    // Test clear of empty map
-    let _ = db.unsafe_clear();
-
-    let keys_vals = (0..101).map(|i| (i, i.to_string()));
-    let mut insert_batch = db.batch();
-    insert_batch
-        .insert_batch(&db, keys_vals)
-        .expect("Failed to batch insert");
-
-    insert_batch.write().expect("Failed to execute batch");
-
-    // Check we have multiple entries
-    assert!(db.safe_iter().count() > 1);
-    let _ = db.unsafe_clear();
-    assert_eq!(db.safe_iter().count(), 0);
-    // Clear again to ensure safety when clearing empty map
-    let _ = db.unsafe_clear();
-    assert_eq!(db.safe_iter().count(), 0);
-    // Clear with one item
-    let _ = db.insert(&1, &"e".to_string());
-    assert_eq!(db.safe_iter().count(), 1);
-    let _ = db.unsafe_clear();
-    assert_eq!(db.safe_iter().count(), 0);
-}
-
-#[tokio::test]
 async fn test_iter_with_bounds() {
     let db = open_map(temp_dir(), None);
 
@@ -576,10 +548,7 @@ async fn test_range_iter() {
 #[tokio::test]
 async fn test_is_empty() {
     let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
-
     // Test empty map is truly empty
-    assert!(db.is_empty());
-    let _ = db.unsafe_clear();
     assert!(db.is_empty());
 
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
@@ -593,11 +562,6 @@ async fn test_is_empty() {
     // Check we have multiple entries and not empty
     assert!(db.safe_iter().count() > 1);
     assert!(!db.is_empty());
-
-    // Clear again to ensure empty works after clearing
-    let _ = db.unsafe_clear();
-    assert_eq!(db.safe_iter().count(), 0);
-    assert!(db.is_empty());
 }
 
 #[tokio::test]

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -250,12 +250,6 @@ where
         Ok(())
     }
 
-    fn unsafe_clear(&self) -> Result<(), Self::Error> {
-        let mut locked = self.rows.write().unwrap();
-        locked.clear();
-        Ok(())
-    }
-
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let mut locked = self.rows.write().unwrap();
         locked.clear();
@@ -655,40 +649,10 @@ mod test {
     }
 
     #[test]
-    fn test_clear() {
-        let db: TestDB<i32, String> = TestDB::open();
-
-        // Test clear of empty map
-        let _ = db.unsafe_clear();
-
-        let keys_vals = (0..101).map(|i| (i, i.to_string()));
-        let mut wb = db.batch();
-        wb.insert_batch(&db, keys_vals)
-            .expect("Failed to batch insert");
-
-        wb.write().expect("Failed to execute batch");
-
-        // Check we have multiple entries
-        assert!(db.safe_iter().count() > 1);
-        let _ = db.unsafe_clear();
-        assert_eq!(db.safe_iter().count(), 0);
-        // Clear again to ensure safety when clearing empty map
-        let _ = db.unsafe_clear();
-        assert_eq!(db.safe_iter().count(), 0);
-        // Clear with one item
-        let _ = db.insert(&1, &"e".to_string());
-        assert_eq!(db.safe_iter().count(), 1);
-        let _ = db.unsafe_clear();
-        assert_eq!(db.safe_iter().count(), 0);
-    }
-
-    #[test]
     fn test_is_empty() {
         let db: TestDB<i32, String> = TestDB::open();
 
         // Test empty map is truly empty
-        assert!(db.is_empty());
-        let _ = db.unsafe_clear();
         assert!(db.is_empty());
 
         let keys_vals = (0..101).map(|i| (i, i.to_string()));
@@ -701,11 +665,6 @@ mod test {
         // Check we have multiple entries and not empty
         assert!(db.safe_iter().count() > 1);
         assert!(!db.is_empty());
-
-        // Clear again to ensure empty works after clearing
-        let _ = db.unsafe_clear();
-        assert_eq!(db.safe_iter().count(), 0);
-        assert!(db.is_empty());
     }
 
     #[test]

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -42,9 +42,6 @@ where
     /// Removes the entry for the given key from the map.
     fn remove(&self, key: &K) -> Result<(), Self::Error>;
 
-    /// Removes every key-value pair from the map.
-    fn unsafe_clear(&self) -> Result<(), Self::Error>;
-
     /// Uses delete range on the entire key range
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError>;
 


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@8f8258d](https://github.com/MystenLabs/sui/commit/8f8258db75f548aa2b7c70814f3403b24df68585)
- Description:

PR removes the following typed store methods: `unsafe_clear`, `create_cf`, `flush`.

These methods are safe to remove because:

- **`unsafe_clear`**: Was non-atomic — it dropped a column family and re-created it as two separate operations, leaving a window where the CF did not exist. No production code paths require it; callers either no longer need the operation or can use `schedule_delete_all` (which writes a range-delete tombstone) instead. The `reset_db_to_genesis` tool, which was the primary user, is replaced with `safe_drop_db` that atomically destroys the entire DB directory.
- **`flush`**: Was only called before `compact_range` in tests and before `unsafe_clear` in `reset_db_to_genesis`. RocksDB's `compact_range` and `safe_drop_db` do not require an explicit prior flush — data large enough to matter will have been auto-flushed by RocksDB's write-buffer threshold, and `safe_drop_db` works at the filesystem level regardless.
- **`create_cf`**: Was only used internally by `unsafe_clear` to recreate a dropped column family. With `unsafe_clear` removed, `create_cf` has no remaining callers.

`unsafe_clear` callers in `starfish` are migrated to `schedule_delete_all`, which achieves the same logical effect (clearing all entries) through RocksDB range tombstones rather than CF recreation.

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes