### PR TITLE
chore(indexer): drop redundant objects_owner index

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-04-06-082402_drop_objects_owner_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-06-082402_drop_objects_owner_index/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS objects_owner ON objects (owner_type, owner_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;

--- a/crates/iota-indexer/migrations/pg/2026-04-06-082402_drop_objects_owner_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2026-04-06-082402_drop_objects_owner_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2026-04-06-082402_drop_objects_owner_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-06-082402_drop_objects_owner_index/up.sql
@@ -1,0 +1,2 @@
+-- Superseded by objects_owner_object_id
+DROP INDEX CONCURRENTLY IF EXISTS objects_owner;


### PR DESCRIPTION
# Description of change

This patch includes a database migration to drop the redundant `objects_owner` index following #10976.

## Links to any relevant issues

Fixes #11099 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: :warning: Maintenance required: Introducing a new migration in to remove the redundant `objects_owner` index following v1.20. Operators should update their IOTA Indexer instances and restart the writer service.
- [x] GraphQL:  :warning: Maintenance required: Introducing a new migration in IOTA Indexer requires updating GraphQL and restarting service.
