### PR TITLE
chore(apps-backend): More conservative apps-backend deploys

### DIFF
--- a/.github/workflows/apps_apps-backend_deploy.yml
+++ b/.github/workflows/apps_apps-backend_deploy.yml
@@ -3,6 +3,8 @@ name: Deploy Apps-Backend
 on:
   push:
     branches: [develop]
+    paths:
+      - "apps/apps-backend/**"
   workflow_dispatch:
     inputs:
       deploy_type:
@@ -13,6 +15,10 @@ on:
           - staging
           - rc
           - production
+
+concurrency:
+  group: apps-backend-deploy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
 
 jobs:
   resolve-deploy-type:

--- a/.github/workflows/apps_apps-backend_deploy.yml
+++ b/.github/workflows/apps_apps-backend_deploy.yml
@@ -5,6 +5,8 @@ on:
     branches: [develop]
     paths:
       - "apps/apps-backend/**"
+      - "pnpm-lock.yaml"
+      - "turbo.json"
   workflow_dispatch:
     inputs:
       deploy_type:

--- a/.github/workflows/apps_apps-backend_deploy.yml
+++ b/.github/workflows/apps_apps-backend_deploy.yml
@@ -19,8 +19,8 @@ on:
           - production
 
 concurrency:
-  group: apps-backend-deploy-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+  group: apps-backend-deploy-${{ github.workflow }}-${{ inputs.deploy_type || 'staging' }}
+  cancel-in-progress: true
 
 jobs:
   resolve-deploy-type:


### PR DESCRIPTION
This way we:
- Dont redeploy for any change
- We dont have deploy conflicts (kinda breaks docker)

Fixes https://github.com/iotaledger/iota/actions/runs/23843077034/job/69503423651