### PR TITLE
fix(iota-indexer): resolve all objects needed for calculating balance changes in dry run

### DIFF
--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -588,20 +588,21 @@ impl ObjectProvider for TxObjectResolver {
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<Object, Self::Error> {
-        // try in-memory cache first 
+        // try in-memory cache first
         if let Some(o) = self.object_cache.get(id, Some(version)) {
             return Ok(o.clone());
         }
 
-        // fallback: query the indexer's objects table.
-        // for dry_run, the pre-mutation version should match the latest
-        // version in the objects table since the simulation didn't commit.
-        self.reader
-            .get_object_in_blocking_task(*id)
-            .await?
-            .ok_or_else(|| {
-                IndexerError::Generic(format!("object {id} not found in cache or indexer DB"))
-            })
+        let past_read = self
+            .reader
+            .get_past_object_read(*id, *version, false)
+            .await?;
+
+        past_read.into_object().map_err(|e| {
+            IndexerError::Generic(format!(
+                "object {id} at version {version} not found in cache or indexer DB: {e}"
+            ))
+        })
     }
 
     async fn find_object_lt_or_eq_version(
@@ -621,7 +622,9 @@ impl ObjectProvider for TxObjectResolver {
             }
         }
 
-        // fallback to indexer DB
-        self.reader.get_object_in_blocking_task(*id).await
+        self.reader
+            .get_past_object_read_with_fallback(*id, *version, false)
+            .await
+            .map(|past_read| past_read.into_object().ok())
     }
 }

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -10,7 +10,9 @@ use futures::{FutureExt, TryFutureExt};
 use iota_grpc_client::Client as GrpcClient;
 use iota_grpc_types::field::{FieldMask, FieldMaskUtil};
 use iota_json::IotaJsonValue;
-use iota_json_rpc::IotaRpcModule;
+use iota_json_rpc::{
+    IotaRpcModule, ObjectProvider, get_balance_changes_from_effect, get_object_changes,
+};
 use iota_json_rpc_api::WriteApiServer;
 use iota_json_rpc_types::{
     DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, IotaMoveViewCallResults,
@@ -22,15 +24,17 @@ use iota_package_resolver::{PackageStore, Resolver};
 use iota_protocol_config::Chain;
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
-    base_types::IotaAddress,
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
+    digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::ExecutionError,
     iota_serde::BigInt,
+    object::Object,
     quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,
     transaction::{
-        GasData, SenderSignedData, TransactionData, TransactionDataV1, TransactionExpiration,
-        TransactionKind,
+        GasData, SenderSignedData, TransactionData, TransactionDataAPI, TransactionDataV1,
+        TransactionExpiration, TransactionKind,
     },
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
@@ -38,13 +42,12 @@ use jsonrpsee::{RpcModule, core::RpcResult};
 use crate::{
     apis::error::Error as ApiError,
     errors::{IndexerError, IndexerResult},
-    ingestion::primary::prepare::InMemTxChanges,
-    metrics::IndexerMetrics,
+    ingestion::primary::prepare::InMemObjectCache,
     models::transactions::tx_events_to_iota_tx_events,
     optimistic_indexing::OptimisticTransactionExecutor,
     read::IndexerReader,
     store::package_resolver::IndexerStorePackageResolver,
-    types::{IotaTransactionBlockResponseWithOptions, grpc_conversion},
+    types::{IndexedObjectChange, IotaTransactionBlockResponseWithOptions, grpc_conversion},
 };
 
 // As an optimization, we're trying to request only the fields we actually need.
@@ -79,6 +82,7 @@ pub struct WriteApi {
     fullnode_grpc_client: GrpcClient,
     transaction_builder: TransactionBuilder,
     package_resolver: Arc<Resolver<IndexerStorePackageResolver>>,
+    reader: Arc<IndexerReader>,
 }
 
 #[derive(Clone)]
@@ -92,6 +96,7 @@ impl WriteApi {
         let package_resolver = IndexerStorePackageResolver::new(reader.get_pool());
         let data_reader = Arc::new(reader);
         Self {
+            reader: data_reader.clone(),
             fullnode_grpc_client,
             transaction_builder: TransactionBuilder::new(data_reader),
             package_resolver: Arc::new(Resolver::new(package_resolver)),
@@ -148,8 +153,7 @@ impl WriteApi {
 
         let tx_events = TransactionEvents::try_from(executed_transaction.events()?.events()?)?;
 
-        let in_mem_tx_changes =
-            InMemTxChanges::new(&objects, IndexerMetrics::new(&Default::default()));
+        let in_mem_tx_changes = TxObjectResolver::new(&objects, self.reader.clone());
 
         // as a minor optimization we will run concurrently the following four futures
         let fut1 = in_mem_tx_changes
@@ -517,5 +521,107 @@ impl IotaRpcModule for OptimisticWriteApi {
 
     fn rpc_doc_module() -> Module {
         iota_json_rpc_api::WriteApiOpenRpc::module_doc()
+    }
+}
+
+/// Resolves balance and object changes in dry_run.
+///
+/// Checks the in-memory cache (from the simulate
+/// response) first, then falls back to the indexer's `objects` table for
+/// dynamically loaded objects not included in the response.
+pub struct TxObjectResolver {
+    object_cache: InMemObjectCache,
+    reader: Arc<IndexerReader>,
+}
+
+impl TxObjectResolver {
+    pub fn new(objects: &[&Object], reader: Arc<IndexerReader>) -> Self {
+        let mut object_cache = InMemObjectCache::new();
+        for obj in objects {
+            object_cache.insert_object(<&Object>::clone(obj).clone());
+        }
+        Self {
+            object_cache,
+            reader,
+        }
+    }
+
+    pub(crate) async fn get_changes(
+        &self,
+        tx: &TransactionData,
+        effects: &TransactionEffects,
+        tx_digest: &TransactionDigest,
+    ) -> IndexerResult<(
+        Vec<iota_json_rpc_types::BalanceChange>,
+        Vec<IndexedObjectChange>,
+    )> {
+        let object_change: Vec<_> = get_object_changes(
+            self,
+            tx.sender(),
+            effects.modified_at_versions(),
+            effects.all_changed_objects(),
+            effects.all_removed_objects(),
+        )
+        .await?
+        .into_iter()
+        .map(IndexedObjectChange::from)
+        .collect();
+        let balance_change = get_balance_changes_from_effect(
+            self,
+            effects,
+            tx.input_objects().unwrap_or_else(|e| {
+                panic!("checkpointed tx {tx_digest:?} has invalid input objects: {e}")
+            }),
+            None,
+        )
+        .await?;
+        Ok((balance_change, object_change))
+    }
+}
+
+#[async_trait]
+impl ObjectProvider for TxObjectResolver {
+    type Error = IndexerError;
+
+    async fn get_object(
+        &self,
+        id: &ObjectID,
+        version: &SequenceNumber,
+    ) -> Result<Object, Self::Error> {
+        // try in-memory cache first (simulate response objects)
+        if let Some(o) = self.object_cache.get(id, Some(version)) {
+            return Ok(o.clone());
+        }
+
+        // fallback: query the indexer's objects table.
+        // for dry_run, the pre-mutation version should match the latest
+        // version in the objects table since the simulation didn't commit.
+        self.reader
+            .get_object_in_blocking_task(*id)
+            .await?
+            .ok_or_else(|| {
+                IndexerError::Generic(format!("object {id} not found in cache or indexer DB"))
+            })
+    }
+
+    async fn find_object_lt_or_eq_version(
+        &self,
+        id: &ObjectID,
+        version: &SequenceNumber,
+    ) -> Result<Option<Object>, Self::Error> {
+        // try exact version in cache
+        if let Some(o) = self.object_cache.get(id, Some(version)) {
+            return Ok(Some(o.clone()));
+        }
+
+        // try latest in cache
+        if let Some(o) = self.object_cache.get(id, None) {
+            if o.version() <= *version {
+                return Ok(Some(o.clone()));
+            }
+        }
+
+        // fallback to indexer DB
+        self.reader.get_object_in_blocking_task(*id).await
     }
 }

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -575,7 +575,7 @@ impl TxObjectResolver {
             None,
         )
         .await?;
-        Ok((balance_change, object_change))
+        Ok((balance_changes, object_changes))
     }
 }
 

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use fastcrypto::encoding::Base64;
@@ -29,7 +29,7 @@ use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::ExecutionError,
     iota_serde::BigInt,
-    object::Object,
+    object::{Object, PastObjectRead},
     quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,
     transaction::{
@@ -546,6 +546,27 @@ impl TxObjectResolver {
         }
     }
 
+    async fn get_past_object_read_with_retry(
+        &self,
+        id: ObjectID,
+        version: SequenceNumber,
+    ) -> IndexerResult<PastObjectRead> {
+        let backoff = backoff::ExponentialBackoff {
+            initial_interval: Duration::from_millis(100),
+            max_elapsed_time: Some(Duration::from_secs(3)),
+            multiplier: 2.0,
+            ..Default::default()
+        };
+
+        backoff::future::retry(backoff, || async {
+            self.reader
+                .get_past_object_read_with_fallback(id, version, false)
+                .await
+                .map_err(backoff::Error::transient)
+        })
+        .await
+    }
+
     pub(crate) async fn get_changes(
         &self,
         tx: &TransactionData,
@@ -593,10 +614,7 @@ impl ObjectProvider for TxObjectResolver {
             return Ok(o.clone());
         }
 
-        let past_read = self
-            .reader
-            .get_past_object_read(*id, *version, false)
-            .await?;
+        let past_read = self.get_past_object_read_with_retry(*id, *version).await?;
 
         past_read.into_object().map_err(|e| {
             IndexerError::Generic(format!(
@@ -622,8 +640,7 @@ impl ObjectProvider for TxObjectResolver {
             }
         }
 
-        self.reader
-            .get_past_object_read_with_fallback(*id, *version, false)
+        self.get_past_object_read_with_retry(*id, *version)
             .await
             .map(|past_read| past_read.into_object().ok())
     }

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -588,7 +588,7 @@ impl ObjectProvider for TxObjectResolver {
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<Object, Self::Error> {
-        // try in-memory cache first (simulate response objects)
+        // try in-memory cache first 
         if let Some(o) = self.object_cache.get(id, Some(version)) {
             return Ok(o.clone());
         }

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -566,7 +566,7 @@ impl TxObjectResolver {
         .into_iter()
         .map(IndexedObjectChange::from)
         .collect();
-        let balance_change = get_balance_changes_from_effect(
+        let balance_changes = get_balance_changes_from_effect(
             self,
             effects,
             tx.input_objects().unwrap_or_else(|e| {

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -555,7 +555,7 @@ impl TxObjectResolver {
         Vec<iota_json_rpc_types::BalanceChange>,
         Vec<IndexedObjectChange>,
     )> {
-        let object_change: Vec<_> = get_object_changes(
+        let object_changes: Vec<_> = get_object_changes(
             self,
             tx.sender(),
             effects.modified_at_versions(),

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -22,7 +22,8 @@ use iota_indexer::{
 };
 use iota_json::{call_arg, call_args, type_args};
 use iota_json_rpc_api::{
-    CoinReadApiClient, IndexerApiClient, ReadApiClient, TransactionBuilderClient, WriteApiClient,
+    CoinReadApiClient, GovernanceReadApiClient, IndexerApiClient, ReadApiClient,
+    TransactionBuilderClient, WriteApiClient,
 };
 use iota_json_rpc_types::{
     IotaData, IotaExecutionStatus, IotaMoveStruct, IotaMoveValue, IotaObjectDataOptions,
@@ -87,6 +88,36 @@ fn assert_transaction_success(res: &IotaTransactionBlockResponse) {
         res.effects.as_ref().map(|e| e.status()),
         res.errors
     );
+}
+
+async fn get_counter_value(counter_obj_id: ObjectID, client: &HttpClient) -> u64 {
+    let counter_content = client
+        .get_object(
+            counter_obj_id,
+            Some(IotaObjectDataOptions::new().with_content()),
+        )
+        .await
+        .unwrap()
+        .data
+        .unwrap()
+        .content
+        .unwrap();
+
+    let value_field = &counter_content
+        .try_as_move()
+        .unwrap()
+        .fields
+        .read_dynamic_field_value("value")
+        .unwrap();
+
+    if let IotaMoveValue::String(counter_value_str) = &value_field {
+        counter_value_str.parse().unwrap()
+    } else {
+        panic!(
+            "Counter value field is not a string (expected u64 serialized as string), got: {:?}",
+            value_field
+        );
+    }
 }
 
 #[test]
@@ -1553,32 +1584,62 @@ fn clever_errors() {
     });
 }
 
-async fn get_counter_value(counter_obj_id: ObjectID, client: &HttpClient) -> u64 {
-    let counter_content = client
-        .get_object(
-            counter_obj_id,
-            Some(IotaObjectDataOptions::new().with_content()),
-        )
-        .await
-        .unwrap()
-        .data
-        .unwrap()
-        .content
-        .unwrap();
+#[test]
+fn dry_run_request_add_stake() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
 
-    let value_field = &counter_content
-        .try_as_move()
-        .unwrap()
-        .fields
-        .read_dynamic_field_value("value")
-        .unwrap();
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+        let (sender, _key_pair): (_, AccountKeyPair) = get_key_pair();
 
-    if let IotaMoveValue::String(counter_value_str) = &value_field {
-        counter_value_str.parse().unwrap()
-    } else {
-        panic!(
-            "Counter value field is not a string (expected u64 serialized as string), got: {:?}",
-            value_field
-        );
-    }
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(NANOS_PER_IOTA * 10),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+
+        let coin_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(NANOS_PER_IOTA * 2),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, coin_ref.0, coin_ref.1).await;
+
+        let validator = client
+            .get_latest_iota_system_state_v2()
+            .await
+            .unwrap()
+            .active_validators()[0]
+            .iota_address;
+
+        let tx_bytes: TransactionBlockBytes = client
+            .request_add_stake(
+                sender,
+                vec![coin_ref.0],
+                Some((NANOS_PER_IOTA * 2).into()),
+                validator,
+                Some(gas_ref.0),
+                100_000_000.into(),
+            )
+            .await
+            .unwrap();
+
+        let dry_run_resp = client
+            .dry_run_transaction_block(tx_bytes.tx_bytes)
+            .await
+            .unwrap();
+
+        assert_eq!(dry_run_resp.effects.status(), &IotaExecutionStatus::Success);
+        assert!(!dry_run_resp.balance_changes.is_empty());
+    });
 }


### PR DESCRIPTION
# Description of change

This PR fixes a panic during `dry_run_transaction_block` when the transaction dynamically loads child objects at runtime (e.g. staking pool objects in `request_add_stake`).

Previously, the node's JSON-RPC `dry_run` used `ObjectProviderCache` backed by the full `AuthorityState`, which could resolve any object from the node's database as a fallback. With the gRPC migration, balance and object change computation moved to the indexer, which only had objects from the `simulate_transaction` response — no fallback. Dynamically loaded objects (not in the response's input/output sets) caused a panic.
 
The fix introduces `TxObjectResolver`, which checks the in-memory cache first (simulate response objects), then falls back to the indexer's `objects` table for any missing objects.

## Links to any relevant issues

fixes #11085 

## How the change has been tested

Describe the tests that you ran to verify your changes.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

- Tested the by applying the changes on a branch that mathes the version deployed on the devnet
```shell
git log --oneline -1
git checkout -b fix/dry-run-object-resolution v1.20.0-beta
git cherry-pick <commit-hash>
```
- Started locally a indexer reader by providng as database the devent one and the node gRPC, 
- Ran the query which was previously was panicking 
```shell
curl --location 'localhost:9000' \
--header 'content-type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "id": 57,
    "method": "iota_dryRunTransactionBlock",
    "params": [
        "AAADAAgA1hF+AwAAAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUBAAAAAAAAAAEAIERrerzKU8WOumcgMJvujVAXrRD95mbzl7ucBHVsGCWXAgIAAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwtpb3RhX3N5c3RlbRFyZXF1ZXN0X2FkZF9zdGFrZQADAQEAAgAAAQIAy7PxV/mY4SLcAGbzpg3Lj3bjD5vA4nLOGtR0S0xKDHYAy7PxV/mY4SLcAGbzpg3Lj3bjD5vA4nLOGtR0S0xKDHboAwAAAAAAAAB0O6QLAAAAAA=="
    ]
}'
```
- Response received.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the ingestion path, thus no further tests were conducted
