### PR TITLE
feat(indexer): set up pruning for objects_backward_history

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/prune/backward_history_pruning.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/backward_history_pruning.move
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 12 --addresses P0=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module P0::m {
+    public struct Foo has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public struct Wrapper has key, store {
+        id: UID,
+        foo: Foo,
+    }
+
+    public fun create_foo(ctx: &mut TxContext): Foo {
+        Foo { id: object::new(ctx), value: 0 }
+    }
+
+    public fun mutate_foo(foo: &mut Foo) {
+        foo.value = foo.value + 1;
+    }
+
+    public fun wrap_foo(foo: Foo, ctx: &mut TxContext): Wrapper {
+        Wrapper { id: object::new(ctx), foo }
+    }
+
+    public fun unwrap_foo(w: Wrapper): Foo {
+        let Wrapper { id, foo } = w;
+        object::delete(id);
+        foo
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: P0::m::create_foo();
+//> TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs @A object(2,0)
+//> 0: P0::m::wrap_foo(Input(1));
+//> TransferObjects([Result(0)], Input(0))
+
+//# transfer-object 4,0 --sender A --recipient A
+
+//# transfer-object 4,0 --sender A --recipient A
+
+//# transfer-object 4,0 --sender A --recipient A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# programmable --sender A --inputs @A object(4,0)
+//> 0: P0::m::unwrap_foo(Input(1));
+//> TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(2,0)
+//> 0: P0::m::mutate_foo(Input(0));
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql
+{
+  real_tombstone_v3: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 3}]}) {
+    nodes { status version }
+  }
+  lamport_v6: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 6}]}) {
+    nodes { status version }
+  }
+  previous_active_v7: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 7}]}) {
+    nodes { status version }
+  }
+  current_active_v8: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 8}]}) {
+    nodes { status version }
+  }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: P0::m::create_foo();
+//> TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# programmable --sender A --inputs @A
+//> 0: P0::m::create_foo();
+//> TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql --wait-for-checkpoint-pruned 4
+{
+  real_tombstone_v3: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 3}]}) {
+    nodes { status version }
+  }
+  lamport_v6: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 6}]}) {
+    nodes { status version }
+  }
+  previous_active_v7: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 7}]}) {
+    nodes { status version }
+  }
+  current_active_v8: objects(filter: {objectKeys: [{objectId: "@{obj_2_0}", version: 8}]}) {
+    nodes { status version }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/backward_history_pruning.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/backward_history_pruning.snap
@@ -1,0 +1,179 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 23 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-35:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6315600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 37-39:
+//# programmable --sender A --inputs @A
+//> 0: P0::m::create_foo();
+//> TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 41:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 43-45:
+//# programmable --sender A --inputs @A object(2,0)
+//> 0: P0::m::wrap_foo(Input(1));
+//> TransferObjects([Result(0)], Input(0))
+created: object(4,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2530800,  storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 5, line 47:
+//# transfer-object 4,0 --sender A --recipient A
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2530800,  storage_rebate: 2530800, non_refundable_storage_fee: 0
+
+task 6, line 49:
+//# transfer-object 4,0 --sender A --recipient A
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2530800,  storage_rebate: 2530800, non_refundable_storage_fee: 0
+
+task 7, line 51:
+//# transfer-object 4,0 --sender A --recipient A
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2530800,  storage_rebate: 2530800, non_refundable_storage_fee: 0
+
+task 8, line 53:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, line 55:
+//# advance-epoch
+Epoch advanced: 0
+
+task 10, lines 57-59:
+//# programmable --sender A --inputs @A object(4,0)
+//> 0: P0::m::unwrap_foo(Input(1));
+//> TransferObjects([Result(0)], Input(0))
+mutated: object(0,0)
+unwrapped: object(2,0)
+deleted: object(4,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200,  storage_rebate: 2530800, non_refundable_storage_fee: 0
+
+task 11, line 61:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 12, lines 63-64:
+//# programmable --sender A --inputs object(2,0)
+//> 0: P0::m::mutate_foo(Input(0));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200,  storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 13, line 66:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 14, line 68:
+//# advance-epoch
+Epoch advanced: 1
+
+task 15, lines 70-84:
+//# run-graphql
+Response: {
+  "data": {
+    "current_active_v8": {
+      "nodes": [
+        {
+          "status": "INDEXED",
+          "version": 8
+        }
+      ]
+    },
+    "lamport_v6": {
+      "nodes": [
+        {
+          "status": "WRAPPED_OR_DELETED",
+          "version": 3
+        }
+      ]
+    },
+    "previous_active_v7": {
+      "nodes": [
+        {
+          "status": "INDEXED",
+          "version": 7
+        }
+      ]
+    },
+    "real_tombstone_v3": {
+      "nodes": [
+        {
+          "status": "WRAPPED_OR_DELETED",
+          "version": 3
+        }
+      ]
+    }
+  }
+}
+
+task 16, lines 86-88:
+//# programmable --sender A --inputs @A
+//> 0: P0::m::create_foo();
+//> TransferObjects([Result(0)], Input(0))
+created: object(16,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200,  storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 17, line 90:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 18, line 92:
+//# advance-epoch
+Epoch advanced: 2
+
+task 19, lines 94-96:
+//# programmable --sender A --inputs @A
+//> 0: P0::m::create_foo();
+//> TransferObjects([Result(0)], Input(0))
+created: object(19,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200,  storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 20, line 98:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 21, line 100:
+//# advance-epoch
+Epoch advanced: 3
+
+task 22, lines 102-116:
+//# run-graphql --wait-for-checkpoint-pruned 4
+Response: {
+  "data": {
+    "current_active_v8": {
+      "nodes": [
+        {
+          "status": "INDEXED",
+          "version": 8
+        }
+      ]
+    },
+    "lamport_v6": {
+      "nodes": []
+    },
+    "previous_active_v7": {
+      "nodes": []
+    },
+    "real_tombstone_v3": {
+      "nodes": []
+    }
+  }
+}

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -101,6 +101,7 @@ pub enum PrunableTable {
     Checkpoints,
     PrunerCpWatermark,
     OptimisticTransactions,
+    ObjectsBackwardHistory,
 }
 
 /// Represents how a table is pruned
@@ -114,6 +115,10 @@ pub enum PruningStrategy {
     ByTransaction,
     /// Delete rows by global sequence number
     ByGlobalSeq,
+    /// Delete rows by checkpoint range with a per-statement row limit.
+    /// Used for tables with variable rows per checkpoint (e.g. backward
+    /// history).
+    ByCheckpointWithLimit,
 }
 
 /// Represents a specific chunk of data to be pruned
@@ -127,6 +132,8 @@ enum PruningChunk {
     TransactionRange(u64, u64),
     /// Prune by global_sequence_number range [start..=end] inclusive
     GlobalSeqRange(u64, u64),
+    /// Prune by checkpoint range [start..=end] with row-limited deletes
+    CheckpointRangeWithLimit(u64, u64),
 }
 
 impl PruningChunk {
@@ -138,6 +145,7 @@ impl PruningChunk {
             PruningChunk::CheckpointRange(_, end) => end + 1,
             PruningChunk::TransactionRange(_, end) => end + 1,
             PruningChunk::GlobalSeqRange(_, end) => end + 1,
+            PruningChunk::CheckpointRangeWithLimit(_, end) => end + 1,
         }
     }
 }
@@ -181,6 +189,9 @@ impl PrunableTable {
 
             // Optimistic transactions table - pruned by global sequence number
             PrunableTable::OptimisticTransactions => PruningStrategy::ByGlobalSeq,
+
+            // Backward history - pruned by checkpoint with row limit
+            PrunableTable::ObjectsBackwardHistory => PruningStrategy::ByCheckpointWithLimit,
         }
     }
 }
@@ -370,6 +381,21 @@ impl<'a> TablePruner<'a> {
                         }),
                 )
             }
+            PruningStrategy::ByCheckpointWithLimit => {
+                let range_end = min_available_cp;
+                info!(
+                    "pruning table {} in checkpoint range (with limit): [{lowest_unpruned_key}..{range_end})",
+                    self.table.as_ref()
+                );
+                Box::new(
+                    (lowest_unpruned_key..range_end)
+                        .step_by(MAX_CHECKPOINTS_PER_PRUNE_BATCH as usize)
+                        .map(move |start| {
+                            let end = (start + MAX_CHECKPOINTS_PER_PRUNE_BATCH).min(range_end);
+                            PruningChunk::CheckpointRangeWithLimit(start, end - 1)
+                        }),
+                )
+            }
         }
     }
 
@@ -462,6 +488,10 @@ impl<'a> TablePruner<'a> {
             PruningChunk::GlobalSeqRange(start, end) => {
                 self.prune_by_global_seq_with_limit(start, end).await?;
             }
+
+            PruningChunk::CheckpointRangeWithLimit(start, end) => {
+                self.prune_by_checkpoint_with_limit(start, end).await?;
+            }
         }
         Ok(())
     }
@@ -498,6 +528,42 @@ impl<'a> TablePruner<'a> {
             );
 
             // Brief pause between batches
+            tokio::time::sleep(DELAY_BETWEEN_PRUNING_CHUNKS).await;
+        }
+        Ok(())
+    }
+
+    /// Prune table by checkpoint range with row-limited deletes.
+    /// Keeps deleting batches until no more rows remain in the range.
+    async fn prune_by_checkpoint_with_limit(
+        &self,
+        start: u64,
+        end: u64,
+    ) -> Result<(), IndexerError> {
+        loop {
+            let deleted = self
+                .store
+                .prune_table_by_checkpoint_with_limit(
+                    &self.table,
+                    start,
+                    end,
+                    MAX_CHECKPOINTS_PER_PRUNE_BATCH as i64,
+                )
+                .await?;
+
+            if deleted < MAX_CHECKPOINTS_PER_PRUNE_BATCH as usize {
+                info!(
+                    "finished pruning table {} for checkpoint range [{start}..={end}]",
+                    self.table.as_ref(),
+                );
+                break;
+            }
+
+            info!(
+                "pruned {deleted} rows from table {} (checkpoint range [{start}..={end}])",
+                self.table.as_ref(),
+            );
+
             tokio::time::sleep(DELAY_BETWEEN_PRUNING_CHUNKS).await;
         }
         Ok(())

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -186,6 +186,14 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         limit: i64,
     ) -> Result<usize, IndexerError>;
 
+    async fn prune_table_by_checkpoint_with_limit(
+        &self,
+        table: &PrunableTable,
+        start: u64,
+        end: u64,
+        limit: i64,
+    ) -> Result<usize, IndexerError>;
+
     async fn update_watermark_lowest_unpruned_key(
         &self,
         table: &PrunableTable,

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1553,6 +1553,48 @@ impl PgIndexerStore {
         )
     }
 
+    fn prune_backward_history_by_checkpoint_with_limit(
+        &self,
+        start: u64,
+        end: u64,
+        limit: i64,
+    ) -> Result<usize, IndexerError> {
+        use diesel::prelude::*;
+
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                let sql = r#"
+                    WITH to_delete AS (
+                        SELECT superseded_at_checkpoint, object_id, object_version
+                        FROM objects_backward_history
+                        WHERE superseded_at_checkpoint BETWEEN $1 AND $2
+                        ORDER BY superseded_at_checkpoint, object_id, object_version
+                        FOR UPDATE
+                        LIMIT $3
+                    )
+                    DELETE FROM objects_backward_history bh
+                    USING to_delete
+                    WHERE (bh.superseded_at_checkpoint, bh.object_id, bh.object_version) =
+                          (to_delete.superseded_at_checkpoint, to_delete.object_id, to_delete.object_version)
+                "#;
+                diesel::sql_query(sql)
+                    .bind::<diesel::sql_types::BigInt, _>(start as i64)
+                    .bind::<diesel::sql_types::BigInt, _>(end as i64)
+                    .bind::<diesel::sql_types::BigInt, _>(limit)
+                    .execute(conn)
+                    .map_err(IndexerError::from)
+                    .context(
+                        format!(
+                            "failed to prune objects_backward_history by checkpoint range [{start}..={end}] with limit {limit}"
+                        )
+                        .as_str(),
+                    )
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+    }
+
     fn prune_cp_tx_table_by_range(&self, min_cp: u64, max_cp: u64) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
@@ -2599,6 +2641,28 @@ impl IndexerStore for PgIndexerStore {
 
         self.execute_in_blocking_worker(move |this| {
             this.prune_optimistic_tx_by_global_seq(start, end, limit)
+        })
+        .await
+    }
+
+    async fn prune_table_by_checkpoint_with_limit(
+        &self,
+        table: &crate::pruning::pruner::PrunableTable,
+        start: u64,
+        end: u64,
+        limit: i64,
+    ) -> Result<usize, IndexerError> {
+        use crate::pruning::pruner::PrunableTable;
+
+        if !matches!(table, PrunableTable::ObjectsBackwardHistory) {
+            return Err(IndexerError::InvalidArgument(format!(
+                "table {} does not support pruning by checkpoint with limit",
+                table.as_ref()
+            )));
+        }
+
+        self.execute_in_blocking_worker(move |this| {
+            this.prune_backward_history_by_checkpoint_with_limit(start, end, limit)
         })
         .await
     }


### PR DESCRIPTION
# Description of change

Add pruning support for `objects_backward_history`.

**New `ByCheckpointWithLimit` pruning strategy:**
- Deletes by `superseded_at_checkpoint` range with a per-statement row limit via a CTE with `FOR UPDATE LIMIT`, same pattern as `optimistic_transactions` pruning
- Handles variable batch sizes — a single checkpoint range can contain many rows depending on traffic, unlike `checkpoints`/`pruner_cp_watermark` which have O(1) rows per checkpoint
- The pruner loop repeats row-limited deletes until the range is fully pruned, with pauses between batches

**Changes:**
- `ObjectsBackwardHistory` added to `PrunableTable` enum
- `ByCheckpointWithLimit` strategy + `CheckpointRangeWithLimit` chunk variant
- Row-limited delete function in `pg_indexer_store.rs`

**E2e test (`backward_history_pruning`):** queries 4 object versions via `objectKeys` before and after pruning — real tombstone (v3), lamport-1 tombstone (v6), previous active from backward history (v7), current active from checkpointed_objects (v8). Verifies all 4 are findable before pruning, and only the current active survives after.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11168

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
    - `backward_history_pruning`: e2e test with `--epochs-to-keep 1`, verifies objectKeys behavior before and after pruning
    - Benchmarked DELETE performance with EXPLAIN ANALYZE on 1M row table

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
