### PR TITLE
fix(docs): fix event filters

### DIFF
--- a/docs/content/developer/iota-101/using-events.mdx
+++ b/docs/content/developer/iota-101/using-events.mdx
@@ -362,43 +362,31 @@ queryTransactionBlocks();
 
 You can filter events when [querying](#querying-events) or [subscribing](#subscribing-to-events) to receive only the events you are interested in.
 
-:::info
+The available filters depend on whether you query against a full node or an indexer endpoint.
 
-This set of filters applies only to event querying APIs. It differs from the filters offered for the subscriptions API (see following section). In particular, it does not support combinations like `"All": [...]`, `"Any": [...]`, `"And": [_, _]`, `"Or": [_, _]`, and `"Not": _`.
+### Full Node Filters
 
-:::
+The following filters are supported when querying a full node (e.g. `api.mainnet.iota.cafe`):
 
-### Filtering Event Queries
+| Filter             | Description                                                                                                                                                                                   | JSON-RPC Parameter Example                                                                            |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `Sender`           | Query by sender address                                                                                                                                                                       | `{"Sender":"0x008e9c621f4fdb210b873aab59a1e5bf32ddb1d33ee85eb069b348c234465106"}`                     |
+| `Transaction`      | Events emitted from the specified transaction                                                                                                                                                 | `{"Transaction":"DGUe2TXiJdN3FI6MH1FwghYbiHw+NKu8Nh579zdFtUk="}`                                     |
+| `MoveModule`       | Events emitted in the specified Move module. If the event is defined in Module A but emitted in a tx with Module B, query by Module B returns the event.                                      | `{"MoveModule":{"package":"<PACKAGE-ID>", "module":"nft"}}`                                           |
+| `MoveEventType`    | Events with the given Move event struct name (struct tag), e.g. `<PACKAGE-ID>::MyModule::Foo`                                                                                                 | `{"MoveEventType":"<PACKAGE-ID>::nft::MintNFTEvent"}`                                                 |
+| `MoveEventModule`  | Events where the event struct is defined in the specified Move module. If the event is defined in Module A but emitted in a tx with Module B, query by Module A returns the event.             | `{"MoveEventModule":{"package":"<PACKAGE-ID>", "module":"nft"}}`                                      |
+| `TimeRange`        | Events emitted in [start_time, end_time] interval (milliseconds since epoch, start inclusive, end exclusive)                                                                                  | `{"TimeRange":{"startTime":"1669039504014", "endTime":"1669039604014"}}`                              |
 
-When querying events, use the following filters:
+### Indexer Filters
 
-| Query         | Description                                              | JSON-RPC Parameter Example                                                                          |
-| ------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `All`         | All events                                               | `{"All"}`                                                                                             |
-| `Transaction` | Events emitted from the specified transaction            | `{"Transaction":"DGUe2TXiJdN3FI6MH1FwghYbiHw+NKu8Nh579zdFtUk="}`                                      |
-| `MoveModule`  | Events emitted from the specified Move module            | `{"MoveModule":{"package":"<PACKAGE-ID>", "module":"nft"}}`                                                       |
-| `MoveEventModule` | Events emitted, defined on the specified Move module.           | `{"MoveEventModule": {"package": "<DEFINING-PACKAGE-ID>", "module": "nft"}}` |
-| `MoveEvent`   | Move struct name of the event                            | `{"MoveEvent":"::nft::MintNFTEvent"}`                                                                 |
-| `EventType`   | Type of event described in Events section                | `{"EventType": "NewObject"}`                                                                          |
-| `Sender`      | Query by sender address                                  | `{"Sender":"0x008e9c621f4fdb210b873aab59a1e5bf32ddb1d33ee85eb069b348c234465106"}`                     |
-| `Recipient`   | Query by recipient                                       | `{"Recipient":{"AddressOwner":"0xa3c00467938b392a12355397bdd3d319cea5c9b8f4fc9c51b46b8e15a807f030"}}` |
-| `Object`      | Return events associated with the given object           | `{"Object":"0x727b37454ab13d5c1dbb22e8741bff72b145d1e660f71b275c01f24e7860e5e5"}`                     |
-| `TimeRange`   | Return events emitted in [start_time, end_time] interval | `{"TimeRange":{"startTime":1669039504014, "endTime":1669039604014}}`                                  |
+The following filters are supported when querying an indexer endpoint (e.g. `indexer.mainnet.iota.cafe`):
 
-### Filtering Events for Subscription
-
-When subscribing to events, you can combine filters for more precise results:
-
-| Filter            | Description                                           | JSON-RPC Parameter Example                                                                 |
-| ----------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `Package`         | Move package ID                                       | `{"Package":"<PACKAGE-ID>"}`                                                                 |
-| `MoveModule`      | Move module where the event was emitted               | `{"MoveModule": {"package": "<PACKAGE-ID>", "module": "nft"}}`                               |
-| `MoveEventType`   | Move event type defined in the move code              | `{"MoveEventType":"<PACKAGE-ID>::nft::MintNFTEvent"}`                                        |
-| `MoveEventModule` | Move event module defined in the move code            | `{"MoveEventModule": {"package": "<PACKAGE-ID>", "module": "nft", "event": "MintNFTEvent"}}` |
-| `MoveEventField`  | Filter using the data fields in the move event object | `{"MoveEventField":{ "path":"/name", "value":"NFT"}}`                                        |
-| `SenderAddress`   | Address that started the transaction                  | `{"SenderAddress": "0x008e9c621f4fdb210b873aab59a1e5bf32ddb1d33ee85eb069b348c234465106"}`    |
-| `Sender`          | Sender address                                        | `{"Sender":"0x008e9c621f4fdb210b873aab59a1e5bf32ddb1d33ee85eb069b348c234465106"}`            |
-| `Transaction`     | Transaction hash                                      | `{"Transaction":"ENmjG42TE4GyqYb1fGNwJe7oxBbbXWCdNfRiQhCNLBJQ"}`                             |
-| `TimeRange`       | Time range in millisecond                             | `{"TimeRange": {"start_time": "1685959791871", "end_time": "1685959791871"}}`                |
+| Filter             | Description                                                                                                                                                                                   | JSON-RPC Parameter Example                                                                            |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `Sender`           | Query by sender address                                                                                                                                                                       | `{"Sender":"0x008e9c621f4fdb210b873aab59a1e5bf32ddb1d33ee85eb069b348c234465106"}`                     |
+| `Transaction`      | Events emitted from the specified transaction                                                                                                                                                 | `{"Transaction":"DGUe2TXiJdN3FI6MH1FwghYbiHw+NKu8Nh579zdFtUk="}`                                     |
+| `Package`          | Events emitted in the specified package                                                                                                                                                       | `{"Package":"<PACKAGE-ID>"}`                                                                          |
+| `MoveModule`       | Events emitted in the specified Move module. If the event is defined in Module A but emitted in a tx with Module B, query by Module B returns the event.                                      | `{"MoveModule":{"package":"<PACKAGE-ID>", "module":"nft"}}`                                           |
+| `MoveEventType`    | Events with the given Move event struct name (struct tag), e.g. `<PACKAGE-ID>::MyModule::Foo`                                                                                                 | `{"MoveEventType":"<PACKAGE-ID>::nft::MintNFTEvent"}`                                                 |
 
 <Quiz questions={questions} />


### PR DESCRIPTION
# Description of change

Fix event filters as they were outdated and not working

Tested with the commands:
```bash
#!/usr/bin/env bash
# Examples for querying events using iotax_queryEvents with different filters.
# Each request returns up to 50 events in ascending order.
# Tested against IOTA mainnet.

FULL_NODE="https://api.mainnet.iota.cafe"
INDEXER="https://indexer.mainnet.iota.cafe"

# --- Full Node Filters ---

# Sender: query events by the address that sent the transaction.
curl --location "$FULL_NODE" \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "Sender": "0x6aa418b93bba776af32bdb5af2ced1cf4987b7a8a15eb9b8f5361da16625266c"
    },
    null,
    50,
    false
  ]
}'

# Transaction: query events emitted by a specific transaction.
curl --location "$FULL_NODE" \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "Transaction": "3oxLBoVpMi52H8JzZL1BzmUfVttJ85F7qg7xdeR43LAk"
    },
    null,
    50,
    false
  ]
}'

# MoveModule: query events emitted in the specified Move module.
# Note: this filters by the module that *emitted* the event (the transaction
# module), not the module where the event struct is defined.
curl --location "$FULL_NODE" \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "MoveModule": {
        "package": "0x3",
        "module": "iota_system"
      }
    },
    null,
    50,
    false
  ]
}'

# MoveEventType: query events by their Move struct tag.
curl --location "$FULL_NODE" \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "MoveEventType": "0x3::validator::StakingRequestEvent"
    },
    null,
    50,
    false
  ]
}'

# MoveEventModule: query events by the module where the event struct is defined.
# Note: this filters by the module that *defines* the event struct, not the
# module that emitted the event.
curl --location "$FULL_NODE" \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "MoveEventModule": {
        "package": "0x3",
        "module": "validator"
      }
    },
    null,
    50,
    false
  ]
}'

# TimeRange: query events within a time interval (milliseconds since epoch).
# start_time is inclusive, end_time is exclusive.
curl --location "$FULL_NODE" \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "TimeRange": {
        "startTime": "1774620950000",
        "endTime": "1774620960000"
      }
    },
    null,
    50,
    false
  ]
}'

# --- Indexer-Only Filters ---

# Package: query events emitted in the specified package.
# This filter is only available on indexer endpoints.
curl --location "$INDEXER" \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "Package": "0x3"
    },
    null,
    50,
    false
  ]
}'

```