### PR TITLE
fix(ci): use `xvfb-run --auto-servernum` for Move IDE tests

### DIFF
--- a/.github/workflows/_move_ide.yml
+++ b/.github/workflows/_move_ide.yml
@@ -61,16 +61,11 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Install dependencies and start Xvfb (emulate a display so VS Code can be started)
+      - name: Install dependencies (emulate a display so VS Code can be started)
         working-directory: ./external-crates/move/crates/move-analyzer/editors/code
         run: |
           sudo apt install libgtk-3-0 -y
           sudo apt-get install -y xvfb x11-apps x11-xkb-utils libx11-6 libx11-xcb1
-          set -eux
-          # Start server
-          /usr/bin/Xvfb :99 -screen 0 1024x768x24 &
-          sleep 1
-          ps aux | grep Xvfb --color=always | grep -v grep
           sudo add-apt-repository ppa:kisak/kisak-mesa -y
           sudo apt update
           sudo apt upgrade -y
@@ -85,7 +80,7 @@ jobs:
       - name: Run npm test
         working-directory: ./external-crates/move/crates/move-analyzer/editors/code
         shell: bash
-        run: npm run pretest && DISPLAY=:99.0 npm run test
+        run: npm run pretest && xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm run test
 
   move-ide-test-cancel:
     needs: [move-ide-test]

--- a/external-crates/move/crates/bytecode-interpreter-crypto/src/lib.rs
+++ b/external-crates/move/crates/bytecode-interpreter-crypto/src/lib.rs
@@ -13,6 +13,8 @@
 //! diem-framework) and be passed into the VM for execution. In this way we no
 //! longer need to worry about depending on diem-crypto.
 
+// Triggering CI
+
 use std::cmp::Ordering;
 
 use anyhow::{Result, bail};

--- a/external-crates/move/crates/bytecode-interpreter-crypto/src/lib.rs
+++ b/external-crates/move/crates/bytecode-interpreter-crypto/src/lib.rs
@@ -13,8 +13,6 @@
 //! diem-framework) and be passed into the VM for execution. In this way we no
 //! longer need to worry about depending on diem-crypto.
 
-// Triggering CI
-
 use std::cmp::Ordering;
 
 use anyhow::{Result, bail};


### PR DESCRIPTION
## Summary
- Replace hardcoded Xvfb `:99` display with `xvfb-run --auto-servernum` in the Move IDE test workflow
- Removes manual Xvfb lifecycle management (start, sleep, process check)

## Problem
The Move IDE CI job was starting Xvfb on a hardcoded display `:99`. On self-hosted runners, if a previous run was interrupted or another job already claimed display `:99`, the lock file `/tmp/.X99-lock` persists and Xvfb fails to start with:

```
(EE) Server is already active for display 99
```

This caused the entire Move IDE test job to fail.
Example: https://github.com/iotaledger/iota/actions/runs/23750515861/job/69192092373?pr=11010#step:5:36

## Fix
Switched to `xvfb-run --auto-servernum`, which automatically picks a free display number, avoiding lock file conflicts. This is the same approach already used by the e2e tests in `_e2e.yml`. The Xvfb process is now scoped to the test step and cleaned up automatically when it exits.

