### PR TITLE
fix(indexer): unbox IngestionConfig in ObjectChangesUnwrapped backfill

### DIFF
--- a/crates/iota-indexer/src/backfill/mod.rs
+++ b/crates/iota-indexer/src/backfill/mod.rs
@@ -100,7 +100,7 @@ pub(crate) async fn get_backfill(
             )),
             IngestionBackfillKind::ObjectChangesUnwrapped => Ok(Arc::new(
                 IngestionBackfillTask::<ObjectChangesUnwrappedBackfill>::new(
-                    config,
+                    *config,
                     range_start as CheckpointSequenceNumber,
                 )
                 .await?,


### PR DESCRIPTION
# Description of change

Add missing `*` dereference when passing `config` (a Box<IngestionConfig>) to IngestionBackfillTask::new(), fixing cargo doc --workspace failure.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
