### PR TITLE
fix(ui-kit): Align title padding

### DIFF
--- a/.changeset/pretty-mails-draw.md
+++ b/.changeset/pretty-mails-draw.md
@@ -1,0 +1,5 @@
+---
+'@iota/apps-ui-kit': patch
+---
+
+Updates the title paddings to be better aligned.

--- a/apps/ui-kit/src/lib/components/atoms/panel/Panel.tsx
+++ b/apps/ui-kit/src/lib/components/atoms/panel/Panel.tsx
@@ -21,7 +21,7 @@ export function Panel({
 }: React.PropsWithChildren<PanelProps>): React.JSX.Element {
     const borderClass = hasBorder ? 'border panel-border-color' : 'border border-transparent';
     return (
-        <div className={cx('flex w-full flex-col rounded-xl', bgColor, borderClass)}>
+        <div className={cx('flex w-full flex-col rounded-xl pt-sm--rs', bgColor, borderClass)}>
             {children}
         </div>
     );

--- a/apps/ui-kit/src/lib/components/molecules/title/titleClasses.constants.ts
+++ b/apps/ui-kit/src/lib/components/molecules/title/titleClasses.constants.ts
@@ -4,8 +4,8 @@
 import { TitleSize } from './titleSize.enums';
 
 export const TITLE_PADDINGS: Record<TitleSize, string> = {
-    [TitleSize.Small]: 'px-md pt-md pb-sm--rs',
-    [TitleSize.Medium]: 'px-md--rs pt-md--rs pb-sm--rs',
+    [TitleSize.Small]: 'px-md py-sm--rs',
+    [TitleSize.Medium]: 'px-md--rs py-sm--rs',
 };
 
 export const TITLE_SIZE: Record<TitleSize, string> = {

--- a/apps/ui-kit/src/lib/components/molecules/title/titleClasses.constants.ts
+++ b/apps/ui-kit/src/lib/components/molecules/title/titleClasses.constants.ts
@@ -4,8 +4,8 @@
 import { TitleSize } from './titleSize.enums';
 
 export const TITLE_PADDINGS: Record<TitleSize, string> = {
-    [TitleSize.Small]: 'px-md py-sm--rs',
-    [TitleSize.Medium]: 'px-md--rs py-sm--rs',
+    [TitleSize.Small]: 'px-md pt-md pb-sm--rs',
+    [TitleSize.Medium]: 'px-md--rs pt-md--rs pb-sm--rs',
 };
 
 export const TITLE_SIZE: Record<TitleSize, string> = {


### PR DESCRIPTION
Before:

<img width="1329" height="735" alt="image" src="https://github.com/user-attachments/assets/e96483be-3f73-403b-982e-72b154d265a2" />

After:
<img width="1329" height="735" alt="image" src="https://github.com/user-attachments/assets/d404d0c7-19ca-4560-bafa-3a6e0167a0c8" />
