### PR TITLE
upstream(core): Add support for multi_get_objects in kvstore

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5815,6 +5815,16 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
             .try_get_object_by_key(&object_id, version)
     }
 
+    #[instrument(skip_all)]
+    async fn multi_get_objects(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> IotaResult<Vec<Option<Object>>> {
+        Ok(self
+            .get_object_cache_reader()
+            .multi_get_objects_by_key(object_keys))
+    }
+
     async fn multi_get_transactions_perpetual_checkpoints(
         &self,
         digests: &[TransactionDigest],

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -16,6 +16,7 @@ use iota_types::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
     },
     object::Object,
+    storage::ObjectKey,
     transaction::Transaction,
 };
 use moka::sync::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
@@ -477,7 +478,7 @@ impl KeyValueStoreClient for HttpRestKVClient {
     ) -> IndexerResult<Vec<Option<Object>>> {
         let keys = object_refs
             .iter()
-            .map(|(object_id, version)| Key::ObjectKey(*object_id, *version))
+            .map(|(object_id, version)| Key::ObjectKey(ObjectKey(*object_id, *version)))
             .collect::<Vec<_>>();
 
         let fetches = self.multi_fetch(keys).await?;

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -613,6 +613,7 @@ mod tests {
             ) -> IotaResult<Option<CheckpointSequenceNumber>>;
 
             async fn get_object(&self, object_id: ObjectID, version: SequenceNumber) -> IotaResult<Option<Object>>;
+            async fn multi_get_objects(&self, object_keys: &[iota_types::storage::ObjectKey]) -> IotaResult<Vec<Option<Object>>>;
 
             async fn multi_get_transactions_perpetual_checkpoints(
                 &self,

--- a/crates/iota-rest-kv/src/aws.rs
+++ b/crates/iota-rest-kv/src/aws.rs
@@ -14,7 +14,6 @@ use aws_sdk_dynamodb::{Client, config::Credentials, primitives::Blob, types::Att
 use bytes::Bytes;
 use iota_config::object_storage_config::ObjectStoreConfig;
 use iota_storage::http_key_value_store::{Key, TaggedKey};
-use iota_types::storage::ObjectKey;
 use object_store::{DynObjectStore, ObjectStoreExt, path::Path};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -349,8 +348,7 @@ impl KvStoreClient {
             Key::TransactionToCheckpoint(transaction_digest) => {
                 self.get_from_dynamodb(transaction_digest, item_type).await
             }
-            Key::ObjectKey(object_id, sequence_number) => {
-                let object_key = ObjectKey(object_id, sequence_number);
+            Key::ObjectKey(object_key) => {
                 let serialized_object_key = bcs::to_bytes(&object_key)?;
                 self.get_from_dynamodb(serialized_object_key, item_type)
                     .await

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -22,7 +22,7 @@ use iota_kvstore::{
     proto::bigtable::v2::{RowFilter, row_filter::Filter},
 };
 use iota_storage::http_key_value_store::Key;
-use iota_types::{effects::TransactionEvents, storage::ObjectKey};
+use iota_types::effects::TransactionEvents;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -212,11 +212,9 @@ impl KvStoreClient {
                 )
                 .await
             }
-            Key::ObjectKey(_, _) => {
+            Key::ObjectKey(_) => {
                 let object_keys = Self::extract_keys(&keys, |k| match k {
-                    Key::ObjectKey(object_id, sequence_number) => {
-                        Some(ObjectKey(*object_id, *sequence_number))
-                    }
+                    Key::ObjectKey(object_key) => Some(*object_key),
                     _ => None,
                 })?;
 

--- a/crates/iota-storage/src/http_key_value_store.rs
+++ b/crates/iota-storage/src/http_key_value_store.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, StreamExt};
 use iota_types::{
-    base_types::{ObjectID, SequenceNumber, VersionNumber},
+    base_types::{ObjectID, SequenceNumber},
     digests::{CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{IotaError, IotaResult},
@@ -58,9 +58,8 @@ pub fn encoded_tagged_key(key: &TaggedKey) -> String {
     base64_url::encode(&bytes)
 }
 
-pub fn encode_object_key(object_id: &ObjectID, version: &VersionNumber) -> String {
-    let bytes =
-        bcs::to_bytes(&ObjectKey(*object_id, *version)).expect("failed to serialize object key");
+pub fn encode_object_key(object_key: &ObjectKey) -> String {
+    let bytes = bcs::to_bytes(object_key).expect("failed to serialize object key");
     base64_url::encode(&bytes)
 }
 
@@ -124,7 +123,7 @@ pub enum Key {
     CheckpointSummary(CheckpointSequenceNumber),
     CheckpointSummaryByDigest(CheckpointDigest),
     TransactionToCheckpoint(TransactionDigest),
-    ObjectKey(ObjectID, VersionNumber),
+    ObjectKey(ObjectKey),
     EventsByTransactionDigest(TransactionDigest),
 }
 
@@ -194,7 +193,7 @@ impl Key {
                 let object_key: ObjectKey = bcs::from_bytes(&decoded_key)
                     .map_err(|err| anyhow::anyhow!("failed to deserialize object key: {err}"))?;
 
-                Ok(Key::ObjectKey(object_key.0, object_key.1))
+                Ok(Key::ObjectKey(ObjectKey(object_key.0, object_key.1)))
             }
             ItemType::EventTransactionDigest => Ok(Key::EventsByTransactionDigest(
                 TransactionDigest::try_from(decoded_key.as_slice())?,
@@ -229,7 +228,7 @@ impl Key {
                 ItemType::CheckpointSummary
             }
             Key::TransactionToCheckpoint(_) => ItemType::TransactionToCheckpoint,
-            Key::ObjectKey(_, _) => ItemType::Object,
+            Key::ObjectKey(_) => ItemType::Object,
             Key::EventsByTransactionDigest(_) => ItemType::EventTransactionDigest,
         }
     }
@@ -276,7 +275,7 @@ impl Key {
             }
             Key::CheckpointSummaryByDigest(digest) => encode_digest(digest),
             Key::TransactionToCheckpoint(digest) => encode_digest(digest),
-            Key::ObjectKey(object_id, version) => encode_object_key(object_id, version),
+            Key::ObjectKey(object_key) => encode_object_key(object_key),
             Key::EventsByTransactionDigest(digest) => encode_digest(digest),
         };
 
@@ -594,10 +593,32 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>> {
-        let key = Key::ObjectKey(object_id, version);
+        let key = Key::ObjectKey(ObjectKey(object_id, version));
         self.fetch(key)
             .await
             .map(|maybe| maybe.and_then(|bytes| deser::<_, Object>(&key, bytes.as_ref())))
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn multi_get_objects(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> IotaResult<Vec<Option<Object>>> {
+        let keys = object_keys
+            .iter()
+            .map(|key| Key::ObjectKey(*key))
+            .collect::<Vec<_>>();
+
+        let fetches = self.multi_fetch(keys).await;
+
+        let results = fetches
+            .iter()
+            .zip(object_keys.iter())
+            .map(map_fetch)
+            .map(|maybe_bytes| maybe_bytes.and_then(|(bytes, key)| deser::<_, Object>(&key, bytes)))
+            .collect::<Vec<_>>();
+
+        Ok(results)
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/crates/iota-storage/src/key_value_store.rs
+++ b/crates/iota-storage/src/key_value_store.rs
@@ -17,6 +17,7 @@ use iota_types::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
     },
     object::Object,
+    storage::ObjectKey,
     transaction::Transaction,
 };
 use tracing::instrument;
@@ -334,6 +335,13 @@ impl TransactionKeyValueStore {
         self.inner.get_object(object_id, version).await
     }
 
+    pub async fn multi_get_objects(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> IotaResult<Vec<Option<Object>>> {
+        self.inner.multi_get_objects(object_keys).await
+    }
+
     pub async fn multi_get_transactions_perpetual_checkpoints(
         &self,
         digests: &[TransactionDigest],
@@ -383,6 +391,9 @@ pub trait TransactionKeyValueStoreTrait {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>>;
+
+    async fn multi_get_objects(&self, object_keys: &[ObjectKey])
+    -> IotaResult<Vec<Option<Object>>>;
 
     async fn multi_get_transactions_perpetual_checkpoints(
         &self,
@@ -534,6 +545,26 @@ impl TransactionKeyValueStoreTrait for FallbackTransactionKVStore {
         if res.is_none() {
             res = self.fallback.get_object(object_id, version).await?;
         }
+        Ok(res)
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn multi_get_objects(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> IotaResult<Vec<Option<Object>>> {
+        let mut res = self.primary.multi_get_objects(object_keys).await?;
+
+        let (fallback, indices) = find_fallback(&res, object_keys);
+
+        if fallback.is_empty() {
+            return Ok(res);
+        }
+
+        let secondary_res = self.fallback.multi_get_objects(&fallback).await?;
+
+        merge_res(&mut res, secondary_res, &indices);
+
         Ok(res)
     }
 

--- a/crates/iota-storage/tests/key_value_tests.rs
+++ b/crates/iota-storage/tests/key_value_tests.rs
@@ -194,6 +194,16 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
         Ok(self.objects.get(&ObjectKey(object_id, version)).cloned())
     }
 
+    async fn multi_get_objects(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> IotaResult<Vec<Option<Object>>> {
+        Ok(object_keys
+            .iter()
+            .map(|key| self.objects.get(key).cloned())
+            .collect())
+    }
+
     async fn multi_get_transactions_perpetual_checkpoints(
         &self,
         digests: &[TransactionDigest],


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@1e114d6](https://github.com/MystenLabs/sui/commit/1e114d605abd8d5ad9bf63f7f604c8e18a3998e5)
- Description:

Add support for `multi_get_objects` in the kvstore, enabling batch retrieval of objects by key. Also refactors the `Key::ObjectKey` enum variant to wrap an `ObjectKey` struct instead of individual `ObjectID` and `VersionNumber` fields.

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes