### PR TITLE
fix(iota-core): add retry with backoff for EndOfPublish submission

### DIFF
--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -913,7 +913,16 @@ impl ConsensusAdapter {
             false
         };
         if send_end_of_publish {
-            self.submit_end_of_publish_with_retry(epoch_store).await;
+            if epoch_store
+                .within_alive_epoch(self.submit_end_of_publish_with_retry(epoch_store))
+                .await
+                .is_err()
+            {
+                warn!(
+                    epoch = ?epoch_store.epoch(),
+                    "EndOfPublish submission cancelled: epoch has ended",
+                );
+            }
         }
         self.metrics
             .sequencing_certificate_success
@@ -1058,11 +1067,13 @@ impl ConsensusAdapter {
         ProcessedMethod::Consensus
     }
 
-    /// Submits an `EndOfPublish` message to consensus with indefinite retry
-    /// and exponential backoff (capped at `MAX_BACKOFF`). On transient
-    /// failures (e.g. DB write errors in
-    /// `insert_pending_consensus_transactions`), retries until success since
-    /// a missing `EndOfPublish` would stall the epoch.
+    /// Submits an `EndOfPublish` message to consensus with exponential
+    /// backoff (capped at `MAX_BACKOFF`). On transient failures (e.g. DB
+    /// write errors in `insert_pending_consensus_transactions`), retries
+    /// until success since a missing `EndOfPublish` would stall the epoch.
+    ///
+    /// Callers should wrap this with `epoch_store.within_alive_epoch()` to
+    /// cancel retries when the epoch terminates.
     async fn submit_end_of_publish_with_retry(
         self: &Arc<Self>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
@@ -1207,7 +1218,20 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
         if send_end_of_publish {
             let adapter = self.clone();
             let epoch_store = epoch_store.clone();
-            spawn_monitored_task!(adapter.submit_end_of_publish_with_retry(&epoch_store));
+            spawn_monitored_task!(async move {
+                if epoch_store
+                    .within_alive_epoch(
+                        adapter.submit_end_of_publish_with_retry(&epoch_store),
+                    )
+                    .await
+                    .is_err()
+                {
+                    warn!(
+                        epoch = ?epoch_store.epoch(),
+                        "EndOfPublish submission cancelled: epoch has ended",
+                    );
+                }
+            });
         }
     }
 }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -45,7 +45,7 @@ use tokio::{
         Duration, {self},
     },
 };
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
@@ -913,7 +913,7 @@ impl ConsensusAdapter {
             false
         };
         if send_end_of_publish {
-            self.submit_end_of_publish_with_retry(epoch_store);
+            self.submit_end_of_publish_with_retry(epoch_store).await;
         }
         self.metrics
             .sequencing_certificate_success
@@ -1063,7 +1063,7 @@ impl ConsensusAdapter {
     /// failures (e.g. DB write errors in
     /// `insert_pending_consensus_transactions`), retries until success since
     /// a missing `EndOfPublish` would stall the epoch.
-    fn submit_end_of_publish_with_retry(
+    async fn submit_end_of_publish_with_retry(
         self: &Arc<Self>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
@@ -1094,7 +1094,7 @@ impl ConsensusAdapter {
                         backoff,
                         err,
                     );
-                    std::thread::sleep(backoff);
+                    tokio::time::sleep(backoff).await;
                     attempt = attempt.saturating_add(1);
                 }
             }
@@ -1205,7 +1205,9 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
         };
 
         if send_end_of_publish {
-            self.submit_end_of_publish_with_retry(epoch_store);
+            let adapter = self.clone();
+            let epoch_store = epoch_store.clone();
+            spawn_monitored_task!(adapter.submit_end_of_publish_with_retry(&epoch_store));
         }
     }
 }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -45,7 +45,7 @@ use tokio::{
         Duration, {self},
     },
 };
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
@@ -913,15 +913,7 @@ impl ConsensusAdapter {
             false
         };
         if send_end_of_publish {
-            // sending message outside of any locks scope
-            info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
-            if let Err(err) = self.submit(
-                ConsensusTransaction::new_end_of_publish(self.authority),
-                None,
-                epoch_store,
-            ) {
-                warn!("Error when sending end of publish message: {:?}", err);
-            }
+            self.submit_end_of_publish_with_retry(epoch_store);
         }
         self.metrics
             .sequencing_certificate_success
@@ -1065,6 +1057,59 @@ impl ConsensusAdapter {
         }
         ProcessedMethod::Consensus
     }
+
+    /// Submits an `EndOfPublish` message to consensus with bounded retry and
+    /// exponential backoff. On transient failures (e.g. DB write errors in
+    /// `insert_pending_consensus_transactions`), retries up to
+    /// `MAX_RETRIES` times. If all attempts fail, logs at `error!` level
+    /// and relies on crash recovery via `submit_recovered` as the ultimate
+    /// backstop.
+    fn submit_end_of_publish_with_retry(
+        self: &Arc<Self>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) {
+        const MAX_RETRIES: u32 = 5;
+        const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+
+        info!(
+            epoch = ?epoch_store.epoch(),
+            authority = ?self.authority,
+            "Sending EndOfPublish message to consensus",
+        );
+
+        for attempt in 0..=MAX_RETRIES {
+            match self.submit(
+                ConsensusTransaction::new_end_of_publish(self.authority),
+                None,
+                epoch_store,
+            ) {
+                Ok(_) => return,
+                Err(err) => {
+                    if attempt == MAX_RETRIES {
+                        error!(
+                            epoch = ?epoch_store.epoch(),
+                            authority = ?self.authority,
+                            "Failed to submit EndOfPublish after {} attempts: {:?}. \
+                             Will rely on crash recovery via submit_recovered.",
+                            MAX_RETRIES + 1,
+                            err,
+                        );
+                        return;
+                    }
+                    let backoff = INITIAL_BACKOFF * 2u32.pow(attempt);
+                    warn!(
+                        epoch = ?epoch_store.epoch(),
+                        authority = ?self.authority,
+                        attempt,
+                        "Failed to submit EndOfPublish, retrying in {:?}: {:?}",
+                        backoff,
+                        err,
+                    );
+                    std::thread::sleep(backoff);
+                }
+            }
+        }
+    }
 }
 
 impl CheckConnection for ConnectionMonitorStatus {
@@ -1170,14 +1215,7 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
         };
 
         if send_end_of_publish {
-            info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
-            if let Err(err) = self.submit(
-                ConsensusTransaction::new_end_of_publish(self.authority),
-                None,
-                epoch_store,
-            ) {
-                warn!("Error when sending end of publish message: {:?}", err);
-            }
+            self.submit_end_of_publish_with_retry(epoch_store);
         }
     }
 }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -922,9 +922,7 @@ impl ConsensusAdapter {
             let epoch_store = epoch_store.clone();
             spawn_monitored_task!(async move {
                 if epoch_store
-                    .within_alive_epoch(
-                        adapter.submit_end_of_publish_with_retry(&epoch_store),
-                    )
+                    .within_alive_epoch(adapter.submit_end_of_publish_with_retry(&epoch_store))
                     .await
                     .is_err()
                 {
@@ -1249,9 +1247,7 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
             let epoch_store = epoch_store.clone();
             spawn_monitored_task!(async move {
                 if epoch_store
-                    .within_alive_epoch(
-                        adapter.submit_end_of_publish_with_retry(&epoch_store),
-                    )
+                    .within_alive_epoch(adapter.submit_end_of_publish_with_retry(&epoch_store))
                     .await
                     .is_err()
                 {

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -1058,18 +1058,17 @@ impl ConsensusAdapter {
         ProcessedMethod::Consensus
     }
 
-    /// Submits an `EndOfPublish` message to consensus with bounded retry and
-    /// exponential backoff. On transient failures (e.g. DB write errors in
-    /// `insert_pending_consensus_transactions`), retries up to
-    /// `MAX_RETRIES` times. If all attempts fail, logs at `error!` level
-    /// and relies on crash recovery via `submit_recovered` as the ultimate
-    /// backstop.
+    /// Submits an `EndOfPublish` message to consensus with indefinite retry
+    /// and exponential backoff (capped at `MAX_BACKOFF`). On transient
+    /// failures (e.g. DB write errors in
+    /// `insert_pending_consensus_transactions`), retries until success since
+    /// a missing `EndOfPublish` would stall the epoch.
     fn submit_end_of_publish_with_retry(
         self: &Arc<Self>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
-        const MAX_RETRIES: u32 = 5;
         const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+        const MAX_BACKOFF: Duration = Duration::from_secs(10);
 
         info!(
             epoch = ?epoch_store.epoch(),
@@ -1077,7 +1076,8 @@ impl ConsensusAdapter {
             "Sending EndOfPublish message to consensus",
         );
 
-        for attempt in 0..=MAX_RETRIES {
+        let mut attempt: u32 = 0;
+        loop {
             match self.submit(
                 ConsensusTransaction::new_end_of_publish(self.authority),
                 None,
@@ -1085,18 +1085,7 @@ impl ConsensusAdapter {
             ) {
                 Ok(_) => return,
                 Err(err) => {
-                    if attempt == MAX_RETRIES {
-                        error!(
-                            epoch = ?epoch_store.epoch(),
-                            authority = ?self.authority,
-                            "Failed to submit EndOfPublish after {} attempts: {:?}. \
-                             Will rely on crash recovery via submit_recovered.",
-                            MAX_RETRIES + 1,
-                            err,
-                        );
-                        return;
-                    }
-                    let backoff = INITIAL_BACKOFF * 2u32.pow(attempt);
+                    let backoff = (INITIAL_BACKOFF * 2u32.pow(attempt.min(10))).min(MAX_BACKOFF);
                     warn!(
                         epoch = ?epoch_store.epoch(),
                         authority = ?self.authority,
@@ -1106,6 +1095,7 @@ impl ConsensusAdapter {
                         err,
                     );
                     std::thread::sleep(backoff);
+                    attempt = attempt.saturating_add(1);
                 }
             }
         }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -913,16 +913,27 @@ impl ConsensusAdapter {
             false
         };
         if send_end_of_publish {
-            if epoch_store
-                .within_alive_epoch(self.submit_end_of_publish_with_retry(epoch_store))
-                .await
-                .is_err()
-            {
-                warn!(
-                    epoch = ?epoch_store.epoch(),
-                    "EndOfPublish submission cancelled: epoch has ended",
-                );
-            }
+            // Spawn a separate task for EndOfPublish so that
+            // submit_and_wait_inner returns promptly after the original
+            // transaction is processed. Awaiting the retry loop inline
+            // would hold the InflightDropGuard and inflate in-flight
+            // metrics for the duration of retries.
+            let adapter = self.clone();
+            let epoch_store = epoch_store.clone();
+            spawn_monitored_task!(async move {
+                if epoch_store
+                    .within_alive_epoch(
+                        adapter.submit_end_of_publish_with_retry(&epoch_store),
+                    )
+                    .await
+                    .is_err()
+                {
+                    warn!(
+                        epoch = ?epoch_store.epoch(),
+                        "EndOfPublish submission cancelled: epoch has ended",
+                    );
+                }
+            });
         }
         self.metrics
             .sequencing_certificate_success
@@ -1068,12 +1079,15 @@ impl ConsensusAdapter {
     }
 
     /// Submits an `EndOfPublish` message to consensus with exponential
-    /// backoff (capped at `MAX_BACKOFF`). On transient failures (e.g. DB
-    /// write errors in `insert_pending_consensus_transactions`), retries
-    /// until success since a missing `EndOfPublish` would stall the epoch.
+    /// backoff (capped at `MAX_BACKOFF`). Retries indefinitely on any
+    /// error — both transient failures (e.g. DB write errors in
+    /// `insert_pending_consensus_transactions`) and permanent ones (e.g.
+    /// `EpochEnded` from `tables()`). A missing `EndOfPublish` would
+    /// stall the epoch, so the loop never gives up on its own.
     ///
-    /// Callers should wrap this with `epoch_store.within_alive_epoch()` to
-    /// cancel retries when the epoch terminates.
+    /// Callers **must** wrap this with `epoch_store.within_alive_epoch()`
+    /// to cancel retries when the epoch terminates — this is the
+    /// mechanism that stops the loop on permanent `EpochEnded` errors.
     async fn submit_end_of_publish_with_retry(
         self: &Arc<Self>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
@@ -1095,6 +1109,14 @@ impl ConsensusAdapter {
                 epoch_store,
             ) {
                 Ok(_) => return,
+                Err(IotaError::EpochEnded(_)) => {
+                    warn!(
+                        epoch = ?epoch_store.epoch(),
+                        authority = ?self.authority,
+                        "EndOfPublish submission stopped: epoch has ended",
+                    );
+                    return;
+                }
                 Err(err) => {
                     let backoff = (INITIAL_BACKOFF * 2u32.pow(attempt.min(10))).min(MAX_BACKOFF);
                     warn!(
@@ -1184,8 +1206,9 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
     /// This method is called externally to begin reconfiguration.
     /// It transitions the reconfig state to reject new user transactions.
     /// `ConsensusAdapter` will send `EndOfPublish` once all pending
-    /// transactions are drained (in the certificate mode) or immediately
-    /// (in the certificate-less mode).
+    /// transactions are drained (in the certificate mode) or right away
+    /// (in the certificate-less mode). Submission is asynchronous —
+    /// a background task handles retries so this method returns promptly.
     fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
         let send_end_of_publish = {
             let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
@@ -1216,6 +1239,12 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
         };
 
         if send_end_of_publish {
+            // Spawned because ReconfigurationInitiator::close_epoch is
+            // sync — it cannot await. This is safe: by this point
+            // close_user_certs() has already set the reconfig state to
+            // reject new transactions, so no further user work depends
+            // on this method returning. The background task retries
+            // until the message is delivered or the epoch terminates.
             let adapter = self.clone();
             let epoch_store = epoch_store.clone();
             spawn_monitored_task!(async move {


### PR DESCRIPTION
# Description of change

This pull request improves the reliability of sending `EndOfPublish` messages to consensus by introducing an indefinite retry mechanism with exponential backoff. Previously, if sending failed due to transient errors (like database write issues), the process would not retry, potentially stalling the epoch. Now, the system will keep retrying until the message is successfully sent, ensuring forward progress.

**Reliability improvements for EndOfPublish message delivery:**

* Added a new async method `submit_end_of_publish_with_retry` to `ConsensusAdapter` that retries sending the `EndOfPublish` message with exponential backoff, capped at 10 seconds, until it succeeds. This prevents epoch stalls due to transient errors.
* Updated existing code paths to use the new retry method:
  - In the main consensus adapter logic, replaced the direct call to `submit` with `submit_end_of_publish_with_retry`.
  - In the `ReconfigurationInitiator` implementation, replaced the direct call with a monitored task that invokes the retry method asynchronously.

Both `close_epoch` and `submit_and_wait_inner` (certificate-mode path) now use the retry helper.

## Links to any relevant issues

Fixes #10926

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes