### PR TITLE
fix(ts-sdk): Avoid using pnpm in build scripts, use tsc directly

### DIFF
--- a/sdk/build-scripts/src/utils/buildPackage.ts
+++ b/sdk/build-scripts/src/utils/buildPackage.ts
@@ -132,7 +132,8 @@ async function buildESM(
 }
 
 async function buildTypes(config: string) {
-    execSync(`pnpm tsc --build ${config}`, {
+    const tsc = require.resolve('typescript/bin/tsc');
+    execSync(`node ${tsc} --build ${config}`, {
         stdio: 'inherit',
         cwd: process.cwd(),
     });

--- a/sdk/signers/src/ledger/objects.ts
+++ b/sdk/signers/src/ledger/objects.ts
@@ -50,7 +50,7 @@ export const getInputObjects = async (transaction: Transaction, client: IotaClie
                 storageRebate: object.data.storageRebate!,
             }).toBytes();
         })
-        .filter((bcsBytes): bcsBytes is Uint8Array<ArrayBuffer> => !!bcsBytes);
+        .filter((bcsBytes): bcsBytes is Uint8Array => !!bcsBytes);
 
     return { bcsObjects };
 };


### PR DESCRIPTION
A jump of faith.

Hopefully fixes https://github.com/iotaledger/iota/actions/runs/23657260477/job/68918377469, the theory is that concurrent build scripts might be breaking pnpm sometimes.