### PR TITLE
fix(starfish): pause regular sync and header fetcher while fast sync is active

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::{Arc, atomic::AtomicBool},
+    time::Instant,
+};
 
 use iota_protocol_config::ProtocolConfig;
 use itertools::Itertools;
@@ -202,6 +205,28 @@ impl ConsensusAuthority {
 
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
+        // `fast_sync_active` is a shared flag used by the fast syncer to
+        // signal when it has any work in flight. The regular commit syncer
+        // and the header synchronizer both read it to pause their
+        // dispatch loops while fast sync is active, avoiding overlapping
+        // ancestor fetches. Only created when fast sync will actually run;
+        // `None` keeps the gate a no-op on deployments (e.g. mainnet today)
+        // where fast sync is disabled.
+        //
+        // Seeded from the durable `DagState::fast_sync_ongoing` flag so a
+        // restart mid-fast-sync starts in the paused state, without
+        // waiting for fast sync's first schedule-loop tick to set it.
+        // Afterwards fast sync owns the atomic; the durable flag is not
+        // reactive enough for runtime gating.
+        let fast_sync_active: Option<Arc<AtomicBool>> =
+            if context.protocol_config.consensus_fast_commit_sync()
+                && context.parameters.enable_fast_commit_syncer
+            {
+                Some(Arc::new(AtomicBool::new(fast_sync_ongoing)))
+            } else {
+                None
+            };
+
         let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
             context.clone(),
@@ -211,10 +236,12 @@ impl ConsensusAuthority {
             block_verifier.clone(),
             dag_state.clone(),
             sync_last_known_own_block,
+            fast_sync_active.clone(),
         );
 
         // Both commit syncers run, but only one actively fetches based on the gap.
         // CommitSyncer handles small gaps, FastCommitSyncer handles large gaps.
+
         let regular_commit_syncer_handle = RegularCommitSyncer::new(
             context.clone(),
             core_dispatcher.clone(),
@@ -224,6 +251,7 @@ impl ConsensusAuthority {
             block_verifier.clone(),
             dag_state.clone(),
             header_synchronizer.clone(),
+            fast_sync_active.clone(),
         )
         .start();
 
@@ -231,25 +259,20 @@ impl ConsensusAuthority {
         // config flag are enabled. The protocol flag also controls gRPC endpoint
         // availability, while the local flag allows operators to disable the
         // syncer without a protocol upgrade.
-        let fast_commit_syncer_handle = if context.protocol_config.consensus_fast_commit_sync()
-            && context.parameters.enable_fast_commit_syncer
-        {
-            Some(
-                FastCommitSyncer::new(
-                    context.clone(),
-                    core_dispatcher.clone(),
-                    commit_vote_monitor.clone(),
-                    commit_consumer_monitor.clone(),
-                    network_client.clone(),
-                    block_verifier.clone(),
-                    dag_state.clone(),
-                    header_synchronizer.clone(),
-                )
-                .start(),
+        let fast_commit_syncer_handle = fast_sync_active.as_ref().map(|flag| {
+            FastCommitSyncer::new(
+                context.clone(),
+                core_dispatcher.clone(),
+                commit_vote_monitor.clone(),
+                commit_consumer_monitor.clone(),
+                network_client.clone(),
+                block_verifier.clone(),
+                dag_state.clone(),
+                header_synchronizer.clone(),
+                flag.clone(),
             )
-        } else {
-            None
-        };
+            .start()
+        });
 
         let network_service = Arc::new(AuthorityService::new(
             context.clone(),

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1755,6 +1755,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         let authority_service = Arc::new(AuthorityService::new(
@@ -1839,6 +1840,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         let authority_service = Arc::new(AuthorityService::new(
@@ -1934,6 +1936,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         let authority_service = Arc::new(AuthorityService::new(
@@ -2020,6 +2023,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         let authority_service = Arc::new(AuthorityService::new(
@@ -2157,6 +2161,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         let authority_service = Arc::new(AuthorityService::new(
@@ -2239,6 +2244,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             true,
+            None,
         );
 
         let authority_service = Arc::new(AuthorityService::new(
@@ -2475,6 +2481,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
@@ -2639,6 +2646,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
@@ -2819,6 +2827,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         // Create the authority service
@@ -3147,6 +3156,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         // Create the authority service
@@ -3287,6 +3297,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         // Create the authority service
@@ -3453,6 +3464,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         // Create the authority service
@@ -3644,6 +3656,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         // Create the authority service
@@ -3867,6 +3880,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         let authority_service = Arc::new(AuthorityService::new(

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -4,7 +4,10 @@
 use std::{
     cmp::max,
     collections::{BTreeMap, BTreeSet},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
@@ -39,6 +42,58 @@ use crate::{
 
 /// Timeout for fetching block headers during close-to-quorum finalization.
 const FETCH_HEADERS_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Which worker skipped a step because the fast commit syncer was active.
+/// Used as the `source` label on `syncer_paused_by_fast_sync`. All
+/// variants share a single metric; keeping them in one enum makes the
+/// label space disjoint and centrally visible.
+#[derive(Clone, Copy)]
+pub(crate) enum FastSyncPauseSource {
+    /// `RegularCommitSyncer::try_schedule_once` skipped adding new ranges
+    /// to `pending_fetches`.
+    RegularSchedule,
+    /// `RegularCommitSyncer::try_start_fetches` skipped moving ranges
+    /// from `pending_fetches` into `inflight_fetches`.
+    RegularStartFetches,
+    /// `HeaderSynchronizer` dropped a `FetchBlockHeaders` command
+    /// instead of dispatching it.
+    HeaderCommand,
+    /// `HeaderSynchronizer`'s periodic scheduler tick skipped starting
+    /// a new sync task.
+    HeaderScheduler,
+}
+
+impl FastSyncPauseSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::RegularSchedule => "regular_schedule",
+            Self::RegularStartFetches => "regular_start_fetches",
+            Self::HeaderCommand => "header_command",
+            Self::HeaderScheduler => "header_scheduler",
+        }
+    }
+}
+
+/// Returns true if the fast commit syncer is currently doing work and the
+/// caller should skip its gated step. Bumps the shared
+/// `syncer_paused_by_fast_sync` metric with the given source label when
+/// the gate fires. Returns false when fast sync is disabled at this
+/// deployment (`fast_sync_active` is `None`) — the call is then an
+/// unconditional pass-through with no metric mutation.
+pub(crate) fn paused_by_fast_sync(
+    fast_sync_active: Option<&Arc<AtomicBool>>,
+    metrics: &crate::metrics::NodeMetrics,
+    source: FastSyncPauseSource,
+) -> bool {
+    let paused = fast_sync_active.is_some_and(|flag| flag.load(Ordering::Relaxed));
+    if paused {
+        metrics
+            .syncer_paused_by_fast_sync
+            .with_label_values(&[source.as_str()])
+            .inc();
+    }
+    paused
+}
 
 /// Output from fast sync fetch operations containing commits, subdags, and
 /// voting headers.
@@ -91,6 +146,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
         header_synchronizer: Arc<HeaderSynchronizerHandle>,
+        fast_sync_active: Arc<AtomicBool>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -102,6 +158,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             dag_state,
             header_synchronizer,
             sync_type: CommitSyncType::Fast,
+            fast_sync_active: Some(fast_sync_active),
         });
         let last_solid_commit_index = inner.dag_state.read().last_solid_commit_index();
         info!(
@@ -222,6 +279,20 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                     "[{}] Fast sync complete, staying active for potential reactivation",
                     self.inner.sync_type.as_str()
                 );
+            }
+
+            // TODO(user contribution): review this `active` expression and
+            // simplify if any term is implied by the others. See plan
+            // §"Activity definition". Conservative form is used here — any
+            // of these being true means fast sync still has work that
+            // regular sync must not overlap with.
+            let active = self.has_fetched_data
+                || self.close_to_quorum_mode
+                || !self.inflight_fetches.is_empty()
+                || !self.pending_fetches.is_empty()
+                || !self.fetched_ranges.is_empty();
+            if let Some(flag) = &self.inner.fast_sync_active {
+                flag.store(active, Ordering::Relaxed);
             }
         }
     }

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -281,11 +281,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 );
             }
 
-            // TODO(user contribution): review this `active` expression and
-            // simplify if any term is implied by the others. See plan
-            // §"Activity definition". Conservative form is used here — any
-            // of these being true means fast sync still has work that
-            // regular sync must not overlap with.
+            // Any of these being true means fast sync still has work; regular
+            // sync and the header synchronizer must stay paused.
             let active = self.has_fetched_data
                 || self.close_to_quorum_mode
                 || !self.inflight_fetches.is_empty()

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -34,7 +34,7 @@ pub mod regular;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::Arc,
+    sync::{Arc, atomic::AtomicBool},
     time::Duration,
 };
 
@@ -165,6 +165,16 @@ pub(crate) struct Inner<C: NetworkClient> {
     pub(crate) dag_state: Arc<RwLock<DagState>>,
     pub(crate) header_synchronizer: Arc<HeaderSynchronizerHandle>,
     pub(crate) sync_type: CommitSyncType,
+    /// Present only when `FastCommitSyncer` is constructed (both the
+    /// protocol flag `consensus_fast_commit_sync` and the local flag
+    /// `enable_fast_commit_syncer` are on). The atomic is seeded at
+    /// startup from the durable `DagState::fast_sync_ongoing()` flag so
+    /// that a restart during fast sync correctly pauses regular syncing
+    /// before fast sync's own loop has had a chance to run. After
+    /// startup, fast sync owns the atomic and updates it each schedule
+    /// iteration — the durable flag is not reactive enough for runtime
+    /// gating. `None` on deployments where fast sync is disabled.
+    pub(crate) fast_sync_active: Option<Arc<AtomicBool>>,
 }
 
 impl<C: NetworkClient> Inner<C> {

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -871,7 +871,10 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{
+        sync::{Arc, atomic::AtomicBool},
+        time::Duration,
+    };
 
     use bytes::Bytes;
     use parking_lot::RwLock;
@@ -1072,5 +1075,103 @@ mod tests {
             assert_eq!(range.start(), start);
             assert_eq!(range.end(), start + 4);
         }
+    }
+
+    /// Exercises both branches of the `fast_sync_active` gate on
+    /// `try_schedule_once`: when the gate is `None` (fast sync disabled at
+    /// this deployment) scheduling proceeds normally; when the gate is
+    /// `Some(true)` (fast sync currently active) scheduling is skipped and
+    /// the `syncer_paused_by_fast_sync{source="regular_schedule"}` counter
+    /// is bumped.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn try_schedule_once_gated_by_fast_sync_active() {
+        async fn run_scenario(fast_sync_active: Option<Arc<AtomicBool>>) -> (usize, u64) {
+            let (context, _) = Context::new_for_test(4);
+            let context = Context {
+                own_index: AuthorityIndex::new_for_test(3),
+                parameters: Parameters {
+                    commit_sync_batch_size: 5,
+                    commit_sync_batches_ahead: 5,
+                    commit_sync_parallel_fetches: 5,
+                    max_headers_per_commit_sync_fetch: 5,
+                    ..context.parameters
+                },
+                ..context
+            };
+            let context = Arc::new(context);
+            let block_verifier = Arc::new(NoopBlockVerifier {});
+            let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+            let network_client = Arc::new(FakeNetworkClient::default());
+            let store: Arc<dyn Store> = Arc::new(MemStore::new(context.clone()));
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+            let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+            let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0));
+
+            let transactions_synchronizer =
+                crate::transactions_synchronizer::TransactionsSynchronizer::start(
+                    network_client.clone(),
+                    context.clone(),
+                    core_thread_dispatcher.clone(),
+                    dag_state.clone(),
+                );
+            let header_synchronizer = HeaderSynchronizer::start(
+                network_client.clone(),
+                context.clone(),
+                core_thread_dispatcher.clone(),
+                commit_vote_monitor.clone(),
+                transactions_synchronizer,
+                block_verifier.clone(),
+                dag_state.clone(),
+                false,
+                None,
+            );
+
+            let mut commit_syncer = RegularCommitSyncer::new(
+                context.clone(),
+                core_thread_dispatcher,
+                commit_vote_monitor.clone(),
+                commit_consumer_monitor,
+                network_client,
+                block_verifier,
+                dag_state,
+                header_synchronizer,
+                fast_sync_active,
+            );
+
+            // Push quorum_commit_index to 10 so scheduling has a non-empty gap.
+            for i in 0..3 {
+                let test_block = TestBlockHeader::new(15, i)
+                    .set_commit_votes(vec![CommitRef::new(10, CommitDigest::MIN)])
+                    .build();
+                let block = VerifiedBlockHeader::new_for_test(test_block);
+                commit_vote_monitor.observe_block(&block);
+            }
+
+            commit_syncer.try_schedule_once();
+
+            let paused = context
+                .metrics
+                .node_metrics
+                .syncer_paused_by_fast_sync
+                .with_label_values(&["regular_schedule"])
+                .get();
+            (commit_syncer.pending_fetches().len(), paused)
+        }
+
+        // Flag off (mainnet-style): scheduling proceeds, gate never fires.
+        let (pending, paused) = run_scenario(None).await;
+        assert!(
+            pending > 0,
+            "expected regular sync to schedule ranges when fast_sync_active is None"
+        );
+        assert_eq!(paused, 0);
+
+        // Fast sync active: scheduling is skipped, metric bumped exactly once.
+        let (pending, paused) = run_scenario(Some(Arc::new(AtomicBool::new(true)))).await;
+        assert_eq!(
+            pending, 0,
+            "expected no ranges scheduled while fast sync is active"
+        );
+        assert_eq!(paused, 1);
     }
 }

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -4,7 +4,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::Arc,
+    sync::{Arc, atomic::AtomicBool},
     time::Duration,
 };
 
@@ -28,10 +28,12 @@ use crate::{
     block_verifier::BlockVerifier,
     commit::{CertifiedCommit, CertifiedCommits, CommitAPI as _, CommitRange},
     commit_syncer::{
-        CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
-        handle_fetch_join_error, requeue_partial_range, schedule_commit_ranges,
-        try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
-        verify_transactions_with_headers, verify_transactions_with_transactions_refs,
+        CommitSyncType, CommitSyncerHandle, Inner,
+        fast::{FastSyncPauseSource, paused_by_fast_sync},
+        fetch_loop as shared_fetch_loop, handle_fetch_join_error, requeue_partial_range,
+        schedule_commit_ranges, try_start_fetches as shared_try_start_fetches,
+        verify_fetched_headers, verify_transactions_with_headers,
+        verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -78,6 +80,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         block_verifier: Arc<dyn BlockVerifier>,
         dag_state: Arc<RwLock<DagState>>,
         header_synchronizer: Arc<HeaderSynchronizerHandle>,
+        fast_sync_active: Option<Arc<AtomicBool>>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -89,6 +92,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             dag_state,
             header_synchronizer,
             sync_type: CommitSyncType::Regular,
+            fast_sync_active,
         });
         let synced_commit_index = inner.dag_state.read().last_commit_index();
         RegularCommitSyncer {
@@ -162,6 +166,19 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                 .protocol_config
                 .consensus_fast_commit_sync()
                 && self.inner.context.parameters.enable_fast_commit_syncer,
+        ) {
+            return;
+        }
+
+        // Pause regular scheduling while the fast commit syncer has any work
+        // in flight. Prevents both syncers from racing on overlapping commit
+        // ranges and forcing duplicate ancestor fetches through the
+        // HeaderSynchronizer. When fast sync is disabled at this deployment,
+        // `fast_sync_active` is `None` and this gate short-circuits.
+        if paused_by_fast_sync(
+            self.inner.fast_sync_active.as_ref(),
+            &self.inner.context.metrics.node_metrics,
+            FastSyncPauseSource::RegularSchedule,
         ) {
             return;
         }
@@ -451,6 +468,18 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
     }
 
     fn try_start_fetches(&mut self) {
+        // Do not move entries from `pending_fetches` into `inflight_fetches`
+        // while the fast commit syncer is doing work. Already-inflight fetches
+        // are not touched — they complete naturally and their results are
+        // deduped against `synced_commit_index` in `handle_fetch_result`.
+        if paused_by_fast_sync(
+            self.inner.fast_sync_active.as_ref(),
+            &self.inner.context.metrics.node_metrics,
+            FastSyncPauseSource::RegularStartFetches,
+        ) {
+            return;
+        }
+
         let inner = self.inner.clone();
         shared_try_start_fetches(
             &self.inner,
@@ -968,6 +997,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         let mut commit_syncer = RegularCommitSyncer::new(
@@ -979,6 +1009,7 @@ mod tests {
             block_verifier,
             dag_state,
             header_synchronizer,
+            None,
         );
 
         // Check initial state.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -611,6 +611,14 @@ impl Core {
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
     ) -> ConsensusResult<()> {
+        let _scope = monitored_scope("Core::reinitialize_components");
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Core::reinitialize_components"])
+            .start_timer();
         info!(
             "Reinitializing components with {} block headers",
             block_headers.len(),

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -5,7 +5,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     num::NonZeroUsize,
-    sync::Arc,
+    sync::{Arc, atomic::AtomicBool},
     time::Duration,
 };
 
@@ -43,6 +43,7 @@ use crate::{
         VerifiedBlockHeader,
     },
     block_verifier::BlockVerifier,
+    commit_syncer::fast::{FastSyncPauseSource, paused_by_fast_sync},
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
@@ -343,6 +344,13 @@ pub(crate) struct HeaderSynchronizer<C: NetworkClient, V: BlockVerifier, D: Core
     inflight_block_headers_map: Arc<InflightBlockHeadersMap>,
     verified_headers_cache: Arc<Mutex<LruCache<BlockHeaderDigest, ()>>>,
     commands_sender: Sender<Command>,
+    /// Present only when the fast commit syncer is running at this
+    /// deployment. When it reads `true`, the header synchronizer skips
+    /// dispatching new fetches (explicit commands and periodic scheduler)
+    /// because fast sync is about to supply the corresponding headers via
+    /// reinitialization. `None` on deployments where fast sync is disabled
+    /// — the gate becomes an unconditional pass-through.
+    fast_sync_active: Option<Arc<AtomicBool>>,
 }
 
 impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchronizer<C, V, D> {
@@ -357,6 +365,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
         sync_last_known_own_block: bool,
+        fast_sync_active: Option<Arc<AtomicBool>>,
     ) -> Arc<HeaderSynchronizerHandle> {
         let (commands_sender, commands_receiver) =
             channel("consensus_synchronizer_commands", 1_000);
@@ -419,6 +428,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 verified_headers_cache,
                 commands_sender: commands_sender_clone,
                 dag_state,
+                fast_sync_active,
             };
             s.run().await;
         }));
@@ -447,6 +457,19 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                         Command::FetchBlockHeaders{ missing_block_refs, peer_index, result } => {
                             if peer_index == self.context.own_index {
                                 error!("We should never attempt to fetch block headers from our own node");
+                                continue;
+                            }
+
+                            // Skip while fast commit syncer is active — headers for
+                            // committed ranges will be supplied by fast sync's
+                            // reinitialization. Prevents racing with fast sync and
+                            // avoids fetching now-stale ancestors post-reinit.
+                            if paused_by_fast_sync(
+                                self.fast_sync_active.as_ref(),
+                                &self.context.metrics.node_metrics,
+                                FastSyncPauseSource::HeaderCommand,
+                            ) {
+                                result.send(Ok(())).ok();
                                 continue;
                             }
 
@@ -527,6 +550,21 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                     };
                 },
                 () = &mut scheduler_timeout => {
+                    // Skip firing the periodic sync task while fast commit
+                    // syncer is active. The timer is still rearmed so the
+                    // scheduler resumes at the next tick after fast sync
+                    // becomes idle.
+                    if paused_by_fast_sync(
+                        self.fast_sync_active.as_ref(),
+                        &self.context.metrics.node_metrics,
+                        FastSyncPauseSource::HeaderScheduler,
+                    ) {
+                        scheduler_timeout
+                            .as_mut()
+                            .reset(Instant::now() + PERIODIC_SYNCHRONIZER_TIMEOUT);
+                        continue;
+                    }
+
                     // we want to start a new task only if the previous one has already finished.
                     if self.fetch_block_headers_scheduler_task.is_empty() {
                         if let Err(err) = self.start_periodic_sync_task().await {
@@ -2095,6 +2133,7 @@ mod tests {
             block_verifier,
             dag_state,
             false,
+            None,
         );
 
         // Create some test block headers
@@ -2163,6 +2202,7 @@ mod tests {
             block_verifier,
             dag_state,
             false,
+            None,
         );
 
         // Create some test block headers
@@ -2299,6 +2339,7 @@ mod tests {
             block_verifier,
             dag_state,
             false,
+            None,
         );
 
         sleep(8 * FETCH_REQUEST_TIMEOUT).await;
@@ -2443,6 +2484,7 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
             false,
+            None,
         );
 
         sleep(4 * FETCH_REQUEST_TIMEOUT).await;
@@ -2552,6 +2594,7 @@ mod tests {
             block_verifier,
             dag_state.clone(),
             false,
+            None,
         );
 
         sleep(4 * FETCH_REQUEST_TIMEOUT).await;
@@ -2706,6 +2749,7 @@ mod tests {
             block_verifier,
             dag_state,
             true,
+            None,
         );
 
         // Wait at least for the timeout time

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -243,6 +243,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_missing_transactions: IntCounterVec,
     pub(crate) commit_sync_voting_block_headers_hits: IntCounter,
     pub(crate) commit_sync_voting_block_headers_fallbacks: IntCounter,
+    pub(crate) syncer_paused_by_fast_sync: IntCounterVec,
     pub(crate) uptime: Histogram,
 }
 
@@ -1061,6 +1062,12 @@ impl NodeMetrics {
                 "commit_sync_voting_block_headers_fallbacks",
                 "Number of voting block headers served from regular storage (fallback) during commit sync.",
                 registry
+            ).unwrap(),
+            syncer_paused_by_fast_sync: register_int_counter_vec_with_registry!(
+                "syncer_paused_by_fast_sync",
+                "Number of times a syncer (regular commit syncer, header synchronizer) skipped dispatching work because the fast commit syncer was active.",
+                &["source"],
+                registry,
             ).unwrap(),
             uptime: register_histogram_with_registry!(
                 "uptime",


### PR DESCRIPTION
# Description of change

`RegularCommitSyncer` and `HeaderSynchronizer` continued scheduling new work while `FastCommitSyncer` was still draining inflight fetches or finalizing close-to-quorum mode. Stale regular-sync commit ranges and concurrent header fetches triggered missing-ancestor downloads against the freshly reinitialized block manager, pushing affected validators into a fast-sync loop.

- **Shared gate** (`commit_syncer/fast.rs`): new `FastSyncPauseSource` enum + `paused_by_fast_sync()` reused from regular sync and header synchronizer.
- **Atomic** (`authority_node.rs`): `Option<Arc<AtomicBool>>` created only when fast sync is active at this deployment; seeded from the durable `DagState::fast_sync_ongoing` flag so a restart mid-fast-sync starts already paused. Fast sync owns the atomic at runtime — the durable flag in the dag state is not reactive enough for per-tick gating.
- **FastCommitSyncer**: updates the atomic at the bottom of each `schedule_loop` iteration as `has_fetched_data || close_to_quorum_mode || !inflight_fetches.is_empty() || !pending_fetches.is_empty() || !fetched_ranges.is_empty()`.
- **Gate points**:
  - `RegularCommitSyncer::try_schedule_once` — no new ranges added to `pending_fetches`.
  - `RegularCommitSyncer::try_start_fetches` — no pending moved to `inflight_fetches`.
  - `HeaderSynchronizer` `FetchBlockHeaders` command handler — dropped.
  - `HeaderSynchronizer` periodic scheduler tick — skipped, timer rearmed.
- **In-flight fetches drain naturally** — they are not interrupted; regular sync dedupes results against `synced_commit_index`.
- **Metric** `syncer_paused_by_fast_sync` with typed `source` label (`regular_schedule`, `regular_start_fetches`, `header_command`, `header_scheduler`).
- **Mainnet-safe and Testnet-affected**: when fast sync is disabled at this deployment, the `Option` is `None` and every gate short-circuits to a no-op — zero behavior change. For Testnet,Devnet, Alphanet it will be enabled automatically during upgrade.

Important: this fix can be considered as safe for upgrading which is likely resolve the issues stemming from fast and regular commit syncing, header synchronizer overlapping. However, it does not resolve the issue in the core: a block that is received by some path to the block manager will force fetching of old data through header synchronizer. This requires a more complex eviction for the block manager that should use garbage collection. However, the latter would change the core behaviour and would require gating via a new protocol config flag.

## Links to any relevant issues

Fixes #11241

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes