### PR TITLE
feat(iota-graphql-rpc): add subscription recovery

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -4390,14 +4390,40 @@ type Subscription {
 	Subscribe to incoming transactions from the IOTA network.
 	
 	If no filter is provided, all transactions will be returned.
+	
+	# Stream recovery
+	
+	When `start_after` is provided with the digest of the last transaction
+	the client received, the stream resumes from the transaction
+	immediately after it. The identified transaction itself is not
+	emitted.
 	"""
-	transactions(filter: SubscriptionTransactionFilter): TransactionBlockSubscriptionPayload!
+	transactions(startAfter: String, filter: SubscriptionTransactionFilter): TransactionBlockSubscriptionPayload!
 	"""
 	Subscribe to incoming events from the IOTA network.
 	
 	If no filter is provided, all events will be returned.
+	
+	# Stream recovery
+	
+	Events are streamed in transaction order, all events from a single
+	transaction arrive contiguously before any events from the next one.
+	
+	When `start_after` is provided with a transaction digest, the stream
+	resumes from the transaction immediately after it.
+	
+	Because a single transaction can emit multiple events, a disconnection
+	may leave the client with only a partial set of events from the
+	transaction it was last receiving. A transaction is considered fully
+	received only once the client has seen an event from the following
+	transaction (a digest change signals the previous transaction is
+	complete).
+	
+	On reconnect, clients should pass the digest of the last fully
+	received transaction as `start_after`. The stream resumes from the
+	next transaction, so no partial transaction is ever observed.
 	"""
-	events(filter: SubscriptionEventFilter): EventSubscriptionPayload!
+	events(startAfter: String, filter: SubscriptionEventFilter): EventSubscriptionPayload!
 }
 
 """

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -8,11 +8,11 @@ use futures::{Stream, StreamExt, TryStreamExt, future};
 use iota_indexer::read::IndexerReader;
 use iota_indexer_streaming::{
     error::IndexerStreamingError,
-    memory::{Config, InMemory},
+    memory::{Config, InMemory, RecoveryPoint},
     metrics::InMemoryStreamMetrics,
 };
 use iota_json_rpc_types::Filter;
-use iota_types::supported_protocol_versions::Chain;
+use iota_types::{digests::TransactionDigest, supported_protocol_versions::Chain};
 use prometheus::Registry;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tracing::warn;
@@ -21,6 +21,7 @@ use crate::{
     error::Error,
     types::{
         chain_identifier::ChainIdentifierCache,
+        digest::Digest,
         event::Event,
         subscription::filter::{SubscriptionEventFilter, SubscriptionTransactionFilter},
         transaction_block::{TransactionBlock, TransactionBlockInner},
@@ -65,9 +66,17 @@ impl Subscription {
     /// Subscribe to incoming transactions from the IOTA network.
     ///
     /// If no filter is provided, all transactions will be returned.
+    ///
+    /// # Stream recovery
+    ///
+    /// When `start_after` is provided with the digest of the last transaction
+    /// the client received, the stream resumes from the transaction
+    /// immediately after it. The identified transaction itself is not
+    /// emitted.
     async fn transactions(
         &self,
         ctx: &Context<'_>,
+        start_after: Option<Digest>,
         filter: Option<SubscriptionTransactionFilter>,
     ) -> async_graphql::Result<impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>>>
     {
@@ -91,15 +100,35 @@ impl Subscription {
         }
 
         let streams = ctx.data_unchecked::<GraphQLStream>();
-        Ok(streams.subscribe_transactions(filter))
+        Ok(streams.subscribe_transactions(start_after, filter))
     }
 
     /// Subscribe to incoming events from the IOTA network.
     ///
     /// If no filter is provided, all events will be returned.
+    ///
+    /// # Stream recovery
+    ///
+    /// Events are streamed in transaction order, all events from a single
+    /// transaction arrive contiguously before any events from the next one.
+    ///
+    /// When `start_after` is provided with a transaction digest, the stream
+    /// resumes from the transaction immediately after it.
+    ///
+    /// Because a single transaction can emit multiple events, a disconnection
+    /// may leave the client with only a partial set of events from the
+    /// transaction it was last receiving. A transaction is considered fully
+    /// received only once the client has seen an event from the following
+    /// transaction (a digest change signals the previous transaction is
+    /// complete).
+    ///
+    /// On reconnect, clients should pass the digest of the last fully
+    /// received transaction as `start_after`. The stream resumes from the
+    /// next transaction, so no partial transaction is ever observed.
     async fn events(
         &self,
         ctx: &Context<'_>,
+        start_after: Option<Digest>,
         filter: Option<SubscriptionEventFilter>,
     ) -> async_graphql::Result<impl Stream<Item = Result<SubscriptionItem<Event>, Error>>> {
         let chain_id_cache: &ChainIdentifierCache = ctx.data_unchecked();
@@ -122,7 +151,7 @@ impl Subscription {
         }
 
         let streams = ctx.data_unchecked::<GraphQLStream>();
-        Ok(streams.subscribe_events(filter))
+        Ok(streams.subscribe_events(start_after, filter))
     }
 }
 
@@ -167,10 +196,13 @@ impl GraphQLStream {
     /// Subscribe to transactions from IOTA Network.
     pub(crate) fn subscribe_transactions(
         &self,
+        start_after: Option<Digest>,
         filter: Option<SubscriptionTransactionFilter>,
     ) -> impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>> {
         self.streamer
-            .subscribe_transactions(None)
+            .subscribe_transactions(
+                start_after.map(|digest| RecoveryPoint::Exclusive(TransactionDigest::from(digest))),
+            )
             .try_filter(move |stored| future::ready(Self::matches_filter(filter.as_ref(), stored)))
             .then(|stored| {
                 let subscription_item = match stored {
@@ -205,10 +237,13 @@ impl GraphQLStream {
     /// Subscribe to events from IOTA Network.
     pub(crate) fn subscribe_events(
         &self,
+        start_after: Option<Digest>,
         filter: Option<SubscriptionEventFilter>,
     ) -> impl Stream<Item = Result<SubscriptionItem<Event>, Error>> {
         self.streamer
-            .subscribe_events(None)
+            .subscribe_events(
+                start_after.map(|digest| RecoveryPoint::Exclusive(TransactionDigest::from(digest))),
+            )
             .try_filter(move |stored| future::ready(Self::matches_filter(filter.as_ref(), stored)))
             .then(|stored| {
                 let subscription_item = match stored {

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -4394,14 +4394,40 @@ type Subscription {
 	Subscribe to incoming transactions from the IOTA network.
 	
 	If no filter is provided, all transactions will be returned.
+	
+	# Stream recovery
+	
+	When `start_after` is provided with the digest of the last transaction
+	the client received, the stream resumes from the transaction
+	immediately after it. The identified transaction itself is not
+	emitted.
 	"""
-	transactions(filter: SubscriptionTransactionFilter): TransactionBlockSubscriptionPayload!
+	transactions(startAfter: String, filter: SubscriptionTransactionFilter): TransactionBlockSubscriptionPayload!
 	"""
 	Subscribe to incoming events from the IOTA network.
 	
 	If no filter is provided, all events will be returned.
+	
+	# Stream recovery
+	
+	Events are streamed in transaction order, all events from a single
+	transaction arrive contiguously before any events from the next one.
+	
+	When `start_after` is provided with a transaction digest, the stream
+	resumes from the transaction immediately after it.
+	
+	Because a single transaction can emit multiple events, a disconnection
+	may leave the client with only a partial set of events from the
+	transaction it was last receiving. A transaction is considered fully
+	received only once the client has seen an event from the following
+	transaction (a digest change signals the previous transaction is
+	complete).
+	
+	On reconnect, clients should pass the digest of the last fully
+	received transaction as `start_after`. The stream resumes from the
+	next transaction, so no partial transaction is ever observed.
 	"""
-	events(filter: SubscriptionEventFilter): EventSubscriptionPayload!
+	events(startAfter: String, filter: SubscriptionEventFilter): EventSubscriptionPayload!
 }
 
 """


### PR DESCRIPTION
# Description of change

This PR adds subscription recovery support to `iota-graphql-rpc`, allowing clients to resume transaction and event subscriptions from a specific transaction digest after a disconnection.

When a `startAfter` digest is provided, the stream first backfills historical data from the database, then seamlessly transitions to live data from the broadcast channel. Without `startAfter`, behavior is unchanged.

## Links to any relevant issues

fixes #11199 

## How the change has been tested

- started a local network using the `iota-localnet`
```shell
cargo r --features indexer  -- start --force-regenesis --with-indexer --with-graphql
```
- First started a grpahql subscription through the grpahiql on `http://localhost:9125`
```graphql
subscription Transactions {
    transactions {
        __typename
        ... on TransactionBlock {
            digest,
           effects {
            checkpoint {
              sequenceNumber,
            }
          }
        }
        ... on Lagged {
            count
        }
    }
}
```
- Stopped the subscription and got the latest digest it returned. Used that digest to start a new subscription.

```graphql
subscription Transactions {
    transactions(startAfter: "5GJHkPzZq94pn74q5Mfd1GtZPC6TXNFN8a2sXYoEVkkd") {
        __typename
        ... on TransactionBlock {
            digest,
           effects {
            checkpoint {
              sequenceNumber,
            }
          }
        }
        ... on Lagged {
            count
        }
    }
}
```

- The client received historical transactions noticeably faster than live ones. Historical data is fetched from the database in batches, limited only by query speed. Live data depends on the network's checkpoint production rate, which is inherently slower. The debug logs confirmed the transition from historical backfill to live streaming.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes
- [x] GraphQL: Subscription queries now accept an optional `startAfter` transaction digest to resume receiving transactions and events from a specific point. For more detailed information consult the graphql schema.