### PR TITLE
fix(gRPC): only modify gas budget if vm checks are skipped

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -66,7 +66,7 @@ async fn simulate_transaction_scenarios() {
         "Effects should be present with minimal mask"
     );
 
-    // Test: insufficient gas budget returns InvalidArgument error
+    // Test: insufficient gas budget returns gRPC error
     // Gas budget validation (min/max bounds) happens upfront in
     // check_gas_balance(), so a budget of 1 (below minimum) is rejected before
     // execution begins.
@@ -83,7 +83,7 @@ async fn simulate_transaction_scenarios() {
         .build();
     let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
     let result = client.simulate_transaction(transaction, false, None).await;
-    assert_grpc_error(result, Code::InvalidArgument);
+    assert_grpc_error(result, Code::Internal);
 
     // Test: transfer exceeding balance returns Ok with failed effects
     // Transfer amount validation happens during Move VM execution, not upfront,

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -17,11 +17,11 @@ async fn simulate_transaction_scenarios() {
     let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
 
     // Test: regular and dev-inspect simulation modes
-    for (dev_inspect, mode_name) in [(false, "regular"), (true, "dev-inspect")] {
+    for (skip_checks, mode_name) in [(false, "regular"), (true, "dev-inspect")] {
         let transaction = create_transaction_for_simulation(&test_cluster).await;
 
         let result = client
-            .simulate_transaction(transaction, dev_inspect, None)
+            .simulate_transaction(transaction, skip_checks, None)
             .await
             .unwrap_or_else(|e| panic!("Failed to simulate transaction in {mode_name} mode: {e}"));
 

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
@@ -10,7 +10,8 @@ use iota_grpc_types::{
         transaction::Transaction as ProtoTransaction,
         transaction_execution_service::{
             SimulateTransactionItem, SimulateTransactionsRequest, SimulateTransactionsResponse,
-            SimulatedTransaction, simulated_transaction::ExecutionResult,
+            SimulatedTransaction, simulate_transaction_item::TransactionCheckModes,
+            simulated_transaction::ExecutionResult,
             transaction_execution_service_client::TransactionExecutionServiceClient,
         },
     },
@@ -151,7 +152,9 @@ async fn simulate_transaction_zero_gas_budget_uses_max() {
     let transaction = ProtoTransaction::default()
         .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap()));
 
-    let item = build_simulate_item(transaction);
+    let item = SimulateTransactionItem::default()
+        .with_transaction(transaction)
+        .with_tx_checks(vec![TransactionCheckModes::DisableVmChecks as i32]);
     let request = SimulateTransactionsRequest::default().with_transactions(vec![item]);
 
     // Simulate the transaction
@@ -219,21 +222,17 @@ async fn simulate_transaction_below_min_gas_budget_returns_error() {
         .unwrap()
         .into_inner();
 
-    // The per-item result should be an error
+    // With upfront gas validation removed, the simulation engine itself
+    // rejects the insufficient budget, producing an Internal error.
     let result = response.transaction_results.first().unwrap();
     let error = result
         .error()
         .expect("Expected per-item error for below-minimum gas budget");
     assert_eq!(
         error.code,
-        tonic::Code::InvalidArgument as i32,
-        "Expected InvalidArgument error code, got code {}",
+        tonic::Code::Internal as i32,
+        "Expected Internal error code, got code {}",
         error.code
-    );
-    assert!(
-        error.message.contains("below the minimum"),
-        "Error message should mention 'below the minimum', got: {}",
-        error.message
     );
 }
 

--- a/crates/iota-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-grpc-client/src/api/execution/simulate.rs
@@ -23,7 +23,7 @@ pub struct SimulateTransactionInput {
     pub transaction: Transaction,
     /// Set to true for relaxed Move VM checks (useful for debugging and
     /// development).
-    pub dev_inspect: bool,
+    pub skip_checks: bool,
 }
 
 impl Client {
@@ -35,7 +35,7 @@ impl Client {
     /// # Parameters
     ///
     /// - `transaction`: The transaction to simulate
-    /// - `dev_inspect`: Set to true for relaxed Move VM checks (useful for
+    /// - `skip_checks`: Set to true for relaxed Move VM checks (useful for
     ///   debugging and development)
     /// - `read_mask`: Optional field mask to control which fields are returned
     ///
@@ -181,13 +181,13 @@ impl Client {
     pub async fn simulate_transaction(
         &self,
         transaction: Transaction,
-        dev_inspect: bool,
+        skip_checks: bool,
         read_mask: Option<&str>,
     ) -> Result<MetadataEnvelope<SimulatedTransaction>> {
         self.simulate_transactions(
             vec![SimulateTransactionInput {
                 transaction,
-                dev_inspect,
+                skip_checks,
             }],
             read_mask,
         )
@@ -225,7 +225,7 @@ impl Client {
 
         let items = transactions
             .into_iter()
-            .map(|input| build_simulate_item(input.transaction, input.dev_inspect))
+            .map(|input| build_simulate_item(input.transaction, input.skip_checks))
             .collect::<Result<Vec<_>>>()?;
 
         let request = SimulateTransactionsRequest::default()
@@ -252,11 +252,11 @@ impl Client {
 /// Convert a transaction and options into a proto `SimulateTransactionItem`.
 fn build_simulate_item(
     transaction: Transaction,
-    dev_inspect: bool,
+    skip_checks: bool,
 ) -> Result<SimulateTransactionItem> {
     let proto_transaction = build_proto_transaction(&transaction, transaction.digest())?;
 
-    let tx_checks = if dev_inspect {
+    let tx_checks = if skip_checks {
         vec![TransactionCheckModes::DisableVmChecks as i32]
     } else {
         vec![]

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -197,8 +197,14 @@ async fn simulate_single_transaction(
             )
         })?;
 
+    // If the transaction has a zero gas budget and VM checks are disabled, we'll
+    // set the gas budget in the result to the actual cost from the simulation.
+    // This allows clients to estimate the gas cost by simulating with a zero
+    // budget.
+    let set_gas_budget = vm_checks.disabled() && transaction_data.gas_data().budget == 0;
+
     let system_state = if read_mask.contains(SimulatedTransaction::SUGGESTED_GAS_PRICE_FIELD.name)
-        || vm_checks.enabled()
+        || set_gas_budget
     {
         Some(reader.get_system_state_summary().map_err(|e| {
             RpcError::new(
@@ -210,16 +216,7 @@ async fn simulate_single_transaction(
         None
     };
 
-    // If the transaction has a zero gas budget and VM checks are enabled, we'll set
-    // the gas budget in the result to the actual cost from the simulation. This
-    // allows clients to estimate the gas cost by simulating with a zero budget.
-    let set_gas_budget = vm_checks.enabled() && transaction_data.gas_data().budget == 0;
-    let mut min_gas_budget_opt = None;
-
-    // Validate and adjust gas budget when VM checks are enabled.
-    // (It makes no sense to validate gas if checks are disabled because such a
-    // transaction can't ever be committed to the chain.)
-    if vm_checks.enabled() {
+    if set_gas_budget {
         let protocol_config = ProtocolConfig::get_for_version_if_supported(
             system_state
                 .as_ref()
@@ -234,25 +231,9 @@ async fn simulate_single_transaction(
             )
         })?;
 
-        let min_gas_budget =
-            protocol_config.base_tx_cost_fixed() * transaction_data.gas_data().price;
-
-        let gas_budget = transaction_data.gas_data().budget;
-        if gas_budget == 0 {
-            // A zero budget signals "use maximum" — run the dry run with
-            // max_tx_gas so the actual cost shows up in the gas status.
-            transaction_data.gas_data_mut().budget = protocol_config.max_tx_gas();
-        } else if gas_budget < min_gas_budget {
-            return Err(RpcError::new(
-                tonic::Code::InvalidArgument,
-                format!(
-                    "Gas budget {gas_budget} NANOS is below the minimum required \
-                        gas budget of {min_gas_budget} NANOS"
-                ),
-            ));
-        }
-
-        min_gas_budget_opt = Some(min_gas_budget);
+        // A zero budget signals "use maximum" — run the dry run with
+        // max_tx_gas so the actual cost shows up in the gas status.
+        transaction_data.gas_data_mut().budget = protocol_config.max_tx_gas();
     }
 
     // Simulate the transaction
@@ -280,10 +261,7 @@ async fn simulate_single_transaction(
     if let Some(tx_mask) = read_mask.subtree(SimulatedTransaction::EXECUTED_TRANSACTION_FIELD.name)
     {
         if set_gas_budget {
-            transaction_data.gas_data_mut().budget = effects
-                .gas_cost_summary()
-                .gas_used()
-                .max(min_gas_budget_opt.expect("min_gas_budget_opt should exist"));
+            transaction_data.gas_data_mut().budget = effects.gas_cost_summary().gas_used();
         }
 
         let transaction: iota_sdk_types::Transaction = transaction_data.try_into()?;


### PR DESCRIPTION
# Description of change

We should only modify the gas budget of transactions in `dev_inspect` mode (`vm_checks.disabled()`).
This enables users to estimate the gas needed to issue the tx.

fixes #10973 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes