### PR TITLE
fix(iota-core): add protocol-version-aware validation for MisbehaviorReport

### DIFF
--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -82,10 +82,22 @@ impl IotaTxValidator {
                     authority_cap_batch.push(signed_cap);
                 }
 
+                ConsensusTransactionKind::MisbehaviorReport(_, _, _) => {
+                    if !self
+                        .epoch_store
+                        .protocol_config()
+                        .calculate_validator_scores()
+                    {
+                        return Err(IotaError::UnsupportedFeature {
+                            error: "MisbehaviorReport not supported at current protocol version"
+                                .into(),
+                        });
+                    }
+                }
+
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::NewJWKFetched(_, _, _)
-                | ConsensusTransactionKind::CapabilityNotificationV1(_)
-                | ConsensusTransactionKind::MisbehaviorReport(_, _, _) => {}
+                | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
             }
         }
 
@@ -212,8 +224,15 @@ mod tests {
 
     use consensus_core::TransactionVerifier as _;
     use iota_macros::sim_test;
+    use iota_protocol_config::Chain;
     use iota_types::{
-        crypto::Ed25519IotaSignature, messages_consensus::ConsensusTransaction, object::Object,
+        crypto::Ed25519IotaSignature,
+        error::IotaError,
+        messages_consensus::{
+            ConsensusTransaction, ConsensusTransactionKind, MisbehaviorsV1,
+            VersionedMisbehaviorReport,
+        },
+        object::Object,
         signature::GenericSignature,
     };
 
@@ -291,5 +310,147 @@ mod tests {
             .collect();
         let res_batch = validator.verify_batch(&batch);
         assert!(res_batch.is_err());
+    }
+
+    /// Verifies that `validate_transactions` correctly gates every
+    /// `ConsensusTransactionKind` variant against the current protocol config's
+    /// feature flags.
+    ///
+    /// The exhaustive match forces a compile error when new variants are added,
+    /// so the developer must explicitly map each variant to its gating flag.
+    #[sim_test]
+    async fn validate_transactions_feature_gating() {
+        use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
+        use iota_protocol_config::ProtocolConfig;
+        use iota_types::crypto::AuthorityPublicKeyBytes;
+
+        let network_config =
+            iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir().build();
+
+        let state = TestAuthorityBuilder::new()
+            .with_network_config(&network_config, 0)
+            .with_chain_override(Chain::Mainnet)
+            .build()
+            .await;
+
+        let metrics = IotaTxValidatorMetrics::new(&Default::default());
+        let validator = IotaTxValidator::new(
+            state.epoch_store_for_testing().clone(),
+            Arc::new(CheckpointServiceNoop {}),
+            state.transaction_manager().clone(),
+            metrics,
+        );
+
+        let protocol_config = validator.epoch_store.protocol_config();
+        let authority = AuthorityPublicKeyBytes::default();
+
+        // Returns the feature flag value that gates a variant, or `None` if the
+        // variant is always allowed. The exhaustive match ensures this function
+        // must be updated when new variants are added to ConsensusTransactionKind.
+        fn is_feature_gated(
+            kind: &ConsensusTransactionKind,
+            config: &ProtocolConfig,
+        ) -> Option<bool> {
+            match kind {
+                // Always allowed (no feature flag gating).
+                ConsensusTransactionKind::CertifiedTransaction(_)
+                | ConsensusTransactionKind::CheckpointSignature(_)
+                | ConsensusTransactionKind::EndOfPublish(_)
+                | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+                | ConsensusTransactionKind::NewJWKFetched(_, _, _)
+                | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
+                | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _) => None,
+
+                // Gated behind `calculate_validator_scores`.
+                ConsensusTransactionKind::MisbehaviorReport(_, _, _) => {
+                    Some(config.calculate_validator_scores())
+                }
+            }
+        }
+
+        // Variants that can be validated without signature verification setup.
+        // CertifiedTransaction, CheckpointSignature, and
+        // SignedCapabilityNotificationV1 are excluded because they require valid
+        // cryptographic signatures and would fail before reaching the feature
+        // gate check; their gating is verified by the exhaustive match above.
+        let testable_variants: Vec<(&str, ConsensusTransactionKind)> = vec![
+            (
+                "EndOfPublish",
+                ConsensusTransactionKind::EndOfPublish(authority),
+            ),
+            (
+                "NewJWKFetched",
+                ConsensusTransactionKind::NewJWKFetched(
+                    authority,
+                    JwkId {
+                        iss: "test".into(),
+                        kid: "test".into(),
+                    },
+                    JWK {
+                        kty: "RSA".into(),
+                        e: "AQAB".into(),
+                        n: "test".into(),
+                        alg: "RS256".into(),
+                    },
+                ),
+            ),
+            (
+                "CapabilityNotificationV1",
+                ConsensusTransactionKind::CapabilityNotificationV1(
+                    iota_types::messages_consensus::AuthorityCapabilitiesV1::new(
+                        authority,
+                        Chain::Mainnet,
+                        iota_types::supported_protocol_versions::SupportedProtocolVersions::SYSTEM_DEFAULT,
+                        vec![],
+                    ),
+                ),
+            ),
+            (
+                "RandomnessDkgMessage",
+                ConsensusTransactionKind::RandomnessDkgMessage(authority, vec![]),
+            ),
+            (
+                "RandomnessDkgConfirmation",
+                ConsensusTransactionKind::RandomnessDkgConfirmation(authority, vec![]),
+            ),
+            (
+                "MisbehaviorReport",
+                ConsensusTransactionKind::MisbehaviorReport(
+                    authority,
+                    VersionedMisbehaviorReport::new_v1(MisbehaviorsV1 {
+                        faulty_blocks_provable: vec![],
+                        faulty_blocks_unprovable: vec![],
+                        missing_proposals: vec![],
+                        equivocations: vec![],
+                    }),
+                    0,
+                ),
+            ),
+        ];
+
+        for (name, kind) in testable_variants {
+            let gated = is_feature_gated(&kind, protocol_config);
+            let result = validator.validate_transactions(vec![kind]);
+
+            match gated {
+                Some(false) => {
+                    // Feature flag is disabled: must be rejected.
+                    assert!(
+                        matches!(&result, Err(IotaError::UnsupportedFeature { .. })),
+                        "{name}: feature flag is disabled, expected UnsupportedFeature, \
+                         got {result:?}",
+                    );
+                }
+                Some(true) | None => {
+                    // Feature flag is enabled or variant is ungated: must not
+                    // be rejected as unsupported.
+                    assert!(
+                        !matches!(&result, Err(IotaError::UnsupportedFeature { .. })),
+                        "{name}: should not be rejected as UnsupportedFeature, got {result:?}",
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description of change

Add a feature-flag check in `validate_transactions()` that rejects `MisbehaviorReport` consensus transactions when `calculate_validator_scores` is disabled. This prevents a consensus fork during protocol upgrades where upgraded validators would accept blocks containing `MisbehaviorReport` while non-upgraded validators would reject them due to BCS deserialization failure on the unknown enum variant.

Also adds a test that exhaustively verifies feature-flag gating for all `ConsensusTransactionKind` variants against the mainnet protocol config. The exhaustive match forces a compile error when new variants are added, ensuring developers explicitly handle gating for each new variant.

## Links to any relevant issues

fixes #11060

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes