### PR TITLE
feat(consensus): classify committed leaders by StarfishSpeed metastate

### DIFF
--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -117,33 +117,27 @@ impl BaseCommitter {
             .unwrap_or(LeaderStatus::Undecided(leader))
     }
 
-    /// Apply the indirect decision rule to the specified leader to see whether
-    /// we can indirect-commit or indirect-skip it.
-    #[tracing::instrument(skip_all, fields(leader = %leader_slot))]
+    /// Apply the indirect rule; return `current` unchanged if no committed
+    /// anchor is reachable.
+    #[tracing::instrument(skip_all, fields(leader = %current))]
     pub fn try_indirect_decide<'a>(
         &self,
-        leader_slot: Slot,
+        current: LeaderStatus,
         leaders: impl Iterator<Item = &'a LeaderStatus>,
     ) -> LeaderStatus {
-        // The anchor is the first committed leader with round higher than the decision
-        // round of the target leader. We must stop the iteration upon
-        // encountering an undecided leader.
-        let anchors = leaders.filter(|x| leader_slot.round + WAVE_LENGTH <= x.round());
-
+        let slot = current.slot();
+        let anchors = leaders.filter(|x| slot.round + WAVE_LENGTH <= x.round());
         for anchor in anchors {
-            tracing::trace!(
-                "[{self}] Trying to indirect-decide {leader_slot} using anchor {anchor}",
-            );
+            tracing::trace!("[{self}] Trying to indirect-decide {slot} using anchor {anchor}",);
             match anchor {
                 LeaderStatus::Commit(anchor, _) => {
-                    return self.decide_leader_from_anchor(anchor, leader_slot);
+                    return self.decide_leader_from_anchor(anchor, slot);
                 }
                 LeaderStatus::Skip(..) => (),
-                LeaderStatus::Undecided(..) => break,
+                LeaderStatus::Undecided(..) => return current,
             }
         }
-
-        LeaderStatus::Undecided(leader_slot)
+        current
     }
 
     pub fn elect_leader(&self, round: Round) -> Option<Slot> {

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -2,7 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, fmt::Display, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+    sync::Arc,
+};
 
 use parking_lot::RwLock;
 use starfish_config::{AuthorityIndex, Stake};
@@ -10,7 +14,7 @@ use tracing::warn;
 
 use crate::{
     block_header::{BlockHeaderAPI, BlockRef, Round, Slot, VerifiedBlockHeader},
-    commit::{LeaderStatus, WAVE_LENGTH, WaveNumber},
+    commit::{CommitMetastate, LeaderStatus, WAVE_LENGTH, WaveNumber},
     context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
@@ -24,6 +28,10 @@ mod base_committer_tests;
 #[cfg(test)]
 #[path = "tests/base_committer_declarative_tests.rs"]
 mod base_committer_declarative_tests;
+
+#[cfg(test)]
+#[path = "tests/base_committer_metastate_tests.rs"]
+mod base_committer_metastate_tests;
 
 #[derive(Default)]
 pub(crate) struct BaseCommitterOptions {
@@ -92,7 +100,10 @@ impl BaseCommitter {
         let mut leaders_with_enough_support: Vec<_> = leader_blocks
             .into_iter()
             .filter(|l| self.enough_leader_support(certifying_round, l))
-            .map(LeaderStatus::Commit)
+            .map(|leader_block| {
+                let metastate = self.determine_metastate(&leader_block);
+                LeaderStatus::Commit(leader_block, metastate)
+            })
             .collect();
 
         // There can be at most one leader with enough support for each round, otherwise
@@ -124,7 +135,7 @@ impl BaseCommitter {
                 "[{self}] Trying to indirect-decide {leader_slot} using anchor {anchor}",
             );
             match anchor {
-                LeaderStatus::Commit(anchor) => {
+                LeaderStatus::Commit(anchor, _) => {
                     return self.decide_leader_from_anchor(anchor, leader_slot);
                 }
                 LeaderStatus::Skip(..) => (),
@@ -324,7 +335,10 @@ impl BaseCommitter {
         // We commit the target leader if it has a certificate that is an ancestor of
         // the anchor. Otherwise skip it.
         match certified_leader_blocks.pop() {
-            Some(certified_leader_block) => LeaderStatus::Commit(certified_leader_block),
+            Some(certified_leader_block) => {
+                let metastate = self.determine_metastate(&certified_leader_block);
+                LeaderStatus::Commit(certified_leader_block, metastate)
+            }
             None => LeaderStatus::Skip(leader_slot),
         }
     }
@@ -394,6 +408,112 @@ impl BaseCommitter {
             let authority = decision_block.reference().author;
             if self.is_certificate(decision_block, leader_block, &mut all_votes)
                 && certificate_stake_aggregator.add(authority, &self.context.committee)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Classify a freshly committed leader into `Optimistic`/`Standard`/`Pending`
+    /// based on the strong-vote evidence at the voting and certifying rounds.
+    /// Returns `None` when the StarfishSpeed protocol flag is disabled.
+    ///
+    /// 1. 2f+1 certifiers at `r+2` each carrying a StrongQC → `Optimistic`.
+    /// 2. 2f+1 voters at `r+1` with `is_strong_blame() == true` → `Standard`.
+    /// 3. Otherwise → `Pending`.
+    fn determine_metastate(
+        &self,
+        leader_block: &VerifiedBlockHeader,
+    ) -> Option<CommitMetastate> {
+        if !self.context.protocol_config.consensus_starfish_speed() {
+            return None;
+        }
+
+        if self.has_strong_qc_quorum(leader_block) {
+            return Some(CommitMetastate::Optimistic);
+        }
+
+        if self.has_strong_blame_quorum(leader_block) {
+            return Some(CommitMetastate::Standard);
+        }
+
+        Some(CommitMetastate::Pending)
+    }
+
+    /// Check whether 2f+1 blocks at `r+2` each carry a StrongQC for
+    /// `leader_block`. A block carries a StrongQC when 2f+1 of its ancestors at
+    /// `r+1` are votes for the leader **and** have `is_strong_vote() == true`.
+    ///
+    /// `is_strong_vote()` is a self-declared flag on the voter. `is_vote()`
+    /// checks that the voter's support tree actually points at *this* leader
+    /// block — both are needed because a Byzantine equivocating leader can
+    /// produce two blocks at the same slot, and a voter may flag itself as a
+    /// strong vote while supporting the other block.
+    fn has_strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
+        let voting_round = leader_block.round() + 1;
+        let certifying_round = leader_block.round() + 2;
+
+        let dag_state = self.dag_state.read();
+        let strong_vote_refs: HashSet<BlockRef> = dag_state
+            .get_uncommitted_block_headers_at_round(voting_round)
+            .into_iter()
+            .filter(|b| b.is_strong_vote() && self.is_vote(b, leader_block))
+            .map(|b| b.reference())
+            .collect();
+        let decision_blocks = dag_state.get_uncommitted_block_headers_at_round(certifying_round);
+        drop(dag_state);
+
+        let mut strong_qc_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        for decision_block in &decision_blocks {
+            let authority = decision_block.reference().author;
+            if self.is_strong_certificate(decision_block, &strong_vote_refs)
+                && strong_qc_stake_aggregator.add(authority, &self.context.committee)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check whether `potential_certificate`'s ancestors contain 2f+1 stake of
+    /// strong votes. `strong_vote_refs` is the pre-filtered set of voting-round
+    /// blocks that are strong votes for the target leader.
+    fn is_strong_certificate(
+        &self,
+        potential_certificate: &VerifiedBlockHeader,
+        strong_vote_refs: &HashSet<BlockRef>,
+    ) -> bool {
+        let mut strong_votes_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        for reference in potential_certificate.ancestors() {
+            if strong_vote_refs.contains(reference)
+                && strong_votes_stake_aggregator.add(reference.author, &self.context.committee)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check whether 2f+1 blocks at `r+1` both vote for `leader_block` and
+    /// carry `is_strong_blame() == true`.
+    fn has_strong_blame_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
+        let voting_round = leader_block.round() + 1;
+        let voting_blocks = self
+            .dag_state
+            .read()
+            .get_uncommitted_block_headers_at_round(voting_round);
+
+        let mut strong_blame_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        for voting_block in &voting_blocks {
+            if !voting_block.is_strong_blame() {
+                continue;
+            }
+            if !self.is_vote(voting_block, leader_block) {
+                continue;
+            }
+            if strong_blame_stake_aggregator
+                .add(voting_block.reference().author, &self.context.committee)
             {
                 return true;
             }

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -101,7 +101,7 @@ impl BaseCommitter {
             .into_iter()
             .filter(|l| self.enough_leader_support(certifying_round, l))
             .map(|leader_block| {
-                let metastate = self.determine_metastate(&leader_block);
+                let metastate = self.determine_metastate_direct(&leader_block);
                 LeaderStatus::Commit(leader_block, metastate)
             })
             .collect();
@@ -315,16 +315,51 @@ impl BaseCommitter {
             .ancestors_at_round(anchor, certifying_round);
 
         // Use those potential certificates to determine which (if any) of the target
-        // leader blocks can be committed.
-        let mut certified_leader_blocks: Vec<_> = leader_blocks
-            .into_iter()
-            .filter(|leader_block| {
+        // leader blocks can be committed, and — when StarfishSpeed is enabled —
+        // classify the metastate in the same walk. When the flag is off we
+        // stick to the cheap regular-certificate-only check.
+        let starfish_speed = self.context.protocol_config.consensus_starfish_speed();
+        let mut certified_leader_blocks: Vec<(VerifiedBlockHeader, Option<CommitMetastate>)> =
+            Vec::new();
+        for leader_block in leader_blocks {
+            let (any_cert, metastate) = if starfish_speed {
+                let (vote_refs, strong_vote_refs) =
+                    self.vote_and_strong_vote_refs_for_leader(&leader_block);
+                let mut any_cert = false;
+                let mut any_strong = false;
+                for potential_certificate in &potential_certificates {
+                    let (is_cert, is_strong) = self.classify_certificate(
+                        potential_certificate,
+                        &vote_refs,
+                        &strong_vote_refs,
+                    );
+                    any_cert |= is_cert;
+                    any_strong |= is_strong;
+                    if any_cert && any_strong {
+                        break;
+                    }
+                }
+                let metastate = if any_cert {
+                    Some(if any_strong {
+                        CommitMetastate::Optimistic
+                    } else {
+                        CommitMetastate::Standard
+                    })
+                } else {
+                    None
+                };
+                (any_cert, metastate)
+            } else {
                 let mut all_votes = HashMap::new();
-                potential_certificates.iter().any(|potential_certificate| {
-                    self.is_certificate(potential_certificate, leader_block, &mut all_votes)
-                })
-            })
-            .collect();
+                let any_cert = potential_certificates.iter().any(|potential_certificate| {
+                    self.is_certificate(potential_certificate, &leader_block, &mut all_votes)
+                });
+                (any_cert, None)
+            };
+            if any_cert {
+                certified_leader_blocks.push((leader_block, metastate));
+            }
+        }
 
         // There can be at most one certified leader, otherwise it means the BFT
         // assumption is broken.
@@ -332,11 +367,8 @@ impl BaseCommitter {
             panic!("More than one certified block at wave {wave} from leader {leader_slot}")
         }
 
-        // We commit the target leader if it has a certificate that is an ancestor of
-        // the anchor. Otherwise skip it.
         match certified_leader_blocks.pop() {
-            Some(certified_leader_block) => {
-                let metastate = self.determine_metastate(&certified_leader_block);
+            Some((certified_leader_block, metastate)) => {
                 LeaderStatus::Commit(certified_leader_block, metastate)
             }
             None => LeaderStatus::Skip(leader_slot),
@@ -415,15 +447,12 @@ impl BaseCommitter {
         false
     }
 
-    /// Classify a freshly committed leader into
-    /// `Optimistic`/`Standard`/`Pending` based on the strong-vote evidence
-    /// at the voting and certifying rounds. Returns `None` when the
-    /// StarfishSpeed protocol flag is disabled.
-    ///
-    /// 1. 2f+1 certifiers at `r+2` each carrying a StrongQC → `Optimistic`.
-    /// 2. 2f+1 voters at `r+1` with `is_strong_blame() == true` → `Standard`.
-    /// 3. Otherwise → `Pending`.
-    fn determine_metastate(&self, leader_block: &VerifiedBlockHeader) -> Option<CommitMetastate> {
+    /// Direct-commit metastate: StrongQC quorum → `Optimistic`, strong-blame
+    /// quorum → `Standard`, else `Pending`. `None` when the flag is off.
+    fn determine_metastate_direct(
+        &self,
+        leader_block: &VerifiedBlockHeader,
+    ) -> Option<CommitMetastate> {
         if !self.context.protocol_config.consensus_starfish_speed() {
             return None;
         }
@@ -439,28 +468,43 @@ impl BaseCommitter {
         Some(CommitMetastate::Pending)
     }
 
-    /// Check whether 2f+1 blocks at `r+2` each carry a StrongQC for
-    /// `leader_block`. A block carries a StrongQC when 2f+1 of its ancestors at
-    /// `r+1` are votes for the leader **and** have `is_strong_vote() == true`.
-    ///
-    /// `is_strong_vote()` is a self-declared flag on the voter. `is_vote()`
-    /// checks that the voter's support tree actually points at *this* leader
-    /// block — both are needed because a Byzantine equivocating leader can
-    /// produce two blocks at the same slot, and a voter may flag itself as a
-    /// strong vote while supporting the other block.
-    fn has_strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
+    /// `(vote_refs, strong_vote_refs)` at r+1 for `leader_block`, built in a
+    /// single pass. Strong votes are a subset of votes; `is_strong_vote()`
+    /// alone is insufficient (a voter may flag itself strong while supporting
+    /// an equivocating leader).
+    fn vote_and_strong_vote_refs_for_leader(
+        &self,
+        leader_block: &VerifiedBlockHeader,
+    ) -> (HashSet<BlockRef>, HashSet<BlockRef>) {
         let voting_round = leader_block.round() + 1;
+        let voters = self
+            .dag_state
+            .read()
+            .get_uncommitted_block_headers_at_round(voting_round);
+        let mut vote_refs = HashSet::new();
+        let mut strong_vote_refs = HashSet::new();
+        for voter in &voters {
+            if self.is_vote(voter, leader_block) {
+                let r = voter.reference();
+                vote_refs.insert(r);
+                if voter.is_strong_vote() {
+                    strong_vote_refs.insert(r);
+                }
+            }
+        }
+        (vote_refs, strong_vote_refs)
+    }
+
+    /// 2f+1 StrongQCs at `r+2` for `leader_block`.
+    fn has_strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
         let certifying_round = leader_block.round() + 2;
 
-        let dag_state = self.dag_state.read();
-        let strong_vote_refs: HashSet<BlockRef> = dag_state
-            .get_uncommitted_block_headers_at_round(voting_round)
-            .into_iter()
-            .filter(|b| b.is_strong_vote() && self.is_vote(b, leader_block))
-            .map(|b| b.reference())
-            .collect();
-        let decision_blocks = dag_state.get_uncommitted_block_headers_at_round(certifying_round);
-        drop(dag_state);
+        let (_vote_refs, strong_vote_refs) =
+            self.vote_and_strong_vote_refs_for_leader(leader_block);
+        let decision_blocks = self
+            .dag_state
+            .read()
+            .get_uncommitted_block_headers_at_round(certifying_round);
 
         let mut strong_qc_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         for decision_block in &decision_blocks {
@@ -474,9 +518,8 @@ impl BaseCommitter {
         false
     }
 
-    /// Check whether `potential_certificate`'s ancestors contain 2f+1 stake of
-    /// strong votes. `strong_vote_refs` is the pre-filtered set of voting-round
-    /// blocks that are strong votes for the target leader.
+    /// True if `potential_certificate` carries a StrongQC for the leader
+    /// whose strong votes are pre-filtered in `strong_vote_refs`.
     fn is_strong_certificate(
         &self,
         potential_certificate: &VerifiedBlockHeader,
@@ -491,6 +534,39 @@ impl BaseCommitter {
             }
         }
         false
+    }
+
+    /// Single-walk `(is_certificate, is_strong_certificate)` classifier.
+    /// `vote_refs`/`strong_vote_refs` are the pre-computed voter sets.
+    /// Invariant: `is_strong ⇒ is_certificate`.
+    fn classify_certificate(
+        &self,
+        potential_certificate: &VerifiedBlockHeader,
+        vote_refs: &HashSet<BlockRef>,
+        strong_vote_refs: &HashSet<BlockRef>,
+    ) -> (bool, bool) {
+        let mut vote_agg = StakeAggregator::<QuorumThreshold>::new();
+        let mut strong_agg = StakeAggregator::<QuorumThreshold>::new();
+        let mut is_cert = false;
+        let mut is_strong = false;
+        for reference in potential_certificate.ancestors() {
+            if !is_cert
+                && vote_refs.contains(reference)
+                && vote_agg.add(reference.author, &self.context.committee)
+            {
+                is_cert = true;
+            }
+            if !is_strong
+                && strong_vote_refs.contains(reference)
+                && strong_agg.add(reference.author, &self.context.committee)
+            {
+                is_strong = true;
+            }
+            if is_cert && is_strong {
+                break;
+            }
+        }
+        (is_cert, is_strong)
     }
 
     /// Check whether 2f+1 blocks at `r+1` both vote for `leader_block` and

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -415,17 +415,15 @@ impl BaseCommitter {
         false
     }
 
-    /// Classify a freshly committed leader into `Optimistic`/`Standard`/`Pending`
-    /// based on the strong-vote evidence at the voting and certifying rounds.
-    /// Returns `None` when the StarfishSpeed protocol flag is disabled.
+    /// Classify a freshly committed leader into
+    /// `Optimistic`/`Standard`/`Pending` based on the strong-vote evidence
+    /// at the voting and certifying rounds. Returns `None` when the
+    /// StarfishSpeed protocol flag is disabled.
     ///
     /// 1. 2f+1 certifiers at `r+2` each carrying a StrongQC → `Optimistic`.
     /// 2. 2f+1 voters at `r+1` with `is_strong_blame() == true` → `Standard`.
     /// 3. Otherwise → `Pending`.
-    fn determine_metastate(
-        &self,
-        leader_block: &VerifiedBlockHeader,
-    ) -> Option<CommitMetastate> {
+    fn determine_metastate(&self, leader_block: &VerifiedBlockHeader) -> Option<CommitMetastate> {
         if !self.context.protocol_config.consensus_starfish_speed() {
             return None;
         }

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -497,14 +497,22 @@ impl BaseCommitter {
 
     /// 2f+1 StrongQCs at `r+2` for `leader_block`.
     fn has_strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
+        let voting_round = leader_block.round() + 1;
         let certifying_round = leader_block.round() + 2;
 
-        let (_vote_refs, strong_vote_refs) =
-            self.vote_and_strong_vote_refs_for_leader(leader_block);
-        let decision_blocks = self
-            .dag_state
-            .read()
-            .get_uncommitted_block_headers_at_round(certifying_round);
+        let (voters, decision_blocks) = {
+            let dag_state = self.dag_state.read();
+            (
+                dag_state.get_uncommitted_block_headers_at_round(voting_round),
+                dag_state.get_uncommitted_block_headers_at_round(certifying_round),
+            )
+        };
+
+        let strong_vote_refs: HashSet<BlockRef> = voters
+            .into_iter()
+            .filter(|b| b.is_strong_vote() && self.is_vote(b, leader_block))
+            .map(|b| b.reference())
+            .collect();
 
         let mut strong_qc_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         for decision_block in &decision_blocks {

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -829,18 +829,8 @@ impl LeaderStatus {
         }
     }
 
-    pub(crate) fn is_decided(&self) -> bool {
-        match self {
-            Self::Commit(..) => true,
-            Self::Skip(_) => true,
-            Self::Undecided(_) => false,
-        }
-    }
-
-    /// A leader decision is *final* if sequencing can proceed past it.
-    /// `Commit(Pending)` is decided (the slot won't flip to Skip) but not
-    /// final — its metastate has not yet been resolved, so sequencing waits
-    /// until the indirect rule upgrades it.
+    /// True when sequencing can proceed past this leader. `Commit(Pending)`
+    /// and `Undecided` are non-final.
     pub(crate) fn is_final(&self) -> bool {
         match self {
             Self::Commit(_, Some(CommitMetastate::Pending)) => false,

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -829,6 +829,14 @@ impl LeaderStatus {
         }
     }
 
+    /// Slot of the leader this status refers to.
+    pub(crate) fn slot(&self) -> Slot {
+        match self {
+            Self::Commit(block, _) => block.reference().into(),
+            Self::Skip(leader) | Self::Undecided(leader) => *leader,
+        }
+    }
+
     /// True when sequencing can proceed past this leader. `Commit(Pending)`
     /// and `Undecided` are non-final.
     pub(crate) fn is_final(&self) -> bool {

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -802,7 +802,13 @@ fn format_block_digests(blocks: &[BlockRef]) -> String {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum Decision {
+    /// Direct rule produced the final status.
     Direct,
+    /// Direct rule produced `Commit(Pending)`; indirect rule later examined
+    /// an anchor's path and upgraded the metastate to Optimistic/Standard.
+    Upgraded,
+    /// Direct rule left the slot Undecided; indirect rule produced the
+    /// final status.
     Indirect,
 }
 
@@ -827,6 +833,18 @@ impl LeaderStatus {
         match self {
             Self::Commit(..) => true,
             Self::Skip(_) => true,
+            Self::Undecided(_) => false,
+        }
+    }
+
+    /// A leader decision is *final* if sequencing can proceed past it.
+    /// `Commit(Pending)` is decided (the slot won't flip to Skip) but not
+    /// final — its metastate has not yet been resolved, so sequencing waits
+    /// until the indirect rule upgrades it.
+    pub(crate) fn is_final(&self) -> bool {
+        match self {
+            Self::Commit(_, Some(CommitMetastate::Pending)) => false,
+            Self::Commit(..) | Self::Skip(_) => true,
             Self::Undecided(_) => false,
         }
     }

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -809,7 +809,7 @@ pub(crate) enum Decision {
 /// The status of a leader slot from the direct and indirect commit rules.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum LeaderStatus {
-    Commit(VerifiedBlockHeader),
+    Commit(VerifiedBlockHeader, Option<CommitMetastate>),
     Skip(Slot),
     Undecided(Slot),
 }
@@ -817,7 +817,7 @@ pub(crate) enum LeaderStatus {
 impl LeaderStatus {
     pub(crate) fn round(&self) -> Round {
         match self {
-            Self::Commit(block) => block.round(),
+            Self::Commit(block, _) => block.round(),
             Self::Skip(leader) => leader.round,
             Self::Undecided(leader) => leader.round,
         }
@@ -825,7 +825,7 @@ impl LeaderStatus {
 
     pub(crate) fn is_decided(&self) -> bool {
         match self {
-            Self::Commit(_) => true,
+            Self::Commit(..) => true,
             Self::Skip(_) => true,
             Self::Undecided(_) => false,
         }
@@ -833,7 +833,7 @@ impl LeaderStatus {
 
     pub(crate) fn into_decided_leader(self) -> Option<DecidedLeader> {
         match self {
-            Self::Commit(block) => Some(DecidedLeader::Commit(block)),
+            Self::Commit(block, metastate) => Some(DecidedLeader::Commit(block, metastate)),
             Self::Skip(slot) => Some(DecidedLeader::Skip(slot)),
             Self::Undecided(..) => None,
         }
@@ -843,7 +843,10 @@ impl LeaderStatus {
 impl Display for LeaderStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Commit(block) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, None) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, Some(metastate)) => {
+                write!(f, "Commit({},{metastate})", block.reference())
+            }
             Self::Skip(slot) => write!(f, "Skip({slot})"),
             Self::Undecided(slot) => write!(f, "Undecided({slot})"),
         }
@@ -853,7 +856,7 @@ impl Display for LeaderStatus {
 /// Decision of each leader slot.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum DecidedLeader {
-    Commit(VerifiedBlockHeader),
+    Commit(VerifiedBlockHeader, Option<CommitMetastate>),
     Skip(Slot),
 }
 
@@ -861,7 +864,7 @@ impl DecidedLeader {
     // Slot where the leader is decided.
     pub(crate) fn slot(&self) -> Slot {
         match self {
-            Self::Commit(block) => block.reference().into(),
+            Self::Commit(block, _) => block.reference().into(),
             Self::Skip(slot) => *slot,
         }
     }
@@ -870,7 +873,7 @@ impl DecidedLeader {
     // otherwise.
     pub(crate) fn into_committed_block(self) -> Option<VerifiedBlockHeader> {
         match self {
-            Self::Commit(block) => Some(block),
+            Self::Commit(block, _) => Some(block),
             Self::Skip(_) => None,
         }
     }
@@ -878,7 +881,7 @@ impl DecidedLeader {
     #[cfg(test)]
     pub(crate) fn round(&self) -> Round {
         match self {
-            Self::Commit(block) => block.round(),
+            Self::Commit(block, _) => block.round(),
             Self::Skip(leader) => leader.round,
         }
     }
@@ -886,7 +889,7 @@ impl DecidedLeader {
     #[cfg(test)]
     pub(crate) fn authority(&self) -> AuthorityIndex {
         match self {
-            Self::Commit(block) => block.author(),
+            Self::Commit(block, _) => block.author(),
             Self::Skip(leader) => leader.authority,
         }
     }
@@ -895,8 +898,36 @@ impl DecidedLeader {
 impl Display for DecidedLeader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Commit(block) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, None) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, Some(metastate)) => {
+                write!(f, "Commit({},{metastate})", block.reference())
+            }
             Self::Skip(slot) => write!(f, "Skip({slot})"),
+        }
+    }
+}
+
+/// Refined commit state for StarfishSpeed leaders, determined at commit time
+/// from the strong-vote evidence at rounds r+1 (voting) and r+2 (certifying).
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub(crate) enum CommitMetastate {
+    /// Strong-vote quorum at r+1 AND StrongQC quorum at r+2.
+    /// Sequence histDA(L) + leader acknowledgment blocks.
+    Optimistic,
+    /// Strong-blame quorum observed at r+1 (no StrongQC quorum possible).
+    /// Sequence histDA(L) only (same as base Starfish).
+    Standard,
+    /// Neither a strong-vote nor a strong-blame quorum observed.
+    /// Metastate is resolved later (by the indirect rule).
+    Pending,
+}
+
+impl Display for CommitMetastate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Optimistic => write!(f, "optimistic"),
+            Self::Standard => write!(f, "standard"),
+            Self::Pending => write!(f, "pending"),
         }
     }
 }

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -245,8 +245,8 @@ async fn indirect_commit() {
         );
     };
 
-    let leader_status_wave1_indirect =
-        committer.try_indirect_decide(leader, [leader_status_wave_2].iter());
+    let leader_status_wave1_indirect = committer
+        .try_indirect_decide(LeaderStatus::Undecided(leader), [leader_status_wave_2].iter());
 
     if let LeaderStatus::Commit(committed, _) = leader_status_wave1_indirect {
         tracing::info!("Indirect committed leader at wave 1: {committed}");
@@ -362,7 +362,8 @@ async fn indirect_skip() {
 
     // 3. Ensure we skip leader of wave 2 indirectly.
     tracing::info!("Try indirect commit for leader {leader_wave_2}",);
-    let leader_status = committer.try_indirect_decide(leader_wave_2, decided_leaders.iter());
+    let leader_status = committer
+        .try_indirect_decide(LeaderStatus::Undecided(leader_wave_2), decided_leaders.iter());
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Skip(skipped_slot) = leader_status {

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -55,7 +55,7 @@ async fn direct_commit() {
         .elect_leader(leader_round)
         .expect("there should be a leader at wave 1");
     let leader_status = committer.try_direct_decide(leader);
-    if let LeaderStatus::Commit(_) = leader_status {
+    if let LeaderStatus::Commit(..) = leader_status {
         tracing::info!("Committed: {leader_status}");
     } else {
         panic!("Expected a committed leader, got {leader_status}");
@@ -237,7 +237,7 @@ async fn indirect_commit() {
     tracing::info!("Leader index wave 2: {leader_index_wave2}");
 
     let leader_status_wave_2 = committer.try_direct_decide(leader_wave2);
-    if let LeaderStatus::Commit(committed) = leader_status_wave_2.clone() {
+    if let LeaderStatus::Commit(committed, _) = leader_status_wave_2.clone() {
         tracing::info!("Direct committed leader at wave 2: {committed}");
     } else {
         panic!(
@@ -248,7 +248,7 @@ async fn indirect_commit() {
     let leader_status_wave1_indirect =
         committer.try_indirect_decide(leader, [leader_status_wave_2].iter());
 
-    if let LeaderStatus::Commit(committed) = leader_status_wave1_indirect {
+    if let LeaderStatus::Commit(committed, _) = leader_status_wave1_indirect {
         tracing::info!("Indirect committed leader at wave 1: {committed}");
     } else {
         panic!(
@@ -302,7 +302,7 @@ async fn indirect_skip() {
     tracing::info!("Leader index wave 1: {leader_index}");
 
     let leader_status_wave1 = committer.try_direct_decide(leader);
-    if let LeaderStatus::Commit(committed) = leader_status_wave1 {
+    if let LeaderStatus::Commit(committed, _) = leader_status_wave1 {
         tracing::info!("Direct undecided leader at wave 1: {committed}");
     } else {
         panic!(
@@ -339,7 +339,7 @@ async fn indirect_skip() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_3.authority);
         decided_leaders.push(leader_status);
     } else {

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -245,8 +245,10 @@ async fn indirect_commit() {
         );
     };
 
-    let leader_status_wave1_indirect = committer
-        .try_indirect_decide(LeaderStatus::Undecided(leader), [leader_status_wave_2].iter());
+    let leader_status_wave1_indirect = committer.try_indirect_decide(
+        LeaderStatus::Undecided(leader),
+        [leader_status_wave_2].iter(),
+    );
 
     if let LeaderStatus::Commit(committed, _) = leader_status_wave1_indirect {
         tracing::info!("Indirect committed leader at wave 1: {committed}");
@@ -362,8 +364,10 @@ async fn indirect_skip() {
 
     // 3. Ensure we skip leader of wave 2 indirectly.
     tracing::info!("Try indirect commit for leader {leader_wave_2}",);
-    let leader_status = committer
-        .try_indirect_decide(LeaderStatus::Undecided(leader_wave_2), decided_leaders.iter());
+    let leader_status = committer.try_indirect_decide(
+        LeaderStatus::Undecided(leader_wave_2),
+        decided_leaders.iter(),
+    );
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Skip(skipped_slot) = leader_status {

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -10,13 +10,15 @@ use crate::{
     authority_set::AuthoritySet,
     base_committer::base_committer_builder::BaseCommitterBuilder,
     block_header::{
-        BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, Round, TransactionsCommitment,
-        VerifiedBlockHeader, genesis_block_headers,
+        BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
+        TransactionsCommitment, VerifiedBlockHeader, genesis_block_headers,
     },
-    commit::{CommitMetastate, LeaderStatus},
+    commit::{CommitMetastate, DecidedLeader, LeaderStatus},
     context::Context,
     dag_state::{DagState, DataSource},
+    leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
+    universal_committer::universal_committer_builder::UniversalCommitterBuilder,
 };
 
 /// Verified V2 header for tests. `timestamp_ms` distinguishes equivocating
@@ -442,14 +444,6 @@ async fn determine_metastate_pending_when_equivocating_strong_blame_is_filtered(
     }
 }
 
-// === Indirect-rule tests ===
-//
-// The indirect rule resolves a leader when the anchor (a later committed
-// leader) is already known. Metastate is determined by the r+2 blocks in the
-// anchor's causal history (`potential_certificates`): if any is a StrongQC →
-// Optimistic, otherwise Standard. This differs from the direct rule, which
-// scans all r+2 blocks globally and requires a 2f+1 StrongQC quorum.
-
 /// Populate `dag_state` through round 4 (voters link to all round-3 blocks).
 /// Returns the leader slot and voter refs indexed by author.
 fn build_through_voting_round(
@@ -597,4 +591,143 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
         }
         status => panic!("expected Commit, got {status}"),
     }
+}
+
+#[tokio::test]
+async fn leader_status_is_final_classification() {
+    use crate::block_header::Slot;
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Build a minimal DAG to source a VerifiedBlockHeader for the Commit arms.
+    let refs = build_v2_layers(&context, &dag_state, None, 1);
+    let block = dag_state
+        .read()
+        .get_verified_block_header(&refs[0])
+        .expect("round-1 block exists");
+
+    let slot = Slot::new(3, AuthorityIndex::from(0u8));
+    let _ = &committer; // keep committer alive for dag_state lifetime
+
+    assert!(!LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending)).is_final());
+    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic)).is_final());
+    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard)).is_final());
+    assert!(LeaderStatus::Commit(block, None).is_final());
+    assert!(LeaderStatus::Skip(slot).is_final());
+    assert!(!LeaderStatus::Undecided(slot).is_final());
+}
+
+fn build_universal_committer(
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+) -> crate::universal_committer::UniversalCommitter {
+    let leader_schedule = Arc::new(LeaderSchedule::new(
+        context.clone(),
+        LeaderSwapTable::default(),
+    ));
+    UniversalCommitterBuilder::new(context, leader_schedule, dag_state).build()
+}
+
+/// Round-3 leader's metastate in `decided`. Panics if not a Commit.
+fn round_3_metastate(
+    universal: &crate::universal_committer::UniversalCommitter,
+    decided: &[DecidedLeader],
+) -> Option<CommitMetastate> {
+    let leader_authority = universal
+        .get_leaders(3)
+        .into_iter()
+        .next()
+        .expect("round-3 has a leader");
+    let slot = Slot::new(3, leader_authority);
+    let decided = decided
+        .iter()
+        .find(|d| d.slot() == slot)
+        .expect("round-3 leader should be decided");
+    match decided {
+        DecidedLeader::Commit(_, m) => *m,
+        other => panic!("expected round-3 Commit, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn pending_leader_resolves_to_optimistic() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let universal = build_universal_committer(context.clone(), dag_state.clone());
+
+    let round_3_refs = build_v2_layers(&context, &dag_state, None, 3);
+
+    // 3 strong + 1 regular voter at round 4 → one StrongQC at round 5 is
+    // reachable, but a StrongQC quorum (2f+1 = 3) is not. Direct → Pending.
+    let strong = Some(AuthoritySet::new());
+    let voter_configs = [strong, strong, strong, None];
+    let mut round_4_refs = Vec::new();
+    for (author, sv) in voter_configs.iter().enumerate() {
+        let author = author as u8;
+        let block = v2_block(
+            4,
+            author,
+            round_3_refs.clone(),
+            sv.clone(),
+            default_ts(4, author),
+        );
+        round_4_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    // c0 is the only StrongQC (links to all 3 strong voters); others miss one.
+    let c0 = v2_block(5, 0, vec![round_4_refs[0], round_4_refs[1], round_4_refs[2]], None, default_ts(5, 0));
+    let c1 = v2_block(5, 1, vec![round_4_refs[0], round_4_refs[1], round_4_refs[3]], None, default_ts(5, 1));
+    let c2 = v2_block(5, 2, vec![round_4_refs[0], round_4_refs[2], round_4_refs[3]], None, default_ts(5, 2));
+    let c3 = v2_block(5, 3, vec![round_4_refs[1], round_4_refs[2], round_4_refs[3]], None, default_ts(5, 3));
+    let round_5_refs: Vec<BlockRef> = [&c0, &c1, &c2, &c3].iter().map(|b| b.reference()).collect();
+    for b in [c0, c1, c2, c3] {
+        dag_state.write().accept_block_header(b, DataSource::Test);
+    }
+
+    // Direct rule commits round 3 as Pending; no wave-2 anchor yet, so the
+    // upgrade can't happen.
+    let base = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+    let round_3_slot = base.elect_leader(3).expect("round 3 has a leader");
+    match base.try_direct_decide(round_3_slot) {
+        LeaderStatus::Commit(_, m) => assert_eq!(m, Some(CommitMetastate::Pending)),
+        other => panic!("expected Commit(Pending), got {other}"),
+    }
+
+    // Add wave 2: the round-6 anchor's round-5 causal history contains c0.
+    build_v2_layers(&context, &dag_state, Some(round_5_refs), 8);
+
+    let decided = universal.try_decide(Slot::new(GENESIS_ROUND, 0u8));
+    assert_eq!(
+        round_3_metastate(&universal, &decided),
+        Some(CommitMetastate::Optimistic),
+    );
+}
+
+#[tokio::test]
+async fn pending_leader_resolves_to_standard() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let universal = build_universal_committer(context.clone(), dag_state.clone());
+
+    // Wave 1 only — strong_vote = None everywhere → direct → Pending.
+    let round_5_refs = build_v2_layers(&context, &dag_state, None, 5);
+    let base = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+    let round_3_slot = base.elect_leader(3).expect("round 3 has a leader");
+    match base.try_direct_decide(round_3_slot) {
+        LeaderStatus::Commit(_, m) => assert_eq!(m, Some(CommitMetastate::Pending)),
+        other => panic!("expected Commit(Pending), got {other}"),
+    }
+
+    // Add wave 2. The round-6 anchor's round-5 path has only regular QCs
+    // → Standard.
+    build_v2_layers(&context, &dag_state, Some(round_5_refs), 8);
+
+    let decided = universal.try_decide(Slot::new(GENESIS_ROUND, 0u8));
+    assert_eq!(
+        round_3_metastate(&universal, &decided),
+        Some(CommitMetastate::Standard),
+    );
 }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -19,9 +19,8 @@ use crate::{
     storage::mem_store::MemStore,
 };
 
-/// Build a `BlockHeaderV2` wrapped as a verified block header for test use.
-/// `timestamp_ms` is exposed so callers can produce two equivocating blocks
-/// with the same `(round, author)` but distinct `BlockRef`s.
+/// Verified V2 header for tests. `timestamp_ms` distinguishes equivocating
+/// blocks at the same `(round, author)`.
 fn v2_block(
     round: Round,
     author: u8,
@@ -48,19 +47,17 @@ fn default_ts(round: Round, author: u8) -> BlockTimestampMs {
     round as BlockTimestampMs * 1000 + author as BlockTimestampMs
 }
 
-/// `strong_vote` payload that flags the carrier as a strong blame. Only the
-/// emptiness of the set matters (empty → strong vote, non-empty → strong
-/// blame); the specific authority is immaterial for these tests.
+/// Non-empty `AuthoritySet` — flags the carrier as a strong blame. The
+/// specific authority is immaterial; only emptiness matters.
 fn strong_blame() -> Option<AuthoritySet> {
     let mut s = AuthoritySet::new();
     s.insert(AuthorityIndex::from(0u8));
     Some(s)
 }
 
-/// Build fully-connected V2 layers from `start` (or genesis if `None`) up to
-/// and including `stop`. All blocks have `strong_vote = None`. Returns the
-/// refs at `stop`. Mirrors `test_dag::build_dag` but produces V2 headers so
-/// the DAG matches what `consensus_starfish_speed` actually runs.
+/// Fully-connected V2 layers from `start` (or genesis) through `stop`. V2
+/// mirror of `test_dag::build_dag`, matching the DAG shape used when
+/// `consensus_starfish_speed` is enabled.
 fn build_v2_layers(
     context: &Context,
     dag_state: &Arc<RwLock<DagState>>,
@@ -96,8 +93,7 @@ fn build_v2_layers(
     ancestors
 }
 
-/// Test context with starfish-speed enabled by default. Returns the context
-/// and an empty in-memory DAG state.
+/// Test context with the starfish-speed flag set, plus an empty DAG state.
 fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwLock<DagState>>) {
     let (mut ctx, _) = Context::new_for_test(4);
     ctx.protocol_config
@@ -110,9 +106,8 @@ fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwL
     (ctx, dag_state)
 }
 
-/// Populate `dag_state` through round 5 (leader at round 3). Each round-4
-/// voter carries `strong_vote == voter_strong_votes[i]`; each round-5
-/// certifier links to all four voters. Returns the leader slot.
+/// Populate `dag_state` through round 5; round-4 voters carry the given
+/// `strong_vote` values. Returns the leader slot at round 3.
 fn build_metastate_dag(
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
@@ -258,20 +253,16 @@ async fn determine_metastate_pending_when_neither_quorum() {
     }
 }
 
-/// Selects which of the two equivocating leader blocks a round-4 voter supports
-/// via its ancestor chain.
+/// Which equivocating leader a voter supports.
 #[derive(Clone, Copy)]
 enum LeaderChoice {
     A,
     B,
 }
 
-/// Populate `dag_state` through round 5 with two equivocating leader blocks
-/// `L_A` and `L_B` at round 3 (same leader author, different timestamps).
-/// Each round-4 voter includes either `L_A` or `L_B` (per `voter_config`)
-/// plus the three non-leader round-3 blocks, and carries the configured
-/// `strong_vote`. Round-5 certifiers link to all four voters. Returns
-/// `(leader_slot, L_A ref, L_B ref)`.
+/// Same as `build_metastate_dag`, but the leader author produces two
+/// equivocating blocks `L_A`/`L_B` at round 3 and voters split per
+/// `voter_config`. Returns `(leader_slot, L_A, L_B)`.
 fn build_equivocating_metastate_dag(
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
@@ -446,6 +437,167 @@ async fn determine_metastate_pending_when_equivocating_strong_blame_is_filtered(
         LeaderStatus::Commit(block, metastate) => {
             assert_eq!(block.reference(), leader_a_ref);
             assert_eq!(metastate, Some(CommitMetastate::Pending));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+// === Indirect-rule tests ===
+//
+// The indirect rule resolves a leader when the anchor (a later committed
+// leader) is already known. Metastate is determined by the r+2 blocks in the
+// anchor's causal history (`potential_certificates`): if any is a StrongQC →
+// Optimistic, otherwise Standard. This differs from the direct rule, which
+// scans all r+2 blocks globally and requires a 2f+1 StrongQC quorum.
+
+/// Populate `dag_state` through round 4 (voters link to all round-3 blocks).
+/// Returns the leader slot and voter refs indexed by author.
+fn build_through_voting_round(
+    context: &Context,
+    dag_state: &Arc<RwLock<DagState>>,
+    committer: &crate::base_committer::BaseCommitter,
+    voter_strong_votes: [Option<AuthoritySet>; 4],
+) -> (crate::block_header::Slot, Vec<BlockRef>) {
+    let leader_round = committer.leader_round(1);
+    let voting_round = leader_round + 1;
+    let round_3_refs = build_v2_layers(context, dag_state, None, leader_round);
+
+    let mut voter_refs = Vec::with_capacity(4);
+    for (author, strong_vote) in voter_strong_votes.into_iter().enumerate() {
+        let author = author as u8;
+        let block = v2_block(
+            voting_round,
+            author,
+            round_3_refs.clone(),
+            strong_vote,
+            default_ts(voting_round, author),
+        );
+        voter_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    let leader_slot = committer
+        .elect_leader(leader_round)
+        .expect("should elect a leader");
+    (leader_slot, voter_refs)
+}
+
+/// Build one round-5 certifier from the specified round-4 voter refs.
+fn certifier(
+    committer: &crate::base_committer::BaseCommitter,
+    author: u8,
+    voter_refs: Vec<BlockRef>,
+) -> VerifiedBlockHeader {
+    let round = committer.certifying_round(1);
+    v2_block(round, author, voter_refs, None, default_ts(round, author))
+}
+
+#[tokio::test]
+async fn indirect_metastate_optimistic_when_anchor_path_contains_strong_qc() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // v0, v1, v2 are strong votes for L; v3 is a regular vote.
+    let strong = Some(AuthoritySet::new());
+    let (leader_slot, voters) = build_through_voting_round(
+        &context,
+        &dag_state,
+        &committer,
+        [strong, strong, strong, None],
+    );
+
+    // Round-5 certifiers:
+    // - c0 has 3 strong voters in ancestors → StrongQC for L.
+    // - c1, c2, c3 each have only 2 strong voters → regular QC, not StrongQC.
+    // Only one StrongQC exists globally, so the *direct* rule would say
+    // Pending (< 2f+1 StrongQCs, no blames).
+    let c0 = certifier(&committer, 0, vec![voters[0], voters[1], voters[2]]);
+    let c1 = certifier(&committer, 1, vec![voters[0], voters[1], voters[3]]);
+    let c2 = certifier(&committer, 2, vec![voters[0], voters[2], voters[3]]);
+    let c3 = certifier(&committer, 3, vec![voters[1], voters[2], voters[3]]);
+    let (c0_ref, c1_ref, c2_ref) = (c0.reference(), c1.reference(), c2.reference());
+    for b in [c0, c1, c2, c3] {
+        dag_state
+            .write()
+            .accept_block_header(b, DataSource::Test);
+    }
+
+    // Anchor at round 6 includes c0 (StrongQC) in its round-5 ancestors.
+    let anchor_round = committer.certifying_round(1) + 1;
+    let anchor = v2_block(
+        anchor_round,
+        0,
+        vec![c0_ref, c1_ref, c2_ref],
+        None,
+        default_ts(anchor_round, 0),
+    );
+    dag_state
+        .write()
+        .accept_block_header(anchor.clone(), DataSource::Test);
+
+    let anchor_status = LeaderStatus::Commit(anchor, None);
+    match committer.try_indirect_decide(leader_slot, std::iter::once(&anchor_status)) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference().round, leader_slot.round);
+            assert_eq!(block.reference().author, leader_slot.authority);
+            assert_eq!(metastate, Some(CommitMetastate::Optimistic));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Same round-4 setup as the Optimistic test: v0, v1, v2 are strong votes.
+    let strong = Some(AuthoritySet::new());
+    let (leader_slot, voters) = build_through_voting_round(
+        &context,
+        &dag_state,
+        &committer,
+        [strong, strong, strong, None],
+    );
+
+    // Same round-5 layout: c0 is the only StrongQC; c1, c2, c3 are regular
+    // QCs. StrongQC exists *globally* (but well below a 2f+1 quorum).
+    let c0 = certifier(&committer, 0, vec![voters[0], voters[1], voters[2]]);
+    let c1 = certifier(&committer, 1, vec![voters[0], voters[1], voters[3]]);
+    let c2 = certifier(&committer, 2, vec![voters[0], voters[2], voters[3]]);
+    let c3 = certifier(&committer, 3, vec![voters[1], voters[2], voters[3]]);
+    let (c1_ref, c2_ref, c3_ref) = (c1.reference(), c2.reference(), c3.reference());
+    for b in [c0, c1, c2, c3] {
+        dag_state
+            .write()
+            .accept_block_header(b, DataSource::Test);
+    }
+
+    // Anchor excludes c0 — its round-5 path contains only regular QCs. The
+    // indirect rule must restrict its StrongQC search to this path and return
+    // Standard, even though a StrongQC exists elsewhere in the DAG.
+    let anchor_round = committer.certifying_round(1) + 1;
+    let anchor = v2_block(
+        anchor_round,
+        1,
+        vec![c1_ref, c2_ref, c3_ref],
+        None,
+        default_ts(anchor_round, 1),
+    );
+    dag_state
+        .write()
+        .accept_block_header(anchor.clone(), DataSource::Test);
+
+    let anchor_status = LeaderStatus::Commit(anchor, None);
+    match committer.try_indirect_decide(leader_slot, std::iter::once(&anchor_status)) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference().round, leader_slot.round);
+            assert_eq!(block.reference().author, leader_slot.authority);
+            assert_eq!(metastate, Some(CommitMetastate::Standard));
         }
         status => panic!("expected Commit, got {status}"),
     }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -519,7 +519,8 @@ async fn indirect_metastate_optimistic_when_anchor_path_contains_strong_qc() {
         .accept_block_header(anchor.clone(), DataSource::Test);
 
     let anchor_status = LeaderStatus::Commit(anchor, None);
-    match committer.try_indirect_decide(leader_slot, std::iter::once(&anchor_status)) {
+    let current = LeaderStatus::Undecided(leader_slot);
+    match committer.try_indirect_decide(current, std::iter::once(&anchor_status)) {
         LeaderStatus::Commit(block, metastate) => {
             assert_eq!(block.reference().round, leader_slot.round);
             assert_eq!(block.reference().author, leader_slot.authority);
@@ -553,7 +554,8 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
         .accept_block_header(anchor.clone(), DataSource::Test);
 
     let anchor_status = LeaderStatus::Commit(anchor, None);
-    match committer.try_indirect_decide(leader_slot, std::iter::once(&anchor_status)) {
+    let current = LeaderStatus::Undecided(leader_slot);
+    match committer.try_indirect_decide(current, std::iter::once(&anchor_status)) {
         LeaderStatus::Commit(block, metastate) => {
             assert_eq!(block.reference().round, leader_slot.round);
             assert_eq!(block.reference().author, leader_slot.authority);

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -678,10 +678,34 @@ async fn pending_leader_resolves_to_optimistic() {
     }
 
     // c0 is the only StrongQC (links to all 3 strong voters); others miss one.
-    let c0 = v2_block(5, 0, vec![round_4_refs[0], round_4_refs[1], round_4_refs[2]], None, default_ts(5, 0));
-    let c1 = v2_block(5, 1, vec![round_4_refs[0], round_4_refs[1], round_4_refs[3]], None, default_ts(5, 1));
-    let c2 = v2_block(5, 2, vec![round_4_refs[0], round_4_refs[2], round_4_refs[3]], None, default_ts(5, 2));
-    let c3 = v2_block(5, 3, vec![round_4_refs[1], round_4_refs[2], round_4_refs[3]], None, default_ts(5, 3));
+    let c0 = v2_block(
+        5,
+        0,
+        vec![round_4_refs[0], round_4_refs[1], round_4_refs[2]],
+        None,
+        default_ts(5, 0),
+    );
+    let c1 = v2_block(
+        5,
+        1,
+        vec![round_4_refs[0], round_4_refs[1], round_4_refs[3]],
+        None,
+        default_ts(5, 1),
+    );
+    let c2 = v2_block(
+        5,
+        2,
+        vec![round_4_refs[0], round_4_refs[2], round_4_refs[3]],
+        None,
+        default_ts(5, 2),
+    );
+    let c3 = v2_block(
+        5,
+        3,
+        vec![round_4_refs[1], round_4_refs[2], round_4_refs[3]],
+        None,
+        default_ts(5, 3),
+    );
     let round_5_refs: Vec<BlockRef> = [&c0, &c1, &c2, &c3].iter().map(|b| b.reference()).collect();
     for b in [c0, c1, c2, c3] {
         dag_state.write().accept_block_header(b, DataSource::Test);

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -49,12 +49,29 @@ fn default_ts(round: Round, author: u8) -> BlockTimestampMs {
     round as BlockTimestampMs * 1000 + author as BlockTimestampMs
 }
 
+/// Empty `AuthoritySet` — flags the carrier as a strong vote.
+fn strong_vote() -> Option<AuthoritySet> {
+    Some(AuthoritySet::new())
+}
+
 /// Non-empty `AuthoritySet` — flags the carrier as a strong blame. The
 /// specific authority is immaterial; only emptiness matters.
 fn strong_blame() -> Option<AuthoritySet> {
     let mut s = AuthoritySet::new();
     s.insert(AuthorityIndex::from(0u8));
     Some(s)
+}
+
+/// Assert that direct-committing `slot` yields `Commit(_, expected)`.
+fn assert_direct_commit_metastate(
+    committer: &crate::base_committer::BaseCommitter,
+    slot: Slot,
+    expected: Option<CommitMetastate>,
+) {
+    match committer.try_direct_decide(slot) {
+        LeaderStatus::Commit(_, metastate) => assert_eq!(metastate, expected),
+        status => panic!("expected Commit, got {status}"),
+    }
 }
 
 /// Fully-connected V2 layers from `start` (or genesis) through `stop`. V2
@@ -164,17 +181,8 @@ async fn determine_metastate_disabled_returns_none() {
     let (context, dag_state) = test_context_with_flag(false);
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
-    let leader = build_metastate_dag(
-        context,
-        dag_state,
-        &committer,
-        [Some(AuthoritySet::new()); 4],
-    );
-
-    match committer.try_direct_decide(leader) {
-        LeaderStatus::Commit(_, metastate) => assert_eq!(metastate, None),
-        status => panic!("expected Commit, got {status}"),
-    }
+    let leader = build_metastate_dag(context, dag_state, &committer, [strong_vote(); 4]);
+    assert_direct_commit_metastate(&committer, leader, None);
 }
 
 #[tokio::test]
@@ -183,22 +191,10 @@ async fn determine_metastate_optimistic_when_strong_qc_quorum() {
     let (context, dag_state) = test_context_with_flag(true);
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
-    // All four voters carry strong_vote = Some(empty) → every certifier at r+2
-    // will observe four strong votes in its ancestry, so it is a StrongQC. The
-    // 2f+1 StrongQC quorum at r+2 is reached → Optimistic.
-    let leader = build_metastate_dag(
-        context,
-        dag_state,
-        &committer,
-        [Some(AuthoritySet::new()); 4],
-    );
-
-    match committer.try_direct_decide(leader) {
-        LeaderStatus::Commit(_, metastate) => {
-            assert_eq!(metastate, Some(CommitMetastate::Optimistic))
-        }
-        status => panic!("expected Commit, got {status}"),
-    }
+    // Four strong votes at r+1 → every r+2 certifier observes a StrongQC →
+    // 2f+1 StrongQC quorum → Optimistic.
+    let leader = build_metastate_dag(context, dag_state, &committer, [strong_vote(); 4]);
+    assert_direct_commit_metastate(&committer, leader, Some(CommitMetastate::Optimistic));
 }
 
 #[tokio::test]
@@ -207,23 +203,16 @@ async fn determine_metastate_standard_when_strong_blame_quorum() {
     let (context, dag_state) = test_context_with_flag(true);
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
-    // Three voters carry strong_vote = Some(nonempty) (strong blame). Only one
-    // voter is a strong vote → no StrongQC quorum possible. 2f+1 strong blames
-    // form a quorum → Standard.
+    // 3 strong blames + 1 strong vote → no StrongQC quorum, 2f+1 strong-blame
+    // quorum → Standard.
     let blame = strong_blame();
     let leader = build_metastate_dag(
         context,
         dag_state,
         &committer,
-        [Some(AuthoritySet::new()), blame, blame, blame],
+        [strong_vote(), blame, blame, blame],
     );
-
-    match committer.try_direct_decide(leader) {
-        LeaderStatus::Commit(_, metastate) => {
-            assert_eq!(metastate, Some(CommitMetastate::Standard))
-        }
-        status => panic!("expected Commit, got {status}"),
-    }
+    assert_direct_commit_metastate(&committer, leader, Some(CommitMetastate::Standard));
 }
 
 #[tokio::test]
@@ -232,27 +221,15 @@ async fn determine_metastate_pending_when_neither_quorum() {
     let (context, dag_state) = test_context_with_flag(true);
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
-    // Split: 2 strong votes, 2 strong blames. Neither side reaches the 2f+1 = 3
-    // threshold → Pending.
+    // 2 strong votes + 2 strong blames → neither side reaches 2f+1 = 3 → Pending.
     let blame = strong_blame();
     let leader = build_metastate_dag(
         context,
         dag_state,
         &committer,
-        [
-            Some(AuthoritySet::new()),
-            Some(AuthoritySet::new()),
-            blame,
-            blame,
-        ],
+        [strong_vote(), strong_vote(), blame, blame],
     );
-
-    match committer.try_direct_decide(leader) {
-        LeaderStatus::Commit(_, metastate) => {
-            assert_eq!(metastate, Some(CommitMetastate::Pending))
-        }
-        status => panic!("expected Commit, got {status}"),
-    }
+    assert_direct_commit_metastate(&committer, leader, Some(CommitMetastate::Pending));
 }
 
 /// Which equivocating leader a voter supports.
@@ -384,7 +361,7 @@ async fn determine_metastate_pending_when_equivocating_strong_vote_is_filtered()
     // and not `Standard` (no blames) → `Pending`. If the `is_vote()` filter
     // were missing, the `L_B`-directed strong vote would be miscounted for
     // `L_A`, reaching the threshold and yielding a wrong `Optimistic`.
-    let strong = Some(AuthoritySet::new());
+    let strong = strong_vote();
     let (leader_slot, leader_a_ref, _leader_b_ref) = build_equivocating_metastate_dag(
         context,
         dag_state,
@@ -488,41 +465,52 @@ fn certifier(
     v2_block(round, author, voter_refs, None, default_ts(round, author))
 }
 
+/// Wave-1 DAG with a single StrongQC at r+2 (the others are regular QCs).
+/// The direct rule classifies the round-3 leader as Pending under this
+/// setup. Returns `(leader_slot, [c0, c1, c2, c3])` where `c0` is the
+/// StrongQC and `c1..c3` are regular QCs.
+fn build_wave_one_with_single_strong_qc(
+    context: &Context,
+    dag_state: &Arc<RwLock<DagState>>,
+    committer: &crate::base_committer::BaseCommitter,
+) -> (Slot, [BlockRef; 4]) {
+    let (leader_slot, voters) = build_through_voting_round(
+        context,
+        dag_state,
+        committer,
+        [strong_vote(), strong_vote(), strong_vote(), None],
+    );
+    let c0 = certifier(committer, 0, vec![voters[0], voters[1], voters[2]]);
+    let c1 = certifier(committer, 1, vec![voters[0], voters[1], voters[3]]);
+    let c2 = certifier(committer, 2, vec![voters[0], voters[2], voters[3]]);
+    let c3 = certifier(committer, 3, vec![voters[1], voters[2], voters[3]]);
+    let refs = [
+        c0.reference(),
+        c1.reference(),
+        c2.reference(),
+        c3.reference(),
+    ];
+    for b in [c0, c1, c2, c3] {
+        dag_state.write().accept_block_header(b, DataSource::Test);
+    }
+    (leader_slot, refs)
+}
+
 #[tokio::test]
 async fn indirect_metastate_optimistic_when_anchor_path_contains_strong_qc() {
     telemetry_subscribers::init_for_testing();
     let (context, dag_state) = test_context_with_flag(true);
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
-    // v0, v1, v2 are strong votes for L; v3 is a regular vote.
-    let strong = Some(AuthoritySet::new());
-    let (leader_slot, voters) = build_through_voting_round(
-        &context,
-        &dag_state,
-        &committer,
-        [strong, strong, strong, None],
-    );
+    let (leader_slot, [c0, c1, c2, _c3]) =
+        build_wave_one_with_single_strong_qc(&context, &dag_state, &committer);
 
-    // Round-5 certifiers:
-    // - c0 has 3 strong voters in ancestors → StrongQC for L.
-    // - c1, c2, c3 each have only 2 strong voters → regular QC, not StrongQC.
-    // Only one StrongQC exists globally, so the *direct* rule would say
-    // Pending (< 2f+1 StrongQCs, no blames).
-    let c0 = certifier(&committer, 0, vec![voters[0], voters[1], voters[2]]);
-    let c1 = certifier(&committer, 1, vec![voters[0], voters[1], voters[3]]);
-    let c2 = certifier(&committer, 2, vec![voters[0], voters[2], voters[3]]);
-    let c3 = certifier(&committer, 3, vec![voters[1], voters[2], voters[3]]);
-    let (c0_ref, c1_ref, c2_ref) = (c0.reference(), c1.reference(), c2.reference());
-    for b in [c0, c1, c2, c3] {
-        dag_state.write().accept_block_header(b, DataSource::Test);
-    }
-
-    // Anchor at round 6 includes c0 (StrongQC) in its round-5 ancestors.
+    // Anchor at round 6 includes the StrongQC c0 in its round-5 ancestors.
     let anchor_round = committer.certifying_round(1) + 1;
     let anchor = v2_block(
         anchor_round,
         0,
-        vec![c0_ref, c1_ref, c2_ref],
+        vec![c0, c1, c2],
         None,
         default_ts(anchor_round, 0),
     );
@@ -547,34 +535,16 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
     let (context, dag_state) = test_context_with_flag(true);
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
-    // Same round-4 setup as the Optimistic test: v0, v1, v2 are strong votes.
-    let strong = Some(AuthoritySet::new());
-    let (leader_slot, voters) = build_through_voting_round(
-        &context,
-        &dag_state,
-        &committer,
-        [strong, strong, strong, None],
-    );
+    let (leader_slot, [_c0, c1, c2, c3]) =
+        build_wave_one_with_single_strong_qc(&context, &dag_state, &committer);
 
-    // Same round-5 layout: c0 is the only StrongQC; c1, c2, c3 are regular
-    // QCs. StrongQC exists *globally* (but well below a 2f+1 quorum).
-    let c0 = certifier(&committer, 0, vec![voters[0], voters[1], voters[2]]);
-    let c1 = certifier(&committer, 1, vec![voters[0], voters[1], voters[3]]);
-    let c2 = certifier(&committer, 2, vec![voters[0], voters[2], voters[3]]);
-    let c3 = certifier(&committer, 3, vec![voters[1], voters[2], voters[3]]);
-    let (c1_ref, c2_ref, c3_ref) = (c1.reference(), c2.reference(), c3.reference());
-    for b in [c0, c1, c2, c3] {
-        dag_state.write().accept_block_header(b, DataSource::Test);
-    }
-
-    // Anchor excludes c0 — its round-5 path contains only regular QCs. The
-    // indirect rule must restrict its StrongQC search to this path and return
-    // Standard, even though a StrongQC exists elsewhere in the DAG.
+    // Anchor excludes the StrongQC c0. Indirect must still resolve from the
+    // restricted r+2 path and pick Standard, not Optimistic.
     let anchor_round = committer.certifying_round(1) + 1;
     let anchor = v2_block(
         anchor_round,
         1,
-        vec![c1_ref, c2_ref, c3_ref],
+        vec![c1, c2, c3],
         None,
         default_ts(anchor_round, 1),
     );
@@ -595,11 +565,7 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
 
 #[tokio::test]
 async fn leader_status_is_final_classification() {
-    use crate::block_header::Slot;
     let (context, dag_state) = test_context_with_flag(true);
-    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
-
-    // Build a minimal DAG to source a VerifiedBlockHeader for the Commit arms.
     let refs = build_v2_layers(&context, &dag_state, None, 1);
     let block = dag_state
         .read()
@@ -607,8 +573,6 @@ async fn leader_status_is_final_classification() {
         .expect("round-1 block exists");
 
     let slot = Slot::new(3, AuthorityIndex::from(0u8));
-    let _ = &committer; // keep committer alive for dag_state lifetime
-
     assert!(!LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending)).is_final());
     assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic)).is_final());
     assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard)).is_final());
@@ -654,74 +618,16 @@ async fn pending_leader_resolves_to_optimistic() {
     telemetry_subscribers::init_for_testing();
     let (context, dag_state) = test_context_with_flag(true);
     let universal = build_universal_committer(context.clone(), dag_state.clone());
-
-    let round_3_refs = build_v2_layers(&context, &dag_state, None, 3);
-
-    // 3 strong + 1 regular voter at round 4 → one StrongQC at round 5 is
-    // reachable, but a StrongQC quorum (2f+1 = 3) is not. Direct → Pending.
-    let strong = Some(AuthoritySet::new());
-    let voter_configs = [strong, strong, strong, None];
-    let mut round_4_refs = Vec::new();
-    for (author, sv) in voter_configs.iter().enumerate() {
-        let author = author as u8;
-        let block = v2_block(
-            4,
-            author,
-            round_3_refs.clone(),
-            sv.clone(),
-            default_ts(4, author),
-        );
-        round_4_refs.push(block.reference());
-        dag_state
-            .write()
-            .accept_block_header(block, DataSource::Test);
-    }
-
-    // c0 is the only StrongQC (links to all 3 strong voters); others miss one.
-    let c0 = v2_block(
-        5,
-        0,
-        vec![round_4_refs[0], round_4_refs[1], round_4_refs[2]],
-        None,
-        default_ts(5, 0),
-    );
-    let c1 = v2_block(
-        5,
-        1,
-        vec![round_4_refs[0], round_4_refs[1], round_4_refs[3]],
-        None,
-        default_ts(5, 1),
-    );
-    let c2 = v2_block(
-        5,
-        2,
-        vec![round_4_refs[0], round_4_refs[2], round_4_refs[3]],
-        None,
-        default_ts(5, 2),
-    );
-    let c3 = v2_block(
-        5,
-        3,
-        vec![round_4_refs[1], round_4_refs[2], round_4_refs[3]],
-        None,
-        default_ts(5, 3),
-    );
-    let round_5_refs: Vec<BlockRef> = [&c0, &c1, &c2, &c3].iter().map(|b| b.reference()).collect();
-    for b in [c0, c1, c2, c3] {
-        dag_state.write().accept_block_header(b, DataSource::Test);
-    }
-
-    // Direct rule commits round 3 as Pending; no wave-2 anchor yet, so the
-    // upgrade can't happen.
     let base = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
-    let round_3_slot = base.elect_leader(3).expect("round 3 has a leader");
-    match base.try_direct_decide(round_3_slot) {
-        LeaderStatus::Commit(_, m) => assert_eq!(m, Some(CommitMetastate::Pending)),
-        other => panic!("expected Commit(Pending), got {other}"),
-    }
 
-    // Add wave 2: the round-6 anchor's round-5 causal history contains c0.
-    build_v2_layers(&context, &dag_state, Some(round_5_refs), 8);
+    let (round_3_slot, round_5_refs) =
+        build_wave_one_with_single_strong_qc(&context, &dag_state, &base);
+
+    // No wave-2 anchor yet — direct says Pending and can't upgrade.
+    assert_direct_commit_metastate(&base, round_3_slot, Some(CommitMetastate::Pending));
+
+    // Wave 2 pulls the StrongQC (c0) into the round-6 anchor's r+2 path.
+    build_v2_layers(&context, &dag_state, Some(round_5_refs.to_vec()), 8);
 
     let decided = universal.try_decide(Slot::new(GENESIS_ROUND, 0u8));
     assert_eq!(
@@ -735,18 +641,14 @@ async fn pending_leader_resolves_to_standard() {
     telemetry_subscribers::init_for_testing();
     let (context, dag_state) = test_context_with_flag(true);
     let universal = build_universal_committer(context.clone(), dag_state.clone());
-
-    // Wave 1 only — strong_vote = None everywhere → direct → Pending.
-    let round_5_refs = build_v2_layers(&context, &dag_state, None, 5);
     let base = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
-    let round_3_slot = base.elect_leader(3).expect("round 3 has a leader");
-    match base.try_direct_decide(round_3_slot) {
-        LeaderStatus::Commit(_, m) => assert_eq!(m, Some(CommitMetastate::Pending)),
-        other => panic!("expected Commit(Pending), got {other}"),
-    }
 
-    // Add wave 2. The round-6 anchor's round-5 path has only regular QCs
-    // → Standard.
+    // Wave 1 only — strong_vote = None everywhere → direct says Pending.
+    let round_5_refs = build_v2_layers(&context, &dag_state, None, 5);
+    let round_3_slot = base.elect_leader(3).expect("round 3 has a leader");
+    assert_direct_commit_metastate(&base, round_3_slot, Some(CommitMetastate::Pending));
+
+    // Wave 2 arrives. The round-6 anchor's r+2 path has only regular QCs.
     build_v2_layers(&context, &dag_state, Some(round_5_refs), 8);
 
     let decided = universal.try_decide(Slot::new(GENESIS_ROUND, 0u8));

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -11,13 +11,12 @@ use crate::{
     base_committer::base_committer_builder::BaseCommitterBuilder,
     block_header::{
         BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, Round, TransactionsCommitment,
-        VerifiedBlockHeader,
+        VerifiedBlockHeader, genesis_block_headers,
     },
     commit::{CommitMetastate, LeaderStatus},
     context::Context,
     dag_state::{DagState, DataSource},
     storage::mem_store::MemStore,
-    test_dag::build_dag,
 };
 
 /// Build a `BlockHeaderV2` wrapped as a verified block header for test use.
@@ -49,6 +48,54 @@ fn default_ts(round: Round, author: u8) -> BlockTimestampMs {
     round as BlockTimestampMs * 1000 + author as BlockTimestampMs
 }
 
+/// `strong_vote` payload that flags the carrier as a strong blame. Only the
+/// emptiness of the set matters (empty → strong vote, non-empty → strong
+/// blame); the specific authority is immaterial for these tests.
+fn strong_blame() -> Option<AuthoritySet> {
+    let mut s = AuthoritySet::new();
+    s.insert(AuthorityIndex::from(0u8));
+    Some(s)
+}
+
+/// Build fully-connected V2 layers from `start` (or genesis if `None`) up to
+/// and including `stop`. All blocks have `strong_vote = None`. Returns the
+/// refs at `stop`. Mirrors `test_dag::build_dag` but produces V2 headers so
+/// the DAG matches what `consensus_starfish_speed` actually runs.
+fn build_v2_layers(
+    context: &Context,
+    dag_state: &Arc<RwLock<DagState>>,
+    start: Option<Vec<BlockRef>>,
+    stop: Round,
+) -> Vec<BlockRef> {
+    let mut ancestors: Vec<BlockRef> = match start {
+        Some(refs) => refs,
+        None => genesis_block_headers(context)
+            .iter()
+            .map(|b| b.reference())
+            .collect(),
+    };
+    let starting_round = ancestors.first().map(|r| r.round).unwrap_or(0) + 1;
+    for round in starting_round..=stop {
+        let mut refs = Vec::new();
+        for author in 0..context.committee.size() {
+            let author = author as u8;
+            let block = v2_block(
+                round,
+                author,
+                ancestors.clone(),
+                None,
+                default_ts(round, author),
+            );
+            refs.push(block.reference());
+            dag_state
+                .write()
+                .accept_block_header(block, DataSource::Test);
+        }
+        ancestors = refs;
+    }
+    ancestors
+}
+
 /// Test context with starfish-speed enabled by default. Returns the context
 /// and an empty in-memory DAG state.
 fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwLock<DagState>>) {
@@ -63,22 +110,16 @@ fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwL
     (ctx, dag_state)
 }
 
-/// Populate `dag_state` with a wave-1 DAG in which every round-4 voter has
-/// `strong_vote == voter_strong_votes[i]` and every round-5 certifier links
-/// to all four round-4 voters. Returns the elected leader slot at round 3.
+/// Populate `dag_state` through round 5 (leader at round 3). Each round-4
+/// voter carries `strong_vote == voter_strong_votes[i]`; each round-5
+/// certifier links to all four voters. Returns the leader slot.
 fn build_metastate_dag(
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     committer: &crate::base_committer::BaseCommitter,
     voter_strong_votes: [Option<AuthoritySet>; 4],
 ) -> crate::block_header::Slot {
-    // Rounds 1..=3 are built fully-connected with V1 blocks.
-    let round_3_refs = build_dag(
-        context.clone(),
-        dag_state.clone(),
-        None,
-        committer.leader_round(1),
-    );
+    let round_3_refs = build_v2_layers(&context, &dag_state, None, committer.leader_round(1));
 
     // Round 4 (voting): each voter links to all round-3 blocks and carries the
     // configured strong_vote.
@@ -117,7 +158,7 @@ fn build_metastate_dag(
 
     committer
         .elect_leader(committer.leader_round(1))
-        .expect("wave 1 should elect a leader")
+        .expect("should elect a leader")
 }
 
 #[tokio::test]
@@ -172,10 +213,7 @@ async fn determine_metastate_standard_when_strong_blame_quorum() {
     // Three voters carry strong_vote = Some(nonempty) (strong blame). Only one
     // voter is a strong vote → no StrongQC quorum possible. 2f+1 strong blames
     // form a quorum → Standard.
-    let blame = Some(AuthoritySet::new_with(
-        AuthorityIndex::from(0u8),
-        AuthorityIndex::from(0u8),
-    ));
+    let blame = strong_blame();
     let leader = build_metastate_dag(
         context,
         dag_state,
@@ -199,10 +237,7 @@ async fn determine_metastate_pending_when_neither_quorum() {
 
     // Split: 2 strong votes, 2 strong blames. Neither side reaches the 2f+1 = 3
     // threshold → Pending.
-    let blame = Some(AuthoritySet::new_with(
-        AuthorityIndex::from(0u8),
-        AuthorityIndex::from(0u8),
-    ));
+    let blame = strong_blame();
     let leader = build_metastate_dag(
         context,
         dag_state,
@@ -231,12 +266,12 @@ enum LeaderChoice {
     B,
 }
 
-/// Populate `dag_state` with a wave-1 DAG where the leader author produces two
-/// equivocating blocks `L_A` and `L_B` at the leader round. Each round-4 voter
-/// is wired (per `voter_config`) to include **either** `L_A` or `L_B` in its
-/// ancestors, plus all three non-leader round-3 blocks, and carries the
-/// configured `strong_vote`. Round 5 certifiers link to all four voters.
-/// Returns `(leader_slot, L_A ref, L_B ref)`.
+/// Populate `dag_state` through round 5 with two equivocating leader blocks
+/// `L_A` and `L_B` at round 3 (same leader author, different timestamps).
+/// Each round-4 voter includes either `L_A` or `L_B` (per `voter_config`)
+/// plus the three non-leader round-3 blocks, and carries the configured
+/// `strong_vote`. Round-5 certifiers link to all four voters. Returns
+/// `(leader_slot, L_A ref, L_B ref)`.
 fn build_equivocating_metastate_dag(
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
@@ -247,12 +282,11 @@ fn build_equivocating_metastate_dag(
     let voting_round = leader_round + 1;
     let certifying_round = committer.certifying_round(1);
 
-    // Rounds 1..=leader_round-1 built uniformly.
-    let prev_refs = build_dag(context.clone(), dag_state.clone(), None, leader_round - 1);
+    let prev_refs = build_v2_layers(&context, &dag_state, None, leader_round - 1);
 
     let leader_slot = committer
         .elect_leader(leader_round)
-        .expect("wave 1 should elect a leader");
+        .expect("should elect a leader");
     let leader_author: u8 = leader_slot.authority.value() as u8;
 
     // Round `leader_round`: one block per non-leader authority, plus TWO
@@ -342,62 +376,30 @@ fn build_equivocating_metastate_dag(
 }
 
 #[tokio::test]
-async fn determine_metastate_optimistic_under_equivocation() {
+async fn determine_metastate_pending_when_equivocating_strong_vote_is_filtered() {
     telemetry_subscribers::init_for_testing();
     let (context, dag_state) = test_context_with_flag(true);
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
-    // All four voters carry `is_strong_vote() == true`, but one supports the
-    // equivocating `L_B` instead of `L_A`. Only the three voters whose
-    // ancestor chain resolves to `L_A` count as strong votes for `L_A`, which
-    // still meets the 2f+1 threshold → Optimistic. This exercises the
-    // `is_vote()` conjunction inside `has_strong_qc_quorum`.
-    let strong = || Some(AuthoritySet::new());
-    let (leader_slot, leader_a_ref, _leader_b_ref) = build_equivocating_metastate_dag(
-        context,
-        dag_state,
-        &committer,
-        [
-            (LeaderChoice::A, strong()),
-            (LeaderChoice::A, strong()),
-            (LeaderChoice::A, strong()),
-            (LeaderChoice::B, strong()),
-        ],
-    );
-
-    match committer.try_direct_decide(leader_slot) {
-        LeaderStatus::Commit(block, metastate) => {
-            assert_eq!(block.reference(), leader_a_ref);
-            assert_eq!(metastate, Some(CommitMetastate::Optimistic));
-        }
-        status => panic!("expected Commit, got {status}"),
-    }
-}
-
-#[tokio::test]
-async fn determine_metastate_standard_under_equivocation() {
-    telemetry_subscribers::init_for_testing();
-    let (context, dag_state) = test_context_with_flag(true);
-    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
-
-    // Three voters supporting `L_A` carry strong_blame, one voter supporting
-    // `L_B` carries strong_vote. For `L_A`: no strong-vote-for-A exists (the
-    // lone strong vote points at L_B and must be filtered out), and the three
-    // blamers of `L_A` meet the 2f+1 threshold → Standard. This exercises the
-    // `is_vote()` filter inside both quorum checks.
-    let blame = Some(AuthoritySet::new_with(
-        AuthorityIndex::from(0u8),
-        AuthorityIndex::from(0u8),
-    ));
+    // Discriminator for the `is_vote()` filter in `has_strong_qc_quorum`:
+    // - 2 voters are strong votes for `L_A`
+    // - 1 voter votes for `L_A` with no strong_vote
+    // - 1 voter is a strong vote for the equivocating `L_B`
+    //
+    // `L_A` has 3 regular votes → committable. Strong votes *attributable*
+    // to `L_A` are only 2 → below the 2f+1 = 3 threshold → not `Optimistic`
+    // and not `Standard` (no blames) → `Pending`. If the `is_vote()` filter
+    // were missing, the `L_B`-directed strong vote would be miscounted for
+    // `L_A`, reaching the threshold and yielding a wrong `Optimistic`.
     let strong = Some(AuthoritySet::new());
     let (leader_slot, leader_a_ref, _leader_b_ref) = build_equivocating_metastate_dag(
         context,
         dag_state,
         &committer,
         [
-            (LeaderChoice::A, blame),
-            (LeaderChoice::A, blame),
-            (LeaderChoice::A, blame),
+            (LeaderChoice::A, strong),
+            (LeaderChoice::A, strong),
+            (LeaderChoice::A, None),
             (LeaderChoice::B, strong),
         ],
     );
@@ -405,7 +407,45 @@ async fn determine_metastate_standard_under_equivocation() {
     match committer.try_direct_decide(leader_slot) {
         LeaderStatus::Commit(block, metastate) => {
             assert_eq!(block.reference(), leader_a_ref);
-            assert_eq!(metastate, Some(CommitMetastate::Standard));
+            assert_eq!(metastate, Some(CommitMetastate::Pending));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn determine_metastate_pending_when_equivocating_strong_blame_is_filtered() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Discriminator for the `is_vote()` filter in `has_strong_blame_quorum`:
+    // - 2 voters blame `L_A`
+    // - 1 voter votes for `L_A` with no strong_vote
+    // - 1 voter blames the equivocating `L_B`
+    //
+    // `L_A` has 3 regular votes → committable. Strong blames *attributable*
+    // to `L_A` are only 2 → below the 2f+1 = 3 threshold → `Pending`. If
+    // the `is_vote()` filter were missing, the `L_B`-directed strong blame
+    // would be miscounted for `L_A`, reaching the threshold and yielding a
+    // wrong `Standard`.
+    let blame = strong_blame();
+    let (leader_slot, leader_a_ref, _leader_b_ref) = build_equivocating_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [
+            (LeaderChoice::A, blame),
+            (LeaderChoice::A, blame),
+            (LeaderChoice::A, None),
+            (LeaderChoice::B, blame),
+        ],
+    );
+
+    match committer.try_direct_decide(leader_slot) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference(), leader_a_ref);
+            assert_eq!(metastate, Some(CommitMetastate::Pending));
         }
         status => panic!("expected Commit, got {status}"),
     }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -1,0 +1,412 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use starfish_config::AuthorityIndex;
+
+use crate::{
+    authority_set::AuthoritySet,
+    base_committer::base_committer_builder::BaseCommitterBuilder,
+    block_header::{
+        BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, Round, TransactionsCommitment,
+        VerifiedBlockHeader,
+    },
+    commit::{CommitMetastate, LeaderStatus},
+    context::Context,
+    dag_state::{DagState, DataSource},
+    storage::mem_store::MemStore,
+    test_dag::build_dag,
+};
+
+/// Build a `BlockHeaderV2` wrapped as a verified block header for test use.
+/// `timestamp_ms` is exposed so callers can produce two equivocating blocks
+/// with the same `(round, author)` but distinct `BlockRef`s.
+fn v2_block(
+    round: Round,
+    author: u8,
+    ancestors: Vec<BlockRef>,
+    strong_vote: Option<AuthoritySet>,
+    timestamp_ms: BlockTimestampMs,
+) -> VerifiedBlockHeader {
+    let header = BlockHeaderV2::new(
+        0,
+        round,
+        AuthorityIndex::from(author),
+        timestamp_ms,
+        ancestors,
+        vec![],
+        vec![],
+        TransactionsCommitment::DEFAULT_FOR_TEST,
+        strong_vote,
+    );
+    VerifiedBlockHeader::new_for_test(BlockHeader::V2(header))
+}
+
+/// Default timestamp for single-block-per-slot callers.
+fn default_ts(round: Round, author: u8) -> BlockTimestampMs {
+    round as BlockTimestampMs * 1000 + author as BlockTimestampMs
+}
+
+/// Test context with starfish-speed enabled by default. Returns the context
+/// and an empty in-memory DAG state.
+fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwLock<DagState>>) {
+    let (mut ctx, _) = Context::new_for_test(4);
+    ctx.protocol_config
+        .set_consensus_starfish_speed_for_testing(enable_starfish_speed);
+    let ctx = Arc::new(ctx);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        ctx.clone(),
+        Arc::new(MemStore::new(ctx.clone())),
+    )));
+    (ctx, dag_state)
+}
+
+/// Populate `dag_state` with a wave-1 DAG in which every round-4 voter has
+/// `strong_vote == voter_strong_votes[i]` and every round-5 certifier links
+/// to all four round-4 voters. Returns the elected leader slot at round 3.
+fn build_metastate_dag(
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+    committer: &crate::base_committer::BaseCommitter,
+    voter_strong_votes: [Option<AuthoritySet>; 4],
+) -> crate::block_header::Slot {
+    // Rounds 1..=3 are built fully-connected with V1 blocks.
+    let round_3_refs = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        None,
+        committer.leader_round(1),
+    );
+
+    // Round 4 (voting): each voter links to all round-3 blocks and carries the
+    // configured strong_vote.
+    let mut round_4_refs = Vec::new();
+    let voting_round = committer.leader_round(1) + 1;
+    for (author, strong_vote) in voter_strong_votes.into_iter().enumerate() {
+        let author = author as u8;
+        let block = v2_block(
+            voting_round,
+            author,
+            round_3_refs.clone(),
+            strong_vote,
+            default_ts(voting_round, author),
+        );
+        round_4_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    // Round 5 (certifying): each certifier links to all round-4 blocks.
+    let certifying_round = committer.certifying_round(1);
+    for author in 0..context.committee.size() {
+        let author = author as u8;
+        let block = v2_block(
+            certifying_round,
+            author,
+            round_4_refs.clone(),
+            None,
+            default_ts(certifying_round, author),
+        );
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    committer
+        .elect_leader(committer.leader_round(1))
+        .expect("wave 1 should elect a leader")
+}
+
+#[tokio::test]
+async fn determine_metastate_disabled_returns_none() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(false);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let leader = build_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [Some(AuthoritySet::new()); 4],
+    );
+
+    match committer.try_direct_decide(leader) {
+        LeaderStatus::Commit(_, metastate) => assert_eq!(metastate, None),
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn determine_metastate_optimistic_when_strong_qc_quorum() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // All four voters carry strong_vote = Some(empty) → every certifier at r+2
+    // will observe four strong votes in its ancestry, so it is a StrongQC. The
+    // 2f+1 StrongQC quorum at r+2 is reached → Optimistic.
+    let leader = build_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [Some(AuthoritySet::new()); 4],
+    );
+
+    match committer.try_direct_decide(leader) {
+        LeaderStatus::Commit(_, metastate) => {
+            assert_eq!(metastate, Some(CommitMetastate::Optimistic))
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn determine_metastate_standard_when_strong_blame_quorum() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Three voters carry strong_vote = Some(nonempty) (strong blame). Only one
+    // voter is a strong vote → no StrongQC quorum possible. 2f+1 strong blames
+    // form a quorum → Standard.
+    let blame = Some(AuthoritySet::new_with(
+        AuthorityIndex::from(0u8),
+        AuthorityIndex::from(0u8),
+    ));
+    let leader = build_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [Some(AuthoritySet::new()), blame, blame, blame],
+    );
+
+    match committer.try_direct_decide(leader) {
+        LeaderStatus::Commit(_, metastate) => {
+            assert_eq!(metastate, Some(CommitMetastate::Standard))
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn determine_metastate_pending_when_neither_quorum() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Split: 2 strong votes, 2 strong blames. Neither side reaches the 2f+1 = 3
+    // threshold → Pending.
+    let blame = Some(AuthoritySet::new_with(
+        AuthorityIndex::from(0u8),
+        AuthorityIndex::from(0u8),
+    ));
+    let leader = build_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [
+            Some(AuthoritySet::new()),
+            Some(AuthoritySet::new()),
+            blame,
+            blame,
+        ],
+    );
+
+    match committer.try_direct_decide(leader) {
+        LeaderStatus::Commit(_, metastate) => {
+            assert_eq!(metastate, Some(CommitMetastate::Pending))
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+/// Selects which of the two equivocating leader blocks a round-4 voter supports
+/// via its ancestor chain.
+#[derive(Clone, Copy)]
+enum LeaderChoice {
+    A,
+    B,
+}
+
+/// Populate `dag_state` with a wave-1 DAG where the leader author produces two
+/// equivocating blocks `L_A` and `L_B` at the leader round. Each round-4 voter
+/// is wired (per `voter_config`) to include **either** `L_A` or `L_B` in its
+/// ancestors, plus all three non-leader round-3 blocks, and carries the
+/// configured `strong_vote`. Round 5 certifiers link to all four voters.
+/// Returns `(leader_slot, L_A ref, L_B ref)`.
+fn build_equivocating_metastate_dag(
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+    committer: &crate::base_committer::BaseCommitter,
+    voter_config: [(LeaderChoice, Option<AuthoritySet>); 4],
+) -> (crate::block_header::Slot, BlockRef, BlockRef) {
+    let leader_round = committer.leader_round(1);
+    let voting_round = leader_round + 1;
+    let certifying_round = committer.certifying_round(1);
+
+    // Rounds 1..=leader_round-1 built uniformly.
+    let prev_refs = build_dag(context.clone(), dag_state.clone(), None, leader_round - 1);
+
+    let leader_slot = committer
+        .elect_leader(leader_round)
+        .expect("wave 1 should elect a leader");
+    let leader_author: u8 = leader_slot.authority.value() as u8;
+
+    // Round `leader_round`: one block per non-leader authority, plus TWO
+    // equivocating leader blocks (different timestamps → distinct refs).
+    let mut non_leader_refs = Vec::new();
+    for author in 0..context.committee.size() {
+        let author = author as u8;
+        if author == leader_author {
+            continue;
+        }
+        let block = v2_block(
+            leader_round,
+            author,
+            prev_refs.clone(),
+            None,
+            default_ts(leader_round, author),
+        );
+        non_leader_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    let leader_a = v2_block(
+        leader_round,
+        leader_author,
+        prev_refs.clone(),
+        None,
+        default_ts(leader_round, leader_author),
+    );
+    let leader_b = v2_block(
+        leader_round,
+        leader_author,
+        prev_refs,
+        None,
+        default_ts(leader_round, leader_author) + 1,
+    );
+    let leader_a_ref = leader_a.reference();
+    let leader_b_ref = leader_b.reference();
+    dag_state
+        .write()
+        .accept_block_header(leader_a, DataSource::Test);
+    dag_state
+        .write()
+        .accept_block_header(leader_b, DataSource::Test);
+
+    // Round `voting_round`: each voter includes all non-leader round-3 blocks
+    // plus the chosen leader block, and carries the configured strong_vote.
+    let mut round_4_refs = Vec::new();
+    for (author, (leader_choice, strong_vote)) in voter_config.into_iter().enumerate() {
+        let author = author as u8;
+        let chosen_leader = match leader_choice {
+            LeaderChoice::A => leader_a_ref,
+            LeaderChoice::B => leader_b_ref,
+        };
+        let mut ancestors = non_leader_refs.clone();
+        ancestors.push(chosen_leader);
+        let block = v2_block(
+            voting_round,
+            author,
+            ancestors,
+            strong_vote,
+            default_ts(voting_round, author),
+        );
+        round_4_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    // Round `certifying_round`: each certifier links to all voters.
+    for author in 0..context.committee.size() {
+        let author = author as u8;
+        let block = v2_block(
+            certifying_round,
+            author,
+            round_4_refs.clone(),
+            None,
+            default_ts(certifying_round, author),
+        );
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    (leader_slot, leader_a_ref, leader_b_ref)
+}
+
+#[tokio::test]
+async fn determine_metastate_optimistic_under_equivocation() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // All four voters carry `is_strong_vote() == true`, but one supports the
+    // equivocating `L_B` instead of `L_A`. Only the three voters whose
+    // ancestor chain resolves to `L_A` count as strong votes for `L_A`, which
+    // still meets the 2f+1 threshold → Optimistic. This exercises the
+    // `is_vote()` conjunction inside `has_strong_qc_quorum`.
+    let strong = || Some(AuthoritySet::new());
+    let (leader_slot, leader_a_ref, _leader_b_ref) = build_equivocating_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [
+            (LeaderChoice::A, strong()),
+            (LeaderChoice::A, strong()),
+            (LeaderChoice::A, strong()),
+            (LeaderChoice::B, strong()),
+        ],
+    );
+
+    match committer.try_direct_decide(leader_slot) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference(), leader_a_ref);
+            assert_eq!(metastate, Some(CommitMetastate::Optimistic));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn determine_metastate_standard_under_equivocation() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Three voters supporting `L_A` carry strong_blame, one voter supporting
+    // `L_B` carries strong_vote. For `L_A`: no strong-vote-for-A exists (the
+    // lone strong vote points at L_B and must be filtered out), and the three
+    // blamers of `L_A` meet the 2f+1 threshold → Standard. This exercises the
+    // `is_vote()` filter inside both quorum checks.
+    let blame = Some(AuthoritySet::new_with(
+        AuthorityIndex::from(0u8),
+        AuthorityIndex::from(0u8),
+    ));
+    let strong = Some(AuthoritySet::new());
+    let (leader_slot, leader_a_ref, _leader_b_ref) = build_equivocating_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [
+            (LeaderChoice::A, blame),
+            (LeaderChoice::A, blame),
+            (LeaderChoice::A, blame),
+            (LeaderChoice::B, strong),
+        ],
+    );
+
+    match committer.try_direct_decide(leader_slot) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference(), leader_a_ref);
+            assert_eq!(metastate, Some(CommitMetastate::Standard));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -520,9 +520,7 @@ async fn indirect_metastate_optimistic_when_anchor_path_contains_strong_qc() {
     let c3 = certifier(&committer, 3, vec![voters[1], voters[2], voters[3]]);
     let (c0_ref, c1_ref, c2_ref) = (c0.reference(), c1.reference(), c2.reference());
     for b in [c0, c1, c2, c3] {
-        dag_state
-            .write()
-            .accept_block_header(b, DataSource::Test);
+        dag_state.write().accept_block_header(b, DataSource::Test);
     }
 
     // Anchor at round 6 includes c0 (StrongQC) in its round-5 ancestors.
@@ -572,9 +570,7 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
     let c3 = certifier(&committer, 3, vec![voters[1], voters[2], voters[3]]);
     let (c1_ref, c2_ref, c3_ref) = (c1.reference(), c2.reference(), c3.reference());
     for b in [c0, c1, c2, c3] {
-        dag_state
-            .write()
-            .accept_block_header(b, DataSource::Test);
+        dag_state.write().accept_block_header(b, DataSource::Test);
     }
 
     // Anchor excludes c0 — its round-5 path contains only regular QCs. The

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -344,8 +344,10 @@ async fn indirect_commit() {
     // Ensure we commit the leader of wave 1 indirectly with the committed leader
     // of wave 2 as the anchor.
     tracing::info!("Try indirect commit for leader {leader_wave_1}",);
-    let leader_status = committer
-        .try_indirect_decide(LeaderStatus::Undecided(leader_wave_1), decided_leaders.iter());
+    let leader_status = committer.try_indirect_decide(
+        LeaderStatus::Undecided(leader_wave_1),
+        decided_leaders.iter(),
+    );
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
@@ -460,8 +462,10 @@ async fn indirect_skip() {
 
     // 3. Ensure we skip leader of wave 2 indirectly.
     tracing::info!("Try indirect commit for leader {leader_wave_2}",);
-    let leader_status = committer
-        .try_indirect_decide(LeaderStatus::Undecided(leader_wave_2), decided_leaders.iter());
+    let leader_status = committer.try_indirect_decide(
+        LeaderStatus::Undecided(leader_wave_2),
+        decided_leaders.iter(),
+    );
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Skip(skipped_slot) = leader_status {

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -55,7 +55,7 @@ async fn try_direct_commit() {
         tracing::info!("Leader commit status: {leader_status}");
 
         if round < incomplete_wave_leader_round {
-            if let LeaderStatus::Commit(ref committed_block) = leader_status {
+            if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
                 assert_eq!(committed_block.author(), leader.authority)
             } else {
                 panic!("Expected a committed leader at round {round}")
@@ -99,7 +99,7 @@ async fn idempotence() {
     let leader_status = committer.try_direct_decide(leader);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref block) = leader_status {
+    if let LeaderStatus::Commit(ref block, _) = leader_status {
         assert_eq!(block.author(), leader.authority)
     } else {
         panic!("Expected a committed leader")
@@ -110,7 +110,7 @@ async fn idempotence() {
     let leader_status = committer.try_direct_decide(leader);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader.authority)
     } else {
         panic!("Expected a committed leader")
@@ -150,7 +150,7 @@ async fn multiple_direct_commit() {
         let leader_status = committer.try_direct_decide(leader);
         tracing::info!("Leader commit status: {leader_status}");
 
-        if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
             assert_eq!(committed_block.author(), leader.authority)
         } else {
             panic!("Expected a committed leader")
@@ -314,7 +314,7 @@ async fn indirect_commit() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_2.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -347,7 +347,7 @@ async fn indirect_commit() {
     let leader_status = committer.try_indirect_decide(leader_wave_1, decided_leaders.iter());
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority)
     } else {
         panic!("Expected a committed leader")
@@ -433,7 +433,7 @@ async fn indirect_skip() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_3.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -477,7 +477,7 @@ async fn indirect_skip() {
     let leader_status = committer.try_direct_decide(leader_wave_1);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority);
     } else {
         panic!("Expected a committed leader")
@@ -729,7 +729,7 @@ async fn test_byzantine_direct_commit() {
     let leader_status = committer.try_direct_decide(leader_wave_4);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_4.authority);
     } else {
         panic!("Expected a committed leader")

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -344,7 +344,8 @@ async fn indirect_commit() {
     // Ensure we commit the leader of wave 1 indirectly with the committed leader
     // of wave 2 as the anchor.
     tracing::info!("Try indirect commit for leader {leader_wave_1}",);
-    let leader_status = committer.try_indirect_decide(leader_wave_1, decided_leaders.iter());
+    let leader_status = committer
+        .try_indirect_decide(LeaderStatus::Undecided(leader_wave_1), decided_leaders.iter());
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
@@ -459,7 +460,8 @@ async fn indirect_skip() {
 
     // 3. Ensure we skip leader of wave 2 indirectly.
     tracing::info!("Try indirect commit for leader {leader_wave_2}",);
-    let leader_status = committer.try_indirect_decide(leader_wave_2, decided_leaders.iter());
+    let leader_status = committer
+        .try_indirect_decide(LeaderStatus::Undecided(leader_wave_2), decided_leaders.iter());
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Skip(skipped_slot) = leader_status {
@@ -560,7 +562,8 @@ async fn undecided() {
     // Ensure we indirectly mark leader of wave 1 undecided as there is no anchor
     // to make an indirect decision.
     tracing::info!("Try indirect commit for leader {leader_wave_1}");
-    let leader_status = committer.try_indirect_decide(leader_wave_1, [].iter());
+    let leader_status =
+        committer.try_indirect_decide(LeaderStatus::Undecided(leader_wave_1), [].iter());
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Undecided(undecided_slot) = leader_status {

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -33,7 +33,7 @@ async fn direct_commit() {
     assert_eq!(sequence.len(), 1);
 
     let leader_round_wave_0_pipeline_1 = committer.committers[1].leader_round(0);
-    if let DecidedLeader::Commit(ref block) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
         assert_eq!(block.round(), leader_round_wave_0_pipeline_1);
         assert_eq!(
             block.author(),
@@ -61,7 +61,7 @@ async fn idempotence() {
     assert_eq!(first_sequence.len(), 1);
     tracing::info!("Commit sequence: {first_sequence:#?}");
 
-    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
         assert_eq!(block.round(), leader_round_pipeline_1_wave_0);
         assert_eq!(
             block.author(),
@@ -76,7 +76,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
         assert_eq!(block.round(), leader_round_pipeline_1_wave_0);
         assert_eq!(
             block.author(),
@@ -122,7 +122,7 @@ async fn multiple_direct_commit() {
         tracing::info!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), 1);
-        if let DecidedLeader::Commit(ref block) = sequence[0] {
+        if let DecidedLeader::Commit(ref block, _) = sequence[0] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(
                 block.author(),
@@ -161,7 +161,7 @@ async fn direct_commit_late_call() {
     for (i, leader_block) in sequence.iter().enumerate() {
         // First sequenced leader should be in round 1.
         let leader_round = i as u32 + 1;
-        if let DecidedLeader::Commit(ref block) = leader_block {
+        if let DecidedLeader::Commit(ref block, _) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -415,7 +415,7 @@ async fn indirect_commit() {
 
     let committed_leader_round = 1;
     let leader = committer.get_leaders(committed_leader_round)[0];
-    if let DecidedLeader::Commit(ref block) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
         assert_eq!(block.round(), committed_leader_round);
         assert_eq!(block.author(), leader);
     } else {
@@ -499,7 +499,7 @@ async fn indirect_skip() {
         // First sequenced leader should be in round 1.
         let leader_round = i + 1;
         let leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block) = sequence[i as usize] {
+        if let DecidedLeader::Commit(ref block, _) = sequence[i as usize] {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -518,7 +518,7 @@ async fn indirect_skip() {
     for i in 4..=6 {
         let leader_round = i + 1;
         let leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block) = sequence[i as usize] {
+        if let DecidedLeader::Commit(ref block, _) = sequence[i as usize] {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -730,7 +730,7 @@ async fn test_byzantine_validator() {
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
-    if let DecidedLeader::Commit(ref block) = sequence[11] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[11] {
         assert_eq!(block.round(), leader_round_12);
         assert_eq!(block.author(), committer.get_leaders(leader_round_12)[0])
     } else {

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -61,7 +61,7 @@ async fn test_randomized_dag_all_direct_commit() {
         for (i, leader_block) in sequence.iter().enumerate() {
             // First sequenced leader should be in round 1.
             let leader_round = i as u32 + 1;
-            if let DecidedLeader::Commit(ref block) = leader_block {
+            if let DecidedLeader::Commit(ref block, _) = leader_block {
                 assert_eq!(block.round(), leader_round);
                 assert_eq!(
                     block.author(),

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -52,7 +52,7 @@ async fn direct_commit() {
     tracing::info!("Commit sequence: {sequence:#?}");
     // The decided leaders should be all from round 1 to round 5
     assert_eq!(sequence.len(), 5);
-    if let DecidedLeader::Commit(ref block) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
         assert_eq!(
             block.author(),
             test_setup
@@ -84,7 +84,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
     assert_eq!(first_sequence.len(), 1);
 
-    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), first_non_genesis_leader_round);
         assert_eq!(
             block.author(),
@@ -99,7 +99,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), first_non_genesis_leader_round);
         assert_eq!(
             block.author(),
@@ -132,7 +132,7 @@ async fn idempotence() {
     // Expect that all leaders between round 2 and round 5 are committed.
     // The last one is a block of leader from round 5
     assert_eq!(second_sequence.len(), 4);
-    if let DecidedLeader::Commit(ref block) = second_sequence[3] {
+    if let DecidedLeader::Commit(ref block, _) = second_sequence[3] {
         assert_eq!(block.round(), round_5);
         assert_eq!(block.author(), committer.get_leaders(round_5)[0]);
     } else {
@@ -164,7 +164,7 @@ async fn multiple_direct_commit() {
         let sequence = committer.try_decide(last_decided);
         tracing::info!("Commit sequence: {sequence:#?}");
         assert_eq!(sequence.len(), 3);
-        if let DecidedLeader::Commit(ref block) = sequence[2] {
+        if let DecidedLeader::Commit(ref block, _) = sequence[2] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -198,7 +198,7 @@ async fn direct_commit_late_call() {
     assert_eq!(sequence.len(), 3 * (num_waves - 1_usize));
     for (i, leader_block) in sequence.iter().enumerate() {
         let leader_round = committer.committers[(i + 1) % 3].leader_round((i as u32 + 1) / 3);
-        if let DecidedLeader::Commit(ref block) = leader_block {
+        if let DecidedLeader::Commit(ref block, _) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -394,7 +394,7 @@ async fn indirect_commit() {
         let leader_round =
             committer.committers[(idx + 1) % 3].leader_round(((idx + 1) / 3) as WaveNumber);
         let expected_leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block) = decided_leader {
+        if let DecidedLeader::Commit(ref block, _) = decided_leader {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), expected_leader);
         } else {
@@ -469,7 +469,7 @@ async fn indirect_skip() {
     assert_eq!(sequence.len(), 7);
 
     for (idx, decided_leader) in sequence.iter().enumerate() {
-        if let DecidedLeader::Commit(ref block) = decided_leader {
+        if let DecidedLeader::Commit(ref block, _) = decided_leader {
             assert_eq!(block.round(), (idx + 1) as Round);
             assert_eq!(
                 block.author(),
@@ -699,7 +699,7 @@ async fn test_byzantine_direct_commit() {
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
-    if let DecidedLeader::Commit(ref block) = sequence[11] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[11] {
         assert_eq!(block.author(), committer.get_leaders(round_12)[0])
     } else {
         panic!("Expected a committed leader")

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -80,22 +80,18 @@ impl UniversalCommitter {
                 // committed anchor's path can upgrade the metastate; for
                 // Undecided, indirect may resolve the slot entirely.
                 if !status.is_final() {
-                    let indirect =
-                        committer.try_indirect_decide(slot, leaders.iter().map(|(x, _)| x));
-                    tracing::debug!("Outcome of indirect rule: {indirect}");
-                    match (&status, &indirect) {
-                        (
-                            LeaderStatus::Commit(_, Some(CommitMetastate::Pending)),
-                            LeaderStatus::Commit(_, Some(m)),
-                        ) if *m != CommitMetastate::Pending => {
-                            status = indirect;
-                            decision = Decision::Upgraded;
-                        }
-                        (LeaderStatus::Undecided(_), _) => {
-                            status = indirect;
-                            decision = Decision::Indirect;
-                        }
-                        _ => {}
+                    let indirect = committer
+                        .try_indirect_decide(status.clone(), leaders.iter().map(|(x, _)| x));
+                    if indirect != status {
+                        tracing::debug!("Outcome of indirect rule: {indirect}");
+                        decision = match (&status, &indirect) {
+                            (
+                                LeaderStatus::Commit(_, Some(CommitMetastate::Pending)),
+                                LeaderStatus::Commit(_, Some(m)),
+                            ) if *m != CommitMetastate::Pending => Decision::Upgraded,
+                            _ => Decision::Indirect,
+                        };
+                        status = indirect;
                     }
                 }
                 leaders.push_front((status, decision));

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -10,7 +10,7 @@ use starfish_config::AuthorityIndex;
 use crate::{
     base_committer::BaseCommitter,
     block_header::{GENESIS_ROUND, Round, Slot},
-    commit::{DecidedLeader, Decision},
+    commit::{CommitMetastate, DecidedLeader, Decision, LeaderStatus},
     context::Context,
     dag_state::DagState,
 };
@@ -47,25 +47,9 @@ impl UniversalCommitter {
         let highest_accepted_round = self.dag_state.read().highest_accepted_round();
 
         // Try to decide as many leaders as possible, starting with the highest round.
-        let mut leaders = VecDeque::new();
+        let mut leaders: VecDeque<(LeaderStatus, Decision)> = VecDeque::new();
 
         let last_round = last_decided.round + 1;
-
-        // Keep this code commented for re-use when we re-enable multiple leaders.
-        // let last_round = match self
-        //     .context
-        //     .protocol_config
-        //     .mysticeti_num_leaders_per_round()
-        // {
-        //     Some(1) => {
-        // Ensure that we don't commit any leaders from the same round as last_decided
-        // until we have full support for multi-leader per round.
-        // This can happen when we are on a leader schedule boundary and the leader
-        // elected for the round changes with the new schedule.
-        //         last_decided.round + 1
-        //     }
-        //     _ => last_decided.round,
-        // };
 
         // try to commit a leader up to the highest_accepted_round - 2. There is no
         // reason to try and iterate on higher rounds as in order to make a direct
@@ -87,30 +71,51 @@ impl UniversalCommitter {
 
                 tracing::debug!("Trying to decide {slot} with {committer}",);
 
-                // Try to directly decide the leader.
                 let mut status = committer.try_direct_decide(slot);
+                let mut decision = Decision::Direct;
                 tracing::debug!("Outcome of direct rule: {status}");
 
-                // If we can't directly decide the leader, try to indirectly decide it.
-                if status.is_decided() {
-                    leaders.push_front((status, Decision::Direct));
-                } else {
-                    status = committer.try_indirect_decide(slot, leaders.iter().map(|(x, _)| x));
-                    tracing::debug!("Outcome of indirect rule: {status}");
-                    leaders.push_front((status, Decision::Indirect));
+                // If the direct result is not final (Commit(Pending) or
+                // Undecided), run the indirect rule. For Pending, a
+                // committed anchor's path can upgrade the metastate; for
+                // Undecided, indirect may resolve the slot entirely.
+                if !status.is_final() {
+                    let indirect = committer
+                        .try_indirect_decide(slot, leaders.iter().map(|(x, _)| x));
+                    tracing::debug!("Outcome of indirect rule: {indirect}");
+                    match (&status, &indirect) {
+                        (
+                            LeaderStatus::Commit(_, Some(CommitMetastate::Pending)),
+                            LeaderStatus::Commit(_, Some(m)),
+                        ) if *m != CommitMetastate::Pending => {
+                            status = indirect;
+                            decision = Decision::Upgraded;
+                        }
+                        (LeaderStatus::Undecided(_), _) => {
+                            status = indirect;
+                            decision = Decision::Indirect;
+                        }
+                        _ => {}
+                    }
                 }
+                leaders.push_front((status, decision));
             }
         }
 
-        // The decided sequence is the longest prefix of decided leaders.
+        // The decided sequence is the longest prefix of final decisions.
+        // Commit(Pending) is decided but non-final — sequencing stops until
+        // the metastate is upgraded on a subsequent commit pass.
         let mut decided_leaders = Vec::new();
         for (leader, decision) in leaders {
             if leader.round() == GENESIS_ROUND {
                 continue;
             }
-            let Some(decided_leader) = leader.into_decided_leader() else {
+            if !leader.is_final() {
                 break;
-            };
+            }
+            let decided_leader = leader
+                .into_decided_leader()
+                .expect("is_final implies decided");
             Self::update_metrics(&self.context, &decided_leader, decision);
             decided_leaders.push(decided_leader);
         }
@@ -136,6 +141,7 @@ impl UniversalCommitter {
     ) {
         let decision_str = match decision {
             Decision::Direct => "direct",
+            Decision::Upgraded => "upgraded",
             Decision::Indirect => "indirect",
         };
         let status = match decided_leader {

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -139,7 +139,10 @@ impl UniversalCommitter {
             Decision::Indirect => "indirect",
         };
         let status = match decided_leader {
-            DecidedLeader::Commit(..) => format!("{decision_str}-commit"),
+            DecidedLeader::Commit(_, None) => format!("{decision_str}-commit"),
+            DecidedLeader::Commit(_, Some(metastate)) => {
+                format!("{decision_str}-commit-{metastate}")
+            }
             DecidedLeader::Skip(..) => format!("{decision_str}-skip"),
         };
         let leader_host = &context

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -80,8 +80,8 @@ impl UniversalCommitter {
                 // committed anchor's path can upgrade the metastate; for
                 // Undecided, indirect may resolve the slot entirely.
                 if !status.is_final() {
-                    let indirect = committer
-                        .try_indirect_decide(slot, leaders.iter().map(|(x, _)| x));
+                    let indirect =
+                        committer.try_indirect_decide(slot, leaders.iter().map(|(x, _)| x));
                     tracing::debug!("Outcome of indirect rule: {indirect}");
                     match (&status, &indirect) {
                         (


### PR DESCRIPTION
# Description of change

Adds `CommitMetastate` classification to StarfishSpeed-committed leaders and propagates it through `LeaderStatus::Commit` and `DecidedLeader::Commit`. Three variants — `Optimistic` / `Standard` / `Pending`; metastate is `None` when `consensus_starfish_speed` is off.

## Classification rules

**Direct rule** (when 2f+1 QCs are observed locally for the slot):
- `Optimistic` — 2f+1 StrongQCs at `r+2`, each backed by 2f+1 strong-vote ancestors at `r+1`.
- `Standard` — 2f+1 strong-blame quorum at `r+1`.
- Otherwise `Pending`.

**Indirect rule** (when `decide_leader_from_anchor` resolves a previously Pending / Undecided slot via a later-committed anchor): restricted to the anchor's causal history and based on the *existence* of a StrongQC in that path — present → `Optimistic`, else `Standard`. `Skip` is unreachable once the slot has a certificate in the anchor's path (by quorum intersection).

Both rules apply an `is_vote(_, leader_block) ∧ is_strong_vote()` conjunction so a Byzantine equivocating leader cannot have its strong-vote flag count for the wrong leader block at the same slot.

## Changes

- `commit.rs`: `LeaderStatus::Commit` and `DecidedLeader::Commit` carry `Option<CommitMetastate>`; `Display` prints `optimistic` / `standard` / `pending`.
- `base_committer.rs`: `determine_metastate_direct` for the direct path; `decide_leader_from_anchor` inlines the indirect classifier with a single ancestor scan returning `(is_certificate, is_strong_certificate)`. Flag-off keeps the cheaper `is_certificate`-only walk.
- `universal_committer.rs`: metrics labels include the metastate when present.
- Existing tests: pattern matches updated for the new `Commit(_, _)` shape.
- `base_committer_metastate_tests.rs` (new, 8 tests):
  - Direct rule: Optimistic / Standard / Pending / flag-off (4).
  - Direct under equivocation: 2 tests validating the `is_vote()` conjunction is load-bearing — without it, a strong-vote/strong-blame quorum would be wrongly crossed.
  - Indirect rule: 2 tests for the anchor's-path-only semantic — StrongQC inside path → Optimistic; outside path → Standard.

## Links to any relevant issues

Part of #11009
Fixes #11137

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
