### PR TITLE
fix(dashboard): Build apps-backend when running dashboard e2e tests

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Build apps-backend
         id: build-apps-backend
-        if: (!cancelled() && !failure()) && steps.conditions.outputs.runAppsBackend == 'true'
+        if: (!cancelled() && !failure()) && (steps.conditions.outputs.runAppsBackend == 'true' || steps.conditions.outputs.runDashboard == 'true')
         continue-on-error: ${{ inputs.isNightly }}
         run: pnpm turbo --filter apps-backend build
 


### PR DESCRIPTION
This is required because of  https://github.com/iotaledger/iota/blob/36bf42050ef6ecd56fc0bc8233e542d202b67643/apps/wallet-dashboard/playwright.config.ts#L63

which when the apps backend is not built it causes https://github.com/iotaledger/iota/actions/runs/23784936677/job/69307298911?pr=11010#step:22:49