### PR TITLE
fix(starfish): bound depth-orphaned authority retention by gc window

### DIFF
--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -840,6 +840,7 @@ mod tests {
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_fast_commit_sync_for_testing(true);
+        protocol_config.set_gc_depth_for_testing(5);
 
         let temp_dirs: Vec<TempDir> = (0..NUM_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2713,7 +2713,6 @@ mod test {
 
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context.protocol_config.set_gc_depth_for_testing(0);
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new(context.clone()));
@@ -2850,20 +2849,22 @@ mod test {
         expected = "Attempted to check for slot S8[0] that is <= the last evicted round 8"
     )]
     async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range() {
-        /// Only keep elements up to 2 rounds before the last committed round
         const CACHED_ROUNDS: Round = 2;
+        const GC_DEPTH: Round = 3;
+        // With 14 rounds: gc_round = 14 - 6 = 8, eviction = min(8, 14 - 2) = 8
+        const NUM_ROUNDS: Round = 2 * GC_DEPTH + CACHED_ROUNDS + 6;
 
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context.protocol_config.set_gc_depth_for_testing(0);
+        context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new(context.clone()));
         let mut dag_state = DagState::new(context.clone(), store);
 
-        // Create test block headers for round 1 ~ 10 for authority 0
+        // Create test block headers for authority 0
         let mut block_headers = Vec::new();
-        for round in 1..=10 {
+        for round in 1..=NUM_ROUNDS {
             let block_header =
                 VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build());
             block_headers.push(block_header.clone());
@@ -2886,9 +2887,8 @@ mod test {
 
         dag_state.flush();
 
-        // When trying to request a header from authority 0 at round 8, it should panic,
-        // as anything that is <= commit_round - cached_rounds = 10 - 2 = 8 should be
-        // evicted.
+        // Eviction round = min(gc_round, last_round - cached_rounds) = min(8, 12) = 8.
+        // Querying at round 8 should panic since it is <= evicted round.
         let _ = dag_state
             .contains_cached_block_header_at_slot(Slot::new(8, AuthorityIndex::new_for_test(0)));
     }
@@ -3479,26 +3479,27 @@ mod test {
 
     #[tokio::test]
     #[should_panic(
-        expected = "Attempted to request for blocks of rounds < 2, when the last evicted round is 1 for authority [2]"
+        expected = "Attempted to request for blocks of rounds < 4, when the last evicted round is 3 for authority [2]"
     )]
     async fn test_get_cached_last_block_header_per_authority_requesting_out_of_round_range() {
         // GIVEN
         const CACHED_ROUNDS: Round = 1;
+        const GC_DEPTH: Round = 3;
+
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context.protocol_config.set_gc_depth_for_testing(0);
+        context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new(context.clone()));
         let mut dag_state = DagState::new(context.clone(), store);
 
         // Create no block headers for authority 0
-        // Create one block header (round 1) for authority 1
-        // Create two block headers (rounds 1,2) for authority 2
-        // Create three block headers (rounds 1,2,3) for authority 3
+        // Create block headers for authorities 1..=3, scaled so gc_round > 0.
+        // auth 1: rounds 1..=3, auth 2: rounds 1..=6, auth 3: rounds 1..=9
         let mut all_blocks_headers = Vec::new();
-        for author in 1..=3 {
-            for round in 1..=author {
+        for author in 1..=3u32 {
+            for round in 1..=(author * 3) {
                 let block_header = VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(round, author as u8).build(),
                 );
@@ -3520,13 +3521,12 @@ mod test {
             vec![],
         ));
 
-        // Flush to the store so we keep in memory only the last 1 round from the last
-        // commit for each authority.
+        // Flush: gc_round = 9 - 6 = 3. Authority 2 (last_round=6): eviction = min(3, 5) = 3.
         dag_state.flush();
 
-        // THEN the method should panic, as some authorities have already evicted rounds
-        // <= round 2
-        let end_round = 2;
+        // THEN the method should panic, as authority 2 has evicted round 3
+        // and end_round - 1 = 3 <= 3.
+        let end_round = 4;
         dag_state.get_last_cached_block_header_per_authority(end_round);
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3521,7 +3521,8 @@ mod test {
             vec![],
         ));
 
-        // Flush: gc_round = 9 - 6 = 3. Authority 2 (last_round=6): eviction = min(3, 5) = 3.
+        // Flush: gc_round = 9 - 6 = 3. Authority 2 (last_round=6): eviction = min(3, 5)
+        // = 3.
         dag_state.flush();
 
         // THEN the method should panic, as authority 2 has evicted round 3

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -130,9 +130,9 @@ pub(crate) struct DagState {
     /// The genesis blocks
     genesis: BTreeMap<BlockRef, VerifiedBlock>,
 
-    /// Contains block headers kept in memory within the per-authority
-    /// retention window. Older headers may be evicted after flush since they
-    /// don't have a chance to be committed due to garbage collection.
+    /// Contains recent block headers within CACHED_ROUNDS from the last
+    /// traversed round per authority. Note: all uncommitted block headers
+    /// are kept in memory.
     recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
     /// Contains recent verified transactions per authority. To access a
@@ -371,11 +371,7 @@ impl DagState {
         // Reload transactions from storage
         let transactions = self
             .store
-            .scan_transactions_by_author(
-                authority_index,
-                eviction_round + 1,
-                self.context.clone(),
-            )
+            .scan_transactions_by_author(authority_index, eviction_round + 1, self.context.clone())
             .expect("Database error");
         for txn in &transactions {
             self.update_transaction_metadata(txn, data_source);
@@ -1959,6 +1955,7 @@ impl DagState {
         let transaction_gc_round = self.gc_round_for_last_solid_commit();
         for (authority_index, _) in self.context.committee.authorities() {
             let eviction_round = self.calculate_authority_eviction_round(authority_index);
+            // Take minimum between transaction_gc_round and eviction_round
             let transaction_eviction_round = min(transaction_gc_round, eviction_round + 1);
 
             // Evict everything below split_key
@@ -2345,30 +2342,14 @@ impl DagState {
     /// from that authority. For any round that is <= `last_evicted_round`
     /// we don't have such guarantees as out of order blocks might exist.
     fn calculate_authority_eviction_round(&self, authority_index: AuthorityIndex) -> Round {
-        let last_round = self.latest_cached_round_for_authority(authority_index);
-        Self::gc_eviction_round(
-            last_round,
-            self.gc_round_for_last_commit(),
-            self.cached_rounds,
-        )
-    }
-
-    /// Calculates the last eviction round. Starfish runs with GC enabled on
-    /// every network, so eviction is bounded by the global GC round while
-    /// keeping a recent window per authority.
-    ///
-    /// The goal is to
-    /// keep at least `cached_rounds` of the latest blocks for the authority
-    /// while never evicting above the current global GC round.
-    fn gc_eviction_round(last_round: Round, gc_round: Round, cached_rounds: Round) -> Round {
-        gc_round.min(last_round.saturating_sub(cached_rounds))
-    }
-
-    fn latest_cached_round_for_authority(&self, authority_index: AuthorityIndex) -> Round {
-        self.recent_headers_refs_by_authority[authority_index]
+        let last_round = self.recent_headers_refs_by_authority[authority_index]
             .last()
             .map(|block_ref| block_ref.round)
-            .unwrap_or(GENESIS_ROUND)
+            .unwrap_or(GENESIS_ROUND);
+        // Keep at least cached_rounds of blocks, but never evict above the
+        // global GC round derived from the last commit.
+        self.gc_round_for_last_commit()
+            .min(last_round.saturating_sub(self.cached_rounds))
     }
 
     /// Detects and returns the blocks of the round that forms the last quorum.
@@ -4053,11 +4034,9 @@ mod test {
 
         dag_state.flush();
 
-        let expected_eviction_round = DagState::gc_eviction_round(
-            last_accepted_round,
-            dag_state.gc_round_for_last_commit(),
-            CACHED_ROUNDS,
-        );
+        let expected_eviction_round = dag_state
+            .gc_round_for_last_commit()
+            .min(last_accepted_round.saturating_sub(CACHED_ROUNDS));
         assert_eq!(
             dag_state.evicted_rounds[authority_to_skip],
             expected_eviction_round

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -356,7 +356,7 @@ impl DagState {
         committed_round: Round,
         data_source: DataSource,
     ) {
-        let eviction_round = committed_round.saturating_sub(self.cached_rounds);
+        let eviction_round = Self::eviction_round(committed_round, self.cached_rounds);
         self.evicted_rounds[authority_index] = eviction_round;
 
         // Reload block headers from storage
@@ -2349,7 +2349,13 @@ impl DagState {
         // Keep at least cached_rounds of blocks, but never evict above the
         // global GC round derived from the last commit.
         self.gc_round_for_last_commit()
-            .min(last_round.saturating_sub(self.cached_rounds))
+            .min(Self::eviction_round(last_round, self.cached_rounds))
+    }
+
+    /// Calculates the last eviction round based on the provided `commit_round`.
+    /// Any blocks with round <= the evict round have been cleaned up.
+    fn eviction_round(commit_round: Round, cached_rounds: Round) -> Round {
+        commit_round.saturating_sub(cached_rounds)
     }
 
     /// Detects and returns the blocks of the round that forms the last quorum.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3995,7 +3995,7 @@ mod test {
             .collect::<Vec<_>>();
 
         let total_rounds = 2 * (CACHED_ROUNDS + GC_DEPTH);
-        let mut dag_builder = DagBuilder::new(context.clone());
+        let mut dag_builder = DagBuilder::new(context);
         dag_builder
             .layers(1..=total_rounds)
             .authorities(active_authorities)

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -130,9 +130,9 @@ pub(crate) struct DagState {
     /// The genesis blocks
     genesis: BTreeMap<BlockRef, VerifiedBlock>,
 
-    /// Contains recent block headers within CACHED_ROUNDS from the last
-    /// traversed round per authority. Note: all uncommitted block headers
-    /// are kept in memory.
+    /// Contains block headers kept in memory within the per-authority
+    /// retention window. Older headers may be evicted after flush since they
+    /// don't have a chance to be committed due to garbage collection.
     recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
     /// Contains recent verified transactions per authority. To access a
@@ -356,7 +356,7 @@ impl DagState {
         committed_round: Round,
         data_source: DataSource,
     ) {
-        let eviction_round = Self::eviction_round(committed_round, self.cached_rounds);
+        let eviction_round = committed_round.saturating_sub(self.cached_rounds);
         self.evicted_rounds[authority_index] = eviction_round;
 
         // Reload block headers from storage
@@ -371,7 +371,11 @@ impl DagState {
         // Reload transactions from storage
         let transactions = self
             .store
-            .scan_transactions_by_author(authority_index, eviction_round + 1, self.context.clone())
+            .scan_transactions_by_author(
+                authority_index,
+                eviction_round + 1,
+                self.context.clone(),
+            )
             .expect("Database error");
         for txn in &transactions {
             self.update_transaction_metadata(txn, data_source);
@@ -1955,7 +1959,6 @@ impl DagState {
         let transaction_gc_round = self.gc_round_for_last_solid_commit();
         for (authority_index, _) in self.context.committee.authorities() {
             let eviction_round = self.calculate_authority_eviction_round(authority_index);
-            // Take minimum between transaction_gc_round and eviction_round
             let transaction_eviction_round = min(transaction_gc_round, eviction_round + 1);
 
             // Evict everything below split_key
@@ -2342,14 +2345,30 @@ impl DagState {
     /// from that authority. For any round that is <= `last_evicted_round`
     /// we don't have such guarantees as out of order blocks might exist.
     fn calculate_authority_eviction_round(&self, authority_index: AuthorityIndex) -> Round {
-        let commit_round = self.last_committed_rounds[authority_index];
-        Self::eviction_round(commit_round, self.cached_rounds)
+        let last_round = self.latest_cached_round_for_authority(authority_index);
+        Self::gc_eviction_round(
+            last_round,
+            self.gc_round_for_last_commit(),
+            self.cached_rounds,
+        )
     }
 
-    /// Calculates the last eviction round based on the provided `commit_round`.
-    /// Any blocks with round <= the evict round have been cleaned up.
-    fn eviction_round(commit_round: Round, cached_rounds: Round) -> Round {
-        commit_round.saturating_sub(cached_rounds)
+    /// Calculates the last eviction round. Starfish runs with GC enabled on
+    /// every network, so eviction is bounded by the global GC round while
+    /// keeping a recent window per authority.
+    ///
+    /// The goal is to
+    /// keep at least `cached_rounds` of the latest blocks for the authority
+    /// while never evicting above the current global GC round.
+    fn gc_eviction_round(last_round: Round, gc_round: Round, cached_rounds: Round) -> Round {
+        gc_round.min(last_round.saturating_sub(cached_rounds))
+    }
+
+    fn latest_cached_round_for_authority(&self, authority_index: AuthorityIndex) -> Round {
+        self.recent_headers_refs_by_authority[authority_index]
+            .last()
+            .map(|block_ref| block_ref.round)
+            .unwrap_or(GENESIS_ROUND)
     }
 
     /// Detects and returns the blocks of the round that forms the last quorum.
@@ -2707,6 +2726,7 @@ mod test {
 
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+        context.protocol_config.set_gc_depth_for_testing(0);
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new(context.clone()));
@@ -2848,6 +2868,7 @@ mod test {
 
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+        context.protocol_config.set_gc_depth_for_testing(0);
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new(context.clone()));
@@ -3478,6 +3499,7 @@ mod test {
         const CACHED_ROUNDS: Round = 1;
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+        context.protocol_config.set_gc_depth_for_testing(0);
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new(context.clone()));
@@ -3834,7 +3856,7 @@ mod test {
         let expected_block_headers = all_block_headers
             .iter()
             .filter(|x| {
-                x.round() > last_committed_round[x.author().value()] - CACHED_ROUNDS
+                x.round() > dag_state.evicted_rounds[x.author().value()]
                     || x.round() == GENESIS_ROUND
             })
             .cloned()
@@ -3960,6 +3982,97 @@ mod test {
                 block_ref.round
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_gc_eviction_advances_for_skipped_authority() {
+        telemetry_subscribers::init_for_testing();
+
+        const COMMITTEE_SIZE: usize = 10;
+        const CACHED_ROUNDS: Round = 5;
+        const GC_DEPTH: Round = 3;
+
+        let (mut context, _) = Context::new_for_test(COMMITTEE_SIZE);
+        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+        context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
+
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let mut dag_state = DagState::new(context.clone(), store);
+
+        let authority_to_skip = AuthorityIndex::new_for_test((COMMITTEE_SIZE - 2) as u8);
+        let catch_up_index = AuthorityIndex::new_for_test((COMMITTEE_SIZE - 1) as u8);
+        let active_authorities = (0..(COMMITTEE_SIZE - 1) as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect::<Vec<_>>();
+
+        let total_rounds = 2 * (CACHED_ROUNDS + GC_DEPTH);
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder
+            .layers(1..=total_rounds)
+            .authorities(active_authorities)
+            .skip_ancestor_links(vec![authority_to_skip, catch_up_index])
+            .build();
+
+        let subdags_and_commits = dag_builder.get_sub_dag_and_commits(1..=total_rounds);
+        let subdag_bases = subdags_and_commits
+            .iter()
+            .map(|(subdag, _)| subdag.base.clone())
+            .collect::<Vec<_>>();
+        let commits = subdags_and_commits
+            .into_iter()
+            .map(|(_, commit)| commit)
+            .collect::<Vec<_>>();
+
+        dag_state.accept_block_headers(
+            dag_builder.block_headers(1..=total_rounds),
+            DataSource::Test,
+        );
+        for verified_transactions in dag_builder.transactions(1..=total_rounds) {
+            dag_state.add_transactions(verified_transactions, DataSource::Test);
+        }
+        for commit in commits {
+            dag_state.add_commit(commit);
+        }
+        dag_state.update_last_solid_subdag_base(
+            subdag_bases
+                .last()
+                .expect("expected at least one committed subdag")
+                .clone(),
+        );
+
+        let last_accepted_round = dag_builder
+            .block_headers(1..=total_rounds)
+            .into_iter()
+            .filter(|header| header.author() == authority_to_skip)
+            .map(|header| header.round())
+            .max()
+            .expect("skipped authority should have blocks");
+        let skipped_committed_round = dag_state.last_committed_rounds()[authority_to_skip];
+        assert!(skipped_committed_round < last_accepted_round);
+
+        dag_state.flush();
+
+        let expected_eviction_round = DagState::gc_eviction_round(
+            last_accepted_round,
+            dag_state.gc_round_for_last_commit(),
+            CACHED_ROUNDS,
+        );
+        assert_eq!(
+            dag_state.evicted_rounds[authority_to_skip],
+            expected_eviction_round
+        );
+
+        let cached_headers =
+            dag_state.get_cached_block_headers_since_round(authority_to_skip, GENESIS_ROUND + 1);
+        assert_eq!(
+            cached_headers.first().map(|header| header.round()),
+            Some(expected_eviction_round + 1)
+        );
+        assert_eq!(
+            cached_headers.last().map(|header| header.round()),
+            Some(last_accepted_round)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description of change

Fix DAG-state memory leak: when the linearizer skips blocks beyond `gc_depth`, `last_committed_rounds[authority]` freezes, but new headers keep arriving. Eviction was keyed off the frozen round, so the cache grew without bound.

Runtime eviction now uses the latest cached round per authority, capped by the global GC round.

## Links to any relevant issues

Fixes #11146

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
  - `test_gc_eviction_advances_for_skipped_authority` — regression test for the fix
  - Existing eviction and out-of-range panic tests adjusted for realistic `gc_depth`