### PR TITLE
fix(apps-backend-client): Move `url` to shareable attributes

### DIFF
--- a/.changeset/mighty-geckos-pull.md
+++ b/.changeset/mighty-geckos-pull.md
@@ -1,0 +1,5 @@
+---
+'@iota/apps-backend-client': minor
+---
+
+Change the url to be an attribute that can be shared with getAttributes and updated with setAttributes

--- a/apps/apps-backend-client/src/client.ts
+++ b/apps/apps-backend-client/src/client.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
-    AppsBackendClientOptions,
     CoinPriceResponse,
     FeatureDefinition,
     FeaturesResponse,
@@ -11,14 +10,19 @@ import type {
 } from './types';
 
 export class AppsBackendClient {
-    private url: string;
     private features: Record<string, FeatureDefinition> = {};
     private attributes: Record<string, unknown> = {};
     private listeners: Set<() => void> = new Set();
     private snapshot: Record<string, FeatureDefinition> = this.features;
 
-    constructor(options: AppsBackendClientOptions) {
-        this.url = options.url;
+    constructor(url?: string) {
+        if (url) {
+            this.attributes.url = url;
+        }
+    }
+
+    private get url(): string {
+        return (this.attributes.url as string) ?? '';
     }
 
     async init(): Promise<void> {
@@ -52,7 +56,7 @@ export class AppsBackendClient {
     }
 
     setAttributes(attrs: Record<string, unknown>): void {
-        this.attributes = attrs;
+        this.attributes = { ...this.attributes, ...attrs };
     }
 
     getAttributes(): Record<string, unknown> {

--- a/apps/apps-backend-client/src/index.ts
+++ b/apps/apps-backend-client/src/index.ts
@@ -3,7 +3,6 @@
 
 export { AppsBackendClient } from './client';
 export type {
-    AppsBackendClientOptions,
     CoinPriceResponse,
     FeatureDefinition,
     FeaturesResponse,

--- a/apps/apps-backend-client/src/types.ts
+++ b/apps/apps-backend-client/src/types.ts
@@ -1,10 +1,6 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-export interface AppsBackendClientOptions {
-    url: string;
-}
-
 export interface FeatureDefinition<T = unknown> {
     defaultValue?: T;
 }

--- a/apps/evm-bridge/src/lib/utils/apps-backend.ts
+++ b/apps/evm-bridge/src/lib/utils/apps-backend.ts
@@ -4,6 +4,4 @@
 import { AppsBackendClient } from '@iota/apps-backend-client';
 import { getAppsBackend } from '@iota/core';
 
-export const appsBackendClient = new AppsBackendClient({
-    url: getAppsBackend(),
-});
+export const appsBackendClient = new AppsBackendClient(getAppsBackend());

--- a/apps/explorer/src/lib/utils/apps-backend.ts
+++ b/apps/explorer/src/lib/utils/apps-backend.ts
@@ -4,6 +4,4 @@
 import { AppsBackendClient } from '@iota/apps-backend-client';
 import { getAppsBackend } from '@iota/core';
 
-export const appsBackendClient = new AppsBackendClient({
-    url: getAppsBackend(),
-});
+export const appsBackendClient = new AppsBackendClient(getAppsBackend());

--- a/apps/wallet-dashboard/lib/utils/apps-backend.ts
+++ b/apps/wallet-dashboard/lib/utils/apps-backend.ts
@@ -4,6 +4,4 @@
 import { AppsBackendClient } from '@iota/apps-backend-client';
 import { getAppsBackend } from '@iota/core';
 
-export const appsBackendClient = new AppsBackendClient({
-    url: getAppsBackend(),
-});
+export const appsBackendClient = new AppsBackendClient(getAppsBackend());

--- a/apps/wallet/src/shared/experimentation/features.ts
+++ b/apps/wallet/src/shared/experimentation/features.ts
@@ -7,9 +7,7 @@ import { getAppsBackend } from '@iota/core';
 import { Network } from '@iota/iota-sdk/client';
 import Browser from 'webextension-polyfill';
 
-export const appsBackendClient = new AppsBackendClient({
-    url: getAppsBackend(),
-});
+export const appsBackendClient = new AppsBackendClient(getAppsBackend());
 
 export function setAttributes(network?: { network: Network; customRpc?: string | null }) {
     const activeNetwork = network

--- a/apps/wallet/src/ui/app/experimentation/featureGating.ts
+++ b/apps/wallet/src/ui/app/experimentation/featureGating.ts
@@ -5,4 +5,4 @@
 import { AppsBackendClient } from '@iota/apps-backend-client';
 
 // This is a separate client instance for the wallet UI, with flag values synced from the service worker.
-export const appsBackendClient = new AppsBackendClient({ url: '' });
+export const appsBackendClient = new AppsBackendClient();


### PR DESCRIPTION
this way when the background client calls setAttributes the url is also shared.

Fixes 
<img width="1085" height="255" alt="image" src="https://github.com/user-attachments/assets/515bd726-f935-4fa0-b4c1-255229b26332" />
