### PR TITLE
feat: add `iota-localnet` to homebrew formula

### DIFF
--- a/scripts/homebrew/template.rb
+++ b/scripts/homebrew/template.rb
@@ -43,11 +43,13 @@ class Iota < Formula
     def install
         if @@arch == "source"
             ENV["GIT_REVISION"] = ""
-            system "cargo", "build", "--release", "--bin", "iota", "--bin", "iota-tool", "-F", "indexer,iota-names,gen-completions,tracing"
+            system "cargo", "build", "--release", "--bin", "iota", "--bin", "iota-localnet", "--bin", "iota-tool", "-F", "indexer,iota-names,gen-completions,tracing"
             bin.install "target/release/iota" => "iota"
+            bin.install "target/release/iota-localnet" => "iota-localnet"
             bin.install "target/release/iota-tool" => "iota-tool"
         else
             bin.install "iota" => "iota"
+            bin.install "iota-localnet" => "iota-localnet"
             bin.install "iota-tool" => "iota-tool"
         end
     end


### PR DESCRIPTION
# Description of change

Add steps to the homebrew formula to install `iota-localnet` from source and from released archive.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/11025

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
