### PR TITLE
chore: Replace REST API with gRPC in PR templates and release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default_external_contributors.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_external_contributors.md
@@ -39,4 +39,4 @@ For each box you select, include information after the relevant heading that des
 - [ ] GraphQL:
 - [ ] CLI:
 - [ ] Rust SDK:
-- [ ] REST API:
+- [ ] gRPC:

--- a/.github/PULL_REQUEST_TEMPLATE/default_internal_contributors.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_internal_contributors.md
@@ -22,4 +22,4 @@ Be sure to reference any related issues by adding `fixes #(issue)`.
 - [ ] GraphQL:
 - [ ] CLI:
 - [ ] Rust SDK:
-- [ ] REST API:
+- [ ] gRPC:

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -32,4 +32,4 @@ Make sure to provide instructions for the maintainer as well as any relevant con
 - [ ] GraphQL:
 - [ ] CLI:
 - [ ] Rust SDK:
-- [ ] REST API:
+- [ ] gRPC:

--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -62,6 +62,7 @@ NOTE_ORDER = [
     "GraphQL",
     "CLI",
     "Rust SDK",
+    "gRPC",
     "REST API",
     "Internal gRPC API",
 ]


### PR DESCRIPTION
# Description of change

Update all PR templates to use the gRPC impact area instead of REST API.
Add gRPC to the release notes script while keeping REST API recognized for backward compatibility with existing PRs.