### PR TITLE
feat(consensus): add BlockHeaderV2 with strong_vote field

### DIFF
--- a/crates/starfish/core/src/authority_set.rs
+++ b/crates/starfish/core/src/authority_set.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeSet, fmt};
+
+use serde::{Deserialize, Serialize};
+use starfish_config::AuthorityIndex;
+
+/// Compact bitmask representing a subset of authorities.
+/// Supports up to 256 authorities (AuthorityIndex is u8).
+#[derive(Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AuthoritySet([u64; 4]);
+
+impl AuthoritySet {
+    /// Creates an empty authority set.
+    pub fn new() -> Self {
+        Self([0; 4])
+    }
+
+    /// Creates a set with two authorities pre-inserted.
+    pub fn new_with(a: AuthorityIndex, b: AuthorityIndex) -> Self {
+        let mut s = Self::new();
+        s.insert(a);
+        s.insert(b);
+        s
+    }
+
+    /// Inserts an authority into the set. Returns true if the authority was
+    /// not already present.
+    pub fn insert(&mut self, index: AuthorityIndex) -> bool {
+        let i = index.value();
+        let array_index = i / 64;
+        let bit_pos = i % 64;
+        let mask = 1u64 << bit_pos;
+        let already_present = (self.0[array_index] & mask) != 0;
+        self.0[array_index] |= mask;
+        !already_present
+    }
+
+    /// Returns true if the set contains the given authority.
+    pub fn contains(&self, index: AuthorityIndex) -> bool {
+        let i = index.value();
+        let array_index = i / 64;
+        let bit_pos = i % 64;
+        (self.0[array_index] & (1u64 << bit_pos)) != 0
+    }
+
+    /// Returns true if the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.iter().all(|&bits| bits == 0)
+    }
+
+    /// Returns the number of authorities in the set.
+    pub fn len(&self) -> usize {
+        self.0.iter().map(|bits| bits.count_ones() as usize).sum()
+    }
+
+    /// Iterates over the authority indices in the set, in ascending order.
+    pub fn iter(&self) -> impl Iterator<Item = AuthorityIndex> + '_ {
+        self.0.iter().enumerate().flat_map(|(array_index, &bits)| {
+            let base = array_index * 64;
+            BitIter(bits).map(move |bit| AuthorityIndex::from((base + bit) as u8))
+        })
+    }
+
+    /// Converts to a BTreeSet of AuthorityIndex.
+    pub fn to_btreeset(&self) -> BTreeSet<AuthorityIndex> {
+        self.iter().collect()
+    }
+}
+
+impl From<&BTreeSet<AuthorityIndex>> for AuthoritySet {
+    fn from(set: &BTreeSet<AuthorityIndex>) -> Self {
+        let mut result = Self::new();
+        for &index in set {
+            result.insert(index);
+        }
+        result
+    }
+}
+
+impl fmt::Debug for AuthoritySet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let indices: Vec<_> = self.iter().collect();
+        write!(f, "AuthoritySet({indices:?})")
+    }
+}
+
+/// Iterator over set bits in a u64.
+struct BitIter(u64);
+
+impl Iterator for BitIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        if self.0 == 0 {
+            return None;
+        }
+        let bit = self.0.trailing_zeros() as usize;
+        self.0 &= self.0 - 1;
+        Some(bit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_set() {
+        let set = AuthoritySet::new();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+        assert_eq!(set.iter().count(), 0);
+    }
+
+    #[test]
+    fn test_insert_and_contains() {
+        let mut set = AuthoritySet::new();
+        let idx = AuthorityIndex::new_for_test(5);
+
+        assert!(!set.contains(idx));
+        assert!(set.insert(idx));
+        assert!(set.contains(idx));
+        assert!(!set.insert(idx)); // duplicate
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn test_across_buckets() {
+        let mut set = AuthoritySet::new();
+        set.insert(AuthorityIndex::new_for_test(0));
+        set.insert(AuthorityIndex::new_for_test(63));
+        set.insert(AuthorityIndex::new_for_test(64));
+        set.insert(AuthorityIndex::new_for_test(127));
+        set.insert(AuthorityIndex::new_for_test(128));
+        set.insert(AuthorityIndex::new_for_test(255));
+
+        assert_eq!(set.len(), 6);
+        assert!(set.contains(AuthorityIndex::new_for_test(0)));
+        assert!(set.contains(AuthorityIndex::new_for_test(255)));
+        assert!(!set.contains(AuthorityIndex::new_for_test(1)));
+    }
+
+    #[test]
+    fn test_iter_order() {
+        let mut set = AuthoritySet::new();
+        set.insert(AuthorityIndex::new_for_test(200));
+        set.insert(AuthorityIndex::new_for_test(3));
+        set.insert(AuthorityIndex::new_for_test(100));
+        set.insert(AuthorityIndex::new_for_test(65));
+
+        let indices: Vec<_> = set.iter().map(|i| i.value()).collect();
+        assert_eq!(indices, vec![3, 65, 100, 200]);
+    }
+
+    #[test]
+    fn test_new_with() {
+        let a = AuthorityIndex::new_for_test(3);
+        let b = AuthorityIndex::new_for_test(7);
+        let set = AuthoritySet::new_with(a, b);
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(a));
+        assert!(set.contains(b));
+    }
+
+    #[test]
+    fn test_btreeset_roundtrip() {
+        let mut btree = BTreeSet::new();
+        btree.insert(AuthorityIndex::new_for_test(10));
+        btree.insert(AuthorityIndex::new_for_test(50));
+        btree.insert(AuthorityIndex::new_for_test(200));
+
+        let authority_set = AuthoritySet::from(&btree);
+        assert_eq!(authority_set.to_btreeset(), btree);
+    }
+}

--- a/crates/starfish/core/src/authority_set.rs
+++ b/crates/starfish/core/src/authority_set.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::BTreeSet, fmt};

--- a/crates/starfish/core/src/authority_set.rs
+++ b/crates/starfish/core/src/authority_set.rs
@@ -64,7 +64,7 @@ impl AuthoritySet {
     }
 
     /// Converts to a BTreeSet of AuthorityIndex.
-    pub fn to_btreeset(&self) -> BTreeSet<AuthorityIndex> {
+    pub fn to_btreeset(self) -> BTreeSet<AuthorityIndex> {
         self.iter().collect()
     }
 }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -344,7 +344,8 @@ impl BlockHeaderV2 {
         }
     }
 
-    // Will be used when genesis block construction is gated on consensus_starfish_speed.
+    // Will be used when genesis block construction is gated on
+    // consensus_starfish_speed.
     #[expect(dead_code)]
     fn genesis_block_header(context: &Context, author: AuthorityIndex) -> Self {
         Self {
@@ -1599,7 +1600,6 @@ mod tests {
     use std::sync::Arc;
 
     use fastcrypto::error::FastCryptoError;
-
     use starfish_config::AuthorityIndex;
 
     use crate::{

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -219,7 +219,7 @@ impl BlockHeaderV1 {
         transactions_commitment: TransactionsCommitment,
     ) -> BlockHeaderV1 {
         let (references, overlap_start_index, overlap_end_index) =
-            Self::compress_references(ancestors, acknowledgments);
+            BlockHeader::compress_references(ancestors, acknowledgments);
         Self {
             epoch,
             round,
@@ -231,55 +231,6 @@ impl BlockHeaderV1 {
             transactions_commitment,
             commit_votes,
         }
-    }
-    /// Compresses ancestors and acknowledgments into a single references
-    /// vector, and returns the overlap indices. The first ancestor is
-    /// always the first reference (ref0). If it is also in acknowledgments,
-    /// it is appended to the end of references.
-    pub(crate) fn compress_references(
-        ancestors: Vec<BlockRef>,
-        acknowledgments: Vec<BlockRef>,
-    ) -> (Vec<BlockRef>, u8, u8) {
-        if ancestors.is_empty() {
-            return (acknowledgments, 0, 0);
-        }
-        // Sets for membership checks
-        let ancestor_set: HashSet<_> = ancestors.iter().cloned().collect();
-        let ack_set: HashSet<_> = acknowledgments.into_iter().collect();
-        // ref0 is the first ancestor, and is also always the first reference
-        let ref0 = ancestors[0];
-        // if it is also in acknowledgments, it is appended to the end of references
-        let append_ref0 = ack_set.contains(&ref0);
-
-        // partition ancestors into overlap and ancestors_only (excluding ref0)
-        let (overlap, mut ancestors_only): (Vec<_>, Vec<_>) = ancestors
-            .into_iter()
-            .skip(1)
-            .partition(|a| ack_set.contains(a));
-        // insert ref0 back to the front of ancestors_only
-        ancestors_only.insert(0, ref0);
-
-        // acknowledgments_only excludes any overlap with ancestors
-        let acknowledgments_only: Vec<_> = ack_set
-            .into_iter()
-            .filter(|a| !ancestor_set.contains(a))
-            .collect();
-
-        let overlap_start_index = ancestors_only.len();
-        let overlap_end_index = overlap_start_index + overlap.len();
-        // combine all parts into references
-        // |ancestors_only|overlap|acknowledgments_only|ref0?|
-        let mut references = ancestors_only;
-        references.extend(overlap);
-        references.extend(acknowledgments_only);
-        if append_ref0 {
-            references.push(ref0);
-        }
-        (
-            references,
-            overlap_start_index as u8,
-            overlap_end_index as u8,
-        )
     }
 
     fn genesis_block_header(context: &Context, author: AuthorityIndex) -> Self {
@@ -373,7 +324,7 @@ impl BlockHeaderV2 {
         strong_vote: Option<AuthoritySet>,
     ) -> BlockHeaderV2 {
         let (references, overlap_start_index, overlap_end_index) =
-            BlockHeaderV1::compress_references(ancestors, acknowledgments);
+            BlockHeader::compress_references(ancestors, acknowledgments);
         Self {
             epoch,
             round,
@@ -549,6 +500,58 @@ impl From<BlockHeaderV1> for BlockHeader {
 impl From<BlockHeaderV2> for BlockHeader {
     fn from(header: BlockHeaderV2) -> Self {
         BlockHeader::V2(header)
+    }
+}
+
+impl BlockHeader {
+    /// Compresses ancestors and acknowledgments into a single references
+    /// vector, and returns the overlap indices. The first ancestor is
+    /// always the first reference (ref0). If it is also in acknowledgments,
+    /// it is appended to the end of references.
+    pub(crate) fn compress_references(
+        ancestors: Vec<BlockRef>,
+        acknowledgments: Vec<BlockRef>,
+    ) -> (Vec<BlockRef>, u8, u8) {
+        if ancestors.is_empty() {
+            return (acknowledgments, 0, 0);
+        }
+        // Sets for membership checks
+        let ancestor_set: HashSet<_> = ancestors.iter().cloned().collect();
+        let ack_set: HashSet<_> = acknowledgments.into_iter().collect();
+        // ref0 is the first ancestor, and is also always the first reference
+        let ref0 = ancestors[0];
+        // if it is also in acknowledgments, it is appended to the end of references
+        let append_ref0 = ack_set.contains(&ref0);
+
+        // partition ancestors into overlap and ancestors_only (excluding ref0)
+        let (overlap, mut ancestors_only): (Vec<_>, Vec<_>) = ancestors
+            .into_iter()
+            .skip(1)
+            .partition(|a| ack_set.contains(a));
+        // insert ref0 back to the front of ancestors_only
+        ancestors_only.insert(0, ref0);
+
+        // acknowledgments_only excludes any overlap with ancestors
+        let acknowledgments_only: Vec<_> = ack_set
+            .into_iter()
+            .filter(|a| !ancestor_set.contains(a))
+            .collect();
+
+        let overlap_start_index = ancestors_only.len();
+        let overlap_end_index = overlap_start_index + overlap.len();
+        // combine all parts into references
+        // |ancestors_only|overlap|acknowledgments_only|ref0?|
+        let mut references = ancestors_only;
+        references.extend(overlap);
+        references.extend(acknowledgments_only);
+        if append_ref0 {
+            references.push(ref0);
+        }
+        (
+            references,
+            overlap_start_index as u8,
+            overlap_end_index as u8,
+        )
     }
 }
 
@@ -1453,7 +1456,6 @@ pub struct TestBlockHeader {
     ancestors: Vec<BlockRef>,
     acknowledgments: Vec<BlockRef>,
     block_header: BlockHeaderV1,
-    strong_vote: Option<AuthoritySet>,
 }
 
 impl TestBlockHeader {
@@ -1470,7 +1472,6 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
-            strong_vote: None,
         }
     }
 
@@ -1498,7 +1499,6 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
-            strong_vote: None,
         }
     }
 
@@ -1530,7 +1530,6 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
-            strong_vote: None,
         }
     }
 
@@ -1574,36 +1573,14 @@ impl TestBlockHeader {
         self
     }
 
-    pub fn set_strong_vote(mut self, strong_vote: Option<AuthoritySet>) -> Self {
-        self.strong_vote = strong_vote;
-        self
-    }
-
     pub fn build(mut self) -> BlockHeader {
         let (references, overlap_start_index, overlap_end_index) =
-            BlockHeaderV1::compress_references(self.ancestors, self.acknowledgments);
+            BlockHeader::compress_references(self.ancestors, self.acknowledgments);
         self.block_header.references = references;
         self.block_header.overlap_start_index = overlap_start_index;
         self.block_header.overlap_end_index = overlap_end_index;
 
         BlockHeader::V1(self.block_header)
-    }
-
-    pub fn build_v2(self) -> BlockHeader {
-        let (references, overlap_start_index, overlap_end_index) =
-            BlockHeaderV1::compress_references(self.ancestors, self.acknowledgments);
-        BlockHeader::V2(BlockHeaderV2 {
-            epoch: self.block_header.epoch,
-            round: self.block_header.round,
-            author: self.block_header.author,
-            timestamp_ms: self.block_header.timestamp_ms,
-            references,
-            overlap_start_index,
-            overlap_end_index,
-            transactions_commitment: self.block_header.transactions_commitment,
-            commit_votes: self.block_header.commit_votes,
-            strong_vote: self.strong_vote,
-        })
     }
 }
 
@@ -1689,7 +1666,7 @@ mod tests {
         let ancestors = vec![ref_a, ref_b];
         let acknowledgments = vec![ref_c, ref_d];
         let (references, overlap_start_index, overlap_end_index) =
-            crate::block_header::BlockHeaderV1::compress_references(ancestors, acknowledgments);
+            crate::block_header::BlockHeader::compress_references(ancestors, acknowledgments);
         let expected = [ref_a, ref_b, ref_c, ref_d];
         assert_eq!(references.len(), expected.len());
         for r in references.iter() {
@@ -1703,7 +1680,7 @@ mod tests {
         let ancestors = vec![ref_a, ref_b, ref_c];
         let acknowledgments = vec![ref_c, ref_d];
         let (references, overlap_start_index, overlap_end_index) =
-            crate::block_header::BlockHeaderV1::compress_references(ancestors, acknowledgments);
+            crate::block_header::BlockHeader::compress_references(ancestors, acknowledgments);
         let expected = [ref_a, ref_b, ref_c, ref_d];
         assert_eq!(references.len(), expected.len());
         for r in references.iter() {
@@ -1718,7 +1695,7 @@ mod tests {
         let acknowledgments = vec![ref_a, ref_c, ref_d, ref_e];
 
         let (references, overlap_start_index, overlap_end_index) =
-            crate::block_header::BlockHeaderV1::compress_references(ancestors, acknowledgments);
+            crate::block_header::BlockHeader::compress_references(ancestors, acknowledgments);
 
         let expected = [ref_a, ref_b, ref_c, ref_d, ref_e, ref_a];
         assert_eq!(references.len(), expected.len());
@@ -1735,7 +1712,7 @@ mod tests {
         let ancestors = vec![ref_a, ref_b, ref_c];
         let acknowledgments = vec![ref_a, ref_b, ref_c];
         let (references, overlap_start_index, overlap_end_index) =
-            crate::block_header::BlockHeaderV1::compress_references(
+            crate::block_header::BlockHeader::compress_references(
                 ancestors.clone(),
                 acknowledgments.clone(),
             );

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -317,6 +317,8 @@ pub struct BlockHeaderV2 {
 }
 
 impl BlockHeaderV2 {
+    // Will be used when block construction is gated on consensus_starfish_speed.
+    #[expect(dead_code)]
     pub(crate) fn new(
         epoch: Epoch,
         round: Round,

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -90,6 +90,79 @@ impl Transaction {
     }
 }
 
+/// Compact bitmask representing a subset of authorities.
+/// Supports up to 256 authorities (AuthorityIndex is u8).
+#[derive(Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct AuthoritySet([u64; 4]);
+
+impl AuthoritySet {
+    /// Creates an empty authority set.
+    pub fn new() -> Self {
+        Self([0; 4])
+    }
+
+    /// Inserts an authority into the set. Returns true if the authority was
+    /// not already present.
+    pub fn insert(&mut self, index: AuthorityIndex) -> bool {
+        let i = index.value();
+        let array_index = i / 64;
+        let bit_pos = i % 64;
+        let mask = 1u64 << bit_pos;
+        let already_present = (self.0[array_index] & mask) != 0;
+        self.0[array_index] |= mask;
+        !already_present
+    }
+
+    /// Returns true if the set contains the given authority.
+    pub fn contains(&self, index: AuthorityIndex) -> bool {
+        let i = index.value();
+        let array_index = i / 64;
+        let bit_pos = i % 64;
+        (self.0[array_index] & (1u64 << bit_pos)) != 0
+    }
+
+    /// Returns true if the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.iter().all(|&bits| bits == 0)
+    }
+
+    /// Returns the number of authorities in the set.
+    pub fn len(&self) -> usize {
+        self.0.iter().map(|bits| bits.count_ones() as usize).sum()
+    }
+
+    /// Iterates over the authority indices in the set, in ascending order.
+    pub fn iter(&self) -> impl Iterator<Item = AuthorityIndex> + '_ {
+        self.0.iter().enumerate().flat_map(|(array_index, &bits)| {
+            let base = array_index * 64;
+            BitIter(bits).map(move |bit| AuthorityIndex::from((base + bit) as u8))
+        })
+    }
+}
+
+impl fmt::Debug for AuthoritySet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let indices: Vec<_> = self.iter().collect();
+        write!(f, "AuthoritySet({indices:?})")
+    }
+}
+
+/// Iterator over set bits in a u64.
+struct BitIter(u64);
+
+impl Iterator for BitIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        if self.0 == 0 {
+            return None;
+        }
+        let bit = self.0.trailing_zeros() as usize;
+        self.0 &= self.0 - 1;
+        Some(bit)
+    }
+}
+
 /// A block header includes references to previous round blocks and a commitment
 /// to transactions that the authority considers valid.
 /// Well behaved authorities produce at most one block header per round, but
@@ -97,6 +170,7 @@ impl Transaction {
 #[derive(Clone, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
 pub enum BlockHeader {
     V1(BlockHeaderV1),
+    V2(BlockHeaderV2),
 }
 
 pub trait BlockHeaderAPI {
@@ -109,6 +183,9 @@ pub trait BlockHeaderAPI {
     fn ancestors(&self) -> &[BlockRef];
     fn commit_votes(&self) -> &[CommitVote];
     fn transactions_commitment(&self) -> TransactionsCommitment;
+    fn strong_vote(&self) -> Option<AuthoritySet>;
+    fn is_strong_vote(&self) -> bool;
+    fn is_strong_blame(&self) -> bool;
 }
 
 #[derive(Clone, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
@@ -255,60 +332,210 @@ impl BlockHeaderAPI for BlockHeaderV1 {
     fn transactions_commitment(&self) -> TransactionsCommitment {
         self.transactions_commitment
     }
+
+    fn strong_vote(&self) -> Option<AuthoritySet> {
+        None
+    }
+
+    fn is_strong_vote(&self) -> bool {
+        false
+    }
+
+    fn is_strong_blame(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
+pub struct BlockHeaderV2 {
+    epoch: Epoch,
+    round: Round,
+    author: AuthorityIndex,
+    timestamp_ms: BlockTimestampMs,
+    references: Vec<BlockRef>,
+    overlap_start_index: u8,
+    overlap_end_index: u8,
+    transactions_commitment: TransactionsCommitment,
+    commit_votes: Vec<CommitVote>,
+    strong_vote: Option<AuthoritySet>,
+}
+
+impl BlockHeaderV2 {
+    pub(crate) fn new(
+        epoch: Epoch,
+        round: Round,
+        author: AuthorityIndex,
+        timestamp_ms: BlockTimestampMs,
+        ancestors: Vec<BlockRef>,
+        acknowledgments: Vec<BlockRef>,
+        commit_votes: Vec<CommitVote>,
+        transactions_commitment: TransactionsCommitment,
+        strong_vote: Option<AuthoritySet>,
+    ) -> BlockHeaderV2 {
+        let (references, overlap_start_index, overlap_end_index) =
+            BlockHeaderV1::compress_references(ancestors, acknowledgments);
+        Self {
+            epoch,
+            round,
+            author,
+            timestamp_ms,
+            references,
+            overlap_start_index,
+            overlap_end_index,
+            transactions_commitment,
+            commit_votes,
+            strong_vote,
+        }
+    }
+
+    fn genesis_block_header(context: &Context, author: AuthorityIndex) -> Self {
+        Self {
+            epoch: context.committee.epoch(),
+            round: GENESIS_ROUND,
+            author,
+            timestamp_ms: context.epoch_start_timestamp_ms,
+            references: vec![],
+            overlap_start_index: 0,
+            overlap_end_index: 0,
+            commit_votes: vec![],
+            transactions_commitment: TransactionsCommitment::default(),
+            strong_vote: None,
+        }
+    }
+}
+
+impl BlockHeaderAPI for BlockHeaderV2 {
+    fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    fn round(&self) -> Round {
+        self.round
+    }
+
+    fn author(&self) -> AuthorityIndex {
+        self.author
+    }
+
+    fn slot(&self) -> Slot {
+        Slot::new(self.round, self.author)
+    }
+
+    fn acknowledgments(&self) -> &[BlockRef] {
+        &self.references[self.overlap_start_index as usize..]
+    }
+
+    fn timestamp_ms(&self) -> BlockTimestampMs {
+        self.timestamp_ms
+    }
+
+    fn ancestors(&self) -> &[BlockRef] {
+        &self.references[..self.overlap_end_index as usize]
+    }
+
+    fn commit_votes(&self) -> &[CommitVote] {
+        &self.commit_votes
+    }
+
+    fn transactions_commitment(&self) -> TransactionsCommitment {
+        self.transactions_commitment
+    }
+
+    fn strong_vote(&self) -> Option<AuthoritySet> {
+        self.strong_vote
+    }
+
+    fn is_strong_vote(&self) -> bool {
+        self.strong_vote.is_some_and(|s| s.is_empty())
+    }
+
+    fn is_strong_blame(&self) -> bool {
+        self.strong_vote.is_some_and(|s| !s.is_empty())
+    }
 }
 
 impl BlockHeaderAPI for BlockHeader {
     fn epoch(&self) -> Epoch {
         match self {
             BlockHeader::V1(header) => header.epoch(),
+            BlockHeader::V2(header) => header.epoch(),
         }
     }
 
     fn round(&self) -> Round {
         match self {
             BlockHeader::V1(header) => header.round(),
+            BlockHeader::V2(header) => header.round(),
         }
     }
 
     fn author(&self) -> AuthorityIndex {
         match self {
             BlockHeader::V1(header) => header.author(),
+            BlockHeader::V2(header) => header.author(),
         }
     }
 
     fn slot(&self) -> Slot {
         match self {
             BlockHeader::V1(header) => header.slot(),
+            BlockHeader::V2(header) => header.slot(),
         }
     }
 
     fn acknowledgments(&self) -> &[BlockRef] {
         match self {
             BlockHeader::V1(header) => header.acknowledgments(),
+            BlockHeader::V2(header) => header.acknowledgments(),
         }
     }
 
     fn timestamp_ms(&self) -> BlockTimestampMs {
         match self {
             BlockHeader::V1(header) => header.timestamp_ms(),
+            BlockHeader::V2(header) => header.timestamp_ms(),
         }
     }
 
     fn ancestors(&self) -> &[BlockRef] {
         match self {
             BlockHeader::V1(header) => header.ancestors(),
+            BlockHeader::V2(header) => header.ancestors(),
         }
     }
 
     fn commit_votes(&self) -> &[CommitVote] {
         match self {
             BlockHeader::V1(header) => header.commit_votes(),
+            BlockHeader::V2(header) => header.commit_votes(),
         }
     }
 
     fn transactions_commitment(&self) -> TransactionsCommitment {
         match self {
             BlockHeader::V1(header) => header.transactions_commitment(),
+            BlockHeader::V2(header) => header.transactions_commitment(),
+        }
+    }
+
+    fn strong_vote(&self) -> Option<AuthoritySet> {
+        match self {
+            BlockHeader::V1(header) => header.strong_vote(),
+            BlockHeader::V2(header) => header.strong_vote(),
+        }
+    }
+
+    fn is_strong_vote(&self) -> bool {
+        match self {
+            BlockHeader::V1(header) => header.is_strong_vote(),
+            BlockHeader::V2(header) => header.is_strong_vote(),
+        }
+    }
+
+    fn is_strong_blame(&self) -> bool {
+        match self {
+            BlockHeader::V1(header) => header.is_strong_blame(),
+            BlockHeader::V2(header) => header.is_strong_blame(),
         }
     }
 }
@@ -316,6 +543,12 @@ impl BlockHeaderAPI for BlockHeader {
 impl From<BlockHeaderV1> for BlockHeader {
     fn from(header: BlockHeaderV1) -> Self {
         BlockHeader::V1(header)
+    }
+}
+
+impl From<BlockHeaderV2> for BlockHeader {
+    fn from(header: BlockHeaderV2) -> Self {
+        BlockHeader::V2(header)
     }
 }
 
@@ -1220,6 +1453,7 @@ pub struct TestBlockHeader {
     ancestors: Vec<BlockRef>,
     acknowledgments: Vec<BlockRef>,
     block_header: BlockHeaderV1,
+    strong_vote: Option<AuthoritySet>,
 }
 
 impl TestBlockHeader {
@@ -1236,6 +1470,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1263,6 +1498,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1294,6 +1530,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1337,6 +1574,11 @@ impl TestBlockHeader {
         self
     }
 
+    pub fn set_strong_vote(mut self, strong_vote: Option<AuthoritySet>) -> Self {
+        self.strong_vote = strong_vote;
+        self
+    }
+
     pub fn build(mut self) -> BlockHeader {
         let (references, overlap_start_index, overlap_end_index) =
             BlockHeaderV1::compress_references(self.ancestors, self.acknowledgments);
@@ -1345,6 +1587,23 @@ impl TestBlockHeader {
         self.block_header.overlap_end_index = overlap_end_index;
 
         BlockHeader::V1(self.block_header)
+    }
+
+    pub fn build_v2(self) -> BlockHeader {
+        let (references, overlap_start_index, overlap_end_index) =
+            BlockHeaderV1::compress_references(self.ancestors, self.acknowledgments);
+        BlockHeader::V2(BlockHeaderV2 {
+            epoch: self.block_header.epoch,
+            round: self.block_header.round,
+            author: self.block_header.author,
+            timestamp_ms: self.block_header.timestamp_ms,
+            references,
+            overlap_start_index,
+            overlap_end_index,
+            transactions_commitment: self.block_header.transactions_commitment,
+            commit_votes: self.block_header.commit_votes,
+            strong_vote: self.strong_vote,
+        })
     }
 }
 
@@ -1357,10 +1616,13 @@ mod tests {
 
     use fastcrypto::error::FastCryptoError;
 
+    use starfish_config::AuthorityIndex;
+
     use crate::{
         BlockHeaderAPI,
         block_header::{
-            BlockHeaderDigest, SignedBlockHeader, TestBlockHeader, genesis_block_headers,
+            AuthoritySet, BlockHeaderDigest, SignedBlockHeader, TestBlockHeader,
+            genesis_block_headers,
         },
         context::Context,
         error::ConsensusError,
@@ -1498,5 +1760,53 @@ mod tests {
         for ack in acknowledgments.iter() {
             assert!(compressed_acknowledgments.contains(ack));
         }
+    }
+
+    #[test]
+    fn test_authority_set_empty() {
+        let set = AuthoritySet::new();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+        assert_eq!(set.iter().count(), 0);
+    }
+
+    #[test]
+    fn test_authority_set_insert_and_contains() {
+        let mut set = AuthoritySet::new();
+        let idx = AuthorityIndex::new_for_test(5);
+
+        assert!(!set.contains(idx));
+        assert!(set.insert(idx));
+        assert!(set.contains(idx));
+        assert!(!set.insert(idx)); // duplicate
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn test_authority_set_across_buckets() {
+        let mut set = AuthoritySet::new();
+        set.insert(AuthorityIndex::new_for_test(0));
+        set.insert(AuthorityIndex::new_for_test(63));
+        set.insert(AuthorityIndex::new_for_test(64));
+        set.insert(AuthorityIndex::new_for_test(127));
+        set.insert(AuthorityIndex::new_for_test(128));
+        set.insert(AuthorityIndex::new_for_test(255));
+
+        assert_eq!(set.len(), 6);
+        assert!(set.contains(AuthorityIndex::new_for_test(0)));
+        assert!(set.contains(AuthorityIndex::new_for_test(255)));
+        assert!(!set.contains(AuthorityIndex::new_for_test(1)));
+    }
+
+    #[test]
+    fn test_authority_set_iter_order() {
+        let mut set = AuthoritySet::new();
+        set.insert(AuthorityIndex::new_for_test(200));
+        set.insert(AuthorityIndex::new_for_test(3));
+        set.insert(AuthorityIndex::new_for_test(100));
+        set.insert(AuthorityIndex::new_for_test(65));
+
+        let indices: Vec<_> = set.iter().map(|i| i.value()).collect();
+        assert_eq!(indices, vec![3, 65, 100, 200]);
     }
 }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -93,7 +93,7 @@ impl Transaction {
 /// Compact bitmask representing a subset of authorities.
 /// Supports up to 256 authorities (AuthorityIndex is u8).
 #[derive(Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct AuthoritySet([u64; 4]);
+pub struct AuthoritySet([u64; 4]);
 
 impl AuthoritySet {
     /// Creates an empty authority set.
@@ -284,6 +284,7 @@ impl BlockHeaderAPI for BlockHeaderV1 {
         self.transactions_commitment
     }
 
+    // V1 blocks do not carry a strong vote; always returns None.
     fn strong_vote(&self) -> Option<AuthoritySet> {
         None
     }
@@ -308,6 +309,10 @@ pub struct BlockHeaderV2 {
     overlap_end_index: u8,
     transactions_commitment: TransactionsCommitment,
     commit_votes: Vec<CommitVote>,
+    // Bitmask of authorities whose transaction data (announced by the leader)
+    // is not available. None means no vote. Some(empty) means all data is
+    // available (strong vote). Some(nonempty) means some data is missing
+    // (strong blame).
     strong_vote: Option<AuthoritySet>,
 }
 
@@ -339,6 +344,8 @@ impl BlockHeaderV2 {
         }
     }
 
+    // Will be used when genesis block construction is gated on consensus_starfish_speed.
+    #[expect(dead_code)]
     fn genesis_block_header(context: &Context, author: AuthorityIndex) -> Self {
         Self {
             epoch: context.committee.epoch(),

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -22,6 +22,7 @@ use starfish_config::{
 use tracing::instrument;
 
 use crate::{
+    authority_set::AuthoritySet,
     commit::CommitVote,
     context::Context,
     encoder::ShardEncoder,
@@ -87,79 +88,6 @@ impl Transaction {
         Transaction {
             data: Bytes::from(buf),
         }
-    }
-}
-
-/// Compact bitmask representing a subset of authorities.
-/// Supports up to 256 authorities (AuthorityIndex is u8).
-#[derive(Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AuthoritySet([u64; 4]);
-
-impl AuthoritySet {
-    /// Creates an empty authority set.
-    pub fn new() -> Self {
-        Self([0; 4])
-    }
-
-    /// Inserts an authority into the set. Returns true if the authority was
-    /// not already present.
-    pub fn insert(&mut self, index: AuthorityIndex) -> bool {
-        let i = index.value();
-        let array_index = i / 64;
-        let bit_pos = i % 64;
-        let mask = 1u64 << bit_pos;
-        let already_present = (self.0[array_index] & mask) != 0;
-        self.0[array_index] |= mask;
-        !already_present
-    }
-
-    /// Returns true if the set contains the given authority.
-    pub fn contains(&self, index: AuthorityIndex) -> bool {
-        let i = index.value();
-        let array_index = i / 64;
-        let bit_pos = i % 64;
-        (self.0[array_index] & (1u64 << bit_pos)) != 0
-    }
-
-    /// Returns true if the set is empty.
-    pub fn is_empty(&self) -> bool {
-        self.0.iter().all(|&bits| bits == 0)
-    }
-
-    /// Returns the number of authorities in the set.
-    pub fn len(&self) -> usize {
-        self.0.iter().map(|bits| bits.count_ones() as usize).sum()
-    }
-
-    /// Iterates over the authority indices in the set, in ascending order.
-    pub fn iter(&self) -> impl Iterator<Item = AuthorityIndex> + '_ {
-        self.0.iter().enumerate().flat_map(|(array_index, &bits)| {
-            let base = array_index * 64;
-            BitIter(bits).map(move |bit| AuthorityIndex::from((base + bit) as u8))
-        })
-    }
-}
-
-impl fmt::Debug for AuthoritySet {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let indices: Vec<_> = self.iter().collect();
-        write!(f, "AuthoritySet({indices:?})")
-    }
-}
-
-/// Iterator over set bits in a u64.
-struct BitIter(u64);
-
-impl Iterator for BitIter {
-    type Item = usize;
-
-    fn next(&mut self) -> Option<usize> {
-        if self.0 == 0 {
-            return None;
-        }
-        let bit = self.0.trailing_zeros() as usize;
-        self.0 &= self.0 - 1;
-        Some(bit)
     }
 }
 
@@ -1602,13 +1530,11 @@ mod tests {
     use std::sync::Arc;
 
     use fastcrypto::error::FastCryptoError;
-    use starfish_config::AuthorityIndex;
 
     use crate::{
         BlockHeaderAPI,
         block_header::{
-            AuthoritySet, BlockHeaderDigest, SignedBlockHeader, TestBlockHeader,
-            genesis_block_headers,
+            BlockHeaderDigest, SignedBlockHeader, TestBlockHeader, genesis_block_headers,
         },
         context::Context,
         error::ConsensusError,
@@ -1746,53 +1672,5 @@ mod tests {
         for ack in acknowledgments.iter() {
             assert!(compressed_acknowledgments.contains(ack));
         }
-    }
-
-    #[test]
-    fn test_authority_set_empty() {
-        let set = AuthoritySet::new();
-        assert!(set.is_empty());
-        assert_eq!(set.len(), 0);
-        assert_eq!(set.iter().count(), 0);
-    }
-
-    #[test]
-    fn test_authority_set_insert_and_contains() {
-        let mut set = AuthoritySet::new();
-        let idx = AuthorityIndex::new_for_test(5);
-
-        assert!(!set.contains(idx));
-        assert!(set.insert(idx));
-        assert!(set.contains(idx));
-        assert!(!set.insert(idx)); // duplicate
-        assert_eq!(set.len(), 1);
-    }
-
-    #[test]
-    fn test_authority_set_across_buckets() {
-        let mut set = AuthoritySet::new();
-        set.insert(AuthorityIndex::new_for_test(0));
-        set.insert(AuthorityIndex::new_for_test(63));
-        set.insert(AuthorityIndex::new_for_test(64));
-        set.insert(AuthorityIndex::new_for_test(127));
-        set.insert(AuthorityIndex::new_for_test(128));
-        set.insert(AuthorityIndex::new_for_test(255));
-
-        assert_eq!(set.len(), 6);
-        assert!(set.contains(AuthorityIndex::new_for_test(0)));
-        assert!(set.contains(AuthorityIndex::new_for_test(255)));
-        assert!(!set.contains(AuthorityIndex::new_for_test(1)));
-    }
-
-    #[test]
-    fn test_authority_set_iter_order() {
-        let mut set = AuthoritySet::new();
-        set.insert(AuthorityIndex::new_for_test(200));
-        set.insert(AuthorityIndex::new_for_test(3));
-        set.insert(AuthorityIndex::new_for_test(100));
-        set.insert(AuthorityIndex::new_for_test(65));
-
-        let indices: Vec<_> = set.iter().map(|i| i.value()).collect();
-        assert_eq!(indices, vec![3, 65, 100, 200]);
     }
 }

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -162,6 +162,21 @@ impl BlockVerifier for SignedBlockVerifier {
             });
         }
 
+        // Validate strong_vote field.
+        if let Some(authority_set) = block.strong_vote() {
+            if !self.context.protocol_config.consensus_starfish_speed() {
+                return Err(ConsensusError::UnexpectedStrongVote);
+            }
+            for authority_index in authority_set.iter() {
+                if !committee.is_valid_index(authority_index) {
+                    return Err(ConsensusError::InvalidStrongVoteAuthority {
+                        index: authority_index,
+                        max: committee.size(),
+                    });
+                }
+            }
+        }
+
         // TODO: transaction verification is removed from here. It should be done when
         // the transaction data gets available by Data/Transaction Manager
         Ok(())

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -20,6 +20,7 @@ use tracing::{debug, warn};
 
 use crate::{
     BlockHeaderAPI, BlockRef, Round, VerifiedBlockHeader,
+    authority_set::AuthoritySet,
     block_header::{BlockHeaderDigest, TransactionsCommitment, VerifiedBlock},
     context::Context,
     dag_state::DagState,
@@ -43,43 +44,7 @@ const CORDIAL_KNOWLEDGE_CHANNEL_CAPACITY: usize = 10_000;
 /// skip evictions for too long either.
 const EVICTION_CHECK_INTERVAL: usize = 10_000;
 
-/// Represents a subset of authorities using a bitmask.
-/// Each bit in the `low` and `high` fields corresponds to an authority index.
-/// The maximum number of authorities supported is 256 (0-255).
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct SubsetAuthorities {
-    low: u128,
-    high: u128,
-}
-
 pub type Ancestors = Arc<[BlockRef]>;
-impl SubsetAuthorities {
-    #[inline]
-    pub fn new_with(author: usize, own: usize) -> Self {
-        let mut s = Self { low: 0, high: 0 };
-        s.insert(author);
-        s.insert(own);
-        s
-    }
-
-    /// Insert an authority into the subset. Returns true if the authority was
-    /// not already present.
-    #[inline]
-    pub fn insert(&mut self, i: usize) -> bool {
-        if i < 128 {
-            let mask = 1u128 << i;
-            let already_present = (self.low & mask) != 0;
-            self.low |= mask;
-            !already_present
-        } else {
-            let bit = i - 128;
-            let mask = 1u128 << bit;
-            let already_present = (self.high & mask) != 0;
-            self.high |= mask;
-            !already_present
-        }
-    }
-}
 
 /// Manages the global cordial knowledge state.
 /// Receives high-level updates from DagState and AuthorityService and
@@ -105,8 +70,7 @@ pub(crate) struct CordialKnowledge {
     /// shall retrieve it from `cordial_knowledge[block_ref.
     /// author][block_ref.round][block_ref.digest]`. The provided value is a
     /// tuple of (ancestors, who knows the block header).
-    cordial_knowledge:
-        Vec<BTreeMap<Round, AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>>>,
+    cordial_knowledge: Vec<BTreeMap<Round, AHashMap<BlockHeaderDigest, (Ancestors, AuthoritySet)>>>,
     /// Each Connection Knowledge corresponds to one peer. Upon reception of a
     /// message from CordialKnowledge, we propagate the respected
     /// information for each connection.
@@ -623,7 +587,7 @@ impl CordialKnowledge {
 
         // Insert block into cordial knowledge
         let ancestors: Ancestors = Arc::from(header.ancestors());
-        let who_knows_this_block = SubsetAuthorities::new_with(block_author, own_index);
+        let who_knows_this_block = AuthoritySet::new_with(block_ref.author, self.context.own_index);
         round_map.insert(block_digest, (ancestors, who_knows_this_block));
 
         // 2) Notify all *other* authorities (except self and block_author) about new
@@ -693,7 +657,7 @@ impl CordialKnowledge {
                 if let Some(parent_round_map) = parent_author_map.get_mut(&parent_round) {
                     if let Some((_, who_knows_parent)) = parent_round_map.get_mut(&parent_digest) {
                         // Mark that block_author now knows this parent
-                        if who_knows_parent.insert(block_author) {
+                        if who_knows_parent.insert(block_ref.author) {
                             vec_knowledge_msgs[block_author].push(
                                 ConnectionKnowledgeMessage::RemoveHeader {
                                     block_ref: *parent_ref,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -34,7 +34,8 @@ use crate::{CommitConsumer, CommittedSubDag, TransactionClient, storage::mem_sto
 use crate::{
     Transaction,
     block_header::{
-        BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
+        BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockHeaderV2, BlockRef, BlockTimestampMs,
+        GENESIS_ROUND,
         Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
         VerifiedOwnShard, VerifiedTransactions,
     },
@@ -892,16 +893,31 @@ impl Core {
         });
 
         // Create the block and insert to storage.
-        let block_header = BlockHeader::V1(BlockHeaderV1::new(
-            self.context.committee.epoch(),
-            clock_round,
-            self.context.own_index,
-            now,
-            ancestors.iter().map(|b| b.reference()).collect(),
-            acknowledgments,
-            commit_votes,
-            transactions_commitment,
-        ));
+        let ancestor_refs = ancestors.iter().map(|b| b.reference()).collect();
+        let block_header = if self.context.protocol_config.consensus_starfish_speed() {
+            BlockHeader::V2(BlockHeaderV2::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestor_refs,
+                acknowledgments,
+                commit_votes,
+                transactions_commitment,
+                None, // strong_vote populated in later StarfishSpeed steps
+            ))
+        } else {
+            BlockHeader::V1(BlockHeaderV1::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestor_refs,
+                acknowledgments,
+                commit_votes,
+                transactions_commitment,
+            ))
+        };
 
         let signed_block_header = SignedBlockHeader::new(block_header, &self.block_signer)
             .expect("Block signing failed.");

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -34,9 +34,9 @@ use crate::{CommitConsumer, CommittedSubDag, TransactionClient, storage::mem_sto
 use crate::{
     Transaction,
     block_header::{
-        BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockHeaderV2, BlockRef, BlockTimestampMs,
-        GENESIS_ROUND, Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
-        VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
+        BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
+        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
+        VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, CommitAPI, PendingSubDag},
@@ -892,31 +892,16 @@ impl Core {
         });
 
         // Create the block and insert to storage.
-        let ancestor_refs = ancestors.iter().map(|b| b.reference()).collect();
-        let block_header = if self.context.protocol_config.consensus_starfish_speed() {
-            BlockHeader::V2(BlockHeaderV2::new(
-                self.context.committee.epoch(),
-                clock_round,
-                self.context.own_index,
-                now,
-                ancestor_refs,
-                acknowledgments,
-                commit_votes,
-                transactions_commitment,
-                None, // strong_vote populated in later StarfishSpeed steps
-            ))
-        } else {
-            BlockHeader::V1(BlockHeaderV1::new(
-                self.context.committee.epoch(),
-                clock_round,
-                self.context.own_index,
-                now,
-                ancestor_refs,
-                acknowledgments,
-                commit_votes,
-                transactions_commitment,
-            ))
-        };
+        let block_header = BlockHeader::V1(BlockHeaderV1::new(
+            self.context.committee.epoch(),
+            clock_round,
+            self.context.own_index,
+            now,
+            ancestors.iter().map(|b| b.reference()).collect(),
+            acknowledgments,
+            commit_votes,
+            transactions_commitment,
+        ));
 
         let signed_block_header = SignedBlockHeader::new(block_header, &self.block_signer)
             .expect("Block signing failed.");

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -35,9 +35,8 @@ use crate::{
     Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockHeaderV2, BlockRef, BlockTimestampMs,
-        GENESIS_ROUND,
-        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedOwnShard, VerifiedTransactions,
+        GENESIS_ROUND, Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
+        VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, CommitAPI, PendingSubDag},

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -302,6 +302,14 @@ pub(crate) enum ConsensusError {
     // rollout phase.
     #[error("Fast commit sync is not enabled in the current protocol version")]
     FastCommitSyncNotEnabled,
+
+    #[error("Block has strong_vote field but consensus_starfish_speed is disabled")]
+    UnexpectedStrongVote,
+
+    #[error(
+        "Block strong_vote contains invalid authority index {index}, committee size is {max}"
+    )]
+    InvalidStrongVoteAuthority { index: AuthorityIndex, max: usize },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -306,9 +306,7 @@ pub(crate) enum ConsensusError {
     #[error("Block has strong_vote field but consensus_starfish_speed is disabled")]
     UnexpectedStrongVote,
 
-    #[error(
-        "Block strong_vote contains invalid authority index {index}, committee size is {max}"
-    )]
+    #[error("Block strong_vote contains invalid authority index {index}, committee size is {max}")]
     InvalidStrongVoteAuthority { index: AuthorityIndex, max: usize },
 }
 

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod authority_node;
 mod authority_service;
+mod authority_set;
 mod base_committer;
 mod block_header;
 mod block_manager;

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -32,6 +32,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     Round, VerifiedBlockHeader,
+    authority_set::AuthoritySet,
     block_header::{BlockRef, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
@@ -293,41 +294,16 @@ pub(crate) struct SerializedBlockBundleParts {
     pub(crate) serialized_block: Bytes,
     pub(crate) serialized_headers: Vec<Bytes>,
     pub(crate) serialized_shards: Vec<Bytes>,
-    pub(crate) useful_headers_authors_bitmask: [u64; 4],
-    pub(crate) useful_shards_authors_bitmask: [u64; 4],
-}
-
-fn authority_set_to_bitmask(authorities: &BTreeSet<AuthorityIndex>) -> [u64; 4] {
-    let mut bitmask = [0u64; 4];
-    for authority_index in authorities {
-        let index = authority_index.value();
-        let array_index = index / 64;
-        let bit_pos = index % 64;
-        bitmask[array_index] |= 1u64 << bit_pos;
-    }
-    bitmask
-}
-
-fn bitmask_to_authority_set(bitmask: [u64; 4]) -> BTreeSet<AuthorityIndex> {
-    let mut set = BTreeSet::new();
-    for (array_index, &bits) in bitmask.iter().enumerate() {
-        let mut bits = bits;
-        let base = array_index * 64;
-        while bits != 0 {
-            let bit = bits.trailing_zeros() as usize;
-            set.insert(AuthorityIndex::from((base + bit) as u8));
-            bits &= bits - 1;
-        }
-    }
-    set
+    pub(crate) useful_headers_authors_bitmask: AuthoritySet,
+    pub(crate) useful_shards_authors_bitmask: AuthoritySet,
 }
 
 impl SerializedBlockBundleParts {
     pub(crate) fn useful_headers_authors(&self) -> BTreeSet<AuthorityIndex> {
-        bitmask_to_authority_set(self.useful_headers_authors_bitmask)
+        self.useful_headers_authors_bitmask.to_btreeset()
     }
     pub(crate) fn useful_shards_authors(&self) -> BTreeSet<AuthorityIndex> {
-        bitmask_to_authority_set(self.useful_shards_authors_bitmask)
+        self.useful_shards_authors_bitmask.to_btreeset()
     }
 }
 
@@ -350,8 +326,8 @@ impl TryFrom<VerifiedBlock> for SerializedBlockBundleParts {
             serialized_block: Bytes::from(bytes),
             serialized_headers: vec![],
             serialized_shards: vec![],
-            useful_headers_authors_bitmask: [0u64; 4],
-            useful_shards_authors_bitmask: [0u64; 4],
+            useful_headers_authors_bitmask: AuthoritySet::new(),
+            useful_shards_authors_bitmask: AuthoritySet::new(),
         })
     }
 }
@@ -375,12 +351,10 @@ impl TryFrom<BlockBundle> for SerializedBlockBundleParts {
             serialized_block: Bytes::from(bytes),
             serialized_headers: serialized_block_headers,
             serialized_shards: block_bundle.serialized_shards,
-            useful_headers_authors_bitmask: authority_set_to_bitmask(
+            useful_headers_authors_bitmask: AuthoritySet::from(
                 &block_bundle.useful_headers_authors,
             ),
-            useful_shards_authors_bitmask: authority_set_to_bitmask(
-                &block_bundle.useful_shards_authors,
-            ),
+            useful_shards_authors_bitmask: AuthoritySet::from(&block_bundle.useful_shards_authors),
         })
     }
 }


### PR DESCRIPTION
# Description of change

Introduce `AuthoritySet` — a compact `[u64; 4]` bitmask for authority subsets — and `BlockHeaderV2` with an optional `strong_vote` field for the StarfishSpeed optimistic commit rule.                                                                                                                                 
                                                                                                                                                                                                                                                                                                                         
  - **`AuthoritySet`** (`authority_set.rs`): replaces `SubsetAuthorities` (2×u128) in `cordial_knowledge.rs` and raw `[u64; 4]` bitmask helpers in `network/mod.rs` with a single shared type.                                                                                                                           
  - **`BlockHeaderV2`**: mirrors V1 with an added `strong_vote: Option<AuthoritySet>` — `None` = no vote, `Some(empty)` = strong vote, `Some(nonempty)` = strong blame.                                                                                                                                                  
  - **`BlockHeaderAPI`**: new methods `strong_vote()`, `is_strong_vote()`, `is_strong_blame()` (V1 always returns `None`/`false`).                                                                                                                                                                                       
  - **`compress_references`** moved from `BlockHeaderV1` to `BlockHeader` so both versions share it.                                                                                                                                                                                                                     
  - **Block verification**: rejects `strong_vote` when `consensus_starfish_speed` is disabled; validates authority indices against committee size.

## Links to any relevant issues

Part of #11009
Fixes #11132

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes