### PR TITLE
upstream(core): Cleanup serde

### DIFF
--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -30,10 +30,10 @@ use move_core_types::{
 use rand::Rng;
 use schemars::JsonSchema;
 use serde::{
-    Deserialize, Serialize, Serializer,
+    Deserialize, Deserializer, Serialize, Serializer,
     ser::{Error, SerializeSeq},
 };
-use serde_with::serde_as;
+use serde_with::{DeserializeAs, SerializeAs, serde_as};
 
 use crate::{
     IOTA_CLOCK_OBJECT_ID, IOTA_FRAMEWORK_ADDRESS, IOTA_SYSTEM_ADDRESS, MOVE_STDLIB_ADDRESS,
@@ -52,7 +52,7 @@ use crate::{
     gas_coin::{GAS, GasCoin},
     governance::{STAKED_IOTA_STRUCT_NAME, STAKING_POOL_MODULE_NAME, StakedIota},
     id::RESOLVED_IOTA_ID,
-    iota_serde::{HexAccountAddress, Readable, to_iota_struct_tag_string},
+    iota_serde::{Readable, to_custom_deser_error, to_iota_struct_tag_string},
     messages_checkpoint::CheckpointTimestamp,
     multisig::MultiSigPublicKey,
     object::{Object, Owner},
@@ -1699,6 +1699,33 @@ impl From<ObjectID> for AccountAddress {
 impl From<IotaAddress> for AccountAddress {
     fn from(address: IotaAddress) -> Self {
         Self::new(address.0)
+    }
+}
+
+/// Hex serde for AccountAddress
+struct HexAccountAddress;
+
+impl SerializeAs<AccountAddress> for HexAccountAddress {
+    fn serialize_as<S>(value: &AccountAddress, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Hex::serialize_as(value, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, AccountAddress> for HexAccountAddress {
+    fn deserialize_as<D>(deserializer: D) -> Result<AccountAddress, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s.starts_with("0x") {
+            AccountAddress::from_hex_literal(&s)
+        } else {
+            AccountAddress::from_hex(&s)
+        }
+        .map_err(to_custom_deser_error::<'de, D, _>)
     }
 }
 

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -1318,13 +1318,7 @@ impl<const STRONG_THRESHOLD: bool> AuthoritySignInfoTrait
             .get_mut(message_index)
             .ok_or(IotaError::InvalidAuthenticator)?;
 
-        let mut seen = std::collections::BTreeSet::new();
         for authority_index in self.signers_map.iter() {
-            if !seen.insert(authority_index) {
-                continue;
-            }
-
-            // Update weight when seeing the authority for the first time.
             let authority = committee
                 .authority_by_index(authority_index)
                 .ok_or_else(|| IotaError::UnknownSigner {

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -1318,7 +1318,13 @@ impl<const STRONG_THRESHOLD: bool> AuthoritySignInfoTrait
             .get_mut(message_index)
             .ok_or(IotaError::InvalidAuthenticator)?;
 
+        let mut seen = std::collections::BTreeSet::new();
         for authority_index in self.signers_map.iter() {
+            if !seen.insert(authority_index) {
+                continue;
+            }
+
+            // Update weight when seeing the authority for the first time.
             let authority = committee
                 .authority_by_index(authority_index)
                 .ok_or_else(|| IotaError::UnknownSigner {
@@ -1326,8 +1332,6 @@ impl<const STRONG_THRESHOLD: bool> AuthoritySignInfoTrait
                     index: Some(authority_index),
                     committee: Box::new(committee.clone()),
                 })?;
-
-            // Update weight.
             let voting_rights = committee.weight(authority);
             fp_ensure!(
                 voting_rights > 0,

--- a/crates/iota-types/src/iota_serde.rs
+++ b/crates/iota-types/src/iota_serde.rs
@@ -342,11 +342,13 @@ impl<'de> DeserializeAs<'de, roaring::RoaringBitmap> for IotaBitmap {
     }
 }
 
-// RoaringBitmap::deserialize_from() or iter() do not check for duplicates.
-// So this function is needed to sanitize the bitmap to ensure unique entries.
+// Deserializes a RoaringBitmap, ensuring entries are unique and sorted.
+// NOTE: roaring 0.11+ validates container key ordering in deserialize_from(),
+// so bitmaps with unsorted/duplicate container keys are already rejected at the
+// deserialization level. The explicit dedup below is kept as defense-in-depth.
 fn deserialize_iota_bitmap(bytes: &[u8]) -> std::io::Result<roaring::RoaringBitmap> {
     let orig_bitmap = roaring::RoaringBitmap::deserialize_from(bytes)?;
-    // Ensure there is no duplicated entries in the bitmap.
+    // Ensure there are no duplicated entries in the bitmap.
     let mut seen = std::collections::BTreeSet::new();
     let mut new_bitmap = roaring::RoaringBitmap::new();
     for v in orig_bitmap.iter() {
@@ -364,20 +366,31 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_iota_bitmap_unique_deserialize() {
+    fn test_iota_bitmap_rejects_unsorted_keys() {
+        // This base64 encodes a malformed roaring bitmap with unsorted/duplicate
+        // container keys. roaring 0.11+ rejects such bitmaps at deserialization.
         let raw = "OjAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFoAAABcAAAAXgAAAGAAAABiAAAAZAAAAGYAAABoAAAAagAAAAEAAQABAAEAAQABAAEAAQABAAEA";
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(raw)
             .unwrap();
 
-        let bitmap = roaring::RoaringBitmap::deserialize_from(&bytes[..]).unwrap();
-        assert_eq!(bitmap.len(), 10);
-        let bitmap_values: Vec<u32> = bitmap.iter().collect();
-        assert_eq!(bitmap_values, vec![1; 10]);
+        assert!(deserialize_iota_bitmap(&bytes[..]).is_err());
+    }
 
-        let iota_bitmap = deserialize_iota_bitmap(&bytes[..]).unwrap();
-        assert_eq!(iota_bitmap.len(), 1);
-        let bitmap_values: Vec<u32> = iota_bitmap.iter().collect();
-        assert_eq!(bitmap_values, vec![1]);
+    #[test]
+    fn test_iota_bitmap_valid_roundtrip() {
+        // Build a valid bitmap, serialize it, then deserialize via our function.
+        let mut original = roaring::RoaringBitmap::new();
+        original.insert(1);
+        original.insert(42);
+        original.insert(100);
+
+        let mut bytes = vec![];
+        original.serialize_into(&mut bytes).unwrap();
+
+        let result = deserialize_iota_bitmap(&bytes[..]).unwrap();
+        assert_eq!(result.len(), 3);
+        let values: Vec<u32> = result.iter().collect();
+        assert_eq!(values, vec![1, 42, 100]);
     }
 }

--- a/crates/iota-types/src/iota_serde.rs
+++ b/crates/iota-types/src/iota_serde.rs
@@ -342,21 +342,12 @@ impl<'de> DeserializeAs<'de, roaring::RoaringBitmap> for IotaBitmap {
     }
 }
 
-// Deserializes a RoaringBitmap, ensuring entries are unique and sorted.
+// Deserializes a RoaringBitmap.
 // NOTE: roaring 0.11+ validates container key ordering in deserialize_from(),
 // so bitmaps with unsorted/duplicate container keys are already rejected at the
-// deserialization level. The explicit dedup below is kept as defense-in-depth.
+// deserialization level.
 fn deserialize_iota_bitmap(bytes: &[u8]) -> std::io::Result<roaring::RoaringBitmap> {
-    let orig_bitmap = roaring::RoaringBitmap::deserialize_from(bytes)?;
-    // Ensure there are no duplicated entries in the bitmap.
-    let mut seen = std::collections::BTreeSet::new();
-    let mut new_bitmap = roaring::RoaringBitmap::new();
-    for v in orig_bitmap.iter() {
-        if seen.insert(v) {
-            new_bitmap.insert(v);
-        }
-    }
-    Ok(new_bitmap)
+    roaring::RoaringBitmap::deserialize_from(bytes)
 }
 
 #[cfg(test)]

--- a/crates/iota-types/src/iota_serde.rs
+++ b/crates/iota-types/src/iota_serde.rs
@@ -10,7 +10,6 @@ use std::{
     str::FromStr,
 };
 
-use fastcrypto::encoding::Hex;
 use iota_protocol_config::ProtocolVersion;
 use move_core_types::{
     account_address::AccountAddress,
@@ -30,7 +29,7 @@ use crate::{
 };
 
 #[inline]
-fn to_custom_error<'de, D, E>(e: E) -> D::Error
+pub(crate) fn to_custom_deser_error<'de, D, E>(e: E) -> D::Error
 where
     E: Debug,
     D: Deserializer<'de>,
@@ -39,7 +38,7 @@ where
 }
 
 #[inline]
-fn to_custom_ser_error<S, E>(e: E) -> S::Error
+pub(crate) fn to_custom_ser_error<S, E>(e: E) -> S::Error
 where
     E: Debug,
     S: Serializer,
@@ -98,61 +97,6 @@ where
         } else {
             R::deserialize_as(deserializer)
         }
-    }
-}
-
-/// custom serde for AccountAddress
-pub struct HexAccountAddress;
-
-impl SerializeAs<AccountAddress> for HexAccountAddress {
-    fn serialize_as<S>(value: &AccountAddress, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        Hex::serialize_as(value, serializer)
-    }
-}
-
-impl<'de> DeserializeAs<'de, AccountAddress> for HexAccountAddress {
-    fn deserialize_as<D>(deserializer: D) -> Result<AccountAddress, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        if s.starts_with("0x") {
-            AccountAddress::from_hex_literal(&s)
-        } else {
-            AccountAddress::from_hex(&s)
-        }
-        .map_err(to_custom_error::<'de, D, _>)
-    }
-}
-
-/// Serializes a bitmap according to the roaring bitmap on-disk standard.
-/// <https://github.com/RoaringBitmap/RoaringFormatSpec>
-pub struct IotaBitmap;
-
-impl SerializeAs<roaring::RoaringBitmap> for IotaBitmap {
-    fn serialize_as<S>(source: &roaring::RoaringBitmap, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut bytes = vec![];
-
-        source
-            .serialize_into(&mut bytes)
-            .map_err(to_custom_ser_error::<S, _>)?;
-        Bytes::serialize_as(&bytes, serializer)
-    }
-}
-
-impl<'de> DeserializeAs<'de, roaring::RoaringBitmap> for IotaBitmap {
-    fn deserialize_as<D>(deserializer: D) -> Result<roaring::RoaringBitmap, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
-        roaring::RoaringBitmap::deserialize_from(&bytes[..]).map_err(to_custom_error::<'de, D, _>)
     }
 }
 
@@ -367,5 +311,73 @@ impl<'de> DeserializeAs<'de, ProtocolVersion> for AsProtocolVersion {
     {
         let b = BigInt::<u64>::deserialize(deserializer)?;
         Ok(ProtocolVersion::from(*b))
+    }
+}
+
+/// Serializes and deserializes a RoaringBitmap with its own on-disk standard.
+/// <https://github.com/RoaringBitmap/RoaringFormatSpec>
+pub(crate) struct IotaBitmap;
+
+impl SerializeAs<roaring::RoaringBitmap> for IotaBitmap {
+    fn serialize_as<S>(source: &roaring::RoaringBitmap, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut bytes = vec![];
+
+        source
+            .serialize_into(&mut bytes)
+            .map_err(to_custom_ser_error::<S, _>)?;
+        Bytes::serialize_as(&bytes, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, roaring::RoaringBitmap> for IotaBitmap {
+    fn deserialize_as<D>(deserializer: D) -> Result<roaring::RoaringBitmap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
+        deserialize_iota_bitmap(&bytes).map_err(to_custom_deser_error::<'de, D, _>)
+    }
+}
+
+// RoaringBitmap::deserialize_from() or iter() do not check for duplicates.
+// So this function is needed to sanitize the bitmap to ensure unique entries.
+fn deserialize_iota_bitmap(bytes: &[u8]) -> std::io::Result<roaring::RoaringBitmap> {
+    let orig_bitmap = roaring::RoaringBitmap::deserialize_from(bytes)?;
+    // Ensure there is no duplicated entries in the bitmap.
+    let mut seen = std::collections::BTreeSet::new();
+    let mut new_bitmap = roaring::RoaringBitmap::new();
+    for v in orig_bitmap.iter() {
+        if seen.insert(v) {
+            new_bitmap.insert(v);
+        }
+    }
+    Ok(new_bitmap)
+}
+
+#[cfg(test)]
+mod test {
+    use base64::Engine as _;
+
+    use super::*;
+
+    #[test]
+    fn test_iota_bitmap_unique_deserialize() {
+        let raw = "OjAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFoAAABcAAAAXgAAAGAAAABiAAAAZAAAAGYAAABoAAAAagAAAAEAAQABAAEAAQABAAEAAQABAAEA";
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(raw)
+            .unwrap();
+
+        let bitmap = roaring::RoaringBitmap::deserialize_from(&bytes[..]).unwrap();
+        assert_eq!(bitmap.len(), 10);
+        let bitmap_values: Vec<u32> = bitmap.iter().collect();
+        assert_eq!(bitmap_values, vec![1; 10]);
+
+        let iota_bitmap = deserialize_iota_bitmap(&bytes[..]).unwrap();
+        assert_eq!(iota_bitmap.len(), 1);
+        let bitmap_values: Vec<u32> = iota_bitmap.iter().collect();
+        assert_eq!(bitmap_values, vec![1]);
     }
 }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.47.1, v1.48.4)
- Port commit:
  - [MystenLabs/sui@f17a550](https://github.com/MystenLabs/sui/commit/f17a550d0471616e0b1db1fd68a9ca5b6478d675)
- Description:

Improve RoaringBitmap ser/de. And a few minor cleanups.

## Links to any relevant issues

Part of #10909

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes