### PR TITLE
upstream(core): Upgrade rocksdb to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,21 +1820,18 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "prettyplease",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.108",
 ]
@@ -2406,7 +2403,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -8720,7 +8716,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "thiserror 1.0.64",
@@ -8906,12 +8902,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9091,16 +9081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9119,14 +9099,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -11297,12 +11276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12261,7 +12234,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.2",
  "rustls 0.23.35",
  "socket2 0.6.1",
  "thiserror 2.0.17",
@@ -12282,7 +12255,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.2",
  "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
@@ -12826,9 +12799,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -13058,9 +13031,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc-hex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,6 +2403,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -9078,6 +9079,16 @@ checksum = "9adfd58e79d860f6b9e40e35127bfae9e5bd3ade33201d1347459011a2add034"
 dependencies = [
  "libcrux-secrets",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -20,7 +20,7 @@ once_cell.workspace = true
 ouroboros = "0.18"
 prometheus.workspace = true
 rand.workspace = true
-rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"] }
+rocksdb = { version = "0.24.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"] }
 serde.workspace = true
 tap.workspace = true
 thiserror.workspace = true

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -20,7 +20,7 @@ once_cell.workspace = true
 ouroboros = "0.18"
 prometheus.workspace = true
 rand.workspace = true
-rocksdb = { version = "0.24.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"] }
+rocksdb = { version = "0.24.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf", "bindgen-runtime"] }
 serde.workspace = true
 tap.workspace = true
 thiserror.workspace = true

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -194,9 +194,10 @@ impl Database {
     {
         match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => {
+                let keys_vec: Vec<K> = keys.into_iter().collect();
                 let res = db.underlying.batched_multi_get_cf_opt(
                     &cf.rocks_cf(db),
-                    keys,
+                    keys_vec.iter(),
                     // sorted_input
                     false,
                     readopts,

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -34,6 +34,7 @@ const DEFAULT_TARGET_FILE_SIZE_BASE_MB: usize = 128;
 const ENV_VAR_DISABLE_BLOB_STORAGE: &str = "DISABLE_BLOB_STORAGE";
 const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
 
+// TODO: Remove ReadWriteOptions because `ignore_range_deletions` is deprecated in RocksDB 10.2.1 and has no effect. There is no need to keep this struct or its boolean flag. (trackin issue: https://github.com/iotaledger/iota/issues/11042)
 #[derive(Clone, Debug)]
 pub struct ReadWriteOptions {
     pub ignore_range_deletions: bool,
@@ -42,6 +43,7 @@ pub struct ReadWriteOptions {
 impl ReadWriteOptions {
     pub fn readopts(&self) -> ReadOptions {
         let mut readopts = ReadOptions::default();
+        #[allow(deprecated)]
         readopts.set_ignore_range_deletions(self.ignore_range_deletions);
         readopts
     }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@28dc3](https://github.com/MystenLabs/sui/commit/28dc33fc8fc43e50819c42c22b0d557b889c107e)
- Description:

The upstream commit upgrades rocksdb from 0.21.0 to 0.22.0. In this port, we jumped directly to rocksdb 0.24.0 (the latest available version).

The previous upgrade attempt triggered write stalling and stopping on archival full nodes. Since write stalling has been disabled on full node indexes and perpetual tables (via `disable_write_throttling()`), it should no longer be an issue.

The `bindgen-runtime` feature is explicitly enabled for `rocksdb` so that `clang-sys` uses `dlopen` with its own platform-aware search logic (which knows macOS Command Line Tools and Xcode paths) instead of relying on `dyld` `@rpath` resolution, which fails on macOS due to SIP stripping `DYLD_*` environment variables.

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol:
  - Bump RocksDB version to 0.24.0
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: