### PR TITLE
upstream(core): Re-enqueue pending consensus transactions at startup

### DIFF
--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2527,6 +2527,7 @@ impl CheckpointService {
         tasks.spawn(monitored_future!(accumulator.run()));
 
         // If this times out, the validator may still start up. The worst that can
+        // TODO: Explain why it will crash later on.
         // happen is that we will crash later on instead of immediately. The eventual
         // crash would occur because we may be missing transactions that are below the
         // highest_synced_checkpoint watermark, which can cause a crash in
@@ -2547,7 +2548,10 @@ impl CheckpointService {
 
 impl CheckpointService {
     /// Waits until all checkpoints had been built before the node restarted
-    /// are rebuilt. This is required to preserve the invariant that all
+    /// are rebuilt.
+    /// TODO: Add comments explain why we need to wait for checkpoints to be
+    /// rebuilt.
+    /// This is required to preserve the invariant that all
     /// checkpoints (and their transactions) below the
     /// highest_synced_checkpoint watermark are available. Once the
     /// checkpoints are constructed, we can be sure that the transactions

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2527,7 +2527,6 @@ impl CheckpointService {
         tasks.spawn(monitored_future!(accumulator.run()));
 
         // If this times out, the validator may still start up. The worst that can
-        // TODO: Explain why it will crash later on.
         // happen is that we will crash later on instead of immediately. The eventual
         // crash would occur because we may be missing transactions that are below the
         // highest_synced_checkpoint watermark, which can cause a crash in
@@ -2548,10 +2547,7 @@ impl CheckpointService {
 
 impl CheckpointService {
     /// Waits until all checkpoints had been built before the node restarted
-    /// are rebuilt.
-    /// TODO: Add comments explain why we need to wait for checkpoints to be
-    /// rebuilt.
-    /// This is required to preserve the invariant that all
+    /// are rebuilt. This is required to preserve the invariant that all
     /// checkpoints (and their transactions) below the
     /// highest_synced_checkpoint watermark are available. Once the
     /// checkpoints are constructed, we can be sure that the transactions

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -25,6 +25,7 @@ use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId, OIDCProvider};
 use futures::future::BoxFuture;
 pub use handle::IotaNodeHandle;
 use iota_archival::{reader::ArchiveReaderBalancer, writer::ArchiveWriter};
+use iota_common::debug_fatal;
 use iota_config::{
     ConsensusConfig, NodeConfig,
     node::{DBCheckpointConfig, RunWithRange},
@@ -114,6 +115,7 @@ use iota_types::{
     crypto::{AuthoritySignature, IotaAuthoritySignature, KeypairTraits, RandomnessRound},
     digests::ChainIdentifier,
     error::{IotaError, IotaResult},
+    executable_transaction::VerifiedExecutableTransaction,
     execution_config_utils::to_binary_config,
     full_checkpoint_content::CheckpointData,
     iota_system_state::{
@@ -916,22 +918,24 @@ impl IotaNode {
         .await?;
 
         let validator_components = if state.is_committee_validator(&epoch_store) {
-            Self::reenqueue_pending_consensus_certs(&epoch_store, &state).await;
-            let mut components = Self::construct_validator_components(
-                config.clone(),
-                state.clone(),
-                committee,
-                epoch_store.clone(),
-                checkpoint_store.clone(),
-                state_sync_handle.clone(),
-                randomness_handle.clone(),
-                Arc::downgrade(&accumulator),
-                backpressure_manager.clone(),
-                connection_monitor_status.clone(),
-                &registry_service,
-                iota_node_metrics.clone(),
-            )
-            .await?;
+            let (components, _) = futures::join!(
+                Self::construct_validator_components(
+                    config.clone(),
+                    state.clone(),
+                    committee,
+                    epoch_store.clone(),
+                    checkpoint_store.clone(),
+                    state_sync_handle.clone(),
+                    randomness_handle.clone(),
+                    Arc::downgrade(&accumulator),
+                    backpressure_manager.clone(),
+                    connection_monitor_status.clone(),
+                    &registry_service,
+                    iota_node_metrics.clone(),
+                ),
+                Self::reexecute_pending_consensus_certs(&epoch_store, &state,)
+            );
+            let mut components = components?;
 
             components.consensus_adapter.submit_recovered(&epoch_store);
 
@@ -1619,41 +1623,105 @@ impl IotaNode {
         Ok(SpawnOnce::new(bind_future))
     }
 
-    /// Re-enqueue pending consensus certificates for execution.
-    // TODO: Add comments explain why we need to do this at start up.
-    async fn reenqueue_pending_consensus_certs(
+    /// Re-executes pending consensus certificates, which may not have been
+    /// committed to disk before the node restarted. This is necessary for
+    /// the following reasons:
+    ///
+    /// 1. For any transaction for which we returned signed effects to a client,
+    ///    we must ensure that we have re-executed the transaction before we
+    ///    begin accepting grpc requests. Otherwise we would appear to have
+    ///    forgotten about the transaction.
+    /// 2. While this is running, we are concurrently waiting for all previously
+    ///    built checkpoints to be rebuilt. Since there may be dependencies in
+    ///    either direction (from checkpointed consensus transactions to pending
+    ///    consensus transactions, or vice versa), we must re-execute pending
+    ///    consensus transactions to ensure that both processes can complete.
+    /// 3. Also note that for any pending consensus transactions for which we
+    ///    wrote a signed effects digest to disk, we must re-execute using that
+    ///    digest as the expected effects digest, to ensure that we cannot
+    ///    arrive at different effects than what we previously signed.
+    async fn reexecute_pending_consensus_certs(
         epoch_store: &Arc<AuthorityPerEpochStore>,
         state: &Arc<AuthorityState>,
     ) {
-        let pending_consensus_certificates = epoch_store
-            .get_all_pending_consensus_transactions()
-            .into_iter()
-            .filter_map(|tx| match tx.kind {
-                ConsensusTransactionKind::CertifiedTransaction(tx) => {
-                    if tx.contains_shared_object() {
-                        // We cannot schedule shared object transactions for execution here
-                        // because they must come out of consensus to get prover version assignment.
-                        None
+        let mut pending_consensus_certificates = Vec::new();
+        let mut additional_certs = Vec::new();
+
+        for tx in epoch_store.get_all_pending_consensus_transactions() {
+            match tx.kind {
+                // Shared object txns cannot be re-executed at this point, because we must wait for
+                // consensus replay to assign shared object versions.
+                ConsensusTransactionKind::CertifiedTransaction(tx)
+                    if !tx.contains_shared_object() =>
+                {
+                    let tx = *tx;
+                    // new_unchecked is safe because we never submit a transaction to consensus
+                    // without verifying it
+                    let tx = VerifiedExecutableTransaction::new_from_certificate(
+                        VerifiedCertificate::new_unchecked(tx),
+                    );
+                    // we only need to re-execute if we previously signed the effects (which
+                    // indicates we returned the effects to a client).
+                    if let Some(fx_digest) = epoch_store
+                        .get_signed_effects_digest(tx.digest())
+                        .expect("db error")
+                    {
+                        pending_consensus_certificates.push((tx, fx_digest));
                     } else {
-                        Some(VerifiedCertificate::new_unchecked(*tx))
+                        additional_certs.push(tx);
                     }
                 }
-                _ => None,
-            })
-            .collect::<Vec<_>>();
+                _ => (),
+            }
+        }
 
         let digests = pending_consensus_certificates
             .iter()
-            .map(|tx| *tx.digest())
+            .map(|(tx, _)| *tx.digest())
             .collect::<Vec<_>>();
 
         info!(
-            "re-enqueueing {} pending consensus certificates for execution: {:?}",
+            "reexecuting {} pending consensus certificates: {digests:?}",
             digests.len(),
-            digests
         );
 
-        state.enqueue_certificates_for_execution(pending_consensus_certificates, epoch_store);
+        state.enqueue_with_expected_effects_digest(pending_consensus_certificates, epoch_store);
+        state.enqueue_transactions_for_execution(additional_certs, epoch_store);
+
+        // If this times out, the validator will still almost certainly start up fine.
+        // But, it is possible that it may temporarily "forget" about
+        // transactions that it had previously executed. This could confuse
+        // clients in some circumstances. However, the transactions are still in
+        // pending_consensus_certificates, so we cannot lose any finality guarantees.
+        let timeout = if cfg!(msim) { 120 } else { 60 };
+        if tokio::time::timeout(
+            std::time::Duration::from_secs(timeout),
+            state
+                .get_transaction_cache_reader()
+                .notify_read_executed_effects_digests(&digests),
+        )
+        .await
+        .is_err()
+        {
+            // Log all the digests that were not executed to help debugging.
+            let executed_effects_digests = state
+                .get_transaction_cache_reader()
+                .multi_get_executed_effects_digests(&digests);
+            let pending_digests = digests
+                .iter()
+                .zip(executed_effects_digests.iter())
+                .filter_map(|(digest, executed_effects_digest)| {
+                    if executed_effects_digest.is_none() {
+                        Some(digest)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            debug_fatal!(
+                "Timed out waiting for effects digests to be executed: {pending_digests:?}",
+            );
+        }
     }
 
     pub fn state(&self) -> Arc<AuthorityState> {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -918,24 +918,21 @@ impl IotaNode {
         .await?;
 
         let validator_components = if state.is_committee_validator(&epoch_store) {
-            let (components, _) = futures::join!(
-                Self::construct_validator_components(
-                    config.clone(),
-                    state.clone(),
-                    committee,
-                    epoch_store.clone(),
-                    checkpoint_store.clone(),
-                    state_sync_handle.clone(),
-                    randomness_handle.clone(),
-                    Arc::downgrade(&accumulator),
-                    backpressure_manager.clone(),
-                    connection_monitor_status.clone(),
-                    &registry_service,
-                    iota_node_metrics.clone(),
-                ),
-                Self::reexecute_pending_consensus_certs(&epoch_store, &state,)
-            );
-            let mut components = components?;
+            let mut components = Self::construct_validator_components(
+                config.clone(),
+                state.clone(),
+                committee,
+                epoch_store.clone(),
+                checkpoint_store.clone(),
+                state_sync_handle.clone(),
+                randomness_handle.clone(),
+                Arc::downgrade(&accumulator),
+                backpressure_manager.clone(),
+                connection_monitor_status.clone(),
+                &registry_service,
+                iota_node_metrics.clone(),
+            )
+            .await?;
 
             components.consensus_adapter.submit_recovered(&epoch_store);
 
@@ -1623,24 +1620,14 @@ impl IotaNode {
         Ok(SpawnOnce::new(bind_future))
     }
 
-    /// Re-executes pending consensus certificates, which may not have been
-    /// committed to disk before the node restarted. This is necessary for
-    /// the following reasons:
-    ///
-    /// 1. For any transaction for which we returned signed effects to a client,
-    ///    we must ensure that we have re-executed the transaction before we
-    ///    begin accepting grpc requests. Otherwise we would appear to have
-    ///    forgotten about the transaction.
-    /// 2. While this is running, we are concurrently waiting for all previously
-    ///    built checkpoints to be rebuilt. Since there may be dependencies in
-    ///    either direction (from checkpointed consensus transactions to pending
-    ///    consensus transactions, or vice versa), we must re-execute pending
-    ///    consensus transactions to ensure that both processes can complete.
-    /// 3. Also note that for any pending consensus transactions for which we
-    ///    wrote a signed effects digest to disk, we must re-execute using that
-    ///    digest as the expected effects digest, to ensure that we cannot
-    ///    arrive at different effects than what we previously signed.
-    async fn reexecute_pending_consensus_certs(
+    // TODO: Fix this function.
+    // We only attempt to re-execute pending consensus transactions that is:
+    // 1. Fast-path transaction
+    // 2. Has signed the effects
+    // However it is possible that some dependencies are also in pending consensus
+    // transactions but does not meet the above criteria. This will lead to
+    // timeout on waiting for effects digests to be executed.
+    async fn _reexecute_pending_consensus_certs(
         epoch_store: &Arc<AuthorityPerEpochStore>,
         state: &Arc<AuthorityState>,
     ) {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -25,7 +25,6 @@ use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId, OIDCProvider};
 use futures::future::BoxFuture;
 pub use handle::IotaNodeHandle;
 use iota_archival::{reader::ArchiveReaderBalancer, writer::ArchiveWriter};
-use iota_common::debug_fatal;
 use iota_config::{
     ConsensusConfig, NodeConfig,
     node::{DBCheckpointConfig, RunWithRange},
@@ -115,7 +114,6 @@ use iota_types::{
     crypto::{AuthoritySignature, IotaAuthoritySignature, KeypairTraits, RandomnessRound},
     digests::ChainIdentifier,
     error::{IotaError, IotaResult},
-    executable_transaction::VerifiedExecutableTransaction,
     execution_config_utils::to_binary_config,
     full_checkpoint_content::CheckpointData,
     iota_system_state::{
@@ -918,6 +916,7 @@ impl IotaNode {
         .await?;
 
         let validator_components = if state.is_committee_validator(&epoch_store) {
+            Self::reenqueue_pending_consensus_certs(&epoch_store, &state).await;
             let mut components = Self::construct_validator_components(
                 config.clone(),
                 state.clone(),
@@ -1620,103 +1619,41 @@ impl IotaNode {
         Ok(SpawnOnce::new(bind_future))
     }
 
-    // TODO: Fix this function.
-    // We only attempt to re-execute pending consensus transactions that is:
-    // 1. Fast-path transaction
-    // 2. Has signed the effects
-    // However it is possible that some dependencies are also in pending consensus
-    // transactions but does not meet the above criteria. This will lead to
-    // timeout on waiting for effects digests to be executed.
-    async fn _reexecute_pending_consensus_certs(
+    /// Re-enqueue pending consensus certificates for execution.
+    // TODO: Add comments explain why we need to do this at start up.
+    async fn reenqueue_pending_consensus_certs(
         epoch_store: &Arc<AuthorityPerEpochStore>,
         state: &Arc<AuthorityState>,
     ) {
-        let mut pending_consensus_certificates = Vec::new();
-        let mut additional_certs = Vec::new();
-
-        for tx in epoch_store.get_all_pending_consensus_transactions() {
-            match tx.kind {
-                // Shared object txns cannot be re-executed at this point, because we must wait for
-                // consensus replay to assign shared object versions.
-                ConsensusTransactionKind::CertifiedTransaction(tx)
-                    if !tx.contains_shared_object() =>
-                {
-                    let tx = *tx;
-                    // new_unchecked is safe because we never submit a transaction to consensus
-                    // without verifying it
-                    let tx = VerifiedExecutableTransaction::new_from_certificate(
-                        VerifiedCertificate::new_unchecked(tx),
-                    );
-                    // we only need to re-execute if we previously signed the effects (which
-                    // indicates we returned the effects to a client).
-                    if let Some(fx_digest) = epoch_store
-                        .get_signed_effects_digest(tx.digest())
-                        .expect("db error")
-                    {
-                        pending_consensus_certificates.push((tx, fx_digest));
+        let pending_consensus_certificates = epoch_store
+            .get_all_pending_consensus_transactions()
+            .into_iter()
+            .filter_map(|tx| match tx.kind {
+                ConsensusTransactionKind::CertifiedTransaction(tx) => {
+                    if tx.contains_shared_object() {
+                        // We cannot schedule shared object transactions for execution here
+                        // because they must come out of consensus to get prover version assignment.
+                        None
                     } else {
-                        additional_certs.push(tx);
+                        Some(VerifiedCertificate::new_unchecked(*tx))
                     }
                 }
-                _ => (),
-            }
-        }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
 
         let digests = pending_consensus_certificates
             .iter()
-            .map(|(tx, _)| *tx.digest())
+            .map(|tx| *tx.digest())
             .collect::<Vec<_>>();
 
         info!(
-            "reexecuting {} pending consensus certificates: {:?}",
+            "re-enqueueing {} pending consensus certificates for execution: {:?}",
             digests.len(),
             digests
         );
 
-        state.enqueue_with_expected_effects_digest(pending_consensus_certificates, epoch_store);
-        state.enqueue_transactions_for_execution(additional_certs, epoch_store);
-
-        // If this times out, the validator will still almost certainly start up fine.
-        // But, it is possible that it may temporarily "forget" about
-        // transactions that it had previously executed. This could confuse
-        // clients in some circumstances. However, the transactions are still in
-        // pending_consensus_certificates, so we cannot lose any finality guarantees.
-        let timeout = if cfg!(msim) { 120 } else { 60 };
-        if tokio::time::timeout(
-            std::time::Duration::from_secs(timeout),
-            state
-                .get_transaction_cache_reader()
-                .try_notify_read_executed_effects_digests(&digests),
-        )
-        .await
-        .is_err()
-        {
-            // Log all the digests that were not executed to help debugging.
-            if let Ok(executed_effects_digests) = state
-                .get_transaction_cache_reader()
-                .try_multi_get_executed_effects_digests(&digests)
-            {
-                let pending_digests = digests
-                    .iter()
-                    .zip(executed_effects_digests.iter())
-                    .filter_map(|(digest, executed_effects_digest)| {
-                        if executed_effects_digest.is_none() {
-                            Some(digest)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                debug_fatal!(
-                    "Timed out waiting for effects digests to be executed: {:?}",
-                    pending_digests
-                );
-            } else {
-                debug_fatal!(
-                    "Timed out waiting for effects digests to be executed, digests not found"
-                );
-            }
-        }
+        state.enqueue_certificates_for_execution(pending_consensus_certificates, epoch_store);
     }
 
     pub fn state(&self) -> Arc<AuthorityState> {


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@c2e769e](https://github.com/MystenLabs/sui/commit/c2e769e6e8370cfebae374f0fec636495df82a0a)
  - [MystenLabs/sui@0f0063c](https://github.com/MystenLabs/sui/commit/0f0063cb80dddcbee3bd4fe649055486c5756de1)
  - [MystenLabs/sui@68113e1](https://github.com/MystenLabs/sui/commit/68113e14ae371146856a01614c89cf30e3ee0589)
- Description:

**Commit 1 (c2e769e):** Do not call `reexecute_pending_consensus_certs` at startup.

All transactions in `pending_consensus_transactions` will eventually be executed once they come out of consensus. There is no strong need to proactively execute them upfront. This causes the `debug_fatal` in the function to be triggered, causing both simtest nightly and antithesis to fail.

**Commit 2 (0f0063c):** Re-execute all pending consensus transactions at startup.

Partially reverts the previous change because later on the code will also attempt to rebuild all checkpoints, which depends on all pending transactions being executed. Antithesis starts to report failures after the previous change. Key differences from the original implementation:
1. Instead of just re-scheduling transactions with locally signed effects, we schedule all fast-path pending consensus transactions.
2. We no longer wait here. Instead, when it rebuilds all checkpoints, it will wait anyway.

**Commit 3 (68113e1):** Fix `reexecute_pending_consensus_transactions` and address TODOs.

- Track `expected_effects_digest` for fork detection on signed transactions
- Split pending certs into those with signed effects (re-executed with expected digest) and additional certs (enqueued without)
- Run re-execution concurrently with `construct_validator_components`
- Wait for re-executed transactions to complete with timeout and `debug_fatal` on failure
- Address comment TODOs in checkpoints/mod.rs

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes