### PR TITLE
feat(indexer): add objects_backward_history table and ingestion

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS objects_backward_history;

--- a/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/up.sql
@@ -1,0 +1,50 @@
+-- Backward history table: stores the *previous* state of objects when they are
+-- superseded by a new checkpoint. Combined with `checkpointed_objects`, this
+-- enables consistent view queries via backward diff without the lag and
+-- duplication problems of `objects_snapshot`.
+CREATE TABLE objects_backward_history (
+    object_id                   bytea         NOT NULL,
+    object_version              bigint        NOT NULL,
+    object_status               smallint      NOT NULL,
+    object_digest               bytea,
+    superseded_at_checkpoint    bigint        NOT NULL,
+    owner_type                  smallint,
+    owner_id                    bytea,
+    object_type                 text,
+    object_type_package         bytea,
+    object_type_module          text,
+    object_type_name            text,
+    serialized_object           bytea,
+    coin_type                   text,
+    coin_balance                bigint,
+    df_kind                     smallint,
+    CONSTRAINT objects_backward_history_pk PRIMARY KEY (superseded_at_checkpoint, object_id, object_version)
+);
+
+CREATE INDEX objects_backward_history_id_version
+    ON objects_backward_history (object_id, object_version, superseded_at_checkpoint);
+
+CREATE INDEX objects_backward_history_owner
+    ON objects_backward_history (superseded_at_checkpoint, owner_type, owner_id)
+    WHERE owner_type >= 1 AND owner_type <= 2 AND owner_id IS NOT NULL;
+
+CREATE INDEX objects_backward_history_owner_package_module_name_full_type
+    ON objects_backward_history (superseded_at_checkpoint, owner_id, object_type_package, object_type_module, object_type_name, object_type);
+
+CREATE INDEX objects_backward_history_package_module_name_full_type
+    ON objects_backward_history (superseded_at_checkpoint, object_type_package, object_type_module, object_type_name, object_type);
+
+CREATE INDEX objects_backward_history_type
+    ON objects_backward_history (superseded_at_checkpoint, object_type);
+
+CREATE INDEX objects_backward_history_coin_only
+    ON objects_backward_history (superseded_at_checkpoint, coin_type, object_id)
+    WHERE coin_type IS NOT NULL;
+
+CREATE INDEX objects_backward_history_coin_owner
+    ON objects_backward_history (superseded_at_checkpoint, owner_id, coin_type, object_id)
+    WHERE coin_type IS NOT NULL AND owner_type = 1;
+
+CREATE STATISTICS objects_backward_history_type_stats (dependencies, mcv)
+    ON object_type, object_type_package, object_type_module, object_type_name
+    FROM objects_backward_history;

--- a/crates/iota-indexer/src/ingestion/common/persist.rs
+++ b/crates/iota-indexer/src/ingestion/common/persist.rs
@@ -225,6 +225,7 @@ pub enum CommitterTables {
     Packages,
     ProtocolConfigs,
     // Prunable tables
+    ObjectsBackwardHistory,
     ObjectsHistory,
     Transactions,
     Events,

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -17,6 +17,7 @@ use crate::{
         display::StoredDisplay,
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate},
         obj_indices::StoredObjectVersion,
+        objects::StoredBackwardHistoryObject,
     },
     store::{IndexerStore, PgIndexerStore},
     types::{
@@ -34,6 +35,7 @@ pub(crate) struct CheckpointDataToCommit {
     pub(crate) display_updates: BTreeMap<String, StoredDisplay>,
     pub(crate) object_changes: CheckpointObjectChanges,
     pub(crate) object_history_changes: TransactionObjectChangesToCommit,
+    pub(crate) backward_history_changes: Vec<StoredBackwardHistoryObject>,
     pub(crate) object_versions: Vec<StoredObjectVersion>,
     pub(crate) packages: Vec<IndexedPackage>,
     pub(crate) epoch: Option<EpochToCommit>,
@@ -106,6 +108,7 @@ impl PrimaryWriter {
         let mut display_updates_batch = BTreeMap::new();
         let mut object_changes_batch = Vec::with_capacity(batch_len);
         let mut object_history_changes_batch = Vec::with_capacity(batch_len);
+        let mut backward_history_batch = Vec::new();
         let mut object_versions_batch = Vec::with_capacity(batch_len);
         let mut packages_batch = Vec::with_capacity(batch_len);
 
@@ -119,6 +122,7 @@ impl PrimaryWriter {
                 display_updates,
                 object_changes,
                 object_history_changes,
+                backward_history_changes,
                 object_versions,
                 packages,
                 ..
@@ -131,6 +135,7 @@ impl PrimaryWriter {
             display_updates_batch.extend(display_updates.into_iter());
             object_changes_batch.push(object_changes);
             object_history_changes_batch.push(object_history_changes);
+            backward_history_batch.extend(backward_history_changes);
             object_versions_batch.push(object_versions);
             packages_batch.push(packages);
         }
@@ -184,12 +189,19 @@ impl PrimaryWriter {
                         self.state.persist_objects(object_changes_batch).await
                     }
                 }),
-                // Checkpointed objects are written in a separate task,
-                // independent from the global_order -> objects chain.
-                // Once backward history is added, it will be chained
-                // before this: backward_history -> checkpointed_objects.
-                self.state
-                    .persist_checkpointed_objects(object_changes_batch),
+                // Backward history must be persisted before checkpointed_objects
+                // to prevent read races during consistent view queries.
+                Box::pin({
+                    let object_changes_batch = object_changes_batch.clone();
+                    async move {
+                        self.state
+                            .persist_object_backward_history(backward_history_batch)
+                            .await?;
+                        self.state
+                            .persist_checkpointed_objects(object_changes_batch)
+                            .await
+                    }
+                }),
             ];
             if let Some(epoch_data) = epoch.clone() {
                 persist_tasks.push(self.state.persist_epoch(epoch_data));

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -665,13 +665,25 @@ impl PrimaryWorker {
 
             for input_obj in &tx.input_objects {
                 if superseded_ids.contains(&input_obj.id()) {
-                    result.push(Self::build_active_backward_entry(input_obj, checkpoint_seq));
+                    let df_kind = extract_df_kind(input_obj);
+                    let indexed = IndexedObject::from_object(
+                        Some(checkpoint_seq as u64),
+                        input_obj.clone(),
+                        df_kind,
+                    );
+                    let history = StoredHistoryObject::try_from(indexed).expect(
+                        "StoredHistoryObject conversion should not fail for active objects",
+                    );
+                    result.push(
+                        StoredBackwardHistoryObject::from_active(history)
+                            .expect("input object should have active status"),
+                    );
                 }
             }
 
             // 2. Created objects did not exist before this transaction.
             for ((object_id, _, _), _) in effects.created() {
-                result.push(Self::build_empty_backward_entry(
+                result.push(StoredBackwardHistoryObject::from_empty(
                     object_id,
                     -1,
                     BackwardHistoryObjectStatus::NotYetCreated,
@@ -684,7 +696,7 @@ impl PrimaryWorker {
             let unwrapped_refs = effects.unwrapped().into_iter().map(|(r, _)| r);
             let unwrapped_then_deleted_refs = effects.unwrapped_then_deleted().into_iter();
             for (object_id, version, _) in unwrapped_refs.chain(unwrapped_then_deleted_refs) {
-                result.push(Self::build_empty_backward_entry(
+                result.push(StoredBackwardHistoryObject::from_empty(
                     object_id,
                     version.value() as i64 - 1,
                     BackwardHistoryObjectStatus::WrappedOrDeleted,
@@ -694,51 +706,6 @@ impl PrimaryWorker {
         }
 
         Ok(result)
-    }
-
-    /// Builds a backward history entry for an active object before it was
-    /// superseded.
-    ///
-    /// Reuses `TryFrom<IndexedObject> for StoredHistoryObject` for the
-    /// field-level conversion to avoid duplicating serialization logic.
-    fn build_active_backward_entry(
-        obj: &Object,
-        superseded_at_checkpoint: i64,
-    ) -> StoredBackwardHistoryObject {
-        let df_kind = extract_df_kind(obj);
-        let indexed =
-            IndexedObject::from_object(Some(superseded_at_checkpoint as u64), obj.clone(), df_kind);
-        let history = StoredHistoryObject::try_from(indexed)
-            .expect("StoredHistoryObject conversion should not fail for active objects");
-        StoredBackwardHistoryObject::from(history)
-    }
-
-    /// Builds a backward history entry with no object data.
-    ///
-    /// Used for `NOT_YET_CREATED` and `WRAPPED_OR_DELETED` statuses.
-    fn build_empty_backward_entry(
-        object_id: ObjectID,
-        object_version: i64,
-        status: BackwardHistoryObjectStatus,
-        superseded_at_checkpoint: i64,
-    ) -> StoredBackwardHistoryObject {
-        StoredBackwardHistoryObject {
-            object_id: object_id.to_vec(),
-            object_version,
-            object_status: status as i16,
-            object_digest: None,
-            superseded_at_checkpoint,
-            owner_type: None,
-            owner_id: None,
-            object_type: None,
-            object_type_package: None,
-            object_type_module: None,
-            object_type_name: None,
-            serialized_object: None,
-            coin_type: None,
-            coin_balance: None,
-            df_kind: None,
-        }
     }
 
     fn index_packages(

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     slice,
     sync::Arc,
 };
@@ -42,6 +42,7 @@ use crate::{
         display::StoredDisplay,
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate},
         obj_indices::StoredObjectVersion,
+        objects::{BackwardHistoryObjectStatus, StoredBackwardHistoryObject, StoredHistoryObject},
     },
     store::{IndexerStore, PgIndexerStore},
     types::{
@@ -234,6 +235,7 @@ impl PrimaryWorker {
         let object_history_changes: TransactionObjectChangesToCommit =
             Self::index_objects_history(data).await?;
         let object_versions = Self::derive_object_versions(&object_history_changes)?;
+        let backward_history_changes = Self::index_objects_backward_history(data)?;
 
         let (checkpoint, db_transactions, db_events, db_tx_indices, db_event_indices, db_displays) = {
             let CheckpointData {
@@ -289,6 +291,7 @@ impl PrimaryWorker {
             display_updates: db_displays,
             object_changes,
             object_history_changes,
+            backward_history_changes,
             object_versions,
             packages,
             epoch,
@@ -616,6 +619,126 @@ impl PrimaryWorker {
             changed_objects,
             deleted_objects: indexed_deleted_objects,
         })
+    }
+
+    /// Builds backward history entries for a checkpoint.
+    ///
+    /// For each transaction, records the *previous* state of every object that
+    /// was superseded, so that a consistent view at an earlier checkpoint can
+    /// be reconstructed by applying backward diffs to the current
+    /// `checkpointed_objects` snapshot.
+    ///
+    /// The logic is split into three categories:
+    ///
+    /// 1. **Input objects that were mutated or removed** (mutate, delete,
+    ///    wrap): these had an active prior state available in `input_objects` →
+    ///    `ACTIVE` entries with full data.
+    ///
+    /// 2. **Created objects**: did not exist before → `NOT_YET_CREATED`.
+    ///
+    /// 3. **Unwrapped / unwrapped-then-deleted objects**: were previously
+    ///    wrapped so no prior data is available → `WRAPPED_OR_DELETED` with a
+    ///    lamport version approximation.
+    fn index_objects_backward_history(
+        data: &CheckpointData,
+    ) -> Result<Vec<StoredBackwardHistoryObject>, IndexerError> {
+        let checkpoint_seq = data.checkpoint_summary.sequence_number as i64;
+        let mut result = Vec::new();
+
+        for tx in &data.transactions {
+            let effects = &tx.effects;
+
+            // 1. Input objects that were mutated or removed (deleted/wrapped) had an active
+            //    prior state — record it from input_objects. Collect the affected IDs so we
+            //    can iterate input_objects once.
+            let superseded_ids: HashSet<ObjectID> = effects
+                .mutated()
+                .into_iter()
+                .map(|((id, _, _), _)| id)
+                .chain(
+                    effects
+                        .all_removed_objects()
+                        .into_iter()
+                        .map(|((id, _, _), _)| id),
+                )
+                .collect();
+
+            for input_obj in &tx.input_objects {
+                if superseded_ids.contains(&input_obj.id()) {
+                    result.push(Self::build_active_backward_entry(input_obj, checkpoint_seq));
+                }
+            }
+
+            // 2. Created objects did not exist before this transaction.
+            for ((object_id, _, _), _) in effects.created() {
+                result.push(Self::build_empty_backward_entry(
+                    object_id,
+                    -1,
+                    BackwardHistoryObjectStatus::NotYetCreated,
+                    checkpoint_seq,
+                ));
+            }
+
+            // 3. Unwrapped and unwrapped-then-deleted objects were previously wrapped — no
+            //    data available. Use lamport version - 1 as approximation.
+            let unwrapped_refs = effects.unwrapped().into_iter().map(|(r, _)| r);
+            let unwrapped_then_deleted_refs = effects.unwrapped_then_deleted().into_iter();
+            for (object_id, version, _) in unwrapped_refs.chain(unwrapped_then_deleted_refs) {
+                result.push(Self::build_empty_backward_entry(
+                    object_id,
+                    version.value() as i64 - 1,
+                    BackwardHistoryObjectStatus::WrappedOrDeleted,
+                    checkpoint_seq,
+                ));
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Builds a backward history entry for an active object before it was
+    /// superseded.
+    ///
+    /// Reuses `TryFrom<IndexedObject> for StoredHistoryObject` for the
+    /// field-level conversion to avoid duplicating serialization logic.
+    fn build_active_backward_entry(
+        obj: &Object,
+        superseded_at_checkpoint: i64,
+    ) -> StoredBackwardHistoryObject {
+        let df_kind = extract_df_kind(obj);
+        let indexed =
+            IndexedObject::from_object(Some(superseded_at_checkpoint as u64), obj.clone(), df_kind);
+        let history = StoredHistoryObject::try_from(indexed)
+            .expect("StoredHistoryObject conversion should not fail for active objects");
+        StoredBackwardHistoryObject::from(history)
+    }
+
+    /// Builds a backward history entry with no object data.
+    ///
+    /// Used for `NOT_YET_CREATED` and `WRAPPED_OR_DELETED` statuses.
+    fn build_empty_backward_entry(
+        object_id: ObjectID,
+        object_version: i64,
+        status: BackwardHistoryObjectStatus,
+        superseded_at_checkpoint: i64,
+    ) -> StoredBackwardHistoryObject {
+        StoredBackwardHistoryObject {
+            object_id: object_id.to_vec(),
+            object_version,
+            object_status: status as i16,
+            object_digest: None,
+            superseded_at_checkpoint,
+            owner_type: None,
+            owner_id: None,
+            object_type: None,
+            object_type_package: None,
+            object_type_module: None,
+            object_type_name: None,
+            serialized_object: None,
+            coin_type: None,
+            coin_balance: None,
+            df_kind: None,
+        }
     }
 
     fn index_packages(

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -42,7 +42,7 @@ use crate::{
         display::StoredDisplay,
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate},
         obj_indices::StoredObjectVersion,
-        objects::{BackwardHistoryObjectStatus, StoredBackwardHistoryObject, StoredHistoryObject},
+        objects::{BackwardHistoryObjectStatus, StoredBackwardHistoryObject},
     },
     store::{IndexerStore, PgIndexerStore},
     types::{
@@ -671,13 +671,9 @@ impl PrimaryWorker {
                         input_obj.clone(),
                         df_kind,
                     );
-                    let history = StoredHistoryObject::try_from(indexed).expect(
-                        "StoredHistoryObject conversion should not fail for active objects",
-                    );
-                    result.push(
-                        StoredBackwardHistoryObject::from_active(history)
-                            .expect("input object should have active status"),
-                    );
+                    result.push(StoredBackwardHistoryObject::try_from(indexed).expect(
+                        "backward history conversion should not fail for active input objects",
+                    ));
                 }
             }
 

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -17,7 +17,9 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     errors::IndexerError,
-    schema::{checkpointed_objects, objects, objects_history, objects_snapshot},
+    schema::{
+        checkpointed_objects, objects, objects_backward_history, objects_history, objects_snapshot,
+    },
     types::{IndexedDeletedObject, IndexedObject, ObjectStatus, owner_to_owner_info},
 };
 
@@ -753,6 +755,62 @@ mod tests {
             None => {
                 panic!("object_type should not be none");
             }
+        }
+    }
+}
+
+/// Status of an object in the backward history table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackwardHistoryObjectStatus {
+    /// The object existed and was active before being superseded.
+    Active = 0,
+    /// The object was wrapped or deleted (no data available).
+    WrappedOrDeleted = 1,
+    /// The object did not exist yet (it was created in this checkpoint).
+    NotYetCreated = 2,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Identifiable, Clone, QueryableByName)]
+#[diesel(table_name = objects_backward_history, primary_key(superseded_at_checkpoint, object_id, object_version))]
+pub struct StoredBackwardHistoryObject {
+    pub object_id: Vec<u8>,
+    pub object_version: i64,
+    pub object_status: i16,
+    pub object_digest: Option<Vec<u8>>,
+    pub superseded_at_checkpoint: i64,
+    pub owner_type: Option<i16>,
+    pub owner_id: Option<Vec<u8>>,
+    pub object_type: Option<String>,
+    pub object_type_package: Option<Vec<u8>>,
+    pub object_type_module: Option<String>,
+    pub object_type_name: Option<String>,
+    pub serialized_object: Option<Vec<u8>>,
+    pub coin_type: Option<String>,
+    pub coin_balance: Option<i64>,
+    pub df_kind: Option<i16>,
+}
+
+impl From<StoredHistoryObject> for StoredBackwardHistoryObject {
+    /// Converts a `StoredHistoryObject` into a `StoredBackwardHistoryObject`.
+    ///
+    /// Maps `checkpoint_sequence_number` to `superseded_at_checkpoint`.
+    fn from(h: StoredHistoryObject) -> Self {
+        Self {
+            object_id: h.object_id,
+            object_version: h.object_version,
+            object_status: h.object_status,
+            object_digest: h.object_digest,
+            superseded_at_checkpoint: h.checkpoint_sequence_number,
+            owner_type: h.owner_type,
+            owner_id: h.owner_id,
+            object_type: h.object_type,
+            object_type_package: h.object_type_package,
+            object_type_module: h.object_type_module,
+            object_type_name: h.object_type_name,
+            serialized_object: h.serialized_object,
+            coin_type: h.coin_type,
+            coin_balance: h.coin_balance,
+            df_kind: h.df_kind,
         }
     }
 }

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -790,20 +790,16 @@ pub struct StoredBackwardHistoryObject {
     pub df_kind: Option<i16>,
 }
 
-impl StoredBackwardHistoryObject {
-    /// Builds a backward history entry for an active object from its stored
-    /// history representation.
+impl TryFrom<IndexedObject> for StoredBackwardHistoryObject {
+    type Error = IndexerError;
+
+    /// Builds a backward history entry for an active object.
     ///
-    /// Maps `checkpoint_sequence_number` to `superseded_at_checkpoint`.
-    /// Returns an error if the input object is not active.
-    pub fn from_active(h: StoredHistoryObject) -> Result<Self, IndexerError> {
-        if h.object_status != ObjectStatus::Active as i16 {
-            return Err(IndexerError::InvalidArgument(format!(
-                "expected active object status ({}), got {}",
-                ObjectStatus::Active as i16,
-                h.object_status,
-            )));
-        }
+    /// Reuses `StoredHistoryObject::try_from(IndexedObject)` for field
+    /// conversion, then maps `checkpoint_sequence_number` to
+    /// `superseded_at_checkpoint` and sets the status to `Active`.
+    fn try_from(o: IndexedObject) -> Result<Self, Self::Error> {
+        let h = StoredHistoryObject::try_from(o)?;
         Ok(Self {
             object_id: h.object_id,
             object_version: h.object_version,
@@ -822,7 +818,9 @@ impl StoredBackwardHistoryObject {
             df_kind: h.df_kind,
         })
     }
+}
 
+impl StoredBackwardHistoryObject {
     /// Builds a backward history entry with no object data.
     ///
     /// Used for `NotYetCreated` and `WrappedOrDeleted` statuses.

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -790,15 +790,24 @@ pub struct StoredBackwardHistoryObject {
     pub df_kind: Option<i16>,
 }
 
-impl From<StoredHistoryObject> for StoredBackwardHistoryObject {
-    /// Converts a `StoredHistoryObject` into a `StoredBackwardHistoryObject`.
+impl StoredBackwardHistoryObject {
+    /// Builds a backward history entry for an active object from its stored
+    /// history representation.
     ///
     /// Maps `checkpoint_sequence_number` to `superseded_at_checkpoint`.
-    fn from(h: StoredHistoryObject) -> Self {
-        Self {
+    /// Returns an error if the input object is not active.
+    pub fn from_active(h: StoredHistoryObject) -> Result<Self, IndexerError> {
+        if h.object_status != ObjectStatus::Active as i16 {
+            return Err(IndexerError::InvalidArgument(format!(
+                "expected active object status ({}), got {}",
+                ObjectStatus::Active as i16,
+                h.object_status,
+            )));
+        }
+        Ok(Self {
             object_id: h.object_id,
             object_version: h.object_version,
-            object_status: h.object_status,
+            object_status: BackwardHistoryObjectStatus::Active as i16,
             object_digest: h.object_digest,
             superseded_at_checkpoint: h.checkpoint_sequence_number,
             owner_type: h.owner_type,
@@ -811,6 +820,34 @@ impl From<StoredHistoryObject> for StoredBackwardHistoryObject {
             coin_type: h.coin_type,
             coin_balance: h.coin_balance,
             df_kind: h.df_kind,
+        })
+    }
+
+    /// Builds a backward history entry with no object data.
+    ///
+    /// Used for `NotYetCreated` and `WrappedOrDeleted` statuses.
+    pub fn from_empty(
+        object_id: ObjectID,
+        object_version: i64,
+        status: BackwardHistoryObjectStatus,
+        superseded_at_checkpoint: i64,
+    ) -> Self {
+        Self {
+            object_id: object_id.to_vec(),
+            object_version,
+            object_status: status as i16,
+            object_digest: None,
+            superseded_at_checkpoint,
+            owner_type: None,
+            owner_id: None,
+            object_type: None,
+            object_type_package: None,
+            object_type_module: None,
+            object_type_name: None,
+            serialized_object: None,
+            coin_type: None,
+            coin_balance: None,
+            df_kind: None,
         }
     }
 }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -256,6 +256,26 @@ diesel::table! {
 }
 
 diesel::table! {
+    objects_backward_history (superseded_at_checkpoint, object_id, object_version) {
+        object_id -> Bytea,
+        object_version -> Int8,
+        object_status -> Int2,
+        object_digest -> Nullable<Bytea>,
+        superseded_at_checkpoint -> Int8,
+        owner_type -> Nullable<Int2>,
+        owner_id -> Nullable<Bytea>,
+        object_type -> Nullable<Text>,
+        object_type_package -> Nullable<Bytea>,
+        object_type_module -> Nullable<Text>,
+        object_type_name -> Nullable<Text>,
+        serialized_object -> Nullable<Bytea>,
+        coin_type -> Nullable<Text>,
+        coin_balance -> Nullable<Int8>,
+        df_kind -> Nullable<Int2>,
+    }
+}
+
+diesel::table! {
     objects_history (checkpoint_sequence_number, object_id, object_version) {
         object_id -> Bytea,
         object_version -> Int8,
@@ -499,6 +519,7 @@ macro_rules! for_all_tables {
             move_call_metrics,
             move_calls,
             objects,
+            objects_backward_history,
             objects_history,
             objects_snapshot,
             objects_version,

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -17,6 +17,7 @@ use crate::{
     models::{
         display::StoredDisplay,
         obj_indices::StoredObjectVersion,
+        objects::StoredBackwardHistoryObject,
         transactions::{OptimisticTransaction, TxGlobalOrder},
         watermarks::StoredWatermark,
     },
@@ -141,6 +142,11 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn persist_objects(
         &self,
         objects: Vec<CheckpointObjectChanges>,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_object_backward_history(
+        &self,
+        objects: Vec<StoredBackwardHistoryObject>,
     ) -> Result<(), IndexerError>;
 
     async fn persist_checkpointed_objects(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -52,8 +52,8 @@ use crate::{
         events::StoredEvent,
         obj_indices::StoredObjectVersion,
         objects::{
-            StoredCheckpointedObject, StoredDeletedObject, StoredHistoryObject, StoredObject,
-            StoredObjectSnapshot, StoredObjects,
+            StoredBackwardHistoryObject, StoredCheckpointedObject, StoredDeletedObject,
+            StoredHistoryObject, StoredObject, StoredObjectSnapshot, StoredObjects,
         },
         packages::StoredPackage,
         transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
@@ -67,11 +67,12 @@ use crate::{
     schema::{
         chain_identifier, checkpointed_objects, checkpoints, display, epochs, event_emit_module,
         event_emit_package, event_senders, event_struct_instantiation, event_struct_module,
-        event_struct_name, event_struct_package, events, feature_flags, objects, objects_history,
-        objects_snapshot, objects_version, optimistic_transactions, packages, protocol_configs,
-        pruner_cp_watermark, transactions, tx_calls_fun, tx_calls_mod, tx_calls_pkg,
-        tx_changed_objects, tx_digests, tx_global_order, tx_input_objects, tx_kinds, tx_recipients,
-        tx_senders, tx_wrapped_or_deleted_objects, watermarks,
+        event_struct_name, event_struct_package, events, feature_flags, objects,
+        objects_backward_history, objects_history, objects_snapshot, objects_version,
+        optimistic_transactions, packages, protocol_configs, pruner_cp_watermark, transactions,
+        tx_calls_fun, tx_calls_mod, tx_calls_pkg, tx_changed_objects, tx_digests, tx_global_order,
+        tx_input_objects, tx_kinds, tx_recipients, tx_senders, tx_wrapped_or_deleted_objects,
+        watermarks,
     },
     store::{IndexerStore, diesel_macro::mark_in_blocking_pool},
     transactional_blocking_with_retry,
@@ -719,6 +720,13 @@ impl PgIndexerStore {
         .tap_err(|e| {
             tracing::error!("failed to persist object history with error: {e}");
         })
+    }
+
+    fn persist_objects_backward_history_chunk(
+        &self,
+        stored: Vec<StoredBackwardHistoryObject>,
+    ) -> Result<(), IndexerError> {
+        persist_chunk_into_table!(objects_backward_history::table, stored, &self.blocking_cp)
     }
 
     fn persist_object_version_chunk(
@@ -2435,6 +2443,38 @@ impl IndexerStore for PgIndexerStore {
             elapsed,
             "Persisted objects with {mutation_len} mutations and {deletion_len} deletions",
         );
+        Ok(())
+    }
+
+    async fn persist_object_backward_history(
+        &self,
+        objects: Vec<StoredBackwardHistoryObject>,
+    ) -> Result<(), IndexerError> {
+        if objects.is_empty() {
+            return Ok(());
+        }
+        let len = objects.len();
+        let chunks = chunk!(objects, self.config.parallel_objects_chunk_size);
+        let futures = chunks.into_iter().map(|c| {
+            self.spawn_blocking_task(move |this| this.persist_objects_backward_history_chunk(c))
+        });
+
+        futures::future::try_join_all(futures)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "failed to join persist_objects_backward_history_chunk futures: {e}"
+                );
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "Failed to persist all objects backward history chunks: {e:?}"
+                ))
+            })?;
+        info!("Persisted {} objects backward history", len);
         Ok(())
     }
 

--- a/crates/iota-indexer/tests/common/backward_history.rs
+++ b/crates/iota-indexer/tests/common/backward_history.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared query helpers for `objects_backward_history` tests.
+
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper};
+use iota_indexer::{
+    errors::IndexerError, models::objects::StoredBackwardHistoryObject,
+    schema::objects_backward_history, store::PgIndexerStore,
+};
+
+/// Looks up a backward history entry by object_id and superseded_at_checkpoint.
+pub fn find_backward_entry(
+    store: &PgIndexerStore,
+    object_id: &[u8],
+    checkpoint: i64,
+) -> Result<Option<StoredBackwardHistoryObject>, IndexerError> {
+    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
+        objects_backward_history::table
+            .filter(objects_backward_history::object_id.eq(object_id))
+            .filter(objects_backward_history::superseded_at_checkpoint.eq(checkpoint))
+            .select(StoredBackwardHistoryObject::as_select())
+            .first::<StoredBackwardHistoryObject>(conn)
+            .optional()
+    })
+}
+
+/// Looks up all backward history entries for an object_id at a given
+/// checkpoint, ordered by object_version.
+pub fn find_all_entries_at_checkpoint(
+    store: &PgIndexerStore,
+    object_id: &[u8],
+    checkpoint: i64,
+) -> Result<Vec<StoredBackwardHistoryObject>, IndexerError> {
+    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
+        objects_backward_history::table
+            .filter(objects_backward_history::object_id.eq(object_id))
+            .filter(objects_backward_history::superseded_at_checkpoint.eq(checkpoint))
+            .order(objects_backward_history::object_version.asc())
+            .select(StoredBackwardHistoryObject::as_select())
+            .load::<StoredBackwardHistoryObject>(conn)
+    })
+}
+
+/// Looks up all backward history entries for an object_id, ordered by
+/// superseded_at_checkpoint.
+pub fn find_all_entries_for_object(
+    store: &PgIndexerStore,
+    object_id: &[u8],
+) -> Result<Vec<StoredBackwardHistoryObject>, IndexerError> {
+    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
+        objects_backward_history::table
+            .filter(objects_backward_history::object_id.eq(object_id))
+            .order(objects_backward_history::superseded_at_checkpoint.asc())
+            .select(StoredBackwardHistoryObject::as_select())
+            .load::<StoredBackwardHistoryObject>(conn)
+    })
+}

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod backward_history;
+
 use std::{
     net::SocketAddr,
     path::PathBuf,

--- a/crates/iota-indexer/tests/data/backward_history_test/Move.toml
+++ b/crates/iota-indexer/tests/data/backward_history_test/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "backward_history_test"
+edition = "2024.beta"
+
+[dependencies]
+Iota = { local = "../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+backward_history_test = "0x0"

--- a/crates/iota-indexer/tests/data/backward_history_test/sources/backward_history_test.move
+++ b/crates/iota-indexer/tests/data/backward_history_test/sources/backward_history_test.move
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Test module exercising all object lifecycle events relevant to backward
+/// history ingestion: create, mutate, wrap, unwrap, delete, and
+/// unwrap-then-delete.
+module backward_history_test::backward_history_test {
+
+    /// A simple object that can be created, mutated, wrapped, and deleted.
+    public struct Item has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    /// A wrapper that holds an Item inside it (wrapping it).
+    public struct Box has key, store {
+        id: UID,
+        item: Item,
+    }
+
+    /// Create a new Item and transfer it to the sender.
+    public entry fun create(value: u64, ctx: &mut TxContext) {
+        iota::transfer::public_transfer(
+            Item { id: object::new(ctx), value },
+            tx_context::sender(ctx),
+        );
+    }
+
+    /// Mutate an existing Item by changing its value.
+    public entry fun mutate(item: &mut Item, new_value: u64) {
+        item.value = new_value;
+    }
+
+    /// Wrap an Item inside a Box. The Item disappears from the object store.
+    public entry fun wrap(item: Item, ctx: &mut TxContext) {
+        iota::transfer::public_transfer(
+            Box { id: object::new(ctx), item },
+            tx_context::sender(ctx),
+        );
+    }
+
+    /// Unwrap an Item from a Box. The Box is destroyed and the Item reappears.
+    public entry fun unwrap(box_obj: Box, ctx: &mut TxContext) {
+        let Box { id, item } = box_obj;
+        object::delete(id);
+        iota::transfer::public_transfer(item, tx_context::sender(ctx));
+    }
+
+    /// Delete an Item permanently.
+    public entry fun delete(item: Item) {
+        let Item { id, value: _ } = item;
+        object::delete(id);
+    }
+
+    /// Unwrap-then-delete: destroy both the Box and the Item inside it.
+    /// The Item goes from wrapped → deleted without ever appearing in the
+    /// object store, producing an "unwrapped_then_deleted" effect.
+    public entry fun unwrap_and_delete(box_obj: Box) {
+        let Box { id: box_id, item } = box_obj;
+        object::delete(box_id);
+        let Item { id: item_id, value: _ } = item;
+        object::delete(item_id);
+    }
+}

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -10,8 +10,8 @@ mod ingestion_tests {
     use std::{sync::Arc, time::Duration};
 
     use diesel::{
-        BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl, SelectableHelper,
-        connection::BoxableConnection,
+        BoolExpressionMethods, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl,
+        SelectableHelper, connection::BoxableConnection,
     };
     use iota_indexer::{
         db::get_pool_connection,
@@ -20,13 +20,16 @@ mod ingestion_tests {
         insert_or_ignore_into,
         models::{
             checkpoints::StoredCheckpoint,
-            objects::{StoredCheckpointedObject, StoredObject, StoredObjectSnapshot},
+            objects::{
+                BackwardHistoryObjectStatus, StoredBackwardHistoryObject, StoredCheckpointedObject,
+                StoredObject, StoredObjectSnapshot,
+            },
             transactions::{StoredTransaction, TxGlobalOrder},
             tx_indices::StoredTxDigest,
         },
         schema::{
-            checkpointed_objects, checkpoints, objects, objects_snapshot, transactions, tx_digests,
-            tx_global_order,
+            checkpointed_objects, checkpoints, objects, objects_backward_history, objects_snapshot,
+            transactions, tx_digests, tx_global_order,
         },
         store::{PgIndexerStore, indexer_store::IndexerStore},
         transactional_blocking_with_retry,
@@ -671,6 +674,188 @@ mod ingestion_tests {
                 obj.object_id
             );
         }
+
+        Ok(())
+    }
+
+    /// Verify that `objects_backward_history` is populated correctly, including
+    /// when multiple transactions land in the same checkpoint.
+    ///
+    /// `transfer_txn` splits a coin from the gas object and transfers it.
+    /// Each such transaction produces:
+    ///   - a CREATED coin  → NOT_YET_CREATED backward entry (version=-1)
+    ///   - a MUTATED gas   → ACTIVE backward entry with previous version/data
+    #[tokio::test]
+    pub async fn backward_history_ingestion() -> Result<(), IndexerError> {
+        let sim = Simulacrum::new();
+        let data_ingestion_path = tempdir().unwrap().keep();
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+        // --- checkpoint 1: TWO transfers in the same checkpoint ---
+        // This exercises the case where multiple transactions produce backward
+        // history entries for the same checkpoint, and where the same object
+        // (the gas coin) is mutated by both transactions within one checkpoint.
+        let recipient1 = IotaAddress::random_for_testing_only();
+        let (tx1, _) = sim.transfer_txn(recipient1);
+        let gas_object_id = tx1.gas()[0].0;
+        let gas_version_before_tx1 = tx1.gas()[0].1;
+        let (effects1, err) = sim.execute_transaction(tx1).unwrap();
+        assert!(err.is_none());
+        let created1: Vec<_> = effects1
+            .created()
+            .into_iter()
+            .map(|((id, _, _), _)| id)
+            .collect();
+        assert_eq!(
+            created1.len(),
+            1,
+            "transfer_txn should create exactly 1 coin"
+        );
+        let created_coin_1 = created1[0];
+
+        // Second transfer in the same checkpoint — uses the same gas object
+        // (now at an updated version).
+        let recipient2 = IotaAddress::random_for_testing_only();
+        let (tx2, _) = sim.transfer_txn(recipient2);
+        let gas_version_before_tx2 = tx2.gas()[0].1;
+        assert!(
+            gas_version_before_tx2 > gas_version_before_tx1,
+            "gas should have been bumped after tx1"
+        );
+        let (effects2, err) = sim.execute_transaction(tx2).unwrap();
+        assert!(err.is_none());
+        let created2: Vec<_> = effects2
+            .created()
+            .into_iter()
+            .map(|((id, _, _), _)| id)
+            .collect();
+        assert_eq!(created2.len(), 1);
+        let created_coin_2 = created2[0];
+
+        // Both transactions land in checkpoint 1.
+        sim.create_checkpoint();
+
+        // --- checkpoint 2: one more transfer ---
+        let recipient3 = IotaAddress::random_for_testing_only();
+        let (tx3, _) = sim.transfer_txn(recipient3);
+        let gas_version_before_tx3 = tx3.gas()[0].1;
+        let (effects3, err) = sim.execute_transaction(tx3).unwrap();
+        assert!(err.is_none());
+        let created3: Vec<_> = effects3
+            .created()
+            .into_iter()
+            .map(|((id, _, _), _)| id)
+            .collect();
+        assert_eq!(created3.len(), 1);
+        let created_coin_3 = created3[0];
+        sim.create_checkpoint();
+
+        let (_, pg_store, _) = start_simulacrum_grpc_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path,
+            None,
+            Some("indexer_ingestion_tests_db"),
+            None,
+        )
+        .await;
+
+        indexer_wait_for_checkpoint(&pg_store, 2).await;
+
+        // Helper: look up backward history entries by object_id +
+        // superseded_at_checkpoint.
+        let find_entry =
+            |object_id: &[u8], cp: i64| -> Result<Option<StoredBackwardHistoryObject>, _> {
+                read_only_blocking!(&pg_store.blocking_cp(), |conn| {
+                    objects_backward_history::table
+                        .filter(objects_backward_history::object_id.eq(object_id))
+                        .filter(objects_backward_history::superseded_at_checkpoint.eq(cp))
+                        .select(StoredBackwardHistoryObject::as_select())
+                        .first::<StoredBackwardHistoryObject>(conn)
+                        .optional()
+                })
+            };
+
+        let find_all_entries =
+            |object_id: &[u8], cp: i64| -> Result<Vec<StoredBackwardHistoryObject>, _> {
+                read_only_blocking!(&pg_store.blocking_cp(), |conn| {
+                    objects_backward_history::table
+                        .filter(objects_backward_history::object_id.eq(object_id))
+                        .filter(objects_backward_history::superseded_at_checkpoint.eq(cp))
+                        .order(objects_backward_history::object_version.asc())
+                        .select(StoredBackwardHistoryObject::as_select())
+                        .load::<StoredBackwardHistoryObject>(conn)
+                })
+            };
+
+        // === checkpoint 1 assertions (two transactions) ===
+
+        // Both created coins should have NOT_YET_CREATED entries.
+        let entry = find_entry(&created_coin_1.to_vec(), 1)?
+            .expect("created coin 1 must have a backward history entry at cp 1");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::NotYetCreated as i16
+        );
+        assert_eq!(entry.object_version, -1);
+        assert!(entry.serialized_object.is_none());
+        assert!(entry.object_digest.is_none());
+
+        let entry = find_entry(&created_coin_2.to_vec(), 1)?
+            .expect("created coin 2 must have a backward history entry at cp 1");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::NotYetCreated as i16
+        );
+        assert_eq!(entry.object_version, -1);
+
+        // The gas object was mutated twice in checkpoint 1 — there should be
+        // two ACTIVE entries with different previous versions.
+        let gas_entries = find_all_entries(&gas_object_id.to_vec(), 1)?;
+        assert_eq!(
+            gas_entries.len(),
+            2,
+            "gas object should have 2 backward history entries in cp 1 (one per tx)"
+        );
+        assert_eq!(
+            gas_entries[0].object_status,
+            BackwardHistoryObjectStatus::Active as i16
+        );
+        assert_eq!(
+            gas_entries[0].object_version,
+            gas_version_before_tx1.value() as i64
+        );
+        assert!(gas_entries[0].serialized_object.is_some());
+        assert!(gas_entries[0].object_digest.is_some());
+        assert!(gas_entries[0].owner_type.is_some());
+
+        assert_eq!(
+            gas_entries[1].object_status,
+            BackwardHistoryObjectStatus::Active as i16
+        );
+        assert_eq!(
+            gas_entries[1].object_version,
+            gas_version_before_tx2.value() as i64
+        );
+        assert!(gas_entries[1].serialized_object.is_some());
+
+        // === checkpoint 2 assertions (single transaction) ===
+
+        let entry = find_entry(&created_coin_3.to_vec(), 2)?
+            .expect("created coin 3 must have a backward history entry at cp 2");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::NotYetCreated as i16
+        );
+        assert_eq!(entry.object_version, -1);
+
+        let entry = find_entry(&gas_object_id.to_vec(), 2)?
+            .expect("gas object must have a backward history entry at cp 2");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::Active as i16
+        );
+        assert_eq!(entry.object_version, gas_version_before_tx3.value() as i64);
+        assert!(entry.serialized_object.is_some());
 
         Ok(())
     }

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -10,8 +10,8 @@ mod ingestion_tests {
     use std::{sync::Arc, time::Duration};
 
     use diesel::{
-        BoolExpressionMethods, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl,
-        SelectableHelper, connection::BoxableConnection,
+        BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl, SelectableHelper,
+        connection::BoxableConnection,
     };
     use iota_indexer::{
         db::get_pool_connection,
@@ -21,15 +21,15 @@ mod ingestion_tests {
         models::{
             checkpoints::StoredCheckpoint,
             objects::{
-                BackwardHistoryObjectStatus, StoredBackwardHistoryObject, StoredCheckpointedObject,
-                StoredObject, StoredObjectSnapshot,
+                BackwardHistoryObjectStatus, StoredCheckpointedObject, StoredObject,
+                StoredObjectSnapshot,
             },
             transactions::{StoredTransaction, TxGlobalOrder},
             tx_indices::StoredTxDigest,
         },
         schema::{
-            checkpointed_objects, checkpoints, objects, objects_backward_history, objects_snapshot,
-            transactions, tx_digests, tx_global_order,
+            checkpointed_objects, checkpoints, objects, objects_snapshot, transactions, tx_digests,
+            tx_global_order,
         },
         store::{PgIndexerStore, indexer_store::IndexerStore},
         transactional_blocking_with_retry,
@@ -43,6 +43,7 @@ mod ingestion_tests {
     use tempfile::tempdir;
 
     use crate::common::{
+        backward_history::{find_all_entries_at_checkpoint, find_backward_entry},
         indexer_wait_for_checkpoint, start_simulacrum_grpc_with_write_indexer,
         wait_for_objects_snapshot,
     };
@@ -697,8 +698,7 @@ mod ingestion_tests {
         // (the gas coin) is mutated by both transactions within one checkpoint.
         let recipient1 = IotaAddress::random_for_testing_only();
         let (tx1, _) = sim.transfer_txn(recipient1);
-        let gas_object_id = tx1.gas()[0].0;
-        let gas_version_before_tx1 = tx1.gas()[0].1;
+        let (gas_object_id, gas_version_before_tx1, _) = tx1.gas()[0];
         let (effects1, err) = sim.execute_transaction(tx1).unwrap();
         assert!(err.is_none());
         let created1: Vec<_> = effects1
@@ -717,7 +717,7 @@ mod ingestion_tests {
         // (now at an updated version).
         let recipient2 = IotaAddress::random_for_testing_only();
         let (tx2, _) = sim.transfer_txn(recipient2);
-        let gas_version_before_tx2 = tx2.gas()[0].1;
+        let (_, gas_version_before_tx2, _) = tx2.gas()[0];
         assert!(
             gas_version_before_tx2 > gas_version_before_tx1,
             "gas should have been bumped after tx1"
@@ -738,7 +738,7 @@ mod ingestion_tests {
         // --- checkpoint 2: one more transfer ---
         let recipient3 = IotaAddress::random_for_testing_only();
         let (tx3, _) = sim.transfer_txn(recipient3);
-        let gas_version_before_tx3 = tx3.gas()[0].1;
+        let (_, gas_version_before_tx3, _) = tx3.gas()[0];
         let (effects3, err) = sim.execute_transaction(tx3).unwrap();
         assert!(err.is_none());
         let created3: Vec<_> = effects3
@@ -761,36 +761,10 @@ mod ingestion_tests {
 
         indexer_wait_for_checkpoint(&pg_store, 2).await;
 
-        // Helper: look up backward history entries by object_id +
-        // superseded_at_checkpoint.
-        let find_entry =
-            |object_id: &[u8], cp: i64| -> Result<Option<StoredBackwardHistoryObject>, _> {
-                read_only_blocking!(&pg_store.blocking_cp(), |conn| {
-                    objects_backward_history::table
-                        .filter(objects_backward_history::object_id.eq(object_id))
-                        .filter(objects_backward_history::superseded_at_checkpoint.eq(cp))
-                        .select(StoredBackwardHistoryObject::as_select())
-                        .first::<StoredBackwardHistoryObject>(conn)
-                        .optional()
-                })
-            };
-
-        let find_all_entries =
-            |object_id: &[u8], cp: i64| -> Result<Vec<StoredBackwardHistoryObject>, _> {
-                read_only_blocking!(&pg_store.blocking_cp(), |conn| {
-                    objects_backward_history::table
-                        .filter(objects_backward_history::object_id.eq(object_id))
-                        .filter(objects_backward_history::superseded_at_checkpoint.eq(cp))
-                        .order(objects_backward_history::object_version.asc())
-                        .select(StoredBackwardHistoryObject::as_select())
-                        .load::<StoredBackwardHistoryObject>(conn)
-                })
-            };
-
         // === checkpoint 1 assertions (two transactions) ===
 
         // Both created coins should have NOT_YET_CREATED entries.
-        let entry = find_entry(&created_coin_1.to_vec(), 1)?
+        let entry = find_backward_entry(&pg_store, &created_coin_1.to_vec(), 1)?
             .expect("created coin 1 must have a backward history entry at cp 1");
         assert_eq!(
             entry.object_status,
@@ -800,7 +774,7 @@ mod ingestion_tests {
         assert!(entry.serialized_object.is_none());
         assert!(entry.object_digest.is_none());
 
-        let entry = find_entry(&created_coin_2.to_vec(), 1)?
+        let entry = find_backward_entry(&pg_store, &created_coin_2.to_vec(), 1)?
             .expect("created coin 2 must have a backward history entry at cp 1");
         assert_eq!(
             entry.object_status,
@@ -810,7 +784,7 @@ mod ingestion_tests {
 
         // The gas object was mutated twice in checkpoint 1 — there should be
         // two ACTIVE entries with different previous versions.
-        let gas_entries = find_all_entries(&gas_object_id.to_vec(), 1)?;
+        let gas_entries = find_all_entries_at_checkpoint(&pg_store, &gas_object_id.to_vec(), 1)?;
         assert_eq!(
             gas_entries.len(),
             2,
@@ -840,7 +814,7 @@ mod ingestion_tests {
 
         // === checkpoint 2 assertions (single transaction) ===
 
-        let entry = find_entry(&created_coin_3.to_vec(), 2)?
+        let entry = find_backward_entry(&pg_store, &created_coin_3.to_vec(), 2)?
             .expect("created coin 3 must have a backward history entry at cp 2");
         assert_eq!(
             entry.object_status,
@@ -848,7 +822,7 @@ mod ingestion_tests {
         );
         assert_eq!(entry.object_version, -1);
 
-        let entry = find_entry(&gas_object_id.to_vec(), 2)?
+        let entry = find_backward_entry(&pg_store, &gas_object_id.to_vec(), 2)?
             .expect("gas object must have a backward history entry at cp 2");
         assert_eq!(
             entry.object_status,

--- a/crates/iota-indexer/tests/rpc-tests/backward_history.rs
+++ b/crates/iota-indexer/tests/rpc-tests/backward_history.rs
@@ -7,13 +7,7 @@
 
 use std::str::FromStr;
 
-use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper};
-use iota_indexer::{
-    errors::IndexerError,
-    models::objects::{BackwardHistoryObjectStatus, StoredBackwardHistoryObject},
-    schema::objects_backward_history,
-    store::PgIndexerStore,
-};
+use iota_indexer::{models::objects::BackwardHistoryObjectStatus, store::PgIndexerStore};
 use iota_json::{IotaJsonValue, call_args};
 use iota_json_rpc_api::ReadApiClient;
 use iota_json_rpc_types::{
@@ -28,41 +22,11 @@ use jsonrpsee::http_client::HttpClient;
 use crate::{
     coin_api::execute_move_call,
     common::{
-        ApiTestSetup, indexer_wait_for_object, indexer_wait_for_transaction,
-        publish_test_move_package,
+        ApiTestSetup,
+        backward_history::{find_all_entries_for_object, find_backward_entry},
+        indexer_wait_for_object, indexer_wait_for_transaction, publish_test_move_package,
     },
 };
-
-/// Look up a backward history entry by object_id and superseded_at_checkpoint.
-fn find_backward_entry(
-    store: &PgIndexerStore,
-    object_id: &[u8],
-    checkpoint: i64,
-) -> Result<Option<StoredBackwardHistoryObject>, IndexerError> {
-    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
-        objects_backward_history::table
-            .filter(objects_backward_history::object_id.eq(object_id))
-            .filter(objects_backward_history::superseded_at_checkpoint.eq(checkpoint))
-            .select(StoredBackwardHistoryObject::as_select())
-            .first::<StoredBackwardHistoryObject>(conn)
-            .optional()
-    })
-}
-
-/// Look up all backward history entries for an object_id, ordered by
-/// superseded_at_checkpoint.
-fn find_all_entries_for_object(
-    store: &PgIndexerStore,
-    object_id: &[u8],
-) -> Result<Vec<StoredBackwardHistoryObject>, IndexerError> {
-    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
-        objects_backward_history::table
-            .filter(objects_backward_history::object_id.eq(object_id))
-            .order(objects_backward_history::superseded_at_checkpoint.asc())
-            .select(StoredBackwardHistoryObject::as_select())
-            .load::<StoredBackwardHistoryObject>(conn)
-    })
-}
 
 /// Helper to call a function from the backward_history_test package, wait for
 /// indexer to catch up, and return the response (with checkpoint populated).

--- a/crates/iota-indexer/tests/rpc-tests/backward_history.rs
+++ b/crates/iota-indexer/tests/rpc-tests/backward_history.rs
@@ -1,0 +1,444 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for `objects_backward_history` ingestion covering all
+//! object lifecycle events: create, mutate, wrap, unwrap, delete, and
+//! unwrap-then-delete.
+
+use std::str::FromStr;
+
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper};
+use iota_indexer::{
+    errors::IndexerError,
+    models::objects::{BackwardHistoryObjectStatus, StoredBackwardHistoryObject},
+    schema::objects_backward_history,
+    store::PgIndexerStore,
+};
+use iota_json::{IotaJsonValue, call_args};
+use iota_json_rpc_api::ReadApiClient;
+use iota_json_rpc_types::{
+    IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponseOptions, ObjectChange,
+};
+use iota_types::{
+    base_types::{ObjectID, SequenceNumber},
+    crypto::{AccountKeyPair, IotaKeyPair, get_key_pair},
+};
+use jsonrpsee::http_client::HttpClient;
+
+use crate::{
+    coin_api::execute_move_call,
+    common::{
+        ApiTestSetup, indexer_wait_for_object, indexer_wait_for_transaction,
+        publish_test_move_package,
+    },
+};
+
+/// Look up a backward history entry by object_id and superseded_at_checkpoint.
+fn find_backward_entry(
+    store: &PgIndexerStore,
+    object_id: &[u8],
+    checkpoint: i64,
+) -> Result<Option<StoredBackwardHistoryObject>, IndexerError> {
+    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
+        objects_backward_history::table
+            .filter(objects_backward_history::object_id.eq(object_id))
+            .filter(objects_backward_history::superseded_at_checkpoint.eq(checkpoint))
+            .select(StoredBackwardHistoryObject::as_select())
+            .first::<StoredBackwardHistoryObject>(conn)
+            .optional()
+    })
+}
+
+/// Look up all backward history entries for an object_id, ordered by
+/// superseded_at_checkpoint.
+fn find_all_entries_for_object(
+    store: &PgIndexerStore,
+    object_id: &[u8],
+) -> Result<Vec<StoredBackwardHistoryObject>, IndexerError> {
+    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
+        objects_backward_history::table
+            .filter(objects_backward_history::object_id.eq(object_id))
+            .order(objects_backward_history::superseded_at_checkpoint.asc())
+            .select(StoredBackwardHistoryObject::as_select())
+            .load::<StoredBackwardHistoryObject>(conn)
+    })
+}
+
+/// Helper to call a function from the backward_history_test package, wait for
+/// indexer to catch up, and return the response (with checkpoint populated).
+async fn call_test_fn(
+    client: &HttpClient,
+    store: &PgIndexerStore,
+    sender: iota_types::base_types::IotaAddress,
+    keypair: &IotaKeyPair,
+    package_id: ObjectID,
+    function: &str,
+    arguments: Vec<IotaJsonValue>,
+    gas: Option<ObjectID>,
+) -> iota_json_rpc_types::IotaTransactionBlockResponse {
+    let resp = execute_move_call(
+        client,
+        sender,
+        keypair,
+        package_id,
+        "backward_history_test".to_string(),
+        function.to_string(),
+        vec![],
+        arguments,
+        gas,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        resp.status_ok(),
+        Some(true),
+        "move call `{function}` failed: {resp:?}"
+    );
+
+    // Wait for the indexer to process this transaction, then re-fetch it from
+    // the indexer so that the checkpoint field is populated.
+    indexer_wait_for_transaction(resp.digest, store, client).await;
+    client
+        .get_transaction_block(
+            resp.digest,
+            Some(
+                IotaTransactionBlockResponseOptions::new()
+                    .with_object_changes()
+                    .with_effects(),
+            ),
+        )
+        .await
+        .unwrap()
+}
+
+/// Extract the first created object ID from a transaction response.
+fn first_created_id(resp: &iota_json_rpc_types::IotaTransactionBlockResponse) -> ObjectID {
+    resp.object_changes
+        .as_ref()
+        .unwrap()
+        .iter()
+        .find_map(|c| match c {
+            ObjectChange::Created { object_id, .. } => Some(*object_id),
+            _ => None,
+        })
+        .expect("expected a created object")
+}
+
+/// Extract the version of an unwrapped object from a transaction response.
+fn unwrapped_version(
+    resp: &iota_json_rpc_types::IotaTransactionBlockResponse,
+    object_id: ObjectID,
+) -> SequenceNumber {
+    resp.object_changes
+        .as_ref()
+        .unwrap()
+        .iter()
+        .find_map(|c| match c {
+            ObjectChange::Unwrapped {
+                object_id: id,
+                version,
+                ..
+            } if *id == object_id => Some(*version),
+            _ => None,
+        })
+        .expect("expected an unwrapped object")
+}
+
+/// Extract the version of an unwrapped-then-deleted object from effects.
+fn unwrapped_then_deleted_version(
+    resp: &iota_json_rpc_types::IotaTransactionBlockResponse,
+    object_id: ObjectID,
+) -> SequenceNumber {
+    resp.effects
+        .as_ref()
+        .unwrap()
+        .unwrapped_then_deleted()
+        .iter()
+        .find(|r| r.object_id == object_id)
+        .expect("expected an unwrapped-then-deleted object")
+        .version
+}
+
+#[test]
+fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        // --- Set up a funded address ---
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+        let keypair = IotaKeyPair::Ed25519(keypair);
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000_000),
+                address,
+            )
+            .await;
+        let gas_id = gas.0;
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        // --- Publish the test package ---
+        let ((package_id, _, _), publish_resp) =
+            publish_test_move_package(client, address, &keypair, "backward_history_test").await?;
+        indexer_wait_for_transaction(publish_resp.digest, store, client).await;
+
+        // ================================================================
+        // Step 1: CREATE — create a new Item
+        // ================================================================
+        let resp = call_test_fn(
+            client,
+            store,
+            address,
+            &keypair,
+            package_id,
+            "create",
+            call_args![42u64]?,
+            Some(gas_id),
+        )
+        .await;
+        let item_id = first_created_id(&resp);
+        let create_cp = resp.checkpoint.unwrap() as i64;
+
+        let entry = find_backward_entry(store, &item_id.to_vec(), create_cp)?
+            .expect("item should have backward history at create checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::NotYetCreated as i16
+        );
+        assert_eq!(entry.object_version, -1);
+        assert!(entry.serialized_object.is_none());
+        assert!(entry.object_digest.is_none());
+
+        // ================================================================
+        // Step 2: MUTATE — change the item's value
+        // ================================================================
+        let resp = call_test_fn(
+            client,
+            store,
+            address,
+            &keypair,
+            package_id,
+            "mutate",
+            call_args![item_id, 99u64]?,
+            Some(gas_id),
+        )
+        .await;
+        let mutate_cp = resp.checkpoint.unwrap() as i64;
+
+        let entry = find_backward_entry(store, &item_id.to_vec(), mutate_cp)?
+            .expect("item should have backward history at mutate checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::Active as i16
+        );
+        assert!(
+            entry.serialized_object.is_some(),
+            "ACTIVE entry must have data"
+        );
+        assert!(entry.object_digest.is_some());
+        assert!(entry.owner_type.is_some());
+        assert!(entry.object_version > 0);
+
+        // ================================================================
+        // Step 3: WRAP — wrap the item inside a Box
+        // ================================================================
+        let resp = call_test_fn(
+            client,
+            store,
+            address,
+            &keypair,
+            package_id,
+            "wrap",
+            call_args![item_id]?,
+            Some(gas_id),
+        )
+        .await;
+        let wrap_cp = resp.checkpoint.unwrap() as i64;
+        let box_id = first_created_id(&resp);
+
+        // Item was wrapped → ACTIVE backward entry with previous data.
+        let entry = find_backward_entry(store, &item_id.to_vec(), wrap_cp)?
+            .expect("item should have backward history at wrap checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::Active as i16
+        );
+        assert!(entry.serialized_object.is_some());
+
+        // Box was created → NOT_YET_CREATED.
+        let entry = find_backward_entry(store, &box_id.to_vec(), wrap_cp)?
+            .expect("box should have backward history at wrap checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::NotYetCreated as i16
+        );
+        assert_eq!(entry.object_version, -1);
+
+        // ================================================================
+        // Step 4: UNWRAP — unwrap the item from the Box
+        // ================================================================
+        let resp = call_test_fn(
+            client,
+            store,
+            address,
+            &keypair,
+            package_id,
+            "unwrap",
+            call_args![box_id]?,
+            Some(gas_id),
+        )
+        .await;
+        let unwrap_cp = resp.checkpoint.unwrap() as i64;
+        let item_unwrap_version = unwrapped_version(&resp, item_id);
+
+        // Item was unwrapped → WRAPPED_OR_DELETED (no data available).
+        // Version should be lamport - 1 (the output version minus one).
+        let entry = find_backward_entry(store, &item_id.to_vec(), unwrap_cp)?
+            .expect("item should have backward history at unwrap checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::WrappedOrDeleted as i16
+        );
+        assert_eq!(
+            entry.object_version,
+            item_unwrap_version.value() as i64 - 1,
+            "unwrapped entry should have lamport version - 1"
+        );
+        assert!(entry.serialized_object.is_none());
+        assert!(entry.object_digest.is_none());
+
+        // Box was deleted → ACTIVE backward entry with data.
+        let entry = find_backward_entry(store, &box_id.to_vec(), unwrap_cp)?
+            .expect("box should have backward history at unwrap checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::Active as i16
+        );
+        assert!(entry.serialized_object.is_some());
+
+        // ================================================================
+        // Step 5: DELETE — delete the item directly
+        // ================================================================
+        let resp = call_test_fn(
+            client,
+            store,
+            address,
+            &keypair,
+            package_id,
+            "delete",
+            call_args![item_id]?,
+            Some(gas_id),
+        )
+        .await;
+        let delete_cp = resp.checkpoint.unwrap() as i64;
+
+        // Item was deleted → ACTIVE backward entry with previous data.
+        let entry = find_backward_entry(store, &item_id.to_vec(), delete_cp)?
+            .expect("item should have backward history at delete checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::Active as i16
+        );
+        assert!(entry.serialized_object.is_some());
+
+        // ================================================================
+        // Step 6: UNWRAP-THEN-DELETE
+        // ================================================================
+
+        // 6a. Create a new item.
+        let resp = call_test_fn(
+            client,
+            store,
+            address,
+            &keypair,
+            package_id,
+            "create",
+            call_args![7u64]?,
+            Some(gas_id),
+        )
+        .await;
+        let item2_id = first_created_id(&resp);
+
+        // 6b. Wrap it.
+        let resp = call_test_fn(
+            client,
+            store,
+            address,
+            &keypair,
+            package_id,
+            "wrap",
+            call_args![item2_id]?,
+            Some(gas_id),
+        )
+        .await;
+        let box2_id = first_created_id(&resp);
+
+        // 6c. Unwrap-then-delete.
+        let resp = call_test_fn(
+            client,
+            store,
+            address,
+            &keypair,
+            package_id,
+            "unwrap_and_delete",
+            call_args![box2_id]?,
+            Some(gas_id),
+        )
+        .await;
+        let unwrap_delete_cp = resp.checkpoint.unwrap() as i64;
+
+        // Box was deleted → ACTIVE backward entry.
+        let entry = find_backward_entry(store, &box2_id.to_vec(), unwrap_delete_cp)?
+            .expect("box2 should have backward history at unwrap_and_delete checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::Active as i16
+        );
+        assert!(entry.serialized_object.is_some());
+
+        // Item inside was unwrapped-then-deleted → WRAPPED_OR_DELETED.
+        let item2_utd_version = unwrapped_then_deleted_version(&resp, item2_id);
+        let entry = find_backward_entry(store, &item2_id.to_vec(), unwrap_delete_cp)?
+            .expect("item2 should have backward history at unwrap_and_delete checkpoint");
+        assert_eq!(
+            entry.object_status,
+            BackwardHistoryObjectStatus::WrappedOrDeleted as i16
+        );
+        assert_eq!(
+            entry.object_version,
+            item2_utd_version.value() as i64 - 1,
+            "unwrapped-then-deleted entry should have lamport version - 1"
+        );
+        assert!(entry.serialized_object.is_none());
+        assert!(entry.object_digest.is_none());
+
+        // ================================================================
+        // Verify full history chain for the first item.
+        // ================================================================
+        let all_entries = find_all_entries_for_object(store, &item_id.to_vec())?;
+        assert_eq!(
+            all_entries.len(),
+            5,
+            "item should have 5 backward history entries: create, mutate, wrap, unwrap, delete"
+        );
+        let statuses: Vec<i16> = all_entries.iter().map(|e| e.object_status).collect();
+        assert_eq!(
+            statuses,
+            vec![
+                BackwardHistoryObjectStatus::NotYetCreated as i16, // create
+                BackwardHistoryObjectStatus::Active as i16,        // mutate
+                BackwardHistoryObjectStatus::Active as i16,        // wrap
+                BackwardHistoryObjectStatus::WrappedOrDeleted as i16, // unwrap
+                BackwardHistoryObjectStatus::Active as i16,        // delete
+            ]
+        );
+
+        Ok(())
+    })
+}

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -24,3 +24,6 @@ mod transaction_builder;
 
 #[cfg(feature = "shared_test_runtime")]
 mod write_api;
+
+#[cfg(feature = "shared_test_runtime")]
+mod backward_history;


### PR DESCRIPTION
# Description of change

Add a new `objects_backward_history` table that stores the *previous* state of objects when they are superseded during checkpoint processing. Combined with `checkpointed_objects`, this will enable consistent view queries via backward diff.

For each transaction in a checkpoint, the ingestion logic inspects effects and input_objects to produce backward history entries:

- Created objects → NOT_YET_CREATED (version=-1, no data)
- Mutated/deleted/wrapped objects → ACTIVE (previous version with full data from input_objects)
- Unwrapped/unwrapped-then-deleted → WRAPPED_OR_DELETED (lamport-1 version, no data)

Backward history is persisted before checkpointed_objects to prevent read races during future consistent view queries.

Includes a Move test package exercising all object lifecycle events and two test suites:
- ingestion_tests: verifies multi-transaction-per-checkpoint handling
- rpc-tests: end-to-end test covering create, mutate, wrap, unwrap, delete, and unwrap-then-delete with specific object assertions

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11017

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
