### PR TITLE
chore(iota-indexer,data-ingestion,graphql-rpc): remove unused tonic deps or features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6273,7 +6273,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util 0.7.18",
- "tonic 0.14.2",
  "tracing",
 ]
 
@@ -6309,7 +6308,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.18",
- "tonic 0.14.2",
  "tracing",
  "url",
 ]
@@ -6677,7 +6675,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.18",
  "toml 0.7.8",
- "tonic 0.14.2",
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -27,7 +27,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
-tonic = { workspace = true, features = ["tls-native-roots"] }
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/iota-data-ingestion/Cargo.toml
+++ b/crates/iota-data-ingestion/Cargo.toml
@@ -26,7 +26,6 @@ serde_yaml.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
-tonic = { workspace = true, features = ["tls-native-roots"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -43,7 +43,6 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 toml.workspace = true
-tonic = { workspace = true, features = ["tls-native-roots"] }
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 toml.workspace = true
-tonic = { workspace = true, features = ["tls-native-roots"] }
+tonic.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -175,7 +175,7 @@ impl ReadApi {
                 Ok(executed_tx.transaction()?.digest()? == digest.into())
             }
             Err(e) => {
-                if matches!(e, iota_grpc_client::Error::Server(ref e) if  tonic::Code::from_i32(e.code) == tonic::Code::NotFound)
+                if matches!(e, iota_grpc_client::Error::Server(ref e) if e.to_tonic_status().code() == tonic::Code::NotFound)
                 {
                     return Ok(false);
                 }


### PR DESCRIPTION


# Description of change

After this [PR](https://github.com/iotaledger/iota/pull/10972) was merged to develop, the `iota-grpc-client` is able by default to support TLS connection when provided by the user, making the tonic `tls-native-roots` feature redundant in the infra related crates that use the gRPC client

## Links to any relevant issues

fixes #10995 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- ingesting checkpoints form a local network works and with public TLS.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
