### PR TITLE
fix(split-cluster): use `iota-localnet` binary for genesis

### DIFF
--- a/crates/iota/src/completions.rs
+++ b/crates/iota/src/completions.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-// CI trigger
-
 use clap::{Command, CommandFactory, Parser, ValueEnum};
 use clap_complete::{Generator, Shell, generate, generate_to};
 use strum::{EnumIter, IntoEnumIterator};

--- a/crates/iota/src/completions.rs
+++ b/crates/iota/src/completions.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+// CI trigger
+
 use clap::{Command, CommandFactory, Parser, ValueEnum};
 use clap_complete::{Generator, Shell, generate, generate_to};
 use strum::{EnumIter, IntoEnumIterator};

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -48,9 +48,9 @@ else
   CURRENT_COMMIT=$(git rev-parse HEAD)
 
   git checkout $RELEASE_COMMIT || exit 1
-  cargo build --bin iota-node --bin iota || exit 1
+  cargo build --bin iota-node --bin iota-localnet || exit 1
   cp ./target/debug/iota-node "$WORKING_DIR/iota-node-release"
-  cp ./target/debug/iota "$WORKING_DIR/iota-release"
+  cp ./target/debug/iota-localnet "$WORKING_DIR/iota-release"
 
   echo "Building iota-node at $RELEASE_CANDIDATE_COMMIT"
   git checkout $RELEASE_CANDIDATE_COMMIT || exit 1

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -38,27 +38,28 @@ echo "Using working dir $WORKING_DIR"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+# TODO this can be removed when v1.20 reaches mainnet
+git checkout $RELEASE_COMMIT || exit 1
+if cargo metadata --no-deps --format-version 1 \
+     | jq -e '[.packages[].targets[] | select(.kind[] == "bin") | .name] | contains(["iota-localnet"])' > /dev/null 2>&1; then
+  IOTA_BINARY="iota-localnet"
+  echo "iota-localnet target found"
+else
+  IOTA_BINARY="iota"
+  echo "iota-localnet target NOT found"
+fi
+git checkout $CURRENT_COMMIT || exit 1
+
 # check if binaries have already been built
-if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/iota-release" ] && [ -f "$WORKING_DIR/iota-localnet-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
+if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/$IOTA_BINARY-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
   echo "Binaries already built, skipping build"
 else
-  echo "Building iota-node and iota/iota-localnet at $RELEASE_COMMIT"
+  echo "Building iota-node and $IOTA_BINARY at $RELEASE_COMMIT"
 
   # remember current commit
   CURRENT_COMMIT=$(git rev-parse HEAD)
 
   git checkout $RELEASE_COMMIT || exit 1
-
-  # TODO this can be removed when v1.20 reaches mainnet
-  if cargo metadata --no-deps --format-version 1 \
-       | jq -e '[.packages[].targets[] | select(.kind[] == "bin") | .name] | contains(["iota-localnet"])' > /dev/null 2>&1; then
-    IOTA_BINARY="iota-localnet"
-    echo "iota-localnet target found"
-  else
-    IOTA_BINARY="iota"
-  echo "iota-localnet target NOT found"
-  fi
-
   cargo build --bin iota-node --bin $IOTA_BINARY || exit 1
   cp ./target/debug/iota-node "$WORKING_DIR/iota-node-release"
   cp ./target/debug/$IOTA_BINARY "$WORKING_DIR/$IOTA_BINARY-release"

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -38,26 +38,27 @@ echo "Using working dir $WORKING_DIR"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
-# TODO this can be removed when v1.20 reaches mainnet
-if cargo metadata --no-deps --format-version 1 \
-     | jq -e '[.packages[].targets[] | select(.kind[] == "bin") | .name] | contains(["iota-localnet"])' > /dev/null 2>&1; then
-  IOTA_BINARY="iota-localnet"
-  echo "iota-localnet target found"
-else
-  IOTA_BINARY="iota"
-  echo "iota-localnet target NOT found"
-fi
-
 # check if binaries have already been built
-if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/$IOTA_BINARY-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
+if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/iota-release" ] && [ -f "$WORKING_DIR/iota-localnet-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
   echo "Binaries already built, skipping build"
 else
-  echo "Building iota-node and $IOTA_BINARY at $RELEASE_COMMIT"
+  echo "Building iota-node and iota/iota-localnet at $RELEASE_COMMIT"
 
   # remember current commit
   CURRENT_COMMIT=$(git rev-parse HEAD)
 
   git checkout $RELEASE_COMMIT || exit 1
+
+  # TODO this can be removed when v1.20 reaches mainnet
+  if cargo metadata --no-deps --format-version 1 \
+       | jq -e '[.packages[].targets[] | select(.kind[] == "bin") | .name] | contains(["iota-localnet"])' > /dev/null 2>&1; then
+    IOTA_BINARY="iota-localnet"
+    echo "iota-localnet target found"
+  else
+    IOTA_BINARY="iota"
+  echo "iota-localnet target NOT found"
+  fi
+
   cargo build --bin iota-node --bin $IOTA_BINARY || exit 1
   cp ./target/debug/iota-node "$WORKING_DIR/iota-node-release"
   cp ./target/debug/$IOTA_BINARY "$WORKING_DIR/$IOTA_BINARY-release"

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -38,19 +38,29 @@ echo "Using working dir $WORKING_DIR"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+# TODO this can be removed when v1.20 reaches mainnet
+if cargo metadata --no-deps --format-version 1 \
+     | jq -e '[.packages[].targets[] | select(.kind[] == "bin") | .name] | contains(["iota-localnet"])' > /dev/null 2>&1; then
+  IOTA_BINARY="iota-localnet"
+  echo "iota-localnet target found"
+else
+  IOTA_BINARY="iota"
+  echo "iota-localnet target NOT found"
+fi
+
 # check if binaries have already been built
-if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/iota-localnet-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
+if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/$IOTA_BINARY-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
   echo "Binaries already built, skipping build"
 else
-  echo "Building iota-node and iota-localnet at $RELEASE_COMMIT"
+  echo "Building iota-node and $IOTA_BINARY at $RELEASE_COMMIT"
 
   # remember current commit
   CURRENT_COMMIT=$(git rev-parse HEAD)
 
   git checkout $RELEASE_COMMIT || exit 1
-  cargo build --bin iota-node --bin iota-localnet || exit 1
+  cargo build --bin iota-node --bin $IOTA_BINARY || exit 1
   cp ./target/debug/iota-node "$WORKING_DIR/iota-node-release"
-  cp ./target/debug/iota-localnet "$WORKING_DIR/iota-localnet-release"
+  cp ./target/debug/$IOTA_BINARY "$WORKING_DIR/$IOTA_BINARY-release"
 
   echo "Building iota-node at $RELEASE_CANDIDATE_COMMIT"
   git checkout $RELEASE_CANDIDATE_COMMIT || exit 1
@@ -64,7 +74,7 @@ fi
 export IOTA_CONFIG_DIR="$WORKING_DIR/config"
 rm -rf "$IOTA_CONFIG_DIR"
 
-"$WORKING_DIR/iota-localnet-release" genesis --epoch-duration-ms 20000 --committee-size 4
+"$WORKING_DIR/$IOTA_BINARY-release" genesis --epoch-duration-ms 20000 --committee-size 4
 
 LOG_DIR="$WORKING_DIR/logs"
 

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -39,7 +39,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
 # check if binaries have already been built
-if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/iota-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
+if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/iota-localnet-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
   echo "Binaries already built, skipping build"
 else
   echo "Building iota-node and iota at $RELEASE_COMMIT"
@@ -50,7 +50,7 @@ else
   git checkout $RELEASE_COMMIT || exit 1
   cargo build --bin iota-node --bin iota-localnet || exit 1
   cp ./target/debug/iota-node "$WORKING_DIR/iota-node-release"
-  cp ./target/debug/iota-localnet "$WORKING_DIR/iota-release"
+  cp ./target/debug/iota-localnet "$WORKING_DIR/iota-localnet-release"
 
   echo "Building iota-node at $RELEASE_CANDIDATE_COMMIT"
   git checkout $RELEASE_CANDIDATE_COMMIT || exit 1
@@ -64,7 +64,7 @@ fi
 export IOTA_CONFIG_DIR="$WORKING_DIR/config"
 rm -rf "$IOTA_CONFIG_DIR"
 
-"$WORKING_DIR/iota-release" genesis --epoch-duration-ms 20000 --committee-size 4
+"$WORKING_DIR/iota-localnet-release" genesis --epoch-duration-ms 20000 --committee-size 4
 
 LOG_DIR="$WORKING_DIR/logs"
 

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -42,7 +42,7 @@ cd "$REPO_ROOT"
 if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/iota-localnet-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
   echo "Binaries already built, skipping build"
 else
-  echo "Building iota-node and iota at $RELEASE_COMMIT"
+  echo "Building iota-node and iota-localnet at $RELEASE_COMMIT"
 
   # remember current commit
   CURRENT_COMMIT=$(git rev-parse HEAD)


### PR DESCRIPTION
# Description of change

Use `iota-localnet` instead of `iota` for the `genesis` command since it was moved.
