### PR TITLE
fix(indexer): propagate execution errors on the response

### DIFF
--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 
 use diesel::prelude::*;
 use iota_json_rpc_types::{
-    BalanceChange, IotaEvent, IotaTransactionBlock, IotaTransactionBlockEffects,
-    IotaTransactionBlockEvents, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
-    ObjectChange,
+    BalanceChange, IotaEvent, IotaExecutionStatus, IotaTransactionBlock,
+    IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, IotaTransactionBlockEvents,
+    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
 };
 use iota_package_resolver::{PackageStore, Resolver};
 use iota_types::{
@@ -383,6 +383,11 @@ impl StoredTransaction {
             Default::default()
         };
 
+        let errors = match effects.as_ref().map(|e| e.status()) {
+            Some(IotaExecutionStatus::Failure { error }) => vec![error.clone()],
+            _ => vec![],
+        };
+
         Ok(IotaTransactionBlockResponse {
             digest: tx_digest,
             transaction,
@@ -394,7 +399,7 @@ impl StoredTransaction {
             timestamp_ms,
             checkpoint,
             confirmed_local_execution: None,
-            errors: vec![],
+            errors,
             raw_effects,
         })
     }

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -779,7 +779,7 @@ impl From<IotaTransactionBlockResponseWithOptions> for IotaTransactionBlockRespo
             timestamp_ms: response.timestamp_ms,
             confirmed_local_execution: response.confirmed_local_execution,
             checkpoint: response.checkpoint,
-            errors: vec![],
+            errors: response.errors,
             raw_effects: if options.show_raw_effects {
                 response.raw_effects
             } else {

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1581,6 +1581,13 @@ fn clever_errors() {
             panic!("transaction should have failed");
         };
         assert_eq!(error, &expected_error);
+
+        // Check error in the response as well
+        let response_error = indexer_tx_response
+            .errors
+            .first()
+            .expect("execution error should be in the response");
+        assert_eq!(response_error, &expected_error);
     });
 }
 


### PR DESCRIPTION
# Description of change

This patch fixes an issue with optimistic indexing not propagating execution errors on the response. 

## Links to any relevant issues

Fixes #11115

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

This patch does not affect these assertions.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: :screwdriver: Fixes an issue with execution errors not being propagated on the transaction response `errors` fields.
