### PR TITLE
fix(gRPC): remove legacy index migrations and rename v2 tables to final names

### DIFF
--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 use typed_store::{
     DBMapUtils, TypedStoreError,
+    database::Database,
     rocks::{DBMap, MetricConf},
     traits::Map,
 };
@@ -50,12 +51,7 @@ use crate::{
 /// dedicated `Watermark` variants (`PackageVersionBackfilled`,
 /// `CoinV2Backfilled`, `OwnerV2Backfilled`).  While the backfill runs, affected
 /// endpoints return `Code::Unavailable` with a `RetryInfo` hint.
-///
-/// Version history:
-/// - 1: Initial version with deprecated CF migration + background backfill.
-/// - 2: Removed deprecated CFs (`transactions`, `owner`, `dynamic_field`,
-///   `coin`) and background backfill infrastructure.
-const CURRENT_DB_VERSION: u64 = 2;
+const CURRENT_DB_VERSION: u64 = 1;
 
 /// On-disk directory name for the gRPC indexes store.
 pub const GRPC_INDEXES_DIR: &str = "grpc_indexes";
@@ -361,6 +357,13 @@ struct IndexStoreTables {
     /// the main database.
     transaction_checkpoints: DBMap<TransactionDigest, CheckpointSequenceNumber>,
 
+    /// Deprecated: migrated to `owner`.
+    // TODO(cleanup): Remove this field and `migrate_owner_v2_to_owner` in the
+    // next release once all nodes have migrated.
+    #[allow(dead_code)]
+    #[deprecated_db_map(migration = "migrate_owner_v2_to_owner")]
+    owner_v2: Option<DBMap<OwnerIndexKey, OwnerIndexInfo>>,
+
     /// An index of object ownership.
     ///
     /// Uses fixed-size u64 hash keys for correct RocksDB byte-order iteration.
@@ -372,12 +375,27 @@ struct IndexStoreTables {
     /// address-owned object).
     owner: DBMap<OwnerIndexKey, OwnerIndexInfo>,
 
+    /// Deprecated: migrated to `dynamic_field`.
+    // TODO(cleanup): Remove this field and
+    // `migrate_dynamic_field_v2_to_dynamic_field` in the next release once
+    // all nodes have migrated.
+    #[allow(dead_code)]
+    #[deprecated_db_map(migration = "migrate_dynamic_field_v2_to_dynamic_field")]
+    dynamic_field_v2: Option<DBMap<DynamicFieldKey, ()>>,
+
     /// An index of dynamic fields (children objects).
     ///
     /// Allows an efficient iterator to list all of the dynamic fields owned by
     /// a particular ObjectID. Only the key is stored; field metadata is loaded
     /// on demand from the object store.
     dynamic_field: DBMap<DynamicFieldKey, ()>,
+
+    /// Deprecated: migrated to `coin`.
+    // TODO(cleanup): Remove this field and `migrate_coin_v2_to_coin` in the
+    // next release once all nodes have migrated.
+    #[allow(dead_code)]
+    #[deprecated_db_map(migration = "migrate_coin_v2_to_coin")]
+    coin_v2: Option<DBMap<CoinIndexKey, CoinIndexInfo>>,
 
     /// Coin info with regulated coin metadata.
     /// Bounded by the live object set (one entry per coin type).
@@ -393,6 +411,122 @@ struct IndexStoreTables {
     // NOTE: Authors and Reviewers before adding any new tables ensure that they are either:
     // - bounded in size by the live object set
     // - are prune-able and have corresponding logic in the `prune` function
+}
+
+// ---------------------------------------------------------------------------
+// CF migrations: owner_v2 → owner, dynamic_field_v2 → dynamic_field,
+// coin_v2 → coin.
+//
+// TODO(cleanup): Remove these functions in the next release once all nodes
+// have migrated.
+// ---------------------------------------------------------------------------
+
+/// Migration: copy entries from the deprecated `owner_v2` CF into `owner`.
+fn migrate_owner_v2_to_owner(db: &std::sync::Arc<Database>) -> Result<(), TypedStoreError> {
+    let old = DBMap::<OwnerIndexKey, OwnerIndexInfo>::reopen(
+        db,
+        Some("owner_v2"),
+        &typed_store::rocks::ReadWriteOptions::default(),
+        true,
+    )?;
+    let new = DBMap::<OwnerIndexKey, OwnerIndexInfo>::reopen(
+        db,
+        Some("owner"),
+        &typed_store::rocks::ReadWriteOptions::default(),
+        false,
+    )?;
+
+    const BATCH_SIZE: usize = 10_000;
+    let mut batch = new.batch();
+    let mut count = 0usize;
+    for item in old.safe_iter() {
+        let (key, value) = item?;
+        batch.insert_batch(&new, std::iter::once((key, value)))?;
+        count += 1;
+        if count.is_multiple_of(BATCH_SIZE) {
+            batch.write()?;
+            batch = new.batch();
+        }
+    }
+    if !count.is_multiple_of(BATCH_SIZE) {
+        batch.write()?;
+    }
+
+    info!("migrated owner_v2 -> owner ({count} entries)");
+    Ok(())
+}
+
+/// Migration: copy entries from the deprecated `dynamic_field_v2` CF into
+/// `dynamic_field`.
+fn migrate_dynamic_field_v2_to_dynamic_field(
+    db: &std::sync::Arc<Database>,
+) -> Result<(), TypedStoreError> {
+    let old = DBMap::<DynamicFieldKey, ()>::reopen(
+        db,
+        Some("dynamic_field_v2"),
+        &typed_store::rocks::ReadWriteOptions::default(),
+        true,
+    )?;
+    let new = DBMap::<DynamicFieldKey, ()>::reopen(
+        db,
+        Some("dynamic_field"),
+        &typed_store::rocks::ReadWriteOptions::default(),
+        false,
+    )?;
+
+    const BATCH_SIZE: usize = 10_000;
+    let mut batch = new.batch();
+    let mut count = 0usize;
+    for item in old.safe_iter() {
+        let (key, ()) = item?;
+        batch.insert_batch(&new, std::iter::once((key, ())))?;
+        count += 1;
+        if count.is_multiple_of(BATCH_SIZE) {
+            batch.write()?;
+            batch = new.batch();
+        }
+    }
+    if !count.is_multiple_of(BATCH_SIZE) {
+        batch.write()?;
+    }
+
+    info!("migrated dynamic_field_v2 -> dynamic_field ({count} entries)");
+    Ok(())
+}
+
+/// Migration: copy entries from the deprecated `coin_v2` CF into `coin`.
+fn migrate_coin_v2_to_coin(db: &std::sync::Arc<Database>) -> Result<(), TypedStoreError> {
+    let old = DBMap::<CoinIndexKey, CoinIndexInfo>::reopen(
+        db,
+        Some("coin_v2"),
+        &typed_store::rocks::ReadWriteOptions::default(),
+        true,
+    )?;
+    let new = DBMap::<CoinIndexKey, CoinIndexInfo>::reopen(
+        db,
+        Some("coin"),
+        &typed_store::rocks::ReadWriteOptions::default(),
+        false,
+    )?;
+
+    const BATCH_SIZE: usize = 10_000;
+    let mut batch = new.batch();
+    let mut count = 0usize;
+    for item in old.safe_iter() {
+        let (key, value) = item?;
+        batch.insert_batch(&new, std::iter::once((key, value)))?;
+        count += 1;
+        if count.is_multiple_of(BATCH_SIZE) {
+            batch.write()?;
+            batch = new.batch();
+        }
+    }
+    if !count.is_multiple_of(BATCH_SIZE) {
+        batch.write()?;
+    }
+
+    info!("migrated coin_v2 -> coin ({count} entries)");
+    Ok(())
 }
 
 impl IndexStoreTables {

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -20,14 +20,14 @@ use iota_types::{
     messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber},
     object::{Object, Owner},
     storage::{
-        AccountOwnedObjectInfo, DynamicFieldKey, EpochInfo, OwnedObjectV2Cursor,
-        OwnedObjectV2IteratorItem, PackageVersionInfo, PackageVersionIteratorItem,
-        PackageVersionKey, TransactionInfo, error::Error as StorageError,
+        AccountOwnedObjectInfo, DynamicFieldKey, EpochInfo, OwnedObjectCursor,
+        OwnedObjectIteratorItem, PackageVersionInfo, PackageVersionIteratorItem, PackageVersionKey,
+        TransactionInfo, error::Error as StorageError,
     },
 };
 use move_core_types::language_storage::StructTag;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tracing::{debug, info};
 use typed_store::{
     DBMapUtils, TypedStoreError,
@@ -45,12 +45,6 @@ use crate::{
 /// Bump this when changing the serialization format of an existing table.
 /// A version mismatch triggers a full re-index via
 /// `needs_to_do_initialization`.
-///
-/// NOTE: Adding a *new* table does NOT require a version bump.  New tables
-/// start empty and are populated by a background backfill task tracked via
-/// dedicated `Watermark` variants (`PackageVersionBackfilled`,
-/// `CoinV2Backfilled`, `OwnerV2Backfilled`).  While the backfill runs, affected
-/// endpoints return `Code::Unavailable` with a `RetryInfo` hint.
 const CURRENT_DB_VERSION: u64 = 1;
 
 /// On-disk directory name for the gRPC indexes store.
@@ -82,7 +76,7 @@ pub struct CoinIndexInfo {
     pub regulated_coin_metadata_object_id: Option<ObjectID>,
 }
 
-impl From<CoinIndexInfo> for iota_types::storage::CoinInfoV2 {
+impl From<CoinIndexInfo> for iota_types::storage::CoinInfo {
     fn from(info: CoinIndexInfo) -> Self {
         Self {
             coin_metadata_object_id: info.coin_metadata_object_id,
@@ -233,7 +227,7 @@ fn hash_type_params(tag: &StructTag) -> u64 {
 /// position (inclusive) so that RocksDB can seek directly.
 fn owner_bounds(
     owner: IotaAddress,
-    cursor: Option<&OwnedObjectV2Cursor>,
+    cursor: Option<&OwnedObjectCursor>,
     filter: &OwnerTypeFilter,
 ) -> (OwnerIndexKey, OwnerIndexKey) {
     let lower_bound = if let Some(c) = cursor {
@@ -421,27 +415,43 @@ struct IndexStoreTables {
 // have migrated.
 // ---------------------------------------------------------------------------
 
-/// Migration: copy entries from the deprecated `owner_v2` CF into `owner`.
-fn migrate_owner_v2_to_owner(db: &std::sync::Arc<Database>) -> Result<(), TypedStoreError> {
-    let old = DBMap::<OwnerIndexKey, OwnerIndexInfo>::reopen(
+/// Copy all entries from the `old_cf` column family into `new_cf`, applying
+/// `map_fn` to each `(key, value)` pair along the way. Writes are flushed in
+/// chunks of 10,000 entries.
+///
+/// Returns the number of entries copied.
+fn migrate_cf<K1, V1, K2, V2, F>(
+    db: &std::sync::Arc<Database>,
+    old_cf: &str,
+    new_cf: &str,
+    mut map_fn: F,
+) -> Result<usize, TypedStoreError>
+where
+    K1: Serialize + DeserializeOwned,
+    V1: Serialize + DeserializeOwned,
+    K2: Serialize,
+    V2: Serialize,
+    F: FnMut((K1, V1)) -> (K2, V2),
+{
+    const BATCH_SIZE: usize = 10_000;
+    let old = DBMap::<K1, V1>::reopen(
         db,
-        Some("owner_v2"),
+        Some(old_cf),
         &typed_store::rocks::ReadWriteOptions::default(),
         true,
     )?;
-    let new = DBMap::<OwnerIndexKey, OwnerIndexInfo>::reopen(
+    let new = DBMap::<K2, V2>::reopen(
         db,
-        Some("owner"),
+        Some(new_cf),
         &typed_store::rocks::ReadWriteOptions::default(),
         false,
     )?;
 
-    const BATCH_SIZE: usize = 10_000;
     let mut batch = new.batch();
     let mut count = 0usize;
     for item in old.safe_iter() {
-        let (key, value) = item?;
-        batch.insert_batch(&new, std::iter::once((key, value)))?;
+        let mapped = map_fn(item?);
+        batch.insert_batch(&new, std::iter::once(mapped))?;
         count += 1;
         if count.is_multiple_of(BATCH_SIZE) {
             batch.write()?;
@@ -451,7 +461,17 @@ fn migrate_owner_v2_to_owner(db: &std::sync::Arc<Database>) -> Result<(), TypedS
     if !count.is_multiple_of(BATCH_SIZE) {
         batch.write()?;
     }
+    Ok(count)
+}
 
+/// Migration: copy entries from the deprecated `owner_v2` CF into `owner`.
+fn migrate_owner_v2_to_owner(db: &std::sync::Arc<Database>) -> Result<(), TypedStoreError> {
+    let count = migrate_cf::<OwnerIndexKey, OwnerIndexInfo, _, _, _>(
+        db,
+        "owner_v2",
+        "owner",
+        std::convert::identity,
+    )?;
     info!("migrated owner_v2 -> owner ({count} entries)");
     Ok(())
 }
@@ -461,70 +481,24 @@ fn migrate_owner_v2_to_owner(db: &std::sync::Arc<Database>) -> Result<(), TypedS
 fn migrate_dynamic_field_v2_to_dynamic_field(
     db: &std::sync::Arc<Database>,
 ) -> Result<(), TypedStoreError> {
-    let old = DBMap::<DynamicFieldKey, ()>::reopen(
+    let count = migrate_cf::<DynamicFieldKey, (), _, _, _>(
         db,
-        Some("dynamic_field_v2"),
-        &typed_store::rocks::ReadWriteOptions::default(),
-        true,
+        "dynamic_field_v2",
+        "dynamic_field",
+        std::convert::identity,
     )?;
-    let new = DBMap::<DynamicFieldKey, ()>::reopen(
-        db,
-        Some("dynamic_field"),
-        &typed_store::rocks::ReadWriteOptions::default(),
-        false,
-    )?;
-
-    const BATCH_SIZE: usize = 10_000;
-    let mut batch = new.batch();
-    let mut count = 0usize;
-    for item in old.safe_iter() {
-        let (key, ()) = item?;
-        batch.insert_batch(&new, std::iter::once((key, ())))?;
-        count += 1;
-        if count.is_multiple_of(BATCH_SIZE) {
-            batch.write()?;
-            batch = new.batch();
-        }
-    }
-    if !count.is_multiple_of(BATCH_SIZE) {
-        batch.write()?;
-    }
-
     info!("migrated dynamic_field_v2 -> dynamic_field ({count} entries)");
     Ok(())
 }
 
 /// Migration: copy entries from the deprecated `coin_v2` CF into `coin`.
 fn migrate_coin_v2_to_coin(db: &std::sync::Arc<Database>) -> Result<(), TypedStoreError> {
-    let old = DBMap::<CoinIndexKey, CoinIndexInfo>::reopen(
+    let count = migrate_cf::<CoinIndexKey, CoinIndexInfo, _, _, _>(
         db,
-        Some("coin_v2"),
-        &typed_store::rocks::ReadWriteOptions::default(),
-        true,
+        "coin_v2",
+        "coin",
+        std::convert::identity,
     )?;
-    let new = DBMap::<CoinIndexKey, CoinIndexInfo>::reopen(
-        db,
-        Some("coin"),
-        &typed_store::rocks::ReadWriteOptions::default(),
-        false,
-    )?;
-
-    const BATCH_SIZE: usize = 10_000;
-    let mut batch = new.batch();
-    let mut count = 0usize;
-    for item in old.safe_iter() {
-        let (key, value) = item?;
-        batch.insert_batch(&new, std::iter::once((key, value)))?;
-        count += 1;
-        if count.is_multiple_of(BATCH_SIZE) {
-            batch.write()?;
-            batch = new.batch();
-        }
-    }
-    if !count.is_multiple_of(BATCH_SIZE) {
-        batch.write()?;
-    }
-
     info!("migrated coin_v2 -> coin ({count} entries)");
     Ok(())
 }
@@ -980,7 +954,7 @@ impl IndexStoreTables {
     fn owner_iter(
         &self,
         owner: IotaAddress,
-        cursor: Option<&OwnedObjectV2Cursor>,
+        cursor: Option<&OwnedObjectCursor>,
         type_filter: OwnerTypeFilter,
     ) -> Result<
         impl Iterator<Item = Result<(OwnerIndexKey, OwnerIndexInfo), TypedStoreError>> + '_,
@@ -1169,7 +1143,7 @@ impl GrpcIndexesStore {
     pub fn owner_iter(
         &self,
         owner: IotaAddress,
-        cursor: Option<&OwnedObjectV2Cursor>,
+        cursor: Option<&OwnedObjectCursor>,
         type_filter: OwnerTypeFilter,
     ) -> Result<
         impl Iterator<Item = Result<(OwnerIndexKey, OwnerIndexInfo), TypedStoreError>> + '_,
@@ -1230,9 +1204,9 @@ impl iota_node_storage::GrpcIndexes for GrpcIndexesStore {
     fn account_owned_objects_info_iter(
         &self,
         owner: IotaAddress,
-        cursor: Option<&OwnedObjectV2Cursor>,
+        cursor: Option<&OwnedObjectCursor>,
         object_type: Option<StructTag>,
-    ) -> iota_types::storage::error::Result<Box<dyn Iterator<Item = OwnedObjectV2IteratorItem> + '_>>
+    ) -> iota_types::storage::error::Result<Box<dyn Iterator<Item = OwnedObjectIteratorItem> + '_>>
     {
         let type_filter = OwnerTypeFilter::from_struct_tag(object_type.as_ref());
         let iter = self
@@ -1241,7 +1215,7 @@ impl iota_node_storage::GrpcIndexes for GrpcIndexesStore {
             .map_err(|e| StorageError::custom(e.to_string()))?
             .map(|result| {
                 result.map(|(key, info)| {
-                    let cursor = OwnedObjectV2Cursor {
+                    let cursor = OwnedObjectCursor {
                         object_type_identifier: key.object_type_identifier,
                         object_type_params: key.object_type_params,
                         inverted_balance: key.inverted_balance,
@@ -1276,7 +1250,7 @@ impl iota_node_storage::GrpcIndexes for GrpcIndexesStore {
     fn get_coin_info(
         &self,
         coin_type: &StructTag,
-    ) -> iota_types::storage::error::Result<Option<iota_types::storage::CoinInfoV2>> {
+    ) -> iota_types::storage::error::Result<Option<iota_types::storage::CoinInfo>> {
         self.tables
             .get_coin_info(coin_type)
             .map(|opt| opt.map(Into::into))

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -45,6 +45,12 @@ use crate::{
 /// A version mismatch triggers a full re-index via
 /// `needs_to_do_initialization`.
 ///
+/// NOTE: Adding a *new* table does NOT require a version bump.  New tables
+/// start empty and are populated by a background backfill task tracked via
+/// dedicated `Watermark` variants (`PackageVersionBackfilled`,
+/// `CoinV2Backfilled`, `OwnerV2Backfilled`).  While the backfill runs, affected
+/// endpoints return `Code::Unavailable` with a `RetryInfo` hint.
+///
 /// Version history:
 /// - 1: Initial version with deprecated CF migration + background backfill.
 /// - 2: Removed deprecated CFs (`transactions`, `owner`, `dynamic_field`,

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -6,15 +6,12 @@ use std::{
     collections::{BTreeMap, HashMap},
     hash::Hasher,
     path::{Path, PathBuf},
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
 use iota_types::{
-    base_types::{IotaAddress, MoveObjectType, ObjectID, SequenceNumber},
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
     committee::EpochId,
     digests::TransactionDigest,
     error::IotaResult,
@@ -34,7 +31,6 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 use typed_store::{
     DBMapUtils, TypedStoreError,
-    database::Database,
     rocks::{DBMap, MetricConf},
     traits::Map,
 };
@@ -49,19 +45,14 @@ use crate::{
 /// A version mismatch triggers a full re-index via
 /// `needs_to_do_initialization`.
 ///
-/// NOTE: Adding a *new* table does NOT require a version bump.  New tables
-/// start empty and are populated by a background backfill task tracked via
-/// dedicated `Watermark` variants (`PackageVersionBackfilled`,
-/// `CoinV2Backfilled`, `OwnerV2Backfilled`).  While the backfill runs, affected
-/// endpoints return `Code::Unavailable` with a `RetryInfo` hint.
-const CURRENT_DB_VERSION: u64 = 1;
+/// Version history:
+/// - 1: Initial version with deprecated CF migration + background backfill.
+/// - 2: Removed deprecated CFs (`transactions`, `owner`, `dynamic_field`,
+///   `coin`) and background backfill infrastructure.
+const CURRENT_DB_VERSION: u64 = 2;
 
 /// On-disk directory name for the gRPC indexes store.
 pub const GRPC_INDEXES_DIR: &str = "grpc_indexes";
-
-/// Legacy directory name from before the REST API removal.
-/// Used by `migrate_legacy_dirs` to find and rename the old directory.
-const LEGACY_INDEX_DIR: &str = "rest_index";
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct MetadataInfo {
@@ -74,34 +65,6 @@ struct MetadataInfo {
 pub enum Watermark {
     Indexed,
     Pruned,
-    /// Written once the `package_version` table backfill has completed.
-    PackageVersionBackfilled,
-    /// Written once the `coin_v2` table backfill has completed.
-    CoinV2Backfilled,
-    /// Written once the `owner_v2` table backfill has completed.
-    OwnerV2Backfilled,
-}
-
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct OwnerIndexKey {
-    pub owner: IotaAddress,
-    pub object_id: ObjectID,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct OwnerIndexInfo {
-    // object_id of the object is a part of the Key
-    pub version: SequenceNumber,
-    pub type_: MoveObjectType,
-}
-
-impl OwnerIndexInfo {
-    pub fn new(object: &Object) -> Self {
-        Self {
-            version: object.version(),
-            type_: object.type_().expect("packages cannot be owned").to_owned(),
-        }
-    }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -109,16 +72,16 @@ pub struct CoinIndexKey {
     coin_type: StructTag,
 }
 
-/// Extended coin index value that absorbs `regulated_coin` into a single table.
+/// Coin index value with regulated coin metadata.
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub struct CoinIndexInfoV2 {
+pub struct CoinIndexInfo {
     pub coin_metadata_object_id: Option<ObjectID>,
     pub treasury_object_id: Option<ObjectID>,
     pub regulated_coin_metadata_object_id: Option<ObjectID>,
 }
 
-impl From<CoinIndexInfoV2> for iota_types::storage::CoinInfoV2 {
-    fn from(info: CoinIndexInfoV2) -> Self {
+impl From<CoinIndexInfo> for iota_types::storage::CoinInfoV2 {
+    fn from(info: CoinIndexInfo) -> Self {
         Self {
             coin_metadata_object_id: info.coin_metadata_object_id,
             treasury_object_id: info.treasury_object_id,
@@ -127,7 +90,7 @@ impl From<CoinIndexInfoV2> for iota_types::storage::CoinInfoV2 {
     }
 }
 
-impl CoinIndexInfoV2 {
+impl CoinIndexInfo {
     fn merge(&mut self, other: Self) {
         self.coin_metadata_object_id = self
             .coin_metadata_object_id
@@ -139,35 +102,35 @@ impl CoinIndexInfoV2 {
     }
 }
 
-/// Insert-or-merge a `CoinIndexInfoV2` into an in-memory HashMap.
-fn merge_coin_into_v2(
-    index: &mut HashMap<CoinIndexKey, CoinIndexInfoV2>,
+/// Insert-or-merge a [`CoinIndexInfo`] into an in-memory HashMap.
+fn merge_coin_into(
+    index: &mut HashMap<CoinIndexKey, CoinIndexInfo>,
     key: CoinIndexKey,
-    v2: CoinIndexInfoV2,
+    info: CoinIndexInfo,
 ) {
     use std::collections::hash_map::Entry;
     match index.entry(key) {
-        Entry::Occupied(mut o) => o.get_mut().merge(v2),
+        Entry::Occupied(mut o) => o.get_mut().merge(info),
         Entry::Vacant(v) => {
-            v.insert(v2);
+            v.insert(info);
         }
     }
 }
 
-/// Read-modify-write a `CoinIndexInfoV2` entry in the `coin_v2` DB table.
+/// Read-modify-write a [`CoinIndexInfo`] entry in the `coin` DB table.
 ///
 /// Reads the current value (if any), applies `mutate`, and stages the result
 /// into `batch`.  Used for incremental indexing where the full value is built
 /// across multiple objects (e.g. `CoinMetadata` + `RegulatedCoinMetadata`).
-fn read_merge_write_coin_v2(
-    table: &DBMap<CoinIndexKey, CoinIndexInfoV2>,
+fn read_merge_write_coin(
+    table: &DBMap<CoinIndexKey, CoinIndexInfo>,
     batch: &mut typed_store::rocks::DBBatch,
     key: CoinIndexKey,
-    mutate: impl FnOnce(&mut CoinIndexInfoV2),
+    mutate: impl FnOnce(&mut CoinIndexInfo),
 ) -> Result<(), StorageError> {
-    let mut v2 = table.get(&key).ok().flatten().unwrap_or_default();
-    mutate(&mut v2);
-    batch.insert_batch(table, [(key, v2)])?;
+    let mut entry = table.get(&key).ok().flatten().unwrap_or_default();
+    mutate(&mut entry);
+    batch.insert_batch(table, [(key, entry)])?;
     Ok(())
 }
 
@@ -185,7 +148,7 @@ fn read_merge_write_coin_v2(
 /// group.  Among coins, `!balance` inverts the natural order so that **higher
 /// balances sort first** (richest first).
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct OwnerIndexKeyV2 {
+pub struct OwnerIndexKey {
     pub owner: IotaAddress,
     pub object_type_identifier: u64,
     pub object_type_params: u64,
@@ -194,12 +157,12 @@ pub struct OwnerIndexKeyV2 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct OwnerIndexInfoV2 {
+pub struct OwnerIndexInfo {
     pub object_type: StructTag,
     pub version: SequenceNumber,
 }
 
-/// Type filter for `owner_v2_iter`.
+/// Type filter for `owner_iter`.
 ///
 /// - `None` — all objects for the owner.
 /// - `BaseType` — all objects whose `address::module::name` matches (e.g. all
@@ -207,7 +170,7 @@ pub struct OwnerIndexInfoV2 {
 /// - `ExactType` — only objects of the exact `StructTag` (e.g. `Coin<IOTA>`).
 ///   Post-filters hash collisions via `tag`.
 #[derive(Clone)]
-pub enum OwnerV2TypeFilter {
+pub enum OwnerTypeFilter {
     None,
     BaseType {
         id_hash: u64,
@@ -220,12 +183,12 @@ pub enum OwnerV2TypeFilter {
     },
 }
 
-impl OwnerV2TypeFilter {
-    /// Construct an `OwnerV2TypeFilter` from an optional `StructTag` filter.
+impl OwnerTypeFilter {
+    /// Construct an `OwnerTypeFilter` from an optional `StructTag` filter.
     ///
-    /// If `None`, returns `OwnerV2TypeFilter::None`.  If `Some(tag)` with no
-    /// type params, returns `OwnerV2TypeFilter::BaseType`.  If `Some(tag)`
-    /// with type params, returns `OwnerV2TypeFilter::ExactType`.
+    /// If `None`, returns `OwnerTypeFilter::None`.  If `Some(tag)` with no
+    /// type params, returns `OwnerTypeFilter::BaseType`.  If `Some(tag)`
+    /// with type params, returns `OwnerTypeFilter::ExactType`.
     pub fn from_struct_tag(tag: Option<&StructTag>) -> Self {
         if let Some(tag) = tag {
             if tag.type_params.is_empty() {
@@ -261,19 +224,19 @@ fn hash_type_params(tag: &StructTag) -> u64 {
     hasher.finish()
 }
 
-/// Compute inclusive lower and upper `OwnerIndexKeyV2` bounds for a
+/// Compute inclusive lower and upper `OwnerIndexKey` bounds for a
 /// `safe_iter_with_bounds` range scan, narrowed by `type_filter`.
 ///
 /// When `cursor` is `Some`, the lower bound is set to the cursor's exact
 /// position (inclusive) so that RocksDB can seek directly.
-fn owner_v2_bounds(
+fn owner_bounds(
     owner: IotaAddress,
     cursor: Option<&OwnedObjectV2Cursor>,
-    filter: &OwnerV2TypeFilter,
-) -> (OwnerIndexKeyV2, OwnerIndexKeyV2) {
+    filter: &OwnerTypeFilter,
+) -> (OwnerIndexKey, OwnerIndexKey) {
     let lower_bound = if let Some(c) = cursor {
-        // Resume from the exact cursor position in the v2 key space.
-        OwnerIndexKeyV2 {
+        // Resume from the exact cursor position.
+        OwnerIndexKey {
             owner,
             object_type_identifier: c.object_type_identifier,
             object_type_params: c.object_type_params,
@@ -282,15 +245,15 @@ fn owner_v2_bounds(
         }
     } else {
         let (lower_id, _, lower_params, _) = match filter {
-            OwnerV2TypeFilter::None => (0, u64::MAX, 0, u64::MAX),
-            OwnerV2TypeFilter::BaseType { id_hash, .. } => (*id_hash, *id_hash, 0, u64::MAX),
-            OwnerV2TypeFilter::ExactType {
+            OwnerTypeFilter::None => (0, u64::MAX, 0, u64::MAX),
+            OwnerTypeFilter::BaseType { id_hash, .. } => (*id_hash, *id_hash, 0, u64::MAX),
+            OwnerTypeFilter::ExactType {
                 id_hash,
                 params_hash,
                 ..
             } => (*id_hash, *id_hash, *params_hash, *params_hash),
         };
-        OwnerIndexKeyV2 {
+        OwnerIndexKey {
             owner,
             object_type_identifier: lower_id,
             object_type_params: lower_params,
@@ -300,16 +263,16 @@ fn owner_v2_bounds(
     };
 
     let (_, upper_bound_id, _, upper_bound_params) = match filter {
-        OwnerV2TypeFilter::None => (0, u64::MAX, 0, u64::MAX),
-        OwnerV2TypeFilter::BaseType { id_hash, .. } => (*id_hash, *id_hash, 0, u64::MAX),
-        OwnerV2TypeFilter::ExactType {
+        OwnerTypeFilter::None => (0, u64::MAX, 0, u64::MAX),
+        OwnerTypeFilter::BaseType { id_hash, .. } => (*id_hash, *id_hash, 0, u64::MAX),
+        OwnerTypeFilter::ExactType {
             id_hash,
             params_hash,
             ..
         } => (*id_hash, *id_hash, *params_hash, *params_hash),
     };
 
-    let upper_bound = OwnerIndexKeyV2 {
+    let upper_bound = OwnerIndexKey {
         owner,
         object_type_identifier: upper_bound_id,
         object_type_params: upper_bound_params,
@@ -320,11 +283,8 @@ fn owner_v2_bounds(
     (lower_bound, upper_bound)
 }
 
-/// Build an `OwnerIndexKeyV2` for an address-owned object.
-fn make_owner_v2_key(
-    owner: IotaAddress,
-    object: &Object,
-) -> Option<(OwnerIndexKeyV2, OwnerIndexInfoV2)> {
+/// Build an `OwnerIndexKey` for an address-owned object.
+fn make_owner_key(owner: IotaAddress, object: &Object) -> Option<(OwnerIndexKey, OwnerIndexInfo)> {
     let struct_tag: StructTag = object.type_()?.clone().into();
     let id_hash = hash_type_identifier(&struct_tag);
     let params_hash = hash_type_params(&struct_tag);
@@ -340,14 +300,14 @@ fn make_owner_v2_key(
         None
     };
 
-    let key = OwnerIndexKeyV2 {
+    let key = OwnerIndexKey {
         owner,
         object_type_identifier: id_hash,
         object_type_params: params_hash,
         inverted_balance,
         object_id: object.id(),
     };
-    let info = OwnerIndexInfoV2 {
+    let info = OwnerIndexInfo {
         object_type: struct_tag,
         version: object.version(),
     };
@@ -389,22 +349,11 @@ struct IndexStoreTables {
     // TODO: https://github.com/iotaledger/iota/issues/10957
     epochs: DBMap<EpochId, EpochInfo>,
 
-    /// Deprecated: migrated to `transaction_checkpoints` (checkpoint-only).
-    #[allow(dead_code)]
-    #[deprecated_db_map(migration = "migrate_transactions_to_checkpoints")]
-    transactions: Option<DBMap<TransactionDigest, TransactionInfo>>,
-
     /// Maps transaction digests to the checkpoint that contains them.
     ///
     /// Only contains entries for transactions which have yet to be pruned from
     /// the main database.
     transaction_checkpoints: DBMap<TransactionDigest, CheckpointSequenceNumber>,
-
-    /// Deprecated: was used by the removed REST API for object ownership
-    /// queries.
-    #[allow(dead_code)]
-    #[deprecated_db_map]
-    owner: Option<DBMap<(), ()>>,
 
     /// An index of object ownership.
     ///
@@ -415,33 +364,18 @@ struct IndexStoreTables {
     /// Full `StructTag` stored in value for collision filtering & API
     /// responses. Bounded by the live object set (one entry per
     /// address-owned object).
-    // TODO: Rename to `owner` once the deprecated `owner` CF has been dropped
-    owner_v2: DBMap<OwnerIndexKeyV2, OwnerIndexInfoV2>,
-
-    /// Deprecated: was the dynamic field index with full field metadata.
-    /// Replaced by `dynamic_field_v2` which stores only keys.
-    #[allow(dead_code)]
-    #[deprecated_db_map(migration = "migrate_dynamic_field_to_v2")]
-    dynamic_field: Option<DBMap<DynamicFieldKey, LegacyDynamicFieldIndexInfo>>,
+    owner: DBMap<OwnerIndexKey, OwnerIndexInfo>,
 
     /// An index of dynamic fields (children objects).
     ///
     /// Allows an efficient iterator to list all of the dynamic fields owned by
     /// a particular ObjectID. Only the key is stored; field metadata is loaded
     /// on demand from the object store.
-    // TODO: Rename to `dynamic_field` once the deprecated `dynamic_field` CF
-    // has been dropped
-    dynamic_field_v2: DBMap<DynamicFieldKey, ()>,
+    dynamic_field: DBMap<DynamicFieldKey, ()>,
 
-    /// Deprecated: was used by the removed REST API for coin info queries.
-    #[allow(dead_code)]
-    #[deprecated_db_map]
-    coin: Option<DBMap<(), ()>>,
-
-    /// Same key as `coin`, extended value with regulated coin metadata.
+    /// Coin info with regulated coin metadata.
     /// Bounded by the live object set (one entry per coin type).
-    // TODO: Rename to `coin` once the deprecated `coin` CF has been dropped
-    coin_v2: DBMap<CoinIndexKey, CoinIndexInfoV2>,
+    coin: DBMap<CoinIndexKey, CoinIndexInfo>,
 
     /// An index of Package versions.
     ///
@@ -453,98 +387,6 @@ struct IndexStoreTables {
     // NOTE: Authors and Reviewers before adding any new tables ensure that they are either:
     // - bounded in size by the live object set
     // - are prune-able and have corresponding logic in the `prune` function
-}
-
-/// Retained only for deserializing legacy `dynamic_field` CF entries during
-/// migration to `dynamic_field_v2`.
-#[derive(Serialize, Deserialize)]
-struct LegacyDynamicFieldIndexInfo {
-    #[allow(dead_code)]
-    dynamic_field_type: iota_types::dynamic_field::DynamicFieldType,
-    #[allow(dead_code)]
-    name_type: move_core_types::language_storage::TypeTag,
-    #[allow(dead_code)]
-    name_value: Vec<u8>,
-    #[allow(dead_code)]
-    dynamic_object_id: Option<ObjectID>,
-}
-
-/// Migration: copy keys from the old `dynamic_field` table (which stored full
-/// field metadata) into `dynamic_field_v2` (keys only, unit value).
-fn migrate_dynamic_field_to_v2(db: &std::sync::Arc<Database>) -> Result<(), TypedStoreError> {
-    use typed_store::traits::Map;
-
-    let old = DBMap::<DynamicFieldKey, LegacyDynamicFieldIndexInfo>::reopen(
-        db,
-        Some("dynamic_field"),
-        &typed_store::rocks::ReadWriteOptions::default(),
-        true,
-    )?;
-    let new = DBMap::<DynamicFieldKey, ()>::reopen(
-        db,
-        Some("dynamic_field_v2"),
-        &typed_store::rocks::ReadWriteOptions::default(),
-        false,
-    )?;
-
-    const BATCH_SIZE: usize = 10_000;
-    let mut batch = new.batch();
-    let mut count = 0usize;
-    for item in old.safe_iter() {
-        let (key, _) = item?;
-        batch.insert_batch(&new, std::iter::once((key, ())))?;
-        count += 1;
-        if count.is_multiple_of(BATCH_SIZE) {
-            batch.write()?;
-            batch = new.batch();
-        }
-    }
-    if !count.is_multiple_of(BATCH_SIZE) {
-        batch.write()?;
-    }
-
-    info!("migrated dynamic_field -> dynamic_field_v2 ({count} entries)");
-    Ok(())
-}
-
-/// Migration: copy checkpoint numbers from old `transactions` table into
-/// `transaction_checkpoints`, discarding the now-unused `object_types` field.
-fn migrate_transactions_to_checkpoints(
-    db: &std::sync::Arc<Database>,
-) -> Result<(), TypedStoreError> {
-    use typed_store::traits::Map;
-
-    let old = DBMap::<TransactionDigest, TransactionInfo>::reopen(
-        db,
-        Some("transactions"),
-        &typed_store::rocks::ReadWriteOptions::default(),
-        true,
-    )?;
-    let new = DBMap::<TransactionDigest, CheckpointSequenceNumber>::reopen(
-        db,
-        Some("transaction_checkpoints"),
-        &typed_store::rocks::ReadWriteOptions::default(),
-        false,
-    )?;
-
-    const BATCH_SIZE: usize = 10_000;
-    let mut batch = new.batch();
-    let mut count = 0usize;
-    for item in old.safe_iter() {
-        let (digest, info) = item?;
-        batch.insert_batch(&new, std::iter::once((digest, info.checkpoint)))?;
-        count += 1;
-        if count.is_multiple_of(BATCH_SIZE) {
-            batch.write()?;
-            batch = new.batch();
-        }
-    }
-    if !count.is_multiple_of(BATCH_SIZE) {
-        batch.write()?;
-    }
-
-    info!("migrated transactions -> transaction_checkpoints");
-    Ok(())
 }
 
 impl IndexStoreTables {
@@ -610,11 +452,11 @@ impl IndexStoreTables {
 
         self.initialize_current_epoch(authority_store, checkpoint_store)?;
 
-        let coin_v2_index = Mutex::new(HashMap::new());
+        let coin_index = Mutex::new(HashMap::new());
 
         let make_live_object_indexer = GrpcParLiveObjectSetIndexer {
             tables: self,
-            coin_v2_index: &coin_v2_index,
+            coin_index: &coin_index,
         };
 
         crate::par_index_live_object_set::par_index_live_object_set(
@@ -622,21 +464,12 @@ impl IndexStoreTables {
             &make_live_object_indexer,
         )?;
 
-        self.coin_v2
-            .multi_insert(coin_v2_index.into_inner().unwrap())?;
+        self.coin.multi_insert(coin_index.into_inner().unwrap())?;
 
         self.watermark.insert(
             &Watermark::Indexed,
             &highest_executed_checkpoint.unwrap_or(0),
         )?;
-
-        // Mark the new backfill-only tables as complete: a full init populates
-        // them via par_index_live_object_set, so no background backfill needed.
-        self.watermark
-            .insert(&Watermark::PackageVersionBackfilled, &0u64)?;
-        self.watermark.insert(&Watermark::CoinV2Backfilled, &0u64)?;
-        self.watermark
-            .insert(&Watermark::OwnerV2Backfilled, &0u64)?;
 
         self.meta.insert(
             &(),
@@ -883,21 +716,21 @@ impl IndexStoreTables {
         checkpoint: &CheckpointData,
         batch: &mut typed_store::rocks::DBBatch,
     ) -> Result<(), StorageError> {
-        let mut coin_v2_index: HashMap<CoinIndexKey, CoinIndexInfoV2> = HashMap::new();
+        let mut coin_index: HashMap<CoinIndexKey, CoinIndexInfo> = HashMap::new();
 
         for tx in &checkpoint.transactions {
             // determine changes from removed objects
             for removed_object in tx.removed_objects_pre_version() {
                 match removed_object.owner() {
                     Owner::AddressOwner(address) => {
-                        // owner_v2: delete old entry
-                        if let Some((v2_key, _)) = make_owner_v2_key(*address, removed_object) {
-                            batch.delete_batch(&self.owner_v2, [v2_key])?;
+                        // owner: delete old entry
+                        if let Some((owner_key, _)) = make_owner_key(*address, removed_object) {
+                            batch.delete_batch(&self.owner, [owner_key])?;
                         }
                     }
                     Owner::ObjectOwner(object_id) => {
                         batch.delete_batch(
-                            &self.dynamic_field_v2,
+                            &self.dynamic_field,
                             [DynamicFieldKey::new(*object_id, removed_object.id())],
                         )?;
                     }
@@ -910,16 +743,16 @@ impl IndexStoreTables {
                 if let Some(old_object) = old_object {
                     match old_object.owner() {
                         Owner::AddressOwner(address) => {
-                            // owner_v2: delete old entry
-                            if let Some((v2_key, _)) = make_owner_v2_key(*address, old_object) {
-                                batch.delete_batch(&self.owner_v2, [v2_key])?;
+                            // owner: delete old entry
+                            if let Some((owner_key, _)) = make_owner_key(*address, old_object) {
+                                batch.delete_batch(&self.owner, [owner_key])?;
                             }
                         }
 
                         Owner::ObjectOwner(object_id) => {
                             if old_object.owner() != object.owner() {
                                 batch.delete_batch(
-                                    &self.dynamic_field_v2,
+                                    &self.dynamic_field,
                                     [DynamicFieldKey::new(*object_id, old_object.id())],
                                 )?;
                             }
@@ -931,14 +764,14 @@ impl IndexStoreTables {
 
                 match object.owner() {
                     Owner::AddressOwner(owner) => {
-                        if let Some((v2_key, v2_info)) = make_owner_v2_key(*owner, object) {
-                            batch.insert_batch(&self.owner_v2, [(v2_key, v2_info)])?;
+                        if let Some((owner_key, owner_info)) = make_owner_key(*owner, object) {
+                            batch.insert_batch(&self.owner, [(owner_key, owner_info)])?;
                         }
                     }
                     Owner::ObjectOwner(parent) => {
                         if should_index_dynamic_field(object) {
                             let field_key = DynamicFieldKey::new(*parent, object.id());
-                            batch.insert_batch(&self.dynamic_field_v2, [(field_key, ())])?;
+                            batch.insert_batch(&self.dynamic_field, [(field_key, ())])?;
                         }
                     }
                     Owner::Shared { .. } | Owner::Immutable => {}
@@ -952,35 +785,35 @@ impl IndexStoreTables {
             // overriding any older value that may exist in the database
             // (because there necessarily cannot be).
             for (key, value) in tx.created_objects().flat_map(try_create_coin_index_info) {
-                merge_coin_into_v2(&mut coin_v2_index, key, value);
+                merge_coin_into(&mut coin_index, key, value);
             }
         }
 
-        batch.insert_batch(&self.coin_v2, coin_v2_index)?;
+        batch.insert_batch(&self.coin, coin_index)?;
 
-        // package version + regulated coin -> coin_v2 indexing
+        // package version + regulated coin indexing
         // Both use created_objects(): packages and RegulatedCoinMetadata objects are
         // always created, never mutated in-place, so changed_objects() would only add
         // noise from unrelated object mutations.
         let mut package_version_index: Vec<(PackageVersionKey, PackageVersionInfo)> = Vec::new();
-        let mut regulated_coin_v2_keys: Vec<(CoinIndexKey, ObjectID)> = Vec::new();
+        let mut regulated_coin_keys: Vec<(CoinIndexKey, ObjectID)> = Vec::new();
         for tx in &checkpoint.transactions {
             for object in tx.created_objects() {
                 if let Some((key, info)) = try_create_package_version_info(object) {
                     package_version_index.push((key, info));
                 }
                 if let Some((key, object_id)) = try_create_regulated_coin_info(object) {
-                    regulated_coin_v2_keys.push((key, object_id));
+                    regulated_coin_keys.push((key, object_id));
                 }
             }
         }
         batch.insert_batch(&self.package_version, package_version_index)?;
-        // Merge regulated coin entries into coin_v2.
+        // Merge regulated coin entries into coin table.
         // These are rare (at most one per regulated coin type per checkpoint),
         // so read-modify-write is acceptable.
-        for (key, object_id) in regulated_coin_v2_keys {
-            read_merge_write_coin_v2(&self.coin_v2, batch, key, |v2| {
-                v2.regulated_coin_metadata_object_id = Some(object_id);
+        for (key, object_id) in regulated_coin_keys {
+            read_merge_write_coin(&self.coin, batch, key, |entry| {
+                entry.regulated_coin_metadata_object_id = Some(object_id);
             })?;
         }
 
@@ -1004,30 +837,30 @@ impl IndexStoreTables {
             }))
     }
 
-    fn owner_v2_iter(
+    fn owner_iter(
         &self,
         owner: IotaAddress,
         cursor: Option<&OwnedObjectV2Cursor>,
-        type_filter: OwnerV2TypeFilter,
+        type_filter: OwnerTypeFilter,
     ) -> Result<
-        impl Iterator<Item = Result<(OwnerIndexKeyV2, OwnerIndexInfoV2), TypedStoreError>> + '_,
+        impl Iterator<Item = Result<(OwnerIndexKey, OwnerIndexInfo), TypedStoreError>> + '_,
         TypedStoreError,
     > {
-        let (lower_bound, upper_bound) = owner_v2_bounds(owner, cursor, &type_filter);
+        let (lower_bound, upper_bound) = owner_bounds(owner, cursor, &type_filter);
         Ok(self
-            .owner_v2
+            .owner
             .safe_iter_with_bounds(Some(lower_bound), Some(upper_bound))
             .filter(move |result| match result {
                 // Post-filter out hash collisions based on the full `StructTag` stored in the
                 // value.
                 Ok((_, info)) => match &type_filter {
-                    OwnerV2TypeFilter::None => true,
-                    OwnerV2TypeFilter::BaseType { tag, .. } => {
+                    OwnerTypeFilter::None => true,
+                    OwnerTypeFilter::BaseType { tag, .. } => {
                         info.object_type.address == tag.address
                             && info.object_type.module == tag.module
                             && info.object_type.name == tag.name
                     }
-                    OwnerV2TypeFilter::ExactType { tag, .. } => info.object_type == *tag,
+                    OwnerTypeFilter::ExactType { tag, .. } => info.object_type == *tag,
                 },
                 // Don't filter out DB errors — let them pass through to the caller.
                 Err(_) => true,
@@ -1043,20 +876,20 @@ impl IndexStoreTables {
         let lower_bound = DynamicFieldKey::new(parent, cursor.unwrap_or(ObjectID::ZERO));
         let upper_bound = DynamicFieldKey::new(parent, ObjectID::MAX);
         let iter = self
-            .dynamic_field_v2
+            .dynamic_field
             .safe_iter_with_bounds(Some(lower_bound), Some(upper_bound))
             .map(|r| r.map(|(key, ())| key));
         Ok(iter)
     }
 
-    fn get_coin_v2_info(
+    fn get_coin_info(
         &self,
         coin_type: &StructTag,
-    ) -> Result<Option<CoinIndexInfoV2>, TypedStoreError> {
+    ) -> Result<Option<CoinIndexInfo>, TypedStoreError> {
         let key = CoinIndexKey {
             coin_type: coin_type.to_owned(),
         };
-        self.coin_v2.get(&key)
+        self.coin.get(&key)
     }
 
     fn package_versions_iter(
@@ -1081,47 +914,9 @@ impl IndexStoreTables {
 pub struct GrpcIndexesStore {
     tables: Arc<IndexStoreTables>,
     pending_updates: Mutex<BTreeMap<u64, typed_store::rocks::DBBatch>>,
-    /// Set to `true` once the `package_version` table backfill completes.
-    package_version_ready: Arc<AtomicBool>,
-    /// Set to `true` once the `coin_v2` table backfill completes.
-    coin_v2_ready: Arc<AtomicBool>,
-    /// Set to `true` once the `owner_v2` table backfill completes.
-    owner_v2_ready: Arc<AtomicBool>,
 }
 
 impl GrpcIndexesStore {
-    /// One-time migration: rename the legacy `rest_index` directory to
-    /// [`GRPC_INDEXES_DIR`].
-    ///
-    /// Must be called before [`GrpcIndexesStore::new`] so that the DB is not
-    /// yet open. Safe to call multiple times — it is a no-op when the target
-    /// directory already exists.
-    ///
-    /// TODO(cleanup): Remove after one release cycle once all production nodes
-    /// have upgraded past this version.
-    pub fn migrate_legacy_dirs(db_path: &std::path::Path) {
-        let target = db_path.join(GRPC_INDEXES_DIR);
-        if target.exists() {
-            return;
-        }
-        let legacy = db_path.join(LEGACY_INDEX_DIR);
-        if legacy.exists() {
-            info!(
-                "migrating index directory: renaming {:?} -> {:?}",
-                legacy, target
-            );
-            if let Err(e) = std::fs::rename(&legacy, &target) {
-                // Non-fatal: GrpcIndexesStore::new will re-create and re-index.
-                tracing::warn!(
-                    "failed to rename {:?} to {:?}: {e}. \
-                     The index will be rebuilt from scratch on next startup.",
-                    legacy,
-                    target
-                );
-            }
-        }
-    }
-
     pub async fn new(
         path: PathBuf,
         authority_store: Arc<AuthorityStore>,
@@ -1152,80 +947,9 @@ impl GrpcIndexesStore {
 
         let tables = Arc::new(tables);
 
-        // Check whether the backfill-only tables have been populated.  After a
-        // full `init()` the watermarks are written, so nodes that just ran init
-        // won't spawn any background tasks.  Upgrading nodes that already have
-        // DB version 1 but never ran the new init will have the watermarks
-        // absent and will spawn background backfills.
-        let pkg_done = tables
-            .watermark
-            .get(&Watermark::PackageVersionBackfilled)
-            .ok()
-            .flatten()
-            .is_some();
-        let coin_v2_done = tables
-            .watermark
-            .get(&Watermark::CoinV2Backfilled)
-            .ok()
-            .flatten()
-            .is_some();
-        let owner_v2_done = tables
-            .watermark
-            .get(&Watermark::OwnerV2Backfilled)
-            .ok()
-            .flatten()
-            .is_some();
-
-        let package_version_ready = Arc::new(AtomicBool::new(pkg_done));
-        let coin_v2_ready = Arc::new(AtomicBool::new(coin_v2_done));
-        let owner_v2_ready = Arc::new(AtomicBool::new(owner_v2_done));
-
-        if !pkg_done || !coin_v2_done || !owner_v2_done {
-            let tables_clone = Arc::clone(&tables);
-            let auth_clone = Arc::clone(&authority_store);
-            let pkg_flag = Arc::clone(&package_version_ready);
-            let coin_v2_flag = Arc::clone(&coin_v2_ready);
-            let owner_v2_flag = Arc::clone(&owner_v2_ready);
-            tokio::spawn(async move {
-                match tokio::task::spawn_blocking(move || {
-                    backfill_new_tables(
-                        &tables_clone,
-                        &auth_clone,
-                        &[
-                            BackfillTask {
-                                needed: !pkg_done,
-                                done_flag: &pkg_flag,
-                                watermark: Watermark::PackageVersionBackfilled,
-                            },
-                            BackfillTask {
-                                needed: !coin_v2_done,
-                                done_flag: &coin_v2_flag,
-                                watermark: Watermark::CoinV2Backfilled,
-                            },
-                            BackfillTask {
-                                needed: !owner_v2_done,
-                                done_flag: &owner_v2_flag,
-                                watermark: Watermark::OwnerV2Backfilled,
-                            },
-                        ],
-                    );
-                })
-                .await
-                {
-                    Ok(()) => {}
-                    Err(e) => {
-                        tracing::error!("background backfill task panicked: {e}");
-                    }
-                }
-            });
-        }
-
         Self {
             tables,
             pending_updates: Default::default(),
-            package_version_ready,
-            coin_v2_ready,
-            owner_v2_ready,
         }
     }
 
@@ -1235,12 +959,6 @@ impl GrpcIndexesStore {
         Self {
             tables,
             pending_updates: Default::default(),
-            // new_without_init is used in tests / tooling — mark all tables
-            // as ready so callers don't get spurious "backfill in progress"
-            // errors.
-            package_version_ready: Arc::new(AtomicBool::new(true)),
-            coin_v2_ready: Arc::new(AtomicBool::new(true)),
-            owner_v2_ready: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -1308,16 +1026,16 @@ impl GrpcIndexesStore {
         self.tables.get_transaction_info(digest)
     }
 
-    pub fn owner_v2_iter(
+    pub fn owner_iter(
         &self,
         owner: IotaAddress,
         cursor: Option<&OwnedObjectV2Cursor>,
-        type_filter: OwnerV2TypeFilter,
+        type_filter: OwnerTypeFilter,
     ) -> Result<
-        impl Iterator<Item = Result<(OwnerIndexKeyV2, OwnerIndexInfoV2), TypedStoreError>> + '_,
+        impl Iterator<Item = Result<(OwnerIndexKey, OwnerIndexInfo), TypedStoreError>> + '_,
         TypedStoreError,
     > {
-        self.tables.owner_v2_iter(owner, cursor, type_filter)
+        self.tables.owner_iter(owner, cursor, type_filter)
     }
 
     pub fn dynamic_field_iter(
@@ -1329,11 +1047,11 @@ impl GrpcIndexesStore {
         self.tables.dynamic_field_iter(parent, cursor)
     }
 
-    pub fn get_coin_v2_info(
+    pub fn get_coin_info(
         &self,
         coin_type: &StructTag,
-    ) -> Result<Option<CoinIndexInfoV2>, TypedStoreError> {
-        self.tables.get_coin_v2_info(coin_type)
+    ) -> Result<Option<CoinIndexInfo>, TypedStoreError> {
+        self.tables.get_coin_info(coin_type)
     }
 
     pub fn package_versions_iter(
@@ -1343,18 +1061,6 @@ impl GrpcIndexesStore {
     ) -> Result<impl Iterator<Item = PackageVersionIteratorItem> + '_, TypedStoreError> {
         self.tables
             .package_versions_iter(original_package_id, cursor)
-    }
-
-    pub fn is_coin_v2_index_ready(&self) -> bool {
-        self.coin_v2_ready.load(Ordering::Acquire)
-    }
-
-    pub fn is_owner_v2_index_ready(&self) -> bool {
-        self.owner_v2_ready.load(Ordering::Acquire)
-    }
-
-    pub fn is_package_version_index_ready(&self) -> bool {
-        self.package_version_ready.load(Ordering::Acquire)
     }
 }
 
@@ -1381,17 +1087,17 @@ impl iota_node_storage::GrpcIndexes for GrpcIndexesStore {
             .map_err(|e| StorageError::custom(e.to_string()))
     }
 
-    fn account_owned_objects_info_iter_v2(
+    fn account_owned_objects_info_iter(
         &self,
         owner: IotaAddress,
         cursor: Option<&OwnedObjectV2Cursor>,
         object_type: Option<StructTag>,
     ) -> iota_types::storage::error::Result<Box<dyn Iterator<Item = OwnedObjectV2IteratorItem> + '_>>
     {
-        let type_filter = OwnerV2TypeFilter::from_struct_tag(object_type.as_ref());
+        let type_filter = OwnerTypeFilter::from_struct_tag(object_type.as_ref());
         let iter = self
             .tables
-            .owner_v2_iter(owner, cursor, type_filter)
+            .owner_iter(owner, cursor, type_filter)
             .map_err(|e| StorageError::custom(e.to_string()))?
             .map(|result| {
                 result.map(|(key, info)| {
@@ -1427,12 +1133,12 @@ impl iota_node_storage::GrpcIndexes for GrpcIndexesStore {
         Ok(Box::new(iter))
     }
 
-    fn get_coin_v2_info(
+    fn get_coin_info(
         &self,
         coin_type: &StructTag,
     ) -> iota_types::storage::error::Result<Option<iota_types::storage::CoinInfoV2>> {
         self.tables
-            .get_coin_v2_info(coin_type)
+            .get_coin_info(coin_type)
             .map(|opt| opt.map(Into::into))
             .map_err(|e| StorageError::custom(e.to_string()))
     }
@@ -1449,18 +1155,6 @@ impl iota_node_storage::GrpcIndexes for GrpcIndexesStore {
             .map_err(|e| StorageError::custom(e.to_string()))?;
         Ok(Box::new(iter))
     }
-
-    fn is_owner_v2_index_ready(&self) -> bool {
-        self.owner_v2_ready.load(Ordering::Acquire)
-    }
-
-    fn is_coin_v2_index_ready(&self) -> bool {
-        self.coin_v2_ready.load(Ordering::Acquire)
-    }
-
-    fn is_package_version_index_ready(&self) -> bool {
-        self.package_version_ready.load(Ordering::Acquire)
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1476,7 +1170,7 @@ fn should_index_dynamic_field(object: &Object) -> bool {
         .is_some_and(|move_object| move_object.type_().is_dynamic_field())
 }
 
-fn try_create_coin_index_info(object: &Object) -> Option<(CoinIndexKey, CoinIndexInfoV2)> {
+fn try_create_coin_index_info(object: &Object) -> Option<(CoinIndexKey, CoinIndexInfo)> {
     use iota_types::coin::{CoinMetadata, TreasuryCap};
 
     let object_type = object.type_()?.other()?;
@@ -1484,7 +1178,7 @@ fn try_create_coin_index_info(object: &Object) -> Option<(CoinIndexKey, CoinInde
     if let Some(coin_type) = CoinMetadata::is_coin_metadata_with_coin_type(object_type).cloned() {
         return Some((
             CoinIndexKey { coin_type },
-            CoinIndexInfoV2 {
+            CoinIndexInfo {
                 coin_metadata_object_id: Some(object.id()),
                 ..Default::default()
             },
@@ -1494,7 +1188,7 @@ fn try_create_coin_index_info(object: &Object) -> Option<(CoinIndexKey, CoinInde
     if let Some(coin_type) = TreasuryCap::is_treasury_with_coin_type(object_type).cloned() {
         return Some((
             CoinIndexKey { coin_type },
-            CoinIndexInfoV2 {
+            CoinIndexInfo {
                 treasury_object_id: Some(object.id()),
                 ..Default::default()
             },
@@ -1505,7 +1199,7 @@ fn try_create_coin_index_info(object: &Object) -> Option<(CoinIndexKey, CoinInde
 }
 
 /// Returns `(CoinIndexKey, regulated_coin_metadata_object_id)` if `object` is
-/// a `RegulatedCoinMetadata<T>`.  Used to populate the `coin_v2` table.
+/// a `RegulatedCoinMetadata<T>`.  Used to populate the `coin` table.
 fn try_create_regulated_coin_info(object: &Object) -> Option<(CoinIndexKey, ObjectID)> {
     use move_core_types::language_storage::TypeTag;
 
@@ -1543,13 +1237,13 @@ fn try_create_package_version_info(
 
 struct GrpcParLiveObjectSetIndexer<'a> {
     tables: &'a IndexStoreTables,
-    coin_v2_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfoV2>>,
+    coin_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfo>>,
 }
 
 struct GrpcLiveObjectIndexer<'a> {
     tables: &'a IndexStoreTables,
     batch: typed_store::rocks::DBBatch,
-    coin_v2_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfoV2>>,
+    coin_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfo>>,
 }
 
 impl<'a> ParMakeLiveObjectIndexer for GrpcParLiveObjectSetIndexer<'a> {
@@ -1558,8 +1252,8 @@ impl<'a> ParMakeLiveObjectIndexer for GrpcParLiveObjectSetIndexer<'a> {
     fn make_live_object_indexer(&self) -> Self::ObjectIndexer {
         GrpcLiveObjectIndexer {
             tables: self.tables,
-            batch: self.tables.owner_v2.batch(),
-            coin_v2_index: self.coin_v2_index,
+            batch: self.tables.owner.batch(),
+            coin_index: self.coin_index,
         }
     }
 }
@@ -1568,9 +1262,9 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
     fn index_object(&mut self, object: Object) -> Result<(), StorageError> {
         match object.owner {
             Owner::AddressOwner(owner) => {
-                if let Some((v2_key, v2_info)) = make_owner_v2_key(owner, &object) {
+                if let Some((owner_key, owner_info)) = make_owner_key(owner, &object) {
                     self.batch
-                        .insert_batch(&self.tables.owner_v2, [(v2_key, v2_info)])?;
+                        .insert_batch(&self.tables.owner, [(owner_key, owner_info)])?;
                 }
             }
 
@@ -1579,7 +1273,7 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
                 if should_index_dynamic_field(&object) {
                     let field_key = DynamicFieldKey::new(parent, object.id());
                     self.batch
-                        .insert_batch(&self.tables.dynamic_field_v2, [(field_key, ())])?;
+                        .insert_batch(&self.tables.dynamic_field, [(field_key, ())])?;
                 }
             }
 
@@ -1588,7 +1282,7 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
 
         // Look for CoinMetadata<T> and TreasuryCap<T> objects
         if let Some((key, value)) = try_create_coin_index_info(&object) {
-            merge_coin_into_v2(&mut self.coin_v2_index.lock().unwrap(), key, value);
+            merge_coin_into(&mut self.coin_index.lock().unwrap(), key, value);
         }
 
         // Package version index
@@ -1597,12 +1291,12 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
                 .insert_batch(&self.tables.package_version, [(key, info)])?;
         }
 
-        // Regulated coin index (coin_v2 only)
+        // Regulated coin index
         if let Some((key, object_id)) = try_create_regulated_coin_info(&object) {
-            merge_coin_into_v2(
-                &mut self.coin_v2_index.lock().unwrap(),
+            merge_coin_into(
+                &mut self.coin_index.lock().unwrap(),
                 key,
-                CoinIndexInfoV2 {
+                CoinIndexInfo {
                     regulated_coin_metadata_object_id: Some(object_id),
                     ..Default::default()
                 },
@@ -1612,7 +1306,7 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
         // If the batch size grows to greater that 128MB then write out to the DB so
         // that the data we need to hold in memory doesn't grown unbounded.
         if self.batch.size_in_bytes() >= 1 << 27 {
-            std::mem::replace(&mut self.batch, self.tables.owner_v2.batch()).write()?;
+            std::mem::replace(&mut self.batch, self.tables.owner.batch()).write()?;
         }
 
         Ok(())
@@ -1625,190 +1319,7 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
 }
 
 // ---------------------------------------------------------------------------
-// Background backfill infrastructure
-//
-// When a new index table is added without bumping CURRENT_DB_VERSION, existing
-// nodes will have an empty table.  The functions below scan the live object set
-// in the background and populate the table, then write a Watermark entry so the
-// backfill is not repeated on the next restart.
-// ---------------------------------------------------------------------------
 
-/// Combined backfill indexer that populates `package_version`, `coin_v2`,
-/// and `owner_v2` tables in a single pass over the live object set.
-///
-/// `coin_v2` entries are accumulated in a shared `Mutex<HashMap>` (like the
-/// full-init path) to avoid lost-update races when parallel workers encounter
-/// `CoinMetadata` and `TreasuryCap` for the same coin type in different
-/// ObjectID ranges.
-struct BackfillIndexer<'a> {
-    tables: &'a IndexStoreTables,
-    coin_v2_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfoV2>>,
-    backfill_package_version: bool,
-    backfill_coin_v2: bool,
-    backfill_owner_v2: bool,
-}
-
-struct BackfillBatchIndexer<'a> {
-    tables: &'a IndexStoreTables,
-    batch: typed_store::rocks::DBBatch,
-    coin_v2_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfoV2>>,
-    backfill_package_version: bool,
-    backfill_coin_v2: bool,
-    backfill_owner_v2: bool,
-}
-
-impl<'a> ParMakeLiveObjectIndexer for BackfillIndexer<'a> {
-    type ObjectIndexer = BackfillBatchIndexer<'a>;
-
-    fn make_live_object_indexer(&self) -> Self::ObjectIndexer {
-        BackfillBatchIndexer {
-            batch: self.tables.package_version.batch(),
-            tables: self.tables,
-            coin_v2_index: self.coin_v2_index,
-            backfill_package_version: self.backfill_package_version,
-            backfill_coin_v2: self.backfill_coin_v2,
-            backfill_owner_v2: self.backfill_owner_v2,
-        }
-    }
-}
-
-impl LiveObjectIndexer for BackfillBatchIndexer<'_> {
-    fn index_object(&mut self, object: Object) -> Result<(), StorageError> {
-        if self.backfill_package_version {
-            if let Some((key, info)) = try_create_package_version_info(&object) {
-                self.batch
-                    .insert_batch(&self.tables.package_version, [(key, info)])?;
-            }
-        }
-        if self.backfill_coin_v2 {
-            if let Some((key, value)) = try_create_coin_index_info(&object) {
-                merge_coin_into_v2(&mut self.coin_v2_index.lock().unwrap(), key, value);
-            }
-            if let Some((key, object_id)) = try_create_regulated_coin_info(&object) {
-                merge_coin_into_v2(
-                    &mut self.coin_v2_index.lock().unwrap(),
-                    key,
-                    CoinIndexInfoV2 {
-                        regulated_coin_metadata_object_id: Some(object_id),
-                        ..Default::default()
-                    },
-                );
-            }
-        }
-        if self.backfill_owner_v2 {
-            if let Owner::AddressOwner(owner) = object.owner {
-                if let Some((key, info)) = make_owner_v2_key(owner, &object) {
-                    self.batch
-                        .insert_batch(&self.tables.owner_v2, [(key, info)])?;
-                }
-            }
-        }
-        // If the batch size grows to greater that 128MB then write out to the DB so
-        // that the data we need to hold in memory doesn't grown unbounded.
-        if self.batch.size_in_bytes() >= 1 << 27 {
-            std::mem::replace(&mut self.batch, self.tables.package_version.batch()).write()?;
-        }
-        Ok(())
-    }
-
-    fn finish(self) -> Result<(), StorageError> {
-        self.batch.write()?;
-        Ok(())
-    }
-}
-
-/// Describes a single backfill-only table that needs populating.
-struct BackfillTask<'a> {
-    needed: bool,
-    done_flag: &'a AtomicBool,
-    watermark: Watermark,
-}
-
-/// Run a single pass over the live object set, populating whichever of the
-/// backfill-only tables still need populating.
-fn backfill_new_tables(
-    tables: &IndexStoreTables,
-    authority_store: &AuthorityStore,
-    tasks: &[BackfillTask<'_>],
-) {
-    let (mut backfill_package_version, mut backfill_coin_v2, mut backfill_owner_v2) =
-        (false, false, false);
-    for task in tasks {
-        if !task.needed {
-            continue;
-        }
-        match task.watermark {
-            Watermark::PackageVersionBackfilled => backfill_package_version = true,
-            Watermark::CoinV2Backfilled => backfill_coin_v2 = true,
-            Watermark::OwnerV2Backfilled => backfill_owner_v2 = true,
-            _ => {}
-        }
-    }
-
-    info!(
-        "Starting background backfill (package_version={backfill_package_version}, \
-         coin_v2={backfill_coin_v2}, owner_v2={backfill_owner_v2})"
-    );
-
-    let coin_v2_index = Mutex::new(HashMap::new());
-
-    let indexer = BackfillIndexer {
-        tables,
-        coin_v2_index: &coin_v2_index,
-        backfill_package_version,
-        backfill_coin_v2,
-        backfill_owner_v2,
-    };
-
-    match crate::par_index_live_object_set::par_index_live_object_set(authority_store, &indexer) {
-        Ok(()) => {
-            // Flush coin_v2 entries accumulated in memory to the DB.
-            //
-            // Use per-key read-merge-write instead of `multi_insert` to
-            // avoid clobbering concurrent incremental writes.  While the
-            // backfill was scanning the live object set, the incremental
-            // checkpoint indexer may have written
-            // `regulated_coin_metadata_object_id` (or other fields) for
-            // the same coin type. A plain `multi_insert` would overwrite
-            // those with the backfill's snapshot (which lacks the new
-            // data).  Merging preserves whichever fields are already
-            // present in the DB.
-            //
-            // Each key is read-merged-written individually so that the
-            // TOCTOU window is per-key (microseconds) rather than across
-            // the entire flush.
-            if backfill_coin_v2 {
-                for (key, backfill_value) in coin_v2_index.into_inner().unwrap() {
-                    let mut existing = tables.coin_v2.get(&key).ok().flatten().unwrap_or_default();
-                    existing.merge(backfill_value);
-                    if let Err(e) = tables.coin_v2.insert(&key, &existing) {
-                        tracing::error!("Failed to flush coin_v2 entry: {e}");
-                        return;
-                    }
-                }
-            }
-
-            for task in tasks {
-                if !task.needed {
-                    continue;
-                }
-                if let Err(e) = tables.watermark.insert(&task.watermark, &0u64) {
-                    tracing::error!("Failed to write {:?} watermark: {e}", task.watermark);
-                    return;
-                }
-                task.done_flag.store(true, Ordering::Release);
-                info!("{:?} backfill complete", task.watermark);
-            }
-        }
-        Err(e) => tracing::error!("background backfill failed: {e}"),
-    }
-}
-
-// ---------------------------------------------------------------------------
-
-// TODO figure out a way to dedup this logic. Today we'd need to do quite a bit
-// of refactoring to make it possible.
-//
 // Load a CheckpointData struct without event data
 fn sparse_checkpoint_data_for_backfill(
     authority_store: &AuthorityStore,

--- a/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
@@ -329,7 +329,7 @@ async fn list_owned_objects_filter_by_type_exact_match_with_mint() {
 
 /// Walk through all owned objects one at a time using cursor-based pagination.
 ///
-/// This exercises the real v2 owner index, `owner_v2_bounds` cursor seeking,
+/// This exercises the real owner index, `owner_bounds` cursor seeking,
 /// and page-token round-tripping through the full gRPC stack — something
 /// the unit tests with `MockGrpcStateReader` cannot cover.
 #[sim_test]

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -248,41 +248,6 @@ impl From<TransactionNotFoundError> for RpcError {
     }
 }
 
-/// Returned when an index table has not yet finished its background backfill.
-/// Clients should retry after the suggested delay.
-#[derive(Debug, Clone)]
-pub struct IndexBackfillInProgressError {
-    pub index_name: &'static str,
-}
-
-impl std::fmt::Display for IndexBackfillInProgressError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} index backfill in progress, try again later",
-            self.index_name
-        )
-    }
-}
-
-impl std::error::Error for IndexBackfillInProgressError {}
-
-impl From<IndexBackfillInProgressError> for RpcError {
-    fn from(e: IndexBackfillInProgressError) -> Self {
-        let details = ErrorDetails::new().with_retry_info(RetryInfo {
-            retry_delay: Some(prost_types::Duration {
-                seconds: 30,
-                nanos: 0,
-            }),
-        });
-        RpcError {
-            code: Code::Unavailable,
-            message: Some(e.to_string()),
-            details: Some(Box::new(details)),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct MissingIndexesError;
 

--- a/crates/iota-grpc-server/src/lib.rs
+++ b/crates/iota-grpc-server/src/lib.rs
@@ -31,6 +31,6 @@ pub use server::{GrpcServerHandle, start_grpc_server};
 pub use state_service::StateGrpcService;
 pub use transaction_execution_service::TransactionExecutionGrpcService;
 pub use types::{
-    DynamicFieldIterItem, GrpcCheckpointDataBroadcaster, GrpcReader, OwnedObjectIterItem,
-    OwnedObjectV2Cursor, PackageVersionIterItem,
+    DynamicFieldIterItem, GrpcCheckpointDataBroadcaster, GrpcReader, OwnedObjectCursor,
+    OwnedObjectIterItem, PackageVersionIterItem,
 };

--- a/crates/iota-grpc-server/src/lib.rs
+++ b/crates/iota-grpc-server/src/lib.rs
@@ -32,5 +32,5 @@ pub use state_service::StateGrpcService;
 pub use transaction_execution_service::TransactionExecutionGrpcService;
 pub use types::{
     DynamicFieldIterItem, GrpcCheckpointDataBroadcaster, GrpcReader, OwnedObjectIterItem,
-    OwnedObjectV2Cursor, OwnedObjectV2IterItem, PackageVersionIterItem,
+    OwnedObjectV2Cursor, PackageVersionIterItem,
 };

--- a/crates/iota-grpc-server/src/state_service/get_coin_info.rs
+++ b/crates/iota-grpc-server/src/state_service/get_coin_info.rs
@@ -41,7 +41,7 @@ pub(crate) fn get_coin_info(
             .with_reason(ErrorReason::FieldInvalid)
     })?;
 
-    let coin_info = reader.get_coin_v2_info(&core_coin_type)?;
+    let coin_info = reader.get_coin_info(&core_coin_type)?;
     let coin_info = coin_info.ok_or_else(|| {
         RpcError::new(
             tonic::Code::NotFound,

--- a/crates/iota-grpc-server/src/state_service/list_owned_objects.rs
+++ b/crates/iota-grpc-server/src/state_service/list_owned_objects.rs
@@ -79,7 +79,7 @@ pub(crate) fn list_owned_objects(
     let cursor = page_token.as_ref().map(|t| &t.cursor);
 
     let mut iter =
-        reader.account_owned_objects_info_iter_v2(owner_address, cursor, type_filter.clone())?;
+        reader.account_owned_objects_info_iter(owner_address, cursor, type_filter.clone())?;
 
     let mut objects = Vec::with_capacity(page_size);
     let mut size_bytes = 0usize;

--- a/crates/iota-grpc-server/src/state_service/list_owned_objects.rs
+++ b/crates/iota-grpc-server/src/state_service/list_owned_objects.rs
@@ -20,7 +20,7 @@ use crate::{
     constants::validate_max_message_size,
     error::RpcError,
     merge::Merge,
-    types::{GrpcReader, OwnedObjectV2Cursor},
+    types::{GrpcReader, OwnedObjectCursor},
     validation::{
         decode_page_token, encode_page_token, page_token_mismatch, require_address,
         validate_page_size, validate_read_mask,
@@ -34,7 +34,7 @@ const MAX_PAGE_SIZE: u32 = 1000;
 struct PageToken {
     owner: IotaAddress,
     object_type: Option<move_core_types::language_storage::StructTag>,
-    cursor: OwnedObjectV2Cursor,
+    cursor: OwnedObjectCursor,
 }
 
 #[tracing::instrument(skip(reader))]
@@ -83,7 +83,7 @@ pub(crate) fn list_owned_objects(
 
     let mut objects = Vec::with_capacity(page_size);
     let mut size_bytes = 0usize;
-    let mut last_cursor: Option<OwnedObjectV2Cursor> = None;
+    let mut last_cursor: Option<OwnedObjectCursor> = None;
 
     for result in iter.by_ref() {
         let (info, item_cursor) = result.map_err(RpcError::from)?;

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -139,7 +139,7 @@ pub type CheckpointStreamResult = Result<grpc_ledger_service::CheckpointData, St
 /// A dynamic-field index key (parent + field_id).
 pub type DynamicFieldIterItem = anyhow::Result<iota_types::storage::DynamicFieldKey>;
 
-pub use iota_types::storage::OwnedObjectV2Cursor;
+pub use iota_types::storage::OwnedObjectCursor;
 
 /// An owned-object together with a seek cursor for the position it
 /// occupies in the index.
@@ -148,7 +148,7 @@ pub use iota_types::storage::OwnedObjectV2Cursor;
 /// seek position.
 pub type OwnedObjectIterItem = anyhow::Result<(
     iota_types::storage::AccountOwnedObjectInfo,
-    iota_types::storage::OwnedObjectV2Cursor,
+    iota_types::storage::OwnedObjectCursor,
 )>;
 
 /// A package-version index entry (key + storage info).
@@ -612,7 +612,7 @@ impl GrpcReader {
     pub fn account_owned_objects_info_iter(
         &self,
         owner: iota_types::base_types::IotaAddress,
-        cursor: Option<&OwnedObjectV2Cursor>,
+        cursor: Option<&OwnedObjectCursor>,
         object_type: Option<move_core_types::language_storage::StructTag>,
     ) -> Result<Box<dyn Iterator<Item = OwnedObjectIterItem> + '_>, crate::error::RpcError> {
         let indexes = self
@@ -643,7 +643,7 @@ impl GrpcReader {
     pub fn get_coin_info(
         &self,
         coin_type: &move_core_types::language_storage::StructTag,
-    ) -> Result<Option<iota_types::storage::CoinInfoV2>, crate::error::RpcError> {
+    ) -> Result<Option<iota_types::storage::CoinInfo>, crate::error::RpcError> {
         let indexes = self
             .require_indexes()
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -139,17 +139,14 @@ pub type CheckpointStreamResult = Result<grpc_ledger_service::CheckpointData, St
 /// A dynamic-field index key (parent + field_id).
 pub type DynamicFieldIterItem = anyhow::Result<iota_types::storage::DynamicFieldKey>;
 
-/// An owned-object from the legacy `owner` (v1) index.
-pub type OwnedObjectIterItem = anyhow::Result<iota_types::storage::AccountOwnedObjectInfo>;
-
 pub use iota_types::storage::OwnedObjectV2Cursor;
 
-/// An owned-object together with the v2 seek cursor for the position it
+/// An owned-object together with a seek cursor for the position it
 /// occupies in the index.
 ///
-/// Unlike [`OwnedObjectIterItem`], this carries the full v2 key components
-/// so that page tokens can encode an exact seek position.
-pub type OwnedObjectV2IterItem = anyhow::Result<(
+/// Carries the full key components so that page tokens can encode an exact
+/// seek position.
+pub type OwnedObjectIterItem = anyhow::Result<(
     iota_types::storage::AccountOwnedObjectInfo,
     iota_types::storage::OwnedObjectV2Cursor,
 )>;
@@ -611,28 +608,19 @@ impl GrpcReader {
 
     /// Iterate over objects owned by an account address.
     ///
-    /// Returns `Err(IndexBackfillInProgressError)` when the `owner_v2`
-    /// backfill has not yet completed.
-    ///
     /// The cursor is exclusive: items *after* the cursor position are returned.
-    pub fn account_owned_objects_info_iter_v2(
+    pub fn account_owned_objects_info_iter(
         &self,
         owner: iota_types::base_types::IotaAddress,
         cursor: Option<&OwnedObjectV2Cursor>,
         object_type: Option<move_core_types::language_storage::StructTag>,
-    ) -> Result<Box<dyn Iterator<Item = OwnedObjectV2IterItem> + '_>, crate::error::RpcError> {
+    ) -> Result<Box<dyn Iterator<Item = OwnedObjectIterItem> + '_>, crate::error::RpcError> {
         let indexes = self
             .require_indexes()
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
-        if !indexes.is_owner_v2_index_ready() {
-            return Err(crate::error::IndexBackfillInProgressError {
-                index_name: "owner_v2",
-            }
-            .into());
-        }
         let skip = usize::from(cursor.is_some());
         let iter = indexes
-            .account_owned_objects_info_iter_v2(owner, cursor, object_type)
+            .account_owned_objects_info_iter(owner, cursor, object_type)
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
         Ok(Box::new(iter.map(|r| r.map_err(Into::into)).skip(skip)))
     }
@@ -651,33 +639,21 @@ impl GrpcReader {
         Ok(Box::new(iter.map(|r| r.map_err(Into::into)).skip(skip)))
     }
 
-    /// Get unified coin info from the `coin_v2` table.
-    ///
-    /// Returns `Err(IndexBackfillInProgressError)` when the `coin_v2`
-    /// backfill has not yet completed.
-    pub fn get_coin_v2_info(
+    /// Get unified coin info.
+    pub fn get_coin_info(
         &self,
         coin_type: &move_core_types::language_storage::StructTag,
     ) -> Result<Option<iota_types::storage::CoinInfoV2>, crate::error::RpcError> {
         let indexes = self
             .require_indexes()
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
-        if !indexes.is_coin_v2_index_ready() {
-            return Err(crate::error::IndexBackfillInProgressError {
-                index_name: "coin_v2",
-            }
-            .into());
-        }
         let info = indexes
-            .get_coin_v2_info(coin_type)
+            .get_coin_info(coin_type)
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
         Ok(info)
     }
 
     /// Iterate over all versions of a package by its original package ID.
-    ///
-    /// Returns `Err(IndexBackfillInProgressError)` when the backfill has not
-    /// yet completed so callers receive a retryable `Unavailable` gRPC status.
     pub fn package_versions_iter(
         &self,
         original_package_id: ObjectID,
@@ -686,12 +662,6 @@ impl GrpcReader {
         let indexes = self
             .require_indexes()
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
-        if !indexes.is_package_version_index_ready() {
-            return Err(crate::error::IndexBackfillInProgressError {
-                index_name: "package_version",
-            }
-            .into());
-        }
         let skip = usize::from(cursor.is_some());
         let iter = indexes
             .package_versions_iter(original_package_id, cursor)

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -93,10 +93,11 @@ pub struct MockGrpcStateReader {
     pub objects: HashMap<ObjectID, Object>,
 
     // -- Owned objects (for list_owned_objects pagination tests) --
-    /// Pre-sorted in v2 key order. The iterator respects cursor-based seeking.
+    /// Pre-sorted in owner index key order. The iterator respects cursor-based
+    /// seeking.
     pub owned_objects: Vec<(
         iota_types::storage::AccountOwnedObjectInfo,
-        iota_types::storage::OwnedObjectV2Cursor,
+        iota_types::storage::OwnedObjectCursor,
     )>,
 
     // -- Transactions --
@@ -371,9 +372,9 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
     fn account_owned_objects_info_iter(
         &self,
         owner: iota_types::base_types::IotaAddress,
-        cursor: Option<&iota_types::storage::OwnedObjectV2Cursor>,
+        cursor: Option<&iota_types::storage::OwnedObjectCursor>,
         object_type: Option<move_core_types::language_storage::StructTag>,
-    ) -> StorageResult<Box<dyn Iterator<Item = iota_types::storage::OwnedObjectV2IteratorItem> + '_>>
+    ) -> StorageResult<Box<dyn Iterator<Item = iota_types::storage::OwnedObjectIteratorItem> + '_>>
     {
         // Find the start index: if cursor is provided, seek to its position
         // (inclusive — the GrpcReader wrapper handles skip(1)).
@@ -443,7 +444,7 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
     fn get_coin_info(
         &self,
         _coin_type: &move_core_types::language_storage::StructTag,
-    ) -> StorageResult<Option<iota_types::storage::CoinInfoV2>> {
+    ) -> StorageResult<Option<iota_types::storage::CoinInfo>> {
         Ok(None)
     }
 

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -368,7 +368,7 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
         Ok(None)
     }
 
-    fn account_owned_objects_info_iter_v2(
+    fn account_owned_objects_info_iter(
         &self,
         owner: iota_types::base_types::IotaAddress,
         cursor: Option<&iota_types::storage::OwnedObjectV2Cursor>,
@@ -440,7 +440,7 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
         Ok(Box::new(std::iter::empty()))
     }
 
-    fn get_coin_v2_info(
+    fn get_coin_info(
         &self,
         _coin_type: &move_core_types::language_storage::StructTag,
     ) -> StorageResult<Option<iota_types::storage::CoinInfoV2>> {

--- a/crates/iota-grpc-server/tests/list_owned_objects.rs
+++ b/crates/iota-grpc-server/tests/list_owned_objects.rs
@@ -28,7 +28,7 @@ use iota_types::{
     digests::TransactionDigest,
     gas_coin::GasCoin,
     object::{MoveObject, OBJECT_START_VERSION, Object, Owner},
-    storage::{AccountOwnedObjectInfo, OwnedObjectV2Cursor},
+    storage::{AccountOwnedObjectInfo, OwnedObjectCursor},
 };
 use prost_types::FieldMask;
 use tonic::transport::Channel;
@@ -77,7 +77,7 @@ fn make_large_gas_coin(
     )
 }
 
-/// Build an `(AccountOwnedObjectInfo, OwnedObjectV2Cursor)` entry for the
+/// Build an `(AccountOwnedObjectInfo, OwnedObjectCursor)` entry for the
 /// mock, with the cursor sorted by `(type_id_hash, params_hash,
 /// inverted_balance, object_id)`.
 fn make_owned_entry(
@@ -87,14 +87,14 @@ fn make_owned_entry(
     type_id_hash: u64,
     params_hash: u64,
     balance: Option<u64>,
-) -> (AccountOwnedObjectInfo, OwnedObjectV2Cursor) {
+) -> (AccountOwnedObjectInfo, OwnedObjectCursor) {
     let info = AccountOwnedObjectInfo {
         owner,
         object_id,
         version: OBJECT_START_VERSION,
         type_,
     };
-    let cursor = OwnedObjectV2Cursor {
+    let cursor = OwnedObjectCursor {
         object_type_identifier: type_id_hash,
         object_type_params: params_hash,
         inverted_balance: balance.map(|b| !b),
@@ -159,8 +159,8 @@ fn make_coin_mock(owner: IotaAddress, count: usize) -> (MockGrpcStateReader, Vec
     let params_hash = 99u64; // arbitrary stable hash for <IOTA>
 
     let mut ids: Vec<ObjectID> = (0..count).map(|_| ObjectID::random()).collect();
-    // Sort IDs so the v2 key ordering is deterministic (same type hash →
-    // sorted by inverted_balance then object_id).
+    // Sort IDs so the owner-index key ordering is deterministic (same type
+    // hash → sorted by inverted_balance then object_id).
     ids.sort();
 
     let mut objects = HashMap::new();
@@ -181,7 +181,8 @@ fn make_coin_mock(owner: IotaAddress, count: usize) -> (MockGrpcStateReader, Vec
         ));
     }
 
-    // Sort owned_objects by v2 key order (type_id, params, inv_balance, id).
+    // Sort owned_objects by owner-index key order (type_id, params,
+    // inv_balance, id).
     owned_objects.sort_by(|(_, a), (_, b)| {
         (
             a.object_type_identifier,

--- a/crates/iota-node-storage/src/lib.rs
+++ b/crates/iota-node-storage/src/lib.rs
@@ -18,8 +18,8 @@ use iota_types::{
     digests::{ChainIdentifier, TransactionDigest},
     messages_checkpoint::{CheckpointSequenceNumber, VerifiedCheckpoint},
     storage::{
-        CoinInfoV2, DynamicFieldIteratorItem, EpochInfo, ObjectStore, OwnedObjectV2Cursor,
-        OwnedObjectV2IteratorItem, PackageVersionIteratorItem, ReadStore, TransactionInfo,
+        CoinInfo, DynamicFieldIteratorItem, EpochInfo, ObjectStore, OwnedObjectCursor,
+        OwnedObjectIteratorItem, PackageVersionIteratorItem, ReadStore, TransactionInfo,
         error::Result,
     },
 };
@@ -82,14 +82,14 @@ pub trait GrpcIndexes: Send + Sync {
     /// Iterate over objects owned by `owner`, optionally filtered by
     /// `object_type`.
     ///
-    /// Each item includes an [`OwnedObjectV2Cursor`] for seek-based pagination.
+    /// Each item includes an [`OwnedObjectCursor`] for seek-based pagination.
     /// The `cursor` bound is **inclusive**.
     fn account_owned_objects_info_iter(
         &self,
         owner: IotaAddress,
-        cursor: Option<&OwnedObjectV2Cursor>,
+        cursor: Option<&OwnedObjectCursor>,
         object_type: Option<StructTag>,
-    ) -> Result<Box<dyn Iterator<Item = OwnedObjectV2IteratorItem> + '_>>;
+    ) -> Result<Box<dyn Iterator<Item = OwnedObjectIteratorItem> + '_>>;
 
     /// Iterate over the dynamic fields of `parent`.
     ///
@@ -102,7 +102,7 @@ pub trait GrpcIndexes: Send + Sync {
     ) -> Result<Box<dyn Iterator<Item = DynamicFieldIteratorItem> + '_>>;
 
     /// Get unified coin info.
-    fn get_coin_info(&self, coin_type: &StructTag) -> Result<Option<CoinInfoV2>>;
+    fn get_coin_info(&self, coin_type: &StructTag) -> Result<Option<CoinInfo>>;
 
     /// Iterate over all versions of a package by its original package ID.
     fn package_versions_iter(

--- a/crates/iota-node-storage/src/lib.rs
+++ b/crates/iota-node-storage/src/lib.rs
@@ -79,12 +79,12 @@ pub trait GrpcIndexes: Send + Sync {
 
     fn get_transaction_info(&self, digest: &TransactionDigest) -> Result<Option<TransactionInfo>>;
 
-    /// Iterate over objects owned by `owner` using the v2 index, optionally
-    /// filtered by `object_type`.
+    /// Iterate over objects owned by `owner`, optionally filtered by
+    /// `object_type`.
     ///
     /// Each item includes an [`OwnedObjectV2Cursor`] for seek-based pagination.
     /// The `cursor` bound is **inclusive**.
-    fn account_owned_objects_info_iter_v2(
+    fn account_owned_objects_info_iter(
         &self,
         owner: IotaAddress,
         cursor: Option<&OwnedObjectV2Cursor>,
@@ -101,8 +101,8 @@ pub trait GrpcIndexes: Send + Sync {
         cursor: Option<ObjectID>,
     ) -> Result<Box<dyn Iterator<Item = DynamicFieldIteratorItem> + '_>>;
 
-    /// Get unified coin info from the `coin_v2` table.
-    fn get_coin_v2_info(&self, coin_type: &StructTag) -> Result<Option<CoinInfoV2>>;
+    /// Get unified coin info.
+    fn get_coin_info(&self, coin_type: &StructTag) -> Result<Option<CoinInfoV2>>;
 
     /// Iterate over all versions of a package by its original package ID.
     fn package_versions_iter(
@@ -110,19 +110,4 @@ pub trait GrpcIndexes: Send + Sync {
         original_package_id: ObjectID,
         cursor: Option<u64>,
     ) -> Result<Box<dyn Iterator<Item = PackageVersionIteratorItem> + '_>>;
-
-    /// Returns `true` once the `owner_v2` backfill has completed.
-    fn is_owner_v2_index_ready(&self) -> bool {
-        true
-    }
-
-    /// Returns `true` once the `coin_v2` backfill has completed.
-    fn is_coin_v2_index_ready(&self) -> bool {
-        true
-    }
-
-    /// Returns `true` once the `package_version` backfill has completed.
-    fn is_package_version_index_ready(&self) -> bool {
-        true
-    }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -688,8 +688,6 @@ impl IotaNode {
         };
 
         let grpc_indexes_store = if is_full_node && config.enable_grpc_api {
-            // Migrate legacy directory names before opening the DB.
-            GrpcIndexesStore::migrate_legacy_dirs(&config.db_path());
             Some(Arc::new(
                 GrpcIndexesStore::new(
                     config.db_path().join(GRPC_INDEXES_DIR),

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -21,9 +21,9 @@ use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
 pub use object_store_trait::ObjectStore;
 pub use read_store::{
-    AccountOwnedObjectInfo, CoinInfo, CoinInfoV2, DynamicFieldIteratorItem, DynamicFieldKey,
-    EpochInfo, OwnedObjectV2Cursor, OwnedObjectV2IteratorItem, PackageVersionInfo,
-    PackageVersionIteratorItem, PackageVersionKey, ReadStore, TransactionInfo,
+    AccountOwnedObjectInfo, CoinInfo, DynamicFieldIteratorItem, DynamicFieldKey, EpochInfo,
+    OwnedObjectCursor, OwnedObjectIteratorItem, PackageVersionInfo, PackageVersionIteratorItem,
+    PackageVersionKey, ReadStore, TransactionInfo,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -857,17 +857,17 @@ pub struct AccountOwnedObjectInfo {
     pub type_: MoveObjectType,
 }
 
-/// Opaque cursor for seeking in the `owner_v2` index.
+/// Opaque cursor for seeking in the `owner` index.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct OwnedObjectV2Cursor {
+pub struct OwnedObjectCursor {
     pub object_type_identifier: u64,
     pub object_type_params: u64,
     pub inverted_balance: Option<u64>,
     pub object_id: ObjectID,
 }
 
-pub type OwnedObjectV2IteratorItem =
-    Result<(AccountOwnedObjectInfo, OwnedObjectV2Cursor), TypedStoreError>;
+pub type OwnedObjectIteratorItem =
+    Result<(AccountOwnedObjectInfo, OwnedObjectCursor), TypedStoreError>;
 
 pub type DynamicFieldIteratorItem = Result<DynamicFieldKey, TypedStoreError>;
 
@@ -886,15 +886,9 @@ impl DynamicFieldKey {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub struct CoinInfo {
-    pub coin_metadata_object_id: Option<ObjectID>,
-    pub treasury_object_id: Option<ObjectID>,
-}
-
 /// Coin info including optional regulated coin metadata.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub struct CoinInfoV2 {
+pub struct CoinInfo {
     pub coin_metadata_object_id: Option<ObjectID>,
     pub treasury_object_id: Option<ObjectID>,
     pub regulated_coin_metadata_object_id: Option<ObjectID>,

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -828,7 +828,7 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> GrpcIndexes for Sim
         }))
     }
 
-    fn account_owned_objects_info_iter_v2(
+    fn account_owned_objects_info_iter(
         &self,
         _owner: iota_types::base_types::IotaAddress,
         _cursor: Option<&iota_types::storage::OwnedObjectV2Cursor>,
@@ -856,7 +856,7 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> GrpcIndexes for Sim
         Ok(Box::new(std::iter::empty()))
     }
 
-    fn get_coin_v2_info(
+    fn get_coin_info(
         &self,
         _coin_type: &move_core_types::language_storage::StructTag,
     ) -> iota_types::storage::error::Result<Option<iota_types::storage::CoinInfoV2>> {

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -831,10 +831,10 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> GrpcIndexes for Sim
     fn account_owned_objects_info_iter(
         &self,
         _owner: iota_types::base_types::IotaAddress,
-        _cursor: Option<&iota_types::storage::OwnedObjectV2Cursor>,
+        _cursor: Option<&iota_types::storage::OwnedObjectCursor>,
         _object_type: Option<move_core_types::language_storage::StructTag>,
     ) -> iota_types::storage::error::Result<
-        Box<dyn Iterator<Item = iota_types::storage::OwnedObjectV2IteratorItem> + '_>,
+        Box<dyn Iterator<Item = iota_types::storage::OwnedObjectIteratorItem> + '_>,
     > {
         Ok(Box::new(std::iter::empty()))
     }
@@ -859,7 +859,7 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> GrpcIndexes for Sim
     fn get_coin_info(
         &self,
         _coin_type: &move_core_types::language_storage::StructTag,
-    ) -> iota_types::storage::error::Result<Option<iota_types::storage::CoinInfoV2>> {
+    ) -> iota_types::storage::error::Result<Option<iota_types::storage::CoinInfo>> {
         Ok(None)
     }
 


### PR DESCRIPTION
# Description of change

- Remove deprecated column families (`transactions`, `owner`, `dynamic_field`, `coin`) and their `#[deprecated_db_map]` annotations, migration functions, `LegacyDynamicFieldIndexInfo`, and the legacy directory migration (`migrate_legacy_dirs`, `LEGACY_INDEX_DIR`)
- Remove background backfill infrastructure: `BackfillTask`/`BackfillIndexer`/`BackfillBatchIndexer`, readiness flags, `Watermark` backfill variants, `IndexBackfillInProgressError`, `GrpcReader` readiness guards, and `is_*_index_ready()` trait methods
- Rename all v2 types, methods, and table fields to their final names (e.g. `OwnerIndexKeyV2` -> `OwnerIndexKey`, `CoinIndexInfoV2` -> `CoinIndexInfo`, `owner_v2`/`dynamic_field_v2`/`coin_v2` -> `owner`/`dynamic_field`/`coin`, `OwnedObjectV2Cursor` -> `OwnedObjectCursor`, `iota_types::storage::CoinInfoV2` -> `CoinInfo` — the unused pre-regulated `CoinInfo` struct was removed to free the name)
- Extract a generic `migrate_cf` helper in `grpc_indexes.rs` that batch-copies entries through a caller-supplied map function; the three remaining CF migrations are now thin wrappers around it


## Links to any relevant issues

Parts of #10955 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Remove deprecated gRPC index tables. ⚠️⚠️⚠️ The migration may incur a downtime of several minutes upon restart of the full nodes, so operators are requested to stage it according to their SLA needs.⚠️⚠️⚠️
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

