### PR TITLE
feat(iota-replay): Enable gas profiling move based transaction authentication

### DIFF
--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -877,7 +877,8 @@ impl LocalExec {
                 transaction_kind.clone(),
                 tx_info.sender,
                 *tx_digest,
-                bcs::to_bytes(tx_info.sender_signed_data.transaction_data()).expect("TransactionData serialization cannot fail"),
+                bcs::to_bytes(tx_info.sender_signed_data.transaction_data())
+                    .expect("TransactionData serialization cannot fail"),
                 &mut None,
             )
         };
@@ -1171,7 +1172,8 @@ impl LocalExec {
                 kind,
                 signer,
                 *executable.digest(),
-                bcs::to_bytes(sender_signed_data.transaction_data()).expect("TransactionData serialization cannot fail"),
+                bcs::to_bytes(sender_signed_data.transaction_data())
+                    .expect("TransactionData serialization cannot fail"),
                 &mut None,
             )
         };

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -876,6 +876,7 @@ impl LocalExec {
                 transaction_kind.clone(),
                 tx_info.sender,
                 *tx_digest,
+                bcs::to_bytes(tx_info.sender_signed_data.transaction_data()).expect("TransactionData serialization cannot fail"),
                 &mut None,
             )
         };
@@ -1169,6 +1170,7 @@ impl LocalExec {
                 kind,
                 signer,
                 *executable.digest(),
+                bcs::to_bytes(sender_signed_data.transaction_data()).expect("TransactionData serialization cannot fail"),
                 &mut None,
             )
         };

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -20,9 +20,16 @@ use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk::{IotaClient, IotaClientBuilder};
 use iota_types::{
     IOTA_DENY_LIST_OBJECT_ID,
+    account_abstraction::{
+        account::AuthenticatorFunctionRefV1Key,
+        authenticator_function::{
+            AuthenticatorFunctionRefForExecution, AuthenticatorFunctionRefV1,
+        },
+    },
     base_types::{ObjectID, ObjectRef, SequenceNumber, VersionNumber},
     committee::EpochId,
     digests::{ObjectDigest, TransactionDigest},
+    dynamic_field::{self, Field},
     error::{ExecutionError, IotaError, IotaResult},
     executable_transaction::VerifiedExecutableTransaction,
     gas::IotaGasStatus,
@@ -30,6 +37,7 @@ use iota_types::{
     inner_temporary_store::InnerTemporaryStore,
     message_envelope::Message,
     metrics::LimitsMetrics,
+    move_authenticator::MoveAuthenticator,
     object::{Data, Object, Owner},
     storage::{
         BackingPackageStore, ChildObjectResolver, ObjectStore, PackageObject, get_module,
@@ -726,9 +734,18 @@ impl LocalExec {
         // Initialize the state necessary for execution
         // Get the input objects
         let input_objects = self.initialize_execution_env_state(tx_info).await?;
+        let unique_shared_object_ids: HashSet<_> = input_objects
+            .filter_shared_objects()
+            .iter()
+            .map(|s| match s {
+                iota_types::execution::SharedInput::Existing(obj_ref) => obj_ref.0,
+                iota_types::execution::SharedInput::Deleted((id, _, _, _)) => *id,
+                iota_types::execution::SharedInput::Cancelled((id, _)) => *id,
+            })
+            .collect();
         assert_eq!(
-            &input_objects.filter_shared_objects().len(),
-            &tx_info.shared_object_refs.len()
+            unique_shared_object_ids.len(),
+            tx_info.shared_object_refs.len()
         );
         // At this point we have all the objects needed for replay
 
@@ -770,22 +787,78 @@ impl LocalExec {
             price: tx_info.gas_price,
             budget: tx_info.gas_budget,
         };
-        let (inner_store, gas_status, effects, result) = executor.execute_transaction_to_effects(
-            &self,
-            protocol_config,
-            metrics.clone(),
-            expensive_checks,
-            &certificate_deny_set,
-            &tx_info.executed_epoch,
-            tx_info.epoch_start_timestamp,
-            CheckedInputObjects::new_for_replay(input_objects.clone()),
-            gas_data,
-            gas_status,
-            transaction_kind.clone(),
-            tx_info.sender,
-            *tx_digest,
-            &mut None,
-        );
+        let (inner_store, gas_status, effects, result) = if let Some(move_authenticator) =
+            tx_info.sender_signed_data.sender_move_authenticator()
+        {
+            // MoveAuthenticator path: split input objects and run authentication
+            // before PTB execution, matching the production flow.
+            let (_, auth_input_objects, account_object) = tx_info
+                .sender_signed_data
+                .split_input_objects_into_groups_for_reading(input_objects.clone())
+                .map_err(|e| ReplayEngineError::GeneralError { err: e.to_string() })?;
+
+            let auth_input_objects = auth_input_objects
+                .expect("Auth input objects must be present for MoveAuthenticator transactions");
+            let account_object = account_object
+                .expect("Account object must be present for MoveAuthenticator transactions");
+
+            let account_version = match &account_object.object {
+                ObjectReadResultKind::Object(obj) => obj.version(),
+                _ => {
+                    return Err(ReplayEngineError::GeneralError {
+                        err: format!("Account object {} is not available", account_object.id()),
+                    });
+                }
+            };
+
+            let authenticator_function_ref =
+                load_authenticator_function_ref(move_authenticator, account_version, |id| {
+                    self.storage
+                        .live_objects_store
+                        .lock()
+                        .expect("Can't lock")
+                        .get(id)
+                        .cloned()
+                })?;
+
+            executor.authenticate_then_execute_transaction_to_effects(
+                &self,
+                protocol_config,
+                metrics.clone(),
+                expensive_checks,
+                &certificate_deny_set,
+                &tx_info.executed_epoch,
+                tx_info.epoch_start_timestamp,
+                gas_data,
+                gas_status,
+                move_authenticator.clone(),
+                authenticator_function_ref,
+                CheckedInputObjects::new_for_replay(auth_input_objects),
+                CheckedInputObjects::new_for_replay(input_objects.clone()),
+                transaction_kind.clone(),
+                tx_info.sender,
+                *tx_digest,
+                &mut None,
+            )
+        } else {
+            // Standard path: no MoveAuthenticator
+            executor.execute_transaction_to_effects(
+                &self,
+                protocol_config,
+                metrics.clone(),
+                expensive_checks,
+                &certificate_deny_set,
+                &tx_info.executed_epoch,
+                tx_info.epoch_start_timestamp,
+                CheckedInputObjects::new_for_replay(input_objects.clone()),
+                gas_data,
+                gas_status,
+                transaction_kind.clone(),
+                tx_info.sender,
+                *tx_digest,
+                &mut None,
+            )
+        };
 
         if let Err(err) = self.pretty_print_for_tracing(
             &gas_status,
@@ -924,36 +997,115 @@ impl LocalExec {
         // replicated in several places. We should introduce a few traits and
         // make them shared so that we don't have to fix one by one when we have major
         // execution layer changes.
-        let input_objects = store.read_input_objects_for_transaction(&transaction);
         let executable = VerifiedExecutableTransaction::new_from_quorum_execution(
             VerifiedTransaction::new_unchecked(transaction),
             executed_epoch,
         );
-        let (gas_status, input_objects) = iota_transaction_checks::check_certificate_input(
-            &executable,
-            input_objects,
-            &protocol_config,
-            reference_gas_price,
-        )
-        .unwrap();
-        let (kind, signer, gas_data) = executable.transaction_data().execution_parts();
+        let sender_signed_data = &pre_run_sandbox.transaction_info.sender_signed_data;
         let executor = iota_execution::executor(&protocol_config, true, None).unwrap();
-        let (_, _, effects, exec_res) = executor.execute_transaction_to_effects(
-            &store,
-            &protocol_config,
-            Arc::new(LimitsMetrics::new(&Registry::new())),
-            true,
-            &HashSet::new(),
-            &executed_epoch,
-            epoch_start_timestamp,
-            input_objects,
-            gas_data,
-            gas_status,
-            kind,
-            signer,
-            *executable.digest(),
-            &mut None,
-        );
+
+        let (_, _, effects, exec_res) = if let Some(move_authenticator) =
+            sender_signed_data.sender_move_authenticator()
+        {
+            // MoveAuthenticator path: read all objects (tx + auth), split, and
+            // run authentication before PTB execution.
+            let all_input_object_kinds = sender_signed_data
+                .collect_all_input_object_kind_for_reading()
+                .unwrap();
+            let all_input_objects: InputObjects = all_input_object_kinds
+                .into_iter()
+                .map(|kind| {
+                    let id = kind.object_id();
+                    let obj = store
+                        .get_object(&id)
+                        .expect("Object must be in store")
+                        .clone();
+                    ObjectReadResult::new(kind, obj.into())
+                })
+                .collect::<Vec<_>>()
+                .into();
+
+            let (tx_input_objects, auth_input_objects, account_object) = sender_signed_data
+                .split_input_objects_into_groups_for_reading(all_input_objects)
+                .unwrap();
+
+            let auth_input_objects = auth_input_objects
+                .expect("Auth input objects must be present for MoveAuthenticator transactions");
+            let account_object = account_object
+                .expect("Account object must be present for MoveAuthenticator transactions");
+
+            let account_version = match &account_object.object {
+                ObjectReadResultKind::Object(obj) => obj.version(),
+                _ => panic!("Account object is not available"),
+            };
+
+            let authenticator_function_ref =
+                load_authenticator_function_ref(move_authenticator, account_version, |id| {
+                    store.get_object(id).cloned()
+                })
+                .unwrap();
+
+            let authenticator_gas_budget = protocol_config.max_auth_gas();
+            let (gas_status, authenticator_checked_input_objects, union_checked_input_objects) =
+                iota_transaction_checks::check_certificate_and_move_authenticator_input(
+                    &executable,
+                    tx_input_objects,
+                    auth_input_objects,
+                    authenticator_gas_budget,
+                    &protocol_config,
+                    reference_gas_price,
+                )
+                .unwrap();
+
+            let (kind, signer, gas_data) = executable.transaction_data().execution_parts();
+            executor.authenticate_then_execute_transaction_to_effects(
+                &store,
+                &protocol_config,
+                Arc::new(LimitsMetrics::new(&Registry::new())),
+                true,
+                &HashSet::new(),
+                &executed_epoch,
+                epoch_start_timestamp,
+                gas_data,
+                gas_status,
+                move_authenticator.clone(),
+                authenticator_function_ref,
+                authenticator_checked_input_objects,
+                union_checked_input_objects,
+                kind,
+                signer,
+                *executable.digest(),
+                &mut None,
+            )
+        } else {
+            // Standard path: no MoveAuthenticator
+            let input_objects = store
+                .read_input_objects_for_transaction(&Transaction::new(sender_signed_data.clone()));
+            let (gas_status, input_objects) = iota_transaction_checks::check_certificate_input(
+                &executable,
+                input_objects,
+                &protocol_config,
+                reference_gas_price,
+            )
+            .unwrap();
+            let (kind, signer, gas_data) = executable.transaction_data().execution_parts();
+            executor.execute_transaction_to_effects(
+                &store,
+                &protocol_config,
+                Arc::new(LimitsMetrics::new(&Registry::new())),
+                true,
+                &HashSet::new(),
+                &executed_epoch,
+                epoch_start_timestamp,
+                input_objects,
+                gas_data,
+                gas_status,
+                kind,
+                signer,
+                *executable.digest(),
+                &mut None,
+            )
+        };
 
         let effects =
             IotaTransactionBlockEffects::try_from(effects).map_err(ReplayEngineError::from)?;
@@ -1505,7 +1657,9 @@ impl LocalExec {
             .collect_all_input_object_kind_for_reading()
             .map_err(|e| match e {
                 IotaError::UserInput { error } => ReplayEngineError::UserInputError { err: error },
-                other => ReplayEngineError::GeneralError { err: other.to_string() },
+                other => ReplayEngineError::GeneralError {
+                    err: other.to_string(),
+                },
             })?;
         let tx_kind_orig = orig_tx.transaction_data().kind();
 
@@ -1599,9 +1753,13 @@ impl LocalExec {
         // let tx_info = self.fetcher.get_transaction(tx_digest).await?;
 
         let input_objs = orig_tx
-            .transaction_data()
-            .input_objects()
-            .map_err(|e| ReplayEngineError::UserInputError { err: e })?;
+            .collect_all_input_object_kind_for_reading()
+            .map_err(|e| match e {
+                IotaError::UserInput { error } => ReplayEngineError::UserInputError { err: error },
+                other => ReplayEngineError::GeneralError {
+                    err: other.to_string(),
+                },
+            })?;
         let tx_kind_orig = orig_tx.transaction_data().kind();
 
         // Download the objects at the version right before the execution of this TX
@@ -1856,8 +2014,86 @@ impl LocalExec {
         self.multi_download_and_store(&loaded_child_refs).await?;
         tokio::task::yield_now().await;
 
+        // If the transaction uses a MoveAuthenticator, download the authenticator
+        // function ref dynamic field object so it is available during execution.
+        if let Some(move_authenticator) = tx_info.sender_signed_data.sender_move_authenticator() {
+            let (account_object_id, _, _) = move_authenticator
+                .object_to_authenticate_components()
+                .map_err(|e| ReplayEngineError::GeneralError { err: e.to_string() })?;
+
+            let authenticator_function_ref_field_id = dynamic_field::derive_dynamic_field_id(
+                account_object_id,
+                &AuthenticatorFunctionRefV1Key::tag().into(),
+                &AuthenticatorFunctionRefV1Key::default().to_bcs_bytes(),
+            )
+            .map_err(|e| ReplayEngineError::GeneralError { err: e.to_string() })?;
+
+            // Get account object version from the already-downloaded objects
+            let account_object_version = self
+                .storage
+                .live_objects_store
+                .lock()
+                .expect("Can't lock")
+                .get(&account_object_id)
+                .map(|obj| obj.version())
+                .expect("Account object should have been downloaded as part of input objects");
+
+            self.download_object_by_upper_bound(
+                &authenticator_function_ref_field_id,
+                account_object_version,
+            )?;
+        }
+
         Ok(input_objs)
     }
+}
+
+/// Loads the `AuthenticatorFunctionRefForExecution` from a dynamic field on the
+/// account object. This is a simplified version of `check_move_account()` in
+/// `authority.rs` — we skip validation since we trust on-chain state.
+fn load_authenticator_function_ref(
+    move_authenticator: &MoveAuthenticator,
+    account_object_version: SequenceNumber,
+    get_object: impl Fn(&ObjectID) -> Option<Object>,
+) -> Result<AuthenticatorFunctionRefForExecution, ReplayEngineError> {
+    let (account_object_id, _, _) = move_authenticator
+        .object_to_authenticate_components()
+        .map_err(|e| ReplayEngineError::GeneralError { err: e.to_string() })?;
+
+    let field_id = dynamic_field::derive_dynamic_field_id(
+        account_object_id,
+        &AuthenticatorFunctionRefV1Key::tag().into(),
+        &AuthenticatorFunctionRefV1Key::default().to_bcs_bytes(),
+    )
+    .map_err(|e| ReplayEngineError::GeneralError { err: e.to_string() })?;
+
+    let field_obj = get_object(&field_id).ok_or_else(|| ReplayEngineError::GeneralError {
+        err: format!(
+            "Authenticator function ref dynamic field {field_id} not found in storage \
+             for account object {account_object_id} at version {account_object_version}"
+        ),
+    })?;
+
+    let field_move_object = field_obj
+        .data
+        .try_as_move()
+        .expect("dynamic field should never be a package object");
+
+    let field: Field<AuthenticatorFunctionRefV1Key, AuthenticatorFunctionRefV1> = field_move_object
+        .to_rust()
+        .ok_or_else(|| ReplayEngineError::GeneralError {
+            err: format!(
+                "Failed to deserialize AuthenticatorFunctionRefV1 field for account {account_object_id}"
+            ),
+        })?;
+
+    Ok(AuthenticatorFunctionRefForExecution::new_v1(
+        field.value,
+        field_obj.compute_object_reference(),
+        field_obj.owner,
+        field_obj.storage_rebate,
+        field_obj.previous_transaction,
+    ))
 }
 
 // <---------------------  Implement necessary traits for LocalExec to work with

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -1036,7 +1036,11 @@ impl LocalExec {
 
             let account_version = match &account_object.object {
                 ObjectReadResultKind::Object(obj) => obj.version(),
-                _ => panic!("Account object is not available"),
+                _ => {
+                    return Err(ReplayEngineError::GeneralError {
+                        err: format!("Account object {} is not available", account_object.id()),
+                    });
+                }
             };
 
             let authenticator_function_ref =

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -1502,9 +1502,11 @@ impl LocalExec {
         let raw_tx_bytes = tx_info.clone().raw_transaction;
         let orig_tx: SenderSignedData = bcs::from_bytes(&raw_tx_bytes).unwrap();
         let input_objs = orig_tx
-            .transaction_data()
-            .input_objects()
-            .map_err(|e| ReplayEngineError::UserInputError { err: e })?;
+            .collect_all_input_object_kind_for_reading()
+            .map_err(|e| match e {
+                IotaError::UserInput { error } => ReplayEngineError::UserInputError { err: error },
+                other => ReplayEngineError::GeneralError { err: other.to_string() },
+            })?;
         let tx_kind_orig = orig_tx.transaction_data().kind();
 
         // Download the objects at the version right before the execution of this TX

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -32,6 +32,7 @@ use iota_types::{
     dynamic_field::{self, Field},
     error::{ExecutionError, IotaError, IotaResult},
     executable_transaction::VerifiedExecutableTransaction,
+    execution::SharedInput,
     gas::IotaGasStatus,
     in_memory_storage::InMemoryStorage,
     inner_temporary_store::InnerTemporaryStore,
@@ -738,9 +739,9 @@ impl LocalExec {
             .filter_shared_objects()
             .iter()
             .map(|s| match s {
-                iota_types::execution::SharedInput::Existing(obj_ref) => obj_ref.0,
-                iota_types::execution::SharedInput::Deleted((id, _, _, _)) => *id,
-                iota_types::execution::SharedInput::Cancelled((id, _)) => *id,
+                SharedInput::Existing(obj_ref) => obj_ref.0,
+                SharedInput::Deleted((id, _, _, _)) => *id,
+                SharedInput::Cancelled((id, _)) => *id,
             })
             .collect();
         assert_eq!(

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -787,60 +787,10 @@ impl LocalExec {
             price: tx_info.gas_price,
             budget: tx_info.gas_budget,
         };
-        let (inner_store, gas_status, effects, result) = if let Some(move_authenticator) =
-            tx_info.sender_signed_data.sender_move_authenticator()
-        {
-            // MoveAuthenticator path: split input objects and run authentication
-            // before PTB execution, matching the production flow.
-            let (_, auth_input_objects, account_object) = tx_info
-                .sender_signed_data
-                .split_input_objects_into_groups_for_reading(input_objects.clone())
-                .map_err(|e| ReplayEngineError::GeneralError { err: e.to_string() })?;
 
-            let auth_input_objects = auth_input_objects
-                .expect("Auth input objects must be present for MoveAuthenticator transactions");
-            let account_object = account_object
-                .expect("Account object must be present for MoveAuthenticator transactions");
+        let move_authenticators = tx_info.sender_signed_data.move_authenticators();
 
-            let account_version = match &account_object.object {
-                ObjectReadResultKind::Object(obj) => obj.version(),
-                _ => {
-                    return Err(ReplayEngineError::GeneralError {
-                        err: format!("Account object {} is not available", account_object.id()),
-                    });
-                }
-            };
-
-            let authenticator_function_ref =
-                load_authenticator_function_ref(move_authenticator, account_version, |id| {
-                    self.storage
-                        .live_objects_store
-                        .lock()
-                        .expect("Can't lock")
-                        .get(id)
-                        .cloned()
-                })?;
-
-            executor.authenticate_then_execute_transaction_to_effects(
-                &self,
-                protocol_config,
-                metrics.clone(),
-                expensive_checks,
-                &certificate_deny_set,
-                &tx_info.executed_epoch,
-                tx_info.epoch_start_timestamp,
-                gas_data,
-                gas_status,
-                move_authenticator.clone(),
-                authenticator_function_ref,
-                CheckedInputObjects::new_for_replay(auth_input_objects),
-                CheckedInputObjects::new_for_replay(input_objects.clone()),
-                transaction_kind.clone(),
-                tx_info.sender,
-                *tx_digest,
-                &mut None,
-            )
-        } else {
+        let (inner_store, gas_status, effects, result) = if move_authenticators.is_empty() {
             // Standard path: no MoveAuthenticator
             executor.execute_transaction_to_effects(
                 &self,
@@ -853,6 +803,76 @@ impl LocalExec {
                 CheckedInputObjects::new_for_replay(input_objects.clone()),
                 gas_data,
                 gas_status,
+                transaction_kind.clone(),
+                tx_info.sender,
+                *tx_digest,
+                &mut None,
+            )
+        } else {
+            // MoveAuthenticator path: split input objects and run authentication
+            // before PTB execution, matching the production flow.
+            let (_, per_authenticator_inputs) = tx_info
+                .sender_signed_data
+                .split_input_objects_into_groups_for_reading(input_objects.clone())
+                .map_err(|e| ReplayEngineError::GeneralError { err: e.to_string() })?;
+
+            debug_assert_eq!(
+                move_authenticators.len(),
+                per_authenticator_inputs.len(),
+                "Move authenticators amount must match the number of authenticator inputs"
+            );
+
+            let move_authenticators = move_authenticators
+                .into_iter()
+                .zip(per_authenticator_inputs)
+                .map(
+                    |(move_authenticator, (authenticator_inputs, account_object))| {
+                        let account_version = match &account_object.object {
+                            ObjectReadResultKind::Object(obj) => obj.version(),
+                            _ => {
+                                return Err(ReplayEngineError::GeneralError {
+                                    err: format!(
+                                        "Account object {} is not available",
+                                        account_object.id()
+                                    ),
+                                });
+                            }
+                        };
+
+                        let authenticator_function_ref = load_authenticator_function_ref(
+                            move_authenticator,
+                            account_version,
+                            |id| {
+                                self.storage
+                                    .live_objects_store
+                                    .lock()
+                                    .expect("Can't lock")
+                                    .get(id)
+                                    .cloned()
+                            },
+                        )?;
+
+                        Ok((
+                            move_authenticator.to_owned(),
+                            authenticator_function_ref,
+                            CheckedInputObjects::new_for_replay(authenticator_inputs),
+                        ))
+                    },
+                )
+                .collect::<Result<Vec<_>, ReplayEngineError>>()?;
+
+            executor.authenticate_then_execute_transaction_to_effects(
+                &self,
+                protocol_config,
+                metrics.clone(),
+                expensive_checks,
+                &certificate_deny_set,
+                &tx_info.executed_epoch,
+                tx_info.epoch_start_timestamp,
+                gas_data,
+                gas_status,
+                move_authenticators,
+                CheckedInputObjects::new_for_replay(input_objects.clone()),
                 transaction_kind.clone(),
                 tx_info.sender,
                 *tx_digest,
@@ -1004,84 +1024,9 @@ impl LocalExec {
         let sender_signed_data = &pre_run_sandbox.transaction_info.sender_signed_data;
         let executor = iota_execution::executor(&protocol_config, true, None).unwrap();
 
-        let (_, _, effects, exec_res) = if let Some(move_authenticator) =
-            sender_signed_data.sender_move_authenticator()
-        {
-            // MoveAuthenticator path: read all objects (tx + auth), split, and
-            // run authentication before PTB execution.
-            let all_input_object_kinds = sender_signed_data
-                .collect_all_input_object_kind_for_reading()
-                .unwrap();
-            let all_input_objects: InputObjects = all_input_object_kinds
-                .into_iter()
-                .map(|kind| {
-                    let id = kind.object_id();
-                    let obj = store
-                        .get_object(&id)
-                        .expect("Object must be in store")
-                        .clone();
-                    ObjectReadResult::new(kind, obj.into())
-                })
-                .collect::<Vec<_>>()
-                .into();
+        let move_authenticators = sender_signed_data.move_authenticators();
 
-            let (tx_input_objects, auth_input_objects, account_object) = sender_signed_data
-                .split_input_objects_into_groups_for_reading(all_input_objects)
-                .unwrap();
-
-            let auth_input_objects = auth_input_objects
-                .expect("Auth input objects must be present for MoveAuthenticator transactions");
-            let account_object = account_object
-                .expect("Account object must be present for MoveAuthenticator transactions");
-
-            let account_version = match &account_object.object {
-                ObjectReadResultKind::Object(obj) => obj.version(),
-                _ => {
-                    return Err(ReplayEngineError::GeneralError {
-                        err: format!("Account object {} is not available", account_object.id()),
-                    });
-                }
-            };
-
-            let authenticator_function_ref =
-                load_authenticator_function_ref(move_authenticator, account_version, |id| {
-                    store.get_object(id).cloned()
-                })
-                .unwrap();
-
-            let authenticator_gas_budget = protocol_config.max_auth_gas();
-            let (gas_status, authenticator_checked_input_objects, union_checked_input_objects) =
-                iota_transaction_checks::check_certificate_and_move_authenticator_input(
-                    &executable,
-                    tx_input_objects,
-                    auth_input_objects,
-                    authenticator_gas_budget,
-                    &protocol_config,
-                    reference_gas_price,
-                )
-                .unwrap();
-
-            let (kind, signer, gas_data) = executable.transaction_data().execution_parts();
-            executor.authenticate_then_execute_transaction_to_effects(
-                &store,
-                &protocol_config,
-                Arc::new(LimitsMetrics::new(&Registry::new())),
-                true,
-                &HashSet::new(),
-                &executed_epoch,
-                epoch_start_timestamp,
-                gas_data,
-                gas_status,
-                move_authenticator.clone(),
-                authenticator_function_ref,
-                authenticator_checked_input_objects,
-                union_checked_input_objects,
-                kind,
-                signer,
-                *executable.digest(),
-                &mut None,
-            )
-        } else {
+        let (_, _, effects, exec_res) = if move_authenticators.is_empty() {
             // Standard path: no MoveAuthenticator
             let input_objects = store
                 .read_input_objects_for_transaction(&Transaction::new(sender_signed_data.clone()));
@@ -1104,6 +1049,123 @@ impl LocalExec {
                 input_objects,
                 gas_data,
                 gas_status,
+                kind,
+                signer,
+                *executable.digest(),
+                &mut None,
+            )
+        } else {
+            // MoveAuthenticator path: read all objects (tx + auth), split, and
+            // run authentication before PTB execution.
+            let all_input_object_kinds = sender_signed_data
+                .collect_all_input_object_kind_for_reading()
+                .unwrap();
+            let all_input_objects: InputObjects = all_input_object_kinds
+                .into_iter()
+                .map(|kind| {
+                    let id = kind.object_id();
+                    let obj = store
+                        .get_object(&id)
+                        .expect("Object must be in store")
+                        .clone();
+                    ObjectReadResult::new(kind, obj.into())
+                })
+                .collect::<Vec<_>>()
+                .into();
+
+            let (tx_input_objects, per_authenticator_inputs) = sender_signed_data
+                .split_input_objects_into_groups_for_reading(all_input_objects)
+                .unwrap();
+
+            debug_assert_eq!(
+                move_authenticators.len(),
+                per_authenticator_inputs.len(),
+                "Move authenticators amount must match the number of authenticator inputs"
+            );
+
+            let per_authenticator_inputs = move_authenticators
+                .iter()
+                .zip(per_authenticator_inputs)
+                .map(
+                    |(move_authenticator, (authenticator_inputs, account_object))| {
+                        let account_version = match &account_object.object {
+                            ObjectReadResultKind::Object(obj) => obj.version(),
+                            _ => {
+                                return Err(ReplayEngineError::GeneralError {
+                                    err: format!(
+                                        "Account object {} is not available",
+                                        account_object.id()
+                                    ),
+                                });
+                            }
+                        };
+
+                        let authenticator_function_ref = load_authenticator_function_ref(
+                            move_authenticator,
+                            account_version,
+                            |id| store.get_object(id).cloned(),
+                        )
+                        .unwrap();
+
+                        Ok((authenticator_inputs, authenticator_function_ref))
+                    },
+                )
+                .collect::<Result<Vec<_>, ReplayEngineError>>()?;
+
+            let per_authenticator_input_objects = per_authenticator_inputs
+                .iter()
+                .map(|(authenticator_input_objects, _)| authenticator_input_objects.clone())
+                .collect::<Vec<_>>();
+
+            let authenticator_gas_budget = protocol_config.max_auth_gas();
+            let (gas_status, per_authenticator_checked_input_objects, union_checked_input_objects) =
+                iota_transaction_checks::check_certificate_and_move_authenticator_input(
+                    &executable,
+                    tx_input_objects,
+                    per_authenticator_input_objects,
+                    authenticator_gas_budget,
+                    &protocol_config,
+                    reference_gas_price,
+                )
+                .unwrap();
+
+            debug_assert_eq!(
+                move_authenticators.len(),
+                per_authenticator_checked_input_objects.len(),
+                "Move authenticators amount must match the number of checked authenticator inputs"
+            );
+
+            let move_authenticators = move_authenticators
+                .into_iter()
+                .zip(per_authenticator_inputs)
+                .zip(per_authenticator_checked_input_objects)
+                .map(
+                    |(
+                        (move_authenticator, (_, authenticator_function_ref_for_execution)),
+                        authenticator_checked_input_objects,
+                    )| {
+                        (
+                            move_authenticator.to_owned(),
+                            authenticator_function_ref_for_execution,
+                            authenticator_checked_input_objects,
+                        )
+                    },
+                )
+                .collect::<Vec<_>>();
+
+            let (kind, signer, gas_data) = executable.transaction_data().execution_parts();
+            executor.authenticate_then_execute_transaction_to_effects(
+                &store,
+                &protocol_config,
+                Arc::new(LimitsMetrics::new(&Registry::new())),
+                true,
+                &HashSet::new(),
+                &executed_epoch,
+                epoch_start_timestamp,
+                gas_data,
+                gas_status,
+                move_authenticators,
+                union_checked_input_objects,
                 kind,
                 signer,
                 *executable.digest(),
@@ -2018,9 +2080,9 @@ impl LocalExec {
         self.multi_download_and_store(&loaded_child_refs).await?;
         tokio::task::yield_now().await;
 
-        // If the transaction uses a MoveAuthenticator, download the authenticator
-        // function ref dynamic field object so it is available during execution.
-        if let Some(move_authenticator) = tx_info.sender_signed_data.sender_move_authenticator() {
+        // If the transaction uses MoveAuthenticators, download the authenticator
+        // function ref dynamic field objects so they are available during execution.
+        for move_authenticator in tx_info.sender_signed_data.move_authenticators() {
             let (account_object_id, _, _) = move_authenticator
                 .object_to_authenticate_components()
                 .map_err(|e| ReplayEngineError::GeneralError { err: e.to_string() })?;


### PR DESCRIPTION
# Description of change

`iota-tool` provides the transaction replay and profiling utilities, but they currently only can work on PTBs. This PR enables `iota-tool` to create gas profiles for the authentication phase too. 

## How the change has been tested

Local tests. The replay tool currently has only one integration test against the live testnet, that still works after the change.

The `iota-tool` binary must be built with the `tracing` feature enabled to be able to carry out gas profiling.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
