### PR TITLE
fix(starfish-speed): resolve post-rebase conflicts between PRs #11161 and #11202

### DIFF
--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -161,25 +161,6 @@ impl BlockHeaderV1 {
         }
     }
 
-    /// Validates that overlap_start_index and overlap_end_index are within
-    /// bounds of the references vector. Must be called before accessing
-    /// ancestors() or acknowledgments() on deserialized headers to prevent
-    /// panics from adversarial index values.
-    pub(crate) fn verify_references_indices(&self) -> ConsensusResult<()> {
-        let len = self.references.len();
-        if self.overlap_end_index as usize > len
-            || self.overlap_start_index as usize > len
-            || self.overlap_start_index > self.overlap_end_index
-        {
-            return Err(ConsensusError::InvalidOverlapIndices {
-                overlap_start: self.overlap_start_index,
-                overlap_end: self.overlap_end_index,
-                references_len: len,
-            });
-        }
-        Ok(())
-    }
-
     fn genesis_block_header(context: &Context, author: AuthorityIndex) -> Self {
         Self {
             epoch: context.committee.epoch(),
@@ -449,10 +430,34 @@ impl BlockHeaderAPI for BlockHeader {
 }
 
 impl BlockHeader {
+    /// Validates that overlap_start_index and overlap_end_index are within
+    /// bounds of the references vector. Must be called before accessing
+    /// ancestors() or acknowledgments() on deserialized headers to prevent
+    /// panics from adversarial index values.
     pub(crate) fn verify_references_indices(&self) -> ConsensusResult<()> {
-        match self {
-            BlockHeader::V1(header) => header.verify_references_indices(),
+        let (references_len, overlap_start, overlap_end) = match self {
+            BlockHeader::V1(h) => (
+                h.references.len(),
+                h.overlap_start_index,
+                h.overlap_end_index,
+            ),
+            BlockHeader::V2(h) => (
+                h.references.len(),
+                h.overlap_start_index,
+                h.overlap_end_index,
+            ),
+        };
+        if overlap_end as usize > references_len
+            || overlap_start as usize > references_len
+            || overlap_start > overlap_end
+        {
+            return Err(ConsensusError::InvalidOverlapIndices {
+                overlap_start,
+                overlap_end,
+                references_len,
+            });
         }
+        Ok(())
     }
 }
 

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -298,20 +298,13 @@ pub(crate) struct SerializedBlockBundleParts {
     pub(crate) useful_shards_authors_bitmask: AuthoritySet,
 }
 
-fn validate_authority_bitmask(bitmask: [u64; 4], committee: &Committee) -> ConsensusResult<()> {
-    for (array_index, &bits) in bitmask.iter().enumerate() {
-        let mut bits = bits;
-        let base = array_index * 64;
-        while bits != 0 {
-            let bit = bits.trailing_zeros() as usize;
-            let index = base + bit;
-            if index >= committee.size() {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: AuthorityIndex::from(index as u8),
-                    max: committee.size(),
-                });
-            }
-            bits &= bits - 1;
+fn validate_authority_set(set: &AuthoritySet, committee: &Committee) -> ConsensusResult<()> {
+    for index in set.iter() {
+        if !committee.is_valid_index(index) {
+            return Err(ConsensusError::InvalidAuthorityIndex {
+                index,
+                max: committee.size(),
+            });
         }
     }
     Ok(())
@@ -319,8 +312,8 @@ fn validate_authority_bitmask(bitmask: [u64; 4], committee: &Committee) -> Conse
 
 impl SerializedBlockBundleParts {
     pub(crate) fn validate_useful_authorities(&self, committee: &Committee) -> ConsensusResult<()> {
-        validate_authority_bitmask(self.useful_headers_authors_bitmask, committee)?;
-        validate_authority_bitmask(self.useful_shards_authors_bitmask, committee)?;
+        validate_authority_set(&self.useful_headers_authors_bitmask, committee)?;
+        validate_authority_set(&self.useful_shards_authors_bitmask, committee)?;
         Ok(())
     }
 


### PR DESCRIPTION
# Description of change

Fix compilation errors after rebasing `consensus/feat/starfish-speed` on top of `develop`. PRs #11161 (BlockHeaderV2) and #11202 (peer message hardening) introduced conflicting changes:

- **`network/mod.rs`**: `validate_authority_bitmask` used raw `[u64; 4]` but fields were changed to `AuthoritySet`. Replaced with `validate_authority_set` using `AuthoritySet::iter()` and `committee.is_valid_index()`.
- **`block_header.rs`**: `verify_references_indices` only matched `BlockHeader::V1`. Added V2 support and deduplicated the logic into a single implementation on `BlockHeader`.

## Links to any relevant issues

Resolves conflicts between #11161 and #11202.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
