### PR TITLE
chore(gRPC): update README to reflect current API

### DIFF
--- a/crates/iota-grpc-server/README.md
+++ b/crates/iota-grpc-server/README.md
@@ -1,6 +1,12 @@
 # IOTA gRPC API
 
-This crate implements a gRPC API for IOTA. The primary goal of this API is to provide a more efficient and lower-latency method for data access, intended to replace existing REST-API polling or filesystem-based synchronization. This reduces the delay between data creation and their subsequent processing by external services.
+This crate implements a gRPC API for IOTA. Clients can subscribe to real-time data streams, enabling low-latency access to on-chain data as it is produced.
+
+## Field Masks
+
+Many endpoints support [field masks](https://protobuf.dev/reference/protobuf/google.protobuf/#field-mask) via an optional `read_mask` parameter. A field mask lets clients specify exactly which fields to include in the response, reducing bandwidth and processing overhead. When no field mask is provided, all fields are returned by default.
+
+Endpoints that support field masks are marked with **[FM]** below.
 
 ## Features
 
@@ -10,23 +16,21 @@ The gRPC API provides the following services:
 
 - `GetHealth`: Check node health with optional latency threshold.
 - `GetServiceInfo`: Query service state (chain ID, epoch, checkpoint height, etc.).
-- `GetObjects`: Stream objects by reference with field mask support.
-- `GetTransactions`: Stream transactions by digest with field mask support.
-- `GetCheckpoint`: Stream checkpoint data by sequence number, digest, or latest, with transaction and event filtering.
-- `StreamCheckpoints`: Stream checkpoints with filtering and progress reporting.
-- `GetEpoch`: Query epoch information.
+- `GetObjects` **[FM]**: Stream objects by reference.
+- `GetTransactions` **[FM]**: Stream transactions by digest.
+- `GetCheckpoint` **[FM]**: Stream checkpoint data by sequence number, digest, or latest, with transaction and event filtering.
+- `StreamCheckpoints` **[FM]**: Stream checkpoints with filtering and progress reporting.
+- `GetEpoch` **[FM]**: Query epoch information.
 
 ### Transaction Execution Service
 
-- `ExecuteTransactions`: Execute a batch of transactions sequentially.
-- `SimulateTransactions`: Simulate a batch of transactions (with suggested gas price).
-
-Both support field masks to control response data, per-item error handling, and configurable checkpoint inclusion waiting.
+- `ExecuteTransactions` **[FM]**: Execute a batch of transactions sequentially, with per-item error handling and configurable checkpoint inclusion waiting.
+- `SimulateTransactions` **[FM]**: Simulate a batch of transactions (with suggested gas price), with per-item error handling and configurable checkpoint inclusion waiting.
 
 ### State Service
 
-- `ListDynamicFields`: List dynamic fields owned by a parent object with pagination.
-- `ListOwnedObjects`: List objects owned by an address with optional type filtering and pagination.
+- `ListDynamicFields` **[FM]**: List dynamic fields owned by a parent object with pagination.
+- `ListOwnedObjects` **[FM]**: List objects owned by an address with optional type filtering and pagination.
 - `GetCoinInfo`: Get coin metadata, treasury cap, and regulated coin metadata.
 
 ### Move Package Service
@@ -37,7 +41,7 @@ Both support field masks to control response data, per-item error handling, and 
 
 The `iota-grpc-server` crate implements the gRPC services. The `iota-node` crate integrates and starts this gRPC server if `enable-grpc-api` is set to `true` and `grpc-api-config` is configured.
 
-Shared gRPC clients are provided by the `iota-grpc-client` crate:
+Shared gRPC clients are provided by the [`iota-sdk-grpc-client`](https://github.com/iotaledger/iota-rust-sdk/tree/develop/crates/iota-sdk-grpc-client) crate in the [iota-rust-sdk](https://github.com/iotaledger/iota-rust-sdk):
 
 - `Client`: Factory for creating service-specific clients (`ledger_service_client()`, `execution_service_client()`, `state_service_client()`, `move_package_service_client()`).
 
@@ -61,7 +65,7 @@ grpc-api-config:
 **Client Example:**
 
 ```rust
-use iota_grpc_client::Client;
+use iota_sdk_grpc_client::Client;
 
 // Connect to gRPC node
 let client = Client::connect("http://localhost:50051").await?;
@@ -73,4 +77,4 @@ let mut state = client.state_service_client();
 let mut packages = client.move_package_service_client();
 ```
 
-Proto definitions are in the `iota-grpc-types` crate at `proto/iota/grpc/v1/`.
+Proto definitions are in the [`iota-sdk-grpc-types`](https://github.com/iotaledger/iota-rust-sdk/tree/develop/crates/iota-sdk-grpc-types/proto/iota/grpc/v1) crate in the [iota-rust-sdk](https://github.com/iotaledger/iota-rust-sdk).

--- a/crates/iota-grpc-server/README.md
+++ b/crates/iota-grpc-server/README.md
@@ -1,73 +1,76 @@
 # IOTA gRPC API
 
-> **⚠️ EXPERIMENTAL - INTERNAL USE ONLY**
->
-> This gRPC API is highly experimental and intended for internal use only. The API surface, data formats, and behavior are subject to significant changes without notice. **Do not use this in production or build external integrations against it** as breaking changes are expected and likely.
-
-This crate introduces a gRPC API for IOTA. The primary goal of this API is to provide a more efficient and lower-latency method for data access, intended to replace existing REST-API polling or filesystem-based synchronization. This reduces the delay between data creation and their subsequent processing by external services.
+This crate implements a gRPC API for IOTA. The primary goal of this API is to provide a more efficient and lower-latency method for data access, intended to replace existing REST-API polling or filesystem-based synchronization. This reduces the delay between data creation and their subsequent processing by external services.
 
 ## Features
 
 The gRPC API provides the following services:
 
-### Checkpoint Service
+### Ledger Service
 
-- `StreamCheckpoints`: Stream checkpoint data based on a flexible range.
-- `GetEpochFirstCheckpointSequenceNumber`: Query the first checkpoint sequence number for a given epoch (useful for robust reset and epoch boundary handling).
+- `GetHealth`: Check node health with optional latency threshold.
+- `GetServiceInfo`: Query service state (chain ID, epoch, checkpoint height, etc.).
+- `GetObjects`: Stream objects by reference with field mask support.
+- `GetTransactions`: Stream transactions by digest with field mask support.
+- `GetCheckpoint`: Stream checkpoint data by sequence number, digest, or latest, with transaction and event filtering.
+- `StreamCheckpoints`: Stream checkpoints with filtering and progress reporting.
+- `GetEpoch`: Query epoch information.
 
-### Event Service
+### Transaction Execution Service
 
-- `StreamEvents`: Stream events with flexible filtering capabilities
+- `ExecuteTransactions`: Execute a batch of transactions sequentially.
+- `SimulateTransactions`: Simulate a batch of transactions (with suggested gas price).
 
-Event filters allow precise control over which events are streamed to clients, including filtering by event type, package, sender, transaction, field values, time ranges, and boolean combinations. For the complete list and definitions of available filters, see [`proto/event.proto`](proto/event.proto).
+Both support field masks to control response data, per-item error handling, and configurable checkpoint inclusion waiting.
+
+### State Service
+
+- `ListDynamicFields`: List dynamic fields owned by a parent object with pagination.
+- `ListOwnedObjects`: List objects owned by an address with optional type filtering and pagination.
+- `GetCoinInfo`: Get coin metadata, treasury cap, and regulated coin metadata.
+
+### Move Package Service
+
+- `ListPackageVersions`: List all versions of a Move package with pagination.
 
 ## Usage
 
-The `iota-grpc-server` crate defines the gRPC service and its messages. The `iota-node` crate integrates and starts this gRPC server if `enable-grpc-api` is set to `true` and `grpc-api-config` is configured.
+The `iota-grpc-server` crate implements the gRPC services. The `iota-node` crate integrates and starts this gRPC server if `enable-grpc-api` is set to `true` and `grpc-api-config` is configured.
 
-Shared gRPC clients are provided by this crate:
+Shared gRPC clients are provided by the `iota-grpc-client` crate:
 
-- `CheckpointClient`: For streaming checkpoints and querying epoch information
-- `EventClient`: For streaming events with filtering capabilities
-- `NodeClient`: Factory for creating and managing service clients
+- `Client`: Factory for creating service-specific clients (`ledger_service_client()`, `execution_service_client()`, `state_service_client()`, `move_package_service_client()`).
 
 These clients should be used by downstream consumers to ensure all consumers use the same, up-to-date protocol and data model.
 
 **Configuration Example:**
 
-```toml
+```yaml
 # In your node config file (e.g., fullnode.yaml)
 enable-grpc-api: true
 grpc-api-config:
   address: "0.0.0.0:50051"
-  checkpoint-broadcast-buffer-size: 100
-  event-broadcast-buffer-size: 1000
+  broadcast-buffer-size: 100
+  max-message-size-bytes: 134217728
+  max-json-move-value-size: 1048576
+  max-execute-transaction-batch-size: 20
+  max-simulate-transaction-batch-size: 20
+  max-checkpoint-inclusion-timeout-ms: 60000
 ```
 
-**Client Examples:**
+**Client Example:**
 
 ```rust
-use iota_grpc_client::NodeClient;
+use iota_grpc_client::Client;
 
 // Connect to gRPC node
-let node_client = NodeClient::connect("http://localhost:50051").await?;
+let client = Client::connect("http://localhost:50051").await?;
 
-// Checkpoint streaming example
-let mut checkpoint_client = node_client.checkpoint_client().expect("Checkpoint client available");
-let mut checkpoint_stream = checkpoint_client.stream_checkpoints(Some(0), Some(10), false).await?;
-while let Some(Ok(checkpoint_content)) = checkpoint_stream.next().await {
-    // Process checkpoint data or summary
-}
-
-// Event streaming example
-use iota_grpc_types::v0::events::{EventFilter, AllFilter, event_filter::Filter};
-
-let mut event_client = node_client.event_client().expect("Event client available");
-let all_events_filter = EventFilter {
-    filter: Some(Filter::All(AllFilter {})),
-};
-let mut event_stream = event_client.stream_events(all_events_filter).await?;
-while let Some(Ok(event)) = event_stream.next().await {
-    // Process IotaEvent
-}
+// Get a service-specific client
+let mut ledger = client.ledger_service_client();
+let mut execution = client.execution_service_client();
+let mut state = client.state_service_client();
+let mut packages = client.move_package_service_client();
 ```
+
+Proto definitions are in the `iota-grpc-types` crate at `proto/iota/grpc/v1/`.


### PR DESCRIPTION
# Description of change

Update the `iota-grpc-server` README to accurately document the current gRPC API surface, replacing outdated v0 references.

## Links to any relevant issues

Fixes #8695

## How the change has been tested

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes