### PR TITLE
feat(iota-core): PoC certificate-less pre-consensus load shedding based on consensus queue length

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -808,19 +808,21 @@ impl NodeConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConsensusConfig {
-    // Base consensus DB path for all epochs.
+    /// Base consensus DB path for all epochs.
     pub db_path: PathBuf,
 
-    // The number of epochs for which to retain the consensus DBs. Setting it to 0 will make a
-    // consensus DB getting dropped as soon as system is switched to a new epoch.
+    /// The number of epochs for which to retain the consensus DBs.
+    /// Setting it to 0 will make a consensus DB getting dropped
+    /// as soon as system is switched to a new epoch.
     pub db_retention_epochs: Option<u64>,
 
-    // Pruner will run on every epoch change but it will also check periodically on every
-    // `db_pruner_period_secs` seconds to see if there are any epoch DBs to remove.
+    /// Pruner will run on every epoch change but it will also check
+    /// periodically on every `db_pruner_period_secs` seconds to see
+    /// if there are any epoch DBs to remove.
     pub db_pruner_period_secs: Option<u64>,
 
-    /// Maximum number of pending transactions to submit to consensus, including
-    /// those in submission wait.
+    /// Maximum number of pending transactions to submit to consensus,
+    /// including those in submission wait.
     ///
     /// Default to 20_000 inflight limit, assuming 20_000 txn tps * 1 sec
     /// consensus latency.
@@ -860,6 +862,9 @@ impl ConsensusConfig {
         &self.db_path
     }
 
+    /// Returns the maximum number of pending transactions to submit to
+    /// consensus, including those in submission wait. Defaults to 20_000
+    /// inflight limit, assuming 20_000 txn tps * 1 sec consensus latency.
     pub fn max_pending_transactions(&self) -> usize {
         self.max_pending_transactions.unwrap_or(20_000)
     }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1183,54 +1183,74 @@ pub struct TransactionKeyValueStoreWriteConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct AuthorityOverloadConfig {
+    /// Maximum time a transaction can wait in the transaction manager execution
+    /// queue before it triggers an overload detection on the object it depends
+    /// on.
     #[serde(default = "default_max_txn_age_in_queue")]
     pub max_txn_age_in_queue: Duration,
 
-    // The interval of checking overload signal.
+    /// The interval of checking overload signal.
     #[serde(default = "default_overload_monitor_interval")]
     pub overload_monitor_interval: Duration,
 
-    // The execution queueing latency when entering load shedding mode.
+    /// The execution queueing latency when entering load shedding mode.
     #[serde(default = "default_execution_queue_latency_soft_limit")]
     pub execution_queue_latency_soft_limit: Duration,
 
-    // The execution queueing latency when entering aggressive load shedding mode.
+    /// The execution queueing latency when entering aggressive load shedding
+    /// mode.
     #[serde(default = "default_execution_queue_latency_hard_limit")]
     pub execution_queue_latency_hard_limit: Duration,
 
-    // The maximum percentage of transactions to shed in load shedding mode.
+    /// The maximum percentage of transactions to shed in load shedding mode.
     #[serde(default = "default_max_load_shedding_percentage")]
     pub max_load_shedding_percentage: u32,
 
-    // When in aggressive load shedding mode, the minimum percentage of
-    // transactions to shed.
+    /// When in aggressive load shedding mode, the minimum percentage of
+    /// transactions to shed.
     #[serde(default = "default_min_load_shedding_percentage_above_hard_limit")]
     pub min_load_shedding_percentage_above_hard_limit: u32,
 
-    // If transaction ready rate is below this rate, we consider the validator
-    // is well under used, and will not enter load shedding mode.
+    /// If transaction ready rate is below this rate, we consider the validator
+    /// is well under used, and will not enter load shedding mode.
     #[serde(default = "default_safe_transaction_ready_rate")]
     pub safe_transaction_ready_rate: u32,
 
-    // When set to true, transaction signing may be rejected when the validator
-    // is overloaded.
+    /// When set to true, transaction signing may be rejected when the validator
+    /// is overloaded.
     #[serde(default = "default_check_system_overload_at_signing")]
     pub check_system_overload_at_signing: bool,
 
-    // When set to true, transaction execution may be rejected when the validator
-    // is overloaded.
+    /// When set to true, transaction execution may be rejected when the
+    /// validator is overloaded.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub check_system_overload_at_execution: bool,
 
-    // Reject a transaction if transaction manager queue length is above this threshold.
-    // 100_000 = 10k TPS * 5s resident time in transaction manager (pending + executing) * 2.
+    /// Reject a transaction if transaction manager queue length is above this
+    /// threshold. 100_000 = 10k TPS * 5s resident time in transaction
+    /// manager (pending + executing) * 2.
     #[serde(default = "default_max_transaction_manager_queue_length")]
     pub max_transaction_manager_queue_length: usize,
 
-    // Reject a transaction if the number of pending transactions depending on the object
-    // is above the threshold.
+    /// Reject a transaction if the number of pending transactions depending on
+    /// the object is above the threshold.
     #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
     pub max_transaction_manager_per_object_queue_length: usize,
+
+    /// Consensus queue length at which graduated pre-consensus load shedding
+    /// begins. This is used in the certificate-less (white-flag) mode.
+    #[serde(default = "default_consensus_queue_length_soft_limit")]
+    pub consensus_queue_length_soft_limit: usize,
+
+    /// Consensus queue length at which max pre-consensus load shedding is
+    /// applied. This is used in the certificate-less (white-flag) mode.
+    #[serde(default = "default_consensus_queue_length_hard_limit")]
+    pub consensus_queue_length_hard_limit: usize,
+
+    /// Max percentage of transactions to shed due to consensus queue overload.
+    /// This is used in the certificate-less (white-flag) mode.
+    #[serde(default = "default_max_consensus_load_shedding_percentage")]
+    pub max_consensus_load_shedding_percentage: u32,
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
@@ -1273,6 +1293,31 @@ fn default_max_transaction_manager_per_object_queue_length() -> usize {
     20
 }
 
+/// Default consensus queue length at which graduated pre-consensus load
+/// shedding begins. It is set to 50% of hard limit
+/// `ConsensusConfig::max_pending_transactions` = 20_000. This is used in the
+/// certificate-less (white-flag) mode.
+fn default_consensus_queue_length_soft_limit() -> usize {
+    10_000
+}
+
+/// Default consensus queue length at which max pre-consensus load shedding is
+/// applied. It is set to 100% of hard limit
+/// `ConsensusConfig::max_pending_transactions` = 20_000. This is used in the
+/// certificate-less (white-flag) mode.
+fn default_consensus_queue_length_hard_limit() -> usize {
+    20_000
+}
+
+/// Default max percentage of transactions to shed due to consensus queue
+/// overload. Set to 95% rather than 100% because the existing binary hard
+/// cutoff in `ConsensusAdapter::check_consensus_overload()` serves as a
+/// backstop for the remaining 5% fraction. This is used in the certificate-less
+/// (white-flag) mode.
+fn default_max_consensus_load_shedding_percentage() -> u32 {
+    95
+}
+
 impl Default for AuthorityOverloadConfig {
     fn default() -> Self {
         Self {
@@ -1289,6 +1334,10 @@ impl Default for AuthorityOverloadConfig {
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
+            consensus_queue_length_soft_limit: default_consensus_queue_length_soft_limit(),
+            consensus_queue_length_hard_limit: default_consensus_queue_length_hard_limit(),
+            max_consensus_load_shedding_percentage: default_max_consensus_load_shedding_percentage(
+            ),
         }
     }
 }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -824,9 +824,9 @@ pub struct ConsensusConfig {
     /// Hard limit on the number of pending transactions to submit to
     /// consensus, including those in submission wait. Used as the upper
     /// bound for graduated pre-consensus load shedding
-    /// (`graduated_load_shed_start_pct`) in the certificate-less (pcool
-    /// / white-flag) mode, and as the threshold for the binary cutoff
-    /// in `ConsensusAdapter::check_consensus_overload()` in both
+    /// (`graduated_load_shedding_soft_limit_pct`) in the certificate-less
+    /// (pcool / white-flag) mode, and as the threshold for the binary
+    /// cutoff in `ConsensusAdapter::check_consensus_overload()` in both
     /// certificate-less and certificate-based flows.
     ///
     /// Default to 20_000 inflight limit, assuming 20_000 txn tps * 1 sec
@@ -851,13 +851,14 @@ pub struct ConsensusConfig {
     #[serde(skip_serializing_if = "Option::is_none", alias = "starfish_parameters")]
     pub parameters: Option<StarfishParameters>,
 
-    /// Percentage of `max_pending_transactions` (hard limit) at which graduated
-    /// pre-consensus load shedding begins. At and below this threshold, no
-    /// shedding occurs; above it, the shedding rate scales linearly from 0% to
-    /// 100% at `max_pending_transactions`. Used in the certificate-less
-    /// (pcool / white-flag) mode.
+    /// Percentage of `max_pending_transactions` (hard limit) defining the soft
+    /// limit at which graduated pre-consensus load shedding begins. When
+    /// in-flight transactions are at or below the soft limit, no shedding
+    /// occurs; above it, the shedding rate scales linearly from 0% to 100% at
+    /// `max_pending_transactions`. Used in the certificate-less (pcool /
+    /// white-flag) mode.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub graduated_load_shed_start_pct: Option<u32>,
+    pub graduated_load_shedding_soft_limit_pct: Option<u32>,
 }
 
 impl ConsensusConfig {
@@ -872,11 +873,14 @@ impl ConsensusConfig {
         self.max_pending_transactions.unwrap_or(20_000)
     }
 
-    /// Returns the percentage of `max_pending_transactions` at which
-    /// graduated pre-consensus load shedding begins. Defaults to 50%.
-    /// Used in the certificate-less (pcool / white-flag) mode.
-    pub fn graduated_load_shed_start_pct(&self) -> u32 {
-        self.graduated_load_shed_start_pct.unwrap_or(50).min(100)
+    /// Returns the percentage of `max_pending_transactions` (hard limit)
+    /// defining the soft limit at which graduated pre-consensus load
+    /// shedding begins. Defaults to 50%. Used in the certificate-less
+    /// (pcool / white-flag) mode.
+    pub fn graduated_load_shedding_soft_limit_pct(&self) -> u32 {
+        self.graduated_load_shedding_soft_limit_pct
+            .unwrap_or(50)
+            .min(100)
     }
 
     pub fn submit_delay_step_override(&self) -> Option<Duration> {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -843,6 +843,16 @@ pub struct ConsensusConfig {
     /// Parameters for Starfish consensus
     #[serde(skip_serializing_if = "Option::is_none", alias = "starfish_parameters")]
     pub parameters: Option<StarfishParameters>,
+
+    /// Consensus queue length at which graduated load shedding begins.
+    /// Used in the certificate-less (white-flag) mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub graduated_load_shedding_soft_limit: Option<usize>,
+
+    /// Max percentage of transactions to shed due to consensus queue
+    /// overload. Used in the certificate-less (white-flag) mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub graduated_load_shedding_max_percentage: Option<u32>,
 }
 
 impl ConsensusConfig {
@@ -852,6 +862,22 @@ impl ConsensusConfig {
 
     pub fn max_pending_transactions(&self) -> usize {
         self.max_pending_transactions.unwrap_or(20_000)
+    }
+
+    /// Returns the consensus queue length at which graduated load shedding
+    /// begins. Defaults to `max_pending_transactions / 2`.
+    /// Used in the certificate-less (white-flag) mode.
+    pub fn graduated_load_shedding_soft_limit(&self) -> usize {
+        self.graduated_load_shedding_soft_limit
+            .unwrap_or(self.max_pending_transactions() / 2)
+    }
+
+    /// Returns the max percentage of transactions to shed due to consensus
+    /// queue overload. Defaults to 95%; the remaining ~5% are caught by the
+    /// binary hard cutoff in `check_consensus_overload()`.
+    /// Used in the certificate-less (white-flag) mode.
+    pub fn graduated_load_shedding_max_percentage(&self) -> u32 {
+        self.graduated_load_shedding_max_percentage.unwrap_or(95)
     }
 
     pub fn submit_delay_step_override(&self) -> Option<Duration> {
@@ -1236,21 +1262,6 @@ pub struct AuthorityOverloadConfig {
     /// the object is above the threshold.
     #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
     pub max_transaction_manager_per_object_queue_length: usize,
-
-    /// Consensus queue length at which graduated pre-consensus load shedding
-    /// begins. This is used in the certificate-less (white-flag) mode.
-    #[serde(default = "default_consensus_queue_length_soft_limit")]
-    pub consensus_queue_length_soft_limit: usize,
-
-    /// Consensus queue length at which max pre-consensus load shedding is
-    /// applied. This is used in the certificate-less (white-flag) mode.
-    #[serde(default = "default_consensus_queue_length_hard_limit")]
-    pub consensus_queue_length_hard_limit: usize,
-
-    /// Max percentage of transactions to shed due to consensus queue overload.
-    /// This is used in the certificate-less (white-flag) mode.
-    #[serde(default = "default_max_consensus_load_shedding_percentage")]
-    pub max_consensus_load_shedding_percentage: u32,
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
@@ -1293,31 +1304,6 @@ fn default_max_transaction_manager_per_object_queue_length() -> usize {
     20
 }
 
-/// Default consensus queue length at which graduated pre-consensus load
-/// shedding begins. It is set to 50% of hard limit
-/// `ConsensusConfig::max_pending_transactions` = 20_000. This is used in the
-/// certificate-less (white-flag) mode.
-fn default_consensus_queue_length_soft_limit() -> usize {
-    10_000
-}
-
-/// Default consensus queue length at which max pre-consensus load shedding is
-/// applied. It is set to 100% of hard limit
-/// `ConsensusConfig::max_pending_transactions` = 20_000. This is used in the
-/// certificate-less (white-flag) mode.
-fn default_consensus_queue_length_hard_limit() -> usize {
-    20_000
-}
-
-/// Default max percentage of transactions to shed due to consensus queue
-/// overload. Set to 95% rather than 100% because the existing binary hard
-/// cutoff in `ConsensusAdapter::check_consensus_overload()` serves as a
-/// backstop for the remaining 5% fraction. This is used in the certificate-less
-/// (white-flag) mode.
-fn default_max_consensus_load_shedding_percentage() -> u32 {
-    95
-}
-
 impl Default for AuthorityOverloadConfig {
     fn default() -> Self {
         Self {
@@ -1334,10 +1320,6 @@ impl Default for AuthorityOverloadConfig {
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
-            consensus_queue_length_soft_limit: default_consensus_queue_length_soft_limit(),
-            consensus_queue_length_hard_limit: default_consensus_queue_length_hard_limit(),
-            max_consensus_load_shedding_percentage: default_max_consensus_load_shedding_percentage(
-            ),
         }
     }
 }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -878,11 +878,13 @@ impl ConsensusConfig {
     }
 
     /// Returns the max percentage of transactions to shed due to consensus
-    /// queue overload. Defaults to 95%; the remaining ~5% are caught by the
-    /// binary hard cutoff in `check_consensus_overload()`.
-    /// Used in the certificate-less (white-flag) mode.
+    /// queue overload. Defaults to 100%: at and above
+    /// `max_pending_transactions`, graduated shedding rejects every
+    /// transaction, so the consensus queue cannot grow past the hard limit.
+    /// The binary hard cutoff in `check_consensus_overload()` remains as
+    /// defense-in-depth. Used in the certificate-less (white-flag) mode.
     pub fn graduated_load_shedding_max_percentage(&self) -> u32 {
-        self.graduated_load_shedding_max_percentage.unwrap_or(95)
+        self.graduated_load_shedding_max_percentage.unwrap_or(100)
     }
 
     pub fn submit_delay_step_override(&self) -> Option<Duration> {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -821,8 +821,13 @@ pub struct ConsensusConfig {
     /// if there are any epoch DBs to remove.
     pub db_pruner_period_secs: Option<u64>,
 
-    /// Maximum number of pending transactions to submit to consensus,
-    /// including those in submission wait.
+    /// Hard limit on the number of pending transactions to submit to
+    /// consensus, including those in submission wait. Used as the upper
+    /// bound for graduated pre-consensus load shedding
+    /// (`graduated_load_shed_start_pct`) in the certificate-less (pcool
+    /// / white-flag) mode, and as the threshold for the binary cutoff
+    /// in `ConsensusAdapter::check_consensus_overload()` in both
+    /// certificate-less and certificate-based flows.
     ///
     /// Default to 20_000 inflight limit, assuming 20_000 txn tps * 1 sec
     /// consensus latency.
@@ -846,10 +851,13 @@ pub struct ConsensusConfig {
     #[serde(skip_serializing_if = "Option::is_none", alias = "starfish_parameters")]
     pub parameters: Option<StarfishParameters>,
 
-    /// Consensus queue length at which graduated load shedding begins.
-    /// Used in the certificate-less (white-flag) mode.
+    /// Percentage of `max_pending_transactions` (hard limit) at which graduated
+    /// pre-consensus load shedding begins. At and below this threshold, no
+    /// shedding occurs; above it, the shedding rate scales linearly from 0% to
+    /// 100% at `max_pending_transactions`. Used in the certificate-less
+    /// (pcool / white-flag) mode.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub graduated_load_shedding_soft_limit: Option<usize>,
+    pub graduated_load_shed_start_pct: Option<u32>,
 }
 
 impl ConsensusConfig {
@@ -857,19 +865,18 @@ impl ConsensusConfig {
         &self.db_path
     }
 
-    /// Returns the maximum number of pending transactions to submit to
-    /// consensus, including those in submission wait. Defaults to 20_000
+    /// Returns the hard limit on the number of pending transactions to submit
+    /// to consensus, including those in submission wait. Defaults to 20_000
     /// inflight limit, assuming 20_000 txn tps * 1 sec consensus latency.
     pub fn max_pending_transactions(&self) -> usize {
         self.max_pending_transactions.unwrap_or(20_000)
     }
 
-    /// Returns the consensus queue length at which graduated load shedding
-    /// begins. Defaults to `max_pending_transactions / 2`.
-    /// Used in the certificate-less (white-flag) mode.
-    pub fn graduated_load_shedding_soft_limit(&self) -> usize {
-        self.graduated_load_shedding_soft_limit
-            .unwrap_or(self.max_pending_transactions() / 2)
+    /// Returns the percentage of `max_pending_transactions` at which
+    /// graduated pre-consensus load shedding begins. Defaults to 50%.
+    /// Used in the certificate-less (pcool / white-flag) mode.
+    pub fn graduated_load_shed_start_pct(&self) -> u32 {
+        self.graduated_load_shed_start_pct.unwrap_or(50).min(100)
     }
 
     pub fn submit_delay_step_override(&self) -> Option<Duration> {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -850,11 +850,6 @@ pub struct ConsensusConfig {
     /// Used in the certificate-less (white-flag) mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub graduated_load_shedding_soft_limit: Option<usize>,
-
-    /// Max percentage of transactions to shed due to consensus queue
-    /// overload. Used in the certificate-less (white-flag) mode.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub graduated_load_shedding_max_percentage: Option<u32>,
 }
 
 impl ConsensusConfig {
@@ -875,16 +870,6 @@ impl ConsensusConfig {
     pub fn graduated_load_shedding_soft_limit(&self) -> usize {
         self.graduated_load_shedding_soft_limit
             .unwrap_or(self.max_pending_transactions() / 2)
-    }
-
-    /// Returns the max percentage of transactions to shed due to consensus
-    /// queue overload. Defaults to 100%: at and above
-    /// `max_pending_transactions`, graduated shedding rejects every
-    /// transaction, so the consensus queue cannot grow past the hard limit.
-    /// The binary hard cutoff in `check_consensus_overload()` remains as
-    /// defense-in-depth. Used in the certificate-less (white-flag) mode.
-    pub fn graduated_load_shedding_max_percentage(&self) -> u32 {
-        self.graduated_load_shedding_max_percentage.unwrap_or(100)
     }
 
     pub fn submit_delay_step_override(&self) -> Option<Duration> {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1145,7 +1145,7 @@ impl AuthorityState {
         if white_flag_flow_enabled {
             // Graduated shedding: 0% to 100% as consensus queue fills from soft
             // to hard limit.
-            self.check_consensus_queue_overload(consensus_adapter, tx_data)
+            self.check_consensus_queue_graduated_limits(consensus_adapter, tx_data)
                 .tap_err(|_| {
                     self.update_overload_metrics("consensus");
                 })?;
@@ -1154,7 +1154,7 @@ impl AuthorityState {
             // `max_pending_transactions`, so the queue-length part of the check below
             // is redundant but harmless. But `check_consensus_overload()` should be
             // kept here because it also verifies that `submit_semaphore` has permits
-            // (see `check_consensus_limits` in consensus_adapter.rs), which is a
+            // (see `check_consensus_hard_limits` in consensus_adapter.rs), which is a
             // separate concurrency limit not covered by the graduated shedding.
             consensus_adapter.check_consensus_overload().tap_err(|_| {
                 self.update_overload_metrics("consensus");
@@ -1193,12 +1193,14 @@ impl AuthorityState {
         Ok(())
     }
 
-    /// Graduated pre-consensus load shedding based on consensus queue length.
-    /// Computes a shedding percentage based on current consensus queue length
-    /// and deterministically rejects transactions using
-    /// `overload_monitor_accept_tx`. Updates the
-    /// `consensus_queue_load_shedding_percentage` metric on each call.
-    fn check_consensus_queue_overload(
+    /// Rejects `tx_data` via graduated shedding based on consensus queue
+    /// length. Scales from 0% at the soft limit to 100% at
+    /// `max_pending_transactions`. Returns `ValidatorOverloadedRetryAfter`
+    /// for probabilistic rejection (shedding percentage < 100%, via
+    /// `overload_monitor_accept_tx`) or `TooManyTransactionsPendingConsensus`
+    /// for unconditional rejection (shedding percentage >= 100%). Updates
+    /// `consensus_queue_load_shedding_percentage` metric.
+    fn check_consensus_queue_graduated_limits(
         &self,
         consensus_adapter: &Arc<ConsensusAdapter>,
         tx_data: &SenderSignedData,
@@ -1217,6 +1219,14 @@ impl AuthorityState {
 
         if shedding_pct == 0 {
             return Ok(());
+        }
+
+        // At/above the hard limit, rejection is unconditional (not
+        // probabilistic), so the seed-rotation retry hint of
+        // `ValidatorOverloadedRetryAfter` doesn't apply - return the
+        // capacity-bound error instead.
+        if shedding_pct >= 100 {
+            return Err(IotaError::TooManyTransactionsPendingConsensus);
         }
 
         overload_monitor_accept_tx(shedding_pct, tx_data.digest())

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1143,16 +1143,16 @@ impl AuthorityState {
         white_flag_flow_enabled: bool,
     ) -> IotaResult {
         if white_flag_flow_enabled {
-            // Graduated shedding: 0% to 95% as consensus queue fills from soft to hard
-            // limit.
+            // Graduated shedding: 0% to 100% as consensus queue fills from soft
+            // to hard limit.
             self.check_consensus_queue_overload(consensus_adapter, tx_data)
                 .tap_err(|_| {
                     self.update_overload_metrics("consensus");
                 })?;
 
-            // Binary hard cutoff backstop: catches the remaining 5% if queue
-            // exceeds `max_pending_transactions`. Graduated shedding caps at 95%,
-            // so this ensures we never actually exceed the hard limit.
+            // Binary hard cutoff as defense-in-depth: graduated shedding at 100%
+            // already rejects everything at or above `max_pending_transactions`,
+            // so this check is redundant but kept as a safeguard.
             consensus_adapter.check_consensus_overload().tap_err(|_| {
                 self.update_overload_metrics("consensus");
             })?;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -177,7 +177,7 @@ use crate::{
     metrics::{LatencyObserver, RateTracker},
     module_cache_metrics::ResolverMetrics,
     overload_monitor::{
-        AuthorityOverloadInfo, compute_consensus_load_shedding_percentage,
+        AuthorityOverloadInfo, compute_graduated_load_shedding_percentage,
         overload_monitor_accept_tx,
     },
     stake_aggregator::StakeAggregator,
@@ -1205,10 +1205,10 @@ impl AuthorityState {
     ) -> IotaResult {
         let num_inflight_txs = consensus_adapter.num_inflight_transactions() as usize;
 
-        let shedding_pct = compute_consensus_load_shedding_percentage(
+        let shedding_pct = compute_graduated_load_shedding_percentage(
             num_inflight_txs,
-            consensus_adapter.graduated_load_shedding_soft_limit(),
             consensus_adapter.max_pending_transactions(),
+            consensus_adapter.graduated_load_shed_start_pct(),
         );
 
         self.metrics

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1209,7 +1209,6 @@ impl AuthorityState {
             num_inflight_txs,
             consensus_adapter.graduated_load_shedding_soft_limit(),
             consensus_adapter.max_pending_transactions(),
-            consensus_adapter.graduated_load_shedding_max_percentage(),
         );
 
         self.metrics

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -176,7 +176,10 @@ use crate::{
     jsonrpc_index::{CoinInfo, IndexStore, ObjectIndexChanges},
     metrics::{LatencyObserver, RateTracker},
     module_cache_metrics::ResolverMetrics,
-    overload_monitor::{AuthorityOverloadInfo, overload_monitor_accept_tx},
+    overload_monitor::{
+        AuthorityOverloadInfo, compute_consensus_load_shedding_percentage,
+        overload_monitor_accept_tx,
+    },
     stake_aggregator::StakeAggregator,
     subscription_handler::SubscriptionHandler,
     transaction_input_loader::TransactionInputLoader,
@@ -288,16 +291,18 @@ pub struct AuthorityMetrics {
 
     pub(crate) authority_overload_status: IntGauge,
     pub(crate) authority_load_shedding_percentage: IntGauge,
+    /// Percentage of transactions shed due to consensus queue length.
+    pub(crate) consensus_queue_load_shedding_percentage: IntGauge,
 
     pub(crate) transaction_overload_sources: IntCounterVec,
 
-    /// Post processing metrics
+    // Post processing metrics
     post_processing_total_events_emitted: IntCounter,
     post_processing_total_tx_indexed: IntCounter,
     post_processing_total_tx_had_event_processed: IntCounter,
     post_processing_total_failures: IntCounter,
 
-    /// Consensus handler metrics
+    // Consensus handler metrics
     pub consensus_handler_processed: IntCounterVec,
     pub consensus_handler_transaction_sizes: HistogramVec,
     pub consensus_handler_num_low_scoring_authorities: IntGauge,
@@ -543,6 +548,11 @@ impl AuthorityMetrics {
             authority_load_shedding_percentage: register_int_gauge_with_registry!(
                 "authority_load_shedding_percentage",
                 "The percentage of transactions is shed when the authority is in load shedding mode.",
+                registry)
+                .unwrap(),
+            consensus_queue_load_shedding_percentage: register_int_gauge_with_registry!(
+                "consensus_queue_load_shedding_percentage",
+                "Percentage of transactions shed due to consensus queue length.",
                 registry)
                 .unwrap(),
             transaction_manager_object_cache_misses: register_int_counter_with_registry!(
@@ -1133,9 +1143,16 @@ impl AuthorityState {
         white_flag_flow_enabled: bool,
     ) -> IotaResult {
         if white_flag_flow_enabled {
-            // TODO: maybe add graduated consensus overload check: as consensus
-            // queue fills, an increasing percentage of transactions are shed
-            // proportionally.
+            // Graduated shedding: 0% to 95% as consensus queue fills from soft to hard
+            // limit.
+            self.check_consensus_queue_overload(consensus_adapter, tx_data)
+                .tap_err(|_| {
+                    self.update_overload_metrics("consensus");
+                })?;
+
+            // Binary hard cutoff backstop: catches the remaining 5% if queue
+            // exceeds `max_pending_transactions`. Graduated shedding caps at 95%,
+            // so this ensures we never actually exceed the hard limit.
             consensus_adapter.check_consensus_overload().tap_err(|_| {
                 self.update_overload_metrics("consensus");
             })?;
@@ -1171,6 +1188,37 @@ impl AuthorityState {
         }
 
         Ok(())
+    }
+
+    /// Graduated pre-consensus load shedding based on consensus queue length.
+    /// Computes a shedding percentage based on current consensus queue length
+    /// and deterministically rejects transactions using
+    /// `overload_monitor_accept_tx`. Updates the
+    /// `consensus_queue_load_shedding_percentage` metric on each call.
+    fn check_consensus_queue_overload(
+        &self,
+        consensus_adapter: &Arc<ConsensusAdapter>,
+        tx_data: &SenderSignedData,
+    ) -> IotaResult {
+        let num_inflight_txs = consensus_adapter.num_inflight_transactions() as usize;
+        let config = self.overload_config();
+
+        let shedding_pct = compute_consensus_load_shedding_percentage(
+            num_inflight_txs,
+            config.consensus_queue_length_soft_limit,
+            config.consensus_queue_length_hard_limit,
+            config.max_consensus_load_shedding_percentage,
+        );
+
+        self.metrics
+            .consensus_queue_load_shedding_percentage
+            .set(shedding_pct as i64);
+
+        if shedding_pct == 0 {
+            return Ok(());
+        }
+
+        overload_monitor_accept_tx(shedding_pct, tx_data.digest())
     }
 
     fn check_authority_overload(&self, tx_data: &SenderSignedData) -> IotaResult {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1116,39 +1116,58 @@ impl AuthorityState {
             .check_system_overload_at_execution
     }
 
+    /// Checks system overload conditions before accepting a transaction.
+    ///
+    /// In certificate-less (white-flag) mode: only checks consensus
+    /// queue overload, since execution-based overload will be handled
+    /// post-consensus.
+    ///
+    /// In certificate mode: runs all checks — authority overload
+    /// (execution latency), transaction manager (execution queue),
+    /// consensus adapter (queue limit), and writeback cache backpressure.
     pub(crate) fn check_system_overload(
         &self,
         consensus_adapter: &Arc<ConsensusAdapter>,
         tx_data: &SenderSignedData,
         do_authority_overload_check: bool,
+        white_flag_flow_enabled: bool,
     ) -> IotaResult {
-        if do_authority_overload_check {
-            self.check_authority_overload(tx_data).tap_err(|_| {
-                self.update_overload_metrics("execution_queue");
+        if white_flag_flow_enabled {
+            // TODO: maybe add graduated consensus overload check: as consensus
+            // queue fills, an increasing percentage of transactions are shed
+            // proportionally.
+            consensus_adapter.check_consensus_overload().tap_err(|_| {
+                self.update_overload_metrics("consensus");
             })?;
-        }
-        self.transaction_manager
-            .check_execution_overload(self.overload_config(), tx_data)
-            .tap_err(|_| {
-                self.update_overload_metrics("execution_pending");
+        } else {
+            if do_authority_overload_check {
+                self.check_authority_overload(tx_data).tap_err(|_| {
+                    self.update_overload_metrics("execution_queue");
+                })?;
+            }
+            self.transaction_manager
+                .check_execution_overload(self.overload_config(), tx_data)
+                .tap_err(|_| {
+                    self.update_overload_metrics("execution_pending");
+                })?;
+            consensus_adapter.check_consensus_overload().tap_err(|_| {
+                self.update_overload_metrics("consensus");
             })?;
-        consensus_adapter.check_consensus_overload().tap_err(|_| {
-            self.update_overload_metrics("consensus");
-        })?;
 
-        let pending_tx_count = self
-            .get_cache_commit()
-            .approximate_pending_transaction_count();
-        if pending_tx_count
-            > self
-                .config
-                .execution_cache_config
-                .writeback_cache
-                .backpressure_threshold_for_rpc()
-        {
-            return Err(IotaError::ValidatorOverloadedRetryAfter {
-                retry_after_secs: 10,
-            });
+            let pending_tx_count = self
+                .get_cache_commit()
+                .approximate_pending_transaction_count();
+            if pending_tx_count
+                > self
+                    .config
+                    .execution_cache_config
+                    .writeback_cache
+                    .backpressure_threshold_for_rpc()
+            {
+                return Err(IotaError::ValidatorOverloadedRetryAfter {
+                    retry_after_secs: 10,
+                });
+            }
         }
 
         Ok(())

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1150,9 +1150,12 @@ impl AuthorityState {
                     self.update_overload_metrics("consensus");
                 })?;
 
-            // Binary hard cutoff as defense-in-depth: graduated shedding at 100%
-            // already rejects everything at or above `max_pending_transactions`,
-            // so this check is redundant but kept as a safeguard.
+            // NOTE: graduated shedding at 100% already rejects everything at or above
+            // `max_pending_transactions`, so the queue-length part of the check below
+            // is redundant but harmless. But `check_consensus_overload()` should be
+            // kept here because it also verifies that `submit_semaphore` has permits
+            // (see `check_consensus_limits` in consensus_adapter.rs), which is a
+            // separate concurrency limit not covered by the graduated shedding.
             consensus_adapter.check_consensus_overload().tap_err(|_| {
                 self.update_overload_metrics("consensus");
             })?;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1208,7 +1208,7 @@ impl AuthorityState {
         let shedding_pct = compute_graduated_load_shedding_percentage(
             num_inflight_txs,
             consensus_adapter.max_pending_transactions(),
-            consensus_adapter.graduated_load_shed_start_pct(),
+            consensus_adapter.graduated_load_shedding_soft_limit_pct(),
         );
 
         self.metrics

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1201,13 +1201,12 @@ impl AuthorityState {
         tx_data: &SenderSignedData,
     ) -> IotaResult {
         let num_inflight_txs = consensus_adapter.num_inflight_transactions() as usize;
-        let config = self.overload_config();
 
         let shedding_pct = compute_consensus_load_shedding_percentage(
             num_inflight_txs,
-            config.consensus_queue_length_soft_limit,
-            config.consensus_queue_length_hard_limit,
-            config.max_consensus_load_shedding_percentage,
+            consensus_adapter.graduated_load_shedding_soft_limit(),
+            consensus_adapter.max_pending_transactions(),
+            consensus_adapter.graduated_load_shedding_max_percentage(),
         );
 
         self.metrics

--- a/crates/iota-core/src/authority_server/test_server.rs
+++ b/crates/iota-core/src/authority_server/test_server.rs
@@ -84,6 +84,8 @@ impl AuthorityServer {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
+            50_000,
+            95,
         ));
         Self::new_for_test_with_consensus_adapter(state, consensus_adapter)
     }

--- a/crates/iota-core/src/authority_server/test_server.rs
+++ b/crates/iota-core/src/authority_server/test_server.rs
@@ -84,7 +84,7 @@ impl AuthorityServer {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
-            50_000,
+            50,
         ));
         Self::new_for_test_with_consensus_adapter(state, consensus_adapter)
     }

--- a/crates/iota-core/src/authority_server/test_server.rs
+++ b/crates/iota-core/src/authority_server/test_server.rs
@@ -85,7 +85,6 @@ impl AuthorityServer {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            100,
         ));
         Self::new_for_test_with_consensus_adapter(state, consensus_adapter)
     }

--- a/crates/iota-core/src/authority_server/test_server.rs
+++ b/crates/iota-core/src/authority_server/test_server.rs
@@ -85,7 +85,7 @@ impl AuthorityServer {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            95,
+            100,
         ));
         Self::new_for_test_with_consensus_adapter(state, consensus_adapter)
     }

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -77,15 +77,14 @@ impl ValidatorService {
         } = self.clone();
         let transaction = request.into_inner();
         let epoch_store = state.load_epoch_store_one_call_per_task();
-        let white_flag_flow_enabled = epoch_store.protocol_config().enable_white_flag_flow();
 
         // Reject if white flag flow is enabled - transactions should use
-        // `handle_submit_transaction_impl` instead
+        // `submit_tx` (ValidatorV2 service) instead
         fp_ensure!(
-            !white_flag_flow_enabled,
+            !epoch_store.protocol_config().enable_white_flag_flow(),
             IotaError::UnsupportedFeature {
                 error: "handle_transaction is disabled when white flag flow is enabled. \
-                    Use handle_submit_transaction_impl instead."
+                    Use submit_tx (ValidatorV2 service) instead."
                     .to_string()
             }
             .into()
@@ -106,7 +105,7 @@ impl ValidatorService {
             &consensus_adapter,
             transaction.data(),
             state.check_system_overload_at_signing(),
-            white_flag_flow_enabled, // should be false if this point is reached
+            false, // white_flag_flow_enabled
         );
         if let Err(error) = overload_check_res {
             metrics
@@ -239,13 +238,12 @@ impl ValidatorService {
 
         // 2) Verify the certificates.
         // Check system overload
-        let white_flag_flow_enabled = epoch_store.protocol_config().enable_white_flag_flow();
         for certificate in &certificates {
             let overload_check_res = self.state.check_system_overload(
                 &self.consensus_adapter,
                 certificate.data(),
                 self.state.check_system_overload_at_execution(),
-                white_flag_flow_enabled, // should be false if this point is reached
+                false, // white_flag_flow_enabled
             );
             if let Err(error) = overload_check_res {
                 self.metrics
@@ -599,7 +597,7 @@ impl ValidatorService {
             !epoch_store.protocol_config().enable_white_flag_flow(),
             IotaError::UnsupportedFeature {
                 error: "handle_soft_bundle_certificates_v1 is disabled when white flag flow is \
-                    enabled. Use batch submission via handle_submit_transactions_impl instead."
+                    enabled. Use submit_tx (ValidatorV2 service) for batch submission instead."
                     .to_string()
             }
             .into()

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -77,11 +77,12 @@ impl ValidatorService {
         } = self.clone();
         let transaction = request.into_inner();
         let epoch_store = state.load_epoch_store_one_call_per_task();
+        let white_flag_flow_enabled = epoch_store.protocol_config().enable_white_flag_flow();
 
         // Reject if white flag flow is enabled - transactions should use
         // `handle_submit_transaction_impl` instead
         fp_ensure!(
-            !epoch_store.protocol_config().enable_white_flag_flow(),
+            !white_flag_flow_enabled,
             IotaError::UnsupportedFeature {
                 error: "handle_transaction is disabled when white flag flow is enabled. \
                     Use handle_submit_transaction_impl instead."
@@ -105,6 +106,7 @@ impl ValidatorService {
             &consensus_adapter,
             transaction.data(),
             state.check_system_overload_at_signing(),
+            white_flag_flow_enabled, // should be false if this point is reached
         );
         if let Err(error) = overload_check_res {
             metrics
@@ -237,11 +239,13 @@ impl ValidatorService {
 
         // 2) Verify the certificates.
         // Check system overload
+        let white_flag_flow_enabled = epoch_store.protocol_config().enable_white_flag_flow();
         for certificate in &certificates {
             let overload_check_res = self.state.check_system_overload(
                 &self.consensus_adapter,
                 certificate.data(),
                 self.state.check_system_overload_at_execution(),
+                white_flag_flow_enabled, // should be false if this point is reached
             );
             if let Err(error) = overload_check_res {
                 self.metrics

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -105,7 +105,8 @@ impl ValidatorService {
             &consensus_adapter,
             transaction.data(),
             state.check_system_overload_at_signing(),
-            false, // white_flag_flow_enabled
+            // `false` means white-flag flow is disabled - ensured by `fp_ensure!` above
+            false,
         );
         if let Err(error) = overload_check_res {
             metrics
@@ -243,7 +244,8 @@ impl ValidatorService {
                 &self.consensus_adapter,
                 certificate.data(),
                 self.state.check_system_overload_at_execution(),
-                false, // white_flag_flow_enabled
+                // `false` means white-flag flow is disabled - ensured by `fp_ensure!` in callers
+                false,
             );
             if let Err(error) = overload_check_res {
                 self.metrics

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -60,7 +60,9 @@ impl ValidatorService {
         self.transaction(request).await
     }
 
-    /// Handles a `Transaction` request.
+    /// Certificate-only flow: handles and certifies a transaction. Validates,
+    /// checks overload, and returns a signed vote for certificate assembly.
+    /// Called by `transaction_impl`.
     async fn handle_transaction(
         &self,
         request: tonic::Request<Transaction>,
@@ -77,11 +79,13 @@ impl ValidatorService {
         let epoch_store = state.load_epoch_store_one_call_per_task();
 
         // Reject if white flag flow is enabled - transactions should use
-        // submit_transaction instead
+        // `handle_submit_transaction_impl` instead
         fp_ensure!(
             !epoch_store.protocol_config().enable_white_flag_flow(),
             IotaError::UnsupportedFeature {
-                error: "handle_transaction is disabled when white flag flow is enabled. Use submit_transaction instead.".to_string()
+                error: "handle_transaction is disabled when white flag flow is enabled. \
+                    Use handle_submit_transaction_impl instead."
+                    .to_string()
             }
             .into()
         );
@@ -381,7 +385,12 @@ impl ValidatorService {
 
         Ok((Some(responses), Weight::zero()))
     }
+}
 
+impl ValidatorService {
+    /// Certificate-only flow: thin wrapper that delegates to
+    /// `handle_transaction`. Called by the `transaction()`
+    /// gRPC trait method.
     async fn transaction_impl(
         &self,
         request: tonic::Request<Transaction>,
@@ -402,7 +411,9 @@ impl ValidatorService {
         fp_ensure!(
             !epoch_store.protocol_config().enable_white_flag_flow(),
             IotaError::UnsupportedFeature {
-                error: "handle_certificate_v1 is disabled when white flag flow is enabled. Transactions go directly to consensus.".to_string()
+                error: "handle_certificate_v1 is disabled when white flag flow is enabled. \
+                    Transactions go directly to consensus."
+                    .to_string()
             }
             .into()
         );
@@ -443,7 +454,9 @@ impl ValidatorService {
         fp_ensure!(
             !epoch_store.protocol_config().enable_white_flag_flow(),
             IotaError::UnsupportedFeature {
-                error: "handle_certificate_v1 is disabled when white flag flow is enabled. Transactions go directly to consensus.".to_string()
+                error: "handle_certificate_v1 is disabled when white flag flow is enabled. \
+                    Transactions go directly to consensus."
+                    .to_string()
             }
             .into()
         );
@@ -581,7 +594,9 @@ impl ValidatorService {
         fp_ensure!(
             !epoch_store.protocol_config().enable_white_flag_flow(),
             IotaError::UnsupportedFeature {
-                error: "handle_soft_bundle_certificates_v1 is disabled when white flag flow is enabled. Use batch submission via submit_transaction instead.".to_string()
+                error: "handle_soft_bundle_certificates_v1 is disabled when white flag flow is \
+                    enabled. Use batch submission via handle_submit_transactions_impl instead."
+                    .to_string()
             }
             .into()
         );
@@ -617,7 +632,8 @@ impl ValidatorService {
             .await?;
 
         info!(
-            "Received Soft Bundle with {} certificates, from {}, tx digests are [{}], total size [{}]bytes",
+            "Received Soft Bundle with {} certificates, from {}, tx digests are [{}], total size \
+                [{total_size_bytes}]bytes",
             certificates.len(),
             client_addr
                 .map(|x| x.to_string())
@@ -627,7 +643,6 @@ impl ValidatorService {
                 .map(|x| x.digest().to_string())
                 .collect::<Vec<_>>()
                 .join(", "),
-            total_size_bytes
         );
 
         let span = error_span!("handle_soft_bundle_certificates_v1");

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -168,7 +168,7 @@ impl ValidatorService {
             consensus_adapter,
             transaction.data(),
             state.check_system_overload_at_signing(),
-            epoch_store.protocol_config().enable_white_flag_flow(),
+            true, // white_flag_flow_enabled
         ) {
             metrics
                 .num_rejected_tx_during_overload

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -168,6 +168,7 @@ impl ValidatorService {
             consensus_adapter,
             transaction.data(),
             state.check_system_overload_at_signing(),
+            epoch_store.protocol_config().enable_white_flag_flow(),
         ) {
             metrics
                 .num_rejected_tx_during_overload

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -168,7 +168,8 @@ impl ValidatorService {
             consensus_adapter,
             transaction.data(),
             state.check_system_overload_at_signing(),
-            true, // white_flag_flow_enabled
+            // `true` means white-flag flow is enabled - ensured by `fp_ensure!` in the caller
+            true,
         ) {
             metrics
                 .num_rejected_tx_during_overload

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -239,35 +239,55 @@ pub trait ConsensusClient: Sync + Send + 'static {
 pub struct ConsensusAdapter {
     /// The network client connecting to the consensus node of this authority.
     consensus_client: Arc<dyn ConsensusClient>,
+
     /// The checkpoint store for the validator
     checkpoint_store: Arc<CheckpointStore>,
+
     /// Authority pubkey.
     authority: AuthorityName,
-    /// The limit to number of inflight transactions at this node.
+
+    /// The hard limit on the number of inflight transactions at this node.
+    /// Used as the upper bound for graduated pre-consensus load shedding
+    /// (`graduated_load_shed_start_pct`) in the certificate-less (pcool /
+    /// white-flag) mode, and as the threshold for the binary cutoff in
+    /// `ConsensusAdapter::check_consensus_overload()` in both
+    /// certificate-less and certificate-based flows.
     max_pending_transactions: usize,
+
     /// Number of submitted transactions still inflight at this node.
     num_inflight_transactions: AtomicU64,
+
     /// Dictates the maximum position  from which will submit to consensus. Even
     /// if the is elected to submit from a higher position than this, it
     /// will "reset" to the max_submit_position.
     max_submit_position: Option<usize>,
+
     /// When provided it will override the current back off logic and will use
     /// this value instead as delay step.
     submit_delay_step_override: Option<Duration>,
+
     /// A structure to check the connection statuses populated by the Connection
     /// Monitor Listener
     connection_monitor_status: Arc<dyn CheckConnection>,
+
     /// A structure to check the reputation scores populated by Consensus
     low_scoring_authorities: ArcSwap<Arc<ArcSwap<HashMap<AuthorityName, u64>>>>,
+
     /// A structure to register metrics
     metrics: ConsensusAdapterMetrics,
+
     /// Semaphore limiting parallel submissions to consensus
     submit_semaphore: Semaphore,
+
+    /// Tracks consensus submission latency for adaptive submit-delay backoff.
     latency_observer: LatencyObserver,
 
-    /// Consensus queue length at which graduated load shedding begins.
-    /// Used in the certificate-less (white-flag) mode.
-    graduated_load_shedding_soft_limit: usize,
+    /// Percentage of `max_pending_transactions` (hard limit) at which graduated
+    /// pre-consensus load shedding begins. At and below this threshold, no
+    /// shedding occurs; above it, the shedding rate scales linearly from 0% to
+    /// 100% at `max_pending_transactions`. Used in the certificate-less
+    /// (pcool / white-flag) mode.
+    graduated_load_shed_start_pct: u32,
 }
 
 pub trait CheckConnection: Send + Sync {
@@ -300,7 +320,7 @@ impl ConsensusAdapter {
         max_submit_position: Option<usize>,
         submit_delay_step_override: Option<Duration>,
         metrics: ConsensusAdapterMetrics,
-        graduated_load_shedding_soft_limit: usize,
+        graduated_load_shed_start_pct: u32,
     ) -> Self {
         let num_inflight_transactions = Default::default();
         let low_scoring_authorities =
@@ -318,7 +338,7 @@ impl ConsensusAdapter {
             metrics,
             submit_semaphore: Semaphore::new(max_pending_local_submissions),
             latency_observer: LatencyObserver::new(),
-            graduated_load_shedding_soft_limit,
+            graduated_load_shed_start_pct,
         }
     }
 
@@ -627,10 +647,11 @@ impl ConsensusAdapter {
         self.max_pending_transactions
     }
 
-    /// Returns the consensus queue length at which graduated load shedding
-    /// begins. Used in the certificate-less (white-flag) mode.
-    pub(super) fn graduated_load_shedding_soft_limit(&self) -> usize {
-        self.graduated_load_shedding_soft_limit
+    /// Returns the percentage of `max_pending_transactions` at which
+    /// graduated pre-consensus load shedding begins. Used in the
+    /// certificate-less (pcool / white-flag) mode.
+    pub(super) fn graduated_load_shed_start_pct(&self) -> u32 {
+        self.graduated_load_shed_start_pct
     }
 
     /// Returns the number of transactions currently in-flight in consensus.

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -343,7 +343,7 @@ impl ConsensusAdapter {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            95,
+            100,
         )
     }
 
@@ -1517,7 +1517,7 @@ mod adapter_tests {
             Some(Duration::from_secs(2)),
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            95,
+            100,
         );
 
         // transaction to submit
@@ -1549,7 +1549,7 @@ mod adapter_tests {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            95,
+            100,
         );
 
         let (delay_step, position, positions_moved, _) =

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -356,7 +356,7 @@ impl ConsensusAdapter {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
-            50_000,
+            50,
         )
     }
 
@@ -1524,7 +1524,7 @@ mod adapter_tests {
             Some(1),
             Some(Duration::from_secs(2)),
             ConsensusAdapterMetrics::new_test(),
-            50_000,
+            50,
         );
 
         // transaction to submit
@@ -1555,7 +1555,7 @@ mod adapter_tests {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
-            50_000,
+            50,
         );
 
         let (delay_step, position, positions_moved, _) =

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -603,24 +603,33 @@ impl ConsensusAdapter {
         self.num_inflight_transactions.load(Ordering::Relaxed)
     }
 
-    /// Performs weakly consistent checks on internal buffers to quickly
-    /// discard transactions if we are overloaded
-    pub fn check_limits(&self) -> bool {
+    /// Returns `true` if consensus has capacity to accept more transactions.
+    /// Checks that in-flight transactions are below `max_pending_transactions`
+    /// and that submission permits are available. Weakly consistent (relaxed
+    /// atomic reads).
+    fn check_consensus_limits(&self) -> bool {
         // First check total transactions (waiting and in submission)
         if self.num_inflight_transactions.load(Ordering::Relaxed) as usize
             > self.max_pending_transactions
         {
             return false;
         }
-        // Then check if submit_semaphore has permits
+
+        // Then check if `submit_semaphore` has permits
         self.submit_semaphore.available_permits() > 0
     }
 
+    /// Returns an error if the consensus adapter cannot accept more
+    /// transactions. This is a hard cutoff check - if in-flight
+    /// transactions exceed `max_pending_transactions` or no submission
+    /// permits are available, returns `TooManyTransactionsPendingConsensus`.
+    /// Used as a safeguard in both certificate and certificate-less flows.
     pub(crate) fn check_consensus_overload(&self) -> IotaResult {
         fp_ensure!(
-            self.check_limits(),
+            self.check_consensus_limits(),
             IotaError::TooManyTransactionsPendingConsensus
         );
+
         Ok(())
     }
 

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -248,9 +248,9 @@ pub struct ConsensusAdapter {
 
     /// The hard limit on the number of inflight transactions at this node.
     /// Used as the upper bound for graduated pre-consensus load shedding
-    /// (`graduated_load_shed_start_pct`) in the certificate-less (pcool /
-    /// white-flag) mode, and as the threshold for the binary cutoff in
-    /// `ConsensusAdapter::check_consensus_overload()` in both
+    /// (`graduated_load_shedding_soft_limit_pct`) in the certificate-less
+    /// (pcool / white-flag) mode, and as the threshold for the binary
+    /// cutoff in `ConsensusAdapter::check_consensus_overload()` in both
     /// certificate-less and certificate-based flows.
     max_pending_transactions: usize,
 
@@ -282,12 +282,13 @@ pub struct ConsensusAdapter {
     /// Tracks consensus submission latency for adaptive submit-delay backoff.
     latency_observer: LatencyObserver,
 
-    /// Percentage of `max_pending_transactions` (hard limit) at which graduated
-    /// pre-consensus load shedding begins. At and below this threshold, no
-    /// shedding occurs; above it, the shedding rate scales linearly from 0% to
-    /// 100% at `max_pending_transactions`. Used in the certificate-less
-    /// (pcool / white-flag) mode.
-    graduated_load_shed_start_pct: u32,
+    /// Percentage of `max_pending_transactions` (hard limit) defining the soft
+    /// limit at which graduated pre-consensus load shedding begins. When
+    /// in-flight transactions are at or below the soft limit, no shedding
+    /// occurs; above it, the shedding rate scales linearly from 0% to 100% at
+    /// `max_pending_transactions`. Used in the certificate-less (pcool /
+    /// white-flag) mode.
+    graduated_load_shedding_soft_limit_pct: u32,
 }
 
 pub trait CheckConnection: Send + Sync {
@@ -320,7 +321,7 @@ impl ConsensusAdapter {
         max_submit_position: Option<usize>,
         submit_delay_step_override: Option<Duration>,
         metrics: ConsensusAdapterMetrics,
-        graduated_load_shed_start_pct: u32,
+        graduated_load_shedding_soft_limit_pct: u32,
     ) -> Self {
         let num_inflight_transactions = Default::default();
         let low_scoring_authorities =
@@ -338,7 +339,7 @@ impl ConsensusAdapter {
             metrics,
             submit_semaphore: Semaphore::new(max_pending_local_submissions),
             latency_observer: LatencyObserver::new(),
-            graduated_load_shed_start_pct,
+            graduated_load_shedding_soft_limit_pct,
         }
     }
 
@@ -647,11 +648,12 @@ impl ConsensusAdapter {
         self.max_pending_transactions
     }
 
-    /// Returns the percentage of `max_pending_transactions` at which
-    /// graduated pre-consensus load shedding begins. Used in the
-    /// certificate-less (pcool / white-flag) mode.
-    pub(super) fn graduated_load_shed_start_pct(&self) -> u32 {
-        self.graduated_load_shed_start_pct
+    /// Returns the percentage of `max_pending_transactions` (hard limit)
+    /// defining the soft limit at which graduated pre-consensus load
+    /// shedding begins. Defaults to 50%. Used in the certificate-less
+    /// (pcool / white-flag) mode.
+    pub(super) fn graduated_load_shedding_soft_limit_pct(&self) -> u32 {
+        self.graduated_load_shedding_soft_limit_pct
     }
 
     /// Returns the number of transactions currently in-flight in consensus.

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -268,10 +268,6 @@ pub struct ConsensusAdapter {
     /// Consensus queue length at which graduated load shedding begins.
     /// Used in the certificate-less (white-flag) mode.
     graduated_load_shedding_soft_limit: usize,
-
-    /// Max percentage of transactions to shed due to consensus queue
-    /// overload. Used in the certificate-less (white-flag) mode.
-    graduated_load_shedding_max_percentage: u32,
 }
 
 pub trait CheckConnection: Send + Sync {
@@ -305,7 +301,6 @@ impl ConsensusAdapter {
         submit_delay_step_override: Option<Duration>,
         metrics: ConsensusAdapterMetrics,
         graduated_load_shedding_soft_limit: usize,
-        graduated_load_shedding_max_percentage: u32,
     ) -> Self {
         let num_inflight_transactions = Default::default();
         let low_scoring_authorities =
@@ -324,7 +319,6 @@ impl ConsensusAdapter {
             submit_semaphore: Semaphore::new(max_pending_local_submissions),
             latency_observer: LatencyObserver::new(),
             graduated_load_shedding_soft_limit,
-            graduated_load_shedding_max_percentage,
         }
     }
 
@@ -343,7 +337,6 @@ impl ConsensusAdapter {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            100,
         )
     }
 
@@ -638,12 +631,6 @@ impl ConsensusAdapter {
     /// begins. Used in the certificate-less (white-flag) mode.
     pub(super) fn graduated_load_shedding_soft_limit(&self) -> usize {
         self.graduated_load_shedding_soft_limit
-    }
-
-    /// Returns the max percentage of transactions to shed due to consensus
-    /// queue overload. Used in the certificate-less (white-flag) mode.
-    pub(super) fn graduated_load_shedding_max_percentage(&self) -> u32 {
-        self.graduated_load_shedding_max_percentage
     }
 
     /// Returns the number of transactions currently in-flight in consensus.
@@ -1517,7 +1504,6 @@ mod adapter_tests {
             Some(Duration::from_secs(2)),
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            100,
         );
 
         // transaction to submit
@@ -1549,7 +1535,6 @@ mod adapter_tests {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            100,
         );
 
         let (delay_step, position, positions_moved, _) =

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -264,6 +264,14 @@ pub struct ConsensusAdapter {
     /// Semaphore limiting parallel submissions to consensus
     submit_semaphore: Semaphore,
     latency_observer: LatencyObserver,
+
+    /// Consensus queue length at which graduated load shedding begins.
+    /// Used in the certificate-less (white-flag) mode.
+    graduated_load_shedding_soft_limit: usize,
+
+    /// Max percentage of transactions to shed due to consensus queue
+    /// overload. Used in the certificate-less (white-flag) mode.
+    graduated_load_shedding_max_percentage: u32,
 }
 
 pub trait CheckConnection: Send + Sync {
@@ -296,6 +304,8 @@ impl ConsensusAdapter {
         max_submit_position: Option<usize>,
         submit_delay_step_override: Option<Duration>,
         metrics: ConsensusAdapterMetrics,
+        graduated_load_shedding_soft_limit: usize,
+        graduated_load_shedding_max_percentage: u32,
     ) -> Self {
         let num_inflight_transactions = Default::default();
         let low_scoring_authorities =
@@ -313,7 +323,28 @@ impl ConsensusAdapter {
             metrics,
             submit_semaphore: Semaphore::new(max_pending_local_submissions),
             latency_observer: LatencyObserver::new(),
+            graduated_load_shedding_soft_limit,
+            graduated_load_shedding_max_percentage,
         }
+    }
+
+    /// Test-only: creates a consensus adapter with a `MockConsensusClient`,
+    /// default values for all parameters, and the given authority name.
+    #[cfg(test)]
+    pub fn with_authority_name_for_testing(authority_name: AuthorityName) -> Self {
+        Self::new(
+            Arc::new(MockConsensusClient::new()),
+            CheckpointStore::new_for_tests(),
+            authority_name,
+            Arc::new(ConnectionMonitorStatusForTests {}),
+            100_000,
+            100_000,
+            None,
+            None,
+            ConsensusAdapterMetrics::new_test(),
+            50_000,
+            95,
+        )
     }
 
     pub fn swap_low_scoring_authorities(
@@ -598,9 +629,33 @@ impl ConsensusAdapter {
         Ok(self.submit_unchecked(transactions, epoch_store))
     }
 
+    /// Returns the limit on the number of inflight transactions at this node.
+    pub(super) fn max_pending_transactions(&self) -> usize {
+        self.max_pending_transactions
+    }
+
+    /// Returns the consensus queue length at which graduated load shedding
+    /// begins. Used in the certificate-less (white-flag) mode.
+    pub(super) fn graduated_load_shedding_soft_limit(&self) -> usize {
+        self.graduated_load_shedding_soft_limit
+    }
+
+    /// Returns the max percentage of transactions to shed due to consensus
+    /// queue overload. Used in the certificate-less (white-flag) mode.
+    pub(super) fn graduated_load_shedding_max_percentage(&self) -> u32 {
+        self.graduated_load_shedding_max_percentage
+    }
+
     /// Returns the number of transactions currently in-flight in consensus.
-    pub fn num_inflight_transactions(&self) -> u64 {
+    pub(super) fn num_inflight_transactions(&self) -> u64 {
         self.num_inflight_transactions.load(Ordering::Relaxed)
+    }
+
+    /// Test-only: sets the number of in-flight transactions.
+    #[cfg(test)]
+    pub(super) fn set_num_inflight_transactions_for_testing(&self, value: u64) {
+        self.num_inflight_transactions
+            .store(value, Ordering::Relaxed);
     }
 
     /// Returns `true` if consensus has capacity to accept more transactions.
@@ -1461,6 +1516,8 @@ mod adapter_tests {
             Some(1),
             Some(Duration::from_secs(2)),
             ConsensusAdapterMetrics::new_test(),
+            50_000,
+            95,
         );
 
         // transaction to submit
@@ -1491,6 +1548,8 @@ mod adapter_tests {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
+            50_000,
+            95,
         );
 
         let (delay_step, position, positions_moved, _) =

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -668,12 +668,19 @@ impl ConsensusAdapter {
             .store(value, Ordering::Relaxed);
     }
 
-    /// Returns `true` if consensus has capacity to accept more transactions.
-    /// Checks that in-flight transactions are below `max_pending_transactions`
-    /// and that submission permits are available. Weakly consistent (relaxed
-    /// atomic reads).
-    fn check_consensus_limits(&self) -> bool {
-        // First check total transactions (waiting and in submission)
+    /// Returns `true` if both hard limits allow another transaction:
+    /// (i) in-flight count is at or below `max_pending_transactions`, and
+    /// (ii) `submit_semaphore` has at least one available permit.
+    ///
+    /// Uses relaxed atomic reads: the two limits are not observed atomically.
+    fn check_consensus_hard_limits(&self) -> bool {
+        // First check total in-flight transactions (waiting and in submission).
+        // TODO: this check is redundant in the white-flag flow - graduated
+        // shedding already rejects at 100% once `num_inflight_transactions`
+        // reaches `max_pending_transactions`. Remove when the certificate-based
+        // flow is removed from the codebase. The semaphore check below stays in
+        // either case, since it is a separate concurrency limit not covered
+        // by graduated shedding.
         if self.num_inflight_transactions.load(Ordering::Relaxed) as usize
             > self.max_pending_transactions
         {
@@ -684,14 +691,11 @@ impl ConsensusAdapter {
         self.submit_semaphore.available_permits() > 0
     }
 
-    /// Returns an error if the consensus adapter cannot accept more
-    /// transactions. This is a hard cutoff check - if in-flight
-    /// transactions exceed `max_pending_transactions` or no submission
-    /// permits are available, returns `TooManyTransactionsPendingConsensus`.
-    /// Used as a safeguard in both certificate and certificate-less flows.
+    /// `IotaResult` wrapper for `check_consensus_hard_limits`. Returns
+    /// `TooManyTransactionsPendingConsensus` when the hard limits are exceeded.
     pub(crate) fn check_consensus_overload(&self) -> IotaResult {
         fp_ensure!(
-            self.check_consensus_limits(),
+            self.check_consensus_hard_limits(),
             IotaError::TooManyTransactionsPendingConsensus
         );
 

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -331,7 +331,7 @@ impl ConsensusAdapter {
     /// Test-only: creates a consensus adapter with a `MockConsensusClient`,
     /// default values for all parameters, and the given authority name.
     #[cfg(test)]
-    pub fn with_authority_name_for_testing(authority_name: AuthorityName) -> Self {
+    pub fn new_for_testing_with_authority_name(authority_name: AuthorityName) -> Self {
         Self::new(
             Arc::new(MockConsensusClient::new()),
             CheckpointStore::new_for_tests(),

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -905,7 +905,6 @@ mod tests {
                 None,
                 ConsensusAdapterMetrics::new_test(),
                 50_000,
-                100,
             ));
             let epoch_store = state.epoch_store_for_testing();
             let randomness_manager = RandomnessManager::try_new(
@@ -1057,7 +1056,6 @@ mod tests {
                 None,
                 ConsensusAdapterMetrics::new_test(),
                 50_000,
-                100,
             ));
             let epoch_store = state.epoch_store_for_testing();
             let randomness_manager = RandomnessManager::try_new(

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -904,7 +904,7 @@ mod tests {
                 None,
                 None,
                 ConsensusAdapterMetrics::new_test(),
-                50_000,
+                50,
             ));
             let epoch_store = state.epoch_store_for_testing();
             let randomness_manager = RandomnessManager::try_new(
@@ -1055,7 +1055,7 @@ mod tests {
                 None,
                 None,
                 ConsensusAdapterMetrics::new_test(),
-                50_000,
+                50,
             ));
             let epoch_store = state.epoch_store_for_testing();
             let randomness_manager = RandomnessManager::try_new(

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -905,7 +905,7 @@ mod tests {
                 None,
                 ConsensusAdapterMetrics::new_test(),
                 50_000,
-                95,
+                100,
             ));
             let epoch_store = state.epoch_store_for_testing();
             let randomness_manager = RandomnessManager::try_new(
@@ -1057,7 +1057,7 @@ mod tests {
                 None,
                 ConsensusAdapterMetrics::new_test(),
                 50_000,
-                95,
+                100,
             ));
             let epoch_store = state.epoch_store_for_testing();
             let randomness_manager = RandomnessManager::try_new(

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -904,6 +904,8 @@ mod tests {
                 None,
                 None,
                 ConsensusAdapterMetrics::new_test(),
+                50_000,
+                95,
             ));
             let epoch_store = state.epoch_store_for_testing();
             let randomness_manager = RandomnessManager::try_new(
@@ -1054,6 +1056,8 @@ mod tests {
                 None,
                 None,
                 ConsensusAdapterMetrics::new_test(),
+                50_000,
+                95,
             ));
             let epoch_store = state.epoch_store_for_testing();
             let randomness_manager = RandomnessManager::try_new(

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -55,6 +55,11 @@ const ADDITIONAL_LOAD_SHEDDING: f64 = 0.02;
 // be rejected.
 const SEED_UPDATE_DURATION_SECS: u64 = 30;
 
+/// Maximum shedding percentage for consensus queue length at the hard
+/// limit. Hard-coded to 100%: at or above the consensus queue hard
+/// limit, all transactions are rejected.
+const MAX_CONSENSUS_LOAD_SHED_PCT: u32 = 100;
+
 // Monitors the overload signals in `authority_state` periodically, and updates
 // its `overload_info` when the signals indicates overload.
 pub async fn overload_monitor(
@@ -272,15 +277,15 @@ pub fn overload_monitor_accept_tx(
 
 /// Computes the percentage of transactions to shed based on consensus queue
 /// length. Returns 0 if `num_inflight_txs` is below or equal `soft_limit`,
-/// linearly scales to `max_shedding_pct` between soft and hard limits,
-/// and caps at `max_shedding_pct` if `num_inflight_txs` is above or equal
-/// `hard_limit`. Used in the certificate-less (white-flag) flow for graduated
-/// pre-consensus load shedding.
+/// linearly scales to [`MAX_CONSENSUS_LOAD_SHED_PCT`] (100%) between soft
+/// and hard limits, and caps at [`MAX_CONSENSUS_LOAD_SHED_PCT`] if
+/// `num_inflight_txs` is above or equal `hard_limit`. Used in the
+/// certificate-less (white-flag) flow for graduated pre-consensus load
+/// shedding.
 pub(crate) fn compute_consensus_load_shedding_percentage(
     num_inflight_txs: usize,
     soft_limit: usize,
     hard_limit: usize,
-    max_shedding_pct: u32,
 ) -> u32 {
     // No shedding below soft limit, or if limits are misconfigured (soft >= hard).
     if num_inflight_txs <= soft_limit || soft_limit >= hard_limit {
@@ -290,7 +295,7 @@ pub(crate) fn compute_consensus_load_shedding_percentage(
     // At or above hard limit, shed at maximum rate. The binary hard cutoff
     // in check_consensus_overload() serves as a backstop after this.
     if num_inflight_txs >= hard_limit {
-        return max_shedding_pct;
+        return MAX_CONSENSUS_LOAD_SHED_PCT;
     }
 
     debug_assert!(
@@ -305,8 +310,10 @@ pub(crate) fn compute_consensus_load_shedding_percentage(
     );
     let excess = num_inflight_txs - soft_limit;
 
-    // Linear interpolation: 0% at `soft_limit`, `max_shedding_pct` at `hard_limit`.
-    ((excess as u64 * max_shedding_pct as u64) / range as u64).min(max_shedding_pct as u64) as u32
+    // Linear interpolation: 0% at `soft_limit`, `MAX_CONSENSUS_LOAD_SHED_PCT` at
+    // `hard_limit`.
+    ((excess as u64 * MAX_CONSENSUS_LOAD_SHED_PCT as u64) / range as u64)
+        .min(MAX_CONSENSUS_LOAD_SHED_PCT as u64) as u32
 }
 
 #[cfg(test)]
@@ -471,13 +478,12 @@ mod tests {
 
     /// Tests that the consensus load shedding percentage is 0 below soft limit,
     /// scales linearly between soft and hard limits, and caps at
-    /// `max_shedding_pct` at and above the hard limit. Also covers
+    /// [`MAX_CONSENSUS_LOAD_SHED_PCT`] at and above the hard limit. Also covers
     /// misconfigured limits and edge cases.
     #[test]
     fn test_compute_consensus_load_shedding_percentage() {
         let soft_limit = 10_000;
         let hard_limit = 20_000;
-        let max_shedding_pct = 95;
 
         // Below and at soft limit: no shedding.
         for num_inflight_txs in [0, soft_limit - 1, soft_limit] {
@@ -486,7 +492,6 @@ mod tests {
                     num_inflight_txs,
                     soft_limit,
                     hard_limit,
-                    max_shedding_pct
                 ),
                 0,
                 "no shedding expected below/at soft limit ({num_inflight_txs} <= {soft_limit}): \
@@ -495,40 +500,38 @@ mod tests {
         }
 
         // Linear scaling between soft and hard limits:
-        //  - At 25% of range (12_500): 95 * 2_500 / 10_000 = 23
-        //  - At midpoint (15_000):     95 * 5_000 / 10_000 = 47
-        //  - At 75% of range (17_500): 95 * 7_500 / 10_000 = 71
-        //  - Just below hard limit:    95 * 9_999 / 10_000 = 94
+        //  - At 25% of range (12_500): 100 * 2_500 / 10_000 = 25
+        //  - At midpoint (15_000):     100 * 5_000 / 10_000 = 50
+        //  - At 75% of range (17_500): 100 * 7_500 / 10_000 = 75
+        //  - Just below hard limit:    100 * 9_999 / 10_000 = 99
         for (num_inflight_txs, expected_pct) in [
-            (12_500, 23),
-            (15_000, 47),
-            (17_500, 71),
-            (hard_limit - 1, 94),
+            (12_500, 25),
+            (15_000, 50),
+            (17_500, 75),
+            (hard_limit - 1, 99),
         ] {
             assert_eq!(
                 compute_consensus_load_shedding_percentage(
                     num_inflight_txs,
                     soft_limit,
                     hard_limit,
-                    max_shedding_pct
                 ),
                 expected_pct,
                 "expected consensus queue load shedding percentage to be {expected_pct}%",
             );
         }
 
-        // At and above hard limit: capped at `max_shedding_pct`.
+        // At and above hard limit: capped at `MAX_CONSENSUS_LOAD_SHED_PCT`.
         for num_inflight_txs in [hard_limit, hard_limit + 1, 30_000] {
             assert_eq!(
                 compute_consensus_load_shedding_percentage(
                     num_inflight_txs,
                     soft_limit,
                     hard_limit,
-                    max_shedding_pct
                 ),
-                max_shedding_pct,
+                MAX_CONSENSUS_LOAD_SHED_PCT,
                 "at/above hard limit ({num_inflight_txs} >= {hard_limit}), consensus queue load \
-                    shedding percentage should be capped at {max_shedding_pct}%",
+                    shedding percentage should be capped at {MAX_CONSENSUS_LOAD_SHED_PCT}%",
             );
         }
 
@@ -539,46 +542,10 @@ mod tests {
             (20_000, hard_limit, soft_limit), // soft > hard (swapped)
         ] {
             assert_eq!(
-                compute_consensus_load_shedding_percentage(
-                    num_inflight_txs,
-                    soft,
-                    hard,
-                    max_shedding_pct
-                ),
+                compute_consensus_load_shedding_percentage(num_inflight_txs, soft, hard),
                 0,
                 "no shedding expected with misconfigured limits (soft={soft} >= hard={hard}): \
                     consensus queue load shedding percentage should be 0%",
-            );
-        }
-
-        // Edge case: `max_shedding_pct` is 100.
-        for (num_inflight_txs, expected_pct) in
-            [(15_000, 50), (hard_limit, 100), (hard_limit + 1, 100)]
-        {
-            assert_eq!(
-                compute_consensus_load_shedding_percentage(
-                    num_inflight_txs,
-                    soft_limit,
-                    hard_limit,
-                    100,
-                ),
-                expected_pct,
-                "expected consensus queue load shedding percentage to be {expected_pct}%",
-            );
-        }
-
-        // Edge case: `max_shedding_pct` is 0 - never sheds.
-        for num_inflight_txs in [15_000, hard_limit, hard_limit + 1] {
-            assert_eq!(
-                compute_consensus_load_shedding_percentage(
-                    num_inflight_txs,
-                    soft_limit,
-                    hard_limit,
-                    0,
-                ),
-                0,
-                "no shedding expected with max_shedding_pct=0: consensus queue load shedding \
-                    percentage should be 0%",
             );
         }
     }

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -272,35 +272,37 @@ pub fn overload_monitor_accept_tx(
 
 /// Computes the graduated load shedding percentage based on the current value
 /// relative to its hard limit. Returns 0 if `current` is at or below the soft
-/// limit (computed as `hard_limit * start_pct / 100`), linearly scales from 0%
-/// to 100% between soft and hard limits, and returns 100% if `current` is at
-/// or above `hard_limit`.
+/// limit (computed as `hard_limit * soft_limit_pct / 100`), linearly scales
+/// from 0% to 100% between soft and hard limits, and returns 100% if `current`
+/// is at or above `hard_limit`.
 ///
-/// `start_pct` is expected to be in `[0, 100]`. Values above 100 are clamped
-/// to 100 in release builds and trigger a debug assertion in debug builds.
+/// `soft_limit_pct` is expected to be in `[0, 100]`. Values above 100 are
+/// clamped to 100 in release builds and trigger a debug assertion in debug
+/// builds.
 ///
-/// Setting `start_pct = 100` degenerates into a hard binary cutoff: no
+/// Setting `soft_limit_pct = 100` degenerates into a hard binary cutoff: no
 /// shedding below `hard_limit`, full (100%) shedding at and above it.
 ///
-/// NOTE: `soft_limit` uses integer division, so it floors `hard_limit *
-/// start_pct / 100`. This is negligible for typical queue sizes (thousands).
+/// NOTE: `soft_limit` is computed via integer division `hard_limit *
+/// soft_limit_pct / 100`, so it floors. This is negligible for typical
+/// queue sizes (thousands).
 pub(crate) fn compute_graduated_load_shedding_percentage(
     current: usize,
     hard_limit: usize,
-    start_pct: u32,
+    soft_limit_pct: u32,
 ) -> u32 {
     debug_assert!(
-        start_pct <= 100,
-        "start_pct must be <= 100, got {start_pct}"
+        soft_limit_pct <= 100,
+        "soft_limit_pct must be <= 100, got {soft_limit_pct}"
     );
-    // Clamp `start_pct` to 100% to be safe in release builds.
-    let start_pct = start_pct.min(100);
-    // Convert start percentage to absolute soft limit.
-    let soft_limit = hard_limit * start_pct as usize / 100;
+    // Clamp `soft_limit_pct` to 100% to be safe in release builds.
+    let soft_limit_pct = soft_limit_pct.min(100);
+    // Convert soft limit percentage to absolute soft limit.
+    let soft_limit = hard_limit * soft_limit_pct as usize / 100;
 
     // At or above hard limit, shed at maximum percentage.
     // WARN: this hard limit check must come BEFORE the soft limit check.
-    // When `start_pct == 100`, soft_limit == hard_limit, and at `current ==
+    // When `soft_limit_pct == 100`, soft_limit == hard_limit, and at `current ==
     // hard_limit`, we want 100% shedding (binary cutoff behavior), not 0%.
     // Swapping the order would incorrectly return 0 in this degenerate case.
     if current >= hard_limit {
@@ -483,20 +485,20 @@ mod tests {
     }
 
     /// Tests [`compute_graduated_load_shedding_percentage`]:
-    /// - 0% at or below the soft limit (`hard_limit * start_pct / 100`)
+    /// - 0% at or below the soft limit (`hard_limit * soft_limit_pct / 100`)
     /// - linear scaling between soft and hard limits
     /// - 100% at or above the hard limit
-    /// - degenerate cases for `start_pct = 0` and `start_pct = 100`
+    /// - degenerate cases for `soft_limit_pct = 0` and `soft_limit_pct = 100`
     #[test]
     fn test_compute_graduated_load_shedding_percentage() {
         let hard_limit = 20_000;
-        let start_pct = 50;
-        let soft_limit = hard_limit * start_pct as usize / 100; // 10_000
+        let soft_limit_pct = 50;
+        let soft_limit = hard_limit * soft_limit_pct as usize / 100; // 10_000
 
         // Below and at soft limit: no shedding.
         for current in [0, soft_limit - 1, soft_limit] {
             assert_eq!(
-                compute_graduated_load_shedding_percentage(current, hard_limit, start_pct),
+                compute_graduated_load_shedding_percentage(current, hard_limit, soft_limit_pct),
                 0,
                 "no shedding expected at or below soft limit ({current} <= {soft_limit})",
             );
@@ -514,7 +516,7 @@ mod tests {
             (hard_limit - 1, 99),
         ] {
             assert_eq!(
-                compute_graduated_load_shedding_percentage(current, hard_limit, start_pct),
+                compute_graduated_load_shedding_percentage(current, hard_limit, soft_limit_pct),
                 expected_pct,
                 "expected shedding percentage to be {expected_pct}% at current={current}",
             );
@@ -523,45 +525,45 @@ mod tests {
         // At and above hard limit: 100%.
         for current in [hard_limit, hard_limit + 1, 30_000] {
             assert_eq!(
-                compute_graduated_load_shedding_percentage(current, hard_limit, start_pct),
+                compute_graduated_load_shedding_percentage(current, hard_limit, soft_limit_pct),
                 100,
                 "expected 100% shedding at/above hard limit ({current} >= {hard_limit})",
             );
         }
 
-        // Degenerate: start_pct = 100 acts as a binary cutoff:
+        // Degenerate: soft_limit_pct = 100 acts as a binary cutoff:
         // - below hard_limit: 0%; at/above: 100%.
         for current in [0, hard_limit - 1] {
             assert_eq!(
                 compute_graduated_load_shedding_percentage(current, hard_limit, 100),
                 0,
-                "start_pct=100: no shedding expected below hard limit ({current} < {hard_limit})",
+                "soft_limit_pct=100: no shedding expected below hard limit ({current} < {hard_limit})",
             );
         }
         for current in [hard_limit, hard_limit + 1] {
             assert_eq!(
                 compute_graduated_load_shedding_percentage(current, hard_limit, 100),
                 100,
-                "start_pct=100: full shedding expected at/above hard limit ({current} >= \
+                "soft_limit_pct=100: full shedding expected at/above hard limit ({current} >= \
                     {hard_limit})",
             );
         }
 
-        // Degenerate: start_pct = 0 means soft_limit = 0; any current > 0 sheds.
+        // Degenerate: soft_limit_pct = 0 means soft_limit = 0; any current > 0 sheds.
         assert_eq!(
             compute_graduated_load_shedding_percentage(0, hard_limit, 0),
             0,
-            "start_pct=0: at current=0, no shedding expected (current <= soft_limit=0)",
+            "soft_limit_pct=0: at current=0, no shedding expected (current <= soft_limit=0)",
         );
         assert_eq!(
             compute_graduated_load_shedding_percentage(hard_limit / 2, hard_limit, 0),
             50,
-            "start_pct=0: at midpoint of hard_limit, 50% shedding expected",
+            "soft_limit_pct=0: at midpoint of hard_limit, 50% shedding expected",
         );
         assert_eq!(
             compute_graduated_load_shedding_percentage(hard_limit, hard_limit, 0),
             100,
-            "start_pct=0: at hard_limit, 100% shedding expected",
+            "soft_limit_pct=0: at hard_limit, 100% shedding expected",
         );
     }
 

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -333,7 +333,7 @@ mod tests {
     use crate::authority::test_authority_builder::TestAuthorityBuilder;
 
     #[test]
-    pub fn test_authority_overload_info() {
+    fn test_authority_overload_info() {
         let overload_info = AuthorityOverloadInfo::default();
         assert!(!overload_info.is_overload.load(Ordering::Relaxed));
         assert_eq!(
@@ -379,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_calculate_load_shedding_ratio() {
+    fn test_calculate_load_shedding_ratio() {
         assert_eq!(calculate_load_shedding_percentage(95.0, 100.1), 0);
         assert_eq!(calculate_load_shedding_percentage(95.0, 100.0), 2);
         assert_eq!(calculate_load_shedding_percentage(100.0, 100.0), 7);
@@ -390,7 +390,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_check_overload_signals() {
+    fn test_check_overload_signals() {
         let config = AuthorityOverloadConfig {
             execution_queue_latency_hard_limit: Duration::from_secs(10),
             execution_queue_latency_soft_limit: Duration::from_secs(1),
@@ -469,8 +469,205 @@ mod tests {
         );
     }
 
+    /// Tests that the consensus load shedding percentage is 0 below soft limit,
+    /// scales linearly between soft and hard limits, and caps at
+    /// `max_shedding_pct` at and above the hard limit. Also covers
+    /// misconfigured limits and edge cases.
+    #[test]
+    fn test_compute_consensus_load_shedding_percentage() {
+        let soft_limit = 10_000;
+        let hard_limit = 20_000;
+        let max_shedding_pct = 95;
+
+        // Below soft limit: no shedding.
+        // No inflight transactions
+        let num_inflight_txs = 0;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            0
+        );
+        // Just below soft limit (9_999)
+        let num_inflight_txs = soft_limit.checked_sub(1).unwrap();
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            0
+        );
+        // At soft limit (10_000)
+        let num_inflight_txs = soft_limit;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            0
+        );
+
+        // Linear scaling between soft and hard limits.
+        // At 25% of range (12_500): 95 * 2_500 / 10_000 = 23
+        let num_inflight_txs = 12_500;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            23
+        );
+        // At midpoint (15_000): 95 * 5_000 / 10_000 = 47
+        let num_inflight_txs = 15_000;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            47
+        );
+        // At 75% of range (17_500): 95 * 7_500 / 10_000 = 71
+        let num_inflight_txs = 17_500;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            71
+        );
+        // Just below hard limit: 95 * 9_999 / 10_000 = 94
+        let num_inflight_txs = hard_limit.checked_sub(1).unwrap();
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            94
+        );
+
+        // At and above hard limit: capped at `max_shedding_pct`.
+        let num_inflight_txs = hard_limit;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            max_shedding_pct
+        );
+        //
+        let num_inflight_txs = 30_000;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            max_shedding_pct
+        );
+
+        // Edge case: soft >= hard (misconfigured) - no shedding.
+        let num_inflight_txs = 15_000;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                soft_limit,
+                max_shedding_pct
+            ),
+            0
+        );
+        //
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                hard_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            0
+        );
+        //
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                hard_limit,
+                soft_limit,
+                max_shedding_pct
+            ),
+            0
+        );
+
+        // Edge case: `max_shedding_pct` is 100.
+        let max_shedding_pct = 100;
+        // At midpoint (15_000): 100 * 5_000 / 10_000 = 50
+        let num_inflight_txs = 15_000;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            50
+        );
+        // At hard_limit (20_000): 100 * 10_000 / 10_000 = 100
+        let num_inflight_txs = hard_limit;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            100
+        );
+
+        // Edge case: `max_shedding_pct` is 0 - never sheds.
+        let max_shedding_pct = 0;
+        // At midpoint (15_000)
+        let num_inflight_txs = 15_000;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            0
+        );
+        // At hard_limit (20_000)
+        let num_inflight_txs = hard_limit;
+        assert_eq!(
+            compute_consensus_load_shedding_percentage(
+                num_inflight_txs,
+                soft_limit,
+                hard_limit,
+                max_shedding_pct
+            ),
+            0
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
-    pub async fn test_check_authority_overload() {
+    async fn test_check_authority_overload() {
         telemetry_subscribers::init_for_testing();
 
         let config = AuthorityOverloadConfig {
@@ -685,7 +882,7 @@ mod tests {
     // Tests that when request generation rate is slower than execution rate, no
     // requests should be dropped.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    pub async fn test_workload_consistent_no_overload() {
+    async fn test_workload_consistent_no_overload() {
         telemetry_subscribers::init_for_testing();
         run_consistent_workload_test(900.0, 1000.0, 0.0, 0.0).await;
     }
@@ -693,7 +890,7 @@ mod tests {
     // Tests that when request generation rate is slightly above execution rate, a
     // small portion of requests should be dropped.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    pub async fn test_workload_consistent_slightly_overload() {
+    async fn test_workload_consistent_slightly_overload() {
         telemetry_subscribers::init_for_testing();
         // Dropping rate should be around 15%.
         run_consistent_workload_test(1100.0, 1000.0, 0.05, 0.25).await;
@@ -702,7 +899,7 @@ mod tests {
     // Tests that when request generation rate is much higher than execution rate, a
     // large portion of requests should be dropped.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    pub async fn test_workload_consistent_overload() {
+    async fn test_workload_consistent_overload() {
         telemetry_subscribers::init_for_testing();
         // Dropping rate should be around 70%.
         run_consistent_workload_test(3000.0, 1000.0, 0.6, 0.8).await;
@@ -711,7 +908,7 @@ mod tests {
     // Tests that when there is a very short single spike, no request should be
     // dropped.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    pub async fn test_workload_single_spike() {
+    async fn test_workload_single_spike() {
         telemetry_subscribers::init_for_testing();
         let (state, monitor_handle) = start_overload_monitor().await;
 
@@ -750,7 +947,7 @@ mod tests {
     // Tests that when there are regular spikes that keep queueing latency
     // consistently high, overload monitor should kick in and shed load.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    pub async fn test_workload_consistent_short_spike() {
+    async fn test_workload_consistent_short_spike() {
         telemetry_subscribers::init_for_testing();
         let (state, monitor_handle) = start_overload_monitor().await;
 

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -58,7 +58,7 @@ const SEED_UPDATE_DURATION_SECS: u64 = 30;
 /// Maximum shedding percentage for consensus queue length at the hard
 /// limit. Hard-coded to 100%: at or above the consensus queue hard
 /// limit, all transactions are rejected.
-const MAX_CONSENSUS_LOAD_SHED_PCT: u32 = 100;
+pub(super) const MAX_CONSENSUS_LOAD_SHED_PCT: u32 = 100;
 
 // Monitors the overload signals in `authority_state` periodically, and updates
 // its `overload_info` when the signals indicates overload.

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -276,7 +276,7 @@ pub fn overload_monitor_accept_tx(
 /// and caps at `max_shedding_pct` if `num_inflight_txs` is above or equal
 /// `hard_limit`. Used in the certificate-less (white-flag) flow for graduated
 /// pre-consensus load shedding.
-pub fn compute_consensus_load_shedding_percentage(
+pub(crate) fn compute_consensus_load_shedding_percentage(
     num_inflight_txs: usize,
     soft_limit: usize,
     hard_limit: usize,

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -23,7 +23,7 @@ use tokio::time::sleep;
 use tracing::{debug, info};
 use twox_hash::XxHash64;
 
-use crate::authority::AuthorityState;
+use crate::{authority::AuthorityState, consensus_adapter::ConsensusAdapter};
 
 #[derive(Default)]
 pub struct AuthorityOverloadInfo {
@@ -73,6 +73,43 @@ pub async fn overload_monitor(
     }
 
     info!("Shut down system overload monitor.");
+}
+
+/// Periodically refreshes the `consensus_queue_load_shedding_percentage`
+/// metric so it tracks the current consensus queue depth even when no
+/// gRPC traffic is arriving (which would otherwise be the only path that
+/// updates the metric, via `AuthorityState::check_consensus_queue_overload`).
+/// Used only in the certificate-less (pcool / white-flag) mode.
+pub async fn consensus_queue_overload_monitor(
+    authority_state: Weak<AuthorityState>,
+    consensus_adapter: Weak<ConsensusAdapter>,
+    interval: Duration,
+) {
+    info!("Starting consensus queue overload monitor.");
+
+    loop {
+        let (Some(state), Some(adapter)) = (authority_state.upgrade(), consensus_adapter.upgrade())
+        else {
+            // Either `authority_state` or `consensus_adapter` doesn't exist
+            // anymore. Quit monitor.
+            break;
+        };
+
+        let num_inflight_txs = adapter.num_inflight_transactions() as usize;
+        let shedding_pct = compute_graduated_load_shedding_percentage(
+            num_inflight_txs,
+            adapter.max_pending_transactions(),
+            adapter.graduated_load_shedding_soft_limit_pct(),
+        );
+        state
+            .metrics
+            .consensus_queue_load_shedding_percentage
+            .set(shedding_pct as i64);
+
+        sleep(interval).await;
+    }
+
+    info!("Shut down consensus queue overload monitor.");
 }
 
 // Checks authority overload signals, and updates authority's `overload_info`.

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -55,11 +55,6 @@ const ADDITIONAL_LOAD_SHEDDING: f64 = 0.02;
 // be rejected.
 const SEED_UPDATE_DURATION_SECS: u64 = 30;
 
-/// Maximum shedding percentage for consensus queue length at the hard
-/// limit. Hard-coded to 100%: at or above the consensus queue hard
-/// limit, all transactions are rejected.
-pub(super) const MAX_CONSENSUS_LOAD_SHED_PCT: u32 = 100;
-
 // Monitors the overload signals in `authority_state` periodically, and updates
 // its `overload_info` when the signals indicates overload.
 pub async fn overload_monitor(
@@ -275,45 +270,56 @@ pub fn overload_monitor_accept_tx(
     Ok(())
 }
 
-/// Computes the percentage of transactions to shed based on consensus queue
-/// length. Returns 0 if `num_inflight_txs` is below or equal `soft_limit`,
-/// linearly scales to [`MAX_CONSENSUS_LOAD_SHED_PCT`] (100%) between soft
-/// and hard limits, and caps at [`MAX_CONSENSUS_LOAD_SHED_PCT`] if
-/// `num_inflight_txs` is above or equal `hard_limit`. Used in the
-/// certificate-less (white-flag) flow for graduated pre-consensus load
-/// shedding.
-pub(crate) fn compute_consensus_load_shedding_percentage(
-    num_inflight_txs: usize,
-    soft_limit: usize,
+/// Computes the graduated load shedding percentage based on the current value
+/// relative to its hard limit. Returns 0 if `current` is at or below the soft
+/// limit (computed as `hard_limit * start_pct / 100`), linearly scales from 0%
+/// to 100% between soft and hard limits, and returns 100% if `current` is at
+/// or above `hard_limit`.
+///
+/// `start_pct` is expected to be in `[0, 100]`. Values above 100 are clamped
+/// to 100 in release builds and trigger a debug assertion in debug builds.
+///
+/// Setting `start_pct = 100` degenerates into a hard binary cutoff: no
+/// shedding below `hard_limit`, full (100%) shedding at and above it.
+///
+/// NOTE: `soft_limit` uses integer division, so it floors `hard_limit *
+/// start_pct / 100`. This is negligible for typical queue sizes (thousands).
+pub(crate) fn compute_graduated_load_shedding_percentage(
+    current: usize,
     hard_limit: usize,
+    start_pct: u32,
 ) -> u32 {
-    // No shedding below soft limit, or if limits are misconfigured (soft >= hard).
-    if num_inflight_txs <= soft_limit || soft_limit >= hard_limit {
+    debug_assert!(
+        start_pct <= 100,
+        "start_pct must be <= 100, got {start_pct}"
+    );
+    // Clamp `start_pct` to 100% to be safe in release builds.
+    let start_pct = start_pct.min(100);
+    // Convert start percentage to absolute soft limit.
+    let soft_limit = hard_limit * start_pct as usize / 100;
+
+    // At or above hard limit, shed at maximum percentage.
+    // WARN: this hard limit check must come BEFORE the soft limit check.
+    // When `start_pct == 100`, soft_limit == hard_limit, and at `current ==
+    // hard_limit`, we want 100% shedding (binary cutoff behavior), not 0%.
+    // Swapping the order would incorrectly return 0 in this degenerate case.
+    if current >= hard_limit {
+        return 100;
+    }
+
+    // No shedding below or at soft limit.
+    if current <= soft_limit {
         return 0;
     }
 
-    // At or above hard limit, shed at maximum rate. The binary hard cutoff
-    // in check_consensus_overload() serves as a backstop after this.
-    if num_inflight_txs >= hard_limit {
-        return MAX_CONSENSUS_LOAD_SHED_PCT;
-    }
-
-    debug_assert!(
-        hard_limit > soft_limit,
-        "soft_limit >= hard_limit should have returned early above"
-    );
+    // The two early returns above imply that at this point,
+    // `soft_limit < current < hard_limit`, so the following two
+    // subtraction results are guaranteed to be strictly > 0.
     let range = hard_limit - soft_limit;
+    let excess = current - soft_limit;
 
-    debug_assert!(
-        num_inflight_txs > soft_limit,
-        "num_inflight_txs <= soft_limit should have returned early above"
-    );
-    let excess = num_inflight_txs - soft_limit;
-
-    // Linear interpolation: 0% at `soft_limit`, `MAX_CONSENSUS_LOAD_SHED_PCT` at
-    // `hard_limit`.
-    ((excess as u64 * MAX_CONSENSUS_LOAD_SHED_PCT as u64) / range as u64)
-        .min(MAX_CONSENSUS_LOAD_SHED_PCT as u64) as u32
+    // Linear interpolation: 0% at `soft_limit`, 100% at `hard_limit`.
+    (excess * 100 / range) as u32
 }
 
 #[cfg(test)]
@@ -476,26 +482,23 @@ mod tests {
         );
     }
 
-    /// Tests that the consensus load shedding percentage is 0 below soft limit,
-    /// scales linearly between soft and hard limits, and caps at
-    /// [`MAX_CONSENSUS_LOAD_SHED_PCT`] at and above the hard limit. Also covers
-    /// misconfigured limits and edge cases.
+    /// Tests [`compute_graduated_load_shedding_percentage`]:
+    /// - 0% at or below the soft limit (`hard_limit * start_pct / 100`)
+    /// - linear scaling between soft and hard limits
+    /// - 100% at or above the hard limit
+    /// - degenerate cases for `start_pct = 0` and `start_pct = 100`
     #[test]
-    fn test_compute_consensus_load_shedding_percentage() {
-        let soft_limit = 10_000;
+    fn test_compute_graduated_load_shedding_percentage() {
         let hard_limit = 20_000;
+        let start_pct = 50;
+        let soft_limit = hard_limit * start_pct as usize / 100; // 10_000
 
         // Below and at soft limit: no shedding.
-        for num_inflight_txs in [0, soft_limit - 1, soft_limit] {
+        for current in [0, soft_limit - 1, soft_limit] {
             assert_eq!(
-                compute_consensus_load_shedding_percentage(
-                    num_inflight_txs,
-                    soft_limit,
-                    hard_limit,
-                ),
+                compute_graduated_load_shedding_percentage(current, hard_limit, start_pct),
                 0,
-                "no shedding expected below/at soft limit ({num_inflight_txs} <= {soft_limit}): \
-                    consensus queue load shedding percentage should be 0%",
+                "no shedding expected at or below soft limit ({current} <= {soft_limit})",
             );
         }
 
@@ -504,50 +507,62 @@ mod tests {
         //  - At midpoint (15_000):     100 * 5_000 / 10_000 = 50
         //  - At 75% of range (17_500): 100 * 7_500 / 10_000 = 75
         //  - Just below hard limit:    100 * 9_999 / 10_000 = 99
-        for (num_inflight_txs, expected_pct) in [
+        for (current, expected_pct) in [
             (12_500, 25),
             (15_000, 50),
             (17_500, 75),
             (hard_limit - 1, 99),
         ] {
             assert_eq!(
-                compute_consensus_load_shedding_percentage(
-                    num_inflight_txs,
-                    soft_limit,
-                    hard_limit,
-                ),
+                compute_graduated_load_shedding_percentage(current, hard_limit, start_pct),
                 expected_pct,
-                "expected consensus queue load shedding percentage to be {expected_pct}%",
+                "expected shedding percentage to be {expected_pct}% at current={current}",
             );
         }
 
-        // At and above hard limit: capped at `MAX_CONSENSUS_LOAD_SHED_PCT`.
-        for num_inflight_txs in [hard_limit, hard_limit + 1, 30_000] {
+        // At and above hard limit: 100%.
+        for current in [hard_limit, hard_limit + 1, 30_000] {
             assert_eq!(
-                compute_consensus_load_shedding_percentage(
-                    num_inflight_txs,
-                    soft_limit,
-                    hard_limit,
-                ),
-                MAX_CONSENSUS_LOAD_SHED_PCT,
-                "at/above hard limit ({num_inflight_txs} >= {hard_limit}), consensus queue load \
-                    shedding percentage should be capped at {MAX_CONSENSUS_LOAD_SHED_PCT}%",
+                compute_graduated_load_shedding_percentage(current, hard_limit, start_pct),
+                100,
+                "expected 100% shedding at/above hard limit ({current} >= {hard_limit})",
             );
         }
 
-        // Edge case: soft >= hard (misconfigured) - no shedding.
-        for (num_inflight_txs, soft, hard) in [
-            (15_000, soft_limit, soft_limit), // soft == hard
-            (25_000, hard_limit, hard_limit), // soft == hard, at higher value
-            (20_000, hard_limit, soft_limit), // soft > hard (swapped)
-        ] {
+        // Degenerate: start_pct = 100 acts as a binary cutoff:
+        // - below hard_limit: 0%; at/above: 100%.
+        for current in [0, hard_limit - 1] {
             assert_eq!(
-                compute_consensus_load_shedding_percentage(num_inflight_txs, soft, hard),
+                compute_graduated_load_shedding_percentage(current, hard_limit, 100),
                 0,
-                "no shedding expected with misconfigured limits (soft={soft} >= hard={hard}): \
-                    consensus queue load shedding percentage should be 0%",
+                "start_pct=100: no shedding expected below hard limit ({current} < {hard_limit})",
             );
         }
+        for current in [hard_limit, hard_limit + 1] {
+            assert_eq!(
+                compute_graduated_load_shedding_percentage(current, hard_limit, 100),
+                100,
+                "start_pct=100: full shedding expected at/above hard limit ({current} >= \
+                    {hard_limit})",
+            );
+        }
+
+        // Degenerate: start_pct = 0 means soft_limit = 0; any current > 0 sheds.
+        assert_eq!(
+            compute_graduated_load_shedding_percentage(0, hard_limit, 0),
+            0,
+            "start_pct=0: at current=0, no shedding expected (current <= soft_limit=0)",
+        );
+        assert_eq!(
+            compute_graduated_load_shedding_percentage(hard_limit / 2, hard_limit, 0),
+            50,
+            "start_pct=0: at midpoint of hard_limit, 50% shedding expected",
+        );
+        assert_eq!(
+            compute_graduated_load_shedding_percentage(hard_limit, hard_limit, 0),
+            100,
+            "start_pct=0: at hard_limit, 100% shedding expected",
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -229,7 +229,7 @@ fn check_overload_signals(
     (overload_status, load_shedding_percentage)
 }
 
-// Return true if we should reject the txn with `tx_digest`.
+/// Return true if we should reject the txn with `tx_digest`.
 fn should_reject_tx(
     load_shedding_percentage: u32,
     tx_digest: TransactionDigest,
@@ -243,7 +243,7 @@ fn should_reject_tx(
     value % 100 < load_shedding_percentage as u64
 }
 
-// Checks if we can accept the transaction with `tx_digest`.
+/// Checks if we can accept the transaction with `tx_digest`.
 pub fn overload_monitor_accept_tx(
     load_shedding_percentage: u32,
     tx_digest: TransactionDigest,
@@ -268,6 +268,45 @@ pub fn overload_monitor_accept_tx(
         });
     }
     Ok(())
+}
+
+/// Computes the percentage of transactions to shed based on consensus queue
+/// length. Returns 0 if `num_inflight_txs` is below or equal `soft_limit`,
+/// linearly scales to `max_shedding_pct` between soft and hard limits,
+/// and caps at `max_shedding_pct` if `num_inflight_txs` is above or equal
+/// `hard_limit`. Used in the certificate-less (white-flag) flow for graduated
+/// pre-consensus load shedding.
+pub fn compute_consensus_load_shedding_percentage(
+    num_inflight_txs: usize,
+    soft_limit: usize,
+    hard_limit: usize,
+    max_shedding_pct: u32,
+) -> u32 {
+    // No shedding below soft limit, or if limits are misconfigured (soft >= hard).
+    if num_inflight_txs <= soft_limit || soft_limit >= hard_limit {
+        return 0;
+    }
+
+    // At or above hard limit, shed at maximum rate. The binary hard cutoff
+    // in check_consensus_overload() serves as a backstop after this.
+    if num_inflight_txs >= hard_limit {
+        return max_shedding_pct;
+    }
+
+    debug_assert!(
+        hard_limit > soft_limit,
+        "soft_limit >= hard_limit should have returned early above"
+    );
+    let range = hard_limit - soft_limit;
+
+    debug_assert!(
+        num_inflight_txs > soft_limit,
+        "num_inflight_txs <= soft_limit should have returned early above"
+    );
+    let excess = num_inflight_txs - soft_limit;
+
+    // Linear interpolation: 0% at `soft_limit`, `max_shedding_pct` at `hard_limit`.
+    ((excess as u64 * max_shedding_pct as u64) / range as u64).min(max_shedding_pct as u64) as u32
 }
 
 #[cfg(test)]

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -479,191 +479,108 @@ mod tests {
         let hard_limit = 20_000;
         let max_shedding_pct = 95;
 
-        // Below soft limit: no shedding.
-        // No inflight transactions
-        let num_inflight_txs = 0;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            0
-        );
-        // Just below soft limit (9_999)
-        let num_inflight_txs = soft_limit.checked_sub(1).unwrap();
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            0
-        );
-        // At soft limit (10_000)
-        let num_inflight_txs = soft_limit;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            0
-        );
+        // Below and at soft limit: no shedding.
+        for num_inflight_txs in [0, soft_limit - 1, soft_limit] {
+            assert_eq!(
+                compute_consensus_load_shedding_percentage(
+                    num_inflight_txs,
+                    soft_limit,
+                    hard_limit,
+                    max_shedding_pct
+                ),
+                0,
+                "no shedding expected below/at soft limit ({num_inflight_txs} <= {soft_limit}): \
+                    consensus queue load shedding percentage should be 0%",
+            );
+        }
 
-        // Linear scaling between soft and hard limits.
-        // At 25% of range (12_500): 95 * 2_500 / 10_000 = 23
-        let num_inflight_txs = 12_500;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            23
-        );
-        // At midpoint (15_000): 95 * 5_000 / 10_000 = 47
-        let num_inflight_txs = 15_000;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            47
-        );
-        // At 75% of range (17_500): 95 * 7_500 / 10_000 = 71
-        let num_inflight_txs = 17_500;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            71
-        );
-        // Just below hard limit: 95 * 9_999 / 10_000 = 94
-        let num_inflight_txs = hard_limit.checked_sub(1).unwrap();
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            94
-        );
+        // Linear scaling between soft and hard limits:
+        //  - At 25% of range (12_500): 95 * 2_500 / 10_000 = 23
+        //  - At midpoint (15_000):     95 * 5_000 / 10_000 = 47
+        //  - At 75% of range (17_500): 95 * 7_500 / 10_000 = 71
+        //  - Just below hard limit:    95 * 9_999 / 10_000 = 94
+        for (num_inflight_txs, expected_pct) in [
+            (12_500, 23),
+            (15_000, 47),
+            (17_500, 71),
+            (hard_limit - 1, 94),
+        ] {
+            assert_eq!(
+                compute_consensus_load_shedding_percentage(
+                    num_inflight_txs,
+                    soft_limit,
+                    hard_limit,
+                    max_shedding_pct
+                ),
+                expected_pct,
+                "expected consensus queue load shedding percentage to be {expected_pct}%",
+            );
+        }
 
         // At and above hard limit: capped at `max_shedding_pct`.
-        let num_inflight_txs = hard_limit;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            max_shedding_pct
-        );
-        //
-        let num_inflight_txs = 30_000;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            max_shedding_pct
-        );
+        for num_inflight_txs in [hard_limit, hard_limit + 1, 30_000] {
+            assert_eq!(
+                compute_consensus_load_shedding_percentage(
+                    num_inflight_txs,
+                    soft_limit,
+                    hard_limit,
+                    max_shedding_pct
+                ),
+                max_shedding_pct,
+                "at/above hard limit ({num_inflight_txs} >= {hard_limit}), consensus queue load \
+                    shedding percentage should be capped at {max_shedding_pct}%",
+            );
+        }
 
         // Edge case: soft >= hard (misconfigured) - no shedding.
-        let num_inflight_txs = 15_000;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                soft_limit,
-                max_shedding_pct
-            ),
-            0
-        );
-        //
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                hard_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            0
-        );
-        //
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                hard_limit,
-                soft_limit,
-                max_shedding_pct
-            ),
-            0
-        );
+        for (num_inflight_txs, soft, hard) in [
+            (15_000, soft_limit, soft_limit), // soft == hard
+            (25_000, hard_limit, hard_limit), // soft == hard, at higher value
+            (20_000, hard_limit, soft_limit), // soft > hard (swapped)
+        ] {
+            assert_eq!(
+                compute_consensus_load_shedding_percentage(
+                    num_inflight_txs,
+                    soft,
+                    hard,
+                    max_shedding_pct
+                ),
+                0,
+                "no shedding expected with misconfigured limits (soft={soft} >= hard={hard}): \
+                    consensus queue load shedding percentage should be 0%",
+            );
+        }
 
         // Edge case: `max_shedding_pct` is 100.
-        let max_shedding_pct = 100;
-        // At midpoint (15_000): 100 * 5_000 / 10_000 = 50
-        let num_inflight_txs = 15_000;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            50
-        );
-        // At hard_limit (20_000): 100 * 10_000 / 10_000 = 100
-        let num_inflight_txs = hard_limit;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            100
-        );
+        for (num_inflight_txs, expected_pct) in
+            [(15_000, 50), (hard_limit, 100), (hard_limit + 1, 100)]
+        {
+            assert_eq!(
+                compute_consensus_load_shedding_percentage(
+                    num_inflight_txs,
+                    soft_limit,
+                    hard_limit,
+                    100,
+                ),
+                expected_pct,
+                "expected consensus queue load shedding percentage to be {expected_pct}%",
+            );
+        }
 
         // Edge case: `max_shedding_pct` is 0 - never sheds.
-        let max_shedding_pct = 0;
-        // At midpoint (15_000)
-        let num_inflight_txs = 15_000;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            0
-        );
-        // At hard_limit (20_000)
-        let num_inflight_txs = hard_limit;
-        assert_eq!(
-            compute_consensus_load_shedding_percentage(
-                num_inflight_txs,
-                soft_limit,
-                hard_limit,
-                max_shedding_pct
-            ),
-            0
-        );
+        for num_inflight_txs in [15_000, hard_limit, hard_limit + 1] {
+            assert_eq!(
+                compute_consensus_load_shedding_percentage(
+                    num_inflight_txs,
+                    soft_limit,
+                    hard_limit,
+                    0,
+                ),
+                0,
+                "no shedding expected with max_shedding_pct=0: consensus queue load shedding \
+                    percentage should be 0%",
+            );
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -78,8 +78,9 @@ pub async fn overload_monitor(
 /// Periodically refreshes the `consensus_queue_load_shedding_percentage`
 /// metric so it tracks the current consensus queue depth even when no
 /// gRPC traffic is arriving (which would otherwise be the only path that
-/// updates the metric, via `AuthorityState::check_consensus_queue_overload`).
-/// Used only in the certificate-less (pcool / white-flag) mode.
+/// updates the metric, via `check_consensus_queue_graduated_limits` on
+/// `AuthorityState`). Used only in the certificate-less (pcool / white-flag)
+/// mode.
 pub async fn consensus_queue_overload_monitor(
     authority_state: Weak<AuthorityState>,
     consensus_adapter: Weak<ConsensusAdapter>,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -7095,8 +7095,9 @@ async fn test_single_authority_reconfigure() {
 /// - below soft limit: all transactions are accepted
 /// - between soft and hard limit: some transactions are rejected
 /// - at/above hard limit: almost all transactions are rejected
+/// In the certificate flow, graduated load shedding should not run.
 #[tokio::test]
-async fn test_white_flag_pre_consensus_graduated_load_shedding() {
+async fn test_consensus_queue_graduated_load_shedding() {
     telemetry_subscribers::init_for_testing();
 
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
@@ -7141,94 +7142,72 @@ async fn test_white_flag_pre_consensus_graduated_load_shedding() {
     // Does not matter in the white-flag flow.
     let do_authority_overload_check = false;
 
-    // Below soft limit (9_999 < 10_000): all transactions should be accepted.
-    consensus_adapter
-        .set_num_inflight_transactions_for_testing(soft_limit.checked_sub(1).unwrap() as u64);
-    let result = authority_state.check_system_overload(
-        &consensus_adapter,
-        tx.data(),
-        do_authority_overload_check,
-        white_flag_flow_enabled,
-    );
-    assert!(result.is_ok());
+    // Below and at soft limit, all transactions should be accepted.
+    for num_inflight_txs in [0, soft_limit - 1, soft_limit] {
+        consensus_adapter.set_num_inflight_transactions_for_testing(num_inflight_txs as u64);
+        let result = authority_state.check_system_overload(
+            &consensus_adapter,
+            tx.data(),
+            do_authority_overload_check,
+            white_flag_flow_enabled,
+        );
 
-    // At soft limit (10_000): should still be accepted since the soft
-    // boundary is inclusive.
-    consensus_adapter.set_num_inflight_transactions_for_testing(soft_limit as u64);
-    let result = authority_state.check_system_overload(
-        &consensus_adapter,
-        tx.data(),
-        do_authority_overload_check,
-        white_flag_flow_enabled,
-    );
-    assert!(result.is_ok());
+        assert!(
+            result.is_ok(),
+            "no shedding expected below/at soft limit ({num_inflight_txs} <= {soft_limit})",
+        );
+    }
 
-    // Between soft and hard limit (15_000): graduated shedding is active.
-    // shedding_pct = 95 * 5_000 / 10_000 = 47%. Whether this specific tx is
-    // rejected depends on its digest, so we check the metric instead.
-    consensus_adapter.set_num_inflight_transactions_for_testing(15_000);
-    let _ = authority_state.check_system_overload(
-        &consensus_adapter,
-        tx.data(),
-        do_authority_overload_check,
-        white_flag_flow_enabled,
-    );
-    assert_eq!(
-        authority_state
-            .metrics
-            .consensus_queue_load_shedding_percentage
-            .get(),
-        47
-    );
+    // Below, at, and above hard limit: metric should report the graduated
+    // percentage (capped at `max_shedding_pct` at/above hard limit).
+    // At 15_000: 95 * 5_000 / 10_000 = 47%. At/above 20_000: capped at 95%.
+    // Whether a specific tx is rejected depends on its digest, so we check
+    // the metric instead (except for "above hard", where the binary cutoff
+    // rejects deterministically) - `expect_err` variable.
+    for (num_inflight_txs, expected_pct, expect_err) in [
+        (15_000, 47, false),                      // graduated
+        (hard_limit, max_shedding_pct, false),    // at hard limit
+        (hard_limit + 1, max_shedding_pct, true), // above hard limit: binary cutoff rejects
+    ] {
+        consensus_adapter.set_num_inflight_transactions_for_testing(num_inflight_txs as u64);
+        let result = authority_state.check_system_overload(
+            &consensus_adapter,
+            tx.data(),
+            do_authority_overload_check,
+            white_flag_flow_enabled,
+        );
 
-    // At hard limit (20_000): shedding at `max_shedding_pct` (95%). Whether
-    // this specific tx is rejected depends on its digest, so we check the
-    // metric instead.
-    consensus_adapter.set_num_inflight_transactions_for_testing(hard_limit as u64);
-    let _ = authority_state.check_system_overload(
-        &consensus_adapter,
-        tx.data(),
-        do_authority_overload_check,
-        white_flag_flow_enabled,
-    );
-    assert_eq!(
-        authority_state
-            .metrics
-            .consensus_queue_load_shedding_percentage
-            .get(),
-        max_shedding_pct as i64,
-    );
+        assert_eq!(
+            authority_state
+                .metrics
+                .consensus_queue_load_shedding_percentage
+                .get(),
+            expected_pct as i64,
+            "with num_inflight_txs = {num_inflight_txs} and hard_limit = {hard_limit}, expected \
+                consensus queue load shedding percentage metric should be {expected_pct}%",
+        );
 
-    // Above hard limit (20_001): still capped at `max_shedding_pct` (95%), but
-    // tx should be rejected because the hard limit is exceeded and the binary
-    // cutoff kicks in.
-    consensus_adapter
-        .set_num_inflight_transactions_for_testing(hard_limit.checked_add(1).unwrap() as u64);
-    let result = authority_state.check_system_overload(
-        &consensus_adapter,
-        tx.data(),
-        do_authority_overload_check,
-        white_flag_flow_enabled,
-    );
-    assert!(result.is_err());
-    assert_eq!(
-        authority_state
-            .metrics
-            .consensus_queue_load_shedding_percentage
-            .get(),
-        max_shedding_pct as i64,
-    );
+        if expect_err {
+            assert!(
+                result.is_err(),
+                "above hard limit ({num_inflight_txs} > {hard_limit}), transaction should always \
+                    be rejected by the binary hard cutoff"
+            );
+        }
+    }
 
     // Verify that with `white_flag_flow_enabled = false` (certificate flow),
     // the consensus graduated shedding does NOT apply - only the binary
     // hard cutoff runs.
-    consensus_adapter.set_num_inflight_transactions_for_testing(15_000);
+    consensus_adapter.set_num_inflight_transactions_for_testing(hard_limit as u64);
     let result = authority_state.check_system_overload(
         &consensus_adapter,
         tx.data(),
         do_authority_overload_check,
         false, // certificate flow
     );
-    // Should pass because 15_000 < `max_pending_transactions` (20_000).
-    assert!(result.is_ok());
+    assert!(
+        result.is_ok(),
+        "in certificate mode, no graduated shedding expected below/at hard limit",
+    );
 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -68,8 +68,11 @@ use crate::{
     authority_client::{NetworkAuthorityClient, validator::ValidatorAPI},
     authority_server::AuthorityServer,
     checkpoints::CheckpointServiceNoop,
+    consensus_adapter::{
+        ConnectionMonitorStatusForTests, ConsensusAdapterMetrics, MockConsensusClient,
+    },
     consensus_handler::SequencedConsensusTransaction,
-    test_utils::init_state_parameters_from_rng,
+    test_utils::{init_state_parameters_from_rng, make_transfer_object_transaction},
     transaction_input_loader::TransactionInputLoader,
 };
 
@@ -7084,4 +7087,148 @@ async fn test_single_authority_reconfigure() {
     assert_eq!(state.epoch_store_for_testing().epoch(), 0);
     state.reconfigure_for_testing().await;
     assert_eq!(state.epoch_store_for_testing().epoch(), 1);
+}
+
+/// Tests graduated load shedding based on the consensus queue length
+/// in the white-flag (certificate-less) path of
+/// `AuthorityState::check_system_overload()`. Verifies that:
+/// - below soft limit: all transactions are accepted
+/// - between soft and hard limit: some transactions are rejected
+/// - at/above hard limit: almost all transactions are rejected
+#[tokio::test]
+async fn test_white_flag_pre_consensus_graduated_load_shedding() {
+    telemetry_subscribers::init_for_testing();
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object1 = Object::with_owner_for_testing(sender);
+    let gas_object2 = Object::with_owner_for_testing(sender);
+
+    let hard_limit = 20_000;
+    let soft_limit = hard_limit / 2;
+    let max_shedding_pct = 95;
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    authority_state
+        .insert_genesis_objects(&[gas_object1.clone(), gas_object2.clone()])
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        hard_limit,
+        hard_limit / 2,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+        soft_limit,
+        max_shedding_pct,
+    ));
+
+    let (recipient, _): (_, AccountKeyPair) = get_key_pair();
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let tx = make_transfer_object_transaction(
+        gas_object1.compute_object_reference(),
+        gas_object2.compute_object_reference(),
+        sender,
+        &sender_key,
+        recipient,
+        rgp,
+    );
+
+    let white_flag_flow_enabled = true;
+    // Does not matter in the white-flag flow.
+    let do_authority_overload_check = false;
+
+    // Below soft limit (9_999 < 10_000): all transactions should be accepted.
+    consensus_adapter
+        .set_num_inflight_transactions_for_testing(soft_limit.checked_sub(1).unwrap() as u64);
+    let result = authority_state.check_system_overload(
+        &consensus_adapter,
+        tx.data(),
+        do_authority_overload_check,
+        white_flag_flow_enabled,
+    );
+    assert!(result.is_ok());
+
+    // At soft limit (10_000): should still be accepted since the soft
+    // boundary is inclusive.
+    consensus_adapter.set_num_inflight_transactions_for_testing(soft_limit as u64);
+    let result = authority_state.check_system_overload(
+        &consensus_adapter,
+        tx.data(),
+        do_authority_overload_check,
+        white_flag_flow_enabled,
+    );
+    assert!(result.is_ok());
+
+    // Between soft and hard limit (15_000): graduated shedding is active.
+    // shedding_pct = 95 * 5_000 / 10_000 = 47%. Whether this specific tx is
+    // rejected depends on its digest, so we check the metric instead.
+    consensus_adapter.set_num_inflight_transactions_for_testing(15_000);
+    let _ = authority_state.check_system_overload(
+        &consensus_adapter,
+        tx.data(),
+        do_authority_overload_check,
+        white_flag_flow_enabled,
+    );
+    assert_eq!(
+        authority_state
+            .metrics
+            .consensus_queue_load_shedding_percentage
+            .get(),
+        47
+    );
+
+    // At hard limit (20_000): shedding at `max_shedding_pct` (95%). Whether
+    // this specific tx is rejected depends on its digest, so we check the
+    // metric instead.
+    consensus_adapter.set_num_inflight_transactions_for_testing(hard_limit as u64);
+    let _ = authority_state.check_system_overload(
+        &consensus_adapter,
+        tx.data(),
+        do_authority_overload_check,
+        white_flag_flow_enabled,
+    );
+    assert_eq!(
+        authority_state
+            .metrics
+            .consensus_queue_load_shedding_percentage
+            .get(),
+        max_shedding_pct as i64,
+    );
+
+    // Above hard limit (20_001): still capped at `max_shedding_pct` (95%), but
+    // tx should be rejected because the hard limit is exceeded and the binary
+    // cutoff kicks in.
+    consensus_adapter
+        .set_num_inflight_transactions_for_testing(hard_limit.checked_add(1).unwrap() as u64);
+    let result = authority_state.check_system_overload(
+        &consensus_adapter,
+        tx.data(),
+        do_authority_overload_check,
+        white_flag_flow_enabled,
+    );
+    assert!(result.is_err());
+    assert_eq!(
+        authority_state
+            .metrics
+            .consensus_queue_load_shedding_percentage
+            .get(),
+        max_shedding_pct as i64,
+    );
+
+    // Verify that with `white_flag_flow_enabled = false` (certificate flow),
+    // the consensus graduated shedding does NOT apply - only the binary
+    // hard cutoff runs.
+    consensus_adapter.set_num_inflight_transactions_for_testing(15_000);
+    let result = authority_state.check_system_overload(
+        &consensus_adapter,
+        tx.data(),
+        do_authority_overload_check,
+        false, // certificate flow
+    );
+    // Should pass because 15_000 < `max_pending_transactions` (20_000).
+    assert!(result.is_ok());
 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -7124,7 +7124,6 @@ async fn test_consensus_queue_graduated_load_shedding() {
         None,
         ConsensusAdapterMetrics::new_test(),
         soft_limit,
-        max_shedding_pct,
     ));
 
     let (recipient, _): (_, AccountKeyPair) = get_key_pair();

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -7106,7 +7106,7 @@ async fn test_consensus_queue_graduated_load_shedding() {
 
     let hard_limit = 20_000;
     let soft_limit = hard_limit / 2;
-    let max_shedding_pct = 95;
+    let max_shedding_pct = 100;
 
     let authority_state = TestAuthorityBuilder::new().build().await;
     authority_state
@@ -7160,13 +7160,13 @@ async fn test_consensus_queue_graduated_load_shedding() {
 
     // Below, at, and above hard limit: metric should report the graduated
     // percentage (capped at `max_shedding_pct` at/above hard limit).
-    // At 15_000: 95 * 5_000 / 10_000 = 47%. At/above 20_000: capped at 95%.
-    // Whether a specific tx is rejected depends on its digest, so we check
-    // the metric instead (except for "above hard", where the binary cutoff
-    // rejects deterministically) - `expect_err` variable.
+    // At 15_000: 100 * 5_000 / 10_000 = 50%. At/above 20_000: capped at 100%.
+    // At 15_000, whether a specific tx is rejected depends on its digest, so
+    // we check the metric instead. At/above the hard limit, rejection is
+    // deterministic (100% graduated shedding, plus the binary cutoff above).
     for (num_inflight_txs, expected_pct, expect_err) in [
-        (15_000, 47, false),                      // graduated
-        (hard_limit, max_shedding_pct, false),    // at hard limit
+        (15_000, 50, false),                      // graduated, non-deterministic
+        (hard_limit, max_shedding_pct, true),     // at hard limit: 100% shedding
         (hard_limit + 1, max_shedding_pct, true), // above hard limit: binary cutoff rejects
     ] {
         consensus_adapter.set_num_inflight_transactions_for_testing(num_inflight_txs as u64);
@@ -7190,8 +7190,8 @@ async fn test_consensus_queue_graduated_load_shedding() {
         if expect_err {
             assert!(
                 result.is_err(),
-                "above hard limit ({num_inflight_txs} > {hard_limit}), transaction should always \
-                    be rejected by the binary hard cutoff"
+                "at/above hard limit ({num_inflight_txs} >= {hard_limit}), transaction should \
+                    always be rejected (100% graduated shedding, plus binary cutoff above)",
             );
         }
     }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -72,6 +72,7 @@ use crate::{
         ConnectionMonitorStatusForTests, ConsensusAdapterMetrics, MockConsensusClient,
     },
     consensus_handler::SequencedConsensusTransaction,
+    overload_monitor::MAX_CONSENSUS_LOAD_SHED_PCT,
     test_utils::{init_state_parameters_from_rng, make_transfer_object_transaction},
     transaction_input_loader::TransactionInputLoader,
 };
@@ -7091,7 +7092,7 @@ async fn test_single_authority_reconfigure() {
 
 /// Tests graduated load shedding based on the consensus queue length
 /// in the white-flag (certificate-less) path of
-/// `AuthorityState::check_system_overload()`. Verifies that:
+/// [`AuthorityState::check_system_overload`]. Verifies that:
 /// - below soft limit: all transactions are accepted
 /// - between soft and hard limit: some transactions are rejected
 /// - at/above hard limit: almost all transactions are rejected
@@ -7106,7 +7107,6 @@ async fn test_consensus_queue_graduated_load_shedding() {
 
     let hard_limit = 20_000;
     let soft_limit = hard_limit / 2;
-    let max_shedding_pct = 100;
 
     let authority_state = TestAuthorityBuilder::new().build().await;
     authority_state
@@ -7158,15 +7158,15 @@ async fn test_consensus_queue_graduated_load_shedding() {
     }
 
     // Below, at, and above hard limit: metric should report the graduated
-    // percentage (capped at `max_shedding_pct` at/above hard limit).
+    // percentage (capped at `MAX_CONSENSUS_LOAD_SHED_PCT` at/above hard limit).
     // At 15_000: 100 * 5_000 / 10_000 = 50%. At/above 20_000: capped at 100%.
     // At 15_000, whether a specific tx is rejected depends on its digest, so
     // we check the metric instead. At/above the hard limit, rejection is
     // deterministic (100% graduated shedding, plus the binary cutoff above).
     for (num_inflight_txs, expected_pct, expect_err) in [
-        (15_000, 50, false),                      // graduated, non-deterministic
-        (hard_limit, max_shedding_pct, true),     // at hard limit: 100% shedding
-        (hard_limit + 1, max_shedding_pct, true), // above hard limit: binary cutoff rejects
+        (15_000, 50, false),                             // graduated, non-deterministic
+        (hard_limit, MAX_CONSENSUS_LOAD_SHED_PCT, true), // at hard limit: 100% shedding
+        (hard_limit + 1, MAX_CONSENSUS_LOAD_SHED_PCT, true), // above hard limit: 100% shedding
     ] {
         consensus_adapter.set_num_inflight_transactions_for_testing(num_inflight_txs as u64);
         let result = authority_state.check_system_overload(

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -72,7 +72,6 @@ use crate::{
         ConnectionMonitorStatusForTests, ConsensusAdapterMetrics, MockConsensusClient,
     },
     consensus_handler::SequencedConsensusTransaction,
-    overload_monitor::MAX_CONSENSUS_LOAD_SHED_PCT,
     test_utils::{init_state_parameters_from_rng, make_transfer_object_transaction},
     transaction_input_loader::TransactionInputLoader,
 };
@@ -7095,7 +7094,7 @@ async fn test_single_authority_reconfigure() {
 /// [`AuthorityState::check_system_overload`]. Verifies that:
 /// - below soft limit: all transactions are accepted
 /// - between soft and hard limit: some transactions are rejected
-/// - at/above hard limit: almost all transactions are rejected
+/// - at/above hard limit: all transactions are rejected
 /// In the certificate flow, graduated load shedding should not run.
 #[tokio::test]
 async fn test_consensus_queue_graduated_load_shedding() {
@@ -7106,7 +7105,8 @@ async fn test_consensus_queue_graduated_load_shedding() {
     let gas_object2 = Object::with_owner_for_testing(sender);
 
     let hard_limit = 20_000;
-    let soft_limit = hard_limit / 2;
+    let start_pct: u32 = 50;
+    let soft_limit = hard_limit * start_pct as usize / 100;
 
     let authority_state = TestAuthorityBuilder::new().build().await;
     authority_state
@@ -7123,7 +7123,7 @@ async fn test_consensus_queue_graduated_load_shedding() {
         None,
         None,
         ConsensusAdapterMetrics::new_test(),
-        soft_limit,
+        start_pct,
     ));
 
     let (recipient, _): (_, AccountKeyPair) = get_key_pair();
@@ -7158,15 +7158,15 @@ async fn test_consensus_queue_graduated_load_shedding() {
     }
 
     // Below, at, and above hard limit: metric should report the graduated
-    // percentage (capped at `MAX_CONSENSUS_LOAD_SHED_PCT` at/above hard limit).
+    // percentage (capped at 100% at/above hard limit).
     // At 15_000: 100 * 5_000 / 10_000 = 50%. At/above 20_000: capped at 100%.
     // At 15_000, whether a specific tx is rejected depends on its digest, so
     // we check the metric instead. At/above the hard limit, rejection is
     // deterministic (100% graduated shedding, plus the binary cutoff above).
     for (num_inflight_txs, expected_pct, expect_err) in [
-        (15_000, 50, false),                             // graduated, non-deterministic
-        (hard_limit, MAX_CONSENSUS_LOAD_SHED_PCT, true), // at hard limit: 100% shedding
-        (hard_limit + 1, MAX_CONSENSUS_LOAD_SHED_PCT, true), // above hard limit: 100% shedding
+        (15_000, 50, false),         // graduated, non-deterministic
+        (hard_limit, 100, true),     // at hard limit: 100% shedding
+        (hard_limit + 1, 100, true), // above hard limit: 100% shedding
     ] {
         consensus_adapter.set_num_inflight_transactions_for_testing(num_inflight_txs as u64);
         let result = authority_state.check_system_overload(

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -7105,8 +7105,8 @@ async fn test_consensus_queue_graduated_load_shedding() {
     let gas_object2 = Object::with_owner_for_testing(sender);
 
     let hard_limit = 20_000;
-    let start_pct: u32 = 50;
-    let soft_limit = hard_limit * start_pct as usize / 100;
+    let soft_limit_pct: u32 = 50;
+    let soft_limit = hard_limit * soft_limit_pct as usize / 100;
 
     let authority_state = TestAuthorityBuilder::new().build().await;
     authority_state
@@ -7123,7 +7123,7 @@ async fn test_consensus_queue_graduated_load_shedding() {
         None,
         None,
         ConsensusAdapterMetrics::new_test(),
-        start_pct,
+        soft_limit_pct,
     ));
 
     let (recipient, _): (_, AccountKeyPair) = get_key_pair();

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -224,7 +224,7 @@ pub fn make_consensus_adapter_for_test(
         None,
         metrics,
         50_000,
-        95,
+        100,
     ))
 }
 
@@ -536,7 +536,7 @@ async fn submit_recovered_end_of_publish_crash_recovery() {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            95,
+            100,
         ));
 
         adapter.submit_recovered(&epoch_store);
@@ -619,7 +619,7 @@ async fn submit_recovered_end_of_publish_crash_recovery() {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            95,
+            100,
         ));
 
         adapter.submit_recovered(&epoch_store);

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -223,7 +223,7 @@ pub fn make_consensus_adapter_for_test(
         None,
         None,
         metrics,
-        50_000,
+        50,
     ))
 }
 
@@ -534,7 +534,7 @@ async fn submit_recovered_end_of_publish_crash_recovery() {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
-            50_000,
+            50,
         ));
 
         adapter.submit_recovered(&epoch_store);
@@ -616,7 +616,7 @@ async fn submit_recovered_end_of_publish_crash_recovery() {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
-            50_000,
+            50,
         ));
 
         adapter.submit_recovered(&epoch_store);

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -224,7 +224,6 @@ pub fn make_consensus_adapter_for_test(
         None,
         metrics,
         50_000,
-        100,
     ))
 }
 
@@ -536,7 +535,6 @@ async fn submit_recovered_end_of_publish_crash_recovery() {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            100,
         ));
 
         adapter.submit_recovered(&epoch_store);
@@ -619,7 +617,6 @@ async fn submit_recovered_end_of_publish_crash_recovery() {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            100,
         ));
 
         adapter.submit_recovered(&epoch_store);

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -223,6 +223,8 @@ pub fn make_consensus_adapter_for_test(
         None,
         None,
         metrics,
+        50_000,
+        95,
     ))
 }
 
@@ -533,6 +535,8 @@ async fn submit_recovered_end_of_publish_crash_recovery() {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
+            50_000,
+            95,
         ));
 
         adapter.submit_recovered(&epoch_store);
@@ -614,6 +618,8 @@ async fn submit_recovered_end_of_publish_crash_recovery() {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
+            50_000,
+            95,
         ));
 
         adapter.submit_recovered(&epoch_store);

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -741,7 +741,7 @@ async fn test_authority_txn_signing_pushback() {
 
     // Create a validator service around the `authority_state`.
     let epoch_store = authority_state.epoch_store_for_testing();
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -864,7 +864,7 @@ async fn test_authority_txn_execution_pushback() {
         .await;
 
     // Create a validator service around the `authority_state`.
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
     let validator_service = Arc::new(ValidatorService::new_for_tests(

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -39,11 +39,7 @@ use crate::{
         create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
     },
     authority_server::{ValidatorService, ValidatorServiceMetrics},
-    checkpoints::CheckpointStore,
-    consensus_adapter::{
-        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
-        MockConsensusClient,
-    },
+    consensus_adapter::ConsensusAdapter,
     safe_client::SafeClient,
     test_authority_clients::LocalAuthorityClient,
     test_utils::{make_transfer_object_move_transaction, make_transfer_object_transaction},
@@ -745,16 +741,8 @@ async fn test_authority_txn_signing_pushback() {
 
     // Create a validator service around the `authority_state`.
     let epoch_store = authority_state.epoch_store_for_testing();
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
     let validator_service = Arc::new(ValidatorService::new_for_tests(
         authority_state.clone(),
@@ -876,16 +864,8 @@ async fn test_authority_txn_execution_pushback() {
         .await;
 
     // Create a validator service around the `authority_state`.
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
     let validator_service = Arc::new(ValidatorService::new_for_tests(
         authority_state.clone(),

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -103,7 +103,7 @@ async fn test_authority_reject_authority_capabilities() {
         .await;
 
     // Create a validator service around the `authority_state`.
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -202,7 +202,7 @@ async fn test_handle_capability_notification_v1_feature_disabled() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -253,7 +253,7 @@ async fn test_get_checkpoint_happy_path() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -411,7 +411,7 @@ async fn test_v2_submit_tx_success() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -475,7 +475,7 @@ async fn test_v2_submit_tx_invalid_signature() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -535,7 +535,7 @@ async fn test_v2_submit_tx_feature_flag_disabled() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -594,7 +594,7 @@ async fn test_v2_submit_tx_already_executed() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -654,7 +654,7 @@ async fn test_v2_submit_tx_multiple_transactions() {
     let (authority_state, pkg_ref) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_id1), (sender, gas_id2)]).await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -707,7 +707,7 @@ async fn test_v2_submit_tx_invalid_transaction() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -771,7 +771,7 @@ async fn test_v2_submit_tx_gas_object_validation() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -828,7 +828,7 @@ async fn test_v2_submit_tx_different_gas_prices_accepted() {
     let (authority_state, pkg_ref) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_id1), (sender, gas_id2)]).await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -905,7 +905,7 @@ async fn test_v2_submit_tx_oversized_transaction() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1032,7 +1032,7 @@ async fn test_v2_get_tx_status_already_executed() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1107,7 +1107,7 @@ async fn test_v2_get_tx_status_already_executed_with_details() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1180,7 +1180,7 @@ async fn test_v2_get_tx_status_multiple_queries() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1265,7 +1265,7 @@ async fn test_v2_get_tx_status_too_many_queries() {
 
     let authority_state = TestAuthorityBuilder::new().build().await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1301,7 +1301,7 @@ async fn test_v2_get_tx_status_empty_queries_ping() {
 
     let authority_state = TestAuthorityBuilder::new().build().await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1331,7 +1331,7 @@ async fn test_v2_get_tx_status_dropped_digest_rejected() {
 
     let authority_state = TestAuthorityBuilder::new().build().await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1375,7 +1375,7 @@ async fn test_v2_get_tx_status_unknown_digest_expires() {
 
     let authority_state = TestAuthorityBuilder::new().build().await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1431,7 +1431,7 @@ async fn test_v2_notify_capabilities_reject_unauthorized() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 
@@ -1512,7 +1512,7 @@ async fn test_v2_notify_capabilities_feature_disabled() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
         authority_state.name,
     ));
 

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -44,11 +44,7 @@ use crate::{
     },
     authority_client::{NetworkAuthorityClient, validator::ValidatorAPI},
     authority_server::{AuthorityServer, ValidatorServiceMetrics, make_tonic_request_for_testing},
-    checkpoints::CheckpointStore,
-    consensus_adapter::{
-        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
-        MockConsensusClient,
-    },
+    consensus_adapter::ConsensusAdapter,
 };
 
 // This is the most basic example of how to test the server logic
@@ -107,16 +103,8 @@ async fn test_authority_reject_authority_capabilities() {
         .await;
 
     // Create a validator service around the `authority_state`.
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     // Create the validator service that will handle capability notifications
@@ -214,16 +202,8 @@ async fn test_handle_capability_notification_v1_feature_disabled() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -273,16 +253,8 @@ async fn test_get_checkpoint_happy_path() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -439,16 +411,8 @@ async fn test_v2_submit_tx_success() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -511,16 +475,8 @@ async fn test_v2_submit_tx_invalid_signature() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -579,16 +535,8 @@ async fn test_v2_submit_tx_feature_flag_disabled() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -646,16 +594,8 @@ async fn test_v2_submit_tx_already_executed() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -714,16 +654,8 @@ async fn test_v2_submit_tx_multiple_transactions() {
     let (authority_state, pkg_ref) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_id1), (sender, gas_id2)]).await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -775,16 +707,8 @@ async fn test_v2_submit_tx_invalid_transaction() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -847,16 +771,8 @@ async fn test_v2_submit_tx_gas_object_validation() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -912,16 +828,8 @@ async fn test_v2_submit_tx_different_gas_prices_accepted() {
     let (authority_state, pkg_ref) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_id1), (sender, gas_id2)]).await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -997,16 +905,8 @@ async fn test_v2_submit_tx_oversized_transaction() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -1132,16 +1032,8 @@ async fn test_v2_get_tx_status_already_executed() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -1215,16 +1107,8 @@ async fn test_v2_get_tx_status_already_executed_with_details() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -1296,16 +1180,8 @@ async fn test_v2_get_tx_status_multiple_queries() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -1389,16 +1265,8 @@ async fn test_v2_get_tx_status_too_many_queries() {
 
     let authority_state = TestAuthorityBuilder::new().build().await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -1433,16 +1301,8 @@ async fn test_v2_get_tx_status_empty_queries_ping() {
 
     let authority_state = TestAuthorityBuilder::new().build().await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -1471,16 +1331,8 @@ async fn test_v2_get_tx_status_dropped_digest_rejected() {
 
     let authority_state = TestAuthorityBuilder::new().build().await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let dropped_digest = iota_types::digests::TransactionDigest::random();
@@ -1523,16 +1375,8 @@ async fn test_v2_get_tx_status_unknown_digest_expires() {
 
     let authority_state = TestAuthorityBuilder::new().build().await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -1587,16 +1431,8 @@ async fn test_v2_notify_capabilities_reject_unauthorized() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(
@@ -1676,16 +1512,8 @@ async fn test_v2_notify_capabilities_feature_disabled() {
         .build()
         .await;
 
-    let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockConsensusClient::new()),
-        CheckpointStore::new_for_tests(),
+    let consensus_adapter = Arc::new(ConsensusAdapter::with_authority_name_for_testing(
         authority_state.name,
-        Arc::new(ConnectionMonitorStatusForTests {}),
-        100_000,
-        100_000,
-        None,
-        None,
-        ConsensusAdapterMetrics::new_test(),
     ));
 
     let validator_service = Arc::new(ValidatorService::new_for_tests(

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -72,7 +72,7 @@ use iota_core::{
     grpc_indexes::{GRPC_INDEXES_DIR, GrpcIndexesStore},
     jsonrpc_index::IndexStore,
     module_cache_metrics::ResolverMetrics,
-    overload_monitor::overload_monitor,
+    overload_monitor::{consensus_queue_overload_monitor, overload_monitor},
     safe_client::SafeClientMetricsBase,
     signature_verifier::SignatureVerifierMetrics,
     storage::{GrpcReadStore, RocksDbStore},
@@ -159,6 +159,11 @@ pub mod metrics;
 pub struct ValidatorComponents {
     validator_server_handle: SpawnOnce,
     validator_overload_monitor_handle: Option<JoinHandle<()>>,
+    /// Handle for the consensus queue overload monitor task, present only
+    /// when the certificate-less (pcool / white-flag) flow is enabled. The
+    /// task self-terminates via `Weak` references; this handle exists purely
+    /// for ownership clarity.
+    consensus_queue_overload_monitor_handle: Option<JoinHandle<()>>,
     /// Handle for the soft-lock expiry sweep task. The task self-terminates
     /// via a `Weak` reference; this handle exists purely for ownership clarity.
     soft_lock_sweep_handle: JoinHandle<()>,
@@ -1224,6 +1229,27 @@ impl IotaNode {
             None
         };
 
+        // Starts a monitor that periodically refreshes the
+        // `consensus_queue_load_shedding_percentage` metric. Without this, the
+        // metric goes stale once gRPC traffic stops (the only other update
+        // path is `AuthorityState::check_consensus_queue_overload`, called on
+        // each inbound tx). Used in the certificate-less (pcool / white-flag)
+        // mode.
+        let consensus_queue_overload_monitor_handle =
+            if epoch_store.protocol_config().enable_white_flag_flow() {
+                let consensus_queue_monitor_authority_state = Arc::downgrade(&state);
+                let consensus_queue_monitor_consensus_adapter = Arc::downgrade(&consensus_adapter);
+                let consensus_queue_monitor_interval =
+                    config.authority_overload_config.overload_monitor_interval;
+                Some(spawn_monitored_task!(consensus_queue_overload_monitor(
+                    consensus_queue_monitor_authority_state,
+                    consensus_queue_monitor_consensus_adapter,
+                    consensus_queue_monitor_interval,
+                )))
+            } else {
+                None
+            };
+
         Self::start_epoch_specific_validator_components(
             &config,
             state.clone(),
@@ -1239,6 +1265,7 @@ impl IotaNode {
             soft_locks,
             validator_server_handle,
             validator_overload_monitor_handle,
+            consensus_queue_overload_monitor_handle,
             soft_lock_sweep_handle,
             checkpoint_metrics,
             iota_tx_validator_metrics,
@@ -1264,6 +1291,7 @@ impl IotaNode {
         soft_locks: Arc<PreConsensusSoftLocks>,
         validator_server_handle: SpawnOnce,
         validator_overload_monitor_handle: Option<JoinHandle<()>>,
+        consensus_queue_overload_monitor_handle: Option<JoinHandle<()>>,
         soft_lock_sweep_handle: JoinHandle<()>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
         iota_tx_validator_metrics: Arc<IotaTxValidatorMetrics>,
@@ -1338,6 +1366,7 @@ impl IotaNode {
         Ok(ValidatorComponents {
             validator_server_handle,
             validator_overload_monitor_handle,
+            consensus_queue_overload_monitor_handle,
             soft_lock_sweep_handle,
             consensus_manager,
             consensus_store_pruner,
@@ -1831,6 +1860,7 @@ impl IotaNode {
             let new_validator_components = if let Some(ValidatorComponents {
                 validator_server_handle,
                 validator_overload_monitor_handle,
+                consensus_queue_overload_monitor_handle,
                 soft_lock_sweep_handle,
                 consensus_manager,
                 consensus_store_pruner,
@@ -1895,6 +1925,7 @@ impl IotaNode {
                             soft_locks,
                             validator_server_handle,
                             validator_overload_monitor_handle,
+                            consensus_queue_overload_monitor_handle,
                             soft_lock_sweep_handle,
                             checkpoint_metrics,
                             iota_tx_validator_metrics,

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1427,7 +1427,7 @@ impl IotaNode {
             consensus_config.max_submit_position,
             consensus_config.submit_delay_step_override(),
             ca_metrics,
-            consensus_config.graduated_load_shed_start_pct(),
+            consensus_config.graduated_load_shedding_soft_limit_pct(),
         )
     }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1428,7 +1428,6 @@ impl IotaNode {
             consensus_config.submit_delay_step_override(),
             ca_metrics,
             consensus_config.graduated_load_shedding_soft_limit(),
-            consensus_config.graduated_load_shedding_max_percentage(),
         )
     }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1232,7 +1232,7 @@ impl IotaNode {
         // Starts a monitor that periodically refreshes the
         // `consensus_queue_load_shedding_percentage` metric. Without this, the
         // metric goes stale once gRPC traffic stops (the only other update
-        // path is `AuthorityState::check_consensus_queue_overload`, called on
+        // path is `AuthorityState::check_consensus_queue_graduated_limits`, called on
         // each inbound tx). Used in the certificate-less (pcool / white-flag)
         // mode.
         let consensus_queue_overload_monitor_handle =

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1427,6 +1427,8 @@ impl IotaNode {
             consensus_config.max_submit_position,
             consensus_config.submit_delay_step_override(),
             ca_metrics,
+            consensus_config.graduated_load_shedding_soft_limit(),
+            consensus_config.graduated_load_shedding_max_percentage(),
         )
     }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1427,7 +1427,7 @@ impl IotaNode {
             consensus_config.max_submit_position,
             consensus_config.submit_delay_step_override(),
             ca_metrics,
-            consensus_config.graduated_load_shedding_soft_limit(),
+            consensus_config.graduated_load_shed_start_pct(),
         )
     }
 

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -72,7 +72,7 @@ impl SingleValidator {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
-            50_000,
+            50,
         ));
         // TODO: for validator benchmarking purposes, we should allow for traffic
         // control to be configurable and introduce traffic control benchmarks

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -73,7 +73,6 @@ impl SingleValidator {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            100,
         ));
         // TODO: for validator benchmarking purposes, we should allow for traffic
         // control to be configurable and introduce traffic control benchmarks

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -72,6 +72,8 @@ impl SingleValidator {
             None,
             None,
             ConsensusAdapterMetrics::new_test(),
+            50_000,
+            95,
         ));
         // TODO: for validator benchmarking purposes, we should allow for traffic
         // control to be configurable and introduce traffic control benchmarks

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -73,7 +73,7 @@ impl SingleValidator {
             None,
             ConsensusAdapterMetrics::new_test(),
             50_000,
-            95,
+            100,
         ));
         // TODO: for validator benchmarking purposes, we should allow for traffic
         // control to be configurable and introduce traffic control benchmarks

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -158,7 +158,6 @@ impl ValidatorConfigBuilder {
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
             parameters: Default::default(),
             graduated_load_shedding_soft_limit: Default::default(),
-            graduated_load_shedding_max_percentage: Default::default(),
         };
 
         let p2p_config = P2pConfig {

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -157,6 +157,8 @@ impl ValidatorConfigBuilder {
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
             parameters: Default::default(),
+            graduated_load_shedding_soft_limit: Default::default(),
+            graduated_load_shedding_max_percentage: Default::default(),
         };
 
         let p2p_config = P2pConfig {

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -157,7 +157,7 @@ impl ValidatorConfigBuilder {
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
             parameters: Default::default(),
-            graduated_load_shed_start_pct: Default::default(),
+            graduated_load_shedding_soft_limit_pct: Default::default(),
         };
 
         let p2p_config = P2pConfig {

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -157,7 +157,7 @@ impl ValidatorConfigBuilder {
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
             parameters: Default::default(),
-            graduated_load_shedding_soft_limit: Default::default(),
+            graduated_load_shed_start_pct: Default::default(),
         };
 
         let p2p_config = P2pConfig {


### PR DESCRIPTION
 # Description of change

This PR implements the new graduated consensus queue load shedding for the white-flag flow. The core function that calculates the graduated consensus load shedding percentage is `compute_graduated_load_shedding_percentage()`.

### Summary of changes:

- Added a white-flag flow gate to `AuthorityState::check_system_overload()`:
  - In certificate-less mode, it only checks consensus overload. Execution overload checks will be post-consensus and implemented separately.
  - In certificate mode, it runs all existing checks (authority overload, execution queue, consensus queue, and writeback cache).
- New metric `consensus_queue_load_shedding_percentage` in `AuthorityMetrics`.
- Added `AuthorityState::check_consensus_queue_graduated_limits()` that calls `compute_graduated_load_shedding_percentage()`, sets the `consensus_queue_load_shedding_percentage` metric, and decides how to reject: probabilistic rejection (shedding percentage < 100%) returns `ValidatorOverloadedRetryAfter { retry_after_secs: 30 }` via `overload_monitor_accept_tx()`; unconditional rejection (shedding percentage >= 100%) returns `TooManyTransactionsPendingConsensus`.
- Added `consensus_queue_overload_monitor()` (in `overload_monitor.rs`), spawned by `iota-node` only when the white-flag protocol flag is enabled. Periodically refreshes the `consensus_queue_load_shedding_percentage` metric so it tracks queue length even when no gRPC traffic is arriving. Handle is plumbed through `ValidatorComponents` and across epoch reconfig.
- New field to `ConsensusConfig` and `ConsensusAdapter: graduated_load_shedding_soft_limit_pct` (defaults to 50, meaning graduated shedding starts at 50% of the hard limit). The hard limit matches the existing `max_pending_transactions` (default 20_000).
- Renamed `ConsensusAdapter::check_limits()` to `check_consensus_hard_limits()` (private bool helper).

### Other indirectly related changes:

- In `ValidatorService`, replaced stale references to the non-existent `handle_submit_transaction(s)_impl` with `submit_tx` (`ValidatorV2` service).
- Fixed docstrings on fields of `AuthorityOverloadConfig`.
- Added test-only `ConsensusAdapter::new_for_testing_with_authority_name()` which constructs a new consensus adapter frequently used in many tests.
- Removed unnecessary pub visibility in `overload_monitor.rs` tests.
- Added docstrings to `ValidatorService`, `ConsensusAdapter`, and `AuthorityState` methods related to this PR.
- In `ValidatorService`, split long string literals into multiple lines.

## Links to any relevant issues

Closes #11035.

## How the change has been tested

```shell
cargo test -p iota-core test_compute_graduated_load_shedding_percentage
cargo test -p iota-core test_consensus_queue_graduated_load_shedding 
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes