### PR TITLE
fix(ts-sdk): Update the changesets publish workflow to rename the npm token env var

### DIFF
--- a/.github/workflows/changesets_publish.yml
+++ b/.github/workflows/changesets_publish.yml
@@ -76,9 +76,9 @@ jobs:
       - name: Promote next to latest
         if: github.event.inputs.release_type == 'latest'
         env:
-          # NPM_TOKEN is required because `npm dist-tag` does not support OIDC authentication.
+          # NODE_AUTH_TOKEN is required because `npm dist-tag` does not support OIDC authentication.
           # See: https://github.com/npm/cli/issues/8547
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           PACKAGES=$(pnpm ls -r --depth -1 --json | jq -r '.[] | select(.private != true) | .name')
           for NAME in $PACKAGES; do


### PR DESCRIPTION
I have faith.