### PR TITLE
fix(wallet): Only fetch commits on non-production releases

### DIFF
--- a/.github/workflows/apps_wallet_build.yml
+++ b/.github/workflows/apps_wallet_build.yml
@@ -84,6 +84,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-tags: ${{ env.DEPLOY_TYPE == 'production' }}
+          fetch-depth: ${{ env.DEPLOY_TYPE == 'production' && 0 || 1 }}
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - name: Install Nodejs
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0


### PR DESCRIPTION
Brings back https://github.com/iotaledger/iota/blob/9c6137c46cfb01921ad4df91538bacef841e27bb/.github/workflows/apps_wallet_prod_build.yml#L25