### PR TITLE
fix(graphql): resolve real tombstone versions for wrapped/deleted objects

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_wrapped.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_wrapped.snap
@@ -74,7 +74,7 @@ Response: {
         {
           "address": "0x38fd622e5deb258c999e3ebf9ade5488a32cb9a94ab1b120010d36f251202427",
           "status": "WRAPPED_OR_DELETED",
-          "version": 6
+          "version": 3
         }
       ]
     }

--- a/crates/iota-graphql-e2e-tests/tests/consistency/object_keys_tombstone.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/object_keys_tombstone.move
@@ -2,12 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Test objectKeys lookup for wrapped object tombstone versions.
-// cp 1: Foo created (version 2)
-// cp 2: Foo wrapped (tombstone version 3), Wrapper transferred 3 times to
+// cp 1: Foo and Foo2 created (version 2)
+// cp 2: Both wrapped (tombstone version 3), Wrapper transferred 3 times to
 //       pump lamport version
-// cp 3: Foo unwrapped (version 7), backward_history stores lamport-1 = 6
-// Query via objectKeys with version 3 (real tombstone): empty
-// Query via objectKeys with version 6 (lamport-1): returns WRAPPED_OR_DELETED
+// cp 3: Both unwrapped, backward_history stores lamport-1 = 6
+// cp 4: Foo wrapped again (second tombstone v8), Wrapper transferred 3 times
+// cp 5: Foo unwrapped again, backward_history stores lamport-1 = 11
+// Tests:
+//   - old_active_version (v2): returns INDEXED, not a false tombstone
+//   - first_real_tombstone (v3): returns WRAPPED_OR_DELETED via objects_version
+//   - first_lamport_minus_one (v6): version corrected from 6 to 3
+//   - batch_lamport_correction (v6 for Foo + v6 for Foo2): both corrected to v3
+//   - both_real_tombstones (v3 + v8 for same object): returns only the latest
+//     version (v8) since DISTINCT ON keeps one result per object
+//   - both_lamport_approximations (v6 + v11 for same object): returns only the
+//     latest corrected version (v8)
 
 //# init --protocol-version 4 --addresses P0=0x0 --accounts A --simulator --objects-snapshot-min-checkpoint-lag 1
 
@@ -39,23 +48,45 @@ module P0::m {
 
 //# programmable --sender A --inputs @A
 //> 0: P0::m::create_foo();
-//> TransferObjects([Result(0)], Input(0))
+//> 1: P0::m::create_foo();
+//> TransferObjects([Result(0), Result(1)], Input(0))
 
 //# create-checkpoint
 
+//# programmable --sender A --inputs @A object(2,0) object(2,1)
+//> 0: P0::m::wrap_foo(Input(1));
+//> 1: P0::m::wrap_foo(Input(2));
+//> TransferObjects([Result(0), Result(1)], Input(0))
+
+//# transfer-object 4,0 --sender A --recipient A
+
+//# transfer-object 4,0 --sender A --recipient A
+
+//# transfer-object 4,0 --sender A --recipient A
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs @A object(4,0) object(4,1)
+//> 0: P0::m::unwrap_foo(Input(1));
+//> 1: P0::m::unwrap_foo(Input(2));
+//> TransferObjects([Result(0), Result(1)], Input(0))
+
+//# create-checkpoint
+
+// Re-wrap Foo to create a second tombstone version for the same object.
 //# programmable --sender A --inputs @A object(2,0)
 //> 0: P0::m::wrap_foo(Input(1));
 //> TransferObjects([Result(0)], Input(0))
 
-//# transfer-object 4,0 --sender A --recipient A
+//# transfer-object 11,0 --sender A --recipient A
 
-//# transfer-object 4,0 --sender A --recipient A
+//# transfer-object 11,0 --sender A --recipient A
 
-//# transfer-object 4,0 --sender A --recipient A
+//# transfer-object 11,0 --sender A --recipient A
 
 //# create-checkpoint
 
-//# programmable --sender A --inputs @A object(4,0)
+//# programmable --sender A --inputs @A object(11,0)
 //> 0: P0::m::unwrap_foo(Input(1));
 //> TransferObjects([Result(0)], Input(0))
 
@@ -63,14 +94,51 @@ module P0::m {
 
 //# run-graphql
 {
-  real_tombstone: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 3}]}) {
+  old_active_version: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 2}]}) {
     nodes {
       address
       status
       version
     }
   }
-  lamport_minus_one: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 6}]}) {
+  first_real_tombstone: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 3}]}) {
+    nodes {
+      address
+      status
+      version
+    }
+  }
+  first_lamport_minus_one: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 6}]}) {
+    nodes {
+      address
+      status
+      version
+    }
+  }
+  batch_lamport_correction: objects(filter: {objectKeys: [
+    {objectId: "@{obj_2_0}", version: 6},
+    {objectId: "@{obj_2_1}", version: 6}
+  ]}) {
+    nodes {
+      address
+      status
+      version
+    }
+  }
+  both_real_tombstones: objects(filter: {objectKeys: [
+    {objectId: "@{obj_2_0}", version: 3},
+    {objectId: "@{obj_2_0}", version: 8}
+  ]}) {
+    nodes {
+      address
+      status
+      version
+    }
+  }
+  both_lamport_approximations: objects(filter: {objectKeys: [
+    {objectId: "@{obj_2_0}", version: 6},
+    {objectId: "@{obj_2_0}", version: 11}
+  ]}) {
     nodes {
       address
       status

--- a/crates/iota-graphql-e2e-tests/tests/consistency/object_keys_tombstone.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/object_keys_tombstone.snap
@@ -1,85 +1,176 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 12 tasks
+processed 19 tasks
 
 init:
 A: object(0,0)
 
-task 1, lines 14-38:
+task 1, lines 23-47:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5783600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 40-42:
+task 2, lines 49-52:
 //# programmable --sender A --inputs @A
 //> 0: P0::m::create_foo();
-//> TransferObjects([Result(0)], Input(0))
-created: object(2,0)
+//> 1: P0::m::create_foo();
+//> TransferObjects([Result(0), Result(1)], Input(0))
+created: object(2,0), object(2,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2196400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3412400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 44:
+task 3, line 54:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 46-48:
+task 4, lines 56-59:
+//# programmable --sender A --inputs @A object(2,0) object(2,1)
+//> 0: P0::m::wrap_foo(Input(1));
+//> 1: P0::m::wrap_foo(Input(2));
+//> TransferObjects([Result(0), Result(1)], Input(0))
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+wrapped: object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3959600,  storage_rebate: 3412400, non_refundable_storage_fee: 0
+
+task 5, line 61:
+//# transfer-object 4,0 --sender A --recipient A
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2470000,  storage_rebate: 2470000, non_refundable_storage_fee: 0
+
+task 6, line 63:
+//# transfer-object 4,0 --sender A --recipient A
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2470000,  storage_rebate: 2470000, non_refundable_storage_fee: 0
+
+task 7, line 65:
+//# transfer-object 4,0 --sender A --recipient A
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2470000,  storage_rebate: 2470000, non_refundable_storage_fee: 0
+
+task 8, line 67:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, lines 69-72:
+//# programmable --sender A --inputs @A object(4,0) object(4,1)
+//> 0: P0::m::unwrap_foo(Input(1));
+//> 1: P0::m::unwrap_foo(Input(2));
+//> TransferObjects([Result(0), Result(1)], Input(0))
+mutated: object(0,0)
+unwrapped: object(2,0), object(2,1)
+deleted: object(4,0), object(4,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3412400,  storage_rebate: 3959600, non_refundable_storage_fee: 0
+
+task 10, lines 74-76:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 11, lines 77-79:
 //# programmable --sender A --inputs @A object(2,0)
 //> 0: P0::m::wrap_foo(Input(1));
 //> TransferObjects([Result(0)], Input(0))
-created: object(4,0)
+created: object(11,0)
 mutated: object(0,0)
 wrapped: object(2,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2470000,  storage_rebate: 2196400, non_refundable_storage_fee: 0
 
-task 5, line 50:
-//# transfer-object 4,0 --sender A --recipient A
-mutated: object(0,0), object(4,0)
+task 12, line 81:
+//# transfer-object 11,0 --sender A --recipient A
+mutated: object(0,0), object(11,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2470000,  storage_rebate: 2470000, non_refundable_storage_fee: 0
 
-task 6, line 52:
-//# transfer-object 4,0 --sender A --recipient A
-mutated: object(0,0), object(4,0)
+task 13, line 83:
+//# transfer-object 11,0 --sender A --recipient A
+mutated: object(0,0), object(11,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2470000,  storage_rebate: 2470000, non_refundable_storage_fee: 0
 
-task 7, line 54:
-//# transfer-object 4,0 --sender A --recipient A
-mutated: object(0,0), object(4,0)
+task 14, line 85:
+//# transfer-object 11,0 --sender A --recipient A
+mutated: object(0,0), object(11,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2470000,  storage_rebate: 2470000, non_refundable_storage_fee: 0
 
-task 8, line 56:
+task 15, line 87:
 //# create-checkpoint
-Checkpoint created: 2
+Checkpoint created: 4
 
-task 9, lines 58-60:
-//# programmable --sender A --inputs @A object(4,0)
+task 16, lines 89-91:
+//# programmable --sender A --inputs @A object(11,0)
 //> 0: P0::m::unwrap_foo(Input(1));
 //> TransferObjects([Result(0)], Input(0))
 mutated: object(0,0)
 unwrapped: object(2,0)
-deleted: object(4,0)
+deleted: object(11,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2196400,  storage_rebate: 2470000, non_refundable_storage_fee: 0
 
-task 10, line 62:
+task 17, line 93:
 //# create-checkpoint
-Checkpoint created: 3
+Checkpoint created: 5
 
-task 11, lines 64-80:
+task 18, lines 95-148:
 //# run-graphql
 Response: {
   "data": {
-    "lamport_minus_one": {
+    "batch_lamport_correction": {
       "nodes": [
         {
-          "address": "0x38fd622e5deb258c999e3ebf9ade5488a32cb9a94ab1b120010d36f251202427",
+          "address": "0xae06f92c54aa342523aec2a6ff6422044da07598af76755b103cb96c82af2873",
           "status": "WRAPPED_OR_DELETED",
-          "version": 6
+          "version": 3
+        },
+        {
+          "address": "0xf24219a8ec4d654b14dead478a44d4987104f8c397e4621c7b41006d05c764ac",
+          "status": "WRAPPED_OR_DELETED",
+          "version": 3
         }
       ]
     },
-    "real_tombstone": {
-      "nodes": []
+    "both_lamport_approximations": {
+      "nodes": [
+        {
+          "address": "0xae06f92c54aa342523aec2a6ff6422044da07598af76755b103cb96c82af2873",
+          "status": "WRAPPED_OR_DELETED",
+          "version": 8
+        }
+      ]
+    },
+    "both_real_tombstones": {
+      "nodes": [
+        {
+          "address": "0xae06f92c54aa342523aec2a6ff6422044da07598af76755b103cb96c82af2873",
+          "status": "WRAPPED_OR_DELETED",
+          "version": 8
+        }
+      ]
+    },
+    "first_lamport_minus_one": {
+      "nodes": [
+        {
+          "address": "0xae06f92c54aa342523aec2a6ff6422044da07598af76755b103cb96c82af2873",
+          "status": "WRAPPED_OR_DELETED",
+          "version": 3
+        }
+      ]
+    },
+    "first_real_tombstone": {
+      "nodes": [
+        {
+          "address": "0xae06f92c54aa342523aec2a6ff6422044da07598af76755b103cb96c82af2873",
+          "status": "WRAPPED_OR_DELETED",
+          "version": 3
+        }
+      ]
+    },
+    "old_active_version": {
+      "nodes": [
+        {
+          "address": "0xae06f92c54aa342523aec2a6ff6422044da07598af76755b103cb96c82af2873",
+          "status": "INDEXED",
+          "version": 2
+        }
+      ]
     }
   }
 }

--- a/crates/iota-graphql-rpc/src/backward_view/consistent.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/consistent.rs
@@ -26,10 +26,10 @@ pub(crate) fn query(
     filter_fn: impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     let checkpoint_viewed_at = checkpoint_viewed_at as i64;
-    merge_and_deduplicate(
+    merge_and_deduplicate(vec![
         consistent_checkpointed_objects(checkpoint_viewed_at, page, &filter_fn),
         consistent_historical_objects(checkpoint_viewed_at, page, &filter_fn),
-    )
+    ])
 }
 
 /// Returns objects from `checkpointed_objects` (including tombstones) that

--- a/crates/iota-graphql-rpc/src/backward_view/consistent.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/consistent.rs
@@ -5,8 +5,10 @@
 //! by combining unchanged objects from `checkpointed_objects` with previous
 //! versions from `objects_backward_history`.
 
-use super::{CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, NOT_YET_CREATED, merge_and_deduplicate};
 use crate::{
+    backward_view::{
+        CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, NOT_YET_CREATED, merge_and_deduplicate,
+    },
     filter, query,
     raw_query::RawQuery,
     types::{

--- a/crates/iota-graphql-rpc/src/backward_view/consistent.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/consistent.rs
@@ -5,7 +5,7 @@
 //! by combining unchanged objects from `checkpointed_objects` with previous
 //! versions from `objects_backward_history`.
 
-use super::{NOT_YET_CREATED, OBJECT_COLUMNS, merge_and_deduplicate};
+use super::{CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, NOT_YET_CREATED, merge_and_deduplicate};
 use crate::{
     filter, query,
     raw_query::RawQuery,
@@ -41,8 +41,7 @@ fn consistent_checkpointed_objects(
     filter_fn: &impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     let checkpointed_filtered = filter_fn(query!(format!(
-        "SELECT {} FROM checkpointed_objects",
-        OBJECT_COLUMNS
+        "SELECT {CHECKPOINTED_COLUMNS} FROM checkpointed_objects"
     )));
 
     let changed_subquery = query!(format!(
@@ -72,7 +71,7 @@ fn consistent_historical_objects(
     filter_fn: &impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     let history_filtered = filter_fn(query!(format!(
-        "SELECT {OBJECT_COLUMNS} FROM objects_backward_history"
+        "SELECT {HISTORY_COLUMNS} FROM objects_backward_history"
     )));
 
     let history_window = filter!(

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -35,13 +35,14 @@ pub(crate) fn query_with_filter(
 /// Includes synthetic tombstones from `objects_version` for versions not
 /// found in the other sources, since tombstones could match.
 pub(crate) fn query_keys_only(
+    checkpoint_viewed_at: u64,
     page: &Page<Cursor>,
     filter_fn: impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     merge_and_deduplicate_three(
         checkpointed_objects(page, &filter_fn),
         historical_objects(page, &filter_fn),
-        tombstones_from_objects_version(page, &filter_fn),
+        tombstones_from_objects_version(checkpoint_viewed_at, page, &filter_fn),
     )
 }
 
@@ -80,21 +81,41 @@ fn historical_objects(page: &Page<Cursor>, filter_fn: &impl Fn(RawQuery) -> RawQ
 /// or `objects_backward_history`. This allows `objectKeys` lookups to find
 /// objects by their real tombstone version.
 ///
+/// Why surviving rows are necessarily `WrappedOrDeleted`: every version in
+/// `objects_version` falls into exactly one of three cases.
+///   1. Currently-latest state of the object (active row or tombstone) — lives
+///      in `checkpointed_objects` and is filtered out by the first `NOT
+///      EXISTS`.
+///   2. Prior active state superseded by a later transaction — recorded in
+///      `objects_backward_history` at its actual `object_version` with status
+///      `ACTIVE`, and filtered out by the second `NOT EXISTS`.
+///   3. Prior wrap/delete tombstone that was later overwritten in
+///      `checkpointed_objects` (typically by an unwrap). The wrap state is
+///      recorded in `objects_backward_history`, but at `lamport - 1` of the
+///      unwrapping transaction — which generally differs from the real
+///      tombstone version. The real version in `objects_version` therefore
+///      survives both `NOT EXISTS` filters. By construction this is the only
+///      surviving case, hence the static `WrappedOrDeleted` tag.
+///
 /// Only used for keys-only queries where the filter contains only
 /// `(object_id, object_version)` pairs — the `NOT EXISTS` subqueries hit
 /// primary keys so the cost is proportional to the number of requested keys.
 ///
-/// Filters out versions below the backward history watermark to avoid
-/// returning false tombstones for pruned ranges.
+/// Filters out versions outside the `[backward-history watermark,
+/// checkpoint_viewed_at]` window to avoid false tombstones from pruned ranges
+/// and concurrent in-flight batch writes.
 fn tombstones_from_objects_version(
+    checkpoint_viewed_at: u64,
     page: &Page<Cursor>,
     filter_fn: &impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     let wrapped_or_deleted = NativeObjectStatus::WrappedOrDeleted as i16;
+    let checkpoint_viewed_at = checkpoint_viewed_at as i64;
 
-    // Inner query: select from objects_version, excluding versions that already
-    // exist in checkpointed_objects or objects_backward_history, and filtering
-    // out pruned ranges via the backward history watermark.
+    // Inner query: select from objects_version, bounded by the backward
+    // history watermark below and `checkpoint_viewed_at` above, and excluding
+    // versions that already exist in checkpointed_objects or
+    // objects_backward_history.
     let inner = query!(format!(
         "SELECT object_id, object_version, \
          {wrapped_or_deleted}::smallint AS object_status, \
@@ -114,6 +135,7 @@ fn tombstones_from_objects_version(
          WHERE cp_sequence_number >= COALESCE(\
              (SELECT min_available_cp FROM watermarks \
               WHERE entity = '{BACKWARD_HISTORY_WATERMARK_ENTITY}'), 0) \
+         AND cp_sequence_number <= {checkpoint_viewed_at} \
          AND NOT EXISTS (\
              SELECT 1 FROM checkpointed_objects co \
              WHERE co.object_id = ov.object_id \

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -5,7 +5,10 @@
 //! filtering. Combines all objects from `checkpointed_objects` with all
 //! past versions from `objects_backward_history`.
 
-use super::{NOT_YET_CREATED, OBJECT_COLUMNS, merge_and_deduplicate};
+use super::{
+    BACKWARD_HISTORY_WATERMARK_ENTITY, CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, NOT_YET_CREATED,
+    NativeObjectStatus, merge_and_deduplicate, merge_and_deduplicate_three,
+};
 use crate::{
     filter, query,
     raw_query::RawQuery,
@@ -15,13 +18,30 @@ use crate::{
     },
 };
 
-/// Builds a historical view by merging all objects from `checkpointed_objects`
-/// with all past versions from `objects_backward_history`, without consistency
-/// filtering. Used for exact id+version lookups (`objectKeys`).
-pub(crate) fn query(page: &Page<Cursor>, filter_fn: impl Fn(RawQuery) -> RawQuery) -> RawQuery {
+/// Builds a historical view with additional filters (type, owner, etc.).
+/// Since tombstones have NULL data fields, they can never match these
+/// filters, so the `objects_version` fallback is skipped.
+pub(crate) fn query_with_filter(
+    page: &Page<Cursor>,
+    filter_fn: impl Fn(RawQuery) -> RawQuery,
+) -> RawQuery {
     merge_and_deduplicate(
         checkpointed_objects(page, &filter_fn),
         historical_objects(page, &filter_fn),
+    )
+}
+
+/// Builds a historical view with only key filters (no type/owner).
+/// Includes synthetic tombstones from `objects_version` for versions not
+/// found in the other sources, since tombstones could match.
+pub(crate) fn query_keys_only(
+    page: &Page<Cursor>,
+    filter_fn: impl Fn(RawQuery) -> RawQuery,
+) -> RawQuery {
+    merge_and_deduplicate_three(
+        checkpointed_objects(page, &filter_fn),
+        historical_objects(page, &filter_fn),
+        tombstones_from_objects_version(page, &filter_fn),
     )
 }
 
@@ -32,8 +52,7 @@ fn checkpointed_objects(
     filter_fn: &impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     let checkpointed_filtered = filter_fn(query!(format!(
-        "SELECT {} FROM checkpointed_objects",
-        OBJECT_COLUMNS
+        "SELECT {CHECKPOINTED_COLUMNS} FROM checkpointed_objects"
     )));
     let source = query!(
         "SELECT candidates.* FROM ({}) candidates",
@@ -46,12 +65,68 @@ fn checkpointed_objects(
 /// provided filter, excluding `NOT_YET_CREATED` entries.
 fn historical_objects(page: &Page<Cursor>, filter_fn: &impl Fn(RawQuery) -> RawQuery) -> RawQuery {
     let history_filtered = filter_fn(query!(format!(
-        "SELECT {OBJECT_COLUMNS} FROM objects_backward_history"
+        "SELECT {HISTORY_COLUMNS} FROM objects_backward_history"
     )));
     let history_window = filter!(
         history_filtered,
         format!("object_status != {NOT_YET_CREATED}")
     );
     let source = query!("SELECT candidates.* FROM ({}) candidates", history_window);
+    page.apply::<StoredBackwardObject>(source)
+}
+
+/// Returns synthetic `WrappedOrDeleted` tombstone rows from `objects_version`
+/// for versions that exist there but are NOT present in `checkpointed_objects`
+/// or `objects_backward_history`. This allows `objectKeys` lookups to find
+/// objects by their real tombstone version.
+///
+/// Only used for keys-only queries where the filter contains only
+/// `(object_id, object_version)` pairs — the `NOT EXISTS` subqueries hit
+/// primary keys so the cost is proportional to the number of requested keys.
+///
+/// Filters out versions below the backward history watermark to avoid
+/// returning false tombstones for pruned ranges.
+fn tombstones_from_objects_version(
+    page: &Page<Cursor>,
+    filter_fn: &impl Fn(RawQuery) -> RawQuery,
+) -> RawQuery {
+    let wrapped_or_deleted = NativeObjectStatus::WrappedOrDeleted as i16;
+
+    // Inner query: select from objects_version, excluding versions that already
+    // exist in checkpointed_objects or objects_backward_history, and filtering
+    // out pruned ranges via the backward history watermark.
+    let inner = query!(format!(
+        "SELECT object_id, object_version, \
+         {wrapped_or_deleted}::smallint AS object_status, \
+         NULL::bytea AS object_digest, \
+         NULL::smallint AS owner_type, \
+         NULL::bytea AS owner_id, \
+         NULL::text AS object_type, \
+         NULL::bytea AS object_type_package, \
+         NULL::text AS object_type_module, \
+         NULL::text AS object_type_name, \
+         NULL::bytea AS serialized_object, \
+         NULL::text AS coin_type, \
+         NULL::bigint AS coin_balance, \
+         NULL::smallint AS df_kind, \
+         FALSE AS from_backward_history \
+         FROM objects_version ov \
+         WHERE cp_sequence_number >= COALESCE(\
+             (SELECT min_available_cp FROM watermarks \
+              WHERE entity = '{BACKWARD_HISTORY_WATERMARK_ENTITY}'), 0) \
+         AND NOT EXISTS (\
+             SELECT 1 FROM checkpointed_objects co \
+             WHERE co.object_id = ov.object_id \
+               AND co.object_version = ov.object_version) \
+         AND NOT EXISTS (\
+             SELECT 1 FROM objects_backward_history bh \
+             WHERE bh.object_id = ov.object_id \
+               AND bh.object_version = ov.object_version)"
+    ));
+
+    // Wrap in a subquery so filter_fn can apply objectKeys WHERE clause cleanly.
+    let version_filtered = filter_fn(query!("SELECT * FROM ({}) ov_filtered", inner));
+
+    let source = query!("SELECT candidates.* FROM ({}) candidates", version_filtered);
     page.apply::<StoredBackwardObject>(source)
 }

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -5,11 +5,11 @@
 //! filtering. Combines all objects from `checkpointed_objects` with all
 //! past versions from `objects_backward_history`.
 
-use super::{
-    BACKWARD_HISTORY_WATERMARK_ENTITY, CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, HistoricalFilter,
-    NOT_YET_CREATED, NativeObjectStatus, merge_and_deduplicate, merge_and_deduplicate_three,
-};
 use crate::{
+    backward_view::{
+        BACKWARD_HISTORY_WATERMARK_ENTITY, CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, HistoricalFilter,
+        NOT_YET_CREATED, NativeObjectStatus, merge_and_deduplicate, merge_and_deduplicate_three,
+    },
     filter, query,
     raw_query::RawQuery,
     types::{

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -8,7 +8,7 @@
 use crate::{
     backward_view::{
         BACKWARD_HISTORY_WATERMARK_ENTITY, CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, HistoricalFilter,
-        NOT_YET_CREATED, NativeObjectStatus, merge_and_deduplicate, merge_and_deduplicate_three,
+        NOT_YET_CREATED, NativeObjectStatus, merge_and_deduplicate,
     },
     filter, query,
     raw_query::RawQuery,
@@ -30,18 +30,18 @@ pub(crate) fn query(
 ) -> RawQuery {
     let filter_fn = |q| filter.apply(q);
 
-    if filter.has_type_or_owner() {
-        merge_and_deduplicate(
-            checkpointed_objects(page, &filter_fn),
-            historical_objects(page, &filter_fn),
-        )
-    } else {
-        merge_and_deduplicate_three(
-            checkpointed_objects(page, &filter_fn),
-            historical_objects(page, &filter_fn),
-            tombstones_from_objects_version(checkpoint_viewed_at, page, &filter_fn),
-        )
+    let mut sources = vec![
+        checkpointed_objects(page, &filter_fn),
+        historical_objects(page, &filter_fn),
+    ];
+    if !filter.has_type_or_owner() {
+        sources.push(tombstones_from_objects_version(
+            checkpoint_viewed_at,
+            page,
+            &filter_fn,
+        ));
     }
+    merge_and_deduplicate(sources)
 }
 
 /// Returns all objects from `checkpointed_objects` (including tombstones)

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -6,8 +6,8 @@
 //! past versions from `objects_backward_history`.
 
 use super::{
-    BACKWARD_HISTORY_WATERMARK_ENTITY, CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, NOT_YET_CREATED,
-    NativeObjectStatus, merge_and_deduplicate, merge_and_deduplicate_three,
+    BACKWARD_HISTORY_WATERMARK_ENTITY, CHECKPOINTED_COLUMNS, HISTORY_COLUMNS, HistoricalFilter,
+    NOT_YET_CREATED, NativeObjectStatus, merge_and_deduplicate, merge_and_deduplicate_three,
 };
 use crate::{
     filter, query,
@@ -18,32 +18,30 @@ use crate::{
     },
 };
 
-/// Builds a historical view with additional filters (type, owner, etc.).
-/// Since tombstones have NULL data fields, they can never match these
-/// filters, so the `objects_version` fallback is skipped.
-pub(crate) fn query_with_filter(
-    page: &Page<Cursor>,
-    filter_fn: impl Fn(RawQuery) -> RawQuery,
-) -> RawQuery {
-    merge_and_deduplicate(
-        checkpointed_objects(page, &filter_fn),
-        historical_objects(page, &filter_fn),
-    )
-}
-
-/// Builds a historical view with only key filters (no type/owner).
-/// Includes synthetic tombstones from `objects_version` for versions not
-/// found in the other sources, since tombstones could match.
-pub(crate) fn query_keys_only(
+/// Builds a historical view query for a `HistoricalFilter`. Internally
+/// branches on whether type/owner are also constrained: keys-only filters
+/// include the `objects_version` source so real tombstone versions are
+/// reachable, while filters with type/owner skip it (tombstones can't
+/// match).
+pub(crate) fn query(
     checkpoint_viewed_at: u64,
     page: &Page<Cursor>,
-    filter_fn: impl Fn(RawQuery) -> RawQuery,
+    filter: &HistoricalFilter,
 ) -> RawQuery {
-    merge_and_deduplicate_three(
-        checkpointed_objects(page, &filter_fn),
-        historical_objects(page, &filter_fn),
-        tombstones_from_objects_version(checkpoint_viewed_at, page, &filter_fn),
-    )
+    let filter_fn = |q| filter.apply(q);
+
+    if filter.has_type_or_owner() {
+        merge_and_deduplicate(
+            checkpointed_objects(page, &filter_fn),
+            historical_objects(page, &filter_fn),
+        )
+    } else {
+        merge_and_deduplicate_three(
+            checkpointed_objects(page, &filter_fn),
+            historical_objects(page, &filter_fn),
+            tombstones_from_objects_version(checkpoint_viewed_at, page, &filter_fn),
+        )
+    }
 }
 
 /// Returns all objects from `checkpointed_objects` (including tombstones)

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -112,11 +112,12 @@ fn tombstones_from_objects_version(
     let wrapped_or_deleted = NativeObjectStatus::WrappedOrDeleted as i16;
     let checkpoint_viewed_at = checkpoint_viewed_at as i64;
 
-    // Inner query: select from objects_version, bounded by the backward
-    // history watermark below and `checkpoint_viewed_at` above, and excluding
-    // versions that already exist in checkpointed_objects or
-    // objects_backward_history.
-    let inner = query!(format!(
+    // Apply the keys filter directly to the bare table select so its disjunctive
+    // `(object_id = ... AND object_version = ...)` clauses become the leading
+    // WHERE — this lets the planner use the `(object_id, object_version)`
+    // primary key for the lookup instead of scanning the whole cp window. The
+    // cp bounds and the two `NOT EXISTS` checks are then AND'd on top.
+    let base = query!(format!(
         "SELECT object_id, object_version, \
          {wrapped_or_deleted}::smallint AS object_status, \
          NULL::bytea AS object_digest, \
@@ -131,12 +132,24 @@ fn tombstones_from_objects_version(
          NULL::bigint AS coin_balance, \
          NULL::smallint AS df_kind, \
          FALSE AS from_backward_history \
-         FROM objects_version ov \
-         WHERE cp_sequence_number >= COALESCE(\
-             (SELECT min_available_cp FROM watermarks \
-              WHERE entity = '{BACKWARD_HISTORY_WATERMARK_ENTITY}'), 0) \
-         AND cp_sequence_number <= {checkpoint_viewed_at} \
-         AND NOT EXISTS (\
+         FROM objects_version ov"
+    ));
+
+    let with_keys = filter_fn(base);
+
+    let with_bounds = filter!(
+        with_keys,
+        format!(
+            "cp_sequence_number >= COALESCE(\
+                 (SELECT min_available_cp FROM watermarks \
+                  WHERE entity = '{BACKWARD_HISTORY_WATERMARK_ENTITY}'), 0) \
+             AND cp_sequence_number <= {checkpoint_viewed_at}"
+        )
+    );
+
+    let inner = filter!(
+        with_bounds,
+        "NOT EXISTS (\
              SELECT 1 FROM checkpointed_objects co \
              WHERE co.object_id = ov.object_id \
                AND co.object_version = ov.object_version) \
@@ -144,11 +157,8 @@ fn tombstones_from_objects_version(
              SELECT 1 FROM objects_backward_history bh \
              WHERE bh.object_id = ov.object_id \
                AND bh.object_version = ov.object_version)"
-    ));
+    );
 
-    // Wrap in a subquery so filter_fn can apply objectKeys WHERE clause cleanly.
-    let version_filtered = filter_fn(query!("SELECT * FROM ({}) ov_filtered", inner));
-
-    let source = query!("SELECT candidates.* FROM ({}) candidates", version_filtered);
+    let source = query!("SELECT candidates.* FROM ({}) candidates", inner);
     page.apply::<StoredBackwardObject>(source)
 }

--- a/crates/iota-graphql-rpc/src/backward_view/mod.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/mod.rs
@@ -7,7 +7,9 @@
 pub(crate) mod consistent;
 pub(crate) mod historical;
 
-use iota_indexer::models::objects::BackwardHistoryObjectStatus;
+use iota_indexer::{
+    models::objects::BackwardHistoryObjectStatus, types::ObjectStatus as NativeObjectStatus,
+};
 
 use crate::{query, raw_query::RawQuery};
 
@@ -20,12 +22,21 @@ pub(super) const NOT_YET_CREATED: i16 = BackwardHistoryObjectStatus::NotYetCreat
 /// `iota-indexer`.
 pub(crate) const BACKWARD_HISTORY_WATERMARK_ENTITY: &str = "objects_backward_history";
 
-/// Column list shared by both `checkpointed_objects` and
-/// `objects_backward_history` projections into `StoredBackwardObject` layout.
-pub(super) const OBJECT_COLUMNS: &str = "\
+/// Column list for `checkpointed_objects` rows, tagged with
+/// `from_backward_history = FALSE`.
+pub(super) const CHECKPOINTED_COLUMNS: &str = "\
     object_id, object_version, object_status, \
     object_digest, owner_type, owner_id, object_type, object_type_package, object_type_module, \
-    object_type_name, serialized_object, coin_type, coin_balance, df_kind";
+    object_type_name, serialized_object, coin_type, coin_balance, df_kind, \
+    FALSE AS from_backward_history";
+
+/// Column list for `objects_backward_history` rows, tagged with
+/// `from_backward_history = TRUE`.
+pub(super) const HISTORY_COLUMNS: &str = "\
+    object_id, object_version, object_status, \
+    object_digest, owner_type, owner_id, object_type, object_type_package, object_type_module, \
+    object_type_name, serialized_object, coin_type, coin_balance, df_kind, \
+    TRUE AS from_backward_history";
 
 /// Merges two sources with UNION ALL and picks the most recent version per
 /// `object_id` using `DISTINCT ON`.
@@ -37,6 +48,24 @@ pub(super) fn merge_and_deduplicate(source_a: RawQuery, source_b: RawQuery) -> R
         r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ALL ({})) candidates"#,
         source_a,
         source_b
+    )
+    .order_by("object_id")
+    .order_by("object_version DESC");
+
+    query!("SELECT * FROM ({}) candidates", combined)
+}
+
+/// Like `merge_and_deduplicate` but for three sources.
+pub(super) fn merge_and_deduplicate_three(
+    source_a: RawQuery,
+    source_b: RawQuery,
+    source_c: RawQuery,
+) -> RawQuery {
+    let combined = query!(
+        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ALL ({}) UNION ALL ({})) candidates"#,
+        source_a,
+        source_b,
+        source_c
     )
     .order_by("object_id")
     .order_by("object_version DESC");

--- a/crates/iota-graphql-rpc/src/backward_view/mod.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/mod.rs
@@ -11,7 +11,48 @@ use iota_indexer::{
     models::objects::BackwardHistoryObjectStatus, types::ObjectStatus as NativeObjectStatus,
 };
 
-use crate::{query, raw_query::RawQuery};
+use crate::{query, raw_query::RawQuery, types::object::ObjectFilter};
+
+/// An `ObjectFilter` validated for use against the historical view.
+///
+/// The historical view is keyed on `(object_id, object_version)` lookups
+/// against `checkpointed_objects`, `objects_backward_history`, and (for
+/// keys-only queries) `objects_version`, so it only makes sense when the
+/// filter pins down specific keys. Constructible only via
+/// `TryFrom<ObjectFilter>`, which requires `object_keys` to be set.
+#[derive(Debug)]
+pub(crate) struct HistoricalFilter(ObjectFilter);
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum HistoricalFilterError {
+    #[error(
+        "ObjectFilter is missing object_keys; the historical view requires explicit (object_id, object_version) keys"
+    )]
+    MissingKeys,
+}
+
+impl TryFrom<ObjectFilter> for HistoricalFilter {
+    type Error = HistoricalFilterError;
+
+    fn try_from(filter: ObjectFilter) -> Result<Self, Self::Error> {
+        if filter.object_keys.is_some() {
+            Ok(Self(filter))
+        } else {
+            Err(HistoricalFilterError::MissingKeys)
+        }
+    }
+}
+
+impl HistoricalFilter {
+    /// Whether the filter additionally constrains `type_` or `owner`.
+    pub(crate) fn has_type_or_owner(&self) -> bool {
+        self.0.type_.is_some() || self.0.owner.is_some()
+    }
+
+    pub(crate) fn apply(&self, query: RawQuery) -> RawQuery {
+        self.0.apply(query)
+    }
+}
 
 /// Status value for objects that did not exist yet. These entries are excluded
 /// from backward diff results.

--- a/crates/iota-graphql-rpc/src/backward_view/mod.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/mod.rs
@@ -79,37 +79,35 @@ pub(super) const HISTORY_COLUMNS: &str = "\
     object_type_name, serialized_object, coin_type, coin_balance, df_kind, \
     TRUE AS from_backward_history";
 
-/// Merges two sources with UNION ALL and picks the most recent version per
-/// `object_id` using `DISTINCT ON`.
+/// Merges any non-empty set of sources with `UNION ALL` and picks the most
+/// recent version per `object_id` using `DISTINCT ON`.
 ///
 /// The result is wrapped so cursor pagination can reference
 /// `candidates.object_id`.
-pub(super) fn merge_and_deduplicate(source_a: RawQuery, source_b: RawQuery) -> RawQuery {
-    let combined = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ALL ({})) candidates"#,
-        source_a,
-        source_b
-    )
-    .order_by("object_id")
-    .order_by("object_version DESC");
+pub(super) fn merge_and_deduplicate(sources: Vec<RawQuery>) -> RawQuery {
+    assert!(
+        !sources.is_empty(),
+        "merge_and_deduplicate requires at least one source"
+    );
 
-    query!("SELECT * FROM ({}) candidates", combined)
-}
+    let mut binds: Vec<String> = Vec::new();
+    let union_terms: Vec<String> = sources
+        .into_iter()
+        .map(|source| {
+            let (sql, source_binds) = source.finish();
+            binds.extend(source_binds);
+            format!("({sql})")
+        })
+        .collect();
 
-/// Like `merge_and_deduplicate` but for three sources.
-pub(super) fn merge_and_deduplicate_three(
-    source_a: RawQuery,
-    source_b: RawQuery,
-    source_c: RawQuery,
-) -> RawQuery {
-    let combined = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ALL ({}) UNION ALL ({})) candidates"#,
-        source_a,
-        source_b,
-        source_c
-    )
-    .order_by("object_id")
-    .order_by("object_version DESC");
+    let select = format!(
+        r#"SELECT DISTINCT ON (object_id) * FROM ({}) candidates"#,
+        union_terms.join(" UNION ALL ")
+    );
+
+    let combined = RawQuery::new(select, binds)
+        .order_by("object_id")
+        .order_by("object_version DESC");
 
     query!("SELECT * FROM ({}) candidates", combined)
 }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -1462,13 +1462,16 @@ pub(crate) fn resolve_tombstone_versions(
     })?;
 
     // Key by (object_id, backward_history_version) → real_version
-    let resolved_map: HashMap<(Vec<u8>, i64), i64> = rows
+    let resolved_map: HashMap<Vec<u8>, HashMap<i64, i64>> = rows
         .into_iter()
         .filter_map(|r| {
             r.real_version
-                .map(|real| ((r.object_id, r.backward_history_version), real))
+                .map(|real| (r.object_id, r.backward_history_version, real))
         })
-        .collect();
+        .fold(HashMap::new(), |mut acc, (id, ver, real)| {
+            acc.entry(id).or_default().insert(ver, real);
+            acc
+        });
 
     Ok(results
         .into_iter()
@@ -1476,8 +1479,10 @@ pub(crate) fn resolve_tombstone_versions(
             if r.from_backward_history
                 && r.object_status == NativeObjectStatus::WrappedOrDeleted as i16
             {
-                let key = (r.object_id.clone(), r.object_version);
-                if let Some(&real_version) = resolved_map.get(&key) {
+                if let Some(&real_version) = resolved_map
+                    .get(&r.object_id)
+                    .and_then(|versions| versions.get(&r.object_version))
+                {
                     r.object_version = real_version;
                 }
             }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -881,11 +881,14 @@ impl Object {
                     return Ok::<_, diesel::result::Error>(None);
                 };
 
-                Ok(Some(page.paginate_raw_query::<StoredBackwardObject>(
+                let (prev, next, results_iter) = page.paginate_raw_query::<StoredBackwardObject>(
                     conn,
                     checkpoint_viewed_at,
                     backward_objects_query(&filter, checkpoint_viewed_at, &page),
-                )?))
+                )?;
+                let results = results_iter.collect();
+                let results = resolve_tombstone_versions(conn, results)?;
+                Ok(Some((prev, next, results)))
             })
             .await?
         else {
@@ -1117,6 +1120,13 @@ fn version_for_dynamic_fields(native: &NativeObject) -> u64 {
 }
 
 impl ObjectFilter {
+    /// Returns `true` if the filter only constrains on object ID and/or version
+    /// (no type or owner filters). Such filters are safe to apply against
+    /// tables that lack type/owner columns (e.g. `objects_version`).
+    pub(crate) fn is_keys_only(&self) -> bool {
+        self.type_.is_none() && self.owner.is_none()
+    }
+
     /// Try to create a filter whose results are the intersection of objects in
     /// `self`'s results and objects in `other`'s results. This may not be
     /// possible if the resulting filter is inconsistent in some way (e.g. a
@@ -1369,6 +1379,12 @@ pub(crate) struct StoredBackwardObject {
     pub coin_balance: Option<i64>,
     #[diesel(sql_type = sql_types::Nullable<sql_types::SmallInt>)]
     pub df_kind: Option<i16>,
+    /// `TRUE` when the row came from `objects_backward_history`, `FALSE`
+    /// otherwise (from `checkpointed_objects` or `objects_version`). Used to
+    /// decide whether version correction is needed for `WrappedOrDeleted`
+    /// entries, since backward history stores a lamport-1 approximation.
+    #[diesel(sql_type = sql_types::Bool)]
+    pub from_backward_history: bool,
 }
 
 impl StoredBackwardObject {
@@ -1395,6 +1411,83 @@ impl StoredBackwardObject {
             df_kind: self.df_kind,
         }
     }
+}
+
+/// Resolves real tombstone versions for `WrappedOrDeleted` entries from
+/// `objects_backward_history`.
+///
+/// The backward history stores a lamport-1 version approximation which may be
+/// higher than the actual tombstone version. This function looks up the real
+/// version from `objects_version` using a single batch query with a VALUES
+/// list joined via `MAX(object_version) <= backward_history_version`. Only
+/// entries tagged with `from_backward_history = true` are resolved; entries
+/// from `checkpointed_objects` already have the correct version.
+pub(crate) fn resolve_tombstone_versions(
+    conn: &mut crate::data::pg::PgConnection<'_>,
+    results: Vec<StoredBackwardObject>,
+) -> Result<Vec<StoredBackwardObject>, diesel::result::Error> {
+    let to_resolve: Vec<(Vec<u8>, i64)> = results
+        .iter()
+        .filter(|r| {
+            r.from_backward_history
+                && r.object_status == NativeObjectStatus::WrappedOrDeleted as i16
+        })
+        .map(|r| (r.object_id.clone(), r.object_version))
+        .collect();
+
+    if to_resolve.is_empty() {
+        return Ok(results);
+    }
+
+    let values = to_resolve
+        .iter()
+        .map(|(id, ver)| format!("('\\x{}'::bytea, {}::bigint)", hex::encode(id), ver))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let sql = format!(
+        "SELECT pairs.object_id, pairs.backward_history_version, MAX(ov.object_version) AS real_version \
+         FROM (VALUES {values}) AS pairs(object_id, backward_history_version) \
+         LEFT JOIN objects_version ov \
+           ON ov.object_id = pairs.object_id AND ov.object_version <= pairs.backward_history_version \
+         GROUP BY pairs.object_id, pairs.backward_history_version"
+    );
+
+    #[derive(diesel::QueryableByName)]
+    struct ResolvedVersion {
+        #[diesel(sql_type = sql_types::Binary)]
+        object_id: Vec<u8>,
+        #[diesel(sql_type = sql_types::BigInt)]
+        backward_history_version: i64,
+        #[diesel(sql_type = sql_types::Nullable<sql_types::BigInt>)]
+        real_version: Option<i64>,
+    }
+
+    let rows: Vec<ResolvedVersion> = conn.results(move || diesel::sql_query(sql.clone()))?;
+
+    // Key by (object_id, backward_history_version) → real_version
+    let resolved_map: HashMap<(Vec<u8>, i64), i64> = rows
+        .into_iter()
+        .filter_map(|r| {
+            r.real_version
+                .map(|real| ((r.object_id, r.backward_history_version), real))
+        })
+        .collect();
+
+    Ok(results
+        .into_iter()
+        .map(|mut r| {
+            if r.from_backward_history
+                && r.object_status == NativeObjectStatus::WrappedOrDeleted as i16
+            {
+                let key = (r.object_id.clone(), r.object_version);
+                if let Some(&real_version) = resolved_map.get(&key) {
+                    r.object_version = real_version;
+                }
+            }
+            r
+        })
+        .collect())
 }
 
 impl RawPaginated<Cursor> for StoredBackwardObject {
@@ -1728,6 +1821,7 @@ impl Loader<LatestAtKey> for Db {
                             )
                             .into_boxed()
                         })?;
+                        let results = resolve_tombstone_versions(conn, results)?;
 
                         Ok(results
                             .into_iter()
@@ -1841,12 +1935,15 @@ fn backward_objects_query(
         })
         .finish();
 
-        let keys_only_filter = ObjectFilter {
+        let keys_filter = ObjectFilter {
             object_ids: None,
             ..filter.clone()
         };
-        let (key_query, key_bindings) =
-            historical::query(page, move |query| keys_only_filter.apply(query)).finish();
+        let (key_query, key_bindings) = if keys_filter.is_keys_only() {
+            historical::query_keys_only(page, move |query| keys_filter.apply(query)).finish()
+        } else {
+            historical::query_with_filter(page, move |query| keys_filter.apply(query)).finish()
+        };
 
         RawQuery::new(
             format!("SELECT * FROM (({id_query}) UNION ALL ({key_query})) AS candidates",),
@@ -1855,7 +1952,11 @@ fn backward_objects_query(
         .order_by("object_id")
         .limit(page.limit() as i64)
     } else if filter.object_keys.is_some() {
-        historical::query(page, move |query| filter.apply(query))
+        if filter.is_keys_only() {
+            historical::query_keys_only(page, move |query| filter.apply(query))
+        } else {
+            historical::query_with_filter(page, move |query| filter.apply(query))
+        }
     } else {
         consistent::query(checkpoint_viewed_at, page, move |query| filter.apply(query))
     }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -1411,40 +1411,39 @@ impl StoredBackwardObject {
 ///
 /// The backward history stores a lamport-1 version approximation which may be
 /// higher than the actual tombstone version. This function looks up the real
-/// version from `objects_version` using a single batch query with a VALUES
-/// list joined via `MAX(object_version) <= backward_history_version`. Only
-/// entries tagged with `from_backward_history = true` are resolved; entries
-/// from `checkpointed_objects` already have the correct version.
+/// version from `objects_version` using a single batch query that unnests
+/// bound `bytea[]` / `bigint[]` parameter arrays into `(object_id, version)`
+/// pairs and joins them via `MAX(object_version) <= backward_history_version`.
+/// Only entries tagged with `from_backward_history = true` are resolved;
+/// entries from `checkpointed_objects` already have the correct version.
 pub(crate) fn resolve_tombstone_versions(
     conn: &mut crate::data::pg::PgConnection<'_>,
     results: Vec<StoredBackwardObject>,
 ) -> Result<Vec<StoredBackwardObject>, diesel::result::Error> {
-    let to_resolve: Vec<(Vec<u8>, i64)> = results
+    let (ids, versions): (Vec<Vec<u8>>, Vec<i64>) = results
         .iter()
         .filter(|r| {
             r.from_backward_history
                 && r.object_status == NativeObjectStatus::WrappedOrDeleted as i16
         })
         .map(|r| (r.object_id.clone(), r.object_version))
-        .collect();
+        .unzip();
 
-    if to_resolve.is_empty() {
+    if ids.is_empty() {
         return Ok(results);
     }
 
-    let values = to_resolve
-        .iter()
-        .map(|(id, ver)| format!("('\\x{}'::bytea, {}::bigint)", hex::encode(id), ver))
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    let sql = format!(
-        "SELECT pairs.object_id, pairs.backward_history_version, MAX(ov.object_version) AS real_version \
-         FROM (VALUES {values}) AS pairs(object_id, backward_history_version) \
-         LEFT JOIN objects_version ov \
-           ON ov.object_id = pairs.object_id AND ov.object_version <= pairs.backward_history_version \
-         GROUP BY pairs.object_id, pairs.backward_history_version"
-    );
+    // Bound `unnest` arrays (rather than an inlined `VALUES` list) keep the
+    // SQL text constant across calls so Postgres can reuse a cached plan,
+    // and skip the parser cost of every `::bytea` / `::bigint` cast.
+    let sql = "SELECT pairs.object_id, pairs.backward_history_version, \
+                      MAX(ov.object_version) AS real_version \
+               FROM unnest($1::bytea[], $2::bigint[]) \
+                    AS pairs(object_id, backward_history_version) \
+               LEFT JOIN objects_version ov \
+                 ON ov.object_id = pairs.object_id \
+                AND ov.object_version <= pairs.backward_history_version \
+               GROUP BY pairs.object_id, pairs.backward_history_version";
 
     #[derive(diesel::QueryableByName)]
     struct ResolvedVersion {
@@ -1456,7 +1455,11 @@ pub(crate) fn resolve_tombstone_versions(
         real_version: Option<i64>,
     }
 
-    let rows: Vec<ResolvedVersion> = conn.results(move || diesel::sql_query(sql.clone()))?;
+    let rows: Vec<ResolvedVersion> = conn.results(|| {
+        diesel::sql_query(sql)
+            .bind::<sql_types::Array<sql_types::Binary>, _>(ids.clone())
+            .bind::<sql_types::Array<sql_types::BigInt>, _>(versions.clone())
+    })?;
 
     // Key by (object_id, backward_history_version) → real_version
     let resolved_map: HashMap<(Vec<u8>, i64), i64> = rows

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -34,7 +34,7 @@ use move_core_types::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    backward_view::{consistent, historical},
+    backward_view::{HistoricalFilter, consistent, historical},
     config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::Checkpointed,
@@ -1120,13 +1120,6 @@ fn version_for_dynamic_fields(native: &NativeObject) -> u64 {
 }
 
 impl ObjectFilter {
-    /// Returns `true` if the filter only constrains on object ID and/or version
-    /// (no type or owner filters). Such filters are safe to apply against
-    /// tables that lack type/owner columns (e.g. `objects_version`).
-    pub(crate) fn is_keys_only(&self) -> bool {
-        self.type_.is_none() && self.owner.is_none()
-    }
-
     /// Try to create a filter whose results are the intersection of objects in
     /// `self`'s results and objects in `other`'s results. This may not be
     /// possible if the resulting filter is inconsistent in some way (e.g. a
@@ -1935,18 +1928,14 @@ fn backward_objects_query(
         })
         .finish();
 
-        let keys_filter = ObjectFilter {
+        let keys_filter: HistoricalFilter = ObjectFilter {
             object_ids: None,
             ..filter.clone()
-        };
-        let (key_query, key_bindings) = if keys_filter.is_keys_only() {
-            historical::query_keys_only(checkpoint_viewed_at, page, move |query| {
-                keys_filter.apply(query)
-            })
-            .finish()
-        } else {
-            historical::query_with_filter(page, move |query| keys_filter.apply(query)).finish()
-        };
+        }
+        .try_into()
+        .expect("object_keys is Some by match-arm guard");
+        let (key_query, key_bindings) =
+            historical::query(checkpoint_viewed_at, page, &keys_filter).finish();
 
         RawQuery::new(
             format!("SELECT * FROM (({id_query}) UNION ALL ({key_query})) AS candidates",),
@@ -1954,14 +1943,8 @@ fn backward_objects_query(
         )
         .order_by("object_id")
         .limit(page.limit() as i64)
-    } else if filter.object_keys.is_some() {
-        if filter.is_keys_only() {
-            historical::query_keys_only(checkpoint_viewed_at, page, move |query| {
-                filter.apply(query)
-            })
-        } else {
-            historical::query_with_filter(page, move |query| filter.apply(query))
-        }
+    } else if let Ok(keys_filter) = HistoricalFilter::try_from(filter.clone()) {
+        historical::query(checkpoint_viewed_at, page, &keys_filter)
     } else {
         consistent::query(checkpoint_viewed_at, page, move |query| filter.apply(query))
     }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -1940,7 +1940,10 @@ fn backward_objects_query(
             ..filter.clone()
         };
         let (key_query, key_bindings) = if keys_filter.is_keys_only() {
-            historical::query_keys_only(page, move |query| keys_filter.apply(query)).finish()
+            historical::query_keys_only(checkpoint_viewed_at, page, move |query| {
+                keys_filter.apply(query)
+            })
+            .finish()
         } else {
             historical::query_with_filter(page, move |query| keys_filter.apply(query)).finish()
         };
@@ -1953,7 +1956,9 @@ fn backward_objects_query(
         .limit(page.limit() as i64)
     } else if filter.object_keys.is_some() {
         if filter.is_keys_only() {
-            historical::query_keys_only(page, move |query| filter.apply(query))
+            historical::query_keys_only(checkpoint_viewed_at, page, move |query| {
+                filter.apply(query)
+            })
         } else {
             historical::query_with_filter(page, move |query| filter.apply(query))
         }

--- a/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/down.sql
@@ -1,1 +1,2 @@
 DROP TABLE IF EXISTS objects_backward_history;
+DELETE FROM watermarks WHERE entity = 'objects_backward_history';

--- a/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/up.sql
@@ -48,3 +48,26 @@ CREATE INDEX objects_backward_history_coin_owner
 CREATE STATISTICS objects_backward_history_type_stats (dependencies, mcv)
     ON object_type, object_type_package, object_type_module, object_type_name
     FROM objects_backward_history;
+
+-- Initialize a watermark entry for backward history. The table starts empty,
+-- so copy the upper bound from an existing committer table (all committer
+-- tables share the same upper bound) and set the lower bound to indicate
+-- that no backward history data is available yet.
+INSERT INTO watermarks (
+    entity, current_epoch, max_committed_cp, max_committed_tx,
+    min_available_epoch, min_bounds_updated_at_timestamp_ms, lowest_unpruned_key,
+    min_available_tx, min_available_cp
+)
+SELECT
+    'objects_backward_history',
+    current_epoch,
+    max_committed_cp,
+    max_committed_tx,
+    current_epoch,                                    -- min_available_epoch
+    (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000)::bigint, -- min_bounds_updated_at_timestamp_ms
+    max_committed_cp + 1,                             -- lowest_unpruned_key (next cp is first unpruned)
+    max_committed_tx + 1,                             -- min_available_tx
+    max_committed_cp + 1                              -- min_available_cp
+FROM watermarks
+WHERE entity = 'transactions'
+ON CONFLICT (entity) DO NOTHING;


### PR DESCRIPTION
# Description of change

Correct the version reported for `WrappedOrDeleted` objects in backward diff queries and enable `objectKeys` lookups by real tombstone version.

**Problem:** When a wrapped object is later unwrapped, `objects_backward_history` records the previous wrapped state with `version = lamport - 1`, which may be higher than the real tombstone version. For example: object wrapped at v3, unwrapped at v7 → backward history stores v6, but the real tombstone version is 3.

**Version correction:**
- SQL projections tag rows with `from_backward_history` (`TRUE`/`FALSE`) so we can identify which source produced each result
- After the backward diff query, a post-processing step resolves the real tombstone version from `objects_version` for `WrappedOrDeleted` entries from backward history
- Entries from `checkpointed_objects` already have the correct version and are skipped

**objectKeys lookup by real tombstone version:**
- For keys-only queries (no type/owner filters), `objects_version` is used as a third SQL source producing synthetic tombstone rows for `(object_id, version)` pairs not found in `checkpointed_objects` or `objects_backward_history` (`NOT EXISTS` checks)
- When type/owner filters are present (`HistoricalWithFilter`), this source is skipped since tombstones have NULL data fields and would never match
- `BackwardView` enum now has `HistoricalKeysOnly` vs `HistoricalWithFilter` variants to express this distinction
- A pruning watermark (`min_available_cp` from the `objects_backward_history` watermark entry) filters out versions in pruned ranges to prevent false tombstones

**Migration:**
- Backward history migration now initializes a watermark entry from the latest committed checkpoint, with lower bounds set to `max_cp + 1` to indicate no backward history data exists yet
- `down.sql` cleans up the watermark entry on rollback

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11195

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
    - `consistent_view_wrapped`: version corrected from 6 (lamport-1) to 3 (real tombstone)
    - `object_keys_tombstone`: real tombstone version (3) now findable via objectKeys, old active version (2) correctly returns INDEXED (not a false tombstone), lamport-1 version (6) returns corrected version 3
    - `objects_pagination`: objectKeys with type filter uses `HistoricalWithFilter` path (no synthetic tombstones)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
