### PR TITLE
refactor(iota-indexer-streaming, iota-graphql-rpc): use diesel for pg listen notify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4077,12 +4077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
 name = "fastbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6884,6 +6878,7 @@ name = "iota-indexer-streaming"
 version = "1.21.0-alpha"
 dependencies = [
  "backoff",
+ "diesel",
  "futures",
  "iota-indexer",
  "iota-types",
@@ -6892,7 +6887,6 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.64",
  "tokio",
- "tokio-postgres",
  "tokio-stream",
  "tracing",
 ]
@@ -10034,7 +10028,7 @@ name = "move-symbol-pool"
 version = "0.1.0"
 dependencies = [
  "once_cell",
- "phf 0.11.2",
+ "phf",
  "serde",
 ]
 
@@ -11429,17 +11423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
- "phf_shared 0.11.2",
-]
-
-[[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_shared 0.13.1",
- "serde",
+ "phf_shared",
 ]
 
 [[package]]
@@ -11448,7 +11432,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
- "phf_shared 0.11.2",
+ "phf_shared",
  "rand 0.8.5",
 ]
 
@@ -11459,7 +11443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.2",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -11472,15 +11456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -11657,35 +11632,6 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-
-[[package]]
-name = "postgres-protocol"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbef655056b916eb868048276cfd5d6a7dea4f81560dfd047f97c8c6fe3fcfd4"
-dependencies = [
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "hmac",
- "md-5",
- "memchr",
- "rand 0.9.2",
- "sha2 0.10.9",
- "stringprep",
-]
-
-[[package]]
-name = "postgres-types"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4605b7c057056dd35baeb6ac0c0338e4975b1f2bef0f65da953285eb007095"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "postgres-protocol",
-]
 
 [[package]]
 name = "powerfmt"
@@ -14309,17 +14255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15013,32 +14948,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
-]
-
-[[package]]
-name = "tokio-postgres"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40d66d9b2cfe04b628173409368e58247e8eddbbd3b0e6c6ba1d09f20f6c9e"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "futures-channel",
- "futures-util",
- "log",
- "parking_lot 0.12.3",
- "percent-encoding",
- "phf 0.13.1",
- "pin-project-lite",
- "postgres-protocol",
- "postgres-types",
- "rand 0.9.2",
- "socket2 0.6.1",
- "tokio",
- "tokio-util 0.7.18",
- "whoami",
 ]
 
 [[package]]
@@ -15856,12 +15765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15881,12 +15784,6 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -482,8 +482,7 @@ impl ServerBuilder {
             ));
         };
 
-        let graphql_streams =
-            GraphQLStream::new(&config.connection.db_url, reader.clone(), &registry).await?;
+        let graphql_streams = GraphQLStream::new(reader.clone(), &registry).await?;
 
         let fullnode_grpc_client = GrpcClient::connect(fullnode_url)
             .await

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -140,7 +140,6 @@ pub(crate) struct GraphQLStream {
 
 impl GraphQLStream {
     pub(crate) async fn new(
-        db_url: &str,
         indexer_reader: IndexerReader,
         registry: &Registry,
     ) -> Result<Self, Error> {
@@ -148,14 +147,9 @@ impl GraphQLStream {
             channel_buffer_size: BROKER_CHANNEL_SIZE,
             ..Default::default()
         };
-        let streamer = InMemory::new(
-            db_url,
-            config,
-            indexer_reader,
-            InMemoryStreamMetrics::new(registry),
-        )
-        .await
-        .map_err(|e| Error::Internal(format!("failed to connect to postgres: {e}")))?;
+        let streamer = InMemory::new(config, indexer_reader, InMemoryStreamMetrics::new(registry))
+            .await
+            .map_err(|e| Error::Internal(format!("failed to connect to postgres: {e}")))?;
         Ok(Self { streamer })
     }
 

--- a/crates/iota-indexer-streaming/Cargo.toml
+++ b/crates/iota-indexer-streaming/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 [dependencies]
 # external dependencies
 backoff.workspace = true
+diesel = { workspace = true, features = ["r2d2", "postgres"] }
 futures.workspace = true
 prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }
-tokio-postgres = "0.7.15"
 tokio-stream.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-indexer-streaming/src/error.rs
+++ b/crates/iota-indexer-streaming/src/error.rs
@@ -21,8 +21,8 @@ pub enum IndexerStreamingError {
     Lagged(#[from] BroadcastStreamRecvError),
 }
 
-impl From<tokio_postgres::Error> for IndexerStreamingError {
-    fn from(error: tokio_postgres::Error) -> Self {
+impl From<diesel::result::Error> for IndexerStreamingError {
+    fn from(error: diesel::result::Error) -> Self {
         IndexerStreamingError::Postgres(error.to_string())
     }
 }

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -52,7 +52,7 @@ const CHANNEL_NAME: &str = "checkpoint_committed";
 /// of failure.
 const RETRY_POSTGRES_CONNECTION_DELAY: Duration = Duration::from_secs(5);
 /// Interval between polling for new notifications from the Postgres NOTIFY
-/// channel when client processed then all.
+/// channel when client processed them all.
 const PG_NOTIFICATION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Notification received from PostgreSQL NOTIFY channel when a checkpoint is

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -13,13 +13,17 @@ use std::{
     fmt::Debug,
     num::{NonZeroI64, NonZeroUsize},
     pin::Pin,
-    str::FromStr,
     sync::Arc,
     task::{Context, Poll},
     time::{Duration, Instant},
 };
 
-use futures::{Stream, StreamExt, TryFutureExt, stream};
+use diesel::{
+    PgConnection, QueryResult, RunQueryDsl,
+    pg::PgNotification,
+    r2d2::{ConnectionManager, PooledConnection},
+};
+use futures::{Stream, StreamExt, TryFutureExt};
 use iota_indexer::{
     models::{
         events::StoredEvent,
@@ -31,9 +35,6 @@ use iota_types::event::Event;
 use prometheus::IntGauge;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
-use tokio_postgres::{
-    AsyncMessage, Config as PostgresConfig, Connection, NoTls, Socket, tls::NoTlsStream,
-};
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use tracing::{debug, error};
 
@@ -42,12 +43,17 @@ use crate::{
     metrics::{InMemoryStreamMetrics, METRICS_EVENT_LABEL, METRICS_TRANSACTION_LABEL},
 };
 
+pub type PoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
+
 /// Postgres NOTIFY channel name.
 const CHANNEL_NAME: &str = "checkpoint_committed";
 
 /// Delay in seconds before retrying to connect to the Postgres database in case
 /// of failure.
 const RETRY_POSTGRES_CONNECTION_DELAY: Duration = Duration::from_secs(5);
+/// Interval between polling for new notifications from the Postgres NOTIFY
+/// channel when client processed then all.
+const PG_NOTIFICATION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Notification received from PostgreSQL NOTIFY channel when a checkpoint is
 /// committed.
@@ -164,16 +170,11 @@ impl InMemory {
     /// - handles automatically reconnecting to PostgreSQL if the connection is
     ///   lost.
     pub async fn new(
-        db_url: &str,
         config: Config,
         indexer_reader: IndexerReader,
         metrics: impl Into<Arc<InMemoryStreamMetrics>>,
     ) -> IndexerStreamingResult<Self> {
         let metrics = metrics.into();
-
-        let pg_config = PostgresConfig::from_str(db_url).map_err(|e| {
-            IndexerStreamingError::Postgres(format!("failed to parse Postgresdb url: {e}"))
-        })?;
 
         let (event_tx, _) = broadcast::channel(config.channel_buffer_size.get());
         let (transaction_tx, _) = broadcast::channel(config.channel_buffer_size.get());
@@ -188,40 +189,40 @@ impl InMemory {
 
             async move {
                 loop {
-                    let (client, connection) = match pg_config.connect(NoTls).await {
+                    let mut pool = match indexer_reader.get_pool().get() {
                         Ok(value) => value,
                         Err(e) => {
-                            error!("unable to connect to postgres: {e}");
-                            Self::publish_error(e.into(), &event_tx, &transaction_tx);
+                            error!(
+                                "failed to get connection from postgres connection pool with error: {e:?}"
+                            );
+                            Self::publish_error(
+                                IndexerStreamingError::Postgres(e.to_string()),
+                                &event_tx,
+                                &transaction_tx,
+                            );
                             tokio::time::sleep(RETRY_POSTGRES_CONNECTION_DELAY).await;
                             continue;
                         }
                     };
 
-                    // the client's queries require the connection to be actively polled to execute.
-                    // process_checkpoint_notifications is a long-running future that polls the
-                    // connection for notifications and should never resolve (unless a fatal error
-                    // occurs).
-                    let query_fut = async {
-                        client
-                            .query(&format!("LISTEN {CHANNEL_NAME};"), &[])
-                            .await
-                            .map_err(Into::into)
-                    };
+                    if let Err(e) =
+                        diesel::sql_query(format!("LISTEN {CHANNEL_NAME}")).execute(&mut pool)
+                    {
+                        error!("failed listening to postgres notify channel: {e}");
+                        Self::publish_error(e.into(), &event_tx, &transaction_tx);
+                        continue;
+                    }
 
-                    let process_notification_fut = Self::process_checkpoint_notifications(
+                    if let Err(e) = Self::process_checkpoint_notifications(
                         &metrics,
                         &config,
-                        connection,
+                        &mut pool,
                         &indexer_reader,
                         &event_tx,
                         &transaction_tx,
-                    );
-
-                    // by using try_join!, we poll both futures concurrently, which allows the
-                    // client query to execute while the connection is being actively polled
-                    // for incoming notifications.
-                    if let Err(e) = futures::try_join!(query_fut, process_notification_fut) {
+                    )
+                    .await
+                    {
                         error!("processing checkpoint notifications failed: {e}");
                         Self::publish_error(e, &event_tx, &transaction_tx);
                     }
@@ -321,7 +322,7 @@ impl InMemory {
     async fn process_checkpoint_notifications(
         metrics: &InMemoryStreamMetrics,
         config: &Config,
-        mut connection: Connection<Socket, NoTlsStream>,
+        pool: &mut PoolConnection,
         indexer_reader: &IndexerReader,
         event_tx: &broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
         transaction_tx: &broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
@@ -332,11 +333,21 @@ impl InMemory {
         backoff.current_interval = backoff.initial_interval;
         backoff.multiplier = 1.0;
 
-        // create a stream from the connection that forwards messages to the channel.
-        let mut stream = stream::poll_fn(move |cx| connection.poll_message(cx))
-            .ready_chunks(config.notification_chunk_size.get());
+        loop {
+            // Poll the PostgreSQL NOTIFY channel for new checkpoint commit
+            // notifications. The iterator is non-blocking, it drains whatever
+            // is currently buffered and returns None when empty. We re-poll
+            // after a short sleep since new notifications can arrive at any time.
+            let messages = pool
+                .notifications_iter()
+                .take(config.notification_chunk_size.get())
+                .collect::<Vec<QueryResult<PgNotification>>>();
 
-        while let Some(messages) = stream.next().await {
+            if messages.is_empty() {
+                tokio::time::sleep(PG_NOTIFICATION_POLL_INTERVAL).await;
+                continue;
+            }
+
             // auto-records duration on drop (after each iteration).
             let _record_processed_checkpoint_notifications =
                 metrics.process_notification_batch_latency.start_timer();
@@ -389,16 +400,13 @@ impl InMemory {
                 }
             }
         }
-        Err(IndexerStreamingError::Postgres(
-            "postgres notification stream closed, retrying establishing connection...".into(),
-        ))
     }
 
     /// Resolves the transaction sequence number bounds from the given messages
     /// batch.
     fn resolve_tx_bounds(
         metrics: &InMemoryStreamMetrics,
-        messages: &[Result<AsyncMessage, tokio_postgres::Error>],
+        messages: &[QueryResult<PgNotification>],
     ) -> IndexerStreamingResult<Option<(i64, i64)>> {
         let mut filtered_messages = Self::filter_checkpoint_notifications(metrics, messages);
 
@@ -510,32 +518,24 @@ impl InMemory {
     /// [`CheckpointCommitNotification`] from PostgreSQL messages.
     fn filter_checkpoint_notifications<'a>(
         metrics: &'a InMemoryStreamMetrics,
-        messages: &'a [Result<AsyncMessage, tokio_postgres::Error>],
+        messages: &'a [QueryResult<PgNotification>],
     ) -> impl Iterator<Item = IndexerStreamingResult<CheckpointCommitNotification>> + 'a {
-        messages.iter().filter_map(|msg_result| {
-            match msg_result {
-                Ok(AsyncMessage::Notification(n)) => {
-                    match serde_json::from_str::<CheckpointCommitNotification>(n.payload()) {
-                        Ok(notification) => {
-                            metrics
-                                .notified_checkpoint_sequence_number
-                                .set(notification.checkpoint_sequence_number);
+        messages.iter().filter_map(|msg_result| match msg_result {
+            Ok(PgNotification { payload, .. }) => {
+                match serde_json::from_str::<CheckpointCommitNotification>(payload) {
+                    Ok(notification) => {
+                        metrics
+                            .notified_checkpoint_sequence_number
+                            .set(notification.checkpoint_sequence_number);
 
-                            Some(Ok(notification))
-                        }
-                        Err(_) => None,
+                        Some(Ok(notification))
                     }
+                    Err(_) => None,
                 }
-                // not a notification message, skip
-                Ok(AsyncMessage::Notice(msg)) => {
-                    tracing::warn!("received a postgres notice: {msg}");
-                    None
-                }
-                Ok(_) => None,
-                Err(e) => Some(Err(IndexerStreamingError::Postgres(format!(
-                    "database connection error: {e}"
-                )))),
             }
+            Err(e) => Some(Err(IndexerStreamingError::Postgres(format!(
+                "database connection error: {e}"
+            )))),
         })
     }
 

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -189,7 +189,7 @@ impl InMemory {
 
             async move {
                 loop {
-                    let mut pool = match indexer_reader.get_pool().get() {
+                    let mut connection = match indexer_reader.get_pool().get() {
                         Ok(value) => value,
                         Err(e) => {
                             error!(
@@ -206,7 +206,7 @@ impl InMemory {
                     };
 
                     if let Err(e) =
-                        diesel::sql_query(format!("LISTEN {CHANNEL_NAME}")).execute(&mut pool)
+                        diesel::sql_query(format!("LISTEN {CHANNEL_NAME}")).execute(&mut connection)
                     {
                         error!("failed listening to postgres notify channel: {e}");
                         Self::publish_error(e.into(), &event_tx, &transaction_tx);
@@ -216,7 +216,7 @@ impl InMemory {
                     if let Err(e) = Self::process_checkpoint_notifications(
                         &metrics,
                         &config,
-                        &mut pool,
+                        &mut connection,
                         &indexer_reader,
                         &event_tx,
                         &transaction_tx,
@@ -322,7 +322,7 @@ impl InMemory {
     async fn process_checkpoint_notifications(
         metrics: &InMemoryStreamMetrics,
         config: &Config,
-        pool: &mut PoolConnection,
+        connection: &mut PoolConnection,
         indexer_reader: &IndexerReader,
         event_tx: &broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
         transaction_tx: &broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
@@ -338,7 +338,7 @@ impl InMemory {
             // notifications. The iterator is non-blocking, it drains whatever
             // is currently buffered and returns None when empty. We re-poll
             // after a short sleep since new notifications can arrive at any time.
-            let messages = pool
+            let messages = connection
                 .notifications_iter()
                 .take(config.notification_chunk_size.get())
                 .collect::<Vec<QueryResult<PgNotification>>>();


### PR DESCRIPTION
# Description of change

This PR removes the `tokio-postgres` dependency in favor of the already present `diesel`. At the time of implementing the feature, `LISTEN/NOTIFY` support was not yet available in diesel. Starting from version `2.3.2`, diesel added this support, making the separate `tokio-postgres` dependency unnecessary.
 
## Links to any relevant issues

fixes #9950 

## How the change has been tested

- used `iota-localnet` to spin up a private network
```shell
RUST_LOG=iota_graphql_rpc=error,iota_indexer_streaming=info cargo r --features indexer -- start --force-regenesis --with-graphql
```
- connected to graphiQL to execute subscription queries

```graphql
subscription Transactions {
    transactions {
        __typename
        ... on TransactionBlock {
            digest,
           effects {
            checkpoint {
              sequenceNumber,
            }
          }
        }
        ... on Lagged {
            count
        }
    }
}
```

- Compared performance on the staging environment against the previous `tokio-postgres` implementation. Prometheus metrics showed no regression in notification processing, batch querying, or broadcasting latency.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

> [!NOTE]
> These changes do not affect the indexer's main checkpoint ingestion pipeline, so further ingestion tests were not conducted.