### PR TITLE
feat(consensus): add consensus_starfish_speed protocol flag

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1314,6 +1314,7 @@
                 "consensus_round_prober": false,
                 "consensus_round_prober_probe_accepted_rounds": false,
                 "consensus_smart_ancestor_selection": false,
+                "consensus_starfish_speed": false,
                 "consensus_zstd_compression": false,
                 "convert_type_argument_error": true,
                 "dependency_linkage_error": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -470,6 +470,10 @@ struct FeatureFlags {
     // If true, enable `TxContext` Move API to go native.
     #[serde(skip_serializing_if = "is_false")]
     move_native_tx_context: bool,
+
+    // If true, enables the optimistic commit rule (StarfishSpeed) in Starfish consensus.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_starfish_speed: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1662,6 +1666,10 @@ impl ProtocolConfig {
 
     pub fn move_native_tx_context(&self) -> bool {
         self.feature_flags.move_native_tx_context
+    }
+
+    pub fn consensus_starfish_speed(&self) -> bool {
+        self.feature_flags.consensus_starfish_speed
     }
 }
 
@@ -2931,6 +2939,10 @@ impl ProtocolConfig {
 
     pub fn set_consensus_fast_commit_sync_for_testing(&mut self, val: bool) {
         self.feature_flags.consensus_fast_commit_sync = val;
+    }
+
+    pub fn set_consensus_starfish_speed_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_starfish_speed = val;
     }
 }
 


### PR DESCRIPTION
# Description of change

Add a `consensus_starfish_speed` boolean flag to `ProtocolConfig` to gate all StarfishSpeed behavior.

## Links to any relevant issues

Part of #11009
Fixes #11131

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes