### PR TITLE
fix(iota-core): add protocol-version-aware validation for UserTransactionV1

### DIFF
--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -96,6 +96,12 @@ impl IotaTxValidator {
                 }
 
                 ConsensusTransactionKind::UserTransactionV1(transaction) => {
+                    if !self.epoch_store.protocol_config().enable_white_flag_flow() {
+                        return Err(IotaError::UnsupportedFeature {
+                            error: "UserTransactionV1 not supported at current protocol version"
+                                .into(),
+                        });
+                    }
                     // TODO: Batch signature verification for UserTransactionV1.
                     //  For now verify individually, but this should be batched for performance
                     //  similar to how certificates are batch-verified above.
@@ -330,20 +336,47 @@ mod tests {
     ///
     /// The exhaustive match forces a compile error when new variants are added,
     /// so the developer must explicitly map each variant to its gating flag.
+    ///
+    /// NOTE: This test is primarily useful for variants that are under
+    /// development or not yet fully rolled out on all networks. Once all
+    /// feature-gated variants are enabled on every network, this test can be
+    /// ignored — its value lies in catching missing gates during the upgrade
+    /// window between code deployment and protocol activation.
     #[sim_test]
     async fn validate_transactions_feature_gating() {
         use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
         use iota_protocol_config::ProtocolConfig;
-        use iota_types::crypto::AuthorityPublicKeyBytes;
+        use iota_types::{
+            base_types::ObjectID,
+            crypto::{AccountKeyPair, AuthorityPublicKeyBytes, deterministic_random_account_key},
+        };
+
+        use crate::test_utils::make_transfer_iota_transaction;
+
+        let (sender, sender_key): (_, AccountKeyPair) = deterministic_random_account_key();
+        let gas_object_id = ObjectID::random();
+        let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
 
         let network_config =
-            iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir().build();
+            iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                .with_objects(vec![gas_object.clone()])
+                .build();
 
         let state = TestAuthorityBuilder::new()
             .with_network_config(&network_config, 0)
             .with_chain_override(Chain::Mainnet)
             .build()
             .await;
+
+        let rgp = state.epoch_store_for_testing().reference_gas_price();
+        let gas_ref = state
+            .get_object(&gas_object_id)
+            .await
+            .unwrap()
+            .compute_object_reference();
+        let recipient = iota_types::crypto::get_key_pair::<AccountKeyPair>().0;
+        let signed_tx =
+            make_transfer_iota_transaction(gas_ref, recipient, None, sender, &sender_key, rgp);
 
         let metrics = IotaTxValidatorMetrics::new(&Default::default());
         let validator = IotaTxValidator::new(
@@ -378,14 +411,20 @@ mod tests {
                 ConsensusTransactionKind::MisbehaviorReport(_, _, _) => {
                     Some(config.calculate_validator_scores())
                 }
+
+                // Gated behind `enable_white_flag_flow`.
+                ConsensusTransactionKind::UserTransactionV1(_) => {
+                    Some(config.enable_white_flag_flow())
+                }
             }
         }
 
-        // Variants that can be validated without signature verification setup.
+        // Variants that can be validated without signature verification setup
+        // (or that carry a valid signature, like UserTransactionV1).
         // CertifiedTransaction, CheckpointSignature, and
-        // SignedCapabilityNotificationV1 are excluded because they require valid
-        // cryptographic signatures and would fail before reaching the feature
-        // gate check; their gating is verified by the exhaustive match above.
+        // SignedCapabilityNotificationV1 are excluded because they require
+        // authority signatures; their gating is verified by the exhaustive
+        // match above.
         let testable_variants: Vec<(&str, ConsensusTransactionKind)> = vec![
             (
                 "EndOfPublish",
@@ -438,6 +477,10 @@ mod tests {
                     }),
                     0,
                 ),
+            ),
+            (
+                "UserTransactionV1",
+                ConsensusTransactionKind::UserTransactionV1(Box::new(signed_tx)),
             ),
         ];
 


### PR DESCRIPTION
# Description of change

Adds a feature-flag check for `UserTransactionV1` in `validate_transactions()` (consensus block verification) to prevent consensus forks during the protocol upgrade window.

Without this check, during the upgrade window when between f+1 and 2f+1 validators have upgraded code but the protocol version hasn't bumped yet, a malicious validator could craft a block containing `UserTransactionV1`. Upgraded validators would accept it (BCS deserializes fine), while non-upgraded validators would reject it (unknown BCS variant), causing a consensus fork.

The fix mirrors the existing pattern used for `MisbehaviorReport`:
- Check `enable_white_flag_flow()` before signature verification
- Return `UnsupportedFeature` error when the flag is disabled

Also extends the `validate_transactions_feature_gating` test with a properly signed `UserTransactionV1` variant, ensuring the test remains valid regardless of whether the feature flag is enabled on the current network.

## Links to any relevant issues

Closes #11061

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes