### PR TITLE
upstream(core): Fix possible re-entrant lock bug in SharedInMemoryStore

### DIFF
--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -9,7 +9,7 @@ use tracing::error;
 
 use super::{ObjectStore, error::Result};
 use crate::{
-    base_types::{EpochId, TransactionDigest},
+    base_types::{EpochId, ExecutionData, TransactionDigest},
     committee::Committee,
     digests::{CheckpointContentsDigest, CheckpointDigest},
     effects::{TransactionEffects, TransactionEvents},
@@ -90,23 +90,7 @@ impl ReadStore for SharedInMemoryStore {
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>> {
-        // First look to see if we saved the complete contents already.
-        let inner = self.inner();
-        let contents = inner
-            .get_sequence_number_by_contents_digest(digest)
-            .and_then(|seq_num| inner.full_checkpoint_contents.get(&seq_num).cloned());
-        if contents.is_some() {
-            return Ok(contents);
-        }
-
-        // Otherwise gather it from the individual components.
-        inner
-            .get_checkpoint_contents(digest)
-            .map(|contents| {
-                FullCheckpointContents::try_from_checkpoint_contents(self, contents.to_owned())
-            })
-            .transpose()
-            .map(|contents| contents.flatten())
+        Ok(self.inner().get_full_checkpoint_contents(digest))
     }
 
     fn try_get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
@@ -268,6 +252,38 @@ impl InMemoryStore {
         self.sequence_number_to_digest
             .get(&sequence_number)
             .and_then(|digest| self.get_checkpoint_by_digest(digest))
+    }
+
+    fn get_full_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<FullCheckpointContents> {
+        let contents = self
+            .get_sequence_number_by_contents_digest(digest)
+            .and_then(|seq_num| self.full_checkpoint_contents.get(&seq_num).cloned());
+        if contents.is_some() {
+            return contents;
+        }
+
+        let contents = self.get_checkpoint_contents(digest)?;
+
+        let mut transactions = Vec::with_capacity(contents.size());
+
+        for tx in contents.iter() {
+            if let (Some(t), Some(e)) = (
+                self.get_transaction_block(&tx.transaction),
+                self.get_transaction_effects(&tx.transaction),
+            ) {
+                transactions.push(ExecutionData::new((*t).clone().into_inner(), e.clone()))
+            } else {
+                return None;
+            }
+        }
+
+        Some(FullCheckpointContents::from_contents_and_execution_data(
+            contents.to_owned(),
+            transactions.into_iter(),
+        ))
     }
 
     /// Get checkpoint sequence number by contents digest.


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.48.4, v1.49.2)
- Port commit:
  - [MystenLabs/sui@7ddb5f3](https://github.com/MystenLabs/sui/commit/7ddb5f338d838d378cab389ae0a0acdf6fd587b9)
- Description:

Fixes a possible re-entrant lock bug in `SharedInMemoryStore`. The `try_get_full_checkpoint_contents` method was calling `FullCheckpointContents::try_from_checkpoint_contents(self, ...)`, which passed `self` (a `SharedInMemoryStore`) as a `ReadStore` — potentially re-acquiring the `RwLock` while it was already held. The fix moves the assembly logic into `InMemoryStore::get_full_checkpoint_contents`, which operates on the inner store directly without going through `ReadStore`.

Note: Unlike upstream, `try_from_checkpoint_contents` method is retained on our side because it is still used by the `simulacrum` crate. The re-entrant lock bug is still fixed since `SharedInMemoryStore` no longer calls it.

## Links to any relevant issues

Part of #11101

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes