### PR TITLE
fix(dashboard): improve staking tests

### DIFF
--- a/apps/wallet-dashboard/components/dialogs/staking/views/EnterAmountView.tsx
+++ b/apps/wallet-dashboard/components/dialogs/staking/views/EnterAmountView.tsx
@@ -41,7 +41,8 @@ export function EnterAmountView({
     senderAddress,
     onSuccess,
 }: EnterAmountViewProps): JSX.Element {
-    const { mutateAsync: signAndExecuteTransaction } = useSignAndExecuteTransaction();
+    const { mutateAsync: signAndExecuteTransaction, isPending: isTransactionPending } =
+        useSignAndExecuteTransaction();
     const { values, resetForm, setFieldValue } = useFormikContext<FormValues>();
 
     const { data: metadata } = useCoinMetadata(IOTA_TYPE_ARG);
@@ -160,7 +161,7 @@ export function EnterAmountView({
                     />
                 ) : undefined
             }
-            isLoading={isTransactionLoading}
+            isLoading={isTransactionLoading || isTransactionPending}
             onBack={onBack}
             handleClose={handleClose}
             handleStake={handleStake}

--- a/apps/wallet-dashboard/components/dialogs/staking/views/EnterTimelockedAmountView.tsx
+++ b/apps/wallet-dashboard/components/dialogs/staking/views/EnterTimelockedAmountView.tsx
@@ -46,7 +46,8 @@ export function EnterTimelockedAmountView({
     handleClose,
     onSuccess,
 }: EnterTimelockedAmountViewProps): JSX.Element {
-    const { mutateAsync: signAndExecuteTransaction } = useSignAndExecuteTransaction();
+    const { mutateAsync: signAndExecuteTransaction, isPending: isTransactionPending } =
+        useSignAndExecuteTransaction();
     const { values, resetForm } = useFormikContext<FormValues>();
     const [possibleAmount, setPossibleAmount] = useState<bigint | null>(null);
     const [isSearchingProtocolMaxAmount, setSearchingProtocolMaxAmount] = useState(false);
@@ -202,7 +203,7 @@ export function EnterTimelockedAmountView({
                     />
                 ) : undefined
             }
-            isLoading={isTransactionLoading}
+            isLoading={isTransactionLoading || isTransactionPending}
             isStakeDisabled={!hasGroupedTimelockObjects || isSearchingProtocolMaxAmount}
             onBack={onBack}
             handleClose={handleClose}

--- a/apps/wallet-dashboard/tests/utils/staking.ts
+++ b/apps/wallet-dashboard/tests/utils/staking.ts
@@ -26,6 +26,7 @@ export async function setupWalletWithFunds(
 
 export async function navigateToDashboardStakePage(page: Page): Promise<void> {
     await page.getByTestId('sidebar-staking').click();
+    await page.waitForURL('**/staking', { timeout: SHORT_TIMEOUT });
     // Move mouse to avoid keeping tooltip open
     await page.mouse.move(200, 0);
     // Wait for tooltip to disappear


### PR DESCRIPTION
# Description of change

- wait for navigation to Staking page to finish before continuing with test
- adds missing loaders
