### PR TITLE
upstream(core): Use cf name when describe table

### DIFF
--- a/crates/iota-tool/src/db_tool/db_dump.rs
+++ b/crates/iota-tool/src/db_tool/db_dump.rs
@@ -282,6 +282,8 @@ pub fn dump_table(
                     page_number,
                 )
             } else {
+                let perpetual_tables = AuthorityPerpetualTables::describe_tables();
+                assert!(perpetual_tables.contains_key(table_name));
                 AuthorityPerpetualTables::open_readonly(&db_path).dump(
                     table_name,
                     page_size,

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -470,7 +470,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
             /// Returns a list of the tables name and type pairs
             pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
                 vec![#(
-                    (stringify!(#active_field_names).to_owned(), (stringify!(#active_key_names).to_owned(), stringify!(#active_value_names).to_owned())),
+                    (stringify!(#active_cf_names).to_owned(), (stringify!(#active_key_names).to_owned(), stringify!(#active_value_names).to_owned())),
                 )*].into_iter().collect()
             }
 
@@ -576,7 +576,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
 
             pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
                 vec![#(
-                    (stringify!(#active_field_names).to_owned(), (stringify!(#active_key_names).to_owned(), stringify!(#active_value_names).to_owned())),
+                    (stringify!(#active_cf_names).to_owned(), (stringify!(#active_key_names).to_owned(), stringify!(#active_value_names).to_owned())),
                 )*].into_iter().collect()
             }
 


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.48.4, v1.49.2)
- Port commit:
  - [MystenLabs/sui@bcea93b](https://github.com/MystenLabs/sui/commit/bcea93b7e7fd4d6b0b6667071235143910faaa52)
- Description:

Use CF (column family) name instead of field name in `describe_tables()`, so that rename derives work correctly. Also adds an assertion in `db_dump` to verify the table name exists.

## Links to any relevant issues

Part of #11101

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes