### PR TITLE
chore(ci): remove Mysticeti workflows and env-var plumbing

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -86,7 +86,6 @@ jobs:
     uses: ./.github/workflows/_rust_tests.yml
     with:
       isRust: ${{ inputs.isRust }}
-      consensusProtocol: "mysticeti"
       isPgIntegration: ${{ inputs.isPgIntegration }}
       isMoveExampleUsedByOthers: ${{ inputs.isMoveExampleUsedByOthers }}
       runSimtest: true

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -24,10 +24,6 @@ on:
       changedExternalCrates:
         type: string
         required: false
-      consensusProtocol:
-        type: string
-        required: false
-        default: "mysticeti"
       isNightly:
         type: boolean
         default: false
@@ -37,7 +33,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
 
 env:
-  CONSENSUS_PROTOCOL: ${{ inputs.consensusProtocol }}
   CARGO_TERM_COLOR: always
   RUST_LOG: "error"
   # Don't emit giant backtraces in the CI logs.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,20 +83,6 @@ jobs:
       testOnlyChangedCrates: false
       isNightly: true
 
-  tests-with-starfish:
-    if: ${{ inputs.rustTestsOnly || !inputs.simTestsOnly }}
-    uses: ./.github/workflows/_rust_tests.yml
-    with:
-      isRust: true
-      isPgIntegration: true
-      isMoveExampleUsedByOthers: true
-      consensusProtocol: "starfish"
-      # simtest job below runs a superset of these tests
-      runSimtest: false
-      # run all tests by default
-      testOnlyChangedCrates: false
-      isNightly: true
-
   deny:
     if: ${{ !inputs.rustTestsOnly && !inputs.simTestsOnly }}
     uses: ./.github/workflows/_cargo_deny.yml
@@ -125,28 +111,6 @@ jobs:
     if: ${{ inputs.simTestsOnly || !inputs.rustTestsOnly }}
     timeout-minutes: 600
     runs-on: [self-hosted-x64]
-    env:
-      CONSENSUS_PROTOCOL: mysticeti
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ env.IOTA_REF }}
-
-      - name: Get latest simtest script from commit that triggered this workflow
-        run: |
-          git fetch origin ${{ github.sha }}
-          git checkout ${{ github.sha }} -- scripts/simtest/simtest-run.sh
-
-      - name: Run simtest
-        run: scripts/simtest/simtest-run.sh
-
-  simtest-with-starfish:
-    if: ${{ inputs.simTestsOnly || !inputs.rustTestsOnly }}
-    timeout-minutes: 600
-    runs-on: [self-hosted-x64]
-    env:
-      CONSENSUS_PROTOCOL: starfish
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -172,17 +172,7 @@ get_metrics "${CONFIGS[0]}" "$METRICS_DIR/node-0-before-node3.txt"
 INITIAL_COMMIT_INDEX=$(get_metric_value "$METRICS_DIR/node-0-before-node3.txt" "consensus_last_commit_index")
 echo "Initial commit index on node-0: $INITIAL_COMMIT_INDEX"
 
-# Detect consensus protocol (Starfish vs Mysticeti) from the release node log.
-# The consensus manager logs "Starting consensus protocol Mysticeti ..." or
-# "Starting consensus protocol Starfish ..." on every epoch start, making this
-# a reliable signal independent of any metric values.
-if grep -q "Starting consensus protocol Starfish" "$LOG_DIR/node-0.log" 2>/dev/null; then
-  CONSENSUS_TYPE="starfish"
-  echo "Detected consensus protocol: Starfish"
-else
-  CONSENSUS_TYPE="mysticeti"
-  echo "Detected consensus protocol: Mysticeti"
-fi
+echo "Consensus protocol: Starfish"
 
 echo -e "\n=== Phase 2: Late Start of Candidate Node ==="
 echo "Starting node-3 (candidate) - should trigger synchronization to catch up..."
@@ -208,30 +198,18 @@ fi
 
 NODE3_COMMIT_AFTER_JOIN=$(get_metric_value "$METRICS_DIR/node-3-after-join.txt" "consensus_last_commit_index")
 
-if [ "$CONSENSUS_TYPE" = "starfish" ]; then
-  # Starfish: commit_sync_fetched_commits is labeled by source (commit_sync, fast_commit_sync), so sum across labels
-  NODE3_COMMIT_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_fetched_commits")
-  NODE3_HEADER_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_synchronizer_fetched_block_headers_by_peer")
-  NODE3_TXN_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_transaction_synchronizer_fetched_transactions_by_peer")
-  NODE3_COMMIT_SYNC_TXN_SIZE=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_total_fetched_transactions_size")
-else
-  # Mysticeti: commit_sync_fetched_commits is labeled by authority, so sum across labels
-  NODE3_COMMIT_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_fetched_commits")
-  NODE3_BLOCK_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_synchronizer_fetched_blocks_by_peer")
-  NODE3_COMMIT_SYNC_BLOCKS=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_fetched_blocks")
-fi
+# Starfish: commit_sync_fetched_commits is labeled by source (commit_sync, fast_commit_sync), so sum across labels
+NODE3_COMMIT_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_fetched_commits")
+NODE3_HEADER_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_synchronizer_fetched_block_headers_by_peer")
+NODE3_TXN_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_transaction_synchronizer_fetched_transactions_by_peer")
+NODE3_COMMIT_SYNC_TXN_SIZE=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_total_fetched_transactions_size")
 
 echo "Node-3 metrics after initial sync:"
 echo "  last_commit_index: $NODE3_COMMIT_AFTER_JOIN"
 echo "  commit_sync_fetched_commits (sum): $NODE3_COMMIT_SYNC"
-if [ "$CONSENSUS_TYPE" = "starfish" ]; then
-  echo "  synchronizer_fetched_block_headers_by_peer (sum): $NODE3_HEADER_SYNC"
-  echo "  commit_sync_total_fetched_transactions_size: $NODE3_COMMIT_SYNC_TXN_SIZE"
-  echo "  transaction_synchronizer_fetched_transactions_by_peer (sum): $NODE3_TXN_SYNC"
-else
-  echo "  synchronizer_fetched_blocks_by_peer (sum): $NODE3_BLOCK_SYNC"
-  echo "  commit_sync_fetched_blocks (sum): $NODE3_COMMIT_SYNC_BLOCKS"
-fi
+echo "  synchronizer_fetched_block_headers_by_peer (sum): $NODE3_HEADER_SYNC"
+echo "  commit_sync_total_fetched_transactions_size: $NODE3_COMMIT_SYNC_TXN_SIZE"
+echo "  transaction_synchronizer_fetched_transactions_by_peer (sum): $NODE3_TXN_SYNC"
 
 # Check 1: Node-3 caught up past initial commit index
 if [ "$NODE3_COMMIT_AFTER_JOIN" -le "$INITIAL_COMMIT_INDEX" ]; then
@@ -240,45 +218,25 @@ else
   echo "✓ Node-3 caught up past initial commit index"
 fi
 
-# Check 2: Synchronizer was active (protocol-specific)
-if [ "$CONSENSUS_TYPE" = "starfish" ]; then
-  # Starfish has a dedicated block header synchronizer
-  if [ "$NODE3_HEADER_SYNC" -le 0 ]; then
-    FAILURES+=("FAIL: Header synchronizer was not active (consensus_synchronizer_fetched_block_headers_by_peer = $NODE3_HEADER_SYNC)")
-  else
-    echo "✓ Header synchronizer was active (fetched $NODE3_HEADER_SYNC block headers)"
-  fi
+# Check 2: Header synchronizer was active
+if [ "$NODE3_HEADER_SYNC" -le 0 ]; then
+  FAILURES+=("FAIL: Header synchronizer was not active (consensus_synchronizer_fetched_block_headers_by_peer = $NODE3_HEADER_SYNC)")
 else
-  # Mysticeti uses a block synchronizer (no separate header sync)
-  if [ "$NODE3_BLOCK_SYNC" -le 0 ]; then
-    FAILURES+=("FAIL: Block synchronizer was not active (consensus_synchronizer_fetched_blocks_by_peer = $NODE3_BLOCK_SYNC)")
-  else
-    echo "✓ Block synchronizer was active (fetched $NODE3_BLOCK_SYNC blocks)"
-  fi
+  echo "✓ Header synchronizer was active (fetched $NODE3_HEADER_SYNC block headers)"
 fi
 
-# Check 3: Commit syncer was active (applies to both protocols)
+# Check 3: Commit syncer was active
 if [ "$NODE3_COMMIT_SYNC" -le 0 ]; then
   FAILURES+=("FAIL: Commit syncer was not active (consensus_commit_sync_fetched_commits = $NODE3_COMMIT_SYNC)")
 else
   echo "✓ Commit syncer was active (fetched $NODE3_COMMIT_SYNC commits)"
 fi
 
-# Check 4: Data was fetched via commit syncer (protocol-specific)
-if [ "$CONSENSUS_TYPE" = "starfish" ]; then
-  # Starfish: transactions can come from commit syncer or transaction synchronizer
-  if [ "$NODE3_COMMIT_SYNC_TXN_SIZE" -le 0 ] && [ "$NODE3_TXN_SYNC" -le 0 ]; then
-    FAILURES+=("FAIL: No transactions were fetched (commit_sync: $NODE3_COMMIT_SYNC_TXN_SIZE bytes, txn_sync: $NODE3_TXN_SYNC)")
-  else
-    echo "✓ Transactions were fetched (commit_sync: $NODE3_COMMIT_SYNC_TXN_SIZE bytes, txn_sync: $NODE3_TXN_SYNC transactions)"
-  fi
+# Check 4: Transactions can come from commit syncer or transaction synchronizer
+if [ "$NODE3_COMMIT_SYNC_TXN_SIZE" -le 0 ] && [ "$NODE3_TXN_SYNC" -le 0 ]; then
+  FAILURES+=("FAIL: No transactions were fetched (commit_sync: $NODE3_COMMIT_SYNC_TXN_SIZE bytes, txn_sync: $NODE3_TXN_SYNC)")
 else
-  # Mysticeti: no transaction synchronizer; check blocks fetched via commit sync
-  if [ "$NODE3_COMMIT_SYNC_BLOCKS" -le 0 ]; then
-    FAILURES+=("FAIL: No blocks were fetched via commit sync (consensus_commit_sync_fetched_blocks = $NODE3_COMMIT_SYNC_BLOCKS)")
-  else
-    echo "✓ Blocks were fetched via commit sync ($NODE3_COMMIT_SYNC_BLOCKS blocks)"
-  fi
+  echo "✓ Transactions were fetched (commit_sync: $NODE3_COMMIT_SYNC_TXN_SIZE bytes, txn_sync: $NODE3_TXN_SYNC transactions)"
 fi
 
 # Capture final metrics from all nodes
@@ -310,15 +268,10 @@ if [ ${#FAILURES[@]} -eq 0 ]; then
   echo "✓ All checks passed!"
   echo ""
   echo "Successfully verified:"
-  echo "  - Split-cluster with 3 release + 1 candidate node (consensus: $CONSENSUS_TYPE)"
+  echo "  - Split-cluster with 3 release + 1 candidate node (consensus: Starfish)"
   echo "  - Candidate node synchronized after late start (3 minute delay):"
-  if [ "$CONSENSUS_TYPE" = "starfish" ]; then
-    echo "    • Header Synchronizer: fetched $NODE3_HEADER_SYNC block headers"
-    echo "    • Commit Syncer: fetched $NODE3_COMMIT_SYNC commits ($NODE3_COMMIT_SYNC_TXN_SIZE bytes txn, txn_sync: $NODE3_TXN_SYNC transactions)"
-  else
-    echo "    • Block Synchronizer: fetched $NODE3_BLOCK_SYNC blocks"
-    echo "    • Commit Syncer: fetched $NODE3_COMMIT_SYNC commits ($NODE3_COMMIT_SYNC_BLOCKS blocks)"
-  fi
+  echo "    • Header Synchronizer: fetched $NODE3_HEADER_SYNC block headers"
+  echo "    • Commit Syncer: fetched $NODE3_COMMIT_SYNC commits ($NODE3_COMMIT_SYNC_TXN_SIZE bytes txn, txn_sync: $NODE3_TXN_SYNC transactions)"
   echo "    • Caught up from commit $INITIAL_COMMIT_INDEX to $NODE3_COMMIT_AFTER_JOIN"
   echo "  - Synchronization protocols are compatible between release and candidate versions"
   echo ""

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -8,12 +8,9 @@
 MSIM_WATCHDOG_TIMEOUT_MS=${MSIM_WATCHDOG_TIMEOUT_MS:-180000}
 # Override the default dir for logs output:
 SIMTEST_LOGS_DIR="${SIMTEST_LOGS_DIR:-"$HOME/simtest_logs"}"
-# Set default consensus implementation:
-CONSENSUS_PROTOCOL=${CONSENSUS_PROTOCOL:-mysticeti}
 
 echo "Running simulator tests at commit $(git rev-parse HEAD)"
 echo "Using MSIM_WATCHDOG_TIMEOUT_MS=${MSIM_WATCHDOG_TIMEOUT_MS} from env var"
-echo "Using CONSENSUS_PROTOCOL=${CONSENSUS_PROTOCOL}"
 
 # Function to handle SIGINT signal (Ctrl+C)
 cleanup() {
@@ -26,7 +23,7 @@ cleanup() {
 trap cleanup SIGINT
 
 if [ -z "$NUM_CPUS" ]; then
-  if [ "$(uname -s)" == "Darwin" ]; 
+  if [ "$(uname -s)" == "Darwin" ];
     then NUM_CPUS="$(sysctl -n hw.ncpu)"; # mac
     else NUM_CPUS=$(cat /proc/cpuinfo | grep processor | wc -l) # ubuntu
   fi
@@ -63,7 +60,7 @@ echo "================================================"
 echo "Running e2e simtests with $TEST_NUM iterations"
 echo "================================================"
 date
-echo "Using MSIM_TEST_SEED=${MSIM_TEST_SEED}, MSIM_TEST_NUM=${TEST_NUM}, CONSENSUS_PROTOCOL=${CONSENSUS_PROTOCOL}, TEST_FILTER=${FINAL_TEST_FILTER}, logging to $LOG_FILE"
+echo "Using MSIM_TEST_SEED=${MSIM_TEST_SEED}, MSIM_TEST_NUM=${TEST_NUM}, TEST_FILTER=${FINAL_TEST_FILTER}, logging to $LOG_FILE"
 
 # This command runs many different tests, so it already uses all CPUs fairly efficiently, and
 # don't need to be done inside of the for loop below.
@@ -71,7 +68,6 @@ echo "Using MSIM_TEST_SEED=${MSIM_TEST_SEED}, MSIM_TEST_NUM=${TEST_NUM}, CONSENS
 MSIM_TEST_SEED=${MSIM_TEST_SEED} \
 MSIM_TEST_NUM=${TEST_NUM} \
 MSIM_WATCHDOG_TIMEOUT_MS=${MSIM_WATCHDOG_TIMEOUT_MS} \
-CONSENSUS_PROTOCOL=${CONSENSUS_PROTOCOL} \
 scripts/simtest/cargo-simtest simtest \
   --color always \
   --test-threads "$NUM_CPUS" \
@@ -93,14 +89,13 @@ date
 for WORKER_NUMBER in `seq 1 $WORKERS_COUNT`; do
   SUB_SEED="$WORKER_NUMBER$DATE"
   LOG_FILE="$LOG_DIR/log-$SUB_SEED"
-  echo "Iteration $WORKER_NUMBER using MSIM_TEST_SEED=${SUB_SEED}, MSIM_TEST_NUM=1, CONSENSUS_PROTOCOL=${CONSENSUS_PROTOCOL}, SIM_STRESS_TEST_DURATION_SECS=300, TEST_FILTER=${FINAL_TEST_FILTER}, logging to $LOG_FILE"
+  echo "Iteration $WORKER_NUMBER using MSIM_TEST_SEED=${SUB_SEED}, MSIM_TEST_NUM=1, SIM_STRESS_TEST_DURATION_SECS=300, TEST_FILTER=${FINAL_TEST_FILTER}, logging to $LOG_FILE"
 
   # --test-threads 1 is important: parallelism is achieved via the for loop
   MSIM_TEST_SEED="$SUB_SEED" \
   MSIM_TEST_NUM=1 \
   MSIM_WATCHDOG_TIMEOUT_MS=${MSIM_WATCHDOG_TIMEOUT_MS} \
   SIM_STRESS_TEST_DURATION_SECS=300 \
-  CONSENSUS_PROTOCOL=${CONSENSUS_PROTOCOL} \
   scripts/simtest/cargo-simtest simtest \
     --color always \
     --test-threads 1 \
@@ -121,13 +116,12 @@ date
 
 # Check for determinism in stress simtests
 LOG_FILE="$LOG_DIR/determinism-log"
-echo "Using MSIM_TEST_SEED=${MSIM_TEST_SEED}, MSIM_TEST_NUM=1, CONSENSUS_PROTOCOL=${CONSENSUS_PROTOCOL}, MSIM_TEST_CHECK_DETERMINISM=1, TEST_FILTER=${FINAL_TEST_FILTER}, logging to $LOG_FILE"
+echo "Using MSIM_TEST_SEED=${MSIM_TEST_SEED}, MSIM_TEST_NUM=1, MSIM_TEST_CHECK_DETERMINISM=1, TEST_FILTER=${FINAL_TEST_FILTER}, logging to $LOG_FILE"
 
 MSIM_TEST_SEED=${MSIM_TEST_SEED} \
 MSIM_TEST_NUM=1 \
 MSIM_WATCHDOG_TIMEOUT_MS=${MSIM_WATCHDOG_TIMEOUT_MS} \
 MSIM_TEST_CHECK_DETERMINISM=1 \
-CONSENSUS_PROTOCOL=${CONSENSUS_PROTOCOL} \
 scripts/simtest/cargo-simtest simtest \
   --color always \
   --test-threads "$NUM_CPUS" \


### PR DESCRIPTION
# Description of change

Remove Mysticeti-specific CI jobs and the `CONSENSUS_PROTOCOL` environment variable that fed them.

- `nightly.yml`: delete the duplicate `simtest-with-starfish` and `tests-with-starfish` jobs; drop the `CONSENSUS_PROTOCOL: mysticeti` env from the remaining `simtest` job (Starfish is now implicit).
- `_rust_tests.yml`: drop the `consensusProtocol` workflow input and the `CONSENSUS_PROTOCOL` env mapping.
- `_rust.yml`: stop forwarding `consensusProtocol` to rust-tests.
- `scripts/simtest/simtest-run.sh`: drop the `CONSENSUS_PROTOCOL` default and all env forwarding into `cargo-simtest`.
- `scripts/compatibility/split-cluster-sync-check.sh`: simplify to assume Starfish (only remaining protocol).

Part of the decomposition of #11075 into 4 focused PRs.

## Links to any relevant issues

Fixes #11284

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes