### PR TITLE
chore(gRPC): complete and clean up gRPC e2e testing

### DIFF
--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -258,6 +258,10 @@ jobs:
         run: |
           cargo doc --all-features --workspace --no-deps
 
+      - name: iota-grpc-client (no default features)
+        run: |
+          cargo nextest run --profile ci -p iota-grpc-client --no-default-features --no-tests=warn
+
       - name: Install nightly rustfmt
         run: rustup toolchain install nightly --component rustfmt --allow-downgrade
 

--- a/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
@@ -1,7 +1,11 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
+use futures::StreamExt;
 use iota_macros::sim_test;
+use tokio::time::timeout;
 
 use super::{super::utils::setup_grpc_test, common::assert_grpc_not_found};
 
@@ -41,6 +45,23 @@ async fn get_checkpoint_scenarios() {
         "Checkpoint sequence number should match requested"
     );
 
+    // Test: get checkpoint by digest round-trips via the default mask
+    let genesis_digest = genesis
+        .body()
+        .summary()
+        .expect("genesis should have summary")
+        .digest()
+        .expect("genesis summary should have a digest");
+    let by_digest = client
+        .get_checkpoint_by_digest(genesis_digest, None, None, None)
+        .await
+        .expect("Failed to get checkpoint by digest");
+    assert_eq!(
+        by_digest.body().sequence_number(),
+        0,
+        "by-digest lookup should return the genesis checkpoint"
+    );
+
     // Test: nonexistent checkpoint returns not-found error
     let result = client
         .get_checkpoint_by_sequence_number(999_999_999, None, None, None)
@@ -53,4 +74,26 @@ async fn get_checkpoint_scenarios() {
         .get_checkpoint_by_sequence_number(future_sequence, None, None, None)
         .await;
     assert_grpc_not_found(result);
+}
+
+#[sim_test]
+async fn stream_checkpoints_live() {
+    // Live-streaming sanity check: open the stream before checkpoint 2 exists
+    // and verify the broadcaster delivers it within the 120s window. This is
+    // the one test that exercises the live (non-historical) streaming path —
+    // every other checkpoint test either replays historical checkpoints or
+    // pre-waits for the range to be produced.
+    let (_test_cluster, client) = setup_grpc_test(None, None).await;
+
+    let mut stream = client
+        .stream_checkpoints(Some(2), Some(2), None, None, None)
+        .await
+        .expect("Failed to open checkpoint stream");
+
+    let first = timeout(Duration::from_secs(120), stream.body_mut().next())
+        .await
+        .expect("waiting for live checkpoint timed out")
+        .expect("stream ended without a checkpoint")
+        .expect("stream error");
+    assert_eq!(first.sequence_number, 2, "expected checkpoint 2");
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/checkpoints.rs
@@ -78,15 +78,24 @@ async fn get_checkpoint_scenarios() {
 
 #[sim_test]
 async fn stream_checkpoints_live() {
-    // Live-streaming sanity check: open the stream before checkpoint 2 exists
-    // and verify the broadcaster delivers it within the 120s window. This is
-    // the one test that exercises the live (non-historical) streaming path —
-    // every other checkpoint test either replays historical checkpoints or
-    // pre-waits for the range to be produced.
+    // Live-streaming sanity check: target a checkpoint the cluster has not
+    // yet produced (latest + 5) so the stream is forced through the live
+    // (broadcaster) branch in `create_generic_checkpoint_stream` — that
+    // branch is taken when `start > latest_checkpoint_seq` at the moment
+    // the stream is opened. Asking for a fixed sequence like `2` would race
+    // with checkpoint production and could be served from the DB instead.
     let (_test_cluster, client) = setup_grpc_test(None, None).await;
 
+    let latest = client
+        .get_checkpoint_latest(Some(""), None, None)
+        .await
+        .expect("get latest checkpoint")
+        .body()
+        .sequence_number();
+    let target = latest + 5;
+
     let mut stream = client
-        .stream_checkpoints(Some(2), Some(2), None, None, None)
+        .stream_checkpoints(Some(target), Some(target), None, None, None)
         .await
         .expect("Failed to open checkpoint stream");
 
@@ -95,5 +104,8 @@ async fn stream_checkpoints_live() {
         .expect("waiting for live checkpoint timed out")
         .expect("stream ended without a checkpoint")
         .expect("stream error");
-    assert_eq!(first.sequence_number, 2, "expected checkpoint 2");
+    assert_eq!(
+        first.sequence_number, target,
+        "expected checkpoint {target}"
+    );
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/common.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/common.rs
@@ -2,66 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_grpc_client::Error;
-use iota_sdk_types::{Digest, ExecutionStatus, SignedTransaction, Transaction};
-use iota_test_transaction_builder::{TestTransactionBuilder, make_transfer_iota_transaction};
-use iota_types::base_types::IotaAddress;
-use test_cluster::TestCluster;
-
-/// Check if execution status is success.
-pub fn is_success(status: &ExecutionStatus) -> bool {
-    matches!(status, ExecutionStatus::Success)
-}
-
-/// Create a signed transaction for testing (IOTA transfer to random recipient).
-pub async fn create_signed_transaction(test_cluster: &TestCluster) -> SignedTransaction {
-    let recipient = IotaAddress::random();
-    let tx = make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(100)).await;
-    tx.try_into().expect("SDK type conversion failed")
-}
-
-/// Create an unsigned transaction for simulation testing.
-pub async fn create_transaction_for_simulation(test_cluster: &TestCluster) -> Transaction {
-    let (sender, gas) = test_cluster
-        .wallet
-        .get_one_gas_object()
-        .await
-        .unwrap()
-        .unwrap();
-
-    let rgp = test_cluster.get_reference_gas_price().await;
-
-    let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
-        .transfer_iota(None, sender)
-        .build();
-
-    tx_data.try_into().expect("SDK type conversion failed")
-}
-
-/// Execute a transaction and return its digest.
-///
-/// This is useful for tests that need a finalized transaction to query.
-pub async fn execute_transaction_and_get_digest(test_cluster: &TestCluster) -> Digest {
-    let (sender, gas) = test_cluster
-        .wallet
-        .get_one_gas_object()
-        .await
-        .unwrap()
-        .unwrap();
-    let rgp = test_cluster.get_reference_gas_price().await;
-    let transaction_data = TestTransactionBuilder::new(sender, gas, rgp)
-        .transfer_iota(None, sender)
-        .build();
-    let signed_transaction = test_cluster.wallet.sign_transaction(&transaction_data);
-    let transaction_digest = *signed_transaction.digest();
-
-    test_cluster
-        .wallet
-        .execute_transaction_may_fail(signed_transaction)
-        .await
-        .unwrap();
-
-    Digest::new(transaction_digest.into_inner())
-}
 
 /// Check if error is a gRPC error with the specified status code.
 ///

--- a/crates/iota-e2e-tests/tests/grpc/client/event_filters.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/event_filters.rs
@@ -41,7 +41,7 @@ use super::super::utils::{
 ///   E. All (AND) — sender_1 AND NFTMinted
 ///   F. Any (OR) — sender_1 OR NFTMinted
 #[sim_test]
-async fn test_event_filter_scenarios() {
+async fn event_filter_scenarios() {
     let (cluster, client) = setup_grpc_test(None, None).await;
 
     let sender_1 = cluster.get_address_0();
@@ -99,8 +99,8 @@ async fn test_event_filter_scenarios() {
         .body()
         .sequence_number();
 
-    // --- Helper: stream checkpoints with event filter and count events ---
-    let stream_and_count_events = |event_filter: grpc_filter::EventFilter| {
+    // --- Helper: stream checkpoints with event filter and collect events ---
+    let stream_and_collect_events = |event_filter: grpc_filter::EventFilter| {
         let client = client.clone();
         async move {
             let mut stream = client
@@ -114,17 +114,17 @@ async fn test_event_filter_scenarios() {
                 .await
                 .expect("Failed to create stream");
 
-            let mut event_count = 0usize;
+            let mut events: Vec<iota_grpc_types::v1::event::Event> = Vec::new();
             timeout(Duration::from_secs(10), async {
                 while let Some(result) = stream.body_mut().next().await {
                     let cp = result.expect("stream error");
-                    event_count += cp.events().len();
+                    events.extend(cp.events().iter().cloned());
                 }
             })
             .await
             .expect("stream timed out");
 
-            event_count
+            events
         }
     };
 
@@ -135,11 +135,23 @@ async fn test_event_filter_scenarios() {
             grpc_types::Address::default().with_address(sender_1.into_bytes().to_vec()),
         ),
     );
-    let count = stream_and_count_events(sender_1_filter.clone()).await;
+    let events = stream_and_collect_events(sender_1_filter.clone()).await;
     assert_eq!(
-        count, 2,
+        events.len(),
+        2,
         "Scenario A: sender_1 should have 2 events (NFTMinted)"
     );
+    for event in &events {
+        assert!(
+            event.bcs_contents.is_some(),
+            "Scenario A: BCS data must be valid"
+        );
+        assert_eq!(
+            event.sender.as_ref().unwrap().address.as_ref(),
+            sender_1.as_ref(),
+            "Scenario A: events must come from sender_1"
+        );
+    }
 
     // --- Scenario B: MoveEventType filter (NFTMinted) ---
     // 3 NFTMinted events total (2 from sender_1, 1 from sender_2)
@@ -148,11 +160,23 @@ async fn test_event_filter_scenarios() {
             "{nft_package_id}::{NFT_MODULE}::{NFT_MINTED_EVENT}"
         )),
     );
-    let count = stream_and_count_events(nft_event_type_filter.clone()).await;
+    let events = stream_and_collect_events(nft_event_type_filter.clone()).await;
     assert_eq!(
-        count, 3,
+        events.len(),
+        3,
         "Scenario B: should match 3 NFTMinted events from both senders"
     );
+    for event in &events {
+        assert!(
+            event.bcs_contents.is_some(),
+            "Scenario B: BCS data must be valid"
+        );
+        assert_eq!(
+            event.package_id.as_ref().unwrap().object_id.as_ref(),
+            nft_package_id.as_ref(),
+            "Scenario B: events must come from the NFT package"
+        );
+    }
 
     // --- Scenario C: MovePackageAndModule filter (basics::clock) ---
     // 1 TimeEvent from clock::access
@@ -164,21 +188,35 @@ async fn test_event_filter_scenarios() {
             )
             .with_module(CLOCK_MODULE.to_string()),
     );
-    let count = stream_and_count_events(basics_clock_filter).await;
+    let events = stream_and_collect_events(basics_clock_filter).await;
     assert_eq!(
-        count, 1,
+        events.len(),
+        1,
         "Scenario C: should match 1 event from basics::clock"
     );
 
     // --- Scenario D: Negation (NOT sender_1) ---
-    // 0x0 events: 1 DisplayCreated + 1 VersionUpdated = 2
-    // sender_2 events: 1 NFTMinted + 1 TimeEvent = 2
+    // Assert what the filter itself guarantees rather than the total event
+    // count: no sender_1 event may leak through, and the application events
+    // from sender_2 (1 NFTMinted + 1 TimeEvent) must be present.  System
+    // events emitted from 0x0 are intentionally not counted here so the test
+    // stays stable if the framework's set of system events changes.
     let not_sender_1_filter = grpc_filter::EventFilter::default()
         .with_negation(grpc_filter::NotEventFilter::default().with_filter(sender_1_filter.clone()));
-    let count = stream_and_count_events(not_sender_1_filter).await;
+    let events = stream_and_collect_events(not_sender_1_filter).await;
+    assert!(
+        events
+            .iter()
+            .all(|e| { e.sender.as_ref().map(|s| s.address.as_ref()) != Some(sender_1.as_ref()) }),
+        "Scenario D: NOT sender_1 must exclude every sender_1 event"
+    );
+    let sender_2_count = events
+        .iter()
+        .filter(|e| e.sender.as_ref().map(|s| s.address.as_ref()) == Some(sender_2.as_ref()))
+        .count();
     assert_eq!(
-        count, 4,
-        "Scenario D: NOT sender_1 should match 4 events from 0x0 and sender_2"
+        sender_2_count, 2,
+        "Scenario D: sender_2 should contribute 2 events (1 NFTMinted + 1 TimeEvent)"
     );
 
     // --- Scenario E: All (AND) — sender_1 AND NFTMinted ---
@@ -187,9 +225,10 @@ async fn test_event_filter_scenarios() {
         grpc_filter::AllEventFilter::default()
             .with_filters(vec![sender_1_filter.clone(), nft_event_type_filter.clone()]),
     );
-    let count = stream_and_count_events(sender_1_and_nft).await;
+    let events = stream_and_collect_events(sender_1_and_nft).await;
     assert_eq!(
-        count, 2,
+        events.len(),
+        2,
         "Scenario E: sender_1 AND NFTMinted should match 2 events"
     );
 
@@ -200,9 +239,25 @@ async fn test_event_filter_scenarios() {
         grpc_filter::AnyEventFilter::default()
             .with_filters(vec![sender_1_filter, nft_event_type_filter]),
     );
-    let count = stream_and_count_events(sender_1_or_nft).await;
+    let events = stream_and_collect_events(sender_1_or_nft).await;
     assert_eq!(
-        count, 3,
+        events.len(),
+        3,
         "Scenario F: sender_1 OR NFTMinted should match 3 events"
     );
+    for event in &events {
+        assert!(
+            event.bcs_contents.is_some(),
+            "Scenario F: BCS data must be valid"
+        );
+        let sender_matches =
+            event.sender.as_ref().map(|s| s.address.as_ref()) == Some(sender_1.as_ref());
+        let nft_matches = event.package_id.as_ref().map(|p| p.object_id.as_ref())
+            == Some(nft_package_id.as_ref());
+        assert!(
+            sender_matches || nft_matches,
+            "Scenario F: events must match at least one sub-filter: package_id={:?}",
+            event.package_id.as_ref().map(|p| &p.object_id)
+        );
+    }
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/event_filters.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/event_filters.rs
@@ -17,7 +17,7 @@ use tokio::time::timeout;
 
 use super::super::utils::{
     BASICS_PACKAGE, CLOCK_ACCESS_FUNCTION, CLOCK_MODULE, NFT_MINTED_EVENT, NFT_MODULE, NFT_PACKAGE,
-    publish_example_package, setup_grpc_test,
+    publish_example_package, setup_grpc_test, wait_for_executed_transactions_checkpointed,
 };
 
 /// Single test exercising multiple event filter scenarios.
@@ -89,15 +89,7 @@ async fn event_filter_scenarios() {
     let signed_tx = cluster.sign_transaction(&clock_tx);
     cluster.execute_transaction(signed_tx).await;
 
-    // Wait for checkpoints
-    tokio::time::sleep(Duration::from_millis(1500)).await;
-
-    let latest_seq = client
-        .get_checkpoint_latest(Some(""), None, None)
-        .await
-        .expect("get latest checkpoint")
-        .body()
-        .sequence_number();
+    let latest_seq = wait_for_executed_transactions_checkpointed(&cluster, &client).await;
 
     // --- Helper: stream checkpoints with event filter and collect events ---
     let stream_and_collect_events = |event_filter: grpc_filter::EventFilter| {
@@ -148,7 +140,7 @@ async fn event_filter_scenarios() {
         );
         assert_eq!(
             event.sender.as_ref().unwrap().address.as_ref(),
-            sender_1.as_ref(),
+            sender_1.as_bytes(),
             "Scenario A: events must come from sender_1"
         );
     }
@@ -173,7 +165,7 @@ async fn event_filter_scenarios() {
         );
         assert_eq!(
             event.package_id.as_ref().unwrap().object_id.as_ref(),
-            nft_package_id.as_ref(),
+            nft_package_id.as_bytes(),
             "Scenario B: events must come from the NFT package"
         );
     }

--- a/crates/iota-e2e-tests/tests/grpc/client/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/execute.rs
@@ -7,10 +7,7 @@ use iota_sdk_types::UserSignature;
 use iota_test_transaction_builder::make_transfer_iota_transaction;
 use iota_types::base_types::IotaAddress;
 
-use super::{
-    super::utils::setup_grpc_test,
-    common::{create_signed_transaction, is_success},
-};
+use super::super::utils::{create_signed_transaction, is_success, setup_grpc_test};
 
 #[sim_test]
 async fn execute_transaction_transfer() {

--- a/crates/iota-e2e-tests/tests/grpc/client/list.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/list.rs
@@ -2,14 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_macros::sim_test;
-use iota_sdk_types::{Address, ObjectId};
+use iota_sdk_types::ObjectId;
 
-use super::super::utils::setup_grpc_test;
-
-/// Get the first wallet address from a test cluster.
-fn first_sender(cluster: &test_cluster::TestCluster) -> Address {
-    cluster.wallet.get_addresses().first().copied().unwrap()
-}
+use super::super::utils::{first_sender, setup_grpc_test};
 
 // ==========================================================================
 // list_owned_objects

--- a/crates/iota-e2e-tests/tests/grpc/client/metadata.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/metadata.rs
@@ -6,77 +6,59 @@ use iota_macros::sim_test;
 
 use super::super::utils::setup_grpc_test;
 
+/// Assert every standard `x-iota-*` header is present on the given response,
+/// via the [`ResponseExt`] accessors.
+fn assert_standard_headers(response: &impl ResponseExt, label: &str) {
+    assert!(response.chain().is_some(), "{label}: chain header missing");
+    assert!(
+        response.chain_id().is_some(),
+        "{label}: chain_id header missing"
+    );
+    assert!(response.epoch().is_some(), "{label}: epoch header missing");
+    assert!(
+        response.checkpoint_height().is_some(),
+        "{label}: checkpoint_height header missing"
+    );
+    assert!(
+        response.timestamp_ms().is_some(),
+        "{label}: timestamp_ms header missing"
+    );
+    assert!(
+        response.timestamp().is_some(),
+        "{label}: timestamp header missing"
+    );
+    assert!(
+        response.lowest_available_checkpoint().is_some(),
+        "{label}: lowest_available_checkpoint header missing"
+    );
+    assert!(
+        response.lowest_available_checkpoint_objects().is_some(),
+        "{label}: lowest_available_checkpoint_objects header missing"
+    );
+    assert!(
+        response.server_version().is_some(),
+        "{label}: server_version header missing"
+    );
+}
+
+/// Smoke-test that the high-level client surfaces IOTA metadata headers via
+/// the [`ResponseExt`] trait.  Per-endpoint header population is exhaustively
+/// covered at the low level in
+/// `tests/grpc/v1/{ledger_service,transaction_execution_service}/header.rs`;
+/// this test's job is to verify only the client-side `ResponseExt` plumbing.
 #[sim_test]
 async fn metadata_envelope_headers() {
     let (_test_cluster, client) = setup_grpc_test(Some(1), None).await;
 
-    // Use get_service_info to get a MetadataEnvelope and verify metadata headers.
-    let response = client
+    let service_info = client
         .get_service_info(None)
         .await
         .expect("get_service_info should succeed");
+    assert_standard_headers(&service_info, "get_service_info");
 
-    // The server should populate chain metadata in response headers.
-    assert!(response.chain().is_some(), "chain header should be present");
-    assert!(
-        response.chain_id().is_some(),
-        "chain_id header should be present"
-    );
-    assert!(response.epoch().is_some(), "epoch header should be present");
-    assert!(
-        response.checkpoint_height().is_some(),
-        "checkpoint_height header should be present"
-    );
-    assert!(
-        response.timestamp_ms().is_some(),
-        "timestamp_ms header should be present"
-    );
-    assert!(
-        response.timestamp().is_some(),
-        "timestamp header should be present"
-    );
-    assert!(
-        response.lowest_available_checkpoint().is_some(),
-        "lowest_available_checkpoint header should be present"
-    );
-    assert!(
-        response.lowest_available_checkpoint_objects().is_some(),
-        "lowest_available_checkpoint_objects header should be present"
-    );
-    assert!(
-        response.server_version().is_some(),
-        "server_version header should be present"
-    );
-
-    // Verify that the body is also accessible through body().
-    assert!(
-        response.body().chain_id.is_some(),
-        "service info body should contain chain_id"
-    );
-
-    // Both body and header should report a chain_id.
-    assert!(
-        response.chain_id().is_some(),
-        "header chain_id should be present alongside body chain_id"
-    );
-
-    // Also verify with get_health — a different endpoint should also carry
-    // metadata headers.
     let health = client
         .get_health(None)
         .await
         .expect("get_health should succeed");
-
-    assert!(
-        health.epoch().is_some(),
-        "health response should carry epoch header"
-    );
-    assert!(
-        health.checkpoint_height().is_some(),
-        "health response should carry checkpoint_height header"
-    );
-    assert!(
-        health.chain().is_some(),
-        "health response should carry chain header"
-    );
+    assert_standard_headers(&health, "get_health");
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/metadata.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/metadata.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_grpc_client::ResponseExt;
+use iota_grpc_client::{HeadersInterceptor, ResponseExt};
 use iota_macros::sim_test;
 
 use super::super::utils::setup_grpc_test;
@@ -61,4 +61,32 @@ async fn metadata_envelope_headers() {
         .await
         .expect("get_health should succeed");
     assert_standard_headers(&health, "get_health");
+}
+
+/// Verify that the client successfully attaches HTTP auth credentials and the
+/// server still serves the request.  The fixture's gRPC server does not
+/// enforce auth, so this tests only the interceptor wiring end-to-end (request
+/// succeeds with the auth header attached).  Header *content* is verified at
+/// the unit level in `iota_grpc_client::interceptors::tests`.
+#[sim_test]
+async fn metadata_envelope_with_auth() {
+    let (_test_cluster, client) = setup_grpc_test(Some(1), None).await;
+
+    type ConfigureAuth = fn(&mut HeadersInterceptor);
+    let scenarios: &[(&str, ConfigureAuth)] = &[
+        ("basic auth", |i| i.basic_auth("user", Some("pass"))),
+        ("bearer auth", |i| i.bearer_auth("my-token")),
+    ];
+
+    for (label, configure) in scenarios {
+        let mut interceptor = HeadersInterceptor::new();
+        configure(&mut interceptor);
+        let authed_client = client.clone().with_headers(interceptor);
+
+        let service_info = authed_client
+            .get_service_info(None)
+            .await
+            .unwrap_or_else(|e| panic!("get_service_info should succeed with {label}: {e}"));
+        assert_standard_headers(&service_info, &format!("get_service_info ({label})"));
+    }
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -13,8 +13,8 @@ use iota_types::{
 use tonic::Code;
 
 use super::{
-    super::utils::setup_grpc_test,
-    common::{assert_grpc_error, create_transaction_for_simulation, is_success},
+    super::utils::{create_transaction_for_simulation, is_success, setup_grpc_test},
+    common::assert_grpc_error,
 };
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -1,10 +1,15 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use iota_grpc_types::v1::transaction_execution_service::simulated_transaction::ExecutionResult;
 use iota_macros::sim_test;
 use iota_sdk_types::Transaction;
 use iota_test_transaction_builder::TestTransactionBuilder;
-use iota_types::base_types::IotaAddress;
+use iota_types::{
+    base_types::IotaAddress,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{Command, ObjectArg, TransactionData},
+};
 use tonic::Code;
 
 use super::{
@@ -117,5 +122,62 @@ async fn simulate_transaction_scenarios() {
     assert!(
         !is_success(effects.status()),
         "Effects should show failure due to insufficient balance"
+    );
+}
+
+/// Exercise the high-level client's SplitCoins + `command_results` path:
+/// programmable-transaction construction through the SDK `Transaction` type,
+/// read-mask forwarding, and `ExecutionResult::CommandResults` access on the
+/// returned envelope. The exhaustive read-mask projection matrix for
+/// `command_results` / `execution_error` is covered server-side by v1's
+/// `simulate_transaction_readmask_scenarios`.
+#[sim_test]
+async fn simulate_transaction_command_results_split_coins() {
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+
+    let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
+    gas.sort_by_key(|object_ref| object_ref.0);
+    let gas_obj = gas.last().unwrap();
+    let obj_to_split = gas.first().unwrap();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let coin_arg = builder
+        .obj(ObjectArg::ImmOrOwnedObject(*obj_to_split))
+        .unwrap();
+    let amount = builder.pure(1000u64).unwrap();
+    let split_result = builder.command(Command::SplitCoins(coin_arg, vec![amount]));
+    builder.transfer_arg(sender, split_result);
+    let pt = builder.finish();
+
+    let tx_data = TransactionData::new_programmable(
+        sender,
+        vec![*gas_obj],
+        pt,
+        10_000_000, // gas budget
+        test_cluster.get_reference_gas_price().await,
+    );
+    let transaction: Transaction = tx_data.try_into().expect("SDK type conversion failed");
+
+    let response = client
+        .simulate_transaction(transaction, false, Some("execution_result.command_results"))
+        .await
+        .expect("simulate_transaction should succeed");
+
+    let command_results = match response.body().execution_result.as_ref() {
+        Some(ExecutionResult::CommandResults(cr)) => cr,
+        other => panic!("expected CommandResults variant, got: {other:?}"),
+    };
+
+    let first = command_results
+        .results
+        .first()
+        .expect("SplitCoins should produce at least one CommandResult");
+    assert!(
+        first.mutated_by_ref.is_some(),
+        "SplitCoins should populate mutated_by_ref (input coin reference)"
+    );
+    assert!(
+        first.return_values.is_some(),
+        "SplitCoins should populate return_values (split-off coin)"
     );
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -136,7 +136,7 @@ async fn simulate_transaction_command_results_split_coins() {
     let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
 
     let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
-    gas.sort_by_key(|object_ref| object_ref.0);
+    gas.sort_by_key(|object_ref| object_ref.object_id);
     let gas_obj = gas.last().unwrap();
     let obj_to_split = gas.first().unwrap();
 

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -8,7 +8,7 @@ use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     base_types::IotaAddress,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{Command, ObjectArg, TransactionData},
+    transaction::{CallArg, Command, TransactionData},
 };
 use tonic::Code;
 
@@ -142,10 +142,10 @@ async fn simulate_transaction_command_results_split_coins() {
 
     let mut builder = ProgrammableTransactionBuilder::new();
     let coin_arg = builder
-        .obj(ObjectArg::ImmOrOwnedObject(*obj_to_split))
+        .obj(CallArg::ImmutableOrOwned(*obj_to_split))
         .unwrap();
     let amount = builder.pure(1000u64).unwrap();
-    let split_result = builder.command(Command::SplitCoins(coin_arg, vec![amount]));
+    let split_result = builder.command(Command::new_split_coins(coin_arg, vec![amount]));
     builder.transfer_arg(sender, split_result);
     let pt = builder.finish();
 

--- a/crates/iota-e2e-tests/tests/grpc/client/transaction_filters.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transaction_filters.rs
@@ -17,7 +17,7 @@ use tokio::time::timeout;
 
 use super::super::utils::{
     BASICS_PACKAGE, CLOCK_ACCESS_FUNCTION, CLOCK_MODULE, NFT_PACKAGE, publish_example_package,
-    setup_grpc_test,
+    setup_grpc_test, wait_for_executed_transactions_checkpointed,
 };
 
 /// Single test exercising multiple transaction filter scenarios.
@@ -83,15 +83,7 @@ async fn test_transaction_filter_scenarios() {
     let signed_tx = cluster.sign_transaction(&clock_tx);
     cluster.execute_transaction(signed_tx).await;
 
-    // Wait for all transactions to land in checkpoints
-    tokio::time::sleep(Duration::from_millis(1500)).await;
-
-    let latest_seq = client
-        .get_checkpoint_latest(Some(""), None, None)
-        .await
-        .expect("get latest checkpoint")
-        .body()
-        .sequence_number();
+    let latest_seq = wait_for_executed_transactions_checkpointed(&cluster, &client).await;
 
     // --- Helper closure to stream and collect matching transactions ---
     let stream_and_collect = |tx_filter: grpc_filter::TransactionFilter| {

--- a/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
@@ -5,10 +5,8 @@ use iota_macros::sim_test;
 use iota_sdk_types::Digest;
 
 use super::{
-    super::utils::setup_grpc_test,
-    common::{
-        assert_proto_conversion_error, assert_server_not_found, execute_transaction_and_get_digest,
-    },
+    super::utils::{execute_transaction_and_get_digest, setup_grpc_test},
+    common::{assert_proto_conversion_error, assert_server_not_found},
 };
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/grpc/utils.rs
+++ b/crates/iota-e2e-tests/tests/grpc/utils.rs
@@ -4,6 +4,8 @@
 use std::collections::{HashMap, HashSet};
 
 use iota_grpc_types::v1::types::{Address as ProtoAddress, ObjectId as ProtoObjectId};
+use iota_sdk_types::{Digest, ExecutionStatus, SignedTransaction, Transaction};
+use iota_test_transaction_builder::{TestTransactionBuilder, make_transfer_iota_transaction};
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
     effects::TransactionEffectsAPI,
@@ -112,6 +114,81 @@ pub async fn publish_example_package(
         .find(|obj| obj.1.is_immutable())
         .map(|obj| obj.0.object_id)
         .unwrap_or_else(|| panic!("Should have created '{package_name}' package"))
+}
+
+/// Get the first wallet address from a test cluster.
+pub fn first_sender(cluster: &TestCluster) -> IotaAddress {
+    cluster.wallet.get_addresses().first().copied().unwrap()
+}
+
+/// Check if execution status is success.
+pub fn is_success(status: &ExecutionStatus) -> bool {
+    matches!(status, ExecutionStatus::Success)
+}
+
+/// Create a signed transaction for testing (IOTA transfer to random recipient).
+pub async fn create_signed_transaction(test_cluster: &TestCluster) -> SignedTransaction {
+    let recipient = IotaAddress::random();
+    let tx = make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(100)).await;
+    tx.try_into().expect("SDK type conversion failed")
+}
+
+/// Create an unsigned transaction for simulation testing.
+pub async fn create_transaction_for_simulation(test_cluster: &TestCluster) -> Transaction {
+    let (sender, gas) = test_cluster
+        .wallet
+        .get_one_gas_object()
+        .await
+        .unwrap()
+        .unwrap();
+
+    let rgp = test_cluster.get_reference_gas_price().await;
+
+    let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
+        .transfer_iota(None, sender)
+        .build();
+
+    tx_data.try_into().expect("SDK type conversion failed")
+}
+
+/// Execute a transaction and return its digest.
+///
+/// This is useful for tests that need a finalized transaction to query.
+pub async fn execute_transaction_and_get_digest(test_cluster: &TestCluster) -> Digest {
+    let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
+    let digest = *tx.digest();
+    test_cluster
+        .wallet
+        .execute_transaction_may_fail(tx)
+        .await
+        .unwrap();
+    Digest::new(digest.into_inner())
+}
+
+/// Wait until every transaction executed via `cluster.execute_transaction(...)`
+/// is guaranteed to be in a checkpoint executed by the fullnode, then return
+/// a checkpoint sequence number that bounds those transactions.
+///
+/// `cluster.execute_transaction` uses `WaitForLocalExecution`, which only
+/// guarantees the fullnode has executed the transaction locally via the
+/// certificate — checkpoint inclusion is asynchronous.  We read the current
+/// latest as a baseline `N`, then wait for `N + 2`: `N + 1` may have already
+/// had its consensus content sealed before our transaction was certified, in
+/// which case the transaction lands in `N + 2`.  The returned `N + 2` is a
+/// safe upper bound for stream ranges that need to cover those transactions.
+pub async fn wait_for_executed_transactions_checkpointed(
+    cluster: &TestCluster,
+    client: &iota_grpc_client::Client,
+) -> u64 {
+    let baseline_seq = client
+        .get_checkpoint_latest(Some(""), None, None)
+        .await
+        .expect("get latest checkpoint")
+        .body()
+        .sequence_number();
+    let target_seq = baseline_seq + 2;
+    cluster.wait_for_checkpoint(target_seq, None).await;
+    target_seq
 }
 
 /// Assert that a raw tonic result is an error with the expected status code.

--- a/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_checkpoints.rs
@@ -1,106 +1,573 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use futures::StreamExt;
-use iota_grpc_types::v1::{filter as grpc_filter, types as grpc_types};
-use iota_types::transaction::CallArg;
+use iota_grpc_types::{
+    field::FieldMaskUtil,
+    read_masks::GET_CHECKPOINT_READ_MASK,
+    v1::{
+        ledger_service::{
+            CheckpointData, GetCheckpointRequest, StreamCheckpointsRequest, checkpoint_data,
+            ledger_service_client::LedgerServiceClient,
+        },
+        types as grpc_types,
+    },
+};
+use iota_macros::sim_test;
+use prost_types::FieldMask;
 use tokio::time::timeout;
 
 use crate::utils::{
-    BASICS_PACKAGE, CLOCK_ACCESS_FUNCTION, CLOCK_MODULE, NFT_MINTED_EVENT, NFT_MODULE, NFT_PACKAGE,
-    publish_example_package, setup_grpc_test,
+    FieldPresenceChecker, assert_field_presence, assert_tonic_error,
+    comma_separated_field_mask_to_paths, setup_grpc_test,
 };
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_get_checkpoint() {
-    let (_cluster, client) = setup_grpc_test(Some(2), None).await;
+/// `sequence_number` is always populated by the server and not controlled by
+/// the read_mask, so field-presence checks must ignore it.
+const CHECKPOINT_IGNORED_FIELDS: &[&str] = &["sequence_number"];
 
-    // Test getting checkpoint data for sequence number 0
-    let response = client
-        .get_checkpoint_by_sequence_number(
-            0,
-            Some("checkpoint.summary,checkpoint.contents,transactions"),
-            None,
-            None,
-        )
-        .await
-        .expect("gRPC call");
+/// `json_contents` is populated only when the server can resolve the Move
+/// event's type information, which is not guaranteed for system or
+/// test-fixture events. Skip it in field-presence checks so tests stay stable
+/// regardless of which events happen to land in the checkpoint.
+const EVENT_IGNORED_FIELDS: &[&str] = &["json_contents"];
 
-    // Verify the checkpoint data structure
-    assert_eq!(response.body().sequence_number(), 0);
-    let summary = response
-        .body()
-        .summary()
-        .expect("should have summary")
-        .summary()
-        .expect("should deserialize summary");
-    assert_eq!(summary.epoch, 0);
-    assert!(!response.body().executed_transactions.is_empty());
-    assert!(response.body().contents.is_some());
-    let digest_0 = summary.content_digest;
+/// Paths applicable to one `CheckpointData` payload variant.
+///
+/// `wildcard = true` means the caller requested every field (via a bare
+/// `"checkpoint"` / `"transactions"` / `"events"` entry in the read mask).
+/// The concrete field list is then expanded at validation time from the
+/// checker's `top_level_fields()`, keeping the field list authoritative in
+/// one place (the `impl_field_presence_checker!` macro calls in `v1/mod.rs`).
+#[derive(Default)]
+struct PayloadPaths<'a> {
+    wildcard: bool,
+    paths: Vec<&'a str>,
+}
 
-    // Test getting another checkpoint
-    let response_1 = client
-        .get_checkpoint_by_sequence_number(1, Some("checkpoint.summary"), None, None)
-        .await
-        .expect("gRPC call");
+/// Categorize read-mask paths under `CheckpointData`'s top-level payload
+/// fields (`checkpoint.*`, `transactions.*`, `events.*`). Bare prefixes
+/// record a wildcard to be expanded at validation time.
+fn split_checkpoint_paths<'a>(
+    expected: &[&'a str],
+) -> (PayloadPaths<'a>, PayloadPaths<'a>, PayloadPaths<'a>) {
+    let mut checkpoint = PayloadPaths::default();
+    let mut transactions = PayloadPaths::default();
+    let mut events = PayloadPaths::default();
 
-    assert_eq!(response_1.body().sequence_number(), 1);
-    let summary_1 = response_1
-        .body()
-        .summary()
-        .expect("should have summary")
-        .summary()
-        .expect("should deserialize summary");
-    assert_eq!(summary_1.epoch, 0);
-    let digest_1 = summary_1.content_digest;
-
-    // Verify they are different checkpoints
-    assert_ne!(digest_0, digest_1);
-
-    // Test getting checkpoint data for a non-existent sequence number
-    match client
-        .get_checkpoint_by_sequence_number(999999, None, None, None)
-        .await
-    {
-        Ok(_) => {
-            panic!("Unexpectedly found checkpoint data for non-existent sequence number");
+    for path in expected {
+        if let Some(sub) = path.strip_prefix("checkpoint.") {
+            checkpoint.paths.push(sub);
+        } else if *path == "checkpoint" {
+            checkpoint.wildcard = true;
+        } else if let Some(sub) = path.strip_prefix("transactions.") {
+            transactions.paths.push(sub);
+        } else if *path == "transactions" {
+            transactions.wildcard = true;
+        } else if let Some(sub) = path.strip_prefix("events.") {
+            events.paths.push(sub);
+        } else if *path == "events" {
+            events.wildcard = true;
+        } else {
+            panic!(
+                "split_checkpoint_paths: unrecognized CheckpointData path {path:?} — \
+                 valid top-level prefixes are \"checkpoint\", \"transactions\", \"events\""
+            );
         }
-        Err(iota_grpc_client::Error::Grpc(status)) => {
-            assert_eq!(status.code(), tonic::Code::NotFound);
-        }
-        Err(e) => {
-            panic!("Unexpected error type: {e:?}");
-        }
+    }
+
+    (checkpoint, transactions, events)
+}
+
+/// Resolve a `PayloadPaths` bucket to the concrete field list for
+/// [`assert_field_presence`]. A wildcard expands to every top-level field of
+/// `checker` (minus `ignored`); otherwise the explicit dotted sub-paths are
+/// returned as-is.
+fn resolve_payload_paths<'a>(
+    payload: &PayloadPaths<'a>,
+    checker: &dyn FieldPresenceChecker,
+    ignored: &[&str],
+) -> Vec<&'a str> {
+    if payload.wildcard {
+        checker
+            .top_level_fields()
+            .iter()
+            .copied()
+            .filter(|f| !ignored.contains(f))
+            .collect()
+    } else {
+        payload.paths.clone()
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_stream_checkpoints() {
-    let (_cluster, client) = setup_grpc_test(None, None).await;
-
-    let mut stream = client
-        .stream_checkpoints(None, Some(2), None, None, None)
-        .await
-        .unwrap();
-
-    tokio::time::timeout(Duration::from_secs(120), async {
-        if let Some(res) = stream.body_mut().next().await {
-            match res {
-                Ok(response) => {
-                    assert_eq!(response.sequence_number(), 2);
-                }
-                Err(e) => {
-                    panic!("Stream error: {e:?}");
-                }
+/// Validate a single `CheckpointData` payload against the expected field
+/// presence under each top-level `CheckpointData` payload type. Returns `true`
+/// when an `EndMarker` is observed (signalling the end of a checkpoint's
+/// data).
+fn validate_checkpoint_payload(
+    data: &CheckpointData,
+    checkpoint_paths: &PayloadPaths<'_>,
+    transactions_paths: &PayloadPaths<'_>,
+    events_paths: &PayloadPaths<'_>,
+    expected_end_marker_seq: &mut Option<u64>,
+    scenario: &str,
+) -> bool {
+    match data.payload.as_ref() {
+        Some(checkpoint_data::Payload::Checkpoint(checkpoint)) => {
+            assert!(
+                expected_end_marker_seq.is_none(),
+                "{scenario}: received Checkpoint before previous EndMarker"
+            );
+            *expected_end_marker_seq = checkpoint.sequence_number;
+            let paths =
+                resolve_payload_paths(checkpoint_paths, checkpoint, CHECKPOINT_IGNORED_FIELDS);
+            assert_field_presence(
+                checkpoint,
+                &paths,
+                CHECKPOINT_IGNORED_FIELDS,
+                &format!("{scenario}: checkpoint payload"),
+            );
+            false
+        }
+        Some(checkpoint_data::Payload::ExecutedTransactions(txs)) => {
+            for (idx, tx) in txs.executed_transactions.iter().enumerate() {
+                let paths = resolve_payload_paths(transactions_paths, tx, &[]);
+                assert_field_presence(
+                    tx,
+                    &paths,
+                    &[],
+                    &format!("{scenario}: transactions payload (tx {idx})"),
+                );
             }
-        } else {
-            panic!("No checkpoint data returned");
+            false
+        }
+        Some(checkpoint_data::Payload::Events(events)) => {
+            for (idx, event) in events.events.iter().enumerate() {
+                let paths = resolve_payload_paths(events_paths, event, EVENT_IGNORED_FIELDS);
+                assert_field_presence(
+                    event,
+                    &paths,
+                    EVENT_IGNORED_FIELDS,
+                    &format!("{scenario}: events payload (event {idx})"),
+                );
+            }
+            false
+        }
+        Some(checkpoint_data::Payload::EndMarker(marker)) => {
+            assert_eq!(
+                marker.sequence_number,
+                expected_end_marker_seq.take(),
+                "{scenario}: EndMarker sequence_number should match Checkpoint"
+            );
+            true
+        }
+        Some(checkpoint_data::Payload::Progress(_)) => {
+            panic!("{scenario}: unexpected Progress payload outside filter_checkpoints mode");
+        }
+        Some(_) => panic!("{scenario}: unknown CheckpointData payload variant"),
+        None => panic!("{scenario}: unexpected empty payload"),
+    }
+}
+
+/// Helper to issue a `GetCheckpointRequest` and validate every payload in the
+/// response stream against `expected_field_mask_paths` (paths relative to
+/// `CheckpointData`). Returns all received messages.
+///
+/// Asserts that the stream produces exactly one `Checkpoint` payload followed
+/// by optional `ExecutedTransactions` / `Events` payloads and terminates with
+/// a single `EndMarker`.
+async fn assert_get_checkpoint_request(
+    ledger_client: &mut LedgerServiceClient<iota_grpc_client::InterceptedChannel>,
+    request: GetCheckpointRequest,
+    expected_field_mask_paths: &[&str],
+    scenario: &str,
+) -> Vec<CheckpointData> {
+    let (checkpoint_paths, transactions_paths, events_paths) =
+        split_checkpoint_paths(expected_field_mask_paths);
+
+    let mut stream = ledger_client
+        .get_checkpoint(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut messages = Vec::new();
+    let mut saw_end_marker = false;
+    let mut pending_end_marker_seq: Option<u64> = None;
+
+    while let Some(data) = stream.next().await {
+        let data = data.unwrap();
+        let ended = validate_checkpoint_payload(
+            &data,
+            &checkpoint_paths,
+            &transactions_paths,
+            &events_paths,
+            &mut pending_end_marker_seq,
+            scenario,
+        );
+        messages.push(data);
+        if ended {
+            saw_end_marker = true;
+            break;
+        }
+    }
+
+    assert!(saw_end_marker, "{scenario}: expected EndMarker payload");
+    assert!(
+        stream.next().await.is_none(),
+        "{scenario}: stream should be exhausted after EndMarker"
+    );
+
+    messages
+}
+
+/// Helper to issue a `StreamCheckpointsRequest` and validate every payload
+/// across the full range of expected checkpoints. Asserts that exactly
+/// `expected_checkpoint_count` checkpoints are returned, each with a matching
+/// `EndMarker`.
+async fn assert_stream_checkpoints_request(
+    ledger_client: &mut LedgerServiceClient<iota_grpc_client::InterceptedChannel>,
+    request: StreamCheckpointsRequest,
+    expected_field_mask_paths: &[&str],
+    expected_checkpoint_count: usize,
+    scenario: &str,
+) -> Vec<CheckpointData> {
+    let (checkpoint_paths, transactions_paths, events_paths) =
+        split_checkpoint_paths(expected_field_mask_paths);
+
+    let mut stream = ledger_client
+        .stream_checkpoints(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut messages = Vec::new();
+    let mut checkpoint_count = 0usize;
+    let mut pending_end_marker_seq: Option<u64> = None;
+
+    while let Some(data) = stream.next().await {
+        let data = data.unwrap();
+        let ended = validate_checkpoint_payload(
+            &data,
+            &checkpoint_paths,
+            &transactions_paths,
+            &events_paths,
+            &mut pending_end_marker_seq,
+            &format!("{scenario} (checkpoint #{checkpoint_count})"),
+        );
+        messages.push(data);
+        if ended {
+            checkpoint_count += 1;
+            if checkpoint_count >= expected_checkpoint_count {
+                break;
+            }
+        }
+    }
+
+    assert_eq!(
+        checkpoint_count, expected_checkpoint_count,
+        "{scenario}: expected {expected_checkpoint_count} checkpoints, got {checkpoint_count}"
+    );
+
+    messages
+}
+
+#[sim_test]
+async fn get_checkpoint_readmask_scenarios() {
+    let (_test_cluster, client) = setup_grpc_test(Some(2), None).await;
+    let mut ledger_client = client.ledger_service_client();
+
+    type TestCase<'a> = (&'a str, Option<FieldMask>, Vec<&'a str>);
+    let test_cases: Vec<TestCase> = vec![
+        (
+            "default readmask",
+            None,
+            comma_separated_field_mask_to_paths(GET_CHECKPOINT_READ_MASK),
+        ),
+        (
+            "empty readmask",
+            Some(FieldMask::from_paths(&[] as &[&str])),
+            vec![],
+        ),
+        (
+            "checkpoint.summary only",
+            Some(FieldMask::from_paths(["checkpoint.summary"])),
+            vec!["checkpoint.summary"],
+        ),
+        (
+            "checkpoint.contents only",
+            Some(FieldMask::from_paths(["checkpoint.contents"])),
+            vec!["checkpoint.contents"],
+        ),
+        (
+            "checkpoint wildcard",
+            Some(FieldMask::from_paths(["checkpoint"])),
+            vec!["checkpoint"],
+        ),
+        (
+            "partial readmask (summary.digest only)",
+            Some(FieldMask::from_paths(["checkpoint.summary.digest"])),
+            vec!["checkpoint.summary.digest"],
+        ),
+        (
+            "transactions partial (transaction.digest + timestamp)",
+            Some(FieldMask::from_paths([
+                "transactions.transaction.digest",
+                "transactions.timestamp",
+            ])),
+            vec!["transactions.transaction.digest", "transactions.timestamp"],
+        ),
+        (
+            "full readmask",
+            Some(FieldMask::from_paths([
+                "checkpoint",
+                "transactions",
+                "events",
+            ])),
+            vec!["checkpoint", "transactions", "events"],
+        ),
+    ];
+
+    for (scenario, mask, expected_paths) in test_cases {
+        let mut request = GetCheckpointRequest::default().with_sequence_number(0);
+        if let Some(mask) = mask {
+            request = request.with_read_mask(mask);
+        }
+        assert_get_checkpoint_request(&mut ledger_client, request, &expected_paths, scenario).await;
+    }
+}
+
+#[sim_test]
+async fn get_checkpoint_by_digest() {
+    let (_test_cluster, client) = setup_grpc_test(Some(2), None).await;
+    let mut ledger_client = client.ledger_service_client();
+
+    // Step 1: fetch genesis (sequence 0) to learn its summary digest.
+    let by_seq = assert_get_checkpoint_request(
+        &mut ledger_client,
+        GetCheckpointRequest::default()
+            .with_sequence_number(0)
+            .with_read_mask(FieldMask::from_paths(["checkpoint.summary.digest"])),
+        &["checkpoint.summary.digest"],
+        "by-sequence for digest lookup",
+    )
+    .await;
+
+    let digest = by_seq
+        .iter()
+        .find_map(|msg| match msg.payload.as_ref() {
+            Some(checkpoint_data::Payload::Checkpoint(cp)) => {
+                cp.summary.as_ref().and_then(|s| s.digest.clone())
+            }
+            _ => None,
+        })
+        .expect("genesis checkpoint should have a summary digest");
+
+    // Step 2: fetch the same checkpoint by digest and confirm the sequence
+    // number round-trips.
+    let by_digest = assert_get_checkpoint_request(
+        &mut ledger_client,
+        GetCheckpointRequest::default()
+            .with_digest(digest)
+            .with_read_mask(FieldMask::from_paths(["checkpoint.summary.digest"])),
+        &["checkpoint.summary.digest"],
+        "by-digest lookup",
+    )
+    .await;
+
+    let seq = by_digest
+        .iter()
+        .find_map(|msg| match msg.payload.as_ref() {
+            Some(checkpoint_data::Payload::Checkpoint(cp)) => cp.sequence_number,
+            _ => None,
+        })
+        .expect("by-digest response should include a sequence number");
+    assert_eq!(seq, 0, "by-digest: expected genesis sequence number");
+}
+
+#[sim_test]
+async fn get_checkpoint_latest() {
+    let (_test_cluster, client) = setup_grpc_test(Some(2), None).await;
+    let mut ledger_client = client.ledger_service_client();
+
+    let messages = assert_get_checkpoint_request(
+        &mut ledger_client,
+        GetCheckpointRequest::default()
+            .with_latest(true)
+            .with_read_mask(FieldMask::from_paths(["checkpoint.summary"])),
+        &["checkpoint.summary"],
+        "latest checkpoint",
+    )
+    .await;
+
+    let seq = messages
+        .iter()
+        .find_map(|msg| match msg.payload.as_ref() {
+            Some(checkpoint_data::Payload::Checkpoint(cp)) => cp.sequence_number,
+            _ => None,
+        })
+        .expect("latest response should include a sequence number");
+    assert!(
+        seq >= 2,
+        "latest sequence should be >= the waited-for checkpoint (2), got {seq}"
+    );
+}
+
+#[sim_test]
+async fn get_checkpoint_nonexistent() {
+    let (_test_cluster, client) = setup_grpc_test(Some(2), None).await;
+    let mut ledger_client = client.ledger_service_client();
+
+    // Sequence-number lookups: the server opens the stream successfully and
+    // yields the NotFound error as the first stream item (the sequence
+    // number isn't resolved until the stream starts reading the checkpoint).
+    assert_sequence_number_not_found(&mut ledger_client, 999_999_999).await;
+
+    // Probe `latest + 100` by first resolving the current tip through the same
+    // streaming endpoint.  An empty read_mask keeps the payload minimal; the
+    // server always populates `sequence_number` regardless of the mask.
+    let latest_messages = assert_get_checkpoint_request(
+        &mut ledger_client,
+        GetCheckpointRequest::default()
+            .with_latest(true)
+            .with_read_mask(FieldMask::from_paths(&[] as &[&str])),
+        &[],
+        "fetch latest for not-found probe",
+    )
+    .await;
+    let latest = latest_messages
+        .iter()
+        .find_map(|msg| match msg.payload.as_ref() {
+            Some(checkpoint_data::Payload::Checkpoint(cp)) => cp.sequence_number,
+            _ => None,
+        })
+        .expect("latest checkpoint should have sequence_number");
+    assert_sequence_number_not_found(&mut ledger_client, latest + 100).await;
+
+    // Digest lookups: the server resolves the digest to a sequence number
+    // upfront, so an unknown digest is returned as the initial response
+    // error instead.
+    let bogus_digest = grpc_types::Digest::default().with_digest(vec![0u8; 32]);
+    let result = ledger_client
+        .get_checkpoint(GetCheckpointRequest::default().with_digest(bogus_digest))
+        .await;
+    assert_tonic_error(result, tonic::Code::NotFound, "bogus digest");
+}
+
+async fn assert_sequence_number_not_found(
+    ledger_client: &mut LedgerServiceClient<iota_grpc_client::InterceptedChannel>,
+    sequence_number: u64,
+) {
+    let mut stream = ledger_client
+        .get_checkpoint(GetCheckpointRequest::default().with_sequence_number(sequence_number))
+        .await
+        .expect("initial response should succeed for sequence-number lookup")
+        .into_inner();
+    let first = stream
+        .next()
+        .await
+        .expect("stream should yield the NotFound error");
+    assert_tonic_error(
+        first,
+        tonic::Code::NotFound,
+        &format!("sequence number {sequence_number}"),
+    );
+}
+
+#[sim_test]
+async fn stream_checkpoints_readmask_scenarios() {
+    let (_test_cluster, client) = setup_grpc_test(Some(2), None).await;
+    let mut ledger_client = client.ledger_service_client();
+
+    type TestCase<'a> = (&'a str, Option<FieldMask>, Vec<&'a str>);
+    let test_cases: Vec<TestCase> = vec![
+        (
+            "stream default readmask",
+            None,
+            comma_separated_field_mask_to_paths(GET_CHECKPOINT_READ_MASK),
+        ),
+        (
+            "stream empty readmask",
+            Some(FieldMask::from_paths(&[] as &[&str])),
+            vec![],
+        ),
+        (
+            "stream checkpoint wildcard",
+            Some(FieldMask::from_paths(["checkpoint"])),
+            vec!["checkpoint"],
+        ),
+        (
+            "stream transactions partial (effects.digest + timestamp)",
+            Some(FieldMask::from_paths([
+                "transactions.effects.digest",
+                "transactions.timestamp",
+            ])),
+            vec!["transactions.effects.digest", "transactions.timestamp"],
+        ),
+        (
+            "stream full readmask",
+            Some(FieldMask::from_paths([
+                "checkpoint",
+                "transactions",
+                "events",
+            ])),
+            vec!["checkpoint", "transactions", "events"],
+        ),
+    ];
+
+    for (scenario, mask, expected_paths) in test_cases {
+        let mut request = StreamCheckpointsRequest::default()
+            .with_start_sequence_number(0)
+            .with_end_sequence_number(2);
+        if let Some(mask) = mask {
+            request = request.with_read_mask(mask);
+        }
+        assert_stream_checkpoints_request(
+            &mut ledger_client,
+            request,
+            &expected_paths,
+            3, // checkpoints 0, 1, 2
+            scenario,
+        )
+        .await;
+    }
+}
+
+/// Verify the server closes a bounded `[start, end]` stream after delivering
+/// the final `EndMarker`. Guards against two regressions: over-delivery past
+/// `end_sequence_number`, and failure to terminate the stream.
+#[sim_test]
+async fn stream_checkpoints_terminates_on_bounded_range() {
+    let (_test_cluster, client) = setup_grpc_test(Some(2), None).await;
+    let mut ledger_client = client.ledger_service_client();
+
+    let mut stream = ledger_client
+        .stream_checkpoints(
+            StreamCheckpointsRequest::default()
+                .with_start_sequence_number(0)
+                .with_end_sequence_number(2),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut end_markers = 0;
+    timeout(Duration::from_secs(30), async {
+        while let Some(msg) = stream.next().await {
+            if matches!(
+                msg.unwrap().payload,
+                Some(checkpoint_data::Payload::EndMarker(_))
+            ) {
+                end_markers += 1;
+            }
         }
     })
     .await
-    .expect("waiting for checkpoint data timed out");
+    .expect("server did not close stream after final EndMarker");
+
+    assert_eq!(end_markers, 3, "expected EndMarker for checkpoints 0, 1, 2");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_checkpoints.rs
@@ -8,6 +8,7 @@ use iota_grpc_types::{
     field::FieldMaskUtil,
     read_masks::GET_CHECKPOINT_READ_MASK,
     v1::{
+        filter as grpc_filter,
         ledger_service::{
             CheckpointData, GetCheckpointRequest, StreamCheckpointsRequest, checkpoint_data,
             ledger_service_client::LedgerServiceClient,
@@ -16,12 +17,14 @@ use iota_grpc_types::{
     },
 };
 use iota_macros::sim_test;
+use iota_types::transaction::CallArg;
 use prost_types::FieldMask;
 use tokio::time::timeout;
 
 use crate::utils::{
-    FieldPresenceChecker, assert_field_presence, assert_tonic_error,
-    comma_separated_field_mask_to_paths, setup_grpc_test,
+    BASICS_PACKAGE, CLOCK_ACCESS_FUNCTION, CLOCK_MODULE, FieldPresenceChecker, NFT_MINTED_EVENT,
+    NFT_MODULE, NFT_PACKAGE, assert_field_presence, assert_tonic_error,
+    comma_separated_field_mask_to_paths, publish_example_package, setup_grpc_test,
 };
 
 /// `sequence_number` is always populated by the server and not controlled by

--- a/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_epoch.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_epoch.rs
@@ -2,50 +2,106 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_grpc_types::v1::ledger_service::GetEpochRequest;
+use iota_grpc_types::{
+    field::FieldMaskUtil, read_masks::GET_EPOCH_READ_MASK, v1::ledger_service::GetEpochRequest,
+};
 use iota_macros::sim_test;
 use prost_types::FieldMask;
 
-use crate::utils::setup_grpc_test;
+use crate::utils::{assert_field_presence, comma_separated_field_mask_to_paths, setup_grpc_test};
 
 #[sim_test]
-async fn get_epoch() {
+async fn get_epoch_current_and_by_number() {
     let (_test_cluster, client) = setup_grpc_test(Some(1), None).await;
-
     let mut ledger_client = client.ledger_service_client();
 
-    // Get current epoch (no epoch specified means current epoch)
-    let latest_epoch_response = ledger_client
-        .get_epoch(GetEpochRequest::default())
-        .await
-        .unwrap()
-        .into_inner();
+    // The test cluster only spans a single epoch, so a default request
+    // (current epoch) and an explicit `epoch=0` request must return the same
+    // committee. Request `committee` explicitly — it is not in the default
+    // `GET_EPOCH_READ_MASK`, and without it both sides would be `None` and
+    // the comparison would be trivially true.
+    let read_mask = FieldMask::from_paths(["epoch", "first_checkpoint", "committee"]);
 
-    let latest_epoch = latest_epoch_response.epoch.unwrap();
-
-    // Get epoch 0
-    let epoch_0_response = ledger_client
-        .get_epoch(GetEpochRequest::default().with_epoch(0))
-        .await
-        .unwrap()
-        .into_inner();
-
-    let epoch_0 = epoch_0_response.epoch.unwrap();
-
-    assert_eq!(latest_epoch.committee, epoch_0.committee);
-
-    assert_eq!(epoch_0.epoch, Some(0));
-    assert_eq!(epoch_0.first_checkpoint, Some(0));
-
-    // Ensure that fetching the system state for the epoch works (using field mask)
-    let epoch_with_bcs = ledger_client
-        .get_epoch(GetEpochRequest::default().with_read_mask(FieldMask {
-            paths: vec!["bcs_system_state".to_string()],
-        }))
+    let latest_epoch = ledger_client
+        .get_epoch(GetEpochRequest::default().with_read_mask(read_mask.clone()))
         .await
         .unwrap()
         .into_inner()
         .epoch
         .unwrap();
-    assert!(epoch_with_bcs.bcs_system_state.is_some());
+
+    let epoch_0 = ledger_client
+        .get_epoch(
+            GetEpochRequest::default()
+                .with_epoch(0)
+                .with_read_mask(read_mask),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .epoch
+        .unwrap();
+
+    assert!(
+        epoch_0.committee.is_some(),
+        "committee must be populated when requested in the read mask"
+    );
+    assert_eq!(latest_epoch.committee, epoch_0.committee);
+    assert_eq!(epoch_0.epoch, Some(0));
+    assert_eq!(epoch_0.first_checkpoint, Some(0));
+}
+
+#[sim_test]
+async fn get_epoch_readmask_scenarios() {
+    let (_test_cluster, client) = setup_grpc_test(Some(1), None).await;
+    let mut ledger_client = client.ledger_service_client();
+
+    // The default `GET_EPOCH_READ_MASK` requests `end` and `last_checkpoint`,
+    // but the server only populates them for epochs that have already ended.
+    // The test cluster sits in epoch 0 (no epoch boundary is crossed), so for
+    // the default-readmask scenario both fields are deterministically `None` —
+    // we drop them from the expected list and let the per-field assertion
+    // verify they're absent.
+    let default_expected_paths: Vec<&str> =
+        comma_separated_field_mask_to_paths(GET_EPOCH_READ_MASK)
+            .into_iter()
+            .filter(|p| *p != "end" && *p != "last_checkpoint")
+            .collect();
+
+    type TestCase<'a> = (&'a str, Option<FieldMask>, Vec<&'a str>);
+    let test_cases: Vec<TestCase> = vec![
+        ("default readmask", None, default_expected_paths),
+        (
+            "empty readmask",
+            Some(FieldMask::from_paths(&[] as &[&str])),
+            vec![],
+        ),
+        (
+            "partial readmask (bcs_system_state only)",
+            Some(FieldMask::from_paths(["bcs_system_state"])),
+            vec!["bcs_system_state"],
+        ),
+        (
+            "partial readmask (epoch + reference_gas_price)",
+            Some(FieldMask::from_paths(["epoch", "reference_gas_price"])),
+            vec!["epoch", "reference_gas_price"],
+        ),
+    ];
+
+    for (scenario, mask, expected_paths) in test_cases {
+        let mut request = GetEpochRequest::default();
+        if let Some(mask) = mask {
+            request = request.with_read_mask(mask);
+        }
+
+        let epoch = ledger_client
+            .get_epoch(request)
+            .await
+            .unwrap()
+            .into_inner()
+            .epoch
+            .unwrap();
+
+        assert_field_presence(&epoch, &expected_paths, &[], scenario);
+    }
 }

--- a/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_transactions.rs
@@ -11,39 +11,18 @@ use iota_grpc_types::{
     },
 };
 use iota_macros::sim_test;
-use iota_test_transaction_builder::TestTransactionBuilder;
-use iota_types::digests::TransactionDigest;
+use iota_sdk_types::Digest;
 use prost_types::FieldMask;
-use test_cluster::TestCluster;
 
-use crate::utils::{assert_field_presence, comma_separated_field_mask_to_paths, setup_grpc_test};
-
-/// Helper to create a test transaction and return its digest
-async fn create_test_transaction(test_cluster: &TestCluster) -> TransactionDigest {
-    let (sender, gas) = test_cluster
-        .wallet
-        .get_one_gas_object()
-        .await
-        .unwrap()
-        .unwrap();
-    let rgp = test_cluster.get_reference_gas_price().await;
-    let transaction_data = TestTransactionBuilder::new(sender, gas, rgp)
-        .transfer_iota(None, sender)
-        .build();
-    let signed_transaction = test_cluster.wallet.sign_transaction(&transaction_data);
-    let transaction_digest = *signed_transaction.digest();
-    test_cluster
-        .wallet
-        .execute_transaction_may_fail(signed_transaction)
-        .await
-        .unwrap();
-    transaction_digest
-}
+use crate::utils::{
+    assert_field_presence, comma_separated_field_mask_to_paths, execute_transaction_and_get_digest,
+    setup_grpc_test,
+};
 
 /// Helper function to make GetTransactions requests and validate responses..
 async fn assert_get_transactions_request(
     ledger_client: &mut LedgerServiceClient<iota_grpc_client::InterceptedChannel>,
-    digests: Vec<TransactionDigest>,
+    digests: Vec<Digest>,
     read_mask: Option<FieldMask>,
     max_message_size_bytes: Option<u32>,
     expected_field_mask_paths: &[&str],
@@ -136,7 +115,7 @@ async fn get_transactions_readmask_scenarios() {
     let mut ledger_client = client.ledger_service_client();
 
     // Create a test transaction
-    let transaction_digest = create_test_transaction(&test_cluster).await;
+    let transaction_digest = execute_transaction_and_get_digest(&test_cluster).await;
 
     // Tests for single-transaction readmask scenarios
     // Note: When a parent field is specified without nested paths (e.g.,
@@ -231,7 +210,7 @@ async fn get_transactions_batch() {
     // Create multiple test transactions
     let mut digests = Vec::new();
     for _ in 0..3 {
-        let digest = create_test_transaction(&test_cluster).await;
+        let digest = execute_transaction_and_get_digest(&test_cluster).await;
         digests.push(digest);
     }
 
@@ -262,7 +241,7 @@ async fn get_transactions_streaming() {
     // Create multiple test transactions to have enough data for streaming
     let mut digests = Vec::new();
     for _ in 0..10 {
-        let digest = create_test_transaction(&test_cluster).await;
+        let digest = execute_transaction_and_get_digest(&test_cluster).await;
         digests.push(digest);
     }
 
@@ -352,8 +331,8 @@ async fn get_transactions_nonexistent() {
     let mut ledger_client = client.ledger_service_client();
 
     // Request non-existent transactions
-    let fake_digest1 = TransactionDigest::new([0u8; 32]);
-    let fake_digest2 = TransactionDigest::new([1u8; 32]);
+    let fake_digest1 = Digest::new([0u8; 32]);
+    let fake_digest2 = Digest::new([1u8; 32]);
 
     let request = GetTransactionsRequest::default().with_requests(
         TransactionRequests::default().with_requests(vec![
@@ -422,10 +401,10 @@ async fn get_transactions_mixed_valid_invalid() {
     let mut ledger_client = client.ledger_service_client();
 
     // Create a real transaction
-    let real_digest = create_test_transaction(&test_cluster).await;
+    let real_digest = execute_transaction_and_get_digest(&test_cluster).await;
 
     // Request mix of valid and invalid digests
-    let fake_digest = TransactionDigest::new([0u8; 32]);
+    let fake_digest = Digest::new([0u8; 32]);
 
     let request = GetTransactionsRequest::default()
         .with_requests(TransactionRequests::default().with_requests(vec![

--- a/crates/iota-e2e-tests/tests/grpc/v1/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/mod.rs
@@ -8,10 +8,12 @@ mod state_service;
 mod transaction_execution_service;
 
 use iota_grpc_types::v1::{
+    checkpoint::{Checkpoint, CheckpointContents, CheckpointSummary},
     command::{
         Argument, CommandOutput, CommandOutputs, CommandResult, CommandResults,
         argument::{Input, Result},
     },
+    event::Event,
     ledger_service::GetServiceInfoResponse,
     object::Object,
     transaction::{ExecutedTransaction, Transaction, TransactionEffects, TransactionEvents},
@@ -29,6 +31,24 @@ impl_field_presence_checker!(ObjectReference {
 impl_field_presence_checker!(Object {
     reference: ObjectReference,
     bcs,
+});
+
+impl_field_presence_checker!(CheckpointSummary { digest, bcs });
+impl_field_presence_checker!(CheckpointContents { digest, bcs });
+impl_field_presence_checker!(Checkpoint {
+    sequence_number,
+    summary: CheckpointSummary,
+    contents: CheckpointContents,
+    signature,
+});
+impl_field_presence_checker!(Event {
+    bcs,
+    package_id,
+    module,
+    sender,
+    event_type,
+    bcs_contents,
+    json_contents,
 });
 
 impl_field_presence_checker!(GetServiceInfoResponse {

--- a/crates/iota-e2e-tests/tests/grpc/v1/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/mod.rs
@@ -9,13 +9,18 @@ mod transaction_execution_service;
 
 use iota_grpc_types::v1::{
     checkpoint::{Checkpoint, CheckpointContents, CheckpointSummary},
+    coin::{CoinMetadata, CoinTreasury, RegulatedCoinMetadata},
     command::{
         Argument, CommandOutput, CommandOutputs, CommandResult, CommandResults,
         argument::{Input, Result},
     },
+    dynamic_field::DynamicField,
+    epoch::{Epoch, ProtocolConfig},
     event::Event,
     ledger_service::GetServiceInfoResponse,
+    move_package_service::PackageVersion,
     object::Object,
+    state_service::GetCoinInfoResponse,
     transaction::{ExecutedTransaction, Transaction, TransactionEffects, TransactionEvents},
     transaction_execution_service::{ExecutionError, SimulatedTransaction},
     types::ObjectReference,
@@ -110,4 +115,69 @@ impl_field_presence_checker!(SimulatedTransaction {
     executed_transaction: ExecutedTransaction,
     suggested_gas_price,
     execution_result,
+});
+
+impl_field_presence_checker!(ProtocolConfig {
+    protocol_version,
+    feature_flags,
+    attributes,
+});
+impl_field_presence_checker!(Epoch {
+    epoch,
+    committee,
+    bcs_system_state,
+    first_checkpoint,
+    last_checkpoint,
+    start,
+    end,
+    reference_gas_price,
+    protocol_config: ProtocolConfig,
+});
+
+impl_field_presence_checker!(DynamicField {
+    kind,
+    parent,
+    field_id,
+    field_object,
+    name,
+    value,
+    value_type,
+    child_id,
+    child_object,
+});
+
+impl_field_presence_checker!(CoinMetadata {
+    id,
+    decimals,
+    name,
+    symbol,
+    description,
+    icon_url,
+    metadata_cap_id,
+    metadata_cap_state,
+});
+impl_field_presence_checker!(CoinTreasury {
+    id,
+    total_supply,
+    supply_state,
+});
+impl_field_presence_checker!(RegulatedCoinMetadata {
+    id,
+    coin_metadata_object,
+    deny_cap_object,
+    allow_global_pause,
+    variant,
+    coin_regulated_state,
+});
+impl_field_presence_checker!(GetCoinInfoResponse {
+    coin_type,
+    metadata: CoinMetadata,
+    treasury: CoinTreasury,
+    regulated_metadata: RegulatedCoinMetadata,
+});
+
+impl_field_presence_checker!(PackageVersion {
+    original_id,
+    storage_id,
+    version,
 });

--- a/crates/iota-e2e-tests/tests/grpc/v1/move_package_service/list_package_versions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/move_package_service/list_package_versions.rs
@@ -4,7 +4,9 @@
 use iota_grpc_types::v1::move_package_service::ListPackageVersionsRequest;
 use iota_macros::sim_test;
 
-use crate::utils::{assert_tonic_error, object_id_from_hex, setup_grpc_test};
+use crate::utils::{
+    assert_field_presence, assert_tonic_error, object_id_from_hex, setup_grpc_test,
+};
 
 #[sim_test]
 async fn list_package_versions_framework_package() {
@@ -25,19 +27,14 @@ async fn list_package_versions_framework_package() {
         "Framework package should have at least 1 version, got 0"
     );
 
-    // Each version should have original_id, storage_id and version number
-    for version in &response.versions {
-        assert!(
-            version.original_id.is_some(),
-            "Each version should have an original_id"
-        );
-        assert!(
-            version.version.is_some(),
-            "Each version should have a version number"
-        );
-        assert!(
-            version.storage_id.is_some(),
-            "Each version should have a storage_id"
+    // ListPackageVersionsRequest has no `read_mask`; the server populates every
+    // field on each `PackageVersion`.
+    for (idx, version) in response.versions.iter().enumerate() {
+        assert_field_presence(
+            version,
+            &["original_id", "storage_id", "version"],
+            &[],
+            &format!("framework package versions (version {idx})"),
         );
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc/v1/state_service/get_coin_info.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/state_service/get_coin_info.rs
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_grpc_types::v1::state_service::GetCoinInfoRequest;
+use iota_grpc_types::v1::{
+    coin::{coin_treasury::SupplyState, regulated_coin_metadata::CoinRegulatedState},
+    state_service::GetCoinInfoRequest,
+};
 use iota_macros::sim_test;
 
-use crate::utils::{assert_tonic_error, setup_grpc_test};
+use crate::utils::{assert_field_presence, assert_tonic_error, setup_grpc_test};
 
 #[sim_test]
 async fn get_coin_info_iota() {
@@ -19,42 +22,54 @@ async fn get_coin_info_iota() {
         .unwrap()
         .into_inner();
 
-    // IOTA coin should have a coin_type set
-    assert_eq!(
-        response.coin_type.as_deref(),
-        Some("0x2::iota::IOTA"),
-        "coin_type should be 0x2::iota::IOTA"
+    // GetCoinInfoRequest has no `read_mask`; the server populates every field
+    // that exists for this coin. For the native IOTA coin (no on-chain
+    // RegulatedCoinMetadata object), `regulated_metadata` is populated with
+    // ONLY `coin_regulated_state = Unregulated` — the other 5 fields stay None.
+    assert_field_presence(
+        &response,
+        &[
+            "coin_type",
+            "metadata.id",
+            "metadata.decimals",
+            "metadata.name",
+            "metadata.symbol",
+            "metadata.description",
+            "metadata.icon_url",
+            "treasury.id",
+            "treasury.total_supply",
+            "treasury.supply_state",
+            "regulated_metadata.coin_regulated_state",
+        ],
+        &[],
+        "get_coin_info iota",
     );
 
-    // IOTA coin should have metadata with correct content
-    let metadata = response
-        .metadata
-        .as_ref()
-        .expect("IOTA coin should have metadata");
-    assert!(metadata.id.is_some(), "metadata should have an id");
+    // Spot-check stable values for the native coin.
+    assert_eq!(response.coin_type.as_deref(), Some("0x2::iota::IOTA"));
+    let metadata = response.metadata.as_ref().unwrap();
     assert_eq!(metadata.name.as_deref(), Some("IOTA"));
     assert_eq!(metadata.symbol.as_deref(), Some("IOTA"));
-    assert!(
-        metadata.description.is_some(),
-        "metadata should have a description"
-    );
     assert_eq!(metadata.decimals, Some(9), "IOTA has 9 decimal places");
-
-    // IOTA coin should have treasury with correct content
-    let treasury = response
-        .treasury
-        .as_ref()
-        .expect("IOTA coin should have treasury info");
-    assert!(treasury.id.is_some(), "treasury should have an id");
-    assert!(
-        treasury.total_supply.is_some(),
-        "treasury should have total_supply"
+    assert_eq!(
+        metadata.icon_url.as_deref(),
+        Some("https://iota.org/logo.png"),
+        "IOTA icon_url is set deterministically in genesis (see iota.move)"
     );
-    // IOTA native gas coin has fixed supply
+    let treasury = response.treasury.as_ref().unwrap();
     assert_eq!(
         treasury.supply_state,
-        Some(1),
-        "IOTA supply should be FIXED (1)"
+        Some(SupplyState::Fixed as i32),
+        "IOTA supply should be FIXED"
+    );
+    assert_eq!(
+        response
+            .regulated_metadata
+            .as_ref()
+            .unwrap()
+            .coin_regulated_state,
+        Some(CoinRegulatedState::Unregulated as i32),
+        "native IOTA coin has no RegulatedCoinMetadata object → state is Unregulated"
     );
 }
 

--- a/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_dynamic_fields.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_dynamic_fields.rs
@@ -1,11 +1,17 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_grpc_types::{field::FieldMaskUtil, v1::state_service::ListDynamicFieldsRequest};
+use iota_grpc_types::{
+    field::FieldMaskUtil, read_masks::LIST_DYNAMIC_FIELDS_READ_MASK,
+    v1::state_service::ListDynamicFieldsRequest,
+};
 use iota_macros::sim_test;
 use prost_types::FieldMask;
 
-use crate::utils::{assert_tonic_error, object_id_from_hex, setup_grpc_test};
+use crate::utils::{
+    assert_field_presence, assert_tonic_error, comma_separated_field_mask_to_paths,
+    object_id_from_hex, setup_grpc_test,
+};
 
 #[sim_test]
 async fn list_dynamic_fields_missing_parent() {
@@ -21,35 +27,57 @@ async fn list_dynamic_fields_missing_parent() {
 }
 
 #[sim_test]
-async fn list_dynamic_fields_system_state() {
+async fn list_dynamic_fields_readmask_scenarios() {
     let (_test_cluster, client) = setup_grpc_test(Some(1), None).await;
     let mut state_client = client.state_service_client();
 
     // System state object (0x5) wraps `IotaSystemStateInnerV1` as a dynamic
     // field, so it always has at least one dynamic field after genesis.
-    let request = ListDynamicFieldsRequest::default().with_parent(object_id_from_hex("0x5"));
+    type TestCase<'a> = (&'a str, Option<FieldMask>, Vec<&'a str>);
+    let test_cases: Vec<TestCase> = vec![
+        (
+            "default readmask",
+            None,
+            comma_separated_field_mask_to_paths(LIST_DYNAMIC_FIELDS_READ_MASK),
+        ),
+        (
+            "empty readmask",
+            Some(FieldMask::from_paths(&[] as &[&str])),
+            vec![],
+        ),
+        (
+            "partial readmask (kind only)",
+            Some(FieldMask::from_paths(["kind"])),
+            vec!["kind"],
+        ),
+    ];
 
-    let response = state_client
-        .list_dynamic_fields(request)
-        .await
-        .unwrap()
-        .into_inner();
+    for (scenario, mask, expected_paths) in test_cases {
+        let mut request =
+            ListDynamicFieldsRequest::default().with_parent(object_id_from_hex("0x5"));
+        if let Some(mask) = mask {
+            request = request.with_read_mask(mask);
+        }
 
-    assert!(
-        !response.dynamic_fields.is_empty(),
-        "System state object should have at least one dynamic field"
-    );
+        let response = state_client
+            .list_dynamic_fields(request)
+            .await
+            .unwrap()
+            .into_inner();
 
-    // With the default read mask ("parent,field_id"), both fields should be set.
-    for field in &response.dynamic_fields {
         assert!(
-            field.parent.is_some(),
-            "parent should be populated with default read mask"
+            !response.dynamic_fields.is_empty(),
+            "{scenario}: system state object should have at least one dynamic field"
         );
-        assert!(
-            field.field_id.is_some(),
-            "field_id should be populated with default read mask"
-        );
+
+        for (idx, field) in response.dynamic_fields.iter().enumerate() {
+            assert_field_presence(
+                field,
+                &expected_paths,
+                &[],
+                &format!("{scenario} (field {idx})"),
+            );
+        }
     }
 }
 
@@ -76,44 +104,6 @@ async fn list_dynamic_fields_no_fields() {
         response.next_page_token.is_none(),
         "Should have no next page token when there are no results"
     );
-}
-
-#[sim_test]
-async fn list_dynamic_fields_with_readmask() {
-    let (_test_cluster, client) = setup_grpc_test(Some(1), None).await;
-    let mut state_client = client.state_service_client();
-
-    // Request only "kind" — other index-only fields (parent, field_id, etc.)
-    // should be absent.
-    let request = ListDynamicFieldsRequest::default()
-        .with_parent(object_id_from_hex("0x5"))
-        .with_read_mask(FieldMask::from_paths(["kind"]));
-
-    let response = state_client
-        .list_dynamic_fields(request)
-        .await
-        .unwrap()
-        .into_inner();
-
-    assert!(
-        !response.dynamic_fields.is_empty(),
-        "Should return fields with partial mask"
-    );
-
-    for field in &response.dynamic_fields {
-        assert!(
-            field.kind.is_some(),
-            "kind should be populated when requested"
-        );
-        assert!(
-            field.parent.is_none(),
-            "parent should be absent when not in read mask"
-        );
-        assert!(
-            field.field_id.is_none(),
-            "field_id should be absent when not in read mask"
-        );
-    }
 }
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
@@ -25,13 +25,8 @@ use prost_types::FieldMask;
 
 use crate::utils::{
     NFT_PACKAGE, address_proto, assert_field_presence, assert_tonic_error,
-    comma_separated_field_mask_to_paths, publish_example_package, setup_grpc_test,
+    comma_separated_field_mask_to_paths, first_sender, publish_example_package, setup_grpc_test,
 };
-
-/// Get the first wallet address from a test cluster.
-fn first_sender(cluster: &test_cluster::TestCluster) -> IotaAddress {
-    cluster.wallet.get_addresses().first().copied().unwrap()
-}
 
 /// Make a unary call and validate field presence on every returned object.
 async fn list_and_validate(

--- a/crates/iota-grpc-client/Cargo.toml
+++ b/crates/iota-grpc-client/Cargo.toml
@@ -22,7 +22,7 @@ tonic.workspace = true
 
 # internal dependencies
 iota-grpc-types.workspace = true
-iota-sdk-types.workspace = true
+iota-sdk-types = { workspace = true, features = ["serde", "hash"] }
 
 [features]
 default = ["tls-ring", "tls-native-roots"]

--- a/crates/iota-grpc-client/src/client.rs
+++ b/crates/iota-grpc-client/src/client.rs
@@ -193,3 +193,31 @@ impl_grpc_client_config!(
     StateServiceClient<InterceptedChannel>,
     MovePackageServiceClient<InterceptedChannel>,
 );
+
+#[cfg(test)]
+mod tests {
+    // E2E tests always use `http://`, so the HTTPS-without-TLS branch is only
+    // reachable from a unit test compiled with `tls-ring` disabled.
+    #[cfg(not(feature = "tls-ring"))]
+    #[tokio::test]
+    async fn https_without_tls_ring_returns_failed_precondition() {
+        use super::Client;
+
+        let status = match Client::connect("https://example.com").await {
+            Err(crate::api::Error::Grpc(status)) => status,
+            Err(other) => panic!("expected Error::Grpc, got: {other:?}"),
+            Ok(_) => panic!("connect should fail without tls-ring"),
+        };
+
+        assert_eq!(
+            status.code(),
+            tonic::Code::FailedPrecondition,
+            "status: {status:?}"
+        );
+        assert!(
+            status.message().contains("tls-ring"),
+            "error should mention `tls-ring` feature, got: {}",
+            status.message()
+        );
+    }
+}

--- a/crates/iota-grpc-client/src/client.rs
+++ b/crates/iota-grpc-client/src/client.rs
@@ -196,8 +196,10 @@ impl_grpc_client_config!(
 
 #[cfg(test)]
 mod tests {
-    // E2E tests always use `http://`, so the HTTPS-without-TLS branch is only
-    // reachable from a unit test compiled with `tls-ring` disabled.
+    // `iota-grpc-client` e2e tests connect via `test_cluster.grpc_url()`,
+    // which always returns an `http://` URL, so the HTTPS-without-TLS branch
+    // in `Client::connect` is only reachable from a unit test compiled with
+    // `tls-ring` disabled.
     #[cfg(not(feature = "tls-ring"))]
     #[tokio::test]
     async fn https_without_tls_ring_returns_failed_precondition() {

--- a/crates/iota-grpc-client/src/interceptors.rs
+++ b/crates/iota-grpc-client/src/interceptors.rs
@@ -88,3 +88,71 @@ impl tonic::service::Interceptor for HeadersInterceptor {
         (&*self).call(request)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use base64::{Engine as _, prelude::BASE64_STANDARD};
+    use tonic::service::Interceptor as _;
+
+    use super::*;
+
+    fn intercepted_authorization(mut interceptor: HeadersInterceptor) -> String {
+        let request = interceptor
+            .call(tonic::Request::new(()))
+            .expect("interceptor should not fail");
+        request
+            .metadata()
+            .get(http::header::AUTHORIZATION.as_str())
+            .expect("authorization header should be set")
+            .to_str()
+            .expect("authorization header should be valid ASCII")
+            .to_string()
+    }
+
+    #[test]
+    fn basic_auth_sets_authorization_header() {
+        let mut interceptor = HeadersInterceptor::new();
+        interceptor.basic_auth("alice", Some("hunter2"));
+
+        let header = intercepted_authorization(interceptor);
+        let encoded = header
+            .strip_prefix("Basic ")
+            .expect("basic auth header should start with 'Basic '");
+        let decoded = BASE64_STANDARD
+            .decode(encoded)
+            .expect("payload should be valid base64");
+        assert_eq!(decoded, b"alice:hunter2");
+    }
+
+    #[test]
+    fn basic_auth_without_password_emits_trailing_colon() {
+        let mut interceptor = HeadersInterceptor::new();
+        interceptor.basic_auth("alice", None::<&str>);
+
+        let header = intercepted_authorization(interceptor);
+        let encoded = header.strip_prefix("Basic ").unwrap();
+        let decoded = BASE64_STANDARD.decode(encoded).unwrap();
+        assert_eq!(decoded, b"alice:");
+    }
+
+    #[test]
+    fn bearer_auth_sets_authorization_header() {
+        let mut interceptor = HeadersInterceptor::new();
+        interceptor.bearer_auth("my-token");
+
+        let header = intercepted_authorization(interceptor);
+        assert_eq!(header, "Bearer my-token");
+    }
+
+    #[test]
+    fn empty_interceptor_does_not_set_authorization_header() {
+        let mut interceptor = HeadersInterceptor::new();
+        let request = interceptor.call(tonic::Request::new(())).unwrap();
+        assert!(
+            request
+                .metadata()
+                .get(http::header::AUTHORIZATION.as_str())
+                .is_none()
+        );
+    }
+}

--- a/crates/iota-grpc-server/tests/batching_stream.rs
+++ b/crates/iota-grpc-server/tests/batching_stream.rs
@@ -227,13 +227,7 @@ async fn test_get_objects_batching_within_limit() {
     assert_eq!(split_total, NUM_OBJECTS, "All objects must be returned");
 
     // Every response should fit within the message size limit
-    for (i, resp) in split_responses.iter().enumerate() {
-        let size = resp.encoded_len();
-        assert!(
-            size <= usize::try_from(tight_limit).unwrap(),
-            "Response {i} has encoded_len {size} which exceeds limit {tight_limit}"
-        );
-    }
+    common::assert_messages_within_limit(&split_responses, tight_limit);
 
     server_handle.shutdown().await.expect("shutdown");
 }
@@ -392,13 +386,7 @@ async fn test_get_transactions_batching_within_limit() {
     assert_eq!(split_total, NUM_TXS, "All transactions must be returned");
 
     // Every response should fit within the message size limit
-    for (i, resp) in split_responses.iter().enumerate() {
-        let size = resp.encoded_len();
-        assert!(
-            size <= usize::try_from(tight_limit).unwrap(),
-            "Response {i} has encoded_len {size} which exceeds limit {tight_limit}"
-        );
-    }
+    common::assert_messages_within_limit(&split_responses, tight_limit);
 
     server_handle.shutdown().await.expect("shutdown");
 }

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -1072,13 +1072,7 @@ async fn test_chunked_checkpoint_message_sizes_within_limit() {
     );
 
     // Every message must be within the limit.
-    for (i, msg) in all_messages.iter().enumerate() {
-        let size = msg.encoded_len();
-        assert!(
-            size <= usize::try_from(tight_limit).unwrap(),
-            "Message {i} has encoded_len {size} which exceeds limit {tight_limit}"
-        );
-    }
+    common::assert_messages_within_limit(&all_messages, tight_limit);
 
     server_handle.shutdown().await.expect("shutdown");
 }
@@ -1153,13 +1147,7 @@ async fn test_chunked_checkpoint_event_message_sizes_within_limit() {
     );
 
     // Every message must be within the limit.
-    for (i, msg) in all_messages.iter().enumerate() {
-        let size = msg.encoded_len();
-        assert!(
-            size <= usize::try_from(tight_limit).unwrap(),
-            "Message {i} has encoded_len {size} which exceeds limit {tight_limit}"
-        );
-    }
+    common::assert_messages_within_limit(&all_messages, tight_limit);
 
     server_handle.shutdown().await.expect("shutdown");
 }

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -29,6 +29,25 @@ use iota_types::{
 };
 
 // ---------------------------------------------------------------------------
+// Stream invariant helpers
+// ---------------------------------------------------------------------------
+
+/// Assert that every message in `messages` has an encoded size within `limit`
+/// bytes.  Used by the chunking tests to enforce the per-message size invariant
+/// that `create_batching_stream!` and the checkpoint streaming pipeline must
+/// uphold.
+pub fn assert_messages_within_limit<M: prost::Message>(messages: &[M], limit: u32) {
+    let limit_usize = usize::try_from(limit).unwrap();
+    for (i, msg) in messages.iter().enumerate() {
+        let size = msg.encoded_len();
+        assert!(
+            size <= limit_usize,
+            "Message {i} has encoded_len {size} which exceeds limit {limit}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Mock helpers
 // ---------------------------------------------------------------------------
 

--- a/crates/iota-grpc-types/Cargo.toml
+++ b/crates/iota-grpc-types/Cargo.toml
@@ -21,4 +21,4 @@ tonic.workspace = true
 tonic-prost.workspace = true
 
 # internal dependencies
-iota-sdk-types.workspace = true
+iota-sdk-types = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
# Description of change

Reorganizes the gRPC checkpoint e2e tests to match the layout used by `get_objects.rs` / `get_transactions.rs`, and fills in `read_mask` coverage. Also clean up the gRPC e2e testing.

## Links to any relevant issues

fixes #10007 #10009 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes