### PR TITLE
feat(json-rpc): resolve clever errors in Write API

### DIFF
--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -13,13 +13,16 @@ use iota_core::{
 use iota_json::IotaJsonValue;
 use iota_json_rpc_api::{JsonRpcMetrics, WriteApiOpenRpc, WriteApiServer};
 use iota_json_rpc_types::{
-    DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, IotaMoveViewCallResults,
-    IotaTransactionBlock, IotaTransactionBlockEvents, IotaTransactionBlockResponse,
+    DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, IotaExecutionStatus,
+    IotaMoveViewCallResults, IotaTransactionBlock, IotaTransactionBlockEffects,
+    IotaTransactionBlockEffectsAPI, IotaTransactionBlockEvents, IotaTransactionBlockResponse,
     IotaTransactionBlockResponseOptions, IotaTypeTag, MoveFunctionName,
 };
 use iota_metrics::spawn_monitored_task;
 use iota_open_rpc::Module;
-use iota_package_resolver::{Package, PackageStore, error::Error as PackageResolverError};
+use iota_package_resolver::{
+    Package, PackageStore, Resolver, error::Error as PackageResolverError,
+};
 use iota_protocol_config::Chain;
 use iota_sdk_types::crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion};
 use iota_transaction_builder::TransactionBuilder;
@@ -264,21 +267,37 @@ impl TransactionExecutionApi {
         } else {
             vec![]
         };
+        let resolver = Resolver::new(self.clone());
+
+        let effects = if opts.show_effects {
+            Some(
+                IotaTransactionBlockEffects::from_native_with_clever_error(
+                    response.effects.effects,
+                    &resolver,
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+
+        let errors = match effects.as_ref().map(|e| e.status()) {
+            Some(IotaExecutionStatus::Failure { error }) => vec![error.clone()],
+            _ => vec![],
+        };
 
         Ok(IotaTransactionBlockResponse {
             digest,
             transaction,
             raw_transaction,
-            effects: opts
-                .show_effects
-                .then_some(response.effects.effects.try_into()?),
+            effects,
             events,
             object_changes,
             balance_changes,
             timestamp_ms: None,
             confirmed_local_execution: Some(is_executed_locally),
             checkpoint: None,
-            errors: vec![],
+            errors,
             raw_effects,
         })
     }
@@ -336,8 +355,15 @@ impl TransactionExecutionApi {
         )
         .await?;
 
+        let resolver = Resolver::new(self.clone());
+        let effects = IotaTransactionBlockEffects::from_native_with_clever_error(
+            transaction_effects,
+            &resolver,
+        )
+        .await;
+
         Ok(DryRunTransactionBlockResponse {
-            effects: resp.effects,
+            effects,
             events: resp.events,
             object_changes,
             balance_changes,


### PR DESCRIPTION
# Description of change

This patch complements #10087 to resolve clever errors in `iota_{execute,dryRun}TransactionBlock` methods of the fullnode JSON-RPC

## Links to any relevant issues

Fixes #11249

## How the change has been tested

Manually tested the changes by using the fullnode rpc client in the indexer write-api tests. That is because we do not want to extend the test suite on `iota-json-rpc`.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [x] JSON-RPC: `iota_{execute,dryRun}TransactionBlock` endpoints now resolve move clever errors in the response.
