### PR TITLE
fix(split-cluster): cherry-pick iota-localnet genesis fix to testnet

### DIFF
--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -38,19 +38,31 @@ echo "Using working dir $WORKING_DIR"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+# TODO this can be removed when v1.20 reaches mainnet
+git checkout $RELEASE_COMMIT || exit 1
+if cargo metadata --no-deps --format-version 1 \
+     | jq -e '[.packages[].targets[] | select(.kind[] == "bin") | .name] | contains(["iota-localnet"])' > /dev/null 2>&1; then
+  IOTA_BINARY="iota-localnet"
+  echo "iota-localnet target found"
+else
+  IOTA_BINARY="iota"
+  echo "iota-localnet target NOT found"
+fi
+git checkout $CURRENT_COMMIT || exit 1
+
 # check if binaries have already been built
-if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/iota-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
+if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/$IOTA_BINARY-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
   echo "Binaries already built, skipping build"
 else
-  echo "Building iota-node and iota at $RELEASE_COMMIT"
+  echo "Building iota-node and $IOTA_BINARY at $RELEASE_COMMIT"
 
   # remember current commit
   CURRENT_COMMIT=$(git rev-parse HEAD)
 
   git checkout $RELEASE_COMMIT || exit 1
-  cargo build --bin iota-node --bin iota || exit 1
+  cargo build --bin iota-node --bin $IOTA_BINARY || exit 1
   cp ./target/debug/iota-node "$WORKING_DIR/iota-node-release"
-  cp ./target/debug/iota "$WORKING_DIR/iota-release"
+  cp ./target/debug/$IOTA_BINARY "$WORKING_DIR/$IOTA_BINARY-release"
 
   echo "Building iota-node at $RELEASE_CANDIDATE_COMMIT"
   git checkout $RELEASE_CANDIDATE_COMMIT || exit 1
@@ -64,7 +76,7 @@ fi
 export IOTA_CONFIG_DIR="$WORKING_DIR/config"
 rm -rf "$IOTA_CONFIG_DIR"
 
-"$WORKING_DIR/iota-release" genesis --epoch-duration-ms 20000 --committee-size 4
+"$WORKING_DIR/$IOTA_BINARY-release" genesis --epoch-duration-ms 20000 --committee-size 4
 
 LOG_DIR="$WORKING_DIR/logs"
 


### PR DESCRIPTION
# Description of change

Cherry-pick of #11079 to testnet. The `genesis` command moved to `iota-localnet` but the split-cluster CI script still referenced the old `iota` binary, causing testnet split-cluster-sync CI jobs to fail.

## Links to any relevant issues

Backport of #11079

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)