### PR TITLE
chore: bump rust toolchain to `1.94`

### DIFF
--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -201,9 +201,7 @@ impl CommitObserver {
                 .observe(commit.blocks.len() as f64);
 
             for block in &commit.blocks {
-                let latency_ms = utc_now
-                    .checked_sub(block.timestamp_ms())
-                    .unwrap_or_default();
+                let latency_ms = utc_now.saturating_sub(block.timestamp_ms());
                 metrics
                     .block_commit_latency
                     .observe(Duration::from_millis(latency_ms).as_secs_f64());

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -678,9 +678,7 @@ impl AuthorityStorePruner {
         let num_intervals = epoch_duration_ms
             .checked_div(Self::pruning_tick_duration_ms(epoch_duration_ms))
             .unwrap_or(1);
-        let delta = max_eligible_checkpoint
-            .checked_sub(pruned_checkpoint)
-            .unwrap_or_default()
+        let delta = max_eligible_checkpoint.saturating_sub(pruned_checkpoint)
             .checked_div(num_intervals)
             .unwrap_or(1);
         Ok(pruned_checkpoint + delta)

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -678,7 +678,8 @@ impl AuthorityStorePruner {
         let num_intervals = epoch_duration_ms
             .checked_div(Self::pruning_tick_duration_ms(epoch_duration_ms))
             .unwrap_or(1);
-        let delta = max_eligible_checkpoint.saturating_sub(pruned_checkpoint)
+        let delta = max_eligible_checkpoint
+            .saturating_sub(pruned_checkpoint)
             .checked_div(num_intervals)
             .unwrap_or(1);
         Ok(pruned_checkpoint + delta)

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -548,9 +548,7 @@ impl CommitObserver {
                 .observe(commit.headers.len() as f64);
 
             for header in &commit.headers {
-                let latency_ms = utc_now
-                    .checked_sub(header.timestamp_ms())
-                    .unwrap_or_default();
+                let latency_ms = utc_now.saturating_sub(header.timestamp_ms());
                 metrics
                     .block_header_commit_latency
                     .observe(Duration::from_millis(latency_ms).as_secs_f64());
@@ -620,9 +618,7 @@ impl CommitObserver {
                 .collect::<Vec<_>>();
 
             for block_header in headers_for_committed_txs {
-                let latency_ms = utc_now
-                    .checked_sub(block_header.timestamp_ms())
-                    .unwrap_or_default();
+                let latency_ms = utc_now.saturating_sub(block_header.timestamp_ms());
                 metrics
                     .transaction_commit_latency
                     .observe(Duration::from_millis(latency_ms).as_secs_f64());

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -30,7 +30,6 @@ pub(crate) trait Store: Send + Sync {
 
     /// Reads complete blocks by combining transactions and headers for the
     /// given refs.
-    #[cfg_attr(not(test), expect(dead_code))]
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
 
     /// Read and get verified block headers for the given refs.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93"
+channel = "1.94"


### PR DESCRIPTION

# Description of change

Bump rust toolchain to `1.94`.
Addresses the https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#manual_saturating_arithmetic lint.

## Links to any relevant issues

Blocked by https://github.com/iotaledger/iota/pull/11010.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
