### PR TITLE
fix(iota-core): skip duplicate EndOfPublish in white-flag mode

### DIFF
--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -874,35 +874,40 @@ impl ConsensusAdapter {
                 )
             };
         let send_end_of_publish = if is_user_tx {
-            // If we are in `RejectUserCerts` state, we need to send `EndOfPublish` to
-            // signal other validators that we are not submitting more user
-            // transactions in the epoch. Note that there could be a race condition
-            // here where we enter this check in `RejectAllCerts` state. In that case
-            // we don't need to send `EndOfPublish` because the condition to enter
-            // `RejectAllCerts` is when 2f+1 other validators already sequenced their
-            // `EndOfPublish` message. Also note that we could send multiple
-            // `EndOfPublish` messages because multiple tasks can enter here
-            // concurrently. This doesn't affect correctness.
-            if epoch_store
-                .get_reconfig_state_read_lock_guard()
-                .is_reject_user_certs()
-            {
-                if epoch_store.protocol_config().enable_white_flag_flow() {
-                    // In the certificate-less mode, there are no pending consensus
-                    // certificates, so `EndOfPublish` is always sent immediately.
-                    debug!(epoch=?epoch_store.epoch(), "Sending EndOfPublish in certificate-less mode");
-
-                    true
-                } else {
-                    // In certificate mode, `EndOfPublish` is sent only once the list
-                    // of pending consensus certificates is drained.
+            if epoch_store.protocol_config().enable_white_flag_flow() {
+                // In certificate-less mode, `EndOfPublish` is sent solely from
+                // `close_epoch`. There is no pending certificate drain to
+                // monitor here, and sending from this per-transaction callback
+                // would produce N duplicate EndOfPublish messages (one per
+                // in-flight user transaction completing after `RejectUserCerts`
+                // is set).
+                false
+            } else {
+                // In certificate mode, `EndOfPublish` is sent once the list of
+                // pending consensus certificates is drained. Multiple tasks can
+                // enter here concurrently with `pending_count == 0`, producing
+                // duplicate messages — this is rare and does not affect
+                // correctness.
+                //
+                // Note: there could be a race condition here where we enter
+                // this check in `RejectAllCerts` state. In that case we don't
+                // need to send `EndOfPublish` because the condition to enter
+                // `RejectAllCerts` is when 2f+1 other validators already
+                // sequenced their `EndOfPublish` message.
+                //
+                // TODO: This entire certificate-mode drain logic can be removed
+                // once the certificate flow is fully cleaned up.
+                if epoch_store
+                    .get_reconfig_state_read_lock_guard()
+                    .is_reject_user_certs()
+                {
                     let pending_count = epoch_store.pending_consensus_certificates_count();
                     debug!(epoch=?epoch_store.epoch(), ?pending_count, "Deciding whether to send EndOfPublish");
 
                     pending_count == 0 // send end of epoch if no pending certificates
+                } else {
+                    false
                 }
-            } else {
-                false
             }
         } else {
             false


### PR DESCRIPTION
# Description of change

In white-flag (certificate-less) mode, every `UserTransactionV1` completing in `RejectUserCerts` state triggered an `EndOfPublish` submission from `submit_and_wait_inner`, because `pending_consensus_certificates_count()` is always 0. This produced N duplicate `EndOfPublish` messages where N is the number of in-flight user transactions at epoch transition.

The `submit_and_wait_inner` EndOfPublish logic exists for the certificate drain scenario — detecting when the last pending certificate completes. In white-flag mode there's nothing to drain, so `close_epoch` is the correct and sufficient sender.

This change skips the EndOfPublish check in `submit_and_wait_inner` for white-flag mode entirely. The certificate-mode drain logic is preserved but annotated with a TODO for removal when the certificate flow is cleaned up.

## Links to any relevant issues

Fixes #10925

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes