### PR TITLE
fix(split-cluster): use iota-localnet binary for genesis in sync check

### DIFF
--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -43,19 +43,31 @@ echo "Using working dir $WORKING_DIR"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+# remember current commit
+CURRENT_COMMIT=$(git rev-parse HEAD)
+
+# TODO this can be removed when v1.20 reaches mainnet
+git checkout $RELEASE_COMMIT || exit 1
+if cargo metadata --no-deps --format-version 1 \
+     | jq -e '[.packages[].targets[] | select(.kind[] == "bin") | .name] | contains(["iota-localnet"])' > /dev/null 2>&1; then
+  IOTA_BINARY="iota-localnet"
+  echo "iota-localnet target found"
+else
+  IOTA_BINARY="iota"
+  echo "iota-localnet target NOT found"
+fi
+git checkout $CURRENT_COMMIT || exit 1
+
 # check if binaries have already been built
-if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/iota-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
+if [ -f "$WORKING_DIR/iota-node-release" ] && [ -f "$WORKING_DIR/$IOTA_BINARY-release" ] && [ -f "$WORKING_DIR/iota-node-candidate" ]; then
   echo "Binaries already built, skipping build"
 else
-  echo "Building iota-node and iota at $RELEASE_COMMIT"
-
-  # remember current commit
-  CURRENT_COMMIT=$(git rev-parse HEAD)
+  echo "Building iota-node and $IOTA_BINARY at $RELEASE_COMMIT"
 
   git checkout $RELEASE_COMMIT || exit 1
-  cargo build --bin iota-node --bin iota || exit 1
+  cargo build --bin iota-node --bin $IOTA_BINARY || exit 1
   cp ./target/debug/iota-node "$WORKING_DIR/iota-node-release"
-  cp ./target/debug/iota "$WORKING_DIR/iota-release"
+  cp ./target/debug/$IOTA_BINARY "$WORKING_DIR/$IOTA_BINARY-release"
 
   echo "Building iota-node at $RELEASE_CANDIDATE_COMMIT"
   git checkout $RELEASE_CANDIDATE_COMMIT || exit 1
@@ -69,7 +81,7 @@ fi
 export IOTA_CONFIG_DIR="$WORKING_DIR/config"
 rm -rf "$IOTA_CONFIG_DIR"
 
-"$WORKING_DIR/iota-release" genesis --epoch-duration-ms 600000 --committee-size 4
+"$WORKING_DIR/$IOTA_BINARY-release" genesis --epoch-duration-ms 600000 --committee-size 4
 
 LOG_DIR="$WORKING_DIR/logs"
 METRICS_DIR="$WORKING_DIR/metrics"


### PR DESCRIPTION
# Description of change

The `split-cluster-check.sh` script was fixed in #11079 to detect whether the `iota` binary was renamed to `iota-localnet`, but the same fix was never applied to `split-cluster-sync-check.sh`. This causes CI failures on testnet validation when the release commit uses `iota-localnet`.

Applies the same `iota-localnet` detection logic: checks `cargo metadata` at the release commit to determine the correct binary name, then uses it for building and genesis.

## Links to any relevant issues

Fixes CI on #11148

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
  - Verified the script change mirrors the fix from #11079
  - CI will validate by running the split-cluster-sync-check workflow