### PR TITLE
feat(dapp-kit): add useWalletStoreSync

### DIFF
--- a/sdk/dapp-kit/src/hooks/wallet/useWalletStoreSync.ts
+++ b/sdk/dapp-kit/src/hooks/wallet/useWalletStoreSync.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { useContext, useSyncExternalStore } from 'react';
+
+import { WalletContext } from '../../contexts/walletContext.js';
+import type { StoreState } from '../../walletStore.js';
+
+/**
+ * Predefined approved selectors for secure, controlled access to store values.
+ * The selectors control what data is returned and in what format.
+ */
+const APPROVED_SELECTORS = {
+    lastConnectedWalletName: (state: StoreState): string | null => state.lastConnectedWalletName,
+    connectionStatus: (state: StoreState) => state.connectionStatus,
+};
+
+type ApprovedSelectorKey = keyof typeof APPROVED_SELECTORS;
+
+// SSR-safe defaults - the selectors control the return types
+const SSR_DEFAULTS: Record<ApprovedSelectorKey, unknown> = {
+    lastConnectedWalletName: null,
+    connectionStatus: 'disconnected' as const,
+};
+
+// Function overloads for type safety
+export function useWalletStoreSync(selectorKey: 'lastConnectedWalletName'): string | null;
+export function useWalletStoreSync(
+    selectorKey: 'connectionStatus',
+): 'disconnected' | 'connecting' | 'connected';
+
+// Implementation
+export function useWalletStoreSync(selectorKey: ApprovedSelectorKey) {
+    const store = useContext(WalletContext);
+    const selector = APPROVED_SELECTORS[selectorKey];
+    const ssrDefault = SSR_DEFAULTS[selectorKey];
+
+    return useSyncExternalStore(
+        (callback) => {
+            if (!store) return () => {};
+            return store.subscribe(callback);
+        },
+        () => (store ? selector(store.getState()) : ssrDefault),
+        () => ssrDefault,
+    );
+}

--- a/sdk/dapp-kit/src/index.ts
+++ b/sdk/dapp-kit/src/index.ts
@@ -18,6 +18,7 @@ export * from './hooks/wallet/useConnectWallet.js';
 export * from './hooks/wallet/useCurrentAccount.js';
 export * from './hooks/wallet/useCurrentWallet.js';
 export * from './hooks/wallet/useDisconnectWallet.js';
+export * from './hooks/wallet/useWalletStoreSync.js';
 export * from './hooks/wallet/useSignAndExecuteTransaction.js';
 export * from './hooks/wallet/useSignPersonalMessage.js';
 export * from './hooks/wallet/useSignTransaction.js';


### PR DESCRIPTION
**Problem:**
- Zustand's persist middleware has a selector propagation delay during hydration. When a persisted wallet exists in
  localStorage, standard selectors return stale values briefly before hydration completes. This causes ConnectionGuard to incorrectly think no wallet is persisted and prematurely redirect users from protected routes, even though auto-connect is about to restore their session.

**Solution:**
- useWalletStoreSync uses React's useSyncExternalStore to read directly from the Zustand store, bypassing the selector
  propagation delay. This provides immediate access to persisted state during hydration.

**Security:**
- Only pre-approved selectors are exposed (lastConnectedWalletName, connectionStatus) to maintain a controlled public API surface. The selectors themselves control what data is returned and in what format.