### PR TITLE
fix(indexer): Harmonize iota_tryGetObjectBeforeVersion response with node JSON-RPC

### DIFF
--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -336,8 +336,11 @@ impl ReadApiServer for ReadApi {
             .get_past_object_read_with_fallback(object_id, version, true)
             .await?;
 
-        self.past_object_read_to_response(None, past_object_read)
-            .await
+        self.past_object_read_to_response(
+            Some(IotaObjectDataOptions::bcs_lossless()),
+            past_object_read,
+        )
+        .await
     }
 
     async fn try_multi_get_past_objects(


### PR DESCRIPTION
# Description of change

`iota_tryGetObjectBeforeVersion` JSON RPC gives a different response depending on node or indexer backend:

Node JSON RPC:
```
curl -s -X POST https://api.mainnet.iota.cafe \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"iota_tryGetObjectBeforeVersion","params":["0x0dc448563a2c54778215b3d655b0d9f8f69f06cf80a4fc9eada72e96a49e409d",512573048],"id":0}' | jq .

{
  "jsonrpc": "2.0",
  "id": 0,
  "result": {
    "status": "VersionFound",
    "details": {
      "objectId": "0x0dc448563a2c54778215b3d655b0d9f8f69f06cf80a4fc9eada72e96a49e409d",
      "version": "512573048",
      "digest": "GzuXJfdBVeXbxTnFRKoRy699jKwaG8AJSVXDB41B6T49",
      "type": "0x1b33a3cf7eb5dde04ed7ae571db1763006811ff6b7bb35b3d1c780de153af9dd::anchor::Anchor",
      "owner": {
        "AddressOwner": "0x7b4a34f6a011794f0ecbe5e5beb96102d3eef6122eb929b9f50a8d757bfbdd67"
      },
      "previousTransaction": "CY16xZoh57ytaVV69crTv4YGMKshsihjs7Cho4xV1cW4",
      "storageRebate": "2599200",
      "bcs": {
        "dataType": "moveObject",
        "type": "0x1b33a3cf7eb5dde04ed7ae571db1763006811ff6b7bb35b3d1c780de153af9dd::anchor::Anchor",
        "version": 512573048,
        "bcsBytes": "DcRIVjosVHeCFbPWVbDZ+PafBs+ApPyeraculqSeQJ3cg4g8qCDzDELbhHYEo9HWcdzG+XlDPuyUzPGtMkSABwG28RPH4vzvLG8DVBvLAzPkw3fAcuooa2dw0dA3nvRWlzkAAAAAAAAAYAYAAADQG4Atac+B+Z1V5OUnjG/IP03XSGQnMiX/W+sdvuu46Jv62OuGahFttpO2cXyMg7gh4c9GTPexI22xPSWhD24G39sNxfhXJw0BAAAAAQAAAAEAAAAKAAAAAAAAAEr+rgA="
      }
    }
  }
}
```

The same request to the indexer RPC:
```
curl -s -X POST https://indexer.mainnet.iota.cafe \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"iota_tryGetObjectBeforeVersion","params":["0x0dc448563a2c54778215b3d655b0d9f8f69f06cf80a4fc9eada72e96a49e409d",512573048],"id":0}' | jq .

{
  "jsonrpc": "2.0",
  "id": 0,
  "result": {
    "status": "VersionFound",
    "details": {
      "objectId": "0x0dc448563a2c54778215b3d655b0d9f8f69f06cf80a4fc9eada72e96a49e409d",
      "version": "512573047",
      "digest": "DCetNZHeGw6KvRf3EMN3n7Ycv6QvNbAXWTgLt5UutuE8"
    }
  }
}
```

`iota-replay` relies on this endpoint for local execution and fails miserably when pointing it to the indexer JSON-RPC due to the missing bcs bytes. (Pointing it to the node JSON-RPC is also not the best option, as past object versions are pruned from access nodes.)

## Links to any relevant issues

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] Indexer: `iota_tryGetObjectBeforeVersion` JSON-RPC endpoint returns the bcs encoded object bytes when an object is found
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
