### PR TITLE
fix(iota-verifier): adds additional borrow reference safety checks

### DIFF
--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -2263,7 +2263,9 @@ impl IndexerStore for PgIndexerStore {
                 for config_chunk in all_configs.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
                     insert_or_ignore_into!(protocol_configs::table, config_chunk, conn);
                 }
-                insert_or_ignore_into!(feature_flags::table, all_flags.clone(), conn);
+                for flag_chunk in all_flags.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                    insert_or_ignore_into!(feature_flags::table, flag_chunk, conn);
+                }
                 Ok::<(), IndexerError>(())
             },
             PG_DB_COMMIT_SLEEP_DURATION

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1299,6 +1299,7 @@
               "featureFlags": {
                 "accept_passkey_in_multisig": false,
                 "accept_zklogin_in_multisig": false,
+                "additional_borrow_checks": false,
                 "additional_multisig_checks": false,
                 "adjust_rewards_by_score": false,
                 "calculate_validator_scores": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -138,6 +138,7 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 // Version 24: Switch consensus protocol to Starfish in all networks.
 //             Enable Move-based sponsor account authentication in devnet.
 //             Add AuthContext native functions cost for reading tx_data_bytes.
+//             Enable additional borrow checks.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -471,6 +472,10 @@ struct FeatureFlags {
     // If true, enable `TxContext` Move API to go native.
     #[serde(skip_serializing_if = "is_false")]
     move_native_tx_context: bool,
+
+    // If true, perform additional borrow checks
+    #[serde(skip_serializing_if = "is_false")]
+    additional_borrow_checks: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1611,6 +1616,10 @@ impl ProtocolConfig {
         self.feature_flags.enable_move_authentication
     }
 
+    pub fn additional_borrow_checks(&self) -> bool {
+        self.feature_flags.additional_borrow_checks
+    }
+
     pub fn enable_move_authentication_for_sponsor(&self) -> bool {
         let enable_move_authentication_for_sponsor =
             self.feature_flags.enable_move_authentication_for_sponsor;
@@ -2716,6 +2725,9 @@ impl ProtocolConfig {
                     // verification in account abstraction.
                     cfg.auth_context_tx_data_bytes_cost_base = Some(30);
                     cfg.auth_context_tx_data_bytes_cost_per_byte = Some(2);
+
+                    // Enable additional borrow checks.
+                    cfg.feature_flags.additional_borrow_checks = true;
                 }
 
                 // Use this template when making changes:
@@ -2751,6 +2763,14 @@ impl ProtocolConfig {
             (None, None)
         };
 
+        let additional_borrow_checks = if signing_limits.is_some() {
+            // Always apply additional borrow checks during signing regardless of
+            // protocol version, to prevent accepting potentially unsafe bytecode.
+            true
+        } else {
+            self.additional_borrow_checks()
+        };
+
         VerifierConfig {
             max_loop_depth: Some(self.max_loop_depth() as usize),
             max_generic_instantiation_length: Some(self.max_generic_instantiation_length() as usize),
@@ -2772,6 +2792,7 @@ impl ProtocolConfig {
                                                                            * no limit */
             bytecode_version: self.move_binary_format_version(),
             max_variants_in_enum: self.max_move_enum_variants_as_option(),
+            additional_borrow_checks,
         }
     }
 

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_24.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_24.snap
@@ -36,6 +36,7 @@ feature_flags:
   separate_gas_price_feedback_mechanism_for_randomness: true
   pass_validator_scores_to_advance_epoch: true
   move_native_tx_context: true
+  additional_borrow_checks: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_24.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_24.snap
@@ -42,6 +42,7 @@ feature_flags:
   calculate_validator_scores: true
   consensus_fast_commit_sync: true
   move_native_tx_context: true
+  additional_borrow_checks: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_24.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_24.snap
@@ -50,6 +50,7 @@ feature_flags:
   pass_calculated_validator_scores_to_advance_epoch: true
   consensus_fast_commit_sync: true
   move_native_tx_context: true
+  additional_borrow_checks: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -51,6 +51,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             max_identifier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
             bytecode_version: VERSION_MAX,
             max_variants_in_enum: Some(DEFAULT_MAX_VARIANTS),
+            additional_borrow_checks: true,
         },
         MeterConfig::old_default(),
     )

--- a/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -149,6 +149,7 @@ impl<'env> CodeUnitVerifier<'env, '_> {
         type_safety::verify(self.module, &self.function_context, ability_cache, meter)?;
         locals_safety::verify(self.module, &self.function_context, ability_cache, meter)?;
         reference_safety::verify(
+            verifier_config,
             self.module,
             &self.function_context,
             self.name_def_map,

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -23,6 +23,7 @@ use move_binary_format::{
 use move_borrow_graph::references::RefID;
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 
 type BorrowGraph = move_borrow_graph::graph::BorrowGraph<(), Label>;
 
@@ -350,7 +351,11 @@ impl AbstractState {
         &self,
         idx: LocalIndex,
         meter: &mut (impl Meter + ?Sized),
+        config: &VerifierConfig,
     ) -> PartialVMResult<bool> {
+        if config.additional_borrow_checks && self.has_full_borrows(self.frame_root()) {
+            return Ok(true);
+        }
         charge_graph_size(self.graph_size(), meter)?;
         Ok(self.has_consistent_mutable_borrows(self.frame_root(), Some(Label::Local(idx))))
     }
@@ -405,6 +410,7 @@ impl AbstractState {
         offset: CodeOffset,
         local: LocalIndex,
         meter: &mut (impl Meter + ?Sized),
+        config: &VerifierConfig,
     ) -> PartialVMResult<AbstractValue> {
         match safe_unwrap!(self.locals.get(local as usize)) {
             AbstractValue::Reference(id) => {
@@ -413,7 +419,9 @@ impl AbstractState {
                 self.add_copy(id, new_id, meter)?;
                 Ok(AbstractValue::Reference(new_id))
             }
-            AbstractValue::NonReference if self.is_local_mutably_borrowed(local, meter)? => {
+            AbstractValue::NonReference
+                if self.is_local_mutably_borrowed(local, meter, config)? =>
+            {
                 Err(self.error(StatusCode::COPYLOC_EXISTS_BORROW_ERROR, offset))
             }
             AbstractValue::NonReference => Ok(AbstractValue::NonReference),
@@ -534,10 +542,15 @@ impl AbstractState {
         mut_: bool,
         local: LocalIndex,
         meter: &mut (impl Meter + ?Sized),
+        config: &VerifierConfig,
     ) -> PartialVMResult<AbstractValue> {
         // nothing to check in case borrow is mutable since the frame cannot have an
         // full borrow/ epsilon outgoing edge
-        if !mut_ && self.is_local_mutably_borrowed(local, meter)? {
+        if !mut_ && self.is_local_mutably_borrowed(local, meter, config)? {
+            return Err(self.error(StatusCode::BORROWLOC_EXISTS_BORROW_ERROR, offset));
+        }
+
+        if config.additional_borrow_checks && mut_ && self.has_full_borrows(self.frame_root()) {
             return Err(self.error(StatusCode::BORROWLOC_EXISTS_BORROW_ERROR, offset));
         }
 

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -31,10 +31,12 @@ use move_binary_format::{
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 
 use crate::reference_safety::abstract_state::STEP_BASE_COST;
 
 struct ReferenceSafetyAnalysis<'a> {
+    config: &'a VerifierConfig,
     module: &'a CompiledModule,
     function_context: &'a FunctionContext<'a>,
     name_def_map: &'a HashMap<IdentifierIndex, FunctionDefinitionIndex>,
@@ -43,11 +45,13 @@ struct ReferenceSafetyAnalysis<'a> {
 
 impl<'a> ReferenceSafetyAnalysis<'a> {
     fn new(
+        config: &'a VerifierConfig,
         module: &'a CompiledModule,
         function_context: &'a FunctionContext<'a>,
         name_def_map: &'a HashMap<IdentifierIndex, FunctionDefinitionIndex>,
     ) -> Self {
         Self {
+            config,
             module,
             function_context,
             name_def_map,
@@ -67,6 +71,7 @@ impl<'a> ReferenceSafetyAnalysis<'a> {
 }
 
 pub(crate) fn verify<'a>(
+    config: &'a VerifierConfig,
     module: &'a CompiledModule,
     function_context: &FunctionContext,
     name_def_map: &'a HashMap<IdentifierIndex, FunctionDefinitionIndex>,
@@ -74,7 +79,8 @@ pub(crate) fn verify<'a>(
 ) -> PartialVMResult<()> {
     let initial_state = AbstractState::new(function_context);
 
-    let mut verifier = ReferenceSafetyAnalysis::new(module, function_context, name_def_map);
+    let mut verifier =
+        ReferenceSafetyAnalysis::new(config, module, function_context, name_def_map);
     verifier.analyze_function(initial_state, function_context, meter)
 }
 
@@ -189,7 +195,7 @@ fn execute_inner(
         Bytecode::Pop => state.release_value(safe_unwrap_err!(verifier.stack.pop()), meter)?,
 
         Bytecode::CopyLoc(local) => {
-            let value = state.copy_loc(offset, *local, meter)?;
+            let value = state.copy_loc(offset, *local, meter, verifier.config)?;
             verifier.push(value)?
         }
         Bytecode::MoveLoc(local) => {
@@ -227,11 +233,11 @@ fn execute_inner(
         }
 
         Bytecode::MutBorrowLoc(local) => {
-            let value = state.borrow_loc(offset, true, *local, meter)?;
+            let value = state.borrow_loc(offset, true, *local, meter, verifier.config)?;
             verifier.push(value)?
         }
         Bytecode::ImmBorrowLoc(local) => {
-            let value = state.borrow_loc(offset, false, *local, meter)?;
+            let value = state.borrow_loc(offset, false, *local, meter, verifier.config)?;
             verifier.push(value)?
         }
         Bytecode::MutBorrowField(field_handle_index) => {

--- a/external-crates/move/crates/move-vm-config/src/verifier.rs
+++ b/external-crates/move/crates/move-vm-config/src/verifier.rs
@@ -28,6 +28,7 @@ pub struct VerifierConfig {
     pub max_identifier_len: Option<u64>,
     pub bytecode_version: u32,
     pub max_variants_in_enum: Option<u64>,
+    pub additional_borrow_checks: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -70,6 +71,7 @@ impl Default for VerifierConfig {
             max_identifier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
             bytecode_version: VERSION_MAX,
             max_variants_in_enum: Some(DEFAULT_MAX_VARIANTS),
+            additional_borrow_checks: true,
         }
     }
 }

--- a/iota-execution/latest/iota-verifier/src/lib.rs
+++ b/iota-execution/latest/iota-verifier/src/lib.rs
@@ -36,6 +36,8 @@ pub fn check_for_verifier_timeout(major_status_code: &StatusCode) -> bool {
         StatusCode::PROGRAM_TOO_COMPLEX,
         // Do we want to make this a substatus of `PROGRAM_TOO_COMPLEX`?
         StatusCode::TOO_MANY_BACK_EDGES,
+        StatusCode::BORROWLOC_EXISTS_BORROW_ERROR,
+        StatusCode::COPYLOC_EXISTS_BORROW_ERROR,
     ]
     .contains(major_status_code)
 }


### PR DESCRIPTION
# Description of change

 - Adds `additional_borrow_checks` flag to `VerifierConfig` and protocol version 24, enabling stricter reference safety checks in the Move bytecode verifier.
- Extends `borrow_loc` and `is_local_mutably_borrowed` in the borrow graph analysis to cover a previously unchecked case that could allow creating aliased mutable references.
- Applies the additional checks unconditionally during transaction signing regardless of protocol version, as an early rejection barrier.
- Chunks `feature_flags` inserts in the indexer to match existing behavior for `protocol_configs`.

## Links to any relevant issues

Fixes #11211 .

## How the change has been tested

- [x] All `iota-protocol-config` snapshot tests pass
- [x] `move-bytecode-verifier` unit tests pass
- [x] Verify protocol version 24 snapshot contains `additional_borrow_checks
