### PR TITLE
feat(consensus): compute strong_vote mask during block creation

### DIFF
--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -245,8 +245,6 @@ pub struct BlockHeaderV2 {
 }
 
 impl BlockHeaderV2 {
-    // Will be used when block construction is gated on consensus_starfish_speed.
-    #[expect(dead_code)]
     pub(crate) fn new(
         epoch: Epoch,
         round: Round,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -33,10 +33,11 @@ use crate::storage::rocksdb_store::RocksDBStore;
 use crate::{CommitConsumer, CommittedSubDag, TransactionClient, storage::mem_store::MemStore};
 use crate::{
     Transaction,
+    authority_set::AuthoritySet,
     block_header::{
-        BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
-        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedOwnShard, VerifiedTransactions,
+        BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockHeaderV2, BlockRef, BlockTimestampMs,
+        GENESIS_ROUND, Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
+        VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, CommitAPI, PendingSubDag},
@@ -892,16 +893,32 @@ impl Core {
         });
 
         // Create the block and insert to storage.
-        let block_header = BlockHeader::V1(BlockHeaderV1::new(
-            self.context.committee.epoch(),
-            clock_round,
-            self.context.own_index,
-            now,
-            ancestors.iter().map(|b| b.reference()).collect(),
-            acknowledgments,
-            commit_votes,
-            transactions_commitment,
-        ));
+        let strong_vote = self.compute_strong_vote(clock_round, &ancestors);
+        let ancestor_refs = ancestors.iter().map(|b| b.reference()).collect();
+        let block_header = if self.context.protocol_config.consensus_starfish_speed() {
+            BlockHeader::V2(BlockHeaderV2::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestor_refs,
+                acknowledgments,
+                commit_votes,
+                transactions_commitment,
+                strong_vote,
+            ))
+        } else {
+            BlockHeader::V1(BlockHeaderV1::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestor_refs,
+                acknowledgments,
+                commit_votes,
+                transactions_commitment,
+            ))
+        };
 
         let signed_block_header = SignedBlockHeader::new(block_header, &self.block_signer)
             .expect("Block signing failed.");
@@ -1256,6 +1273,42 @@ impl Core {
         );
 
         included_ancestors
+    }
+
+    /// Computes the strong_vote bitmask for a block being proposed at
+    /// `clock_round`. Checks data availability for the previous round's
+    /// leader block and its acknowledgments.
+    fn compute_strong_vote(
+        &self,
+        clock_round: Round,
+        ancestors: &[VerifiedBlockHeader],
+    ) -> Option<AuthoritySet> {
+        if !self.context.protocol_config.consensus_starfish_speed() {
+            return None;
+        }
+
+        let leader_round = clock_round.saturating_sub(1);
+        let leader_authority = self.leader_schedule.elect_leader(leader_round, 0);
+
+        let leader_header = ancestors
+            .iter()
+            .find(|a| a.round() == leader_round && a.author() == leader_authority)?;
+
+        let dag_state = self.dag_state.read();
+        let mut missing = AuthoritySet::new();
+
+        let leader_ref = leader_header.reference();
+        if !dag_state.is_data_available(&leader_ref) {
+            missing.insert(leader_ref.author);
+        }
+
+        for ack_ref in leader_header.acknowledgments() {
+            if !dag_state.is_data_available(ack_ref) {
+                missing.insert(ack_ref.author);
+            }
+        }
+
+        Some(missing)
     }
 
     /// Checks whether the leaders of the round exist.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1288,11 +1288,11 @@ impl Core {
         }
 
         let leader_round = clock_round.saturating_sub(1);
-        let leader_authority = self.leader_schedule.elect_leader(leader_round, 0);
+        let leaders = self.leaders(leader_round);
 
-        let leader_header = ancestors
-            .iter()
-            .find(|a| a.round() == leader_round && a.author() == leader_authority)?;
+        let leader_header = ancestors.iter().find(|a| {
+            a.round() == leader_round && leaders.iter().any(|s| s.authority == a.author())
+        })?;
 
         let dag_state = self.dag_state.read();
         let mut missing = AuthoritySet::new();

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -23,7 +23,7 @@ use tokio::{
     sync::{broadcast, watch},
     time::Instant,
 };
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 #[cfg(test)]
 use crate::storage::Store;
@@ -893,9 +893,9 @@ impl Core {
         });
 
         // Create the block and insert to storage.
-        let strong_vote = self.compute_strong_vote(clock_round, &ancestors);
         let ancestor_refs = ancestors.iter().map(|b| b.reference()).collect();
         let block_header = if self.context.protocol_config.consensus_starfish_speed() {
+            let strong_vote = self.compute_strong_vote(clock_round, &ancestors);
             BlockHeader::V2(BlockHeaderV2::new(
                 self.context.committee.epoch(),
                 clock_round,
@@ -1284,6 +1284,7 @@ impl Core {
         ancestors: &[VerifiedBlockHeader],
     ) -> Option<AuthoritySet> {
         if !self.context.protocol_config.consensus_starfish_speed() {
+            error!("compute_strong_vote called while consensus_starfish_speed is disabled");
             return None;
         }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1899,8 +1899,6 @@ impl DagState {
     }
 
     /// Check if a block's transaction data is locally available.
-    // Will be used by strong-vote computation in a later StarfishSpeed step.
-    #[expect(dead_code)]
     pub(crate) fn is_data_available(&self, block_ref: &BlockRef) -> bool {
         let transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
             let Some(header) = self.recent_block_headers.get(block_ref) else {


### PR DESCRIPTION
# Description of change

Compute `strong_vote` bitmask during block proposal. When `consensus_starfish_speed` is enabled, checks data availability for the previous round's leader and its acknowledgments, then creates a V2 block header with the computed mask.

## Links to any relevant issues

Part of #11009
Fixes #11134

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes