### PR TITLE
feat(consensus): add data availability tracking to DagState

### DIFF
--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -768,11 +768,7 @@ impl DagState {
                 && source != DataSource::CommitSyncer
                 && source != DataSource::Recover
             {
-                self.add_pending_acknowledgment(
-                    transaction_ref,
-                    block_digest,
-                    source,
-                );
+                self.add_pending_acknowledgment(transaction_ref, block_digest, source);
             }
         } else {
             self.context

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -221,10 +221,6 @@ pub(crate) struct DagState {
     /// the previous window.
     commit_info_to_write: Vec<(CommitRef, CommitInfo)>,
 
-    /// Per-authority set of block references with locally available transaction
-    /// data. Only tracked when consensus_starfish_speed is enabled.
-    data_availability: Vec<BTreeSet<BlockRef>>,
-
     /// Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
 
@@ -329,7 +325,6 @@ impl DagState {
             commit_info_to_write: vec![],
             pending_acknowledgments: BTreeSet::new(),
             scoring_subdag,
-            data_availability: vec![BTreeSet::new(); num_authorities],
             store: store.clone(),
             cached_rounds,
             evicted_rounds: vec![0; num_authorities],
@@ -415,7 +410,6 @@ impl DagState {
         self.tx_ref_to_block_digest_by_authority = vec![BTreeMap::new(); num_authorities];
         self.pending_commit_votes.clear();
         self.pending_acknowledgments.clear();
-        self.data_availability = vec![BTreeSet::new(); num_authorities];
 
         // 2. Reinitialize threshold_clock with current round
         let current_round = self.threshold_clock.get_round();
@@ -738,8 +732,6 @@ impl DagState {
         let block_digest = transactions.block_ref().map(|br| br.digest);
         let clock_round = self.threshold_clock_round();
         let min_round: Round = clock_round.saturating_sub(self.context.protocol_config.gc_depth());
-
-        self.update_data_availability(transaction_ref, block_digest);
 
         let hostname = self
             .context
@@ -1909,32 +1901,20 @@ impl DagState {
     /// Check if a block's transaction data is locally available.
     // Will be used by strong-vote computation in a later StarfishSpeed step.
     #[expect(dead_code)]
-    pub(crate) fn is_data_available(&self, reference: &BlockRef) -> bool {
-        self.data_availability[reference.author].contains(reference)
-    }
-
-    /// Mark a block's data as available. Only tracked when
-    /// consensus_starfish_speed is enabled.
-    pub(crate) fn update_data_availability(
-        &mut self,
-        transaction_ref: TransactionRef,
-        block_digest: Option<BlockHeaderDigest>,
-    ) {
-        if !self.context.protocol_config.consensus_starfish_speed() {
-            return;
-        }
-        let block_ref = if let Some(digest) = block_digest {
-            BlockRef::new(transaction_ref.round, transaction_ref.author, digest)
-        } else {
-            let Some(br) = self.resolve_block_ref(&transaction_ref) else {
-                error!(
-                    "block_digest not found for {transaction_ref:?} when updating data availability"
-                );
-                return;
+    pub(crate) fn is_data_available(&self, block_ref: &BlockRef) -> bool {
+        let transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
+            let Some(header) = self.recent_block_headers.get(block_ref) else {
+                return false;
             };
-            br
+            GenericTransactionRef::from(TransactionRef {
+                round: block_ref.round,
+                author: block_ref.author,
+                transactions_commitment: header.transactions_commitment(),
+            })
+        } else {
+            GenericTransactionRef::from(*block_ref)
         };
-        self.data_availability[block_ref.author].insert(block_ref);
+        self.recent_transactions_by_authority[block_ref.author].contains_key(&transaction_ref)
     }
 
     /// Clean up old cached data for each authority, all cached blocks
@@ -2064,16 +2044,6 @@ impl DagState {
             if eviction_sender.send(eviction_rounds).is_err() {
                 warn!("Failed to send cordial knowledge eviction message: channel closed");
             }
-        }
-    }
-
-    fn evict_data_availability(&mut self) {
-        for (authority_index, _) in self.context.committee.authorities() {
-            let eviction_round = self.calculate_authority_eviction_round(authority_index);
-            let split_key =
-                BlockRef::new(eviction_round + 1, authority_index, BlockHeaderDigest::MIN);
-            self.data_availability[authority_index] =
-                self.data_availability[authority_index].split_off(&split_key);
         }
     }
 
@@ -2303,9 +2273,6 @@ impl DagState {
         // Clean up old cordial knowledge.
         self.evict_cordial_knowledge();
 
-        // Clean up old data availability tracking.
-        self.evict_data_availability();
-
         // Update metrics
         let metrics = &self.context.metrics.node_metrics;
         metrics
@@ -2335,12 +2302,6 @@ impl DagState {
         metrics
             .dag_state_pending_acknowledgments
             .set(self.pending_acknowledgments.len() as i64);
-        metrics.dag_state_data_availability.set(
-            self.data_availability
-                .iter()
-                .map(BTreeSet::len)
-                .sum::<usize>() as i64,
-        );
     }
 
     pub(crate) fn recover_last_commit_info(&self) -> Option<(CommitRef, CommitInfo)> {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -738,7 +738,6 @@ impl DagState {
         let block_digest = transactions.block_ref().map(|br| br.digest);
         let clock_round = self.threshold_clock_round();
         let min_round: Round = clock_round.saturating_sub(self.context.protocol_config.gc_depth());
-        let clock_round_gap = clock_round.saturating_sub(transaction_ref.round);
 
         self.update_data_availability(transaction_ref, block_digest);
 
@@ -748,6 +747,7 @@ impl DagState {
             .authority(transaction_ref.author)
             .hostname
             .as_str();
+        let clock_round_gap = clock_round.saturating_sub(transaction_ref.round);
 
         if has_transactions {
             // Record metrics

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -735,20 +735,19 @@ impl DagState {
 
         // Handle pending acknowledgments for recent blocks
         let has_transactions = transactions.has_transactions();
+        let block_digest = transactions.block_ref().map(|br| br.digest);
         let clock_round = self.threshold_clock_round();
         let min_round: Round = clock_round.saturating_sub(self.context.protocol_config.gc_depth());
+        let clock_round_gap = clock_round.saturating_sub(transaction_ref.round);
+
+        self.update_data_availability(transaction_ref, block_digest);
+
         let hostname = self
             .context
             .committee
             .authority(transaction_ref.author)
             .hostname
-            .clone();
-        let clock_round_gap = clock_round.saturating_sub(transaction_ref.round);
-
-        self.update_data_availability(
-            transaction_ref,
-            transactions.block_ref().map(|br| br.digest),
-        );
+            .as_str();
 
         if has_transactions {
             // Record metrics
@@ -756,7 +755,7 @@ impl DagState {
                 .metrics
                 .node_metrics
                 .accepted_transactions_source
-                .with_label_values(&[source.as_str(), hostname.as_str()])
+                .with_label_values(&[source.as_str(), hostname])
                 .inc();
             self.context
                 .metrics
@@ -771,7 +770,7 @@ impl DagState {
             {
                 self.add_pending_acknowledgment(
                     transaction_ref,
-                    transactions.block_ref().map(|br| br.digest),
+                    block_digest,
                     source,
                 );
             }
@@ -780,7 +779,7 @@ impl DagState {
                 .metrics
                 .node_metrics
                 .skipped_empty_transaction_acknowledgments
-                .with_label_values(&[hostname.as_str()])
+                .with_label_values(&[hostname])
                 .inc()
         }
     }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -221,6 +221,10 @@ pub(crate) struct DagState {
     /// the previous window.
     commit_info_to_write: Vec<(CommitRef, CommitInfo)>,
 
+    /// Per-authority set of block references with locally available transaction
+    /// data. Only tracked when consensus_starfish_speed is enabled.
+    data_availability: Vec<BTreeSet<BlockRef>>,
+
     /// Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
 
@@ -325,6 +329,7 @@ impl DagState {
             commit_info_to_write: vec![],
             pending_acknowledgments: BTreeSet::new(),
             scoring_subdag,
+            data_availability: vec![BTreeSet::new(); num_authorities],
             store: store.clone(),
             cached_rounds,
             evicted_rounds: vec![0; num_authorities],
@@ -410,6 +415,7 @@ impl DagState {
         self.tx_ref_to_block_digest_by_authority = vec![BTreeMap::new(); num_authorities];
         self.pending_commit_votes.clear();
         self.pending_acknowledgments.clear();
+        self.data_availability = vec![BTreeSet::new(); num_authorities];
 
         // 2. Reinitialize threshold_clock with current round
         let current_round = self.threshold_clock.get_round();
@@ -736,8 +742,13 @@ impl DagState {
             .committee
             .authority(transaction_ref.author)
             .hostname
-            .as_str();
+            .clone();
         let clock_round_gap = clock_round.saturating_sub(transaction_ref.round);
+
+        self.update_data_availability(
+            transaction_ref,
+            transactions.block_ref().map(|br| br.digest),
+        );
 
         if has_transactions {
             // Record metrics
@@ -745,7 +756,7 @@ impl DagState {
                 .metrics
                 .node_metrics
                 .accepted_transactions_source
-                .with_label_values(&[source.as_str(), hostname])
+                .with_label_values(&[source.as_str(), hostname.as_str()])
                 .inc();
             self.context
                 .metrics
@@ -769,7 +780,7 @@ impl DagState {
                 .metrics
                 .node_metrics
                 .skipped_empty_transaction_acknowledgments
-                .with_label_values(&[hostname])
+                .with_label_values(&[hostname.as_str()])
                 .inc()
         }
     }
@@ -1900,6 +1911,37 @@ impl DagState {
         votes
     }
 
+    /// Check if a block's transaction data is locally available.
+    // Will be used by strong-vote computation in a later StarfishSpeed step.
+    #[expect(dead_code)]
+    pub(crate) fn is_data_available(&self, reference: &BlockRef) -> bool {
+        self.data_availability[reference.author].contains(reference)
+    }
+
+    /// Mark a block's data as available. Only tracked when
+    /// consensus_starfish_speed is enabled.
+    pub(crate) fn update_data_availability(
+        &mut self,
+        transaction_ref: TransactionRef,
+        block_digest: Option<BlockHeaderDigest>,
+    ) {
+        if !self.context.protocol_config.consensus_starfish_speed() {
+            return;
+        }
+        let block_ref = if let Some(digest) = block_digest {
+            BlockRef::new(transaction_ref.round, transaction_ref.author, digest)
+        } else {
+            let Some(br) = self.resolve_block_ref(&transaction_ref) else {
+                error!(
+                    "block_digest not found for {transaction_ref:?} when updating data availability"
+                );
+                return;
+            };
+            br
+        };
+        self.data_availability[block_ref.author].insert(block_ref);
+    }
+
     /// Clean up old cached data for each authority, all cached blocks
     /// are guaranteed to be persisted. Used after flushing.
     pub(crate) fn evict_headers(&mut self) {
@@ -2027,6 +2069,16 @@ impl DagState {
             if eviction_sender.send(eviction_rounds).is_err() {
                 warn!("Failed to send cordial knowledge eviction message: channel closed");
             }
+        }
+    }
+
+    fn evict_data_availability(&mut self) {
+        for (authority_index, _) in self.context.committee.authorities() {
+            let eviction_round = self.calculate_authority_eviction_round(authority_index);
+            let split_key =
+                BlockRef::new(eviction_round + 1, authority_index, BlockHeaderDigest::MIN);
+            self.data_availability[authority_index] =
+                self.data_availability[authority_index].split_off(&split_key);
         }
     }
 
@@ -2256,6 +2308,9 @@ impl DagState {
         // Clean up old cordial knowledge.
         self.evict_cordial_knowledge();
 
+        // Clean up old data availability tracking.
+        self.evict_data_availability();
+
         // Update metrics
         let metrics = &self.context.metrics.node_metrics;
         metrics
@@ -2285,6 +2340,12 @@ impl DagState {
         metrics
             .dag_state_pending_acknowledgments
             .set(self.pending_acknowledgments.len() as i64);
+        metrics.dag_state_data_availability.set(
+            self.data_availability
+                .iter()
+                .map(BTreeSet::len)
+                .sum::<usize>() as i64,
+        );
     }
 
     pub(crate) fn recover_last_commit_info(&self) -> Option<(CommitRef, CommitInfo)> {

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -149,7 +149,6 @@ pub(crate) struct NodeMetrics {
     pub(crate) dag_state_recent_refs: IntGauge,
     pub(crate) dag_state_pending_commit_votes: IntGauge,
     pub(crate) dag_state_pending_acknowledgments: IntGauge,
-    pub(crate) dag_state_data_availability: IntGauge,
     pub(crate) cordial_knowledge_message_batch_size: Histogram,
     pub(crate) cordial_knowledge_processed_messages: IntCounterVec,
     pub(crate) cordial_knowledge_entries: IntGauge,
@@ -537,11 +536,6 @@ impl NodeMetrics {
             dag_state_pending_acknowledgments: register_int_gauge_with_registry!(
                 "dag_state_pending_acknowledgments",
                 "Number of pending acknowledgments in the DagState",
-                registry,
-            ).unwrap(),
-            dag_state_data_availability: register_int_gauge_with_registry!(
-                "dag_state_data_availability",
-                "Number of blocks with locally available transaction data in the DagState",
                 registry,
             ).unwrap(),
             cordial_knowledge_message_batch_size: register_histogram_with_registry!(

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -149,6 +149,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) dag_state_recent_refs: IntGauge,
     pub(crate) dag_state_pending_commit_votes: IntGauge,
     pub(crate) dag_state_pending_acknowledgments: IntGauge,
+    pub(crate) dag_state_data_availability: IntGauge,
     pub(crate) cordial_knowledge_message_batch_size: Histogram,
     pub(crate) cordial_knowledge_processed_messages: IntCounterVec,
     pub(crate) cordial_knowledge_entries: IntGauge,
@@ -536,6 +537,11 @@ impl NodeMetrics {
             dag_state_pending_acknowledgments: register_int_gauge_with_registry!(
                 "dag_state_pending_acknowledgments",
                 "Number of pending acknowledgments in the DagState",
+                registry,
+            ).unwrap(),
+            dag_state_data_availability: register_int_gauge_with_registry!(
+                "dag_state_data_availability",
+                "Number of blocks with locally available transaction data in the DagState",
                 registry,
             ).unwrap(),
             cordial_knowledge_message_batch_size: register_histogram_with_registry!(


### PR DESCRIPTION
# Description of change

Add a function that reports on data availability for a given block_ref. Data is available if the corresponding header and transactions are present in recent headers and recent transactions.

## Links to any relevant issues

Part of #11009
Fixes #11133

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes