### PR TITLE
feat(indexer): add checkpointed_objects table for backward diff consistent views

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-04-02-120000_checkpointed_objects/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-02-120000_checkpointed_objects/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS checkpointed_objects;

--- a/crates/iota-indexer/migrations/pg/2026-04-02-120000_checkpointed_objects/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-02-120000_checkpointed_objects/up.sql
@@ -2,7 +2,9 @@
 -- by the checkpoint ingestion pipeline. Used as the base table for backward
 -- diff consistent views, avoiding race conditions with optimistic indexing
 -- which writes to the regular objects table.
-CREATE TABLE checkpointed_objects (
+
+-- Create as UNLOGGED to skip WAL during bulk load and index creation.
+CREATE UNLOGGED TABLE checkpointed_objects (
     object_id                   bytea         PRIMARY KEY,
     object_version              bigint        NOT NULL,
     object_digest               bytea         NOT NULL,
@@ -18,15 +20,7 @@ CREATE TABLE checkpointed_objects (
     df_kind                     smallint
 );
 
--- Indexes mirror the objects table
-CREATE INDEX checkpointed_objects_owner ON checkpointed_objects (owner_type, owner_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
-CREATE INDEX checkpointed_objects_owner_object_id ON checkpointed_objects (owner_type, owner_id, object_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
-CREATE INDEX checkpointed_objects_coin ON checkpointed_objects (owner_id, coin_type) WHERE coin_type IS NOT NULL AND owner_type = 1;
-CREATE INDEX checkpointed_objects_package_module_name_full_type ON checkpointed_objects (object_type_package, object_type_module, object_type_name, object_type);
-CREATE INDEX checkpointed_objects_owner_package_module_name_full_type ON checkpointed_objects (owner_id, object_type_package, object_type_module, object_type_name, object_type);
-CREATE STATISTICS checkpointed_objects_type_stats (dependencies, mcv) ON object_type, object_type_package, object_type_module, object_type_name FROM checkpointed_objects;
-
--- Create checkpointed_objects as a copy of objects.
+-- Bulk load from objects (fast, no WAL).
 INSERT INTO checkpointed_objects (
     object_id, object_version, object_digest, owner_type, owner_id,
     object_type, object_type_package, object_type_module, object_type_name,
@@ -37,3 +31,14 @@ SELECT
     object_type, object_type_package, object_type_module, object_type_name,
     serialized_object, coin_type, coin_balance, df_kind
 FROM objects;
+
+-- Build indexes (still unlogged, so index creation is also faster).
+CREATE INDEX checkpointed_objects_owner ON checkpointed_objects (owner_type, owner_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
+CREATE INDEX checkpointed_objects_owner_object_id ON checkpointed_objects (owner_type, owner_id, object_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
+CREATE INDEX checkpointed_objects_coin ON checkpointed_objects (owner_id, coin_type) WHERE coin_type IS NOT NULL AND owner_type = 1;
+CREATE INDEX checkpointed_objects_package_module_name_full_type ON checkpointed_objects (object_type_package, object_type_module, object_type_name, object_type);
+CREATE INDEX checkpointed_objects_owner_package_module_name_full_type ON checkpointed_objects (owner_id, object_type_package, object_type_module, object_type_name, object_type);
+CREATE STATISTICS checkpointed_objects_type_stats (dependencies, mcv) ON object_type, object_type_package, object_type_module, object_type_name FROM checkpointed_objects;
+
+-- Make the table durable.
+ALTER TABLE checkpointed_objects SET LOGGED;

--- a/crates/iota-indexer/migrations/pg/2026-04-02-120000_checkpointed_objects/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-02-120000_checkpointed_objects/up.sql
@@ -1,0 +1,27 @@
+-- Checkpointed objects table: exact copy of the objects table, written only
+-- by the checkpoint ingestion pipeline. Used as the base table for backward
+-- diff consistent views, avoiding race conditions with optimistic indexing
+-- which writes to the regular objects table.
+CREATE TABLE checkpointed_objects (
+    object_id                   bytea         PRIMARY KEY,
+    object_version              bigint        NOT NULL,
+    object_digest               bytea         NOT NULL,
+    owner_type                  smallint      NOT NULL,
+    owner_id                    bytea,
+    object_type                 text,
+    object_type_package         bytea,
+    object_type_module          text,
+    object_type_name            text,
+    serialized_object           bytea         NOT NULL,
+    coin_type                   text,
+    coin_balance                bigint,
+    df_kind                     smallint
+);
+
+-- Indexes mirror the objects table
+CREATE INDEX checkpointed_objects_owner ON checkpointed_objects (owner_type, owner_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
+CREATE INDEX checkpointed_objects_owner_object_id ON checkpointed_objects (owner_type, owner_id, object_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
+CREATE INDEX checkpointed_objects_coin ON checkpointed_objects (owner_id, coin_type) WHERE coin_type IS NOT NULL AND owner_type = 1;
+CREATE INDEX checkpointed_objects_package_module_name_full_type ON checkpointed_objects (object_type_package, object_type_module, object_type_name, object_type);
+CREATE INDEX checkpointed_objects_owner_package_module_name_full_type ON checkpointed_objects (owner_id, object_type_package, object_type_module, object_type_name, object_type);
+CREATE STATISTICS checkpointed_objects_type_stats (dependencies, mcv) ON object_type, object_type_package, object_type_module, object_type_name FROM checkpointed_objects;

--- a/crates/iota-indexer/migrations/pg/2026-04-02-120000_checkpointed_objects/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-02-120000_checkpointed_objects/up.sql
@@ -25,3 +25,15 @@ CREATE INDEX checkpointed_objects_coin ON checkpointed_objects (owner_id, coin_t
 CREATE INDEX checkpointed_objects_package_module_name_full_type ON checkpointed_objects (object_type_package, object_type_module, object_type_name, object_type);
 CREATE INDEX checkpointed_objects_owner_package_module_name_full_type ON checkpointed_objects (owner_id, object_type_package, object_type_module, object_type_name, object_type);
 CREATE STATISTICS checkpointed_objects_type_stats (dependencies, mcv) ON object_type, object_type_package, object_type_module, object_type_name FROM checkpointed_objects;
+
+-- Create checkpointed_objects as a copy of objects.
+INSERT INTO checkpointed_objects (
+    object_id, object_version, object_digest, owner_type, owner_id,
+    object_type, object_type_package, object_type_module, object_type_name,
+    serialized_object, coin_type, coin_balance, df_kind
+)
+SELECT
+    object_id, object_version, object_digest, owner_type, owner_id,
+    object_type, object_type_package, object_type_module, object_type_name,
+    serialized_object, coin_type, coin_balance, df_kind
+FROM objects;

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -172,17 +172,24 @@ impl PrimaryWriter {
                     .persist_object_history(object_history_changes_batch.clone()),
                 self.state
                     .persist_object_versions(object_versions_batch.clone()),
-                Box::pin(async {
-                    // We need to persist global order before writing objects, so that optimistic
-                    // indexing is blocked from overwriting objects table with old tx data
-                    // reference: https://github.com/iotaledger/iota/issues/10250
-                    self.state
-                        .persist_tx_global_order(tx_global_order_batch.clone())
-                        .await?;
-                    self.state
-                        .persist_checkpoint_objects(object_changes_batch)
-                        .await
+                Box::pin({
+                    let object_changes_batch = object_changes_batch.clone();
+                    async move {
+                        // We need to persist global order before writing objects, so that
+                        // optimistic indexing is blocked from overwriting
+                        // objects table with old tx data reference: https://github.com/iotaledger/iota/issues/10250
+                        self.state
+                            .persist_tx_global_order(tx_global_order_batch.clone())
+                            .await?;
+                        self.state.persist_objects(object_changes_batch).await
+                    }
                 }),
+                // Checkpointed objects are written in a separate task,
+                // independent from the global_order -> objects chain.
+                // Once backward history is added, it will be chained
+                // before this: backward_history -> checkpointed_objects.
+                self.state
+                    .persist_checkpointed_objects(object_changes_batch),
             ];
             if let Some(epoch_data) = epoch.clone() {
                 persist_tasks.push(self.state.persist_epoch(epoch_data));

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -17,7 +17,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     errors::IndexerError,
-    schema::{objects, objects_history, objects_snapshot},
+    schema::{checkpointed_objects, objects, objects_history, objects_snapshot},
     types::{IndexedDeletedObject, IndexedObject, ObjectStatus, owner_to_owner_info},
 };
 
@@ -342,6 +342,47 @@ pub(crate) struct StoredDeletedHistoryObject {
     pub object_version: i64,
     pub object_status: i16,
     pub checkpoint_sequence_number: i64,
+}
+
+/// Checkpointed objects table: exact copy of the `objects` table schema
+/// (minus `finalized_in_cp`), written only by the checkpoint ingestion
+/// pipeline. Used as the base table for backward diff consistent views.
+#[derive(Queryable, Selectable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
+#[diesel(table_name = checkpointed_objects, primary_key(object_id))]
+pub struct StoredCheckpointedObject {
+    pub object_id: Vec<u8>,
+    pub object_version: i64,
+    pub object_digest: Vec<u8>,
+    pub owner_type: i16,
+    pub owner_id: Option<Vec<u8>>,
+    pub object_type: Option<String>,
+    pub object_type_package: Option<Vec<u8>>,
+    pub object_type_module: Option<String>,
+    pub object_type_name: Option<String>,
+    pub serialized_object: Vec<u8>,
+    pub coin_type: Option<String>,
+    pub coin_balance: Option<i64>,
+    pub df_kind: Option<i16>,
+}
+
+impl From<&StoredObject> for StoredCheckpointedObject {
+    fn from(o: &StoredObject) -> Self {
+        Self {
+            object_id: o.object_id.clone(),
+            object_version: o.object_version,
+            object_digest: o.object_digest.clone(),
+            owner_type: o.owner_type,
+            owner_id: o.owner_id.clone(),
+            object_type: o.object_type.clone(),
+            object_type_package: o.object_type_package.clone(),
+            object_type_module: o.object_type_module.clone(),
+            object_type_name: o.object_type_name.clone(),
+            serialized_object: o.serialized_object.clone(),
+            coin_type: o.coin_type.clone(),
+            coin_balance: o.coin_balance,
+            df_kind: o.df_kind,
+        }
+    }
 }
 
 impl From<IndexedObject> for StoredObject {

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -344,9 +344,11 @@ pub(crate) struct StoredDeletedHistoryObject {
     pub checkpoint_sequence_number: i64,
 }
 
-/// Checkpointed objects table: exact copy of the `objects` table schema
-/// (minus `finalized_in_cp`), written only by the checkpoint ingestion
-/// pipeline. Used as the base table for backward diff consistent views.
+/// Snapshot of the `objects` table written exclusively by checkpoint ingestion.
+///
+/// Mirrors all columns of `objects` except `finalized_in_cp`. Used as the
+/// base table for backward-diff consistent views, avoiding race conditions
+/// with optimistic indexing.
 #[derive(Queryable, Selectable, Insertable, Debug, Identifiable, Clone, QueryableByName)]
 #[diesel(table_name = checkpointed_objects, primary_key(object_id))]
 pub struct StoredCheckpointedObject {

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -41,6 +41,24 @@ diesel::table! {
 }
 
 diesel::table! {
+    checkpointed_objects (object_id) {
+        object_id -> Bytea,
+        object_version -> Int8,
+        object_digest -> Bytea,
+        owner_type -> Int2,
+        owner_id -> Nullable<Bytea>,
+        object_type -> Nullable<Text>,
+        object_type_package -> Nullable<Bytea>,
+        object_type_module -> Nullable<Text>,
+        object_type_name -> Nullable<Text>,
+        serialized_object -> Bytea,
+        coin_type -> Nullable<Text>,
+        coin_balance -> Nullable<Int8>,
+        df_kind -> Nullable<Int2>,
+    }
+}
+
+diesel::table! {
     checkpoints (sequence_number) {
         sequence_number -> Int8,
         checkpoint_digest -> Bytea,
@@ -464,6 +482,7 @@ macro_rules! for_all_tables {
             address_metrics,
             addresses,
             chain_identifier,
+            checkpointed_objects,
             checkpoints,
             display,
             epoch_peak_tps,

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -138,7 +138,12 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     /// the db.
     async fn get_watermarks(&self) -> Result<(Vec<StoredWatermark>, i64), IndexerError>;
 
-    async fn persist_checkpoint_objects(
+    async fn persist_objects(
+        &self,
+        objects: Vec<CheckpointObjectChanges>,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_checkpointed_objects(
         &self,
         objects: Vec<CheckpointObjectChanges>,
     ) -> Result<(), IndexerError>;

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -52,8 +52,8 @@ use crate::{
         events::StoredEvent,
         obj_indices::StoredObjectVersion,
         objects::{
-            StoredDeletedObject, StoredHistoryObject, StoredObject, StoredObjectSnapshot,
-            StoredObjects,
+            StoredCheckpointedObject, StoredDeletedObject, StoredHistoryObject, StoredObject,
+            StoredObjectSnapshot, StoredObjects,
         },
         packages::StoredPackage,
         transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
@@ -65,13 +65,13 @@ use crate::{
     pruning::pruner::PrunableTable,
     read_only_blocking, run_query, run_query_with_retry,
     schema::{
-        chain_identifier, checkpoints, display, epochs, event_emit_module, event_emit_package,
-        event_senders, event_struct_instantiation, event_struct_module, event_struct_name,
-        event_struct_package, events, feature_flags, objects, objects_history, objects_snapshot,
-        objects_version, optimistic_transactions, packages, protocol_configs, pruner_cp_watermark,
-        transactions, tx_calls_fun, tx_calls_mod, tx_calls_pkg, tx_changed_objects, tx_digests,
-        tx_global_order, tx_input_objects, tx_kinds, tx_recipients, tx_senders,
-        tx_wrapped_or_deleted_objects, watermarks,
+        chain_identifier, checkpointed_objects, checkpoints, display, epochs, event_emit_module,
+        event_emit_package, event_senders, event_struct_instantiation, event_struct_module,
+        event_struct_name, event_struct_package, events, feature_flags, objects, objects_history,
+        objects_snapshot, objects_version, optimistic_transactions, packages, protocol_configs,
+        pruner_cp_watermark, transactions, tx_calls_fun, tx_calls_mod, tx_calls_pkg,
+        tx_changed_objects, tx_digests, tx_global_order, tx_input_objects, tx_kinds, tx_recipients,
+        tx_senders, tx_wrapped_or_deleted_objects, watermarks,
     },
     store::{IndexerStore, diesel_macro::mark_in_blocking_pool},
     transactional_blocking_with_retry,
@@ -478,6 +478,93 @@ impl PgIndexerStore {
         })
         .tap_err(|e| {
             tracing::error!("failed to persist object deletions with error: {e}");
+        })
+    }
+
+    fn persist_checkpointed_objects_mutations(
+        &self,
+        objects: Vec<LiveObject>,
+    ) -> Result<(), IndexerError> {
+        use diesel::upsert::excluded;
+
+        let stored: Vec<StoredCheckpointedObject> = objects
+            .into_iter()
+            .map(|lo| {
+                let (indexed, _tx_digest) = lo.split();
+                StoredCheckpointedObject::from(&StoredObject::from(indexed))
+            })
+            .collect();
+        let len = stored.len();
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                for chunk in stored.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                    on_conflict_do_update!(
+                        checkpointed_objects::table,
+                        chunk,
+                        checkpointed_objects::object_id,
+                        (
+                            checkpointed_objects::object_version
+                                .eq(excluded(checkpointed_objects::object_version)),
+                            checkpointed_objects::object_digest
+                                .eq(excluded(checkpointed_objects::object_digest)),
+                            checkpointed_objects::owner_type
+                                .eq(excluded(checkpointed_objects::owner_type)),
+                            checkpointed_objects::owner_id
+                                .eq(excluded(checkpointed_objects::owner_id)),
+                            checkpointed_objects::object_type
+                                .eq(excluded(checkpointed_objects::object_type)),
+                            checkpointed_objects::object_type_package
+                                .eq(excluded(checkpointed_objects::object_type_package)),
+                            checkpointed_objects::object_type_module
+                                .eq(excluded(checkpointed_objects::object_type_module)),
+                            checkpointed_objects::object_type_name
+                                .eq(excluded(checkpointed_objects::object_type_name)),
+                            checkpointed_objects::serialized_object
+                                .eq(excluded(checkpointed_objects::serialized_object)),
+                            checkpointed_objects::coin_type
+                                .eq(excluded(checkpointed_objects::coin_type)),
+                            checkpointed_objects::coin_balance
+                                .eq(excluded(checkpointed_objects::coin_balance)),
+                            checkpointed_objects::df_kind
+                                .eq(excluded(checkpointed_objects::df_kind)),
+                        ),
+                        conn
+                    );
+                }
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            info!("Persisted {len} checkpointed object mutations");
+        })
+        .tap_err(|e| {
+            tracing::error!("failed to persist checkpointed objects: {e}");
+        })
+    }
+
+    fn persist_checkpointed_objects_deletions(
+        &self,
+        objects: Vec<RemovedObject>,
+    ) -> Result<(), IndexerError> {
+        let object_ids: Vec<Vec<u8>> = objects.iter().map(|o| o.object_id().to_vec()).collect();
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                for chunk in object_ids.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                    diesel::delete(
+                        checkpointed_objects::table
+                            .filter(checkpointed_objects::object_id.eq_any(chunk)),
+                    )
+                    .execute(conn)?;
+                }
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_err(|e| {
+            tracing::error!("failed to delete checkpointed objects: {e}");
         })
     }
 
@@ -2305,7 +2392,7 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_checkpoint_objects(
+    async fn persist_objects(
         &self,
         objects: Vec<CheckpointObjectChanges>,
     ) -> Result<(), IndexerError> {
@@ -2347,6 +2434,48 @@ impl IndexerStore for PgIndexerStore {
         info!(
             elapsed,
             "Persisted objects with {mutation_len} mutations and {deletion_len} deletions",
+        );
+        Ok(())
+    }
+
+    async fn persist_checkpointed_objects(
+        &self,
+        objects: Vec<CheckpointObjectChanges>,
+    ) -> Result<(), IndexerError> {
+        if objects.is_empty() {
+            return Ok(());
+        }
+        let CheckpointObjectChanges {
+            changed_objects: mutations,
+            deleted_objects: deletions,
+        } = retain_latest_objects_from_checkpoint_batch(objects);
+        let mutation_len = mutations.len();
+        let deletion_len = deletions.len();
+
+        let mutation_chunks = chunk!(mutations, self.config.parallel_objects_chunk_size);
+        let deletion_chunks = chunk!(deletions, self.config.parallel_objects_chunk_size);
+        let mutation_futures = mutation_chunks.into_iter().map(|c| {
+            self.spawn_blocking_task(move |this| this.persist_checkpointed_objects_mutations(c))
+        });
+        let deletion_futures = deletion_chunks.into_iter().map(|c| {
+            self.spawn_blocking_task(move |this| this.persist_checkpointed_objects_deletions(c))
+        });
+        futures::future::try_join_all(mutation_futures.chain(deletion_futures))
+            .await
+            .map_err(|e| {
+                tracing::error!("failed to join futures for persisting checkpointed objects: {e}");
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "Failed to persist all checkpointed object chunks: {e:?}",
+                ))
+            })?;
+
+        info!(
+            "Persisted checkpointed objects with {mutation_len} mutations and {deletion_len} deletions",
         );
         Ok(())
     }

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -20,12 +20,13 @@ mod ingestion_tests {
         insert_or_ignore_into,
         models::{
             checkpoints::StoredCheckpoint,
-            objects::{StoredObject, StoredObjectSnapshot},
+            objects::{StoredCheckpointedObject, StoredObject, StoredObjectSnapshot},
             transactions::{StoredTransaction, TxGlobalOrder},
             tx_indices::StoredTxDigest,
         },
         schema::{
-            checkpoints, objects, objects_snapshot, transactions, tx_digests, tx_global_order,
+            checkpointed_objects, checkpoints, objects, objects_snapshot, transactions, tx_digests,
+            tx_global_order,
         },
         store::{PgIndexerStore, indexer_store::IndexerStore},
         transactional_blocking_with_retry,
@@ -73,9 +74,7 @@ mod ingestion_tests {
         let checkpoint_objects = (0..1000)
             .map(|_| CheckpointObjectChanges::random())
             .collect();
-        pg_store
-            .persist_checkpoint_objects(checkpoint_objects)
-            .await?;
+        pg_store.persist_objects(checkpoint_objects).await?;
         Ok(())
     }
 
@@ -538,6 +537,141 @@ mod ingestion_tests {
         .context("failed to read checkpoint")?;
         assert_eq!(db_checkpoint.sequence_number, 3);
         assert_eq!(db_checkpoint.epoch, 1);
+        Ok(())
+    }
+
+    /// Verify that `checkpointed_objects` matches `objects` (minus
+    /// `finalized_in_cp`) after checkpoint ingestion with mutations and
+    /// deletions.
+    #[tokio::test]
+    pub async fn checkpointed_objects_match_objects() -> Result<(), IndexerError> {
+        let sim = Simulacrum::new();
+        let data_ingestion_path = tempdir().unwrap().keep();
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+        // Execute several transfers to create mutations.
+        let recipient1 = IotaAddress::random_for_testing_only();
+        let recipient2 = IotaAddress::random_for_testing_only();
+
+        let (tx1, _) = sim.transfer_txn(recipient1);
+        let (_, err) = sim.execute_transaction(tx1).unwrap();
+        assert!(err.is_none());
+        sim.create_checkpoint();
+
+        let (tx2, _) = sim.transfer_txn(recipient2);
+        let (_, err) = sim.execute_transaction(tx2).unwrap();
+        assert!(err.is_none());
+        sim.create_checkpoint();
+
+        // One more transfer to trigger further mutations on gas objects.
+        let (tx3, _) = sim.transfer_txn(recipient1);
+        let (_, err) = sim.execute_transaction(tx3).unwrap();
+        assert!(err.is_none());
+        sim.create_checkpoint();
+
+        let (_, pg_store, _) = start_simulacrum_grpc_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path,
+            None,
+            Some("indexer_ingestion_tests_db"),
+            None,
+        )
+        .await;
+
+        indexer_wait_for_checkpoint(&pg_store, 3).await;
+
+        // Read all rows from both tables.
+        let all_objects: Vec<StoredObject> = read_only_blocking!(&pg_store.blocking_cp(), |conn| {
+            objects::table
+                .order(objects::object_id.asc())
+                .load::<StoredObject>(conn)
+        })
+        .context("failed reading objects")?;
+
+        let all_checkpointed: Vec<StoredCheckpointedObject> =
+            read_only_blocking!(&pg_store.blocking_cp(), |conn| {
+                checkpointed_objects::table
+                    .order(checkpointed_objects::object_id.asc())
+                    .select(StoredCheckpointedObject::as_select())
+                    .load::<StoredCheckpointedObject>(conn)
+            })
+            .context("failed reading checkpointed_objects")?;
+
+        assert!(
+            !all_objects.is_empty(),
+            "objects table should not be empty after ingestion"
+        );
+        assert_eq!(
+            all_objects.len(),
+            all_checkpointed.len(),
+            "objects and checkpointed_objects should have the same number of rows"
+        );
+
+        // Compare each row field by field (minus finalized_in_cp).
+        for (obj, cp_obj) in all_objects.iter().zip(all_checkpointed.iter()) {
+            assert_eq!(obj.object_id, cp_obj.object_id, "object_id mismatch");
+            assert_eq!(
+                obj.object_version, cp_obj.object_version,
+                "object_version mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.object_digest, cp_obj.object_digest,
+                "object_digest mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.owner_type, cp_obj.owner_type,
+                "owner_type mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.owner_id, cp_obj.owner_id,
+                "owner_id mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.object_type, cp_obj.object_type,
+                "object_type mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.object_type_package, cp_obj.object_type_package,
+                "object_type_package mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.object_type_module, cp_obj.object_type_module,
+                "object_type_module mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.object_type_name, cp_obj.object_type_name,
+                "object_type_name mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.serialized_object, cp_obj.serialized_object,
+                "serialized_object mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.coin_type, cp_obj.coin_type,
+                "coin_type mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.coin_balance, cp_obj.coin_balance,
+                "coin_balance mismatch for {:?}",
+                obj.object_id
+            );
+            assert_eq!(
+                obj.df_kind, cp_obj.df_kind,
+                "df_kind mismatch for {:?}",
+                obj.object_id
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
# Description of change

Add a new `checkpointed_objects` table that mirrors the `objects` table schema (minus `finalized_in_cp`), written exclusively by the checkpoint ingestion pipeline. This table will serve as the base for backward diff consistent view queries, free from optimistic indexing race conditions.

- Migration: create table with matching indexes and statistics
- Model: StoredCheckpointedObject with From<&StoredObject> conversion
- Persist: upsert mutations and delete removals in parallel task
- Rename persist_checkpoint_objects -> persist_objects for clarity
- Ingestion test: verify objects and checkpointed_objects match

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11104

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: :hammer_and_wrench: Added `checkpointed_objects` table to improve consistent views support. The migration copies all rows from `objects`, which may take several minutes on large databases. Operators should plan for downtime accordingly. :warning: