### PR TITLE
feat(ts-sdk): add normalize WebAuthn public key inputs for passkeys

### DIFF
--- a/.changeset/passkey-normalize-public-key.md
+++ b/.changeset/passkey-normalize-public-key.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': minor
+---
+
+Add `normalizePasskeyPublicKey` utility and update `PasskeyPublicKey` to accept DER SPKI (91-byte), uncompressed (65-byte), and raw XY (64-byte) passkey public key formats in addition to the standard compressed (33-byte) format.

--- a/sdk/typescript/src/keypairs/passkey/index.ts
+++ b/sdk/typescript/src/keypairs/passkey/index.ts
@@ -4,4 +4,4 @@
 
 export { PasskeyKeypair, BrowserPasskeyProvider, findCommonPublicKey } from './keypair.js';
 export type { PasskeyProvider, BrowserPasswordProviderOptions } from './keypair.js';
-export { PasskeyPublicKey } from './publickey.js';
+export { PasskeyPublicKey, normalizePasskeyPublicKey } from './publickey.js';

--- a/sdk/typescript/src/keypairs/passkey/publickey.ts
+++ b/sdk/typescript/src/keypairs/passkey/publickey.ts
@@ -75,13 +75,16 @@ export class PasskeyPublicKey extends PublicKey {
     constructor(value: PublicKeyInitData) {
         super();
 
+        let bytes: Uint8Array;
         if (typeof value === 'string') {
-            this.data = fromBase64(value);
+            bytes = fromBase64(value);
         } else if (value instanceof Uint8Array) {
-            this.data = value;
+            bytes = value;
         } else {
-            this.data = Uint8Array.from(value);
+            bytes = Uint8Array.from(value);
         }
+
+        this.data = normalizePasskeyPublicKey(bytes);
 
         if (this.data.length !== PASSKEY_PUBLIC_KEY_SIZE) {
             throw new Error(
@@ -168,6 +171,32 @@ export function parseDerSPKI(derBytes: Uint8Array): Uint8Array {
 
     // Returns the last 65 bytes `04 || x || y`
     return derBytes.slice(SECP256R1_SPKI_HEADER.length);
+}
+
+/**
+ * Normalizes a WebAuthn public key to the canonical 33-byte compressed secp256r1 format.
+ * Accepts: 33-byte compressed, 65-byte uncompressed (0x04||x||y), 64-byte raw (x||y), 91-byte DER SPKI.
+ */
+export function normalizePasskeyPublicKey(input: Uint8Array): Uint8Array {
+    if (input.length === PASSKEY_PUBLIC_KEY_SIZE) return input;
+
+    if (input.length === SECP256R1_SPKI_HEADER.length + PASSKEY_UNCOMPRESSED_PUBLIC_KEY_SIZE) {
+        const uncompressed65 = parseDerSPKI(input);
+        return secp256r1.ProjectivePoint.fromHex(uncompressed65).toRawBytes(true);
+    }
+
+    if (input.length === PASSKEY_UNCOMPRESSED_PUBLIC_KEY_SIZE && input[0] === 0x04) {
+        return secp256r1.ProjectivePoint.fromHex(input).toRawBytes(true);
+    }
+
+    if (input.length === PASSKEY_UNCOMPRESSED_PUBLIC_KEY_SIZE - 1) {
+        const uncompressed65 = new Uint8Array(PASSKEY_UNCOMPRESSED_PUBLIC_KEY_SIZE);
+        uncompressed65[0] = 0x04;
+        uncompressed65.set(input, 1);
+        return secp256r1.ProjectivePoint.fromHex(uncompressed65).toRawBytes(true);
+    }
+
+    throw new Error(`Unsupported passkey public key length: ${input.length}`);
 }
 
 /**

--- a/sdk/typescript/test/unit/cryptography/passkey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/passkey.test.ts
@@ -365,3 +365,48 @@ describe('passkey signer E2E testing', () => {
         expect(signer2.getPublicKey().toIotaAddress()).toEqual(address);
     });
 });
+
+describe('PasskeyPublicKey normalization', () => {
+    const compressed = fromBase64('A25OtZSBXLMdIJOgZApGPtgjYcsJmK4ve0+52QRnI4vG');
+
+    it('should handle compressed public key (33 bytes)', () => {
+        const pk = new PasskeyPublicKey(compressed);
+        expect(pk.toRawBytes()).toEqual(compressed);
+        expect(pk.toRawBytes().length).toBe(33);
+    });
+
+    it('should handle uncompressed public key (65 bytes)', () => {
+        const sk = secp256r1.utils.randomPrivateKey();
+        const pkUncompressed = secp256r1.getPublicKey(sk, false);
+        const pkCompressed = secp256r1.getPublicKey(sk, true);
+        const pk = new PasskeyPublicKey(pkUncompressed);
+        expect(pk.toRawBytes()).toEqual(pkCompressed);
+        expect(pk.toRawBytes().length).toBe(33);
+    });
+
+    it('should handle raw public key (64 bytes)', () => {
+        const sk = secp256r1.utils.randomPrivateKey();
+        const pkUncompressed = secp256r1.getPublicKey(sk, false);
+        const pkRaw = pkUncompressed.slice(1);
+        const pkCompressed = secp256r1.getPublicKey(sk, true);
+        const pk = new PasskeyPublicKey(pkRaw);
+        expect(pk.toRawBytes()).toEqual(pkCompressed);
+        expect(pk.toRawBytes().length).toBe(33);
+    });
+
+    it('should handle DER SPKI public key (91 bytes)', () => {
+        const sk = secp256r1.utils.randomPrivateKey();
+        const pkUncompressed = secp256r1.getPublicKey(sk, false);
+        const pkCompressed = secp256r1.getPublicKey(sk, true);
+        const der = new Uint8Array([...SECP256R1_SPKI_HEADER, ...pkUncompressed]);
+        const pk = new PasskeyPublicKey(der);
+        expect(pk.toRawBytes()).toEqual(pkCompressed);
+        expect(pk.toRawBytes().length).toBe(33);
+    });
+
+    it('should throw error for invalid length', () => {
+        expect(() => new PasskeyPublicKey(new Uint8Array(32))).toThrow(
+            'Unsupported passkey public key length: 32',
+        );
+    });
+});


### PR DESCRIPTION

resolves iotaledger/ts-packages#63 

## Summary

Port of https://github.com/iotaledger/iota/pull/10411 by @davidgvf.

Applied manually on a fresh branch to resolve import conflicts introduced
by iotaledger/iota#10445 (removal of deprecated `fromB64`/`toB64` aliases).

No functional changes from the original — only the import names were
updated to `fromBase64`/`toBase64`.