### PR TITLE
fix(grpc): cap concurrent stream_checkpoints subscribers

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -5,7 +5,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::NonZeroUsize,
+    num::{NonZeroU32, NonZeroUsize},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -311,9 +311,9 @@ pub struct GrpcApiConfig {
     /// Maximum number of concurrent subscribers to checkpoint streaming RPCs.
     /// Once the cap is reached, additional subscribe requests are rejected
     /// with `Unavailable` to protect the server from being overwhelmed by
-    /// unbounded streaming clients.
+    /// unbounded streaming clients. Must be non-zero.
     #[serde(default = "default_grpc_api_max_concurrent_stream_subscribers")]
-    pub max_concurrent_stream_subscribers: u32,
+    pub max_concurrent_stream_subscribers: NonZeroU32,
 
     /// Maximum size for Move values when rendering to JSON
     /// in bytes.
@@ -345,8 +345,8 @@ fn default_grpc_api_broadcast_buffer_size() -> u32 {
     100
 }
 
-fn default_grpc_api_max_concurrent_stream_subscribers() -> u32 {
-    1024
+fn default_grpc_api_max_concurrent_stream_subscribers() -> NonZeroU32 {
+    NonZeroU32::new(1024).unwrap()
 }
 
 fn default_grpc_api_max_message_size_bytes() -> u32 {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -308,6 +308,13 @@ pub struct GrpcApiConfig {
     #[serde(default = "default_grpc_api_broadcast_buffer_size")]
     pub broadcast_buffer_size: u32,
 
+    /// Maximum number of concurrent subscribers to checkpoint streaming RPCs.
+    /// Once the cap is reached, additional subscribe requests are rejected
+    /// with `Unavailable` to protect the server from being overwhelmed by
+    /// unbounded streaming clients.
+    #[serde(default = "default_grpc_api_max_concurrent_stream_subscribers")]
+    pub max_concurrent_stream_subscribers: u32,
+
     /// Maximum size for Move values when rendering to JSON
     /// in bytes.
     #[serde(default = "default_grpc_api_max_json_move_value_size")]
@@ -338,6 +345,10 @@ fn default_grpc_api_broadcast_buffer_size() -> u32 {
     100
 }
 
+fn default_grpc_api_max_concurrent_stream_subscribers() -> u32 {
+    1024
+}
+
 fn default_grpc_api_max_message_size_bytes() -> u32 {
     128 * 1024 * 1024 // 128MB
 }
@@ -365,6 +376,7 @@ impl Default for GrpcApiConfig {
             tls: None,
             max_message_size_bytes: default_grpc_api_max_message_size_bytes(),
             broadcast_buffer_size: default_grpc_api_broadcast_buffer_size(),
+            max_concurrent_stream_subscribers: default_grpc_api_max_concurrent_stream_subscribers(),
             max_json_move_value_size: default_grpc_api_max_json_move_value_size(),
             max_execute_transaction_batch_size: default_grpc_api_max_execute_transaction_batch_size(
             ),

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -5,7 +5,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::{NonZeroU32, NonZeroUsize},
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -311,9 +311,10 @@ pub struct GrpcApiConfig {
     /// Maximum number of concurrent subscribers to checkpoint streaming RPCs.
     /// Once the cap is reached, additional subscribe requests are rejected
     /// with `Unavailable` to protect the server from being overwhelmed by
-    /// unbounded streaming clients. Must be non-zero.
+    /// unbounded streaming clients. Values below 1 are clamped to 1 at
+    /// server startup.
     #[serde(default = "default_grpc_api_max_concurrent_stream_subscribers")]
-    pub max_concurrent_stream_subscribers: NonZeroU32,
+    pub max_concurrent_stream_subscribers: u32,
 
     /// Maximum size for Move values when rendering to JSON
     /// in bytes.
@@ -345,8 +346,8 @@ fn default_grpc_api_broadcast_buffer_size() -> u32 {
     100
 }
 
-fn default_grpc_api_max_concurrent_stream_subscribers() -> NonZeroU32 {
-    NonZeroU32::new(1024).unwrap()
+fn default_grpc_api_max_concurrent_stream_subscribers() -> u32 {
+    1024
 }
 
 fn default_grpc_api_max_message_size_bytes() -> u32 {

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -411,7 +411,7 @@ pub(crate) fn stream_checkpoints(
     let subscription = service
         .checkpoint_data_broadcaster
         .subscribe()
-        .ok_or_else(|| Status::unavailable("too many existing subscribers"))?;
+        .ok_or_else(|| Status::unavailable("maximum concurrent stream subscribers reached"))?;
     let stream = Box::pin(service.reader.create_checkpoint_data_stream(
         subscription,
         start_sequence_number,

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -411,12 +411,7 @@ pub(crate) fn stream_checkpoints(
     let subscription = service
         .checkpoint_data_broadcaster
         .subscribe()
-        .ok_or_else(|| {
-            Status::unavailable(format!(
-                "maximum concurrent stream subscribers reached ({})",
-                service.config.max_concurrent_stream_subscribers
-            ))
-        })?;
+        .ok_or_else(|| Status::unavailable("too many existing subscribers"))?;
     let stream = Box::pin(service.reader.create_checkpoint_data_stream(
         subscription,
         start_sequence_number,

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -408,9 +408,17 @@ pub(crate) fn stream_checkpoints(
         return Err(Status::invalid_argument("events_filter requires events in read_mask").into());
     }
 
-    let rx = service.checkpoint_data_broadcaster.subscribe();
+    let subscription = service
+        .checkpoint_data_broadcaster
+        .subscribe()
+        .ok_or_else(|| {
+            Status::unavailable(format!(
+                "maximum concurrent stream subscribers reached ({})",
+                service.config.max_concurrent_stream_subscribers
+            ))
+        })?;
     let stream = Box::pin(service.reader.create_checkpoint_data_stream(
-        rx,
+        subscription,
         start_sequence_number,
         end_sequence_number,
         checkpoint_mask,

--- a/crates/iota-grpc-server/src/metrics.rs
+++ b/crates/iota-grpc-server/src/metrics.rs
@@ -12,8 +12,9 @@ use std::{
 
 use pin_project_lite::pin_project;
 use prometheus::{
-    HistogramVec, IntCounterVec, IntGaugeVec, Registry, register_histogram_vec_with_registry,
-    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
+    HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
 };
 use tonic::{Code, Status};
 use tower::{Layer, Service};
@@ -33,6 +34,7 @@ pub struct GrpcServerMetrics {
     inflight_requests: IntGaugeVec,
     num_requests: IntCounterVec,
     request_latency: HistogramVec,
+    inflight_checkpoint_stream_subscribers: IntGauge,
 }
 
 impl GrpcServerMetrics {
@@ -60,7 +62,19 @@ impl GrpcServerMetrics {
                 registry,
             )
             .unwrap(),
+            inflight_checkpoint_stream_subscribers: register_int_gauge_with_registry!(
+                "node_grpc_inflight_checkpoint_stream_subscribers",
+                "Number of active subscribers to the checkpoint data broadcast",
+                registry,
+            )
+            .unwrap(),
         }
+    }
+
+    /// Gauge tracking the number of active subscribers to the checkpoint
+    /// data broadcast. Cheap to clone (wraps an `Arc` internally).
+    pub fn inflight_checkpoint_stream_subscribers(&self) -> IntGauge {
+        self.inflight_checkpoint_stream_subscribers.clone()
     }
 }
 

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -140,7 +140,7 @@ pub async fn start_grpc_server(
         .map(|m| m.inflight_checkpoint_stream_subscribers());
     let checkpoint_data_broadcaster = GrpcCheckpointDataBroadcaster::new(
         checkpoint_data_tx,
-        config.max_concurrent_stream_subscribers.get() as usize,
+        config.max_concurrent_stream_subscribers.max(1) as usize,
         inflight_subscribers,
     );
 

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -135,7 +135,14 @@ pub async fn start_grpc_server(
     let (checkpoint_data_tx, _) = broadcast::channel(config.broadcast_buffer_size as usize);
 
     // Create broadcasters
-    let checkpoint_data_broadcaster = GrpcCheckpointDataBroadcaster::new(checkpoint_data_tx);
+    let inflight_subscribers = metrics
+        .as_ref()
+        .map(|m| m.inflight_checkpoint_stream_subscribers());
+    let checkpoint_data_broadcaster = GrpcCheckpointDataBroadcaster::new(
+        checkpoint_data_tx,
+        config.max_concurrent_stream_subscribers as usize,
+        inflight_subscribers,
+    );
 
     // Create the gRPC services - get the cancellation token directly from
     // server level

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -140,7 +140,7 @@ pub async fn start_grpc_server(
         .map(|m| m.inflight_checkpoint_stream_subscribers());
     let checkpoint_data_broadcaster = GrpcCheckpointDataBroadcaster::new(
         checkpoint_data_tx,
-        config.max_concurrent_stream_subscribers as usize,
+        config.max_concurrent_stream_subscribers.get() as usize,
         inflight_subscribers,
     );
 

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -28,8 +28,12 @@ use iota_types::{
     object::Object,
     storage::error::Kind,
 };
+use prometheus::IntGauge;
 use prost::Message;
-use tokio::sync::broadcast::{Receiver, Sender, error::RecvError};
+use tokio::sync::{
+    OwnedSemaphorePermit, Semaphore,
+    broadcast::{Receiver, Sender, error::RecvError},
+};
 use tokio_util::sync::CancellationToken;
 use tonic::Status;
 use tracing::debug;
@@ -79,20 +83,88 @@ pub type GetCheckpointStream = Pin<Box<dyn futures::Stream<Item = CheckpointStre
 pub type StreamCheckpointsStream =
     Pin<Box<dyn futures::Stream<Item = CheckpointStreamResult> + Send>>;
 
-/// Wrapper that converts native CheckpointData to gRPC type before broadcasting
+/// Broadcasts checkpoint data to subscribers, capping concurrent subscribers.
 #[derive(Clone)]
 pub struct GrpcCheckpointDataBroadcaster {
     sender: Sender<Arc<IotaTypesCheckpointData>>,
+    /// Semaphore enforcing the concurrent-subscriber cap. Each successful
+    /// `subscribe()` acquires one permit; dropping the returned
+    /// [`SubscriberGuard`] releases it. This makes the cap atomic (no
+    /// check-then-subscribe race).
+    subscription_semaphore: Arc<Semaphore>,
+    /// Optional gauge tracking the number of active subscribers. Incremented
+    /// on `subscribe()`, decremented when the subscriber's
+    /// [`SubscriberGuard`] drops — so the metric is always in sync with
+    /// actual subscriber count, including client disconnects between
+    /// broadcasts.
+    inflight_subscribers: Option<IntGauge>,
+}
+
+/// A broadcast [`Receiver`] bundled with the [`SubscriberGuard`] holding
+/// its slot in the subscriber cap. Bundling them at the `subscribe()`
+/// boundary makes it impossible for callers to acquire a receiver without
+/// also holding the cap/gauge lifetime.
+#[must_use = "dropping the SubscribedReceiver immediately releases the subscriber slot"]
+pub struct SubscribedReceiver {
+    pub(crate) rx: Receiver<Arc<IotaTypesCheckpointData>>,
+    pub(crate) guard: SubscriberGuard,
+}
+
+/// RAII guard that holds one slot in the subscriber cap and keeps the
+/// inflight gauge in sync: the gauge is incremented on construction and
+/// decremented on drop.
+pub struct SubscriberGuard {
+    _permit: OwnedSemaphorePermit,
+    gauge: Option<IntGauge>,
+}
+
+impl SubscriberGuard {
+    fn new(permit: OwnedSemaphorePermit, gauge: Option<IntGauge>) -> Self {
+        if let Some(g) = &gauge {
+            g.inc();
+        }
+        Self {
+            _permit: permit,
+            gauge,
+        }
+    }
+}
+
+impl Drop for SubscriberGuard {
+    fn drop(&mut self) {
+        if let Some(gauge) = &self.gauge {
+            gauge.dec();
+        }
+    }
 }
 
 impl GrpcCheckpointDataBroadcaster {
-    pub fn new(sender: Sender<Arc<IotaTypesCheckpointData>>) -> Self {
-        Self { sender }
+    pub fn new(
+        sender: Sender<Arc<IotaTypesCheckpointData>>,
+        max_subscribers: usize,
+        inflight_subscribers: Option<IntGauge>,
+    ) -> Self {
+        Self {
+            sender,
+            subscription_semaphore: Arc::new(Semaphore::new(max_subscribers)),
+            inflight_subscribers,
+        }
     }
 
-    /// Subscribe to checkpoint data broadcasts
-    pub fn subscribe(&self) -> Receiver<Arc<IotaTypesCheckpointData>> {
-        self.sender.subscribe()
+    /// Subscribe to checkpoint data broadcasts, enforcing the configured cap
+    /// on concurrent subscribers.
+    ///
+    /// Returns `None` when the cap has been reached. Callers should surface
+    /// this as `Unavailable` to the client (transient capacity, retryable).
+    pub fn subscribe(&self) -> Option<SubscribedReceiver> {
+        let permit = self
+            .subscription_semaphore
+            .clone()
+            .try_acquire_owned()
+            .ok()?;
+        let rx = self.sender.subscribe();
+        let guard = SubscriberGuard::new(permit, self.inflight_subscribers.clone());
+        Some(SubscribedReceiver { rx, guard })
     }
 
     /// Get the number of active receivers
@@ -703,6 +775,7 @@ impl GrpcReader {
     fn create_generic_checkpoint_stream<T, S, R>(
         &self,
         mut rx: Receiver<Arc<T>>,
+        subscriber_guard: SubscriberGuard,
         start_sequence_number: Option<u64>,
         end_sequence_number: Option<u64>,
         cancellation_token: CancellationToken,
@@ -731,6 +804,9 @@ impl GrpcReader {
     {
         let state_reader = self.state_reader.clone();
         async_stream::try_stream! {
+            // Capture the guard so it drops (releasing the subscriber slot
+            // and decrementing the gauge) when the stream is dropped.
+            let _subscriber_guard = subscriber_guard;
             let mut latest = latest_checkpoint_seq(&*state_reader)
                 .map_err(|e| Status::internal(format!("Failed to get latest checkpoint: {e}")))?
                 .unwrap_or(0);
@@ -905,7 +981,7 @@ impl GrpcReader {
     /// Create a checkpoint stream implementation
     pub fn create_checkpoint_data_stream(
         &self,
-        rx: Receiver<Arc<IotaTypesCheckpointData>>,
+        subscription: SubscribedReceiver,
         start_sequence_number: Option<u64>,
         end_sequence_number: Option<u64>,
         checkpoint_mask: FieldMaskTree,
@@ -933,7 +1009,8 @@ impl GrpcReader {
         let event_filter_historical = event_filter.clone();
 
         Box::new(Box::pin(reader.create_generic_checkpoint_stream(
-            rx,
+            subscription.rx,
+            subscription.guard,
             start_sequence_number,
             end_sequence_number,
             cancellation_token,

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -167,7 +167,15 @@ impl GrpcCheckpointDataBroadcaster {
         Some(SubscribedReceiver { rx, guard })
     }
 
-    /// Get the number of active receivers
+    /// Get the number of active broadcast receivers.
+    ///
+    /// Counts every receiver on the underlying `broadcast::Sender`, including
+    /// any internal subscribers that did not go through [`subscribe`] and are
+    /// therefore not tracked by the subscriber cap or `inflight_subscribers`
+    /// gauge. Use this when deciding whether to send on the channel; use the
+    /// gauge when reporting externally-subscribed stream count.
+    ///
+    /// [`subscribe`]: Self::subscribe
     pub fn receiver_count(&self) -> usize {
         self.sender.receiver_count()
     }

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -786,6 +786,89 @@ async fn test_get_checkpoint_pruned_returns_not_found() {
 }
 
 #[tokio::test]
+async fn test_stream_checkpoints_subscriber_cap() {
+    // Configure a small cap so we can hit it in the test without opening
+    // dozens of streams. Storage has checkpoints 0..=5; each stream drains
+    // these and then parks in the live phase, keeping its broadcast
+    // receiver alive.
+    let (server_handle, client, _) = test_server_and_client_setup(
+        0..=5,
+        |config| {
+            config.max_concurrent_stream_subscribers = 2;
+        },
+        None,
+        None,
+    )
+    .await;
+
+    let range = (Some(0), None);
+
+    // Open two streams up to the cap.
+    let mut stream1 = client
+        .stream_checkpoints(range.0, range.1, None, None, None)
+        .await
+        .expect("first subscribe should succeed");
+    stream1
+        .body_mut()
+        .next()
+        .await
+        .expect("first stream should yield an item")
+        .expect("first stream item should not be an error");
+
+    let mut stream2 = client
+        .stream_checkpoints(range.0, range.1, None, None, None)
+        .await
+        .expect("second subscribe should succeed");
+    stream2
+        .body_mut()
+        .next()
+        .await
+        .expect("second stream should yield an item")
+        .expect("second stream item should not be an error");
+
+    // A third subscribe must be rejected with Unavailable.
+    match client
+        .stream_checkpoints(range.0, range.1, None, None, None)
+        .await
+    {
+        Err(iota_grpc_client::Error::Grpc(status)) => {
+            assert_eq!(status.code(), tonic::Code::Unavailable);
+        }
+        Err(other) => panic!("expected Unavailable, got: {other:?}"),
+        Ok(_) => panic!("expected Unavailable, got Ok"),
+    }
+
+    // Dropping a stream releases its subscriber slot. Retry until a fresh
+    // subscribe succeeds, to avoid depending on the drop order of locals
+    // inside the server-side stream generator.
+    drop(stream1);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let _stream3 = loop {
+        match client
+            .stream_checkpoints(range.0, range.1, None, None, None)
+            .await
+        {
+            Ok(s) => break s,
+            Err(iota_grpc_client::Error::Grpc(status))
+                if status.code() == tonic::Code::Unavailable =>
+            {
+                if tokio::time::Instant::now() >= deadline {
+                    panic!("subscriber slot did not free within timeout");
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => panic!("unexpected error: {e:?}"),
+        }
+    };
+
+    drop(stream2);
+    server_handle
+        .shutdown()
+        .await
+        .expect("Failed to shutdown server");
+}
+
+#[tokio::test]
 async fn test_stream_checkpoint_pruned_start_returns_not_found() {
     // Set up mock with checkpoints 0..=10 but lowest_available_checkpoint = 5
     let mock =

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -3,6 +3,7 @@
 mod common;
 use std::{
     collections::HashSet,
+    num::NonZeroU32,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -794,7 +795,7 @@ async fn test_stream_checkpoints_subscriber_cap() {
     let (server_handle, client, _) = test_server_and_client_setup(
         0..=5,
         |config| {
-            config.max_concurrent_stream_subscribers = 2;
+            config.max_concurrent_stream_subscribers = NonZeroU32::new(2).unwrap();
         },
         None,
         None,

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -3,7 +3,6 @@
 mod common;
 use std::{
     collections::HashSet,
-    num::NonZeroU32,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -795,7 +794,7 @@ async fn test_stream_checkpoints_subscriber_cap() {
     let (server_handle, client, _) = test_server_and_client_setup(
         0..=5,
         |config| {
-            config.max_concurrent_stream_subscribers = NonZeroU32::new(2).unwrap();
+            config.max_concurrent_stream_subscribers = 2;
         },
         None,
         None,


### PR DESCRIPTION
# Description of change

The `stream_checkpoints` RPC had no limit on subscribers, so a single client could open unlimited streams and overload the server. This PR adds a configurable cap (default `1024`) enforced by a semaphore in `GrpcCheckpointDataBroadcaster`; over-cap requests are rejected with `Unavailable`. A new Prometheus gauge `node_grpc_inflight_checkpoint_stream_subscribers` tracks live subscriber count for alerting.

## Links to any relevant issues

fixes #10540 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] gRPC: New limit on concurrent checkpoint streaming clients (default 1024). Tune via `grpc-api-config.max-concurrent-stream-subscribers`. Monitor via Prometheus metric `node_grpc_inflight_checkpoint_stream_subscribers`.
