### PR TITLE
chore(ci): add consensus team as codeowner of grafana-local and iota-private-network

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,7 +108,8 @@
 # Docker
 /docker/ @iotaledger/infrastructure @iotaledger/node @iotaledger/devops-admin
 /dev-tools/ @iotaledger/infrastructure @iotaledger/node @iotaledger/devops-admin
-/dev-tools/iota-private-network/fuzzer/ @iotaledger/consensus
+/dev-tools/grafana-local/ @iotaledger/infrastructure @iotaledger/node @iotaledger/devops-admin @iotaledger/consensus
+/dev-tools/iota-private-network/ @iotaledger/infrastructure @iotaledger/node @iotaledger/devops-admin @iotaledger/consensus
 /dev-tools/iota-indexer-monitoring/ @iotaledger/infrastructure
 /dev-tools/iota-data-ingestion/ @iotaledger/infrastructure
 /dev-tools/iota-rest-kv/ @iotaledger/infrastructure


### PR DESCRIPTION
# Description of change

Add `@iotaledger/consensus` as a co-owner of two subpaths in `.github/CODEOWNERS`:
- `/dev-tools/grafana-local/`
- `/dev-tools/iota-private-network/`

The consensus team regularly authors changes in both:
- Grafana: starfish-overview dashboard pane
- iota-private-network: fuzzer, network scripts, rolling-migration tests.

Also drops the standalone `/dev-tools/iota-private-network/fuzzer/ @iotaledger/consensus` line from #9644: the new `/dev-tools/iota-private-network/` parent line now covers it with co-ownership (infra + node + devops-admin + consensus).

## Links to any relevant issues

Fixes #11293

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes