### PR TITLE
fix(iota-indexer): [cherry-pick] resolve all objects needed for calculating balance changes in dry run

### DIFF
--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use fastcrypto::encoding::Base64;
@@ -10,7 +10,9 @@ use futures::{FutureExt, TryFutureExt};
 use iota_grpc_client::Client as GrpcClient;
 use iota_grpc_types::field::{FieldMask, FieldMaskUtil};
 use iota_json::IotaJsonValue;
-use iota_json_rpc::IotaRpcModule;
+use iota_json_rpc::{
+    IotaRpcModule, ObjectProvider, get_balance_changes_from_effect, get_object_changes,
+};
 use iota_json_rpc_api::WriteApiServer;
 use iota_json_rpc_types::{
     DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, IotaMoveViewCallResults,
@@ -22,15 +24,17 @@ use iota_package_resolver::{PackageStore, Resolver};
 use iota_protocol_config::Chain;
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
-    base_types::IotaAddress,
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
+    digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::ExecutionError,
     iota_serde::BigInt,
+    object::{Object, PastObjectRead},
     quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,
     transaction::{
-        GasData, SenderSignedData, TransactionData, TransactionDataV1, TransactionExpiration,
-        TransactionKind,
+        GasData, SenderSignedData, TransactionData, TransactionDataAPI, TransactionDataV1,
+        TransactionExpiration, TransactionKind,
     },
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
@@ -38,13 +42,12 @@ use jsonrpsee::{RpcModule, core::RpcResult};
 use crate::{
     apis::error::Error as ApiError,
     errors::{IndexerError, IndexerResult},
-    ingestion::primary::prepare::InMemTxChanges,
-    metrics::IndexerMetrics,
+    ingestion::primary::prepare::InMemObjectCache,
     models::transactions::tx_events_to_iota_tx_events,
     optimistic_indexing::OptimisticTransactionExecutor,
     read::IndexerReader,
     store::package_resolver::IndexerStorePackageResolver,
-    types::{IotaTransactionBlockResponseWithOptions, grpc_conversion},
+    types::{IndexedObjectChange, IotaTransactionBlockResponseWithOptions, grpc_conversion},
 };
 
 // As an optimization, we're trying to request only the fields we actually need.
@@ -79,6 +82,7 @@ pub struct WriteApi {
     fullnode_grpc_client: GrpcClient,
     transaction_builder: TransactionBuilder,
     package_resolver: Arc<Resolver<IndexerStorePackageResolver>>,
+    reader: Arc<IndexerReader>,
 }
 
 #[derive(Clone)]
@@ -92,6 +96,7 @@ impl WriteApi {
         let package_resolver = IndexerStorePackageResolver::new(reader.get_pool());
         let data_reader = Arc::new(reader);
         Self {
+            reader: data_reader.clone(),
             fullnode_grpc_client,
             transaction_builder: TransactionBuilder::new(data_reader),
             package_resolver: Arc::new(Resolver::new(package_resolver)),
@@ -148,8 +153,7 @@ impl WriteApi {
 
         let tx_events = TransactionEvents::try_from(executed_transaction.events()?.events()?)?;
 
-        let in_mem_tx_changes =
-            InMemTxChanges::new(&objects, IndexerMetrics::new(&Default::default()));
+        let in_mem_tx_changes = TxObjectResolver::new(&objects, self.reader.clone());
 
         // as a minor optimization we will run concurrently the following four futures
         let fut1 = in_mem_tx_changes
@@ -517,5 +521,127 @@ impl IotaRpcModule for OptimisticWriteApi {
 
     fn rpc_doc_module() -> Module {
         iota_json_rpc_api::WriteApiOpenRpc::module_doc()
+    }
+}
+
+/// Resolves balance and object changes in dry_run.
+///
+/// Checks the in-memory cache (from the simulate
+/// response) first, then falls back to the indexer's `objects` table for
+/// dynamically loaded objects not included in the response.
+pub struct TxObjectResolver {
+    object_cache: InMemObjectCache,
+    reader: Arc<IndexerReader>,
+}
+
+impl TxObjectResolver {
+    pub fn new(objects: &[&Object], reader: Arc<IndexerReader>) -> Self {
+        let mut object_cache = InMemObjectCache::new();
+        for obj in objects {
+            object_cache.insert_object(<&Object>::clone(obj).clone());
+        }
+        Self {
+            object_cache,
+            reader,
+        }
+    }
+
+    async fn get_past_object_read_with_retry(
+        &self,
+        id: ObjectID,
+        version: SequenceNumber,
+    ) -> IndexerResult<PastObjectRead> {
+        let backoff = backoff::ExponentialBackoff {
+            initial_interval: Duration::from_millis(100),
+            max_elapsed_time: Some(Duration::from_secs(3)),
+            multiplier: 2.0,
+            ..Default::default()
+        };
+
+        backoff::future::retry(backoff, || async {
+            self.reader
+                .get_past_object_read_with_fallback(id, version, false)
+                .await
+                .map_err(backoff::Error::transient)
+        })
+        .await
+    }
+
+    pub(crate) async fn get_changes(
+        &self,
+        tx: &TransactionData,
+        effects: &TransactionEffects,
+        tx_digest: &TransactionDigest,
+    ) -> IndexerResult<(
+        Vec<iota_json_rpc_types::BalanceChange>,
+        Vec<IndexedObjectChange>,
+    )> {
+        let object_changes: Vec<_> = get_object_changes(
+            self,
+            tx.sender(),
+            effects.modified_at_versions(),
+            effects.all_changed_objects(),
+            effects.all_removed_objects(),
+        )
+        .await?
+        .into_iter()
+        .map(IndexedObjectChange::from)
+        .collect();
+        let balance_changes = get_balance_changes_from_effect(
+            self,
+            effects,
+            tx.input_objects().unwrap_or_else(|e| {
+                panic!("checkpointed tx {tx_digest:?} has invalid input objects: {e}")
+            }),
+            None,
+        )
+        .await?;
+        Ok((balance_changes, object_changes))
+    }
+}
+
+#[async_trait]
+impl ObjectProvider for TxObjectResolver {
+    type Error = IndexerError;
+
+    async fn get_object(
+        &self,
+        id: &ObjectID,
+        version: &SequenceNumber,
+    ) -> Result<Object, Self::Error> {
+        // try in-memory cache first
+        if let Some(o) = self.object_cache.get(id, Some(version)) {
+            return Ok(o.clone());
+        }
+
+        let past_read = self.get_past_object_read_with_retry(*id, *version).await?;
+
+        past_read.into_object().map_err(|e| {
+            IndexerError::Generic(format!(
+                "object {id} at version {version} not found in cache or indexer DB: {e}"
+            ))
+        })
+    }
+
+    async fn find_object_lt_or_eq_version(
+        &self,
+        id: &ObjectID,
+        version: &SequenceNumber,
+    ) -> Result<Option<Object>, Self::Error> {
+        // try exact version in cache
+        if let Some(o) = self.object_cache.get(id, Some(version)) {
+            return Ok(Some(o.clone()));
+        }
+
+        // try latest in cache
+        if let Some(o) = self.object_cache.get(id, None) {
+            if o.version() <= *version {
+                return Ok(Some(o.clone()));
+            }
+        }
+
+        self.get_past_object_read_with_retry(*id, *version)
+            .await
+            .map(|past_read| past_read.into_object().ok())
     }
 }

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -15,7 +15,8 @@ use iota_indexer::{
 };
 use iota_json::{call_arg, call_args, type_args};
 use iota_json_rpc_api::{
-    CoinReadApiClient, IndexerApiClient, ReadApiClient, TransactionBuilderClient, WriteApiClient,
+    CoinReadApiClient, GovernanceReadApiClient, IndexerApiClient, ReadApiClient,
+    TransactionBuilderClient, WriteApiClient,
 };
 use iota_json_rpc_types::{
     IotaExecutionStatus, IotaMoveStruct, IotaMoveValue, IotaObjectDataOptions,
@@ -1426,5 +1427,65 @@ fn clever_errors() {
             panic!("transaction should have failed");
         };
         assert_eq!(error, &expected_error);
+    });
+}
+
+#[test]
+fn dry_run_request_add_stake() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+        let (sender, _key_pair): (_, AccountKeyPair) = get_key_pair();
+
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(NANOS_PER_IOTA * 10),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+
+        let coin_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(NANOS_PER_IOTA * 2),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, coin_ref.0, coin_ref.1).await;
+
+        let validator = client
+            .get_latest_iota_system_state_v2()
+            .await
+            .unwrap()
+            .active_validators()[0]
+            .iota_address;
+
+        let tx_bytes: TransactionBlockBytes = client
+            .request_add_stake(
+                sender,
+                vec![coin_ref.0],
+                Some((NANOS_PER_IOTA * 2).into()),
+                validator,
+                Some(gas_ref.0),
+                100_000_000.into(),
+            )
+            .await
+            .unwrap();
+
+        let dry_run_resp = client
+            .dry_run_transaction_block(tx_bytes.tx_bytes)
+            .await
+            .unwrap();
+
+        assert_eq!(dry_run_resp.effects.status(), &IotaExecutionStatus::Success);
+        assert!(!dry_run_resp.balance_changes.is_empty());
     });
 }


### PR DESCRIPTION
# Description of change

This PR cherry pick the fix to resolve all objects needed for calculating balance changes in dry run for the iota-indexer.
- https://github.com/iotaledger/iota/issues/11085

## Links to any relevant issues

fixes #11093 

## How the change has been tested

Describe the tests that you ran to verify your changes.

- Ran indexer tests, the cherry pick contains a test case which catches the issue we fixed.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)