### PR TITLE
upstream(core): Port list_owned_objects transfer-to-object and filter-by-type tests

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/data/trusted_coin/Move.toml
+++ b/crates/iota-e2e-tests/tests/grpc/data/trusted_coin/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Examples"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Iota = { local = "../../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+examples = "0x0"

--- a/crates/iota-e2e-tests/tests/grpc/data/trusted_coin/Move.toml
+++ b/crates/iota-e2e-tests/tests/grpc/data/trusted_coin/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-e2e-tests/tests/grpc/data/trusted_coin/sources/trusted_coin.move
+++ b/crates/iota-e2e-tests/tests/grpc/data/trusted_coin/sources/trusted_coin.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
+module examples::trusted_coin {
+    use std::option;
+    use iota::coin::{Self, TreasuryCap};
+    use iota::transfer;
+    use iota::tx_context::{Self, TxContext};
+
+    /// Name of the coin
+    public struct TRUSTED_COIN has drop {}
+
+    /// Register the trusted currency to acquire its `TreasuryCap`. Because
+    /// this is a module initializer, it ensures the currency only gets
+    /// registered once.
+    fun init(witness: TRUSTED_COIN, ctx: &mut TxContext) {
+        // Get a treasury cap for the coin and give it to the transaction
+        // sender
+        let (treasury_cap, metadata) = coin::create_currency<TRUSTED_COIN>(witness, 2, b"TRUSTED", b"Trusted Coin", b"Trusted Coin for test", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx))
+    }
+
+    public entry fun mint(treasury_cap: &mut TreasuryCap<TRUSTED_COIN>, amount: u64, ctx: &mut TxContext) {
+        let coin = coin::mint<TRUSTED_COIN>(treasury_cap, amount, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+    }
+
+    public entry fun transfer(treasury_cap: TreasuryCap<TRUSTED_COIN>, recipient: address) {
+        transfer::public_transfer(treasury_cap, recipient);
+    }
+
+    #[test_only]
+    /// Wrapper of module initializer for testing
+    public fun test_init(ctx: &mut TxContext) {
+        init(TRUSTED_COIN {}, ctx)
+    }
+}

--- a/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
@@ -1,12 +1,29 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{path::PathBuf, time::Duration};
+
 use iota_grpc_types::{
-    field::FieldMaskUtil, read_masks::LIST_OWNED_OBJECTS_READ_MASK,
-    v1::state_service::ListOwnedObjectsRequest,
+    field::FieldMaskUtil,
+    read_masks::LIST_OWNED_OBJECTS_READ_MASK,
+    v1::state_service::{
+        GetCoinInfoRequest, ListOwnedObjectsRequest, ListOwnedObjectsResponse,
+        state_service_client::StateServiceClient,
+    },
 };
+use iota_json_rpc_types::IotaObjectDataOptions;
 use iota_macros::sim_test;
-use iota_types::base_types::IotaAddress;
+use iota_test_transaction_builder::publish_package;
+use iota_types::{
+    TypeTag,
+    base_types::IotaAddress,
+    coin::TreasuryCap,
+    effects::TransactionEffectsAPI,
+    object::Owner,
+    parse_iota_struct_tag,
+    transaction::{CallArg, ObjectArg},
+};
+use move_core_types::language_storage::StructTag;
 use prost_types::FieldMask;
 
 use crate::utils::{
@@ -441,4 +458,355 @@ async fn list_owned_objects_cursor_pagination_e2e() {
         unique, expected_set,
         "paginated IDs do not match single-page IDs"
     );
+}
+
+/// Poll `list_owned_objects` until `owner` reports exactly `expected_count`
+/// objects, failing the test if the expected state is not observed within
+/// the timeout. Used to bridge the lag between transaction execution on the
+/// fullnode and owner-index updates that happen during checkpoint commit.
+async fn wait_for_owned_count(
+    state_client: &mut StateServiceClient<iota_grpc_client::InterceptedChannel>,
+    owner: IotaAddress,
+    expected_count: usize,
+    scenario: &str,
+) -> ListOwnedObjectsResponse {
+    const TIMEOUT: Duration = Duration::from_secs(30);
+    const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+    tokio::time::timeout(TIMEOUT, async {
+        loop {
+            let response = state_client
+                .list_owned_objects(
+                    ListOwnedObjectsRequest::default().with_owner(address_proto(owner)),
+                )
+                .await
+                .unwrap()
+                .into_inner();
+            if response.objects.len() == expected_count {
+                return response;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!("timed out waiting for {scenario}: expected owned count {expected_count}")
+    })
+}
+
+#[sim_test]
+async fn list_owned_objects_tto_indexing() {
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+    let mut state_client = client.state_service_client();
+
+    let sender = first_sender(&test_cluster);
+
+    // Publish the `move_test_code` package (contains the `tto_coin` module).
+    let package_ref = publish_package(
+        &test_cluster.wallet,
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/move_test_code"),
+    )
+    .await;
+    let package_id = package_ref.0;
+
+    // The sender owns several gas coins by default; pick one that is not the
+    // gas-payment coin so we can pass it as the `Coin<IOTA>` argument to
+    // `start`. `test_transaction_builder_with_sender` picks the first gas
+    // coin returned by the RPC as the payment, so the second one is free
+    // for use as an argument.
+    let coin_ref = {
+        let coins = test_cluster
+            .wallet
+            .get_all_gas_objects_owned_by_address(sender)
+            .await
+            .unwrap();
+        assert!(
+            coins.len() >= 2,
+            "sender needs at least 2 gas coins to separate gas payment from the coin argument"
+        );
+        coins[1]
+    };
+
+    // Run `start(coin)` — creates an `A` object owned by the sender and
+    // transfers `coin` to `A`'s address via TTO.
+    let start_tx = test_cluster
+        .test_transaction_builder_with_sender(sender)
+        .await
+        .move_call(
+            package_id,
+            "tto_coin",
+            "start",
+            vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_ref))],
+        )
+        .build();
+    let signed_start = test_cluster.sign_transaction(&start_tx);
+    let (start_effects, _) = test_cluster
+        .execute_transaction_return_raw_effects(signed_start)
+        .await
+        .unwrap();
+    assert!(start_effects.status().is_ok(), "start tx must succeed");
+
+    let parent_ref = start_effects
+        .created()
+        .iter()
+        .find_map(|(obj_ref, owner)| match owner {
+            Owner::AddressOwner(addr) if *addr == sender => Some(*obj_ref),
+            _ => None,
+        })
+        .expect("start should create an `A` object owned by the sender");
+    let parent_addr = IotaAddress::from(parent_ref.0);
+
+    // The coin is now owned by `parent_addr` via TTO; grab its post-start ref.
+    let coin_after_start = start_effects
+        .mutated_excluding_gas()
+        .iter()
+        .find_map(|(obj_ref, _)| (obj_ref.0 == coin_ref.0).then_some(*obj_ref))
+        .expect("coin must appear in mutated set after start");
+
+    // Parent starts with 1 coin (TTO'd in by `start`).
+    wait_for_owned_count(&mut state_client, parent_addr, 1, "parent after start").await;
+
+    // 0x0 starts with 0 coins.
+    wait_for_owned_count(
+        &mut state_client,
+        IotaAddress::ZERO,
+        0,
+        "0x0 before receive",
+    )
+    .await;
+
+    // Run `receive(parent, coin)` — receives the coin from `A` and transfers
+    // it to `0x0`.
+    let receive_tx = test_cluster
+        .test_transaction_builder_with_sender(sender)
+        .await
+        .move_call(
+            package_id,
+            "tto_coin",
+            "receive",
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(parent_ref)),
+                CallArg::Object(ObjectArg::Receiving(coin_after_start)),
+            ],
+        )
+        .build();
+    let signed_receive = test_cluster.sign_transaction(&receive_tx);
+    let (receive_effects, _) = test_cluster
+        .execute_transaction_return_raw_effects(signed_receive)
+        .await
+        .unwrap();
+    assert!(receive_effects.status().is_ok(), "receive tx must succeed");
+
+    // Parent ends with 0 coins.
+    wait_for_owned_count(&mut state_client, parent_addr, 0, "parent after receive").await;
+
+    // 0x0 ends with 1 coin.
+    wait_for_owned_count(&mut state_client, IotaAddress::ZERO, 1, "0x0 after receive").await;
+}
+
+/// Collect the set of object IDs from a `ListOwnedObjectsResponse`.
+fn object_id_set(response: &ListOwnedObjectsResponse) -> std::collections::HashSet<Vec<u8>> {
+    response
+        .objects
+        .iter()
+        .map(|o| {
+            o.reference
+                .as_ref()
+                .unwrap()
+                .object_id
+                .as_ref()
+                .unwrap()
+                .object_id
+                .to_vec()
+        })
+        .collect()
+}
+
+#[sim_test]
+async fn list_owned_objects_filter_by_type() {
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+    let mut state_client = client.state_service_client();
+
+    let sender = first_sender(&test_cluster);
+
+    let iota = "0x2::coin::Coin<0x2::iota::IOTA>"
+        .parse::<TypeTag>()
+        .unwrap()
+        .to_string();
+
+    // We start with some IOTA coins — verify by filtering by `Coin<IOTA>` and
+    // comparing against the unfiltered list (IOTA's proto `Object` does not
+    // carry an `object_type` string, so we check the "all are Coin<IOTA>"
+    // invariant by ID-set equality against a type-filtered query).
+    let unfiltered = state_client
+        .list_owned_objects(ListOwnedObjectsRequest::default().with_owner(address_proto(sender)))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!unfiltered.objects.is_empty());
+
+    let iota_filtered = state_client
+        .list_owned_objects(
+            ListOwnedObjectsRequest::default()
+                .with_owner(address_proto(sender))
+                .with_object_type(iota.clone()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        object_id_set(&unfiltered),
+        object_id_set(&iota_filtered),
+        "sender should start owning only Coin<IOTA> objects"
+    );
+
+    // Publish the `trusted_coin` package
+    let package_ref = publish_package(
+        &test_cluster.wallet,
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/grpc/data/trusted_coin"),
+    )
+    .await;
+    let package_id = package_ref.0;
+
+    // Wait for the publish tx to land in a checkpoint so the owner_v2 index
+    // reflects the newly-created TreasuryCap.
+    test_cluster.wait_for_checkpoint(2, None).await;
+
+    let trusted = format!("{package_id}::trusted_coin::TRUSTED_COIN")
+        .parse::<TypeTag>()
+        .unwrap()
+        .to_string();
+    let trusted_coin = format!("0x2::coin::Coin<{trusted}>")
+        .parse::<TypeTag>()
+        .unwrap()
+        .to_string();
+    let treasury_cap_type =
+        TreasuryCap::type_(parse_iota_struct_tag(&trusted).unwrap()).to_canonical_string(true);
+
+    // After publishing we have the treasury cap and the coin metadata has 0
+    // supply
+    let coin_info = state_client
+        .get_coin_info(GetCoinInfoRequest::default().with_coin_type(trusted.clone()))
+        .await
+        .unwrap()
+        .into_inner();
+    let metadata = coin_info.metadata.as_ref().expect("should have metadata");
+    assert_eq!(coin_info.coin_type.as_deref(), Some(trusted.as_str()));
+    assert_eq!(metadata.symbol.as_deref(), Some("TRUSTED"));
+    assert_eq!(
+        metadata.description.as_deref(),
+        Some("Trusted Coin for test")
+    );
+    assert_eq!(metadata.name.as_deref(), Some("Trusted Coin"));
+    assert_eq!(metadata.decimals, Some(2));
+    assert_eq!(
+        coin_info.treasury.as_ref().expect("treasury").total_supply,
+        Some(0)
+    );
+
+    let treasury_cap_filtered = state_client
+        .list_owned_objects(
+            ListOwnedObjectsRequest::default()
+                .with_owner(address_proto(sender))
+                .with_object_type(treasury_cap_type.clone()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(treasury_cap_filtered.objects.len(), 1);
+
+    // Look up the TreasuryCap's ObjectRef so we can pass it to `mint`.
+    let owned = test_cluster
+        .get_owned_objects(sender, Some(IotaObjectDataOptions::full_content()))
+        .await
+        .unwrap();
+    let treasury_cap_ref = owned
+        .iter()
+        .find_map(|resp| {
+            let data = resp.data.as_ref()?;
+            let struct_tag: StructTag = data.type_.clone()?.try_into().ok()?;
+            (struct_tag.to_canonical_string(true) == treasury_cap_type).then(|| data.object_ref())
+        })
+        .expect("sender should own a TreasuryCap after publish");
+
+    // Mint some coins
+    let mint_tx = test_cluster
+        .test_transaction_builder_with_sender(sender)
+        .await
+        .move_call(
+            package_id,
+            "trusted_coin",
+            "mint",
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(treasury_cap_ref)),
+                CallArg::Pure(bcs::to_bytes(&100_000u64).unwrap()),
+            ],
+        )
+        .build();
+    let signed_mint = test_cluster.sign_transaction(&mint_tx);
+    let (mint_effects, _) = test_cluster
+        .execute_transaction_return_raw_effects(signed_mint)
+        .await
+        .unwrap();
+    assert!(mint_effects.status().is_ok(), "mint tx must succeed");
+
+    // Wait for the mint tx to land in a checkpoint so the owner_v2 index and
+    // the treasury supply reflect the new coin.
+    test_cluster.wait_for_checkpoint(3, None).await;
+
+    // After minting we should have some of the new coins and the supply should
+    // have updated
+    let coin_info = state_client
+        .get_coin_info(GetCoinInfoRequest::default().with_coin_type(trusted.clone()))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(coin_info.coin_type.as_deref(), Some(trusted.as_str()));
+    assert_eq!(
+        coin_info.treasury.as_ref().expect("treasury").total_supply,
+        Some(100_000)
+    );
+
+    let trusted_coin_filtered = state_client
+        .list_owned_objects(
+            ListOwnedObjectsRequest::default()
+                .with_owner(address_proto(sender))
+                .with_object_type(trusted_coin.clone()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(trusted_coin_filtered.objects.len(), 1);
+
+    let iota_filtered = state_client
+        .list_owned_objects(
+            ListOwnedObjectsRequest::default()
+                .with_owner(address_proto(sender))
+                .with_object_type(iota.clone()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(iota_filtered.objects.len(), 5);
+
+    // Calling `list_owned_objects` with `0x2::coin::Coin` filter (without a
+    // type T) should return all coins
+    let bare_coin_filtered = state_client
+        .list_owned_objects(
+            ListOwnedObjectsRequest::default()
+                .with_owner(address_proto(sender))
+                .with_object_type("0x2::coin::Coin".to_owned()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(bare_coin_filtered.objects.len(), 6);
+    // The 6 returned objects must be exactly the union of the 5 `Coin<IOTA>`
+    // and the 1 `Coin<TRUSTED_COIN>` — proves the bare filter matches all
+    // `Coin<T>` regardless of `T`.
+    let expected_union: std::collections::HashSet<Vec<u8>> = object_id_set(&iota_filtered)
+        .union(&object_id_set(&trusted_coin_filtered))
+        .cloned()
+        .collect();
+    assert_eq!(object_id_set(&bare_coin_filtered), expected_union);
 }

--- a/crates/iota-e2e-tests/tests/move_test_code/sources/tto_coin.move
+++ b/crates/iota-e2e-tests/tests/move_test_code/sources/tto_coin.move
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module move_test_code::tto_coin {
+    use iota::coin::Coin;
+    use iota::iota::IOTA;
+    use iota::transfer::Receiving;
+
+    public struct A has key, store {
+        id: UID,
+    }
+
+    public fun start(coin: Coin<IOTA>, ctx: &mut TxContext) {
+        let a = A { id: object::new(ctx) };
+        let a_address = object::id_address(&a);
+
+        transfer::public_transfer(a, tx_context::sender(ctx));
+        transfer::public_transfer(coin, a_address);
+    }
+
+    public entry fun receive(parent: &mut A, x: Receiving<Coin<IOTA>>) {
+        let coin = transfer::public_receive(&mut parent.id, x);
+        transfer::public_transfer(coin, @0x0);
+    }
+}


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.48.4, v1.49.2)
- Ported 2 Sui tests for `list_owned_objects`: one for transfer-to-object ([MystenLabs/sui@6bcfe](https://github.com/MystenLabs/sui/commit/6bcfe6f101c1dedc13c681d71ca8fded17af64b7)), one for type filter ([MystenLabs/sui@d1fec](https://github.com/MystenLabs/sui/commit/d1fec2761638fd58145b5324fb37c98257504818)).

The **test flow, assertions, and numbers are identical to upstream**. Only the **transaction-building plumbing and harness** differ, and each deviation has one reason.

### Test identity map

| Sui commit | Sui test name | Our test name |
|---|---|---|
| [6bcfe](https://github.com/MystenLabs/sui/commit/6bcfe6f101c1dedc13c681d71ca8fded17af64b7) | `test_indexing_with_tto` | `list_owned_objects_tto_indexing` |
| [d1fec](https://github.com/MystenLabs/sui/commit/d1fec2761638fd58145b5324fb37c98257504818) | `test_filter_by_type` | `list_owned_objects_filter_by_type` |

### What matches upstream exactly

- Test flow: publish → `start` → assert (parent=1, 0x0=0) → `receive` → assert (parent=0, 0x0=1); for filter test: publish → assert treasury cap=1 & supply=0 → mint 100_000 → assert `Coin<TRUSTED>`=1, `Coin<IOTA>`=5, bare `Coin`=6.
- Numbers: mint amount `100_000`, decimals `2`, symbol `"TRUSTED"`, name `"Trusted Coin"`, description `"Trusted Coin for test"`.
- Move modules: same structs, functions, signatures — only `sui::`→`iota::`, `SUI`→`IOTA`, and `@tto`→`@0x0` (we can't use the `@tto` package alias because the TTO module lives in the shared `move_test_code` package, not a new one).

### What differs, and why

**Plumbing — matches IOTA's e2e convention** (hand-building `TransactionData` here would be an anomaly vs. every other IOTA e2e test):

- Sui: hand-builds `TransactionData` / `GasData` / `ProgrammableTransactionBuilder`. Us: `test_transaction_builder_with_sender(…)` + `publish_package(…)` — same result, ~5x fewer lines.
- `LiveDataServiceClient` → `StateServiceClient` (our service is renamed).
- `#[tokio::test]` → `#[sim_test]` (IOTA e2e convention).

**Assertion shape** — our proto `Object` has no `object_type` field, so:

- Sui: `objects.iter().all(|o| o.object_type() == sui_type)`.
- Us: compare ID sets against a type-filtered query — same invariant through the surface we actually expose.

**Flake mitigation** — IOTA's owner index updates lag checkpoint commit, so:

- Added `wait_for_owned_count(…)` polling (30s timeout) in the TTO test.
- Added `wait_for_checkpoint(2)` / `(3)` before reads of `get_coin_info` (supply/metadata) after publish/mint.
- Sui's test does not need these.

**Minor structural choices**:

- TTO Move module placed in the existing `move_test_code` package instead of creating a new `tto` package.
- One extra assertion the upstream doesn't have: bare `Coin` filter = `Coin<IOTA>` ∪ `Coin<TRUSTED>` (Sui only checks the count is 6; we also check the IDs are the union — cheap).
- Skipped Sui's `main.rs` / `mod.rs` edits — equivalent files already exist in our tree.

## Links to any relevant issues

Part of #11101

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes