### PR TITLE
fix(starfish): clear verified_headers_cache on reinitialize

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -223,6 +223,7 @@ impl ConsensusAuthority {
             network_client.clone(),
             block_verifier.clone(),
             dag_state.clone(),
+            header_synchronizer.clone(),
         )
         .start();
 
@@ -242,6 +243,7 @@ impl ConsensusAuthority {
                     network_client.clone(),
                     block_verifier.clone(),
                     dag_state.clone(),
+                    header_synchronizer.clone(),
                 )
                 .start(),
             )

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -31,6 +31,7 @@ use crate::{
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
+    header_synchronizer::HeaderSynchronizerHandle,
     error::{ConsensusError, ConsensusResult},
     network::{NetworkClient, SerializedTransactionsV2},
     transaction_ref::{GenericTransactionRef, TransactionRef},
@@ -89,6 +90,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
+        header_synchronizer: Arc<HeaderSynchronizerHandle>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -98,6 +100,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             network_client,
             block_verifier,
             dag_state,
+            header_synchronizer,
             sync_type: CommitSyncType::Fast,
         });
         let last_solid_commit_index = inner.dag_state.read().last_solid_commit_index();
@@ -189,6 +192,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                                 e
                             );
                         } else {
+                            self.inner.header_synchronizer.clear_verified_headers_cache();
                             info!(
                                 "[{}] Components reinitialized, fast sync complete",
                                 self.inner.sync_type.as_str()

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -31,8 +31,8 @@ use crate::{
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
-    header_synchronizer::HeaderSynchronizerHandle,
     error::{ConsensusError, ConsensusResult},
+    header_synchronizer::HeaderSynchronizerHandle,
     network::{NetworkClient, SerializedTransactionsV2},
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
@@ -192,7 +192,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                                 e
                             );
                         } else {
-                            self.inner.header_synchronizer.clear_verified_headers_cache();
+                            self.inner
+                                .header_synchronizer
+                                .clear_verified_headers_cache();
                             info!(
                                 "[{}] Components reinitialized, fast sync complete",
                                 self.inner.sync_type.as_str()

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -60,6 +60,7 @@ use crate::{
     dag_state::DagState,
     encoder::create_encoder,
     error::{ConsensusError, ConsensusResult},
+    header_synchronizer::HeaderSynchronizerHandle,
     network::NetworkClient,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     transaction_ref::{GenericTransactionRef, TransactionRef},
@@ -162,6 +163,7 @@ pub(crate) struct Inner<C: NetworkClient> {
     pub(crate) network_client: Arc<C>,
     pub(crate) block_verifier: Arc<dyn BlockVerifier>,
     pub(crate) dag_state: Arc<RwLock<DagState>>,
+    pub(crate) header_synchronizer: Arc<HeaderSynchronizerHandle>,
     pub(crate) sync_type: CommitSyncType,
 }
 

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -38,6 +38,7 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
+    header_synchronizer::HeaderSynchronizerHandle,
     network::{NetworkClient, SerializedTransactionsV1, SerializedTransactionsV2},
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
 };
@@ -76,6 +77,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         network_client: Arc<C>,
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
+        header_synchronizer: Arc<HeaderSynchronizerHandle>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -85,6 +87,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             network_client,
             block_verifier,
             dag_state,
+            header_synchronizer,
             sync_type: CommitSyncType::Regular,
         });
         let synced_commit_index = inner.dag_state.read().last_commit_index();
@@ -856,6 +859,7 @@ mod tests {
         core_thread::tests::MockCoreThreadDispatcher,
         dag_state::DagState,
         error::ConsensusResult,
+        header_synchronizer::HeaderSynchronizer,
         network::{BlockBundleStream, NetworkClient},
         storage::{Store, mem_store::MemStore},
         transaction_ref::GenericTransactionRef,
@@ -948,6 +952,23 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0));
 
+        let transactions_synchronizer = crate::transactions_synchronizer::TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_thread_dispatcher.clone(),
+            dag_state.clone(),
+        );
+        let header_synchronizer = HeaderSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_thread_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer,
+            block_verifier.clone(),
+            dag_state.clone(),
+            false,
+        );
+
         let mut commit_syncer = RegularCommitSyncer::new(
             context,
             core_thread_dispatcher,
@@ -956,6 +977,7 @@ mod tests {
             network_client,
             block_verifier,
             dag_state,
+            header_synchronizer,
         );
 
         // Check initial state.

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -952,12 +952,13 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0));
 
-        let transactions_synchronizer = crate::transactions_synchronizer::TransactionsSynchronizer::start(
-            network_client.clone(),
-            context.clone(),
-            core_thread_dispatcher.clone(),
-            dag_state.clone(),
-        );
+        let transactions_synchronizer =
+            crate::transactions_synchronizer::TransactionsSynchronizer::start(
+                network_client.clone(),
+                context.clone(),
+                core_thread_dispatcher.clone(),
+                dag_state.clone(),
+            );
         let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -255,6 +255,7 @@ enum Command {
 pub(crate) struct HeaderSynchronizerHandle {
     commands_sender: Sender<Command>,
     tasks: tokio::sync::Mutex<JoinSet<()>>,
+    verified_headers_cache: Arc<Mutex<LruCache<BlockHeaderDigest, ()>>>,
 }
 
 impl HeaderSynchronizerHandle {
@@ -275,6 +276,10 @@ impl HeaderSynchronizerHandle {
             .await
             .map_err(|_err| ConsensusError::Shutdown)?;
         receiver.await.map_err(|_err| ConsensusError::Shutdown)?
+    }
+
+    pub(crate) fn clear_verified_headers_cache(&self) {
+        self.verified_headers_cache.lock().clear();
     }
 
     pub(crate) async fn stop(&self) -> Result<(), JoinError> {
@@ -389,6 +394,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         }
 
         let commands_sender_clone = commands_sender.clone();
+        let verified_headers_cache_clone = verified_headers_cache.clone();
 
         if sync_last_known_own_block {
             commands_sender
@@ -420,6 +426,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         Arc::new(HeaderSynchronizerHandle {
             commands_sender,
             tasks: tokio::sync::Mutex::new(tasks),
+            verified_headers_cache: verified_headers_cache_clone,
         })
     }
 


### PR DESCRIPTION
# Description of change

Clear the `verified_headers_cache` in `HeaderSynchronizer` after fast commit sync calls `reinitialize_components`. Without this, blocks verified before reinit are skipped on re-fetch.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
