### PR TITLE
refactor(iota-indexer-streaming): streams recovery

### DIFF
--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -170,7 +170,7 @@ impl GraphQLStream {
         filter: Option<SubscriptionTransactionFilter>,
     ) -> impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>> {
         self.streamer
-            .subscribe_transactions()
+            .subscribe_transactions(None)
             .try_filter(move |stored| future::ready(Self::matches_filter(filter.as_ref(), stored)))
             .then(|stored| {
                 let subscription_item = match stored {
@@ -208,7 +208,7 @@ impl GraphQLStream {
         filter: Option<SubscriptionEventFilter>,
     ) -> impl Stream<Item = Result<SubscriptionItem<Event>, Error>> {
         self.streamer
-            .subscribe_events()
+            .subscribe_events(None)
             .try_filter(move |stored| future::ready(Self::matches_filter(filter.as_ref(), stored)))
             .then(|stored| {
                 let subscription_item = match stored {

--- a/crates/iota-indexer-streaming/src/error.rs
+++ b/crates/iota-indexer-streaming/src/error.rs
@@ -19,6 +19,8 @@ pub enum IndexerStreamingError {
     Indexer(String),
     #[error(transparent)]
     Lagged(#[from] BroadcastStreamRecvError),
+    #[error("not found: {0}")]
+    NotFound(String),
 }
 
 impl From<diesel::result::Error> for IndexerStreamingError {

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -264,10 +264,10 @@ impl InMemory {
     /// filtering.
     ///
     /// When `start_from` is `None`, subscribes to live events only. When
-    /// `start_from` is `Some(digest)`, the stream first backfills
-    /// historical events from the transaction identified by the digest,
-    /// then seamlessly transitions to live events. This enables stream
-    /// recovery after a disconnection.
+    /// `start_from` is `Some(digest)`, the stream first backfills historical
+    /// events from the transaction identified by the digest inclusive) up to
+    /// the tip of the network, then seamlessly transitions to live events. This
+    /// enables stream recovery after a disconnection.
     ///
     /// # Note
     /// Since under the hood a [`tokio::sync::broadcast`] channel is used for
@@ -376,10 +376,10 @@ impl InMemory {
     /// filtering.
     ///
     /// When `start_from` is `None`, subscribes to live transactions only. When
-    /// `start_from` is `Some(digest)`, the stream first backfills
-    /// historical transactions from the one identified by the digest,
-    /// then seamlessly transitions to live transactions. This enables
-    /// stream recovery after a disconnection.
+    /// `start_from` is `Some(digest)`, the stream first backfills historical
+    /// transactions from the one identified by the digest (inclusive) up to the
+    /// tip of the network, then seamlessly transitions to live transactions.
+    /// This enables stream recovery after a disconnection.
     ///
     /// # Note
     /// Since under the hood a [`tokio::sync::broadcast`] channel is used for

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -943,8 +943,10 @@ impl HistoricalFetch {
                             Ok(cursor) => state.cursor.store(cursor, Ordering::Relaxed),
                             Err(e) => {
                                 state.should_close_stream = true;
-                                let e = IndexerStreamingError::Postgres(e.to_string());
-                                error!("failed to resolve tx digest into its sequence number: {e}");
+                                let e = IndexerStreamingError::Postgres(format!(
+                                    "unable to resolve transaction, may not exist or has been pruned: {e}"
+                                ));
+                                error!("{e}");
                                 return Some((Err(e), state));
                             }
                         }

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -360,13 +360,20 @@ impl InMemory {
                 // when switching from historical to live, the broadcast buffer may
                 // contain transactions already delivered by the historical backfill.
                 // Filter them out using the cursor to prevent duplicates.
-                .chain(live_stream.filter(move |result| {
-                    future::ready(match result {
-                        Ok(tx) => tx.tx_sequence_number >= cursor.load(Ordering::Relaxed),
-                        // we must include errors.
-                        Err(_) => true,
+                .chain({
+                    let mut initial_lagged_skipped = false;
+                    live_stream.skip_while(move |result| {
+                        future::ready(match result {
+                            Ok(tx) => tx.tx_sequence_number < cursor.load(Ordering::Relaxed),
+                            Err(IndexerStreamingError::Lagged(_)) if !initial_lagged_skipped => {
+                                initial_lagged_skipped = true;
+                                true // skip this one
+                            }
+                            // surface any other error or second Lagged
+                            Err(_) => false,
+                        })
                     })
-                })),
+                }),
         )
     }
 
@@ -458,13 +465,20 @@ impl InMemory {
                 // when switching from historical to live, the broadcast buffer may
                 // contain transactions already delivered by the historical backfill.
                 // Filter them out using the cursor to prevent duplicates.
-                .chain(live_stream.filter(move |result| {
-                    future::ready(match result {
-                        Ok(tx) => tx.tx_sequence_number >= cursor.load(Ordering::Relaxed),
-                        // we must include errors.
-                        Err(_) => true,
+                .chain({
+                    let mut initial_lagged_skipped = false;
+                    live_stream.skip_while(move |result| {
+                        future::ready(match result {
+                            Ok(tx) => tx.tx_sequence_number < cursor.load(Ordering::Relaxed),
+                            Err(IndexerStreamingError::Lagged(_)) if !initial_lagged_skipped => {
+                                initial_lagged_skipped = true;
+                                true // skip this one
+                            }
+                            // surface any other error or second Lagged
+                            Err(_) => false,
+                        })
                     })
-                })),
+                }),
         )
     }
 

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -134,6 +134,34 @@ impl Default for Config {
     }
 }
 
+/// Where to start a recovery stream relative to a known transaction digest.
+///
+/// - [`Inclusive`](Self::Inclusive) — yield the identified transaction, then
+///   everything after it.
+/// - [`Exclusive`](Self::Exclusive) — skip the identified transaction; start
+///   from the next one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
+pub enum RecoveryPoint {
+    /// Include the transaction identified by the digest.
+    Inclusive(TransactionDigest),
+    /// Start after the transaction identified by the digest.
+    Exclusive(TransactionDigest),
+}
+
+impl RecoveryPoint {
+    /// Returns the contained transaction digest.
+    fn digest(&self) -> TransactionDigest {
+        match self {
+            Self::Inclusive(d) | Self::Exclusive(d) => *d,
+        }
+    }
+
+    /// Checks if the starting transaction should be included in the stream.
+    fn is_inclusive(&self) -> bool {
+        matches!(self, Self::Inclusive(_))
+    }
+}
+
 /// Provides real-time streaming of transactions and events from the IOTA
 /// Indexer by listening to PostgreSQL NOTIFY messages triggered when new
 /// checkpoints are committed to the indexer database.
@@ -264,10 +292,19 @@ impl InMemory {
     /// filtering.
     ///
     /// When `start_from` is `None`, subscribes to live events only. When
-    /// `start_from` is `Some(digest)`, the stream first backfills historical
-    /// events from the transaction identified by the digest inclusive) up to
-    /// the tip of the network, then seamlessly transitions to live events. This
-    /// enables stream recovery after a disconnection.
+    /// `start_from` is `Some(recovery_point)`, the stream first backfills
+    /// historical events from the transaction identified by the recovery
+    /// point's digest up to the tip of the network, then seamlessly transitions
+    /// to live events. This enables stream recovery after a disconnection.
+    ///
+    /// The recovery point variant controls whether events of the starting
+    /// transaction are included:
+    /// - [`RecoveryPoint::Inclusive`]: events of the starting transaction are
+    ///   yielded.
+    /// - [`RecoveryPoint::Exclusive`]: events of the starting transaction are
+    ///   skipped; streaming begins from the next transaction onward. Useful for
+    ///   reconnection, where the client already received that transaction's
+    ///   events in the previous session.
     ///
     /// # Note
     /// Since under the hood a [`tokio::sync::broadcast`] channel is used for
@@ -276,7 +313,7 @@ impl InMemory {
     /// # Example
     ///
     /// ```rust,ignore
-    /// use iota_indexer_streaming::error::IndexerStreamingError;
+    /// use iota_indexer_streaming::{error::IndexerStreamingError, memory::RecoveryPoint};
     /// use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     ///
     /// // live events only.
@@ -297,11 +334,11 @@ impl InMemory {
     /// # Example with a starting transaction digest
     ///
     /// ```rust,ignore
-    /// use iota_indexer_streaming::error::IndexerStreamingError;
+    /// use iota_indexer_streaming::{error::IndexerStreamingError, memory::RecoveryPoint};
     /// use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     ///
     /// // recover events from a specific transaction digest onwards.
-    /// let event_stream = streamer.subscribe_events(Some(tx_digest));
+    /// let event_stream = streamer.subscribe_events(Some(RecoveryPoint::Inclusive(tx_digest)));
     /// tokio::spawn(async move {
     ///     use futures::StreamExt;
     ///     while let Some(ev) = event_stream.next().await {
@@ -317,7 +354,7 @@ impl InMemory {
     /// ```
     pub fn subscribe_events(
         &self,
-        start_from: Option<TransactionDigest>,
+        start_from: Option<RecoveryPoint>,
     ) -> Pin<Box<dyn Stream<Item = IndexerStreamingResult<StoredEvent>> + Send>> {
         let stream = BroadcastStream::new(self.event_tx.subscribe());
         let live_stream = SubscriberStream::new(
@@ -327,22 +364,34 @@ impl InMemory {
             start_from.is_some(),
         )
         .map(Self::flatten_error);
-        let Some(tx_digest) = start_from else {
+        let Some(recovery_point) = start_from else {
             return Box::pin(live_stream);
         };
 
         let historical = HistoricalFetch::new(
             METRICS_EVENT_LABEL,
-            tx_digest,
+            recovery_point.digest(),
             self.reader.clone(),
             self.config.transaction_batch_size.get(),
             self.metrics.clone(),
         );
 
-        let cursor = historical.cursor();
+        let cursor = historical.cursor_handle();
 
         let historical_events = historical
             .into_stream()
+            .skip_while({
+                let mut include_starting_tx = recovery_point.is_inclusive();
+                move |result| {
+                    future::ready(match result {
+                        Ok(_) if !include_starting_tx => {
+                            include_starting_tx = true;
+                            true
+                        }
+                        _ => false,
+                    })
+                }
+            })
             // we use Either represented by left/right stream methods to unify the two stream types
             // returned by the closure: stream::iter (multiple events) and stream::once (single
             // error). This avoids an extra heap allocation from Box::pin.
@@ -383,10 +432,18 @@ impl InMemory {
     /// filtering.
     ///
     /// When `start_from` is `None`, subscribes to live transactions only. When
-    /// `start_from` is `Some(digest)`, the stream first backfills historical
-    /// transactions from the one identified by the digest (inclusive) up to the
-    /// tip of the network, then seamlessly transitions to live transactions.
-    /// This enables stream recovery after a disconnection.
+    /// `start_from` is `Some(recovery_point)`, the stream first backfills
+    /// historical transactions from the one identified by the recovery point's
+    /// digest up to the tip of the network, then seamlessly transitions to
+    /// live transactions. This enables stream recovery after a disconnection.
+    ///
+    /// The recovery point variant controls whether the starting transaction
+    /// itself is included:
+    /// - [`RecoveryPoint::Inclusive`]: the starting transaction is yielded.
+    /// - [`RecoveryPoint::Exclusive`]: streaming begins from the transaction
+    ///   immediately after the one identified by the digest. Useful for
+    ///   reconnection, where the client already received that transaction in
+    ///   the previous session.
     ///
     /// # Note
     /// Since under the hood a [`tokio::sync::broadcast`] channel is used for
@@ -414,11 +471,11 @@ impl InMemory {
     /// ```
     /// # Example with a starting transaction digest
     /// ```rust,ignore
-    /// use iota_indexer_streaming::error::IndexerStreamingError;
+    /// use iota_indexer_streaming::{error::IndexerStreamingError, memory::RecoveryPoint};
     /// use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     ///
     /// // recover transactions from a specific transaction digest onwards.
-    /// let tx_stream = streamer.subscribe_transactions(Some(tx_digest));
+    /// let tx_stream = streamer.subscribe_transactions(Some(RecoveryPoint::Inclusive(tx_digest)));
     /// tokio::spawn(async move {
     ///     use futures::StreamExt;
     ///     while let Some(tx) = tx_stream.next().await {
@@ -434,7 +491,7 @@ impl InMemory {
     /// ```
     pub fn subscribe_transactions(
         &self,
-        start_from: Option<TransactionDigest>,
+        start_from: Option<RecoveryPoint>,
     ) -> Pin<Box<dyn Stream<Item = IndexerStreamingResult<StoredTransaction>> + Send>> {
         let stream = BroadcastStream::new(self.transaction_tx.subscribe());
         let live_stream = SubscriberStream::new(
@@ -445,23 +502,35 @@ impl InMemory {
         )
         .map(Self::flatten_error);
 
-        let Some(tx_digest) = start_from else {
+        let Some(recovery_point) = start_from else {
             return Box::pin(live_stream);
         };
 
         let historical = HistoricalFetch::new(
             METRICS_TRANSACTION_LABEL,
-            tx_digest,
+            recovery_point.digest(),
             self.reader.clone(),
             self.config.transaction_batch_size.get(),
             self.metrics.clone(),
         );
 
-        let cursor = historical.cursor();
+        let cursor = historical.cursor_handle();
 
         Box::pin(
             historical
                 .into_stream()
+                .skip_while({
+                    let mut include_starting_tx = recovery_point.is_inclusive();
+                    move |result| {
+                        future::ready(match result {
+                            Ok(_) if !include_starting_tx => {
+                                include_starting_tx = true;
+                                true
+                            }
+                            _ => false,
+                        })
+                    }
+                })
                 // when switching from historical to live, the broadcast buffer may
                 // contain transactions already delivered by the historical backfill.
                 // Filter them out using the cursor to prevent duplicates.
@@ -856,11 +925,17 @@ impl<T: Clone + Send + 'static> Stream for SubscriberStream<T> {
 /// a live broadcast stream to provide gap-free delivery from a recovery point.
 struct HistoricalFetch {
     /// Transaction digest to start fetching from.
-    digest: TransactionDigest,
+    start_from_digest: TransactionDigest,
     /// Next transaction sequence number to fetch.
     cursor: Arc<AtomicI64>,
+    /// Whether [`Self::cursor`] has been resolved from
+    /// [`Self::start_from_digest`].
+    ///
+    /// Needed because `0` is a valid cursor value (the genesis transaction),
+    /// so it cannot be used as a starting point for the unresolved state.
+    cursor_resolved: bool,
     /// Latest committed transaction sequence number in the database.
-    latest: i64,
+    latest_tx_in_db: i64,
     /// Database reader for fetching transactions.
     reader: IndexerReader,
     /// Buffered transactions from the last database batch fetch.
@@ -877,7 +952,7 @@ struct HistoricalFetch {
 impl HistoricalFetch {
     fn new(
         label: &'static str,
-        digest: TransactionDigest,
+        start_from_digest: TransactionDigest,
         reader: IndexerReader,
         batch_size: i64,
         metrics: Arc<InMemoryStreamMetrics>,
@@ -886,9 +961,10 @@ impl HistoricalFetch {
         active_subscriber_number.inc();
 
         Self {
-            digest,
+            start_from_digest,
             cursor: Arc::new(AtomicI64::new(0)),
-            latest: 0,
+            cursor_resolved: false,
+            latest_tx_in_db: 0,
             reader,
             buffer: VecDeque::new(),
             batch_size,
@@ -897,12 +973,22 @@ impl HistoricalFetch {
         }
     }
 
+    /// Returns the current value of the cursor.
+    fn cursor_value(&self) -> i64 {
+        self.cursor.load(Ordering::Relaxed)
+    }
+
+    /// Updates the cursor to the given value.
+    fn update_cursor(&self, value: i64) {
+        self.cursor.store(value, Ordering::Relaxed);
+    }
+
     /// Returns a shared reference to the cursor.
     ///
     /// The cursor tracks the next expected transaction sequence number and
     /// is updated as the historical stream progresses. Used by the live
     /// stream filter to skip already-delivered transactions.
-    fn cursor(&self) -> Arc<AtomicI64> {
+    fn cursor_handle(&self) -> Arc<AtomicI64> {
         self.cursor.clone()
     }
 
@@ -928,7 +1014,7 @@ impl HistoricalFetch {
     /// point the caller can chain a live stream.
     fn into_stream(self) -> impl Stream<Item = IndexerStreamingResult<StoredTransaction>> {
         stream::unfold(self, |mut state| {
-            let start_from = state.digest;
+            let start_from = state.start_from_digest;
             let span = tracing::info_span!("historical_backfill", %start_from);
             async move {
                 loop {
@@ -943,18 +1029,21 @@ impl HistoricalFetch {
                     }
 
                     // resolve the cursor from the digest if it hasn't been set yet.
-                    if state.cursor.load(Ordering::Relaxed) == 0 {
+                    if !state.cursor_resolved {
                         match Self::with_retry(|| async {
                             state
                                 .reader
                                 .db()
-                                .resolve_cursor_tx_digest_to_seq_num(state.digest)
+                                .resolve_cursor_tx_digest_to_seq_num(state.start_from_digest)
                                 .await
                                 .map_err(backoff::Error::transient)
                         })
                         .await
                         {
-                            Ok(cursor) => state.cursor.store(cursor, Ordering::Relaxed),
+                            Ok(cursor) => {
+                                state.cursor_resolved = true;
+                                state.update_cursor(cursor);
+                            },
                             Err(e) => {
                                 state.should_close_stream = true;
                                 let e = IndexerStreamingError::Postgres(format!(
@@ -968,8 +1057,8 @@ impl HistoricalFetch {
 
                     // check if cursor is ahead of latest available transaction on database, if so,
                     // refresh latest, so the stream can continue.
-                    if state.cursor.load(Ordering::Relaxed) > state.latest {
-                        state.latest = match Self::with_retry(|| async {
+                    if state.cursor_value() > state.latest_tx_in_db {
+                        state.latest_tx_in_db = match Self::with_retry(|| async {
                             state
                                 .reader
                                 .db()
@@ -1003,22 +1092,22 @@ impl HistoricalFetch {
                         };
 
                         debug!(
-                            cursor = state.cursor.load(Ordering::Relaxed),
-                            latest = state.latest,
+                            cursor = state.cursor_value(),
+                            latest = state.latest_tx_in_db,
                             "current state"
                         );
 
                         // if latest did not advance, we're at the tip and can close the historical
                         // backfill stream and move to the live one.
-                        if state.cursor.load(Ordering::Relaxed) > state.latest {
+                        if state.cursor_value() > state.latest_tx_in_db {
                             debug!("reached the tip and are in sync with live data");
                             return None;
                         }
                     }
 
                     // fetch transaction batch from database and update the cursor.
-                    let start = state.cursor.load(Ordering::Relaxed);
-                    let end = (start + state.batch_size.saturating_sub(1)).min(state.latest);
+                    let start = state.cursor_value();
+                    let end = (start + state.batch_size.saturating_sub(1)).min(state.latest_tx_in_db);
 
                     let db_query_timer = state.query_tx_from_indexer_db_latency.start_timer();
                     match Self::with_retry(|| async {
@@ -1040,7 +1129,7 @@ impl HistoricalFetch {
                                 batch.len()
                             );
                             state.buffer.extend(batch);
-                            state.cursor.store(end + 1, Ordering::Relaxed);
+                            state.update_cursor(end + 1);
                         }
                         Err(e) => {
                             state.should_close_stream = true;

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -136,9 +136,9 @@ impl Default for Config {
 
 /// Where to start a recovery stream relative to a known transaction digest.
 ///
-/// - [`Inclusive`](Self::Inclusive) — yield the identified transaction, then
+/// - [`Inclusive`](Self::Inclusive): yield the identified transaction, then
 ///   everything after it.
-/// - [`Exclusive`](Self::Exclusive) — skip the identified transaction; start
+/// - [`Exclusive`](Self::Exclusive): skip the identified transaction; start
 ///   from the next one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum RecoveryPoint {

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -7,23 +7,30 @@
 //! It leverages PostgreSQL NOTIFY channel for receiving committed checkpoints
 //! notifications on which it fetches transactions by sequence number ranges,
 //! extracts events from them, and forwards all data to subscribers through
-//! [`tokio::sync::broadcast`].
+//! [`tokio::sync::broadcast`]. Supports backfill of historical data from
+//! indexer database enabling stream recovery after a disconnection.
 
 use std::{
+    collections::VecDeque,
     fmt::Debug,
+    future::Future,
     num::{NonZeroI64, NonZeroUsize},
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicI64, Ordering},
+    },
     task::{Context, Poll},
     time::{Duration, Instant},
 };
 
+use backoff::ExponentialBackoff;
 use diesel::{
     PgConnection, QueryResult, RunQueryDsl,
     pg::PgNotification,
     r2d2::{ConnectionManager, PooledConnection},
 };
-use futures::{Stream, StreamExt, TryFutureExt};
+use futures::{Stream, StreamExt, TryFutureExt, future, stream};
 use iota_indexer::{
     models::{
         events::StoredEvent,
@@ -31,12 +38,12 @@ use iota_indexer::{
     },
     read::IndexerReader,
 };
-use iota_types::event::Event;
-use prometheus::IntGauge;
+use iota_types::{digests::TransactionDigest, event::Event};
+use prometheus::{Histogram, IntGauge};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
-use tracing::{debug, error};
+use tracing::{Instrument, debug, error};
 
 use crate::{
     error::{IndexerStreamingError, IndexerStreamingResult},
@@ -131,6 +138,9 @@ impl Default for Config {
 /// Indexer by listening to PostgreSQL NOTIFY messages triggered when new
 /// checkpoints are committed to the indexer database.
 ///
+/// Also supports backfill of historical data from indexer database enabling
+/// stream recovery after a disconnection.
+///
 /// The streamer consists of:
 /// - A PostgreSQL connection listening for notifications after every committed
 ///   checkpoint.
@@ -140,13 +150,18 @@ impl Default for Config {
 /// # Usage
 ///
 /// ```rust,ignore
-/// use iota_indexer_streaming::memory::{InMemory, StreamTransactionFilter};
+/// use iota_indexer_streaming::{memory::InMemory, metrics::InMemoryStreamMetrics};
 ///
 /// // create a new streamer
-/// let streamer = InMemory::new(db_url, Default::default(), indexer_reader).await?;
+/// let streamer = InMemory::new(
+///     Default::default(),
+///     indexer_reader,
+///     InMemoryStreamMetrics::new(registry),
+/// )
+/// .await?;
 ///
 /// // subscribe to all events
-/// let events = streamer.subscribe_events().unwrap()
+/// let events = streamer.subscribe_events(None);
 /// tokio::spawn(async move {
 ///     use futures::StreamExt;
 ///     while let Some(event) = events.next().await {
@@ -157,7 +172,9 @@ impl Default for Config {
 pub struct InMemory {
     event_tx: broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
     transaction_tx: broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
+    reader: IndexerReader,
     metrics: Arc<InMemoryStreamMetrics>,
+    config: Config,
 }
 
 impl InMemory {
@@ -186,6 +203,8 @@ impl InMemory {
             let event_tx = event_tx.clone();
             let transaction_tx = transaction_tx.clone();
             let metrics = metrics.clone();
+            let indexer_reader = indexer_reader.clone();
+            let span = tracing::info_span!("live_broker");
 
             async move {
                 loop {
@@ -227,13 +246,15 @@ impl InMemory {
                         Self::publish_error(e, &event_tx, &transaction_tx);
                     }
                 }
-            }
+            }.instrument(span)
         });
 
         Ok(Self {
             event_tx,
             transaction_tx,
+            reader: indexer_reader,
             metrics,
+            config,
         })
     }
 
@@ -242,29 +263,111 @@ impl InMemory {
     /// By default all events are received, the client shall handle the
     /// filtering.
     ///
+    /// When `start_from` is `None`, subscribes to live events only. When
+    /// `start_from` is `Some(digest)`, the stream first backfills
+    /// historical events from the transaction identified by the digest,
+    /// then seamlessly transitions to live events. This enables stream
+    /// recovery after a disconnection.
+    ///
     /// # Note
-    /// Since under the hood a [`tokio::sync::broadcast`] channel is used the
-    /// slow subscriber problem will be handled according to [documentation](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html#lagging)
+    /// Since under the hood a [`tokio::sync::broadcast`] channel is used for
+    /// live events, the slow subscriber problem will be handled according to [documentation](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html#lagging)
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// let event_stream = streamer.subscribe_events().unwrap();
+    /// use iota_indexer_streaming::error::IndexerStreamingError;
+    /// use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+    ///
+    /// // live events only.
+    /// let event_stream = streamer.subscribe_events(None);
     /// tokio::spawn(async move {
-    ///    use futures::StreamExt;
-    ///    while let Some(ev) = event_stream.next().await {
-    ///        if let Ok(ev) = ev.inspect_err(|BroadcastStreamRecvError::Lagged(num)| {
-    ///            println!("Lagged by {num} events")
-    ///        }) {
-    ///            println!("Received event: {ev:?}");
-    ///        }
-    ///    }
+    ///     use futures::StreamExt;
+    ///     while let Some(ev) = event_stream.next().await {
+    ///         if let Ok(ev) = ev.inspect_err(
+    ///             |IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(num))| {
+    ///                 println!("Lagged by {num} events")
+    ///             },
+    ///         ) {
+    ///             println!("Received event: {ev:?}");
+    ///         }
+    ///     }
     /// });
     /// ```
-    pub fn subscribe_events(&self) -> impl Stream<Item = IndexerStreamingResult<StoredEvent>> {
+    /// # Example with a starting transaction digest
+    ///
+    /// ```rust,ignore
+    /// use iota_indexer_streaming::error::IndexerStreamingError;
+    /// use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+    ///
+    /// // recover events from a specific transaction digest onwards.
+    /// let event_stream = streamer.subscribe_events(Some(tx_digest));
+    /// tokio::spawn(async move {
+    ///     use futures::StreamExt;
+    ///     while let Some(ev) = event_stream.next().await {
+    ///         if let Ok(ev) = ev.inspect_err(
+    ///             |IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(num))| {
+    ///                 println!("Lagged by {num} events")
+    ///             },
+    ///         ) {
+    ///             println!("Received event: {ev:?}");
+    ///         }
+    ///     }
+    /// });
+    /// ```
+    pub fn subscribe_events(
+        &self,
+        start_from: Option<TransactionDigest>,
+    ) -> Pin<Box<dyn Stream<Item = IndexerStreamingResult<StoredEvent>> + Send>> {
         let stream = BroadcastStream::new(self.event_tx.subscribe());
-        SubscriberStream::new(stream, METRICS_EVENT_LABEL, self.metrics.clone())
-            .map(Self::flatten_error)
+        let live_stream = SubscriberStream::new(
+            stream,
+            METRICS_EVENT_LABEL,
+            self.metrics.clone(),
+            start_from.is_some(),
+        )
+        .map(Self::flatten_error);
+        let Some(tx_digest) = start_from else {
+            return Box::pin(live_stream);
+        };
+
+        let historical = HistoricalFetch::new(
+            METRICS_EVENT_LABEL,
+            tx_digest,
+            self.reader.clone(),
+            self.config.transaction_batch_size.get(),
+            self.metrics.clone(),
+        );
+
+        let cursor = historical.cursor();
+
+        let historical_events = historical
+            .into_stream()
+            // we use Either represented by left/right stream methods to unify the two stream types
+            // returned by the closure: stream::iter (multiple events) and stream::once (single
+            // error). This avoids an extra heap allocation from Box::pin.
+            .map(|result| match result {
+                Ok(tx) => match Self::stored_events_from_transaction(&tx) {
+                    Ok(events) => stream::iter(events.into_iter().map(Ok)).left_stream(),
+                    Err(e) => stream::once(future::err(e)).right_stream(),
+                },
+                Err(e) => stream::once(future::err(e)).right_stream(),
+            })
+            .flatten();
+
+        Box::pin(
+            historical_events
+                // when switching from historical to live, the broadcast buffer may
+                // contain transactions already delivered by the historical backfill.
+                // Filter them out using the cursor to prevent duplicates.
+                .chain(live_stream.filter(move |result| {
+                    future::ready(match result {
+                        Ok(tx) => tx.tx_sequence_number >= cursor.load(Ordering::Relaxed),
+                        // we must include errors.
+                        Err(_) => true,
+                    })
+                })),
+        )
     }
 
     /// Subscribe to a stream of [`StoredTransaction`].
@@ -272,30 +375,97 @@ impl InMemory {
     /// By default all transactions are received, the client shall handle the
     /// filtering.
     ///
+    /// When `start_from` is `None`, subscribes to live transactions only. When
+    /// `start_from` is `Some(digest)`, the stream first backfills
+    /// historical transactions from the one identified by the digest,
+    /// then seamlessly transitions to live transactions. This enables
+    /// stream recovery after a disconnection.
+    ///
     /// # Note
-    /// Since under the hood a [`tokio::sync::broadcast`] channel is used the
-    /// slow subscriber problem will be handled according to [documentation](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html#lagging)
+    /// Since under the hood a [`tokio::sync::broadcast`] channel is used for
+    /// live transactions, the slow subscriber problem will be handled according to [documentation](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html#lagging)
     ///
     /// # Example
     /// ```rust,ignore
-    /// let tx_stream = streamer.subscribe_transactions().unwrap();
+    /// use iota_indexer_streaming::error::IndexerStreamingError;
+    /// use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+    ///
+    /// // live transactions only.
+    /// let tx_stream = streamer.subscribe_transactions(None);
     /// tokio::spawn(async move {
-    ///    use futures::StreamExt;
-    ///    while let Some(tx) = tx_stream.next().await {
-    ///        if let Ok(tx) = tx.inspect_err(|BroadcastStreamRecvError::Lagged(num)| {
-    ///            println!("Lagged by {num} transactions")
-    ///        }) {
-    ///            println!("Received transaction: {tx:?}");
-    ///        }
-    ///    }
+    ///     use futures::StreamExt;
+    ///     while let Some(tx) = tx_stream.next().await {
+    ///         if let Ok(tx) = tx.inspect_err(
+    ///             |IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(num))| {
+    ///                 println!("Lagged by {num} transactions")
+    ///             },
+    ///         ) {
+    ///             println!("Received transaction: {tx:?}");
+    ///         }
+    ///     }
+    /// });
+    /// ```
+    /// # Example with a starting transaction digest
+    /// ```rust,ignore
+    /// use iota_indexer_streaming::error::IndexerStreamingError;
+    /// use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+    ///
+    /// // recover transactions from a specific transaction digest onwards.
+    /// let tx_stream = streamer.subscribe_transactions(Some(tx_digest));
+    /// tokio::spawn(async move {
+    ///     use futures::StreamExt;
+    ///     while let Some(tx) = tx_stream.next().await {
+    ///         if let Ok(tx) = tx.inspect_err(
+    ///             |IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(num))| {
+    ///                 println!("Lagged by {num} transactions")
+    ///             },
+    ///         ) {
+    ///             println!("Received transaction: {tx:?}");
+    ///         }
+    ///     }
     /// });
     /// ```
     pub fn subscribe_transactions(
         &self,
-    ) -> impl Stream<Item = IndexerStreamingResult<StoredTransaction>> {
+        start_from: Option<TransactionDigest>,
+    ) -> Pin<Box<dyn Stream<Item = IndexerStreamingResult<StoredTransaction>> + Send>> {
         let stream = BroadcastStream::new(self.transaction_tx.subscribe());
-        SubscriberStream::new(stream, METRICS_TRANSACTION_LABEL, self.metrics.clone())
-            .map(Self::flatten_error)
+        let live_stream = SubscriberStream::new(
+            stream,
+            METRICS_TRANSACTION_LABEL,
+            self.metrics.clone(),
+            start_from.is_some(),
+        )
+        .map(Self::flatten_error);
+
+        let Some(tx_digest) = start_from else {
+            return Box::pin(live_stream);
+        };
+
+        let historical = HistoricalFetch::new(
+            METRICS_TRANSACTION_LABEL,
+            tx_digest,
+            self.reader.clone(),
+            self.config.transaction_batch_size.get(),
+            self.metrics.clone(),
+        );
+
+        let cursor = historical.cursor();
+
+        Box::pin(
+            historical
+                .into_stream()
+                // when switching from historical to live, the broadcast buffer may
+                // contain transactions already delivered by the historical backfill.
+                // Filter them out using the cursor to prevent duplicates.
+                .chain(live_stream.filter(move |result| {
+                    future::ready(match result {
+                        Ok(tx) => tx.tx_sequence_number >= cursor.load(Ordering::Relaxed),
+                        // we must include errors.
+                        Err(_) => true,
+                    })
+                })),
+        )
     }
 
     /// Flattens nested `Result` types from the broadcast stream.
@@ -327,7 +497,7 @@ impl InMemory {
         event_tx: &broadcast::Sender<IndexerStreamingResult<StoredEvent>>,
         transaction_tx: &broadcast::Sender<IndexerStreamingResult<StoredTransaction>>,
     ) -> IndexerStreamingResult<()> {
-        let mut backoff = backoff::ExponentialBackoff::default();
+        let mut backoff = ExponentialBackoff::default();
         backoff.max_elapsed_time = Some(Duration::from_secs(5));
         backoff.initial_interval = Duration::from_millis(100);
         backoff.current_interval = backoff.initial_interval;
@@ -595,11 +765,14 @@ impl<T> SubscriberStream<T> {
         inner: BroadcastStream<T>,
         label: &'static str,
         metrics: Arc<InMemoryStreamMetrics>,
+        is_historical_used_before: bool,
     ) -> Self {
         let active_subscriber_number = metrics.active_subscriber_number.with_label_values(&[label]);
         let lagging_subscribers = metrics.lagging_subscribers.with_label_values(&[label]);
 
-        active_subscriber_number.inc();
+        if !is_historical_used_before {
+            active_subscriber_number.inc();
+        }
 
         Self {
             inner,
@@ -659,5 +832,215 @@ impl<T: Clone + Send + 'static> Stream for SubscriberStream<T> {
         }
 
         poll
+    }
+}
+
+/// Fetches historical transactions from the indexer database starting from a
+/// given transaction digest up to the latest available sequence number.
+///
+/// This stream is used for stream recovery, the caller chains this stream with
+/// a live broadcast stream to provide gap-free delivery from a recovery point.
+struct HistoricalFetch {
+    /// Transaction digest to start fetching from.
+    digest: TransactionDigest,
+    /// Next transaction sequence number to fetch.
+    cursor: Arc<AtomicI64>,
+    /// Latest committed transaction sequence number in the database.
+    latest: i64,
+    /// Database reader for fetching transactions.
+    reader: IndexerReader,
+    /// Buffered transactions from the last database batch fetch.
+    buffer: VecDeque<StoredTransaction>,
+    /// Number of transactions to fetch per database query.
+    batch_size: i64,
+    /// Upon an unrecoverable error, the stream should be closed.
+    should_close_stream: bool,
+    /// Tracks the latency of querying transaction batch from the indexer
+    /// database.
+    query_tx_from_indexer_db_latency: Histogram,
+}
+
+impl HistoricalFetch {
+    fn new(
+        label: &'static str,
+        digest: TransactionDigest,
+        reader: IndexerReader,
+        batch_size: i64,
+        metrics: Arc<InMemoryStreamMetrics>,
+    ) -> Self {
+        let active_subscriber_number = metrics.active_subscriber_number.with_label_values(&[label]);
+        active_subscriber_number.inc();
+
+        Self {
+            digest,
+            cursor: Arc::new(AtomicI64::new(0)),
+            latest: 0,
+            reader,
+            buffer: VecDeque::new(),
+            batch_size,
+            should_close_stream: false,
+            query_tx_from_indexer_db_latency: metrics.query_tx_from_indexer_db_latency.clone(),
+        }
+    }
+
+    /// Returns a shared reference to the cursor.
+    ///
+    /// The cursor tracks the next expected transaction sequence number and
+    /// is updated as the historical stream progresses. Used by the live
+    /// stream filter to skip already-delivered transactions.
+    fn cursor(&self) -> Arc<AtomicI64> {
+        self.cursor.clone()
+    }
+
+    /// Retries the provided closure using an [`ExponentialBackoff`]
+    async fn with_retry<F, Fut, T, E>(f: F) -> Result<T, E>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = Result<T, backoff::Error<E>>>,
+    {
+        let backoff = ExponentialBackoff {
+            max_elapsed_time: Some(Duration::from_secs(5)),
+            initial_interval: Duration::from_millis(100),
+            multiplier: 1.0,
+            ..Default::default()
+        };
+
+        backoff::future::retry(backoff, f).await
+    }
+
+    /// Converts into a stream that yields historical transactions from the
+    /// database in batches. The stream ends once all transactions up to
+    /// the latest committed transaction to database have been yielded, at which
+    /// point the caller can chain a live stream.
+    fn into_stream(self) -> impl Stream<Item = IndexerStreamingResult<StoredTransaction>> {
+        stream::unfold(self, |mut state| {
+            let start_from = state.digest;
+            let span = tracing::info_span!("historical_backfill", %start_from);
+            async move {
+                loop {
+                    if state.should_close_stream {
+                        return None;
+                    }
+
+                    // drain the buffer before fetching new transactions from the database.
+                    // This is the main point of sending transactions to the caller.
+                    if let Some(tx) = state.buffer.pop_front() {
+                        return Some((Ok(tx), state));
+                    }
+
+                    // resolve the cursor from the digest if it hasn't been set yet.
+                    if state.cursor.load(Ordering::Relaxed) == 0 {
+                        match Self::with_retry(|| async {
+                            state
+                                .reader
+                                .db()
+                                .resolve_cursor_tx_digest_to_seq_num(state.digest)
+                                .await
+                                .map_err(backoff::Error::transient)
+                        })
+                        .await
+                        {
+                            Ok(cursor) => state.cursor.store(cursor, Ordering::Relaxed),
+                            Err(e) => {
+                                state.should_close_stream = true;
+                                let e = IndexerStreamingError::Postgres(e.to_string());
+                                error!("failed to resolve tx digest into its sequence number: {e}");
+                                return Some((Err(e), state));
+                            }
+                        }
+                    }
+
+                    // check if cursor is ahead of latest available transaction on database, if so,
+                    // refresh latest, so the stream can continue.
+                    if state.cursor.load(Ordering::Relaxed) > state.latest {
+                        state.latest = match Self::with_retry(|| async {
+                            state
+                                .reader
+                                .db()
+                                .latest_tx_sequence_number()
+                                .await
+                                .map_err(backoff::Error::transient)
+                        })
+                        .await
+                        {
+                            Ok(Some(latest)) => latest,
+                            // this case is very unlikely, but we should handle it gracefully. This
+                            // is mostly because when we resolve the provided tx digest to a
+                            // sequence number (in the previous step), this implies that we already
+                            // have data in transactions table.
+                            Ok(None) => {
+                                state.should_close_stream = true;
+                                let e = IndexerStreamingError::Postgres(
+                                    "unable to fetch latest tx sequence number".into(),
+                                );
+                                error!("{e}");
+                                return Some((Err(e), state));
+                            }
+                            Err(e) => {
+                                state.should_close_stream = true;
+                                let e = IndexerStreamingError::Postgres(format!(
+                                    "unable to fetch latest tx sequence number: {e}"
+                                ));
+                                error!("{e}");
+                                return Some((Err(e), state));
+                            }
+                        };
+
+                        debug!(
+                            cursor = state.cursor.load(Ordering::Relaxed),
+                            latest = state.latest,
+                            "current state"
+                        );
+
+                        // if latest did not advance, we're at the tip and can close the historical
+                        // backfill stream and move to the live one.
+                        if state.cursor.load(Ordering::Relaxed) > state.latest {
+                            debug!("reached the tip and are in sync with live data");
+                            return None;
+                        }
+                    }
+
+                    // fetch transaction batch from database and update the cursor.
+                    let start = state.cursor.load(Ordering::Relaxed);
+                    let end = (start + state.batch_size.saturating_sub(1)).min(state.latest);
+
+                    let db_query_timer = state.query_tx_from_indexer_db_latency.start_timer();
+                    match Self::with_retry(|| async {
+                        state
+                            .reader
+                            .spawn_blocking(move |this| {
+                                this.multi_get_transactions_by_sequence_numbers_range(start, end)
+                            })
+                            .await
+                            .map_err(backoff::Error::transient)
+                    })
+                    .await
+                    {
+                        Ok(batch) => {
+                            let elapsed = db_query_timer.stop_and_record();
+                            debug!(
+                                "transactions query took: {:?}, tx: {}",
+                                Duration::from_secs_f64(elapsed),
+                                batch.len()
+                            );
+                            state.buffer.extend(batch);
+                            state.cursor.store(end + 1, Ordering::Relaxed);
+                        }
+                        Err(e) => {
+                            state.should_close_stream = true;
+                            let e = IndexerStreamingError::Postgres(e.to_string());
+                            error!(
+                                batch_start = start,
+                                batch_end = end,
+                                error = ?e,
+                                "batch processing failed after retries, publishing error to clients"
+                            );
+                            return Some((Err(e), state));
+                        }
+                    }
+                }
+            }
+            .instrument(span)
+        })
     }
 }

--- a/crates/iota-indexer-streaming/src/memory.rs
+++ b/crates/iota-indexer-streaming/src/memory.rs
@@ -1046,7 +1046,7 @@ impl HistoricalFetch {
                             },
                             Err(e) => {
                                 state.should_close_stream = true;
-                                let e = IndexerStreamingError::Postgres(format!(
+                                let e = IndexerStreamingError::NotFound(format!(
                                     "unable to resolve transaction, may not exist or has been pruned: {e}"
                                 ));
                                 error!("{e}");

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -2718,7 +2718,7 @@ impl<'a> DBReader<'a> {
             .map(|seq| seq.is_none())
     }
 
-    async fn resolve_cursor_tx_digest_to_seq_num(
+    pub async fn resolve_cursor_tx_digest_to_seq_num(
         &self,
         cursor: TransactionDigest,
     ) -> IndexerResult<i64> {
@@ -3054,6 +3054,23 @@ impl<'a> DBReader<'a> {
         };
 
         Ok(result)
+    }
+
+    /// Fetches the latest transaction sequence number from the checkpoints
+    /// table.
+    pub async fn latest_tx_sequence_number(&self) -> Result<Option<i64>, IndexerError> {
+        use crate::schema::checkpoints::dsl;
+
+        let pool = self.main_reader.get_pool();
+
+        run_query_async!(&pool, |conn| {
+            dsl::checkpoints
+                .select(dsl::max_tx_sequence_number)
+                .order(dsl::sequence_number.desc())
+                .first::<Option<i64>>(conn)
+                .optional()
+        })
+        .map(Option::flatten)
     }
 }
 


### PR DESCRIPTION
# Description of change

This PR adds stream recovery support to `iota-indexer-streaming` allowing clients to resume transaction and event subscriptions from a specific transaction digest after a disconnection.

The historical stream uses `futures::stream::unfold` which is demand-driven, it only advances when the consumer polls for the next item. Transactions are fetched from the database in batches and stored in an internal buffer. Each poll drains one item from the buffer, and a new database query is only issued when the buffer is empty. Memory usage is bounded by the configured batch size with no unbounded growth. Once the historical backfill catches up to the latest committed transaction, the stream ends and `chain` seamlessly switches to the live broadcast stream.

When a `start_from` represented by the `RecoveryPoint` enum is provided (can be inclusive or exclusive), the stream first backfills historical data from the database, then seamlessly transitions to live data from the broadcast channel. Without `start_from`, behavior is unchanged.

## Links to any relevant issues

fixes #11013

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

>[!NOTE]
> This patch does not affect the normal operations of the iota-indexer this not further tests were conducted.