### PR TITLE
fix(iota-core): implement notify_capabilities_v2 in test mock clients

### DIFF
--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -86,9 +86,22 @@ impl ValidatorV2API for LocalAuthorityClient {
     }
     async fn notify_capabilities_v2(
         &self,
-        _request: HandleCapabilityNotificationRequestV1,
+        request: HandleCapabilityNotificationRequestV1,
     ) -> Result<HandleCapabilityNotificationResponseV1, IotaError> {
-        unimplemented!()
+        let state = self.state.clone();
+        let epoch_store = state.load_epoch_store_one_call_per_task();
+
+        let verified_authority_capabilities =
+            epoch_store.verify_authority_capabilities(request.message)?;
+
+        info!(
+            "Received capability notification (v2): {:?}",
+            verified_authority_capabilities.data()
+        );
+
+        epoch_store.record_capabilities_v1(verified_authority_capabilities.data())?;
+
+        Ok(HandleCapabilityNotificationResponseV1 { _unused: false })
     }
     async fn health_check(
         &self,
@@ -354,7 +367,12 @@ impl ValidatorV2API for MockAuthorityApi {
         &self,
         _request: HandleCapabilityNotificationRequestV1,
     ) -> Result<HandleCapabilityNotificationResponseV1, IotaError> {
-        unimplemented!()
+        tokio::time::sleep(self.delay).await;
+
+        match &self.handle_capability_notification_result {
+            Some(result) => result.clone(),
+            None => Ok(HandleCapabilityNotificationResponseV1 { _unused: false }),
+        }
     }
     async fn health_check(
         &self,


### PR DESCRIPTION
# Description of change

PR #11150 switched the aggregator to call `notify_capabilities_v2` (ValidatorV2 endpoint) instead of the V1 `handle_capability_notification_v1`, but the test mock implementations in `test_authority_clients.rs` were left as `unimplemented!()`. This caused all `send_capability_notification_*` tests to panic.

This PR implements `notify_capabilities_v2` in the two mock types exercised by those tests:

- **`LocalAuthorityClient`** — mirrors its V1 logic: verifies authority capabilities via the epoch store and records them.
- **`MockAuthorityApi`** — mirrors its V1 logic: respects the configurable delay and returns `handle_capability_notification_result`.

## Links to any relevant issues
fixes #11244.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes