### PR TITLE
upstream(core): Add input object notify in the writeback cache

### DIFF
--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashSet, path::Path, sync::Arc};
 
 use futures::{FutureExt, future::BoxFuture};
-use iota_common::fatal;
+use iota_common::{fatal, sync::notify_read::NotifyRead};
 use iota_config::{ExecutionCacheConfig, ExecutionCacheType};
 use iota_types::{
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData},
@@ -46,10 +46,128 @@ pub mod passthrough_cache;
 pub mod proxy_cache;
 pub mod writeback_cache;
 
+#[cfg(test)]
+#[path = "execution_cache/unit_tests/notify_read_input_objects_tests.rs"]
+mod notify_read_input_objects_tests;
+
 use metrics::ExecutionCacheMetrics;
 pub use passthrough_cache::PassthroughCache;
 pub use proxy_cache::ProxyCache;
 pub use writeback_cache::WritebackCache;
+
+/// Shared implementation of `notify_read_input_objects` used by both
+/// `WritebackCache` and `PassthroughCache`. Waits until all input and receiving
+/// objects become available by checking the cache/store via `ObjectCacheRead`
+/// trait methods and registering for notifications on missing keys.
+fn notify_read_input_objects_impl<'a>(
+    object_notify_read: &'a NotifyRead<InputKey, ()>,
+    cache: &'a (impl ObjectCacheRead + ?Sized),
+    input_and_receiving_keys: &'a [InputKey],
+    receiving_keys: &'a HashSet<InputKey>,
+    epoch: &'a EpochId,
+) -> BoxFuture<'a, Vec<()>> {
+    async move {
+        object_notify_read
+            .read::<std::convert::Infallible>(input_and_receiving_keys, |keys| {
+                let mut results = vec![None; keys.len()];
+
+                let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
+                    .iter()
+                    .enumerate()
+                    .filter(|(idx, key)| {
+                        if key.is_cancelled() {
+                            // Shared objects in canceled transactions are always available.
+                            results[*idx] = Some(());
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .partition(|(_, key)| key.version().is_some());
+                let versioned_object_keys: Vec<_> = keys_with_version
+                    .iter()
+                    .map(|(_, key)| ObjectKey(key.id(), key.version().unwrap()))
+                    .collect();
+                ObjectCacheRead::multi_get_objects_by_key(cache, &versioned_object_keys)
+                    .into_iter()
+                    .zip(keys_with_version.iter())
+                    .for_each(|(o, (idx, input_key))| match o {
+                        Some(_) => results[*idx] = Some(()),
+                        None => {
+                            if receiving_keys.contains(input_key) {
+                                // There could be a more recent version of this object, and the
+                                // object at the specified version could have already been pruned.
+                                // In such a case `has_key` will be false, but since this is a
+                                // receiving object we should mark it as available if we can
+                                // determine that an object with a version greater than or equal to
+                                // the specified version exists or was deleted. We will then let
+                                // mark it as available to let the transaction through so it can
+                                // fail at execution.
+                                let is_available =
+                                    ObjectCacheRead::get_object(cache, &input_key.id())
+                                        .map(|obj| obj.version() >= input_key.version().unwrap())
+                                        .unwrap_or(false);
+                                if is_available {
+                                    results[*idx] = Some(());
+                                }
+                            } else if cache
+                                .get_last_shared_object_deletion_info(&input_key.id(), *epoch)
+                                .is_some()
+                            {
+                                // If the shared object was deleted, mark it as
+                                // available so the transaction can proceed.
+                                results[*idx] = Some(());
+                            }
+                        }
+                    });
+                keys_without_version.iter().for_each(|(idx, key)| {
+                    if cache.get_package_object(&key.id()).is_some() {
+                        results[*idx] = Some(());
+                    }
+                });
+                Ok(results)
+            })
+            .await
+            .unwrap()
+    }
+    .boxed()
+}
+
+/// Notify waiters that a written object is now available. Packages are notified
+/// via `InputKey::Package`, non-child objects via `InputKey::VersionedObject`.
+/// Child objects are never awaited so they are skipped.
+fn notify_object_written(object_notify_read: &NotifyRead<InputKey, ()>, object: &Object) {
+    if object.is_package() {
+        object_notify_read.notify(&InputKey::Package { id: object.id() }, &());
+    } else if !object.is_child_object() {
+        object_notify_read.notify(
+            &InputKey::VersionedObject {
+                id: object.id(),
+                version: object.version(),
+            },
+            &(),
+        );
+    }
+}
+
+/// Notify waiters that a marker value has been written. Only `SharedDeleted`
+/// markers need notification, since they satisfy input object reads for shared
+/// objects that were deleted.
+fn notify_marker_written(
+    object_notify_read: &NotifyRead<InputKey, ()>,
+    object_key: &ObjectKey,
+    marker_value: &MarkerValue,
+) {
+    if matches!(marker_value, MarkerValue::SharedDeleted(_)) {
+        object_notify_read.notify(
+            &InputKey::VersionedObject {
+                id: object_key.0,
+                version: object_key.1,
+            },
+            &(),
+        );
+    }
+}
 
 // If you have Arc<ExecutionCache>, you cannot return a reference to it as
 // an &Arc<dyn ExecutionCacheRead> (for example), because the trait object is a

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -377,7 +377,7 @@ pub trait ObjectCacheRead: Send + Sync {
         ) {
             assert!(
                 input_key.version().is_none() || input_key.version().unwrap().is_valid(),
-                "Shared objects in cancelled transaction should always be available immediately, 
+                "Shared objects in cancelled transaction should always be available immediately,
                  but it appears that transaction manager is waiting for {input_key:?} to become available"
             );
             // If the key exists at the specified version, then the object is available.
@@ -655,6 +655,20 @@ pub trait ObjectCacheRead: Send + Sync {
         self.try_get_highest_pruned_checkpoint()
             .expect("storage access failed")
     }
+
+    /// Given a list of input and receiving objects for a transaction,
+    /// wait until all of them become available, so that the transaction
+    /// can start execution.
+    /// `input_and_receiving_keys` contains both input objects and receiving
+    /// input objects, including canceled objects.
+    /// TODO: Eventually this can return the objects read results,
+    /// so that execution does not need to load them again.
+    fn notify_read_input_objects<'a>(
+        &'a self,
+        input_and_receiving_keys: &'a [InputKey],
+        receiving_keys: &'a HashSet<InputKey>,
+        epoch: &'a EpochId,
+    ) -> BoxFuture<'a, Vec<()>>;
 }
 
 pub trait TransactionCacheRead: Send + Sync {

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -18,7 +18,7 @@ use iota_types::{
     message_envelope::Message,
     messages_checkpoint::CheckpointSequenceNumber,
     object::Object,
-    storage::{MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject},
+    storage::{InputKey, MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject},
     transaction::{VerifiedSignedTransaction, VerifiedTransaction},
 };
 use prometheus::Registry;
@@ -205,6 +205,15 @@ impl ObjectCacheRead for PassthroughCache {
             .perpetual_tables
             .get_highest_pruned_checkpoint()
             .map_err(IotaError::from)
+    }
+
+    fn notify_read_input_objects<'a>(
+        &'a self,
+        _input_and_receiving_keys: &'a [InputKey],
+        _receiving_keys: &'a std::collections::HashSet<InputKey>,
+        _epoch: &'a EpochId,
+    ) -> BoxFuture<'a, Vec<()>> {
+        unimplemented!("PassthroughCache does not support notify_read_input_objects")
     }
 }
 

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use futures::{FutureExt, future::BoxFuture};
 use iota_common::sync::notify_read::NotifyRead;
@@ -47,6 +47,7 @@ pub struct PassthroughCache {
     metrics: Arc<ExecutionCacheMetrics>,
     package_cache: Arc<PackageObjectCache>,
     executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
+    object_notify_read: NotifyRead<InputKey, ()>,
 }
 
 impl PassthroughCache {
@@ -56,6 +57,7 @@ impl PassthroughCache {
             metrics,
             package_cache: PackageObjectCache::new(),
             executed_effects_digests_notify_read: NotifyRead::new(),
+            object_notify_read: NotifyRead::new(),
         }
     }
 
@@ -209,11 +211,17 @@ impl ObjectCacheRead for PassthroughCache {
 
     fn notify_read_input_objects<'a>(
         &'a self,
-        _input_and_receiving_keys: &'a [InputKey],
-        _receiving_keys: &'a std::collections::HashSet<InputKey>,
-        _epoch: &'a EpochId,
+        input_and_receiving_keys: &'a [InputKey],
+        receiving_keys: &'a HashSet<InputKey>,
+        epoch: &'a EpochId,
     ) -> BoxFuture<'a, Vec<()>> {
-        unimplemented!("PassthroughCache does not support notify_read_input_objects")
+        super::notify_read_input_objects_impl(
+            &self.object_notify_read,
+            self,
+            input_and_receiving_keys,
+            receiving_keys,
+            epoch,
+        )
     }
 }
 
@@ -295,11 +303,20 @@ impl ExecutionCacheWrite for PassthroughCache {
         self.store
             .check_owned_objects_are_live(&tx_outputs.live_object_markers_to_delete)?;
 
-        let batch = self.store.build_db_batch(epoch_id, &[tx_outputs])?;
+        let batch = self
+            .store
+            .build_db_batch(epoch_id, std::slice::from_ref(&tx_outputs))?;
         batch.write()?;
 
         self.executed_effects_digests_notify_read
             .notify(&tx_digest, &effects_digest);
+
+        for object in tx_outputs.written.values() {
+            super::notify_object_written(&self.object_notify_read, object);
+        }
+        for (object_key, marker_value) in &tx_outputs.markers {
+            super::notify_marker_written(&self.object_notify_read, object_key, marker_value);
+        }
 
         self.metrics
             .pending_notify_read
@@ -401,3 +418,36 @@ impl StateSyncAPI for PassthroughCache {
 }
 
 implement_passthrough_traits!(PassthroughCache);
+
+#[cfg(test)]
+impl PassthroughCache {
+    pub(super) fn write_object_for_testing(&self, object: Object) {
+        use crate::authority::authority_store_types::get_store_object;
+
+        let object_ref = object.compute_object_reference();
+        let object_key = ObjectKey::from(object_ref);
+        let store_object = get_store_object(object.clone());
+        self.store
+            .perpetual_tables
+            .objects
+            .insert(&object_key, &store_object)
+            .unwrap();
+
+        super::notify_object_written(&self.object_notify_read, &object);
+    }
+
+    pub(super) fn write_marker_for_testing(
+        &self,
+        epoch_id: EpochId,
+        object_key: &ObjectKey,
+        marker_value: MarkerValue,
+    ) {
+        self.store
+            .perpetual_tables
+            .object_per_epoch_marker_table
+            .insert(&(epoch_id, *object_key), &marker_value)
+            .unwrap();
+
+        super::notify_marker_written(&self.object_notify_read, object_key, &marker_value);
+    }
+}

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -16,7 +16,7 @@ use iota_types::{
     iota_system_state::IotaSystemState,
     messages_checkpoint::CheckpointSequenceNumber,
     object::Object,
-    storage::{MarkerValue, ObjectKey, ObjectOrTombstone, PackageObject},
+    storage::{InputKey, MarkerValue, ObjectKey, ObjectOrTombstone, PackageObject},
     transaction::{VerifiedSignedTransaction, VerifiedTransaction},
 };
 use tracing::instrument;
@@ -212,6 +212,19 @@ impl ObjectCacheRead for ProxyCache {
 
     fn try_get_highest_pruned_checkpoint(&self) -> IotaResult<Option<CheckpointSequenceNumber>> {
         delegate_method!(self.try_get_highest_pruned_checkpoint())
+    }
+
+    fn notify_read_input_objects<'a>(
+        &'a self,
+        input_and_receiving_keys: &'a [InputKey],
+        receiving_keys: &'a std::collections::HashSet<InputKey>,
+        epoch: &'a EpochId,
+    ) -> BoxFuture<'a, Vec<()>> {
+        delegate_method!(self.notify_read_input_objects(
+            input_and_receiving_keys,
+            receiving_keys,
+            epoch
+        ))
     }
 }
 

--- a/crates/iota-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
@@ -259,3 +259,71 @@ async fn test_receiving_object_higher_version() {
 
     assert_eq!(result.len(), 1);
 }
+
+#[tokio::test]
+async fn test_immediate_return_shared_deleted() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
+    let epoch_id = 0;
+
+    // Write a SharedDeleted marker
+    cache.write_marker_value(
+        epoch_id,
+        &ObjectKey(object_id, version),
+        MarkerValue::SharedDeleted(TransactionDigest::random()),
+    );
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: object_id,
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &epoch_id;
+
+    // Should return immediately since the shared object was deleted
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_wait_for_shared_deleted() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
+    let epoch_id = 0;
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: object_id,
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &epoch_id;
+
+    // Start notification future
+    let notification = cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch);
+
+    // Write SharedDeleted marker after small delay
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cache.write_marker_value(
+                epoch_id,
+                &ObjectKey(object_id, version),
+                MarkerValue::SharedDeleted(TransactionDigest::random()),
+            );
+        }
+    });
+
+    // Should complete once SharedDeleted marker is written
+    let result = timeout(Duration::from_secs(1), notification).await.unwrap();
+
+    assert_eq!(result.len(), 1);
+}

--- a/crates/iota-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
@@ -1,0 +1,261 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{path::Path, time::Duration};
+
+use futures::FutureExt;
+use iota_framework::BuiltInFramework;
+use iota_move_build::BuildConfig;
+use iota_swarm_config::network_config_builder::ConfigBuilder;
+use iota_types::{
+    IOTA_FRAMEWORK_PACKAGE_ID,
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
+    object::{Object, Owner},
+    storage::InputKey,
+};
+use tempfile::tempdir;
+use tokio::time::timeout;
+
+use super::*;
+use crate::authority::authority_store_tables::AuthorityPerpetualTables;
+
+async fn create_writeback_cache() -> Arc<WritebackCache> {
+    let path = tempdir().unwrap();
+    let tables = Arc::new(AuthorityPerpetualTables::open(path.path(), None));
+    let config = ConfigBuilder::new_with_temp_dir().build();
+    let store = AuthorityStore::open_with_committee_for_testing(
+        tables,
+        config.committee_with_network().committee(),
+        &config.genesis,
+    )
+    .await
+    .unwrap();
+    Arc::new(WritebackCache::new_for_tests(store))
+}
+
+#[tokio::test]
+async fn test_immediate_return_canceled_shared() {
+    let cache = create_writeback_cache().await;
+
+    let canceled_key = InputKey::VersionedObject {
+        id: ObjectID::random(),
+        version: SequenceNumber::CANCELLED_READ,
+    };
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Should return immediately since canceled shared objects are always available
+    let result = cache
+        .notify_read_input_objects(&[canceled_key], &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
+    assert_eq!(result.len(), 1);
+
+    let congested_key = InputKey::VersionedObject {
+        id: ObjectID::random(),
+        version: SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK,
+    };
+
+    let result = cache
+        .notify_read_input_objects(&[congested_key], &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
+    assert_eq!(result.len(), 1);
+
+    let randomness_unavailable_key = InputKey::VersionedObject {
+        id: ObjectID::random(),
+        version: SequenceNumber::RANDOMNESS_UNAVAILABLE,
+    };
+
+    let result = cache
+        .notify_read_input_objects(&[randomness_unavailable_key], &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_immediate_return_cached_object() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
+    let object = Object::with_id_owner_version_for_testing(object_id, version, Owner::Immutable);
+
+    cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: object_id,
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Should return immediately since object is in cache
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_immediate_return_cached_package() {
+    let cache = create_writeback_cache().await;
+
+    let input_keys = vec![InputKey::Package {
+        id: IOTA_FRAMEWORK_PACKAGE_ID,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Should return immediately since system package is available by default.
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_wait_for_object() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: object_id,
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await;
+    assert!(result.is_err());
+
+    // Write an older version of the object.
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let object = Object::with_id_owner_version_for_testing(
+                object_id,
+                SequenceNumber::from(0),
+                Owner::Shared {
+                    initial_shared_version: version,
+                },
+            );
+            cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
+        }
+    });
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await;
+    assert!(result.is_err());
+
+    // Write the correct version of the object.
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let object = Object::with_id_owner_version_for_testing(
+                object_id,
+                version,
+                Owner::Shared {
+                    initial_shared_version: version,
+                },
+            );
+            cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
+        }
+    });
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_wait_for_package() {
+    let cache = create_writeback_cache().await;
+
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/move/basics");
+    let compiled_modules = BuildConfig::new_for_testing()
+        .build(&path)
+        .unwrap()
+        .into_modules();
+    let package = Object::new_package_for_testing(
+        &compiled_modules,
+        TransactionDigest::genesis_marker(),
+        BuiltInFramework::genesis_move_packages(),
+    )
+    .unwrap();
+    let package_id = package.id();
+    let version = package.version();
+
+    let input_keys = vec![InputKey::Package { id: package_id }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Start notification future
+    let notification = cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch);
+
+    // Write package after small delay
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cache.write_object_entry(&package_id, version, ObjectEntry::Object(package));
+        }
+    });
+
+    // Should complete once package is written
+    let result = timeout(Duration::from_secs(1), notification).await.unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_receiving_object_higher_version() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let requested_version = SequenceNumber::from(1);
+    let higher_version = SequenceNumber::from(2);
+    let object = Object::with_id_owner_version_for_testing(
+        object_id,
+        higher_version,
+        Owner::AddressOwner(IotaAddress::default()),
+    );
+
+    // Write higher version to cache
+    cache.write_object_entry(&object_id, higher_version, ObjectEntry::Object(object));
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: object_id,
+        version: requested_version,
+    }];
+    let mut receiving_keys = HashSet::new();
+    receiving_keys.insert(input_keys[0]);
+    let epoch = &0;
+
+    // Should return immediately since a higher version exists for receiving object
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+}

--- a/crates/iota-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::Path, time::Duration};
+use std::{collections::HashSet, path::Path, sync::Arc, time::Duration};
 
 use futures::FutureExt;
 use iota_framework::BuiltInFramework;
@@ -11,33 +11,89 @@ use iota_swarm_config::network_config_builder::ConfigBuilder;
 use iota_types::{
     IOTA_FRAMEWORK_PACKAGE_ID,
     base_types::{IotaAddress, ObjectID, SequenceNumber},
+    digests::TransactionDigest,
     object::{Object, Owner},
-    storage::InputKey,
+    storage::{InputKey, MarkerValue, ObjectKey},
 };
 use tempfile::tempdir;
 use tokio::time::timeout;
 
-use super::*;
-use crate::authority::authority_store_tables::AuthorityPerpetualTables;
+use super::{
+    ObjectCacheRead, passthrough_cache::PassthroughCache, writeback_cache::WritebackCache,
+};
+use crate::authority::{AuthorityStore, authority_store_tables::AuthorityPerpetualTables};
 
-async fn create_writeback_cache() -> Arc<WritebackCache> {
+/// Trait abstracting cache operations needed for notify_read_input_objects
+/// tests, so the same test logic can run against both WritebackCache and
+/// PassthroughCache.
+trait NotifyReadTestCache: ObjectCacheRead + Send + Sync + 'static {
+    fn write_object_for_testing(&self, object: Object);
+    fn write_marker_for_testing(
+        &self,
+        epoch_id: u64,
+        object_key: &ObjectKey,
+        marker_value: MarkerValue,
+    );
+}
+
+impl NotifyReadTestCache for WritebackCache {
+    fn write_object_for_testing(&self, object: Object) {
+        WritebackCache::write_object_for_testing(self, object);
+    }
+
+    fn write_marker_for_testing(
+        &self,
+        epoch_id: u64,
+        object_key: &ObjectKey,
+        marker_value: MarkerValue,
+    ) {
+        WritebackCache::write_marker_for_testing(self, epoch_id, object_key, marker_value);
+    }
+}
+
+impl NotifyReadTestCache for PassthroughCache {
+    fn write_object_for_testing(&self, object: Object) {
+        PassthroughCache::write_object_for_testing(self, object);
+    }
+
+    fn write_marker_for_testing(
+        &self,
+        epoch_id: u64,
+        object_key: &ObjectKey,
+        marker_value: MarkerValue,
+    ) {
+        PassthroughCache::write_marker_for_testing(self, epoch_id, object_key, marker_value);
+    }
+}
+
+async fn create_store() -> Arc<AuthorityStore> {
     let path = tempdir().unwrap();
     let tables = Arc::new(AuthorityPerpetualTables::open(path.path(), None));
     let config = ConfigBuilder::new_with_temp_dir().build();
-    let store = AuthorityStore::open_with_committee_for_testing(
+    AuthorityStore::open_with_committee_for_testing(
         tables,
         config.committee_with_network().committee(),
         &config.genesis,
     )
     .await
-    .unwrap();
-    Arc::new(WritebackCache::new_for_tests(store))
+    .unwrap()
 }
 
-#[tokio::test]
-async fn test_immediate_return_canceled_shared() {
-    let cache = create_writeback_cache().await;
+async fn create_writeback_cache() -> Arc<WritebackCache> {
+    Arc::new(WritebackCache::new_for_tests(create_store().await))
+}
 
+async fn create_passthrough_cache() -> Arc<PassthroughCache> {
+    let store = create_store().await;
+    let registry = prometheus::Registry::new();
+    Arc::new(PassthroughCache::new_for_tests(store, &registry))
+}
+
+// ---------------------------------------------------------------------------
+// Generic test functions
+// ---------------------------------------------------------------------------
+
+async fn test_immediate_return_canceled_shared_impl(cache: &impl NotifyReadTestCache) {
     let canceled_key = InputKey::VersionedObject {
         id: ObjectID::random(),
         version: SequenceNumber::CANCELLED_READ,
@@ -45,7 +101,6 @@ async fn test_immediate_return_canceled_shared() {
     let receiving_keys = HashSet::new();
     let epoch = &0;
 
-    // Should return immediately since canceled shared objects are always available
     let result = cache
         .notify_read_input_objects(&[canceled_key], &receiving_keys, epoch)
         .now_or_never()
@@ -75,15 +130,12 @@ async fn test_immediate_return_canceled_shared() {
     assert_eq!(result.len(), 1);
 }
 
-#[tokio::test]
-async fn test_immediate_return_cached_object() {
-    let cache = create_writeback_cache().await;
-
+async fn test_immediate_return_cached_object_impl(cache: &impl NotifyReadTestCache) {
     let object_id = ObjectID::random();
     let version = SequenceNumber::from(1);
     let object = Object::with_id_owner_version_for_testing(object_id, version, Owner::Immutable);
 
-    cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
+    cache.write_object_for_testing(object);
 
     let input_keys = vec![InputKey::VersionedObject {
         id: object_id,
@@ -92,7 +144,7 @@ async fn test_immediate_return_cached_object() {
     let receiving_keys = HashSet::new();
     let epoch = &0;
 
-    // Should return immediately since object is in cache
+    // Should return immediately since object is in cache/store
     let result = cache
         .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
         .now_or_never()
@@ -101,10 +153,7 @@ async fn test_immediate_return_cached_object() {
     assert_eq!(result.len(), 1);
 }
 
-#[tokio::test]
-async fn test_immediate_return_cached_package() {
-    let cache = create_writeback_cache().await;
-
+async fn test_immediate_return_cached_package_impl(cache: &impl NotifyReadTestCache) {
     let input_keys = vec![InputKey::Package {
         id: IOTA_FRAMEWORK_PACKAGE_ID,
     }];
@@ -120,156 +169,13 @@ async fn test_immediate_return_cached_package() {
     assert_eq!(result.len(), 1);
 }
 
-#[tokio::test]
-async fn test_wait_for_object() {
-    let cache = create_writeback_cache().await;
-
-    let object_id = ObjectID::random();
-    let version = SequenceNumber::from(1);
-
-    let input_keys = vec![InputKey::VersionedObject {
-        id: object_id,
-        version,
-    }];
-    let receiving_keys = HashSet::new();
-    let epoch = &0;
-
-    let result = timeout(
-        Duration::from_secs(3),
-        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
-    )
-    .await;
-    assert!(result.is_err());
-
-    // Write an older version of the object.
-    tokio::spawn({
-        let cache = cache.clone();
-        async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let object = Object::with_id_owner_version_for_testing(
-                object_id,
-                SequenceNumber::from(0),
-                Owner::Shared {
-                    initial_shared_version: version,
-                },
-            );
-            cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
-        }
-    });
-    let result = timeout(
-        Duration::from_secs(3),
-        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
-    )
-    .await;
-    assert!(result.is_err());
-
-    // Write the correct version of the object.
-    tokio::spawn({
-        let cache = cache.clone();
-        async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let object = Object::with_id_owner_version_for_testing(
-                object_id,
-                version,
-                Owner::Shared {
-                    initial_shared_version: version,
-                },
-            );
-            cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
-        }
-    });
-    let result = timeout(
-        Duration::from_secs(3),
-        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
-    )
-    .await
-    .unwrap();
-    assert_eq!(result.len(), 1);
-}
-
-#[tokio::test]
-async fn test_wait_for_package() {
-    let cache = create_writeback_cache().await;
-
-    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/move/basics");
-    let compiled_modules = BuildConfig::new_for_testing()
-        .build(&path)
-        .unwrap()
-        .into_modules();
-    let package = Object::new_package_for_testing(
-        &compiled_modules,
-        TransactionDigest::genesis_marker(),
-        BuiltInFramework::genesis_move_packages(),
-    )
-    .unwrap();
-    let package_id = package.id();
-    let version = package.version();
-
-    let input_keys = vec![InputKey::Package { id: package_id }];
-    let receiving_keys = HashSet::new();
-    let epoch = &0;
-
-    // Start notification future
-    let notification = cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch);
-
-    // Write package after small delay
-    tokio::spawn({
-        let cache = cache.clone();
-        async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            cache.write_object_entry(&package_id, version, ObjectEntry::Object(package));
-        }
-    });
-
-    // Should complete once package is written
-    let result = timeout(Duration::from_secs(1), notification).await.unwrap();
-
-    assert_eq!(result.len(), 1);
-}
-
-#[tokio::test]
-async fn test_receiving_object_higher_version() {
-    let cache = create_writeback_cache().await;
-
-    let object_id = ObjectID::random();
-    let requested_version = SequenceNumber::from(1);
-    let higher_version = SequenceNumber::from(2);
-    let object = Object::with_id_owner_version_for_testing(
-        object_id,
-        higher_version,
-        Owner::AddressOwner(IotaAddress::default()),
-    );
-
-    // Write higher version to cache
-    cache.write_object_entry(&object_id, higher_version, ObjectEntry::Object(object));
-
-    let input_keys = vec![InputKey::VersionedObject {
-        id: object_id,
-        version: requested_version,
-    }];
-    let mut receiving_keys = HashSet::new();
-    receiving_keys.insert(input_keys[0]);
-    let epoch = &0;
-
-    // Should return immediately since a higher version exists for receiving object
-    let result = cache
-        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
-        .now_or_never()
-        .unwrap();
-
-    assert_eq!(result.len(), 1);
-}
-
-#[tokio::test]
-async fn test_immediate_return_shared_deleted() {
-    let cache = create_writeback_cache().await;
-
+async fn test_immediate_return_shared_deleted_impl(cache: &impl NotifyReadTestCache) {
     let object_id = ObjectID::random();
     let version = SequenceNumber::from(1);
     let epoch_id = 0;
 
     // Write a SharedDeleted marker
-    cache.write_marker_value(
+    cache.write_marker_for_testing(
         epoch_id,
         &ObjectKey(object_id, version),
         MarkerValue::SharedDeleted(TransactionDigest::random()),
@@ -291,10 +197,107 @@ async fn test_immediate_return_shared_deleted() {
     assert_eq!(result.len(), 1);
 }
 
-#[tokio::test]
-async fn test_wait_for_shared_deleted() {
-    let cache = create_writeback_cache().await;
+async fn test_wait_for_object_impl<C: NotifyReadTestCache>(cache: Arc<C>) {
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
 
+    let input_keys = vec![InputKey::VersionedObject {
+        id: object_id,
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await;
+    assert!(result.is_err());
+
+    // Write an older version of the object - should NOT unblock.
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let object = Object::with_id_owner_version_for_testing(
+                object_id,
+                SequenceNumber::from(0),
+                Owner::Shared {
+                    initial_shared_version: version,
+                },
+            );
+            cache.write_object_for_testing(object);
+        }
+    });
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await;
+    assert!(result.is_err());
+
+    // Write the correct version of the object.
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let object = Object::with_id_owner_version_for_testing(
+                object_id,
+                version,
+                Owner::Shared {
+                    initial_shared_version: version,
+                },
+            );
+            cache.write_object_for_testing(object);
+        }
+    });
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.len(), 1);
+}
+
+async fn test_wait_for_package_impl<C: NotifyReadTestCache>(cache: Arc<C>) {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/move/basics");
+    let compiled_modules = BuildConfig::new_for_testing()
+        .build(&path)
+        .unwrap()
+        .into_modules();
+    let package = Object::new_package_for_testing(
+        &compiled_modules,
+        TransactionDigest::genesis_marker(),
+        BuiltInFramework::genesis_move_packages(),
+    )
+    .unwrap();
+    let package_id = package.id();
+
+    let input_keys = vec![InputKey::Package { id: package_id }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Start notification future
+    let notification = cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch);
+
+    // Write package after small delay
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cache.write_object_for_testing(package);
+        }
+    });
+
+    // Should complete once package is written
+    let result = timeout(Duration::from_secs(1), notification).await.unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+async fn test_wait_for_shared_deleted_impl<C: NotifyReadTestCache>(cache: Arc<C>) {
     let object_id = ObjectID::random();
     let version = SequenceNumber::from(1);
     let epoch_id = 0;
@@ -314,7 +317,7 @@ async fn test_wait_for_shared_deleted() {
         let cache = cache.clone();
         async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
-            cache.write_marker_value(
+            cache.write_marker_for_testing(
                 epoch_id,
                 &ObjectKey(object_id, version),
                 MarkerValue::SharedDeleted(TransactionDigest::random()),
@@ -326,4 +329,138 @@ async fn test_wait_for_shared_deleted() {
     let result = timeout(Duration::from_secs(1), notification).await.unwrap();
 
     assert_eq!(result.len(), 1);
+}
+
+async fn test_receiving_object_higher_version_impl(cache: &impl NotifyReadTestCache) {
+    let object_id = ObjectID::random();
+    let requested_version = SequenceNumber::from(1);
+    let higher_version = SequenceNumber::from(2);
+    let object = Object::with_id_owner_version_for_testing(
+        object_id,
+        higher_version,
+        Owner::AddressOwner(IotaAddress::default()),
+    );
+
+    // Write higher version to cache
+    cache.write_object_for_testing(object);
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: object_id,
+        version: requested_version,
+    }];
+    let mut receiving_keys = HashSet::new();
+    receiving_keys.insert(input_keys[0]);
+    let epoch = &0;
+
+    // Should return immediately since a higher version exists for receiving object
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// WritebackCache tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_writeback_immediate_return_canceled_shared() {
+    let cache = create_writeback_cache().await;
+    test_immediate_return_canceled_shared_impl(&*cache).await;
+}
+
+#[tokio::test]
+async fn test_writeback_immediate_return_cached_object() {
+    let cache = create_writeback_cache().await;
+    test_immediate_return_cached_object_impl(&*cache).await;
+}
+
+#[tokio::test]
+async fn test_writeback_immediate_return_cached_package() {
+    let cache = create_writeback_cache().await;
+    test_immediate_return_cached_package_impl(&*cache).await;
+}
+
+#[tokio::test]
+async fn test_writeback_immediate_return_shared_deleted() {
+    let cache = create_writeback_cache().await;
+    test_immediate_return_shared_deleted_impl(&*cache).await;
+}
+
+#[tokio::test]
+async fn test_writeback_wait_for_object() {
+    let cache = create_writeback_cache().await;
+    test_wait_for_object_impl(cache).await;
+}
+
+#[tokio::test]
+async fn test_writeback_wait_for_package() {
+    let cache = create_writeback_cache().await;
+    test_wait_for_package_impl(cache).await;
+}
+
+#[tokio::test]
+async fn test_writeback_wait_for_shared_deleted() {
+    let cache = create_writeback_cache().await;
+    test_wait_for_shared_deleted_impl(cache).await;
+}
+
+#[tokio::test]
+async fn test_writeback_receiving_object_higher_version() {
+    let cache = create_writeback_cache().await;
+    test_receiving_object_higher_version_impl(&*cache).await;
+}
+
+// ---------------------------------------------------------------------------
+// PassthroughCache tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_passthrough_immediate_return_canceled_shared() {
+    let cache = create_passthrough_cache().await;
+    test_immediate_return_canceled_shared_impl(&*cache).await;
+}
+
+#[tokio::test]
+async fn test_passthrough_immediate_return_cached_object() {
+    let cache = create_passthrough_cache().await;
+    test_immediate_return_cached_object_impl(&*cache).await;
+}
+
+#[tokio::test]
+async fn test_passthrough_immediate_return_cached_package() {
+    let cache = create_passthrough_cache().await;
+    test_immediate_return_cached_package_impl(&*cache).await;
+}
+
+#[tokio::test]
+async fn test_passthrough_immediate_return_shared_deleted() {
+    let cache = create_passthrough_cache().await;
+    test_immediate_return_shared_deleted_impl(&*cache).await;
+}
+
+#[tokio::test]
+async fn test_passthrough_wait_for_object() {
+    let cache = create_passthrough_cache().await;
+    test_wait_for_object_impl(cache).await;
+}
+
+#[tokio::test]
+async fn test_passthrough_wait_for_package() {
+    let cache = create_passthrough_cache().await;
+    test_wait_for_package_impl(cache).await;
+}
+
+#[tokio::test]
+async fn test_passthrough_wait_for_shared_deleted() {
+    let cache = create_passthrough_cache().await;
+    test_wait_for_shared_deleted_impl(cache).await;
+}
+
+#[tokio::test]
+async fn test_passthrough_receiving_object_higher_version() {
+    let cache = create_passthrough_cache().await;
+    test_receiving_object_higher_version_impl(&*cache).await;
 }

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -613,6 +613,16 @@ impl WritebackCache {
             .or_default()
             .value_mut()
             .insert(object_key.1, marker_value);
+
+        if matches!(marker_value, MarkerValue::SharedDeleted(_)) {
+            self.object_notify_read.notify(
+                &InputKey::VersionedObject {
+                    id: object_key.0,
+                    version: object_key.1,
+                },
+                &(),
+            );
+        }
     }
 
     // lock both the dirty and committed sides of the cache, and then pass the
@@ -1900,6 +1910,13 @@ impl ObjectCacheRead for WritebackCache {
                                     if is_available {
                                         results[*idx] = Some(());
                                     }
+                                } else if self
+                                    .get_last_shared_object_deletion_info(&input_key.id(), *epoch)
+                                    .is_some()
+                                {
+                                    // If the shared object was deleted, mark it as
+                                    // available so the transaction can proceed.
+                                    results[*idx] = Some(());
                                 }
                             }
                         });

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -103,10 +103,6 @@ use crate::{
 #[path = "unit_tests/writeback_cache_tests.rs"]
 pub mod writeback_cache_tests;
 
-#[cfg(test)]
-#[path = "unit_tests/notify_read_input_objects_tests.rs"]
-mod notify_read_input_objects_tests;
-
 #[derive(Clone, PartialEq, Eq)]
 enum ObjectEntry {
     Object(Object),
@@ -579,18 +575,7 @@ impl WritebackCache {
         entry.insert(version, object.clone());
 
         if let ObjectEntry::Object(object) = &object {
-            if object.is_package() {
-                self.object_notify_read
-                    .notify(&InputKey::Package { id: *object_id }, &());
-            } else if !object.is_child_object() {
-                self.object_notify_read.notify(
-                    &InputKey::VersionedObject {
-                        id: object.id(),
-                        version: object.version(),
-                    },
-                    &(),
-                );
-            }
+            super::notify_object_written(&self.object_notify_read, object);
         }
     }
 
@@ -614,15 +599,11 @@ impl WritebackCache {
             .value_mut()
             .insert(object_key.1, marker_value);
 
-        if matches!(marker_value, MarkerValue::SharedDeleted(_)) {
-            self.object_notify_read.notify(
-                &InputKey::VersionedObject {
-                    id: object_key.0,
-                    version: object_key.1,
-                },
-                &(),
-            );
-        }
+        // It is possible for a transaction to use a shared
+        // object in the input, hence we must notify that it is now available
+        // at the assigned version, so that any transaction waiting for this
+        // object version can start execution.
+        super::notify_marker_written(&self.object_notify_read, object_key, &marker_value);
     }
 
     // lock both the dirty and committed sides of the cache, and then pass the
@@ -1862,75 +1843,13 @@ impl ObjectCacheRead for WritebackCache {
         receiving_keys: &'a HashSet<InputKey>,
         epoch: &'a EpochId,
     ) -> BoxFuture<'a, Vec<()>> {
-        async move {
-            self.object_notify_read
-                .read::<std::convert::Infallible>(input_and_receiving_keys, |keys| {
-                    let mut results = vec![None; keys.len()];
-
-                    let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
-                        .iter()
-                        .enumerate()
-                        .filter(|(idx, key)| {
-                            if key.is_cancelled() {
-                                // Shared objects in canceled transactions are always available.
-                                results[*idx] = Some(());
-                                false
-                            } else {
-                                true
-                            }
-                        })
-                        .partition(|(_, key)| key.version().is_some());
-                    let versioned_object_keys: Vec<_> = keys_with_version
-                        .iter()
-                        .map(|(_, key)| ObjectKey(key.id(), key.version().unwrap()))
-                        .collect();
-                    ObjectCacheRead::multi_get_objects_by_key(self, &versioned_object_keys)
-                        .into_iter()
-                        .zip(keys_with_version.iter())
-                        .for_each(|(o, (idx, input_key))| match o {
-                            Some(_) => results[*idx] = Some(()),
-                            None => {
-                                if receiving_keys.contains(input_key) {
-                                    // There could be a more recent version of this object, and the
-                                    // object at the specified version
-                                    // could have already been pruned. In such a case `has_key` will
-                                    // be false, but since this is a receiving object we should mark
-                                    // it as available if we can determine
-                                    // that an object with a version greater than or equal to the
-                                    // specified version exists or was deleted. We will then let
-                                    // mark it as available to
-                                    // let the transaction
-                                    // through so it can fail at execution.
-                                    let is_available =
-                                        ObjectCacheRead::get_object(self, &input_key.id())
-                                            .map(|obj| {
-                                                obj.version() >= input_key.version().unwrap()
-                                            })
-                                            .unwrap_or(false);
-                                    if is_available {
-                                        results[*idx] = Some(());
-                                    }
-                                } else if self
-                                    .get_last_shared_object_deletion_info(&input_key.id(), *epoch)
-                                    .is_some()
-                                {
-                                    // If the shared object was deleted, mark it as
-                                    // available so the transaction can proceed.
-                                    results[*idx] = Some(());
-                                }
-                            }
-                        });
-                    keys_without_version.iter().for_each(|(idx, key)| {
-                        if self.get_package_object(&key.id()).is_some() {
-                            results[*idx] = Some(());
-                        }
-                    });
-                    Ok(results)
-                })
-                .await
-                .unwrap()
-        }
-        .boxed()
+        super::notify_read_input_objects_impl(
+            &self.object_notify_read,
+            self,
+            input_and_receiving_keys,
+            receiving_keys,
+            epoch,
+        )
     }
 }
 
@@ -2371,5 +2290,23 @@ impl StateSyncAPI for WritebackCache {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+impl WritebackCache {
+    pub(super) fn write_object_for_testing(&self, object: Object) {
+        let id = object.id();
+        let version = object.version();
+        self.write_object_entry(&id, version, ObjectEntry::Object(object));
+    }
+
+    pub(super) fn write_marker_for_testing(
+        &self,
+        epoch_id: EpochId,
+        object_key: &ObjectKey,
+        marker_value: MarkerValue,
+    ) {
+        self.write_marker_value(epoch_id, object_key, marker_value);
     }
 }

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -48,7 +48,7 @@
 //! The above design is used for both objects and markers.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     hash::Hash,
     sync::{Arc, atomic::AtomicU64},
 };
@@ -69,12 +69,11 @@ use iota_types::{
     message_envelope::Message,
     messages_checkpoint::CheckpointSequenceNumber,
     object::Object,
-    storage::{MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject},
+    storage::{InputKey, MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject},
     transaction::{VerifiedSignedTransaction, VerifiedTransaction},
 };
 use moka::sync::SegmentedCache as MokaCache;
 use parking_lot::Mutex;
-use prometheus::Registry;
 use tap::TapOptional;
 use tracing::{debug, info, instrument, trace, warn};
 
@@ -103,6 +102,10 @@ use crate::{
 #[cfg(test)]
 #[path = "unit_tests/writeback_cache_tests.rs"]
 pub mod writeback_cache_tests;
+
+#[cfg(test)]
+#[path = "unit_tests/notify_read_input_objects_tests.rs"]
+mod notify_read_input_objects_tests;
 
 #[derive(Clone, PartialEq, Eq)]
 enum ObjectEntry {
@@ -438,6 +441,7 @@ pub struct WritebackCache {
     object_locks: ObjectLocks,
 
     executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
+    object_notify_read: NotifyRead<InputKey, ()>,
     store: Arc<AuthorityStore>,
     backpressure_threshold: u64,
     backpressure_manager: Arc<BackpressureManager>,
@@ -499,6 +503,7 @@ impl WritebackCache {
             packages,
             object_locks: ObjectLocks::new(),
             executed_effects_digests_notify_read: NotifyRead::new(),
+            object_notify_read: NotifyRead::new(),
             store,
             backpressure_manager,
             backpressure_threshold: config.backpressure_threshold(),
@@ -506,11 +511,11 @@ impl WritebackCache {
         }
     }
 
-    pub fn new_for_tests(store: Arc<AuthorityStore>, registry: &Registry) -> Self {
+    pub fn new_for_tests(store: Arc<AuthorityStore>) -> Self {
         Self::new(
             &Default::default(),
             store,
-            ExecutionCacheMetrics::new(registry).into(),
+            ExecutionCacheMetrics::new(&prometheus::Registry::new()).into(),
             BackpressureManager::new_for_tests(),
         )
     }
@@ -571,7 +576,22 @@ impl WritebackCache {
             // See the comment in `MonotonicCache::insert`.
             .ok();
 
-        entry.insert(version, object);
+        entry.insert(version, object.clone());
+
+        if let ObjectEntry::Object(object) = &object {
+            if object.is_package() {
+                self.object_notify_read
+                    .notify(&InputKey::Package { id: *object_id }, &());
+            } else if !object.is_child_object() {
+                self.object_notify_read.notify(
+                    &InputKey::VersionedObject {
+                        id: object.id(),
+                        version: object.version(),
+                    },
+                    &(),
+                );
+            }
+        }
     }
 
     fn write_marker_value(
@@ -1824,6 +1844,76 @@ impl ObjectCacheRead for WritebackCache {
             .perpetual_tables
             .get_highest_pruned_checkpoint()
             .map_err(IotaError::from)
+    }
+
+    fn notify_read_input_objects<'a>(
+        &'a self,
+        input_and_receiving_keys: &'a [InputKey],
+        receiving_keys: &'a HashSet<InputKey>,
+        epoch: &'a EpochId,
+    ) -> BoxFuture<'a, Vec<()>> {
+        async move {
+            self.object_notify_read
+                .read::<std::convert::Infallible>(input_and_receiving_keys, |keys| {
+                    let mut results = vec![None; keys.len()];
+
+                    let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
+                        .iter()
+                        .enumerate()
+                        .filter(|(idx, key)| {
+                            if key.is_cancelled() {
+                                // Shared objects in canceled transactions are always available.
+                                results[*idx] = Some(());
+                                false
+                            } else {
+                                true
+                            }
+                        })
+                        .partition(|(_, key)| key.version().is_some());
+                    let versioned_object_keys: Vec<_> = keys_with_version
+                        .iter()
+                        .map(|(_, key)| ObjectKey(key.id(), key.version().unwrap()))
+                        .collect();
+                    ObjectCacheRead::multi_get_objects_by_key(self, &versioned_object_keys)
+                        .into_iter()
+                        .zip(keys_with_version.iter())
+                        .for_each(|(o, (idx, input_key))| match o {
+                            Some(_) => results[*idx] = Some(()),
+                            None => {
+                                if receiving_keys.contains(input_key) {
+                                    // There could be a more recent version of this object, and the
+                                    // object at the specified version
+                                    // could have already been pruned. In such a case `has_key` will
+                                    // be false, but since this is a receiving object we should mark
+                                    // it as available if we can determine
+                                    // that an object with a version greater than or equal to the
+                                    // specified version exists or was deleted. We will then let
+                                    // mark it as available to
+                                    // let the transaction
+                                    // through so it can fail at execution.
+                                    let is_available =
+                                        ObjectCacheRead::get_object(self, &input_key.id())
+                                            .map(|obj| {
+                                                obj.version() >= input_key.version().unwrap()
+                                            })
+                                            .unwrap_or(false);
+                                    if is_available {
+                                        results[*idx] = Some(());
+                                    }
+                                }
+                            }
+                        });
+                    keys_without_version.iter().for_each(|(idx, key)| {
+                        if self.get_package_object(&key.id()).is_some() {
+                            results[*idx] = Some(());
+                        }
+                    });
+                    Ok(results)
+                })
+                .await
+                .unwrap()
+        }
+        .boxed()
     }
 }
 


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.48.4, v1.49.2)
- Port commit:
  - [MystenLabs/sui@ed70303](https://github.com/MystenLabs/sui/commit/ed70303929d4c87a146abf865233b1821bdd7711)
- Description:

Adds a `notify_read_input_objects` method to the `ObjectCacheRead` trait and implements it in `WritebackCache`  and `PassthroughCache`. This allows transactions to wait until their input objects become available, replacing the need for polling in the transaction manager. The `write_object_entry` method now notifies waiters when objects are written.

## Links to any relevant issues

Part of #11101

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes