### PR TITLE
feat(iota-core): Post consensus load shedding

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1205,25 +1205,25 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_max_transaction_manager_queue_length")]
     pub max_transaction_manager_queue_length: usize,
 
-    /// Inflight execution queue length at which graduated load shedding begins
-    /// in the certificate-less (white-flag) mode. Defaults to
-    /// `max_transaction_manager_queue_length / 2`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_transaction_manager_queue_length_soft_limit: Option<usize>,
-
     /// Reject a transaction if the number of pending transactions depending on
     /// the object is above the threshold.
     #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
     pub max_transaction_manager_per_object_queue_length: usize,
+
+    /// Inflight execution queue length at which graduated load shedding begins
+    /// in the certificate-less (white-flag) mode. Defaults to
+    /// `max_transaction_manager_queue_length / 2`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_transaction_manager_queue_length_soft_limit_pct: Option<u32>,
 }
 
 impl AuthorityOverloadConfig {
-    /// Returns the inflight execution queue length at which graduated load
-    /// shedding begins in the certificate-less (white-flag) mode. Defaults
-    /// to `max_transaction_manager_queue_length / 2`.
-    pub fn max_transaction_manager_queue_length_soft_limit(&self) -> usize {
-        self.max_transaction_manager_queue_length_soft_limit
-            .unwrap_or(self.max_transaction_manager_queue_length / 2)
+    /// Returns the percentage of the max queue length at which graduated load
+    /// shedding should start.
+    pub fn max_transaction_manager_queue_length_soft_limit_pct(&self) -> u32 {
+        self.max_transaction_manager_queue_length_soft_limit_pct
+            .unwrap_or(50)
+            .min(100)
     }
 }
 
@@ -1281,7 +1281,7 @@ impl Default for AuthorityOverloadConfig {
             check_system_overload_at_signing: true,
             check_system_overload_at_execution: false,
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
-            max_transaction_manager_queue_length_soft_limit: None,
+            max_transaction_manager_queue_length_soft_limit_pct: None,
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
         }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -517,10 +517,12 @@ pub struct WritebackCacheConfig {
     pub backpressure_threshold_for_rpc: Option<u64>, // defaults to backpressure_threshold
 
     /// Percentage of `backpressure_threshold` at which graduated load shedding
-    /// based on writeback-cache pending transaction count begins. Sheds
-    /// linearly from 0% to 100% between
-    /// `backpressure_threshold * backpressure_soft_limit_pct / 100` and
-    /// `backpressure_threshold`. Defaults to 50.
+    /// based on writeback-cache pending transaction count begins. The
+    /// locally-calculated shedding percentage increases linearly from 0% at
+    /// `backpressure_threshold * backpressure_soft_limit_pct / 100` up to
+    /// 100% at the `backpressure_threshold` if the cache size continues to
+    /// increase. The calculated shedding percentage is broadcast to other
+    /// validators for a coordinated response. Defaults to 50.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backpressure_soft_limit_pct: Option<u32>,
 }
@@ -1283,19 +1285,18 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
     pub max_transaction_manager_per_object_queue_length: usize,
 
-    /// Inflight execution queue length at which graduated load shedding begins
-    /// in the certificate-less (white-flag) mode. Defaults to
-    /// `max_transaction_manager_queue_length / 2`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_transaction_manager_queue_length_soft_limit_pct: Option<u32>,
+    /// Percentage of `max_transaction_manager_queue_length` at which graduated
+    /// load shedding begins in the certificate-less (white-flag) mode. Read
+    /// via the same-named accessor, which clamps the value to <=100.
+    #[serde(default = "default_max_transaction_manager_queue_length_soft_limit_pct")]
+    pub max_transaction_manager_queue_length_soft_limit_pct: u32,
 }
 
 impl AuthorityOverloadConfig {
-    /// Returns the percentage of the max queue length at which graduated load
-    /// shedding should start.
+    /// Returns the soft-limit percentage, clamped to <=100 to guard against
+    /// out-of-range operator-supplied values.
     pub fn max_transaction_manager_queue_length_soft_limit_pct(&self) -> u32 {
         self.max_transaction_manager_queue_length_soft_limit_pct
-            .unwrap_or(50)
             .min(100)
     }
 }
@@ -1336,6 +1337,10 @@ fn default_max_transaction_manager_queue_length() -> usize {
     100_000
 }
 
+fn default_max_transaction_manager_queue_length_soft_limit_pct() -> u32 {
+    50
+}
+
 fn default_max_transaction_manager_per_object_queue_length() -> usize {
     20
 }
@@ -1354,7 +1359,8 @@ impl Default for AuthorityOverloadConfig {
             check_system_overload_at_signing: true,
             check_system_overload_at_execution: false,
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
-            max_transaction_manager_queue_length_soft_limit_pct: None,
+            max_transaction_manager_queue_length_soft_limit_pct:
+                default_max_transaction_manager_queue_length_soft_limit_pct(),
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
         }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -515,6 +515,14 @@ pub struct WritebackCacheConfig {
     /// if unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backpressure_threshold_for_rpc: Option<u64>, // defaults to backpressure_threshold
+
+    /// Percentage of `backpressure_threshold` at which graduated load shedding
+    /// based on writeback-cache pending transaction count begins. Sheds
+    /// linearly from 0% to 100% between
+    /// `backpressure_threshold * backpressure_soft_limit_pct / 100` and
+    /// `backpressure_threshold`. Defaults to 50.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backpressure_soft_limit_pct: Option<u32>,
 }
 
 impl WritebackCacheConfig {
@@ -612,6 +620,15 @@ impl WritebackCacheConfig {
             .and_then(|s| s.parse().ok())
             .or(self.backpressure_threshold_for_rpc)
             .unwrap_or(self.backpressure_threshold())
+    }
+
+    pub fn backpressure_soft_limit_pct(&self) -> u32 {
+        std::env::var("IOTA_CACHE_WRITEBACK_BACKPRESSURE_SOFT_LIMIT_PCT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .or(self.backpressure_soft_limit_pct)
+            .unwrap_or(50)
+            .min(100)
     }
 }
 

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1205,10 +1205,26 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_max_transaction_manager_queue_length")]
     pub max_transaction_manager_queue_length: usize,
 
+    /// Inflight execution queue length at which graduated load shedding begins
+    /// in the certificate-less (white-flag) mode. Defaults to
+    /// `max_transaction_manager_queue_length / 2`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_transaction_manager_queue_length_soft_limit: Option<usize>,
+
     /// Reject a transaction if the number of pending transactions depending on
     /// the object is above the threshold.
     #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
     pub max_transaction_manager_per_object_queue_length: usize,
+}
+
+impl AuthorityOverloadConfig {
+    /// Returns the inflight execution queue length at which graduated load
+    /// shedding begins in the certificate-less (white-flag) mode. Defaults
+    /// to `max_transaction_manager_queue_length / 2`.
+    pub fn max_transaction_manager_queue_length_soft_limit(&self) -> usize {
+        self.max_transaction_manager_queue_length_soft_limit
+            .unwrap_or(self.max_transaction_manager_queue_length / 2)
+    }
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
@@ -1265,6 +1281,7 @@ impl Default for AuthorityOverloadConfig {
             check_system_overload_at_signing: true,
             check_system_overload_at_execution: false,
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
+            max_transaction_manager_queue_length_soft_limit: None,
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
         }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -470,10 +470,12 @@ pub struct WritebackCacheConfig {
     pub backpressure_threshold_for_rpc: Option<u64>, // defaults to backpressure_threshold
 
     /// Percentage of `backpressure_threshold` at which graduated load shedding
-    /// based on writeback-cache pending transaction count begins. Sheds
-    /// linearly from 0% to 100% between
-    /// `backpressure_threshold * backpressure_soft_limit_pct / 100` and
-    /// `backpressure_threshold`. Defaults to 50.
+    /// based on writeback-cache pending transaction count begins. The
+    /// locally-calculated shedding percentage increases linearly from 0% at
+    /// `backpressure_threshold * backpressure_soft_limit_pct / 100` up to
+    /// 100% at the `backpressure_threshold` if the cache size continues to
+    /// increase. The calculated shedding percentage is broadcast to other
+    /// validators for a coordinated response. Defaults to 50.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backpressure_soft_limit_pct: Option<u32>,
 }
@@ -1227,19 +1229,18 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
     pub max_transaction_manager_per_object_queue_length: usize,
 
-    /// Inflight execution queue length at which graduated load shedding begins
-    /// in the certificate-less (white-flag) mode. Defaults to
-    /// `max_transaction_manager_queue_length / 2`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_transaction_manager_queue_length_soft_limit_pct: Option<u32>,
+    /// Percentage of `max_transaction_manager_queue_length` at which graduated
+    /// load shedding begins in the certificate-less (white-flag) mode. Read
+    /// via the same-named accessor, which clamps the value to <=100.
+    #[serde(default = "default_max_transaction_manager_queue_length_soft_limit_pct")]
+    pub max_transaction_manager_queue_length_soft_limit_pct: u32,
 }
 
 impl AuthorityOverloadConfig {
-    /// Returns the percentage of the max queue length at which graduated load
-    /// shedding should start.
+    /// Returns the soft-limit percentage, clamped to <=100 to guard against
+    /// out-of-range operator-supplied values.
     pub fn max_transaction_manager_queue_length_soft_limit_pct(&self) -> u32 {
         self.max_transaction_manager_queue_length_soft_limit_pct
-            .unwrap_or(50)
             .min(100)
     }
 }
@@ -1280,6 +1281,10 @@ fn default_max_transaction_manager_queue_length() -> usize {
     100_000
 }
 
+fn default_max_transaction_manager_queue_length_soft_limit_pct() -> u32 {
+    50
+}
+
 fn default_max_transaction_manager_per_object_queue_length() -> usize {
     20
 }
@@ -1298,7 +1303,8 @@ impl Default for AuthorityOverloadConfig {
             check_system_overload_at_signing: true,
             check_system_overload_at_execution: false,
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
-            max_transaction_manager_queue_length_soft_limit_pct: None,
+            max_transaction_manager_queue_length_soft_limit_pct:
+                default_max_transaction_manager_queue_length_soft_limit_pct(),
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
         }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1261,25 +1261,25 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_max_transaction_manager_queue_length")]
     pub max_transaction_manager_queue_length: usize,
 
-    /// Inflight execution queue length at which graduated load shedding begins
-    /// in the certificate-less (white-flag) mode. Defaults to
-    /// `max_transaction_manager_queue_length / 2`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_transaction_manager_queue_length_soft_limit: Option<usize>,
-
     /// Reject a transaction if the number of pending transactions depending on
     /// the object is above the threshold.
     #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
     pub max_transaction_manager_per_object_queue_length: usize,
+
+    /// Inflight execution queue length at which graduated load shedding begins
+    /// in the certificate-less (white-flag) mode. Defaults to
+    /// `max_transaction_manager_queue_length / 2`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_transaction_manager_queue_length_soft_limit_pct: Option<u32>,
 }
 
 impl AuthorityOverloadConfig {
-    /// Returns the inflight execution queue length at which graduated load
-    /// shedding begins in the certificate-less (white-flag) mode. Defaults
-    /// to `max_transaction_manager_queue_length / 2`.
-    pub fn max_transaction_manager_queue_length_soft_limit(&self) -> usize {
-        self.max_transaction_manager_queue_length_soft_limit
-            .unwrap_or(self.max_transaction_manager_queue_length / 2)
+    /// Returns the percentage of the max queue length at which graduated load
+    /// shedding should start.
+    pub fn max_transaction_manager_queue_length_soft_limit_pct(&self) -> u32 {
+        self.max_transaction_manager_queue_length_soft_limit_pct
+            .unwrap_or(50)
+            .min(100)
     }
 }
 
@@ -1337,7 +1337,7 @@ impl Default for AuthorityOverloadConfig {
             check_system_overload_at_signing: true,
             check_system_overload_at_execution: false,
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
-            max_transaction_manager_queue_length_soft_limit: None,
+            max_transaction_manager_queue_length_soft_limit_pct: None,
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
         }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1261,10 +1261,26 @@ pub struct AuthorityOverloadConfig {
     #[serde(default = "default_max_transaction_manager_queue_length")]
     pub max_transaction_manager_queue_length: usize,
 
+    /// Inflight execution queue length at which graduated load shedding begins
+    /// in the certificate-less (white-flag) mode. Defaults to
+    /// `max_transaction_manager_queue_length / 2`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_transaction_manager_queue_length_soft_limit: Option<usize>,
+
     /// Reject a transaction if the number of pending transactions depending on
     /// the object is above the threshold.
     #[serde(default = "default_max_transaction_manager_per_object_queue_length")]
     pub max_transaction_manager_per_object_queue_length: usize,
+}
+
+impl AuthorityOverloadConfig {
+    /// Returns the inflight execution queue length at which graduated load
+    /// shedding begins in the certificate-less (white-flag) mode. Defaults
+    /// to `max_transaction_manager_queue_length / 2`.
+    pub fn max_transaction_manager_queue_length_soft_limit(&self) -> usize {
+        self.max_transaction_manager_queue_length_soft_limit
+            .unwrap_or(self.max_transaction_manager_queue_length / 2)
+    }
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
@@ -1321,6 +1337,7 @@ impl Default for AuthorityOverloadConfig {
             check_system_overload_at_signing: true,
             check_system_overload_at_execution: false,
             max_transaction_manager_queue_length: default_max_transaction_manager_queue_length(),
+            max_transaction_manager_queue_length_soft_limit: None,
             max_transaction_manager_per_object_queue_length:
                 default_max_transaction_manager_per_object_queue_length(),
         }

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -468,6 +468,14 @@ pub struct WritebackCacheConfig {
     /// if unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backpressure_threshold_for_rpc: Option<u64>, // defaults to backpressure_threshold
+
+    /// Percentage of `backpressure_threshold` at which graduated load shedding
+    /// based on writeback-cache pending transaction count begins. Sheds
+    /// linearly from 0% to 100% between
+    /// `backpressure_threshold * backpressure_soft_limit_pct / 100` and
+    /// `backpressure_threshold`. Defaults to 50.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backpressure_soft_limit_pct: Option<u32>,
 }
 
 impl WritebackCacheConfig {
@@ -565,6 +573,15 @@ impl WritebackCacheConfig {
             .and_then(|s| s.parse().ok())
             .or(self.backpressure_threshold_for_rpc)
             .unwrap_or(self.backpressure_threshold())
+    }
+
+    pub fn backpressure_soft_limit_pct(&self) -> u32 {
+        std::env::var("IOTA_CACHE_WRITEBACK_BACKPRESSURE_SOFT_LIMIT_PCT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .or(self.backpressure_soft_limit_pct)
+            .unwrap_or(50)
+            .min(100)
     }
 }
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -297,6 +297,7 @@ pub struct AuthorityMetrics {
     pub(crate) authority_load_shedding_percentage: IntGauge,
     /// Percentage of transactions shed due to consensus queue length.
     pub(crate) consensus_queue_load_shedding_percentage: IntGauge,
+    pub(crate) cache_backpressure_load_shedding_percentage: IntGauge,
 
     pub(crate) transaction_overload_sources: IntCounterVec,
 
@@ -560,6 +561,11 @@ impl AuthorityMetrics {
             consensus_queue_load_shedding_percentage: register_int_gauge_with_registry!(
                 "consensus_queue_load_shedding_percentage",
                 "Percentage of transactions shed due to consensus queue length.",
+                registry)
+                .unwrap(),
+            cache_backpressure_load_shedding_percentage: register_int_gauge_with_registry!(
+                "cache_backpressure_load_shedding_percentage",
+                "Percentage of transactions shed due to writeback-cache backpressure.",
                 registry)
                 .unwrap(),
             transaction_manager_object_cache_misses: register_int_counter_with_registry!(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1245,7 +1245,7 @@ impl AuthorityState {
 
         let load_shedding_percentage = self
             .overload_info
-            .load_shedding_percentage
+            .local_load_shedding_percentage
             .load(Ordering::Relaxed);
         overload_monitor_accept_tx(load_shedding_percentage, tx_data.digest())
     }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -293,6 +293,7 @@ pub struct AuthorityMetrics {
     pub(crate) authority_load_shedding_percentage: IntGauge,
     /// Percentage of transactions shed due to consensus queue length.
     pub(crate) consensus_queue_load_shedding_percentage: IntGauge,
+    pub(crate) cache_backpressure_load_shedding_percentage: IntGauge,
 
     pub(crate) transaction_overload_sources: IntCounterVec,
 
@@ -553,6 +554,11 @@ impl AuthorityMetrics {
             consensus_queue_load_shedding_percentage: register_int_gauge_with_registry!(
                 "consensus_queue_load_shedding_percentage",
                 "Percentage of transactions shed due to consensus queue length.",
+                registry)
+                .unwrap(),
+            cache_backpressure_load_shedding_percentage: register_int_gauge_with_registry!(
+                "cache_backpressure_load_shedding_percentage",
+                "Percentage of transactions shed due to writeback-cache backpressure.",
                 registry)
                 .unwrap(),
             transaction_manager_object_cache_misses: register_int_counter_with_registry!(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -294,10 +294,12 @@ pub struct AuthorityMetrics {
     pub(crate) skipped_consensus_txns_cache_hit: IntCounter,
 
     pub(crate) authority_overload_status: IntGauge,
-    pub(crate) authority_load_shedding_percentage: IntGauge,
     /// Percentage of transactions shed due to consensus queue length.
     pub(crate) consensus_queue_load_shedding_percentage: IntGauge,
-    pub(crate) cache_backpressure_load_shedding_percentage: IntGauge,
+    /// This authority's locally computed load shedding percentage, taken as the
+    /// max of its latency/rate-based, transaction-manager-queue-based, and
+    /// writeback-cache-backpressure signals.
+    pub(crate) local_post_consensus_load_shedding_percentage: IntGauge,
 
     pub(crate) transaction_overload_sources: IntCounterVec,
 
@@ -315,7 +317,20 @@ pub struct AuthorityMetrics {
     pub consensus_handler_deferred_transactions: IntCounter,
     pub consensus_handler_congested_transactions: IntCounter,
     pub consensus_handler_cancelled_transactions: IntCounter,
+    /// Number of user transactions dropped during a consensus commit because
+    /// post-consensus conflict/lock validation rejected them. Distinct from
+    /// `consensus_handler_load_shedding_dropped_transactions`.
     pub consensus_handler_validation_dropped_transactions: IntCounter,
+    /// Number of user transactions dropped during a consensus commit by
+    /// post-consensus load shedding, i.e. probabilistically rejected at the
+    /// quorum `consensus_handler_load_shedding_percentage` rate.
+    pub consensus_handler_load_shedding_dropped_transactions: IntCounter,
+    /// Stake-weighted quorum (2f+1) load shedding percentage enforced on user
+    /// transactions in the most recent consensus commit. This is the cluster
+    /// value actually applied post-consensus, as opposed to this authority's
+    /// own `authority_load_shedding_percentage`. 0 when the white-flag flow is
+    /// disabled.
+    pub consensus_handler_load_shedding_percentage: IntGauge,
     pub consensus_handler_max_object_costs: IntGaugeVec,
     pub consensus_committed_subdags: IntCounterVec,
     pub consensus_committed_messages: IntGaugeVec,
@@ -553,19 +568,14 @@ impl AuthorityMetrics {
                 "Whether authority is current experiencing overload and enters load shedding mode.",
                 registry)
                 .unwrap(),
-            authority_load_shedding_percentage: register_int_gauge_with_registry!(
+            local_post_consensus_load_shedding_percentage: register_int_gauge_with_registry!(
                 "authority_load_shedding_percentage",
-                "The percentage of transactions is shed when the authority is in load shedding mode.",
+                "This authority's locally computed load shedding percentage. In the white-flag flow this is the value broadcast to peers, not necessarily the rate enforced (see consensus_handler_load_shedding_percentage).",
                 registry)
                 .unwrap(),
             consensus_queue_load_shedding_percentage: register_int_gauge_with_registry!(
                 "consensus_queue_load_shedding_percentage",
-                "Percentage of transactions shed due to consensus queue length.",
-                registry)
-                .unwrap(),
-            cache_backpressure_load_shedding_percentage: register_int_gauge_with_registry!(
-                "cache_backpressure_load_shedding_percentage",
-                "Percentage of transactions shed due to writeback-cache backpressure.",
+                "Percentage of transactions shed due to consensus queue length. Separate admission-control signal, not an input to authority_load_shedding_percentage.",
                 registry)
                 .unwrap(),
             transaction_manager_object_cache_misses: register_int_counter_with_registry!(
@@ -740,6 +750,16 @@ impl AuthorityMetrics {
             consensus_handler_validation_dropped_transactions: register_int_counter_with_registry!(
                 "consensus_handler_validation_dropped_transactions",
                 "Number of UserTransactionV1 transactions dropped by post-consensus validation",
+                registry,
+            ).unwrap(),
+            consensus_handler_load_shedding_dropped_transactions: register_int_counter_with_registry!(
+                "consensus_handler_load_shedding_dropped_transactions",
+                "Number of user transactions dropped by post-consensus load shedding, based on the quorum load shedding percentage",
+                registry,
+            ).unwrap(),
+            consensus_handler_load_shedding_percentage: register_int_gauge_with_registry!(
+                "consensus_handler_load_shedding_percentage",
+                "Stake-weighted quorum (2f+1) load shedding percentage enforced on user transactions in the most recent consensus commit. 0 when the white-flag flow is disabled.",
                 registry,
             ).unwrap(),
             consensus_handler_max_object_costs: register_int_gauge_vec_with_registry!(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1308,7 +1308,7 @@ impl AuthorityState {
 
         let load_shedding_percentage = self
             .overload_info
-            .load_shedding_percentage
+            .local_load_shedding_percentage
             .load(Ordering::Relaxed);
         overload_monitor_accept_tx(load_shedding_percentage, tx_data.digest())
     }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2842,13 +2842,23 @@ impl AuthorityPerEpochStore {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    /// Loads the persisted overload notifications keyed by authority.
+    /// Loads the current overload notifications keyed by authority. Reads the
+    /// persisted `authority_overload_notifications` DBMap, then overlays every
+    /// queued (processed-but-not-yet-flushed) `ConsensusCommitOutput`'s
+    /// notifications on top. Without the overlay, the read would lag behind
+    /// the logical state by however many commits are sitting in
+    /// `ConsensusOutputQuarantine::output_queue` waiting for the checkpoint
+    /// builder to catch up.
     pub(crate) fn load_overload_notifications(&self) -> IotaResult<HashMap<AuthorityName, u8>> {
-        Ok(self
+        let mut notifications: HashMap<AuthorityName, u8> = self
             .tables()?
             .authority_overload_notifications
             .safe_iter()
-            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?)
+            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?;
+        self.consensus_quarantine
+            .read()
+            .overlay_queued_overload_notifications(&mut notifications);
+        Ok(notifications)
     }
 
     /// Computes the stake-weighted 2f+1 percentile of load shedding percentages

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3350,6 +3350,12 @@ impl AuthorityPerEpochStore {
             .set(drop_percentage as i64);
         let drop_seed = consensus_commit_info.round;
 
+        // Transactions dropped by post-consensus load shedding in this commit.
+        // Fed to `dropped_tx_status_cache.insert_and_notify` after the loop so
+        // the submitter's `await_consensus_or_checkpoint` wait is woken and its
+        // consensus-submission semaphore slot is released.
+        let mut load_shedding_dropped: Vec<(TransactionDigest, IotaError)> = Vec::new();
+
         for tx in verified_transactions {
             if tx.0.is_end_of_publish() {
                 end_of_publish_transactions.push(tx);
@@ -3363,6 +3369,14 @@ impl AuthorityPerEpochStore {
                             authority_metrics
                                 .consensus_handler_load_shedding_dropped_transactions
                                 .inc();
+                            // The retry-after hint matches the pre-consensus
+                            // load-shedding window in `overload_monitor.rs`.
+                            load_shedding_dropped.push((
+                                digest,
+                                IotaError::ValidatorOverloadedRetryAfter {
+                                    retry_after_secs: 30,
+                                },
+                            ));
                             continue;
                         }
                     }
@@ -3376,12 +3390,24 @@ impl AuthorityPerEpochStore {
                             authority_metrics
                                 .consensus_handler_load_shedding_dropped_transactions
                                 .inc();
+                            // The retry-after hint matches the pre-consensus
+                            // load-shedding window in `overload_monitor.rs`.
+                            load_shedding_dropped.push((
+                                digest,
+                                IotaError::ValidatorOverloadedRetryAfter {
+                                    retry_after_secs: 30,
+                                },
+                            ));
                             continue;
                         }
                     }
                 }
                 current_commit_sequenced_consensus_transactions.push(tx);
             }
+        }
+        if !load_shedding_dropped.is_empty() {
+            self.dropped_tx_status_cache
+                .insert_and_notify(&load_shedding_dropped);
         }
 
         let mut output = ConsensusCommitOutput::new(consensus_commit_info.round);

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -5,7 +5,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     future::Future,
-    hash::Hasher as _,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -78,7 +77,6 @@ use tap::TapOptional;
 use tokio::{sync::OnceCell, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
-use twox_hash::XxHash64;
 use typed_store::{
     DBMapUtils, Map,
     rocks::{
@@ -130,6 +128,7 @@ use crate::{
     execution_cache::{ObjectCacheRead, TransactionCacheRead, cache_types::CacheResult},
     fallback_fetch::do_fallback_lookup,
     module_cache_metrics::ResolverMetrics,
+    overload_monitor::should_reject_tx,
     post_consensus_tx_reorder::PostConsensusTxReorder,
     post_consensus_validation,
     signature_verifier::*,
@@ -3306,7 +3305,7 @@ impl AuthorityPerEpochStore {
         // Post-consensus load shedding: compute the drop percentage once before
         // the loop so user transactions can be dropped inline during categorization.
         let drop_percentage = if enable_white_flag {
-            self.get_quorum_load_shedding_percentage()? as u64
+            self.get_quorum_load_shedding_percentage()? as u32
         } else {
             0
         };
@@ -3322,10 +3321,7 @@ impl AuthorityPerEpochStore {
                 // quorum load shedding percentage.
                 if drop_percentage > 0 {
                     if let Some(digest) = tx.0.transaction.executable_transaction_digest() {
-                        let mut hasher = XxHash64::with_seed(drop_seed);
-                        hasher.write(digest.inner());
-                        let hash = hasher.finish();
-                        if hash % 100 < drop_percentage {
+                        if should_reject_tx(drop_percentage, digest, drop_seed) {
                             continue;
                         }
                     }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2842,36 +2842,8 @@ impl AuthorityPerEpochStore {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    pub fn record_overload_notification_v1(
-        &self,
-        authority: &AuthorityName,
-        percentage: u8,
-    ) -> IotaResult {
-        info!(
-            "received overload notification v1 from {:?}: {}%",
-            authority.concise(),
-            percentage
-        );
-        self.tables()?
-            .authority_overload_notifications
-            .insert(authority, &percentage)?;
-        Ok(())
-    }
-
-    pub fn get_overload_notification_v1(
-        &self,
-        authority: &AuthorityName,
-    ) -> IotaResult<Option<u8>> {
-        Ok(self
-            .tables()?
-            .authority_overload_notifications
-            .get(authority)?)
-    }
-
     /// Loads the persisted overload notifications keyed by authority.
-    pub(crate) fn load_overload_notifications(
-        &self,
-    ) -> IotaResult<HashMap<AuthorityName, u8>> {
+    pub(crate) fn load_overload_notifications(&self) -> IotaResult<HashMap<AuthorityName, u8>> {
         Ok(self
             .tables()?
             .authority_overload_notifications
@@ -3321,12 +3293,13 @@ impl AuthorityPerEpochStore {
 
         // Post-consensus load shedding: compute the drop percentage once before
         // the loop so user transactions can be dropped inline during categorization.
-        // OverloadNotificationV1 transactions in this same commit batch are
-        // overlaid on top of the persisted notifications so user txs in the
-        // batch are dropped using the latest load shedding percentage rather
-        // than the previous round's value. The actual DB write still happens
-        // later inside `process_consensus_transactions` and is gated by
-        // `should_accept_consensus_certs`; this overlay mirrors that gate.
+        // `OverloadNotificationV1` transactions from this commit are layered on
+        // top of the persisted notifications now to ensure immediate response to new
+        // notifications which are not yet registered in persistent storage rather than
+        // the previous round's values. The recorder call inside
+        // `process_consensus_transactions` is gated by
+        // `should_accept_consensus_certs`; this overlay mirrors that gate so
+        // the overlaid set matches the set that will be flushed.
         let drop_percentage = if enable_white_flag {
             let mut notifications = self.load_overload_notifications()?;
             if self
@@ -3335,7 +3308,8 @@ impl AuthorityPerEpochStore {
             {
                 for tx in &verified_transactions {
                     if let SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                        kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                        kind:
+                            ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
                         ..
                     }) = &tx.0.transaction
                     {
@@ -4793,7 +4767,7 @@ impl AuthorityPerEpochStore {
                         authority.concise(),
                         percentage
                     );
-                    self.record_overload_notification_v1(authority, *percentage)?;
+                    output.record_overload_notification(*authority, *percentage);
                 } else {
                     debug!(
                         "Ignoring OverloadNotificationV1 from {:?} because of end of epoch",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -35,7 +35,7 @@ use iota_types::{
         AuthorityName, CommitRound, ConciseableName, EpochId, ObjectID, ObjectRef, SequenceNumber,
         TransactionDigest,
     },
-    committee::{Committee, CommitteeTrait},
+    committee::{Committee, CommitteeTrait, StakeUnit},
     crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo, RandomnessRound},
     digests::{ChainIdentifier, TransactionEffectsDigest},
     effects::TransactionEffects,
@@ -2736,6 +2736,48 @@ impl AuthorityPerEpochStore {
             .tables()?
             .authority_overload_notifications
             .get(authority)?)
+    }
+
+    /// Computes the stake-weighted 2f+1 percentile of load shedding percentages
+    /// received via OverloadNotificationV1 consensus transactions. Authorities
+    /// that have not sent a notification are assumed to have a percentage of 0.
+    pub fn get_quorum_load_shedding_percentage(&self) -> IotaResult<u8> {
+        let notifications = self
+            .tables()?
+            .authority_overload_notifications
+            .safe_iter()
+            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?;
+
+        let committee = self.committee();
+
+        // Build a vec of (percentage, stake) for every committee member.
+        // Default to 0% for authorities that haven't reported.
+        let mut weighted_values: Vec<(u8, StakeUnit)> = committee
+            .members()
+            .map(|(authority, stake)| {
+                let percentage = notifications.get(authority).copied().unwrap_or(0);
+                (percentage, *stake)
+            })
+            .collect();
+
+        // Sort ascending by percentage.
+        weighted_values.sort_by_key(|(percentage, _)| *percentage);
+
+        // Walk from lowest to highest, accumulating stake. The value where
+        // cumulative stake first reaches the quorum threshold (2f+1) is the result.
+        let quorum_threshold = committee.quorum_threshold();
+        let mut accumulated_stake: StakeUnit = 0;
+
+        for (percentage, stake) in weighted_values {
+            accumulated_stake += stake;
+            if accumulated_stake >= quorum_threshold {
+                return Ok(percentage);
+            }
+        }
+
+        // Unreachable with a valid committee (total stake >= quorum threshold),
+        // but return 0 as a safe fallback.
+        Ok(0)
     }
 
     pub fn get_quarantined_owned_object_lock(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -39,7 +39,7 @@ use iota_types::{
         AuthorityName, CommitRound, ConciseableName, EpochId, ObjectRef, SequenceNumber,
         TransactionDigest,
     },
-    committee::{Committee, CommitteeTrait},
+    committee::{Committee, CommitteeTrait, StakeUnit},
     crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo, RandomnessRound},
     digests::{ChainIdentifier, TransactionEffectsDigest},
     effects::TransactionEffects,
@@ -2865,6 +2865,48 @@ impl AuthorityPerEpochStore {
             .tables()?
             .authority_overload_notifications
             .get(authority)?)
+    }
+
+    /// Computes the stake-weighted 2f+1 percentile of load shedding percentages
+    /// received via OverloadNotificationV1 consensus transactions. Authorities
+    /// that have not sent a notification are assumed to have a percentage of 0.
+    pub fn get_quorum_load_shedding_percentage(&self) -> IotaResult<u8> {
+        let notifications = self
+            .tables()?
+            .authority_overload_notifications
+            .safe_iter()
+            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?;
+
+        let committee = self.committee();
+
+        // Build a vec of (percentage, stake) for every committee member.
+        // Default to 0% for authorities that haven't reported.
+        let mut weighted_values: Vec<(u8, StakeUnit)> = committee
+            .members()
+            .map(|(authority, stake)| {
+                let percentage = notifications.get(authority).copied().unwrap_or(0);
+                (percentage, *stake)
+            })
+            .collect();
+
+        // Sort ascending by percentage.
+        weighted_values.sort_by_key(|(percentage, _)| *percentage);
+
+        // Walk from lowest to highest, accumulating stake. The value where
+        // cumulative stake first reaches the quorum threshold (2f+1) is the result.
+        let quorum_threshold = committee.quorum_threshold();
+        let mut accumulated_stake: StakeUnit = 0;
+
+        for (percentage, stake) in weighted_values {
+            accumulated_stake += stake;
+            if accumulated_stake >= quorum_threshold {
+                return Ok(percentage);
+            }
+        }
+
+        // Unreachable with a valid committee (total stake >= quorum threshold),
+        // but return 0 as a safe fallback.
+        Ok(0)
     }
 
     pub fn get_quarantined_owned_object_lock(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3182,10 +3182,12 @@ impl AuthorityPerEpochStore {
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
             } else {
-                // For user transactions, deterministically drop based on the
-                // quorum load shedding percentage.
+                // Only user-originated transactions are eligible for load shedding;
+                // internal consensus messages (checkpoint signatures, capability
+                // notifications, randomness DKG, overload notifications, etc.) must
+                // never be dropped here.
                 if drop_percentage > 0 {
-                    if let Some(digest) = tx.0.transaction.executable_transaction_digest() {
+                    if let Some(digest) = tx.0.transaction.user_transaction_digest() {
                         if should_reject_tx(drop_percentage, digest, drop_seed) {
                             continue;
                         }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -828,6 +828,13 @@ pub struct AuthorityEpochTables {
     /// Record of the capabilities advertised by each authority.
     authority_capabilities_v1: DBMap<AuthorityName, AuthorityCapabilitiesV1>,
 
+    /// Record of the latest load shedding percentage from each authority,
+    /// received via OverloadNotificationV1 consensus transactions. Keyed by
+    /// AuthorityName, value is the most recently reported percentage
+    /// (0-100). Overwrites on each new notification from the same
+    /// authority.
+    authority_overload_notifications: DBMap<AuthorityName, u8>,
+
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
     override_protocol_upgrade_buffer_stake: DBMap<u64, u64>,
@@ -2705,6 +2712,32 @@ impl AuthorityPerEpochStore {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
+    pub fn record_overload_notification_v1(
+        &self,
+        authority: &AuthorityName,
+        percentage: u8,
+    ) -> IotaResult {
+        info!(
+            "received overload notification v1 from {:?}: {}%",
+            authority.concise(),
+            percentage
+        );
+        self.tables()?
+            .authority_overload_notifications
+            .insert(authority, &percentage)?;
+        Ok(())
+    }
+
+    pub fn get_overload_notification_v1(
+        &self,
+        authority: &AuthorityName,
+    ) -> IotaResult<Option<u8>> {
+        Ok(self
+            .tables()?
+            .authority_overload_notifications
+            .get(authority)?)
+    }
+
     pub fn get_quarantined_owned_object_lock(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {
         self.consensus_quarantine
             .read()
@@ -3008,6 +3041,26 @@ impl AuthorityPerEpochStore {
                     warn!(
                         "RandomnessDkgConfirmation authority {} does not match its author from consensus {}",
                         authority, transaction.certificate_author_index
+                    );
+                    return None;
+                }
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                ..
+            }) => {
+                if &transaction.sender_authority() != authority {
+                    warn!(
+                        "OverloadNotificationV1 authority {} does not match its author from consensus {}",
+                        authority, transaction.certificate_author_index
+                    );
+                    return None;
+                }
+                if *percentage > 100 {
+                    warn!(
+                        "OverloadNotificationV1 from {:?} has invalid percentage {}",
+                        authority.concise(),
+                        percentage
                     );
                     return None;
                 }
@@ -4457,6 +4510,28 @@ impl AuthorityPerEpochStore {
                     suggested_gas_price_calculator,
                     authority_metrics,
                 )
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                ..
+            }) => {
+                if self
+                    .get_reconfig_state_read_lock_guard()
+                    .should_accept_consensus_certs()
+                {
+                    debug!(
+                        "Received OverloadNotificationV1 from {:?} with percentage {}",
+                        authority.concise(),
+                        percentage
+                    );
+                    self.record_overload_notification_v1(authority, *percentage)?;
+                } else {
+                    debug!(
+                        "Ignoring OverloadNotificationV1 from {:?} because of end of epoch",
+                        authority.concise()
+                    );
+                }
+                Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {
                 Ok(self.process_consensus_system_transaction(system_transaction))

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2713,13 +2713,23 @@ impl AuthorityPerEpochStore {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    /// Loads the persisted overload notifications keyed by authority.
+    /// Loads the current overload notifications keyed by authority. Reads the
+    /// persisted `authority_overload_notifications` DBMap, then overlays every
+    /// queued (processed-but-not-yet-flushed) `ConsensusCommitOutput`'s
+    /// notifications on top. Without the overlay, the read would lag behind
+    /// the logical state by however many commits are sitting in
+    /// `ConsensusOutputQuarantine::output_queue` waiting for the checkpoint
+    /// builder to catch up.
     pub(crate) fn load_overload_notifications(&self) -> IotaResult<HashMap<AuthorityName, u8>> {
-        Ok(self
+        let mut notifications: HashMap<AuthorityName, u8> = self
             .tables()?
             .authority_overload_notifications
             .safe_iter()
-            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?)
+            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?;
+        self.consensus_quarantine
+            .read()
+            .overlay_queued_overload_notifications(&mut notifications);
+        Ok(notifications)
     }
 
     /// Computes the stake-weighted 2f+1 percentile of load shedding percentages

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3245,7 +3245,7 @@ impl AuthorityPerEpochStore {
                 }
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                kind: ConsensusTransactionKind::OverloadNotificationV1(authority, _, percentage),
                 ..
             }) => {
                 if &transaction.sender_authority() != authority {
@@ -3329,7 +3329,11 @@ impl AuthorityPerEpochStore {
                 for tx in &verified_transactions {
                     if let SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         kind:
-                            ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                            ConsensusTransactionKind::OverloadNotificationV1(
+                                authority,
+                                _,
+                                percentage,
+                            ),
                         ..
                     }) = &tx.0.transaction
                     {
@@ -4788,7 +4792,7 @@ impl AuthorityPerEpochStore {
                 )
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                kind: ConsensusTransactionKind::OverloadNotificationV1(authority, _, percentage),
                 ..
             }) => {
                 if self

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1196,6 +1196,15 @@ impl AuthorityPerEpochStore {
 
         let consensus_output_cache = ConsensusOutputCache::new(&tables, metrics.clone());
 
+        // Seed the quarantine's in-memory overload-notification cache from the
+        // persisted table. This is the only point we iterate the table; all
+        // subsequent reads are served from memory.
+        let cached_overload_notifications: HashMap<AuthorityName, u8> = tables
+            .authority_overload_notifications
+            .safe_iter()
+            .collect::<Result<HashMap<AuthorityName, u8>, _>>()
+            .expect("AuthorityEpochTables should contain valid overload notifications");
+
         let committee_size = committee.num_members();
         let report_version = MisbehaviorReportVersion::from_protocol(&protocol_config);
         let misbehavior_monitor = MisbehaviorMonitor::new(name, report_version, committee_size);
@@ -1224,6 +1233,7 @@ impl AuthorityPerEpochStore {
             consensus_output_cache,
             consensus_quarantine: RwLock::new(ConsensusOutputQuarantine::new(
                 highest_executed_checkpoint,
+                cached_overload_notifications,
                 metrics.clone(),
             )),
             parent_path: parent_path.to_path_buf(),
@@ -2842,23 +2852,16 @@ impl AuthorityPerEpochStore {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    /// Loads the current overload notifications keyed by authority. Reads the
-    /// persisted `authority_overload_notifications` DBMap, then overlays every
-    /// queued (processed-but-not-yet-flushed) `ConsensusCommitOutput`'s
-    /// notifications on top. Without the overlay, the read would lag behind
-    /// the logical state by however many commits are sitting in
-    /// `ConsensusOutputQuarantine::output_queue` waiting for the checkpoint
-    /// builder to catch up.
+    /// Loads the current overload notifications keyed by authority. Served from
+    /// the consensus quarantine's in-memory cache of the persisted
+    /// `authority_overload_notifications` table, with every queued
+    /// (processed-but-not-yet-flushed) `ConsensusCommitOutput`'s notifications
+    /// overlaid on top.
     pub(crate) fn load_overload_notifications(&self) -> IotaResult<HashMap<AuthorityName, u8>> {
-        let mut notifications: HashMap<AuthorityName, u8> = self
-            .tables()?
-            .authority_overload_notifications
-            .safe_iter()
-            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?;
-        self.consensus_quarantine
+        Ok(self
+            .consensus_quarantine
             .read()
-            .overlay_queued_overload_notifications(&mut notifications);
-        Ok(notifications)
+            .current_overload_notifications())
     }
 
     /// Returns the load shedding percentage `authority` last broadcasted or 0
@@ -2971,6 +2974,21 @@ impl AuthorityPerEpochStore {
             .write()
             .push_consensus_output(output, self)
             .expect("push_consensus_output should not fail");
+    }
+
+    /// Advances the quarantine's in-memory overload-notification cache, as the
+    /// commit flush loop does for a real commit. Tests that write the
+    /// `authority_overload_notifications` table directly (bypassing the flush
+    /// loop) must call this to keep the cache consistent with the table.
+    #[cfg(test)]
+    pub(crate) fn apply_overload_notification_to_cache_for_test(
+        &self,
+        authority: AuthorityName,
+        percentage: u8,
+    ) {
+        self.consensus_quarantine
+            .write()
+            .apply_cached_overload_notification_for_test(authority, percentage);
     }
 
     fn process_user_signatures<'a>(
@@ -3329,11 +3347,7 @@ impl AuthorityPerEpochStore {
                 for tx in &verified_transactions {
                     if let SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         kind:
-                            ConsensusTransactionKind::OverloadNotificationV1(
-                                authority,
-                                _,
-                                percentage,
-                            ),
+                            ConsensusTransactionKind::OverloadNotificationV1(authority, _, percentage),
                         ..
                     }) = &tx.0.transaction
                     {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -5,6 +5,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     future::Future,
+    hash::Hasher as _,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -77,6 +78,7 @@ use tap::TapOptional;
 use tokio::{sync::OnceCell, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
+use twox_hash::XxHash64;
 use typed_store::{
     DBMapUtils, Map,
     rocks::{
@@ -3300,15 +3302,40 @@ impl AuthorityPerEpochStore {
             Vec::with_capacity(verified_transactions.len());
         let mut end_of_publish_transactions = Vec::with_capacity(verified_transactions.len());
         let enable_white_flag = self.protocol_config.enable_white_flag_flow();
+
+        // Post-consensus load shedding: compute the drop percentage once before
+        // the loop so user transactions can be dropped inline during categorization.
+        let drop_percentage = if enable_white_flag {
+            self.get_quorum_load_shedding_percentage()? as u64
+        } else {
+            0
+        };
+        let drop_seed = consensus_commit_info.round;
+
         for tx in verified_transactions {
             if tx.0.is_end_of_publish() {
                 end_of_publish_transactions.push(tx);
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
-            } else if !enable_white_flag && tx.0.is_user_tx_with_randomness() {
-                current_commit_sequenced_randomness_transactions.push(tx);
             } else {
-                current_commit_sequenced_consensus_transactions.push(tx);
+                // For user transactions, deterministically drop based on the
+                // quorum load shedding percentage.
+                if drop_percentage > 0 {
+                    if let Some(digest) = tx.0.transaction.executable_transaction_digest() {
+                        let mut hasher = XxHash64::with_seed(drop_seed);
+                        hasher.write(digest.inner());
+                        let hash = hasher.finish();
+                        if hash % 100 < drop_percentage {
+                            continue;
+                        }
+                    }
+                }
+
+                if tx.0.is_user_tx_with_randomness() {
+                    current_commit_sequenced_randomness_transactions.push(tx);
+                } else {
+                    current_commit_sequenced_consensus_transactions.push(tx);
+                }
             }
         }
 
@@ -4739,7 +4766,7 @@ impl AuthorityPerEpochStore {
                         authority.concise()
                     );
                 }
-                Ok(ConsensusCertificateResult::ConsensusMessage)
+                Ok(ConsensusTransactionResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {
                 Ok(self.process_consensus_system_transaction(system_transaction))

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -853,6 +853,13 @@ pub struct AuthorityEpochTables {
     /// Record of the capabilities advertised by each authority.
     authority_capabilities_v1: DBMap<AuthorityName, AuthorityCapabilitiesV1>,
 
+    /// Record of the latest load shedding percentage from each authority,
+    /// received via OverloadNotificationV1 consensus transactions. Keyed by
+    /// AuthorityName, value is the most recently reported percentage
+    /// (0-100). Overwrites on each new notification from the same
+    /// authority.
+    authority_overload_notifications: DBMap<AuthorityName, u8>,
+
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
     override_protocol_upgrade_buffer_stake: DBMap<u64, u64>,
@@ -2834,6 +2841,32 @@ impl AuthorityPerEpochStore {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
+    pub fn record_overload_notification_v1(
+        &self,
+        authority: &AuthorityName,
+        percentage: u8,
+    ) -> IotaResult {
+        info!(
+            "received overload notification v1 from {:?}: {}%",
+            authority.concise(),
+            percentage
+        );
+        self.tables()?
+            .authority_overload_notifications
+            .insert(authority, &percentage)?;
+        Ok(())
+    }
+
+    pub fn get_overload_notification_v1(
+        &self,
+        authority: &AuthorityName,
+    ) -> IotaResult<Option<u8>> {
+        Ok(self
+            .tables()?
+            .authority_overload_notifications
+            .get(authority)?)
+    }
+
     pub fn get_quarantined_owned_object_lock(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {
         self.consensus_quarantine
             .read()
@@ -3155,6 +3188,26 @@ impl AuthorityPerEpochStore {
                     warn!(
                         "RandomnessDkgConfirmation authority {} does not match its author from consensus {}",
                         authority, transaction.certificate_author_index
+                    );
+                    return None;
+                }
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                ..
+            }) => {
+                if &transaction.sender_authority() != authority {
+                    warn!(
+                        "OverloadNotificationV1 authority {} does not match its author from consensus {}",
+                        authority, transaction.certificate_author_index
+                    );
+                    return None;
+                }
+                if *percentage > 100 {
+                    warn!(
+                        "OverloadNotificationV1 from {:?} has invalid percentage {}",
+                        authority.concise(),
+                        percentage
                     );
                     return None;
                 }
@@ -4623,6 +4676,28 @@ impl AuthorityPerEpochStore {
                     suggested_gas_price_calculator,
                     authority_metrics,
                 )
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                ..
+            }) => {
+                if self
+                    .get_reconfig_state_read_lock_guard()
+                    .should_accept_consensus_certs()
+                {
+                    debug!(
+                        "Received OverloadNotificationV1 from {:?} with percentage {}",
+                        authority.concise(),
+                        percentage
+                    );
+                    self.record_overload_notification_v1(authority, *percentage)?;
+                } else {
+                    debug!(
+                        "Ignoring OverloadNotificationV1 from {:?} because of end of epoch",
+                        authority.concise()
+                    );
+                }
+                Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {
                 Ok(self.process_consensus_system_transaction(system_transaction))

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -5,7 +5,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     future::Future,
-    hash::Hasher as _,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -74,7 +73,6 @@ use serde::{Deserialize, Serialize};
 use tap::TapOptional;
 use tokio::{sync::OnceCell, time::Instant};
 use tracing::{debug, error, info, instrument, trace, warn};
-use twox_hash::XxHash64;
 use typed_store::{
     DBMapUtils, Map,
     rocks::{
@@ -122,6 +120,7 @@ use crate::{
     execution_cache::{ObjectCacheRead, TransactionCacheRead, cache_types::CacheResult},
     fallback_fetch::do_fallback_lookup,
     module_cache_metrics::ResolverMetrics,
+    overload_monitor::should_reject_tx,
     post_consensus_tx_reorder::PostConsensusTxReorder,
     post_consensus_validation,
     signature_verifier::*,
@@ -3159,7 +3158,7 @@ impl AuthorityPerEpochStore {
         // Post-consensus load shedding: compute the drop percentage once before
         // the loop so user transactions can be dropped inline during categorization.
         let drop_percentage = if enable_white_flag {
-            self.get_quorum_load_shedding_percentage()? as u64
+            self.get_quorum_load_shedding_percentage()? as u32
         } else {
             0
         };
@@ -3175,10 +3174,7 @@ impl AuthorityPerEpochStore {
                 // quorum load shedding percentage.
                 if drop_percentage > 0 {
                     if let Some(digest) = tx.0.transaction.executable_transaction_digest() {
-                        let mut hasher = XxHash64::with_seed(drop_seed);
-                        hasher.write(digest.inner());
-                        let hash = hasher.finish();
-                        if hash % 100 < drop_percentage {
+                        if should_reject_tx(drop_percentage, digest, drop_seed) {
                             continue;
                         }
                     }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -5,6 +5,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     future::Future,
+    hash::Hasher as _,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -73,6 +74,7 @@ use serde::{Deserialize, Serialize};
 use tap::TapOptional;
 use tokio::{sync::OnceCell, time::Instant};
 use tracing::{debug, error, info, instrument, trace, warn};
+use twox_hash::XxHash64;
 use typed_store::{
     DBMapUtils, Map,
     rocks::{
@@ -3153,15 +3155,40 @@ impl AuthorityPerEpochStore {
             Vec::with_capacity(verified_transactions.len());
         let mut end_of_publish_transactions = Vec::with_capacity(verified_transactions.len());
         let enable_white_flag = self.protocol_config.enable_white_flag_flow();
+
+        // Post-consensus load shedding: compute the drop percentage once before
+        // the loop so user transactions can be dropped inline during categorization.
+        let drop_percentage = if enable_white_flag {
+            self.get_quorum_load_shedding_percentage()? as u64
+        } else {
+            0
+        };
+        let drop_seed = consensus_commit_info.round;
+
         for tx in verified_transactions {
             if tx.0.is_end_of_publish() {
                 end_of_publish_transactions.push(tx);
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
-            } else if !enable_white_flag && tx.0.is_user_tx_with_randomness() {
-                current_commit_sequenced_randomness_transactions.push(tx);
             } else {
-                current_commit_sequenced_consensus_transactions.push(tx);
+                // For user transactions, deterministically drop based on the
+                // quorum load shedding percentage.
+                if drop_percentage > 0 {
+                    if let Some(digest) = tx.0.transaction.executable_transaction_digest() {
+                        let mut hasher = XxHash64::with_seed(drop_seed);
+                        hasher.write(digest.inner());
+                        let hash = hasher.finish();
+                        if hash % 100 < drop_percentage {
+                            continue;
+                        }
+                    }
+                }
+
+                if tx.0.is_user_tx_with_randomness() {
+                    current_commit_sequenced_randomness_transactions.push(tx);
+                } else {
+                    current_commit_sequenced_consensus_transactions.push(tx);
+                }
             }
         }
 
@@ -4573,7 +4600,7 @@ impl AuthorityPerEpochStore {
                         authority.concise()
                     );
                 }
-                Ok(ConsensusCertificateResult::ConsensusMessage)
+                Ok(ConsensusTransactionResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {
                 Ok(self.process_consensus_system_transaction(system_transaction))

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3375,6 +3375,9 @@ impl AuthorityPerEpochStore {
                 end_of_publish_transactions.push(tx);
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
+            // In the white-flag flow, randomness transactions are separated
+            // later in the flow to preserve ordering in conflict resolution, so
+            // should be included with the regular transactions here.
             } else if !enable_white_flag && tx.0.is_user_tx_with_randomness() {
                 // Only user-originated transactions are eligible for load shedding
                 if drop_percentage > 0 {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2861,6 +2861,16 @@ impl AuthorityPerEpochStore {
         Ok(notifications)
     }
 
+    /// Returns the load shedding percentage `authority` last broadcasted or 0
+    /// if it has not sent a notification this epoch.
+    pub fn load_overload_notification(&self, authority: &AuthorityName) -> IotaResult<u8> {
+        Ok(self
+            .load_overload_notifications()?
+            .get(authority)
+            .copied()
+            .unwrap_or(0))
+    }
+
     /// Computes the stake-weighted 2f+1 percentile of load shedding percentages
     /// received via OverloadNotificationV1 consensus transactions. Authorities
     /// that have not sent a notification are assumed to have a percentage of 0.
@@ -3331,6 +3341,9 @@ impl AuthorityPerEpochStore {
         } else {
             0
         };
+        authority_metrics
+            .consensus_handler_load_shedding_percentage
+            .set(drop_percentage as i64);
         let drop_seed = consensus_commit_info.round;
 
         for tx in verified_transactions {
@@ -3338,24 +3351,32 @@ impl AuthorityPerEpochStore {
                 end_of_publish_transactions.push(tx);
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
-            } else {
-                // Only user-originated transactions are eligible for load shedding;
-                // internal consensus messages (checkpoint signatures, capability
-                // notifications, randomness DKG, overload notifications, etc.) must
-                // never be dropped here.
+            } else if !enable_white_flag && tx.0.is_user_tx_with_randomness() {
+                // Only user-originated transactions are eligible for load shedding
                 if drop_percentage > 0 {
                     if let Some(digest) = tx.0.transaction.user_transaction_digest() {
                         if should_reject_tx(drop_percentage, digest, drop_seed) {
+                            authority_metrics
+                                .consensus_handler_load_shedding_dropped_transactions
+                                .inc();
                             continue;
                         }
                     }
                 }
-
-                if tx.0.is_user_tx_with_randomness() {
-                    current_commit_sequenced_randomness_transactions.push(tx);
-                } else {
-                    current_commit_sequenced_consensus_transactions.push(tx);
+                current_commit_sequenced_randomness_transactions.push(tx);
+            } else {
+                // Only user-originated transactions are eligible for load shedding
+                if drop_percentage > 0 {
+                    if let Some(digest) = tx.0.transaction.user_transaction_digest() {
+                        if should_reject_tx(drop_percentage, digest, drop_seed) {
+                            authority_metrics
+                                .consensus_handler_load_shedding_dropped_transactions
+                                .inc();
+                            continue;
+                        }
+                    }
                 }
+                current_commit_sequenced_consensus_transactions.push(tx);
             }
         }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2713,36 +2713,8 @@ impl AuthorityPerEpochStore {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    pub fn record_overload_notification_v1(
-        &self,
-        authority: &AuthorityName,
-        percentage: u8,
-    ) -> IotaResult {
-        info!(
-            "received overload notification v1 from {:?}: {}%",
-            authority.concise(),
-            percentage
-        );
-        self.tables()?
-            .authority_overload_notifications
-            .insert(authority, &percentage)?;
-        Ok(())
-    }
-
-    pub fn get_overload_notification_v1(
-        &self,
-        authority: &AuthorityName,
-    ) -> IotaResult<Option<u8>> {
-        Ok(self
-            .tables()?
-            .authority_overload_notifications
-            .get(authority)?)
-    }
-
     /// Loads the persisted overload notifications keyed by authority.
-    pub(crate) fn load_overload_notifications(
-        &self,
-    ) -> IotaResult<HashMap<AuthorityName, u8>> {
+    pub(crate) fn load_overload_notifications(&self) -> IotaResult<HashMap<AuthorityName, u8>> {
         Ok(self
             .tables()?
             .authority_overload_notifications
@@ -3174,12 +3146,13 @@ impl AuthorityPerEpochStore {
 
         // Post-consensus load shedding: compute the drop percentage once before
         // the loop so user transactions can be dropped inline during categorization.
-        // OverloadNotificationV1 transactions in this same commit batch are
-        // overlaid on top of the persisted notifications so user txs in the
-        // batch are dropped using the latest load shedding percentage rather
-        // than the previous round's value. The actual DB write still happens
-        // later inside `process_consensus_transactions` and is gated by
-        // `should_accept_consensus_certs`; this overlay mirrors that gate.
+        // `OverloadNotificationV1` transactions from this commit are layered on
+        // top of the persisted notifications now to ensure immediate response to new
+        // notifications which are not yet registered in persistent storage rather than
+        // the previous round's values. The recorder call inside
+        // `process_consensus_transactions` is gated by
+        // `should_accept_consensus_certs`; this overlay mirrors that gate so
+        // the overlaid set matches the set that will be flushed.
         let drop_percentage = if enable_white_flag {
             let mut notifications = self.load_overload_notifications()?;
             if self
@@ -3188,7 +3161,8 @@ impl AuthorityPerEpochStore {
             {
                 for tx in &verified_transactions {
                     if let SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                        kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                        kind:
+                            ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
                         ..
                     }) = &tx.0.transaction
                     {
@@ -4627,7 +4601,7 @@ impl AuthorityPerEpochStore {
                         authority.concise(),
                         percentage
                     );
-                    self.record_overload_notification_v1(authority, *percentage)?;
+                    output.record_overload_notification(*authority, *percentage);
                 } else {
                     debug!(
                         "Ignoring OverloadNotificationV1 from {:?} because of end of epoch",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2868,16 +2868,33 @@ impl AuthorityPerEpochStore {
             .get(authority)?)
     }
 
+    /// Loads the persisted overload notifications keyed by authority.
+    pub(crate) fn load_overload_notifications(
+        &self,
+    ) -> IotaResult<HashMap<AuthorityName, u8>> {
+        Ok(self
+            .tables()?
+            .authority_overload_notifications
+            .safe_iter()
+            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?)
+    }
+
     /// Computes the stake-weighted 2f+1 percentile of load shedding percentages
     /// received via OverloadNotificationV1 consensus transactions. Authorities
     /// that have not sent a notification are assumed to have a percentage of 0.
     pub fn get_quorum_load_shedding_percentage(&self) -> IotaResult<u8> {
-        let notifications = self
-            .tables()?
-            .authority_overload_notifications
-            .safe_iter()
-            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?;
+        let notifications = self.load_overload_notifications()?;
+        Ok(self.compute_quorum_load_shedding_percentage(&notifications))
+    }
 
+    /// Computes the stake-weighted 2f+1 percentile from an in-memory
+    /// notifications map. Used both by `get_quorum_load_shedding_percentage`
+    /// and by the consensus commit pre-pass that overlays in-batch
+    /// `OverloadNotificationV1` entries on top of the persisted state.
+    pub(crate) fn compute_quorum_load_shedding_percentage(
+        &self,
+        notifications: &HashMap<AuthorityName, u8>,
+    ) -> u8 {
         let committee = self.committee();
 
         // Build a vec of (percentage, stake) for every committee member.
@@ -2901,13 +2918,13 @@ impl AuthorityPerEpochStore {
         for (percentage, stake) in weighted_values {
             accumulated_stake += stake;
             if accumulated_stake >= quorum_threshold {
-                return Ok(percentage);
+                return percentage;
             }
         }
 
         // Unreachable with a valid committee (total stake >= quorum threshold),
         // but return 0 as a safe fallback.
-        Ok(0)
+        0
     }
 
     pub fn get_quarantined_owned_object_lock(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {
@@ -3304,8 +3321,29 @@ impl AuthorityPerEpochStore {
 
         // Post-consensus load shedding: compute the drop percentage once before
         // the loop so user transactions can be dropped inline during categorization.
+        // OverloadNotificationV1 transactions in this same commit batch are
+        // overlaid on top of the persisted notifications so user txs in the
+        // batch are dropped using the latest load shedding percentage rather
+        // than the previous round's value. The actual DB write still happens
+        // later inside `process_consensus_transactions` and is gated by
+        // `should_accept_consensus_certs`; this overlay mirrors that gate.
         let drop_percentage = if enable_white_flag {
-            self.get_quorum_load_shedding_percentage()? as u32
+            let mut notifications = self.load_overload_notifications()?;
+            if self
+                .get_reconfig_state_read_lock_guard()
+                .should_accept_consensus_certs()
+            {
+                for tx in &verified_transactions {
+                    if let SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                        kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                        ..
+                    }) = &tx.0.transaction
+                    {
+                        notifications.insert(*authority, *percentage);
+                    }
+                }
+            }
+            self.compute_quorum_load_shedding_percentage(&notifications) as u32
         } else {
             0
         };

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2739,16 +2739,33 @@ impl AuthorityPerEpochStore {
             .get(authority)?)
     }
 
+    /// Loads the persisted overload notifications keyed by authority.
+    pub(crate) fn load_overload_notifications(
+        &self,
+    ) -> IotaResult<HashMap<AuthorityName, u8>> {
+        Ok(self
+            .tables()?
+            .authority_overload_notifications
+            .safe_iter()
+            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?)
+    }
+
     /// Computes the stake-weighted 2f+1 percentile of load shedding percentages
     /// received via OverloadNotificationV1 consensus transactions. Authorities
     /// that have not sent a notification are assumed to have a percentage of 0.
     pub fn get_quorum_load_shedding_percentage(&self) -> IotaResult<u8> {
-        let notifications = self
-            .tables()?
-            .authority_overload_notifications
-            .safe_iter()
-            .collect::<Result<HashMap<AuthorityName, u8>, _>>()?;
+        let notifications = self.load_overload_notifications()?;
+        Ok(self.compute_quorum_load_shedding_percentage(&notifications))
+    }
 
+    /// Computes the stake-weighted 2f+1 percentile from an in-memory
+    /// notifications map. Used both by `get_quorum_load_shedding_percentage`
+    /// and by the consensus commit pre-pass that overlays in-batch
+    /// `OverloadNotificationV1` entries on top of the persisted state.
+    pub(crate) fn compute_quorum_load_shedding_percentage(
+        &self,
+        notifications: &HashMap<AuthorityName, u8>,
+    ) -> u8 {
         let committee = self.committee();
 
         // Build a vec of (percentage, stake) for every committee member.
@@ -2772,13 +2789,13 @@ impl AuthorityPerEpochStore {
         for (percentage, stake) in weighted_values {
             accumulated_stake += stake;
             if accumulated_stake >= quorum_threshold {
-                return Ok(percentage);
+                return percentage;
             }
         }
 
         // Unreachable with a valid committee (total stake >= quorum threshold),
         // but return 0 as a safe fallback.
-        Ok(0)
+        0
     }
 
     pub fn get_quarantined_owned_object_lock(&self, obj_ref: &ObjectRef) -> Option<LockDetails> {
@@ -3157,8 +3174,29 @@ impl AuthorityPerEpochStore {
 
         // Post-consensus load shedding: compute the drop percentage once before
         // the loop so user transactions can be dropped inline during categorization.
+        // OverloadNotificationV1 transactions in this same commit batch are
+        // overlaid on top of the persisted notifications so user txs in the
+        // batch are dropped using the latest load shedding percentage rather
+        // than the previous round's value. The actual DB write still happens
+        // later inside `process_consensus_transactions` and is gated by
+        // `should_accept_consensus_certs`; this overlay mirrors that gate.
         let drop_percentage = if enable_white_flag {
-            self.get_quorum_load_shedding_percentage()? as u32
+            let mut notifications = self.load_overload_notifications()?;
+            if self
+                .get_reconfig_state_read_lock_guard()
+                .should_accept_consensus_certs()
+            {
+                for tx in &verified_transactions {
+                    if let SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                        kind: ConsensusTransactionKind::OverloadNotificationV1(authority, percentage),
+                        ..
+                    }) = &tx.0.transaction
+                    {
+                        notifications.insert(*authority, *percentage);
+                    }
+                }
+            }
+            self.compute_quorum_load_shedding_percentage(&notifications) as u32
         } else {
             0
         };

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3329,10 +3329,12 @@ impl AuthorityPerEpochStore {
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
             } else {
-                // For user transactions, deterministically drop based on the
-                // quorum load shedding percentage.
+                // Only user-originated transactions are eligible for load shedding;
+                // internal consensus messages (checkpoint signatures, capability
+                // notifications, randomness DKG, overload notifications, etc.) must
+                // never be dropped here.
                 if drop_percentage > 0 {
-                    if let Some(digest) = tx.0.transaction.executable_transaction_digest() {
+                    if let Some(digest) = tx.0.transaction.user_transaction_digest() {
                         if should_reject_tx(drop_percentage, digest, drop_seed) {
                             continue;
                         }

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -74,6 +74,12 @@ pub(crate) struct ConsensusCommitOutput {
 
     // White flag owned object locks acquired in this commit
     owned_object_locks: HashMap<ObjectRef, LockDetails>,
+
+    // Latest overload-shed percentage advertised by each authority via
+    // OverloadNotificationV1 during this commit. Flushed to
+    // `authority_overload_notifications` atomically with `last_consensus_stats`
+    // so a partial pre-flush state can never be observed on disk.
+    overload_notifications: BTreeMap<AuthorityName, u8>,
 }
 
 impl ConsensusCommitOutput {
@@ -199,6 +205,10 @@ impl ConsensusCommitOutput {
         self.owned_object_locks = locks;
     }
 
+    pub fn record_overload_notification(&mut self, authority: AuthorityName, percentage: u8) {
+        self.overload_notifications.insert(authority, percentage);
+    }
+
     pub fn write_to_batch(
         self,
         epoch_store: &AuthorityPerEpochStore,
@@ -315,6 +325,11 @@ impl ConsensusCommitOutput {
                     .map(|(obj_ref, lock)| (obj_ref, LockDetailsWrapper::from(lock))),
             )?;
         }
+
+        batch.insert_batch(
+            &tables.authority_overload_notifications,
+            self.overload_notifications,
+        )?;
 
         Ok(())
     }

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -902,6 +902,23 @@ impl ConsensusOutputQuarantine {
             .any(|output| output.pending_checkpoint_exists(index))
     }
 
+    /// Overlay every queued (processed-but-not-yet-flushed) commit's overload
+    /// notifications onto the provided map, in commit (queue) order. Later
+    /// commits overwrite earlier ones, matching the "most recent wins"
+    /// semantics of the persisted `authority_overload_notifications` table.
+    /// Used by `load_overload_notifications` to make reads reflect the logical
+    /// state across the disk/queue split, not just the lagging persisted half.
+    pub(super) fn overlay_queued_overload_notifications(
+        &self,
+        notifications: &mut HashMap<AuthorityName, u8>,
+    ) {
+        for output in &self.output_queue {
+            for (authority, percentage) in &output.overload_notifications {
+                notifications.insert(*authority, *percentage);
+            }
+        }
+    }
+
     pub(super) fn get_randomness_last_round_timestamp(&self) -> Option<TimestampMs> {
         self.output_queue
             .iter()

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -939,6 +939,23 @@ impl ConsensusOutputQuarantine {
             .any(|output| output.pending_checkpoint_exists(index))
     }
 
+    /// Overlay every queued (processed-but-not-yet-flushed) commit's overload
+    /// notifications onto the provided map, in commit (queue) order. Later
+    /// commits overwrite earlier ones, matching the "most recent wins"
+    /// semantics of the persisted `authority_overload_notifications` table.
+    /// Used by `load_overload_notifications` to make reads reflect the logical
+    /// state across the disk/queue split, not just the lagging persisted half.
+    pub(super) fn overlay_queued_overload_notifications(
+        &self,
+        notifications: &mut HashMap<AuthorityName, u8>,
+    ) {
+        for output in &self.output_queue {
+            for (authority, percentage) in &output.overload_notifications {
+                notifications.insert(*authority, *percentage);
+            }
+        }
+    }
+
     pub(super) fn get_randomness_last_round_timestamp(&self) -> Option<CheckpointTimestamp> {
         self.output_queue
             .iter()

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -567,12 +567,23 @@ pub(crate) struct ConsensusOutputQuarantine {
     // White flag owned object locks (aggregate across all quarantined commits)
     owned_object_locks: HashMap<ObjectRef, LockDetails>,
 
+    // In-memory cache of the `authority_overload_notifications` table: the most
+    // recent load-shedding percentage each authority has broadcast, for the
+    // commits that have already been flushed to disk. Loaded once from the
+    // table when the epoch store is constructed and updated as commits are
+    // flushed, so the per-commit read path never has to iterate RocksDB. The
+    // disk table only exists for persistence across restarts. Notifications
+    // from commits still in `output_queue` are layered on top by
+    // `current_overload_notifications`.
+    cached_overload_notifications: HashMap<AuthorityName, u8>,
+
     metrics: Arc<EpochMetrics>,
 }
 
 impl ConsensusOutputQuarantine {
     pub(super) fn new(
         highest_executed_checkpoint: CheckpointSequenceNumber,
+        cached_overload_notifications: HashMap<AuthorityName, u8>,
         authority_metrics: Arc<EpochMetrics>,
     ) -> Self {
         Self {
@@ -586,6 +597,7 @@ impl ConsensusOutputQuarantine {
             congestion_control_randomness_object_debts: RefCountedHashMap::new(),
             processed_consensus_messages: RefCountedHashMap::new(),
             owned_object_locks: HashMap::new(),
+            cached_overload_notifications,
             metrics: authority_metrics,
         }
     }
@@ -742,6 +754,11 @@ impl ConsensusOutputQuarantine {
                 self.remove_processed_consensus_messages(&output);
                 self.remove_congestion_control_debts(&output);
                 self.remove_owned_object_locks(&output);
+                // Advance the in-memory cache in lockstep with the table write
+                // below, so it stays equal to the persisted state once this
+                // commit leaves the queue.
+                self.cached_overload_notifications
+                    .extend(&output.overload_notifications);
                 epoch_store.remove_shared_version_assignments(
                     output
                         .pending_checkpoints
@@ -939,21 +956,30 @@ impl ConsensusOutputQuarantine {
             .any(|output| output.pending_checkpoint_exists(index))
     }
 
-    /// Overlay every queued (processed-but-not-yet-flushed) commit's overload
-    /// notifications onto the provided map, in commit (queue) order. Later
-    /// commits overwrite earlier ones, matching the "most recent wins"
-    /// semantics of the persisted `authority_overload_notifications` table.
-    /// Used by `load_overload_notifications` to make reads reflect the logical
-    /// state across the disk/queue split, not just the lagging persisted half.
-    pub(super) fn overlay_queued_overload_notifications(
-        &self,
-        notifications: &mut HashMap<AuthorityName, u8>,
-    ) {
+    /// Returns the current overload notifications keyed by authority: the
+    /// in-memory cache of the persisted table with every queued
+    /// (processed-but-not-yet-flushed) commit's notifications layered on top,
+    /// in commit (queue) order. Later commits overwrite earlier ones. This
+    /// reflects the logical state across the disk/queue split without
+    /// iterating the persisted state.
+    pub(super) fn current_overload_notifications(&self) -> HashMap<AuthorityName, u8> {
+        let mut notifications = self.cached_overload_notifications.clone();
         for output in &self.output_queue {
             for (authority, percentage) in &output.overload_notifications {
                 notifications.insert(*authority, *percentage);
             }
         }
+        notifications
+    }
+
+    #[cfg(test)]
+    pub(super) fn apply_cached_overload_notification_for_test(
+        &mut self,
+        authority: AuthorityName,
+        percentage: u8,
+    ) {
+        self.cached_overload_notifications
+            .insert(authority, percentage);
     }
 
     pub(super) fn get_randomness_last_round_timestamp(&self) -> Option<CheckpointTimestamp> {

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -88,6 +88,12 @@ pub(crate) struct ConsensusCommitOutput {
 
     // White flag owned object locks acquired in this commit
     owned_object_locks: HashMap<ObjectRef, LockDetails>,
+
+    // Latest overload-shed percentage advertised by each authority via
+    // OverloadNotificationV1 during this commit. Flushed to
+    // `authority_overload_notifications` atomically with `last_consensus_stats`
+    // so a partial pre-flush state can never be observed on disk.
+    overload_notifications: BTreeMap<AuthorityName, u8>,
 }
 
 impl ConsensusCommitOutput {
@@ -231,6 +237,10 @@ impl ConsensusCommitOutput {
         self.owned_object_locks = locks;
     }
 
+    pub fn record_overload_notification(&mut self, authority: AuthorityName, percentage: u8) {
+        self.overload_notifications.insert(authority, percentage);
+    }
+
     pub fn write_to_batch(
         self,
         epoch_store: &AuthorityPerEpochStore,
@@ -354,6 +364,11 @@ impl ConsensusCommitOutput {
                     .map(|(obj_ref, lock)| (obj_ref, LockDetailsWrapper::from(lock))),
             )?;
         }
+
+        batch.insert_batch(
+            &tables.authority_overload_notifications,
+            self.overload_notifications,
+        )?;
 
         Ok(())
     }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -816,6 +816,7 @@ impl ConsensusAdapter {
                     | ConsensusTransactionKind::CapabilityNotificationV1(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
+                    | ConsensusTransactionKind::OverloadNotificationV1(_, _)
             ) {
             let transaction_keys = transaction_keys.clone();
             Some(CancelOnDrop(spawn_monitored_task!(async {

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -810,6 +810,7 @@ impl ConsensusAdapter {
                     | ConsensusTransactionKind::CapabilityNotificationV1(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
+                    | ConsensusTransactionKind::OverloadNotificationV1(_, _)
             ) {
             let transaction_keys = transaction_keys.clone();
             Some(CancelOnDrop(spawn_monitored_task!(async {

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -816,7 +816,7 @@ impl ConsensusAdapter {
                     | ConsensusTransactionKind::CapabilityNotificationV1(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
-                    | ConsensusTransactionKind::OverloadNotificationV1(_, _)
+                    | ConsensusTransactionKind::OverloadNotificationV1(_, _, _)
             ) {
             let transaction_keys = transaction_keys.clone();
             Some(CancelOnDrop(spawn_monitored_task!(async {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -560,7 +560,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::NewJWKFetchedDeprecated => "new_jwk_fetched_deprecated",
         ConsensusTransactionKind::RandomnessDkgMessage(_, _) => "randomness_dkg_message",
         ConsensusTransactionKind::RandomnessDkgConfirmation(_, _) => "randomness_dkg_confirmation",
-        ConsensusTransactionKind::OverloadNotificationV1(_, _) => "overload_notification_v1",
+        ConsensusTransactionKind::OverloadNotificationV1(_, _, _) => "overload_notification_v1",
     }
 }
 

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -560,6 +560,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::NewJWKFetchedDeprecated => "new_jwk_fetched_deprecated",
         ConsensusTransactionKind::RandomnessDkgMessage(_, _) => "randomness_dkg_message",
         ConsensusTransactionKind::RandomnessDkgConfirmation(_, _) => "randomness_dkg_confirmation",
+        ConsensusTransactionKind::OverloadNotificationV1(_, _) => "overload_notification_v1",
     }
 }
 

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -634,6 +634,22 @@ impl SequencedConsensusTransactionKind {
         }
     }
 
+    /// Returns the digest only for user-originated transaction kinds
+    /// (`CertifiedTransaction` and `UserTransactionV1`). Used by post-consensus
+    /// load shedding to guarantee that no internal consensus messages
+    /// (checkpoint signatures, capability notifications, randomness DKG, etc.)
+    /// are eligible to be dropped.
+    pub fn user_transaction_digest(&self) -> Option<TransactionDigest> {
+        match self {
+            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
+                ConsensusTransactionKind::CertifiedTransaction(txn) => Some(*txn.digest()),
+                ConsensusTransactionKind::UserTransactionV1(txn) => Some(*txn.digest()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     pub fn is_end_of_publish(&self) -> bool {
         match self {
             SequencedConsensusTransactionKind::External(ext) => {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -519,6 +519,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::NewJWKFetchedDeprecated => "new_jwk_fetched_deprecated",
         ConsensusTransactionKind::RandomnessDkgMessage(_, _) => "randomness_dkg_message",
         ConsensusTransactionKind::RandomnessDkgConfirmation(_, _) => "randomness_dkg_confirmation",
+        ConsensusTransactionKind::OverloadNotificationV1(_, _) => "overload_notification_v1",
     }
 }
 

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -675,6 +675,22 @@ impl SequencedConsensusTransactionKind {
         }
     }
 
+    /// Returns the digest only for user-originated transaction kinds
+    /// (`CertifiedTransaction` and `UserTransactionV1`). Used by post-consensus
+    /// load shedding to guarantee that no internal consensus messages
+    /// (checkpoint signatures, capability notifications, randomness DKG, etc.)
+    /// are eligible to be dropped.
+    pub fn user_transaction_digest(&self) -> Option<TransactionDigest> {
+        match self {
+            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
+                ConsensusTransactionKind::CertifiedTransaction(txn) => Some(*txn.digest()),
+                ConsensusTransactionKind::UserTransactionV1(txn) => Some(*txn.digest()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     pub fn is_end_of_publish(&self) -> bool {
         match self {
             SequencedConsensusTransactionKind::External(ext) => {

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -124,7 +124,7 @@ impl IotaTxValidator {
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
 
-                ConsensusTransactionKind::OverloadNotificationV1(authority_name, percentage, _) => {
+                ConsensusTransactionKind::OverloadNotificationV1(authority_name, _, percentage) => {
                     if !self.epoch_store.protocol_config().enable_white_flag_flow() {
                         return Err(IotaError::UnsupportedFeature {
                             error:

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -124,7 +124,7 @@ impl IotaTxValidator {
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
 
-                ConsensusTransactionKind::OverloadNotificationV1(authority_name, percentage) => {
+                ConsensusTransactionKind::OverloadNotificationV1(authority_name, percentage, _) => {
                     if !self.epoch_store.protocol_config().enable_white_flag_flow() {
                         return Err(IotaError::UnsupportedFeature {
                             error:
@@ -433,7 +433,7 @@ mod tests {
                 ConsensusTransactionKind::NewJWKFetchedDeprecated => Some(false),
 
                 // Gated behind `enable_white_flag_flow`.
-                ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
+                ConsensusTransactionKind::OverloadNotificationV1(_, _, _) => {
                     Some(config.enable_white_flag_flow())
                 }
             }
@@ -493,7 +493,7 @@ mod tests {
             ),
             (
                 "OverloadNotificationV1",
-                ConsensusTransactionKind::OverloadNotificationV1(authority, 50),
+                ConsensusTransactionKind::OverloadNotificationV1(authority, 0, 50),
             ),
         ];
 

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -124,11 +124,7 @@ impl IotaTxValidator {
                 | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
 
                 ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
-                    if !self
-                        .epoch_store
-                        .protocol_config()
-                        .post_consensus_load_shedding()
-                    {
+                    if !self.epoch_store.protocol_config().enable_white_flag_flow() {
                         return Err(IotaError::UnsupportedFeature {
                             error:
                                 "OverloadNotificationV1 not supported at current protocol version"
@@ -431,9 +427,10 @@ mod tests {
                 // IOTA and the variant is retained only for serialization
                 // compatibility.
                 ConsensusTransactionKind::NewJWKFetchedDeprecated => Some(false),
-                // Gated behind `post_consensus_load_shedding`.
+
+                // Gated behind `enable_white_flag_flow`.
                 ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
-                    Some(config.post_consensus_load_shedding())
+                    Some(config.enable_white_flag_flow())
                 }
             }
         }

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -122,6 +122,20 @@ impl IotaTxValidator {
 
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
+
+                ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
+                    if !self
+                        .epoch_store
+                        .protocol_config()
+                        .post_consensus_load_shedding()
+                    {
+                        return Err(IotaError::UnsupportedFeature {
+                            error:
+                                "OverloadNotificationV1 not supported at current protocol version"
+                                    .into(),
+                        });
+                    }
+                }
             }
         }
 
@@ -417,6 +431,10 @@ mod tests {
                 // IOTA and the variant is retained only for serialization
                 // compatibility.
                 ConsensusTransactionKind::NewJWKFetchedDeprecated => Some(false),
+                // Gated behind `post_consensus_load_shedding`.
+                ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
+                    Some(config.post_consensus_load_shedding())
+                }
             }
         }
 
@@ -471,6 +489,10 @@ mod tests {
             (
                 "UserTransactionV1",
                 ConsensusTransactionKind::UserTransactionV1(Box::new(signed_tx)),
+            ),
+            (
+                "OverloadNotificationV1",
+                ConsensusTransactionKind::OverloadNotificationV1(authority, 50),
             ),
         ];
 

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -124,11 +124,7 @@ impl IotaTxValidator {
                 | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
 
                 ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
-                    if !self
-                        .epoch_store
-                        .protocol_config()
-                        .post_consensus_load_shedding()
-                    {
+                    if !self.epoch_store.protocol_config().enable_white_flag_flow() {
                         return Err(IotaError::UnsupportedFeature {
                             error:
                                 "OverloadNotificationV1 not supported at current protocol version"
@@ -427,9 +423,10 @@ mod tests {
                 // IOTA and the variant is retained only for serialization
                 // compatibility.
                 ConsensusTransactionKind::NewJWKFetchedDeprecated => Some(false),
-                // Gated behind `post_consensus_load_shedding`.
+
+                // Gated behind `enable_white_flag_flow`.
                 ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
-                    Some(config.post_consensus_load_shedding())
+                    Some(config.enable_white_flag_flow())
                 }
             }
         }

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -122,6 +122,20 @@ impl IotaTxValidator {
 
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
+
+                ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
+                    if !self
+                        .epoch_store
+                        .protocol_config()
+                        .post_consensus_load_shedding()
+                    {
+                        return Err(IotaError::UnsupportedFeature {
+                            error:
+                                "OverloadNotificationV1 not supported at current protocol version"
+                                    .into(),
+                        });
+                    }
+                }
             }
         }
 
@@ -413,6 +427,10 @@ mod tests {
                 // IOTA and the variant is retained only for serialization
                 // compatibility.
                 ConsensusTransactionKind::NewJWKFetchedDeprecated => Some(false),
+                // Gated behind `post_consensus_load_shedding`.
+                ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
+                    Some(config.post_consensus_load_shedding())
+                }
             }
         }
 
@@ -467,6 +485,10 @@ mod tests {
             (
                 "UserTransactionV1",
                 ConsensusTransactionKind::UserTransactionV1(Box::new(signed_tx)),
+            ),
+            (
+                "OverloadNotificationV1",
+                ConsensusTransactionKind::OverloadNotificationV1(authority, 50),
             ),
         ];
 

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -8,6 +8,7 @@ use eyre::WrapErr;
 use fastcrypto_tbls::dkg_v1;
 use iota_metrics::monitored_scope;
 use iota_types::{
+    base_types::ConciseableName,
     error::IotaError,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
 };
@@ -123,13 +124,20 @@ impl IotaTxValidator {
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
 
-                ConsensusTransactionKind::OverloadNotificationV1(_, _) => {
+                ConsensusTransactionKind::OverloadNotificationV1(authority_name, percentage) => {
                     if !self.epoch_store.protocol_config().enable_white_flag_flow() {
                         return Err(IotaError::UnsupportedFeature {
                             error:
                                 "OverloadNotificationV1 not supported at current protocol version"
                                     .into(),
                         });
+                    }
+                    if *percentage > 100 {
+                        return Err(IotaError::HandleConsensusTransactionFailure(format!(
+                            "OverloadNotificationV1 with invalid percentage {percentage} from \
+                                authority {}",
+                            authority_name.concise(),
+                        )));
                     }
                 }
             }

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -181,10 +181,6 @@ fn check_execution_overload(
         cache_config.backpressure_threshold() as usize,
         cache_config.backpressure_soft_limit_pct(),
     );
-    authority
-        .metrics
-        .cache_backpressure_load_shedding_percentage
-        .set(cache_based_percentage as i64);
 
     // The final load shedding percentage combines three signals:
     //   - latency/rate-based, from execution queueing latency,
@@ -220,7 +216,7 @@ fn check_execution_overload(
         .set(is_overload as i64);
     authority
         .metrics
-        .authority_load_shedding_percentage
+        .local_post_consensus_load_shedding_percentage
         .set(load_shedding_percentage as i64);
     true
 }
@@ -831,7 +827,8 @@ mod tests {
 
     /// Verifies that the cache-pressure signal flows end-to-end from
     /// `WritebackCacheConfig` → `check_execution_overload` →
-    /// `overload_info.local_load_shedding_percentage` and the new metric.
+    /// `overload_info.local_load_shedding_percentage` and the
+    /// `local_post_consensus_load_shedding_percentage` metric.
     ///
     /// We can't easily inject a non-zero
     /// `approximate_pending_transaction_count` into the test cache without
@@ -865,13 +862,6 @@ mod tests {
 
         // Cache signal alone should drive 100% shedding via the degenerate
         // threshold; latency and queue signals contribute 0 in a fresh state.
-        assert_eq!(
-            state
-                .metrics
-                .cache_backpressure_load_shedding_percentage
-                .get(),
-            100,
-        );
         assert!(state.overload_info.is_overload.load(Ordering::Relaxed));
         assert_eq!(
             state
@@ -880,7 +870,13 @@ mod tests {
                 .load(Ordering::Relaxed),
             100,
         );
-        assert_eq!(state.metrics.authority_load_shedding_percentage.get(), 100,);
+        assert_eq!(
+            state
+                .metrics
+                .local_post_consensus_load_shedding_percentage
+                .get(),
+            100,
+        );
     }
 
     // Creates an AuthorityState and starts an overload monitor that monitors its

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -156,11 +156,10 @@ fn check_execution_overload(
         execution_rate,
     );
 
-    let queue_based_percentage = compute_queue_load_shedding_percentage(
+    let queue_based_percentage = compute_graduated_load_shedding_percentage(
         inflight_queue_len,
-        config.max_transaction_manager_queue_length_soft_limit(),
         config.max_transaction_manager_queue_length,
-        config.max_load_shedding_percentage,
+        config.max_transaction_manager_queue_length_soft_limit_pct(),
     );
 
     // The final load shedding percentage combines the latency/rate-based

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -140,12 +140,16 @@ fn check_authority_overload(
         queueing_latency, txn_ready_rate, execution_rate
     );
 
+    // Use the quorum load shedding percentage (from consensus) as the reference
+    // point for the current percentage actually used.
+    let current_load_shedding_percentage = authority
+        .load_epoch_store_one_call_per_task()
+        .get_quorum_load_shedding_percentage()
+        .unwrap_or(0) as u32;
+
     let (is_overload, load_shedding_percentage) = check_overload_signals(
         config,
-        authority
-            .overload_info
-            .load_shedding_percentage
-            .load(Ordering::Relaxed),
+        current_load_shedding_percentage,
         queueing_latency,
         txn_ready_rate,
         execution_rate,

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -30,20 +30,26 @@ pub struct AuthorityOverloadInfo {
     /// Whether the authority is overloaded.
     pub is_overload: AtomicBool,
 
-    /// The calculated percentage of transactions to drop.
-    pub load_shedding_percentage: AtomicU32,
+    /// The locally computed percentage of transactions this authority would
+    /// drop. This is the *output* of this authority's overload monitor; it is
+    /// distinct from the quorum-determined percentage actually enforced in the
+    /// post-consensus load-shedding path. It is also read back on the next
+    /// iteration of `check_execution_overload` as the feedback term for the
+    /// latency-based controller.
+    pub local_load_shedding_percentage: AtomicU32,
 }
 
 impl AuthorityOverloadInfo {
-    pub fn set_overload(&self, load_shedding_percentage: u32) {
+    pub fn set_overload(&self, local_load_shedding_percentage: u32) {
         self.is_overload.store(true, Ordering::Relaxed);
-        self.load_shedding_percentage
-            .store(min(load_shedding_percentage, 100), Ordering::Relaxed);
+        self.local_load_shedding_percentage
+            .store(min(local_load_shedding_percentage, 100), Ordering::Relaxed);
     }
 
     pub fn clear_overload(&self) {
         self.is_overload.store(false, Ordering::Relaxed);
-        self.load_shedding_percentage.store(0, Ordering::Relaxed);
+        self.local_load_shedding_percentage
+            .store(0, Ordering::Relaxed);
     }
 }
 
@@ -144,16 +150,20 @@ fn check_execution_overload(
         queueing_latency, txn_ready_rate, execution_rate, inflight_queue_len, cache_pending_count
     );
 
-    // Use the quorum load shedding percentage (from consensus) as the reference
-    // point for the current percentage actually used.
-    let current_load_shedding_percentage = authority
-        .load_epoch_store_one_call_per_task()
-        .get_quorum_load_shedding_percentage()
-        .unwrap_or(0) as u32;
+    // Feedback term: the locally computed percentage this monitor produced on
+    // its previous iteration. We use the *local* value (not the quorum value
+    // enforced post-consensus) because `txn_ready_rate` reflects the load this
+    // authority itself admitted, so the controller must close the loop on its
+    // own last decision to compound shedding over multiple iterations and to
+    // ratchet down gradually as latency recovers.
+    let current_local_load_shedding_percentage = authority
+        .overload_info
+        .local_load_shedding_percentage
+        .load(Ordering::Relaxed);
 
     let (_, latency_based_percentage) = compute_latency_load_shedding_percentage(
         config,
-        current_load_shedding_percentage,
+        current_local_load_shedding_percentage,
         queueing_latency,
         txn_ready_rate,
         execution_rate,
@@ -436,7 +446,7 @@ mod tests {
         assert!(!overload_info.is_overload.load(Ordering::Relaxed));
         assert_eq!(
             overload_info
-                .load_shedding_percentage
+                .local_load_shedding_percentage
                 .load(Ordering::Relaxed),
             0
         );
@@ -446,7 +456,7 @@ mod tests {
             assert!(overload_info.is_overload.load(Ordering::Relaxed));
             assert_eq!(
                 overload_info
-                    .load_shedding_percentage
+                    .local_load_shedding_percentage
                     .load(Ordering::Relaxed),
                 20
             );
@@ -458,7 +468,7 @@ mod tests {
             assert!(overload_info.is_overload.load(Ordering::Relaxed));
             assert_eq!(
                 overload_info
-                    .load_shedding_percentage
+                    .local_load_shedding_percentage
                     .load(Ordering::Relaxed),
                 100
             );
@@ -469,7 +479,7 @@ mod tests {
             assert!(!overload_info.is_overload.load(Ordering::Relaxed));
             assert_eq!(
                 overload_info
-                    .load_shedding_percentage
+                    .local_load_shedding_percentage
                     .load(Ordering::Relaxed),
                 0
             );
@@ -739,7 +749,7 @@ mod tests {
         assert_eq!(
             state
                 .overload_info
-                .load_shedding_percentage
+                .local_load_shedding_percentage
                 .load(Ordering::Relaxed),
             config.min_load_shedding_percentage_above_hard_limit
         );
@@ -821,7 +831,7 @@ mod tests {
 
     /// Verifies that the cache-pressure signal flows end-to-end from
     /// `WritebackCacheConfig` → `check_execution_overload` →
-    /// `overload_info.load_shedding_percentage` and the new metric.
+    /// `overload_info.local_load_shedding_percentage` and the new metric.
     ///
     /// We can't easily inject a non-zero
     /// `approximate_pending_transaction_count` into the test cache without
@@ -866,7 +876,7 @@ mod tests {
         assert_eq!(
             state
                 .overload_info
-                .load_shedding_percentage
+                .local_load_shedding_percentage
                 .load(Ordering::Relaxed),
             100,
         );
@@ -912,7 +922,7 @@ mod tests {
                     if enable_load_shedding {
                         let shedding_percentage = authority
                             .overload_info
-                            .load_shedding_percentage
+                            .local_load_shedding_percentage
                             .load(Ordering::Relaxed);
                         !(shedding_percentage > 0 && rng.gen_range(0..100) < shedding_percentage)
                     } else {
@@ -993,7 +1003,7 @@ mod tests {
                 state.overload_info.is_overload.load(Ordering::Relaxed),
                 state
                     .overload_info
-                    .load_shedding_percentage
+                    .local_load_shedding_percentage
                     .load(Ordering::Relaxed),
                 state.metrics.execution_queueing_latency.latency(),
                 state.metrics.txn_ready_rate_tracker.lock().rate(),

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -64,7 +64,7 @@ pub async fn overload_monitor(
     info!("Starting system overload monitor.");
 
     loop {
-        let authority_exist = check_authority_overload(&authority_state, &config);
+        let authority_exist = check_execution_overload(&authority_state, &config);
         if !authority_exist {
             // `authority_state` doesn't exist anymore. Quit overload monitor.
             break;
@@ -115,7 +115,7 @@ pub async fn consensus_queue_overload_monitor(
 
 // Checks authority overload signals, and updates authority's `overload_info`.
 // Returns whether the authority state exists.
-fn check_authority_overload(
+fn check_execution_overload(
     authority_state: &Weak<AuthorityState>,
     config: &AuthorityOverloadConfig,
 ) -> bool {
@@ -134,10 +134,11 @@ fn check_authority_overload(
         .unwrap_or_default();
     let txn_ready_rate = authority.metrics.txn_ready_rate_tracker.lock().rate();
     let execution_rate = authority.metrics.execution_rate_tracker.lock().rate();
+    let inflight_queue_len = authority.transaction_manager().inflight_queue_len();
 
     debug!(
-        "Check authority overload signal, queueing latency {:?}, ready rate {:?}, execution rate {:?}.",
-        queueing_latency, txn_ready_rate, execution_rate
+        "Check authority overload signal, queueing latency {:?}, ready rate {:?}, execution rate {:?}, inflight queue len {:?}.",
+        queueing_latency, txn_ready_rate, execution_rate, inflight_queue_len
     );
 
     // Use the quorum load shedding percentage (from consensus) as the reference
@@ -147,13 +148,32 @@ fn check_authority_overload(
         .get_quorum_load_shedding_percentage()
         .unwrap_or(0) as u32;
 
-    let (is_overload, load_shedding_percentage) = check_overload_signals(
+    let (_, latency_based_percentage) = compute_latency_load_shedding_percentage(
         config,
         current_load_shedding_percentage,
         queueing_latency,
         txn_ready_rate,
         execution_rate,
     );
+
+    let queue_based_percentage = compute_queue_load_shedding_percentage(
+        inflight_queue_len,
+        config.max_transaction_manager_queue_length_soft_limit(),
+        config.max_transaction_manager_queue_length,
+        config.max_load_shedding_percentage,
+    );
+
+    // The final load shedding percentage combines the latency/rate-based
+    // shedding percentage with a queue length based percentage.
+    //
+    // The two signals are correlated — by Little's Law, `inflight_queue_len ≈
+    // txn_ready_rate × queueing_latency` in steady state — so they are combined
+    // with `max` rather than summed, to avoid double-counting. Under transients
+    // they diverge: queue length reacts to bursts before averaged latency does,
+    // while latency catches sustained slow execution even when queue depth is
+    // modest. Each therefore guards a different failure mode.
+    let load_shedding_percentage = max(latency_based_percentage, queue_based_percentage);
+    let is_overload = load_shedding_percentage > 0;
 
     if is_overload {
         authority
@@ -209,7 +229,7 @@ fn calculate_load_shedding_percentage(txn_ready_rate: f64, execution_rate: f64) 
 // outcome is that we need to shed 40% + (1 - 40%) * 10% = 46%.
 // When txn_ready_rate is less than execution_rate, we gradually reduce load
 // shedding percentage until the queueing latency is back to normal.
-fn check_overload_signals(
+fn compute_latency_load_shedding_percentage(
     config: &AuthorityOverloadConfig,
     current_load_shedding_percentage: u32,
     queueing_latency: Duration,
@@ -458,28 +478,52 @@ mod tests {
         // When execution queueing latency is within soft limit, don't start overload
         // protection.
         assert_eq!(
-            check_overload_signals(&config, 0, Duration::from_millis(500), 1000.0, 10.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                0,
+                Duration::from_millis(500),
+                1000.0,
+                10.0
+            ),
             (false, 0)
         );
 
         // When execution queueing latency hits soft limit and execution rate is higher,
         // don't start overload protection.
         assert_eq!(
-            check_overload_signals(&config, 0, Duration::from_secs(2), 100.0, 120.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                0,
+                Duration::from_secs(2),
+                100.0,
+                120.0
+            ),
             (false, 0)
         );
 
         // When execution queueing latency hits soft limit, but not hard limit, start
         // overload protection.
         assert_eq!(
-            check_overload_signals(&config, 0, Duration::from_secs(2), 100.0, 100.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                0,
+                Duration::from_secs(2),
+                100.0,
+                100.0
+            ),
             (true, 7)
         );
 
         // When execution queueing latency hits hard limit, start more aggressive
         // overload protection.
         assert_eq!(
-            check_overload_signals(&config, 0, Duration::from_secs(11), 100.0, 100.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                0,
+                Duration::from_secs(11),
+                100.0,
+                100.0
+            ),
             (true, 50)
         );
 
@@ -487,20 +531,38 @@ mod tests {
         // percentage is higher than
         // min_load_shedding_percentage_above_hard_limit.
         assert_eq!(
-            check_overload_signals(&config, 0, Duration::from_secs(11), 240.0, 100.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                0,
+                Duration::from_secs(11),
+                240.0,
+                100.0
+            ),
             (true, 62)
         );
 
         // When execution queueing latency hits hard limit, but transaction ready rate
         // is within safe_transaction_ready_rate, don't start overload protection.
         assert_eq!(
-            check_overload_signals(&config, 0, Duration::from_secs(11), 20.0, 100.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                0,
+                Duration::from_secs(11),
+                20.0,
+                100.0
+            ),
             (false, 0)
         );
 
         // Maximum transactions shed is cap by `max_load_shedding_percentage` config.
         assert_eq!(
-            check_overload_signals(&config, 0, Duration::from_secs(11), 100.0, 0.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                0,
+                Duration::from_secs(11),
+                100.0,
+                0.0
+            ),
             (true, 90)
         );
 
@@ -508,20 +570,38 @@ mod tests {
         // rate and execution rate require another 20%, the final shedding rate
         // is 60%.
         assert_eq!(
-            check_overload_signals(&config, 50, Duration::from_secs(2), 116.0, 100.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                50,
+                Duration::from_secs(2),
+                116.0,
+                100.0
+            ),
             (true, 60)
         );
 
         // Load shedding percentage is gradually reduced when txn ready rate is lower
         // than execution rate.
         assert_eq!(
-            check_overload_signals(&config, 90, Duration::from_secs(2), 200.0, 300.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                90,
+                Duration::from_secs(2),
+                200.0,
+                300.0
+            ),
             (true, 80)
         );
 
         // When queueing delay is above hard limit, we shed additional 50% every time.
         assert_eq!(
-            check_overload_signals(&config, 50, Duration::from_secs(11), 100.0, 100.0),
+            compute_latency_load_shedding_percentage(
+                &config,
+                50,
+                Duration::from_secs(11),
+                100.0,
+                100.0
+            ),
             (true, 75)
         );
     }
@@ -633,7 +713,7 @@ mod tests {
         // Creates a simple case to see if authority state overload_info can be updated
         // correctly by check_authority_overload.
         let authority = Arc::downgrade(&state);
-        assert!(check_authority_overload(&authority, &config));
+        assert!(check_execution_overload(&authority, &config));
         assert!(state.overload_info.is_overload.load(Ordering::Relaxed));
         assert_eq!(
             state
@@ -647,7 +727,7 @@ mod tests {
         // authority state doesn't exist.
         let authority = Arc::downgrade(&state);
         drop(state);
-        assert!(!check_authority_overload(&authority, &config));
+        assert!(!check_execution_overload(&authority, &config));
     }
 
     // Creates an AuthorityState and starts an overload monitor that monitors its

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -135,10 +135,13 @@ fn check_execution_overload(
     let txn_ready_rate = authority.metrics.txn_ready_rate_tracker.lock().rate();
     let execution_rate = authority.metrics.execution_rate_tracker.lock().rate();
     let inflight_queue_len = authority.transaction_manager().inflight_queue_len();
+    let cache_pending_count = authority
+        .get_cache_commit()
+        .approximate_pending_transaction_count() as usize;
 
     debug!(
-        "Check authority overload signal, queueing latency {:?}, ready rate {:?}, execution rate {:?}, inflight queue len {:?}.",
-        queueing_latency, txn_ready_rate, execution_rate, inflight_queue_len
+        "Check authority overload signal, queueing latency {:?}, ready rate {:?}, execution rate {:?}, inflight queue len {:?}, cache pending count {:?}.",
+        queueing_latency, txn_ready_rate, execution_rate, inflight_queue_len, cache_pending_count
     );
 
     // Use the quorum load shedding percentage (from consensus) as the reference
@@ -162,16 +165,35 @@ fn check_execution_overload(
         config.max_transaction_manager_queue_length_soft_limit_pct(),
     );
 
-    // The final load shedding percentage combines the latency/rate-based
-    // shedding percentage with a queue length based percentage.
+    let cache_config = &authority.config.execution_cache_config.writeback_cache;
+    let cache_based_percentage = compute_graduated_load_shedding_percentage(
+        cache_pending_count,
+        cache_config.backpressure_threshold() as usize,
+        cache_config.backpressure_soft_limit_pct(),
+    );
+    authority
+        .metrics
+        .cache_backpressure_load_shedding_percentage
+        .set(cache_based_percentage as i64);
+
+    // The final load shedding percentage combines three signals:
+    //   - latency/rate-based, from execution queueing latency,
+    //   - queue-length-based, from the txn manager's inflight queue,
+    //   - cache-backpressure-based, from the writeback cache's pending count.
     //
-    // The two signals are correlated — by Little's Law, `inflight_queue_len ≈
-    // txn_ready_rate × queueing_latency` in steady state — so they are combined
-    // with `max` rather than summed, to avoid double-counting. Under transients
-    // they diverge: queue length reacts to bursts before averaged latency does,
-    // while latency catches sustained slow execution even when queue depth is
-    // modest. Each therefore guards a different failure mode.
-    let load_shedding_percentage = max(latency_based_percentage, queue_based_percentage);
+    // All three are correlated in steady state — by Little's Law,
+    // `inflight_queue_len ≈ txn_ready_rate × queueing_latency`; cache pending
+    // count tracks uncommitted writes which accumulate when execution outpaces
+    // checkpoint flush — so they are combined with `max` rather than summed,
+    // to avoid double-counting. Under transients they diverge: queue length
+    // reacts to arrival bursts before averaged latency does, latency catches
+    // sustained slow execution even when queue depth is modest, and cache
+    // pressure shows up when checkpoint flush stalls even if execution itself
+    // is keeping up. Each therefore guards a different failure mode.
+    let load_shedding_percentage = max(
+        max(latency_based_percentage, queue_based_percentage),
+        cache_based_percentage,
+    );
     let is_overload = load_shedding_percentage > 0;
 
     if is_overload {

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -751,6 +751,130 @@ mod tests {
         assert!(!check_execution_overload(&authority, &config));
     }
 
+    /// Wires `WritebackCacheConfig`'s backpressure thresholds into
+    /// `compute_graduated_load_shedding_percentage` and verifies the
+    /// post-consensus cache-pressure signal at cache-relevant scales.
+    /// Catches regressions in either the config getter defaults or the
+    /// call signature used in `check_execution_overload`.
+    #[test]
+    fn test_writeback_cache_backpressure_soft_limit_pct() {
+        use iota_config::node::WritebackCacheConfig;
+
+        // Default getter: 50% with no explicit value or env override.
+        let default_config = WritebackCacheConfig::default();
+        assert_eq!(default_config.backpressure_soft_limit_pct(), 50);
+        assert_eq!(default_config.backpressure_threshold(), 100_000);
+
+        // Explicit config: soft_limit_pct of 75 against a 1000-pending-tx
+        // hard limit. Soft limit = 1000 * 75 / 100 = 750.
+        let config = WritebackCacheConfig {
+            backpressure_threshold: Some(1000),
+            backpressure_soft_limit_pct: Some(75),
+            ..Default::default()
+        };
+        assert_eq!(config.backpressure_threshold(), 1000);
+        assert_eq!(config.backpressure_soft_limit_pct(), 75);
+
+        // Below soft limit: no shedding.
+        for pending in [0u64, 100, 750] {
+            assert_eq!(
+                compute_graduated_load_shedding_percentage(
+                    pending as usize,
+                    config.backpressure_threshold() as usize,
+                    config.backpressure_soft_limit_pct(),
+                ),
+                0,
+                "no shedding expected at pending={pending} <= soft_limit=750",
+            );
+        }
+
+        // Halfway between soft (750) and hard (1000): 50% shedding.
+        assert_eq!(
+            compute_graduated_load_shedding_percentage(
+                875,
+                config.backpressure_threshold() as usize,
+                config.backpressure_soft_limit_pct(),
+            ),
+            50,
+        );
+
+        // At and above hard limit: 100% shedding.
+        for pending in [1000u64, 1500, 100_000] {
+            assert_eq!(
+                compute_graduated_load_shedding_percentage(
+                    pending as usize,
+                    config.backpressure_threshold() as usize,
+                    config.backpressure_soft_limit_pct(),
+                ),
+                100,
+                "100% shedding expected at pending={pending} >= hard_limit=1000",
+            );
+        }
+
+        // Out-of-range soft_limit_pct is clamped to 100 by the getter.
+        let clamped = WritebackCacheConfig {
+            backpressure_soft_limit_pct: Some(150),
+            ..Default::default()
+        };
+        assert_eq!(clamped.backpressure_soft_limit_pct(), 100);
+    }
+
+    /// Verifies that the cache-pressure signal flows end-to-end from
+    /// `WritebackCacheConfig` → `check_execution_overload` →
+    /// `overload_info.load_shedding_percentage` and the new metric.
+    ///
+    /// We can't easily inject a non-zero `approximate_pending_transaction_count`
+    /// into the test cache without an additional test hook, so this test
+    /// instead degenerates the threshold by setting `backpressure_threshold =
+    /// 0`, which makes `compute_graduated_load_shedding_percentage` return
+    /// 100% even with `pending_count = 0` (the `current >= hard_limit` branch
+    /// with `0 >= 0`). That exercises the full wiring while keeping the test
+    /// self-contained.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_check_execution_overload_cache_signal_drives_shedding() {
+        use iota_config::node::{ExecutionCacheConfig, WritebackCacheConfig};
+
+        telemetry_subscribers::init_for_testing();
+
+        let cache_config = ExecutionCacheConfig {
+            writeback_cache: WritebackCacheConfig {
+                backpressure_threshold: Some(0),
+                ..Default::default()
+            },
+        };
+        let overload_config = AuthorityOverloadConfig::default();
+        let state = TestAuthorityBuilder::new()
+            .with_authority_overload_config(overload_config.clone())
+            .with_cache_config(cache_config)
+            .build()
+            .await;
+
+        let authority = Arc::downgrade(&state);
+        assert!(check_execution_overload(&authority, &overload_config));
+
+        // Cache signal alone should drive 100% shedding via the degenerate
+        // threshold; latency and queue signals contribute 0 in a fresh state.
+        assert_eq!(
+            state
+                .metrics
+                .cache_backpressure_load_shedding_percentage
+                .get(),
+            100,
+        );
+        assert!(state.overload_info.is_overload.load(Ordering::Relaxed));
+        assert_eq!(
+            state
+                .overload_info
+                .load_shedding_percentage
+                .load(Ordering::Relaxed),
+            100,
+        );
+        assert_eq!(
+            state.metrics.authority_load_shedding_percentage.get(),
+            100,
+        );
+    }
+
     // Creates an AuthorityState and starts an overload monitor that monitors its
     // metrics.
     async fn start_overload_monitor() -> (Arc<AuthorityState>, JoinHandle<()>) {

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -823,12 +823,13 @@ mod tests {
     /// `WritebackCacheConfig` → `check_execution_overload` →
     /// `overload_info.load_shedding_percentage` and the new metric.
     ///
-    /// We can't easily inject a non-zero `approximate_pending_transaction_count`
-    /// into the test cache without an additional test hook, so this test
-    /// instead degenerates the threshold by setting `backpressure_threshold =
-    /// 0`, which makes `compute_graduated_load_shedding_percentage` return
-    /// 100% even with `pending_count = 0` (the `current >= hard_limit` branch
-    /// with `0 >= 0`). That exercises the full wiring while keeping the test
+    /// We can't easily inject a non-zero
+    /// `approximate_pending_transaction_count` into the test cache without
+    /// an additional test hook, so this test instead degenerates the
+    /// threshold by setting `backpressure_threshold = 0`, which makes
+    /// `compute_graduated_load_shedding_percentage` return 100% even with
+    /// `pending_count = 0` (the `current >= hard_limit` branch with `0 >=
+    /// 0`). That exercises the full wiring while keeping the test
     /// self-contained.
     #[tokio::test(flavor = "current_thread")]
     async fn test_check_execution_overload_cache_signal_drives_shedding() {
@@ -869,10 +870,7 @@ mod tests {
                 .load(Ordering::Relaxed),
             100,
         );
-        assert_eq!(
-            state.metrics.authority_load_shedding_percentage.get(),
-            100,
-        );
+        assert_eq!(state.metrics.authority_load_shedding_percentage.get(), 100,);
     }
 
     // Creates an AuthorityState and starts an overload monitor that monitors its

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -272,7 +272,7 @@ fn check_overload_signals(
 }
 
 /// Return true if we should reject the txn with `tx_digest`.
-fn should_reject_tx(
+pub(crate) fn should_reject_tx(
     load_shedding_percentage: u32,
     tx_digest: TransactionDigest,
     temporal_seed: u64,

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -31,12 +31,15 @@ pub struct AuthorityOverloadInfo {
     pub is_overload: AtomicBool,
 
     /// The locally computed percentage of transactions this authority would
-    /// drop. This is the *output* of this authority's overload monitor; it is
-    /// distinct from the quorum-determined percentage actually enforced in the
-    /// post-consensus load-shedding path. It is also read back on the next
-    /// iteration of `check_execution_overload` as the feedback term for the
-    /// latency-based controller.
+    /// drop. This is the *output* of this authority's overload monitor (the max
+    /// of the latency-, queue-, and cache-based signals); it is distinct from
+    /// the quorum-determined percentage actually enforced in the post-consensus
+    /// load-shedding path.
     pub local_load_shedding_percentage: AtomicU32,
+
+    /// The latency-based controller's own previous output, kept separately so
+    /// it can be fed back as that controller's input on the next iteration.
+    pub latency_load_shedding_percentage: AtomicU32,
 }
 
 impl AuthorityOverloadInfo {
@@ -49,6 +52,8 @@ impl AuthorityOverloadInfo {
     pub fn clear_overload(&self) {
         self.is_overload.store(false, Ordering::Relaxed);
         self.local_load_shedding_percentage
+            .store(0, Ordering::Relaxed);
+        self.latency_load_shedding_percentage
             .store(0, Ordering::Relaxed);
     }
 }
@@ -150,24 +155,26 @@ fn check_execution_overload(
         queueing_latency, txn_ready_rate, execution_rate, inflight_queue_len, cache_pending_count
     );
 
-    // Feedback term: the locally computed percentage this monitor produced on
-    // its previous iteration. We use the *local* value (not the quorum value
-    // enforced post-consensus) because `txn_ready_rate` reflects the load this
-    // authority itself admitted, so the controller must close the loop on its
-    // own last decision to compound shedding over multiple iterations and to
-    // ratchet down gradually as latency recovers.
-    let current_local_load_shedding_percentage = authority
+    // Feedback term: the latency controller's *own* previous output.
+    let previous_latency_based_percentage = authority
         .overload_info
-        .local_load_shedding_percentage
+        .latency_load_shedding_percentage
         .load(Ordering::Relaxed);
 
     let (_, latency_based_percentage) = compute_latency_load_shedding_percentage(
         config,
-        current_local_load_shedding_percentage,
+        previous_latency_based_percentage,
         queueing_latency,
         txn_ready_rate,
         execution_rate,
     );
+
+    // Persist the latency controller's own output for next iteration's feedback,
+    // independent of the combined max stored via `set_overload` below.
+    authority
+        .overload_info
+        .latency_load_shedding_percentage
+        .store(latency_based_percentage, Ordering::Relaxed);
 
     let queue_based_percentage = compute_graduated_load_shedding_percentage(
         inflight_queue_len,
@@ -470,12 +477,23 @@ mod tests {
             );
         }
 
+        // `clear_overload` also resets the latency controller's feedback term,
+        // keeping it aligned with `local_load_shedding_percentage`.
         {
+            overload_info
+                .latency_load_shedding_percentage
+                .store(30, Ordering::Relaxed);
             overload_info.clear_overload();
             assert!(!overload_info.is_overload.load(Ordering::Relaxed));
             assert_eq!(
                 overload_info
                     .local_load_shedding_percentage
+                    .load(Ordering::Relaxed),
+                0
+            );
+            assert_eq!(
+                overload_info
+                    .latency_load_shedding_percentage
                     .load(Ordering::Relaxed),
                 0
             );

--- a/crates/iota-core/src/starfish_adapter.rs
+++ b/crates/iota-core/src/starfish_adapter.rs
@@ -127,6 +127,7 @@ impl ConsensusClient for LazyStarfishClient {
                     | ConsensusTransactionKind::CapabilityNotificationV1(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
+                    | ConsensusTransactionKind::OverloadNotificationV1(_, _)
             )
         {
             let transaction_key = SequencedConsensusTransactionKey::External(transactions[0].key());

--- a/crates/iota-core/src/starfish_adapter.rs
+++ b/crates/iota-core/src/starfish_adapter.rs
@@ -127,7 +127,7 @@ impl ConsensusClient for LazyStarfishClient {
                     | ConsensusTransactionKind::CapabilityNotificationV1(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
-                    | ConsensusTransactionKind::OverloadNotificationV1(_, _)
+                    | ConsensusTransactionKind::OverloadNotificationV1(_, _, _)
             )
         {
             let transaction_key = SequencedConsensusTransactionKey::External(transactions[0].key());

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -267,7 +267,11 @@ async fn test_load_overload_notifications_invariant_under_disk_queue_split() {
     // Disk holds an earlier value for the authority.
     flush_overload_notification(&store, authority_name, 30);
     assert_eq!(
-        store.load_overload_notifications().unwrap().get(&authority_name).copied(),
+        store
+            .load_overload_notifications()
+            .unwrap()
+            .get(&authority_name)
+            .copied(),
         Some(30),
     );
 

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -33,6 +33,10 @@ fn flush_overload_notification(
     let mut batch: DBBatch = store.db_batch_for_test();
     output.write_to_batch(store, &mut batch).unwrap();
     batch.write().unwrap();
+    // The commit flush loop updates the in-memory cache in lockstep with the
+    // table write; this helper writes the table directly, so update the cache
+    // explicitly to keep the two consistent.
+    store.apply_overload_notification_to_cache_for_test(authority, percentage);
 }
 
 #[tokio::test]

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use iota_types::base_types::TransactionDigest;
 use tokio::time::timeout;
@@ -144,4 +147,72 @@ async fn wait_for_transactions_in_checkpoint_times_out_without_notify() {
         elapsed < wait_timeout * 5,
         "wait took unreasonably long: {elapsed:?}"
     );
+}
+
+/// Persisted overload notifications must round-trip through
+/// `record_overload_notification_v1` -> `load_overload_notifications`.
+/// Re-recording overwrites the previous percentage.
+#[tokio::test]
+async fn test_load_overload_notifications_round_trip() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+
+    assert!(
+        store.load_overload_notifications().unwrap().is_empty(),
+        "no notifications recorded yet",
+    );
+
+    store.record_overload_notification_v1(&me, 25).unwrap();
+    assert_eq!(
+        store
+            .load_overload_notifications()
+            .unwrap()
+            .get(&me)
+            .copied(),
+        Some(25),
+    );
+
+    // A subsequent record from the same authority overwrites the prior value.
+    store.record_overload_notification_v1(&me, 75).unwrap();
+    assert_eq!(
+        store
+            .load_overload_notifications()
+            .unwrap()
+            .get(&me)
+            .copied(),
+        Some(75),
+    );
+}
+
+/// `compute_quorum_load_shedding_percentage` must read the percentile from
+/// the supplied map without consulting the DB. With a single-authority test
+/// committee the 2f+1 quorum value is just that authority's reported value
+/// (or 0 when absent). This is the same code path used to apply in-batch
+/// `OverloadNotificationV1` overrides on top of the persisted map before
+/// dropping user transactions.
+#[tokio::test]
+async fn test_compute_quorum_load_shedding_percentage_uses_overlay() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+
+    // Empty overlay -> 0%.
+    let empty: HashMap<_, _> = HashMap::new();
+    assert_eq!(store.compute_quorum_load_shedding_percentage(&empty), 0);
+
+    // Overlay-only value is reflected without touching the DB.
+    let mut overlay = HashMap::new();
+    overlay.insert(me, 60);
+    assert_eq!(store.compute_quorum_load_shedding_percentage(&overlay), 60);
+
+    // Persist a different value and confirm the overlay wins, mirroring the
+    // last-writer-wins behavior of the pre-pass merge step.
+    store.record_overload_notification_v1(&me, 10).unwrap();
+    let mut merged = store.load_overload_notifications().unwrap();
+    merged.insert(me, 90);
+    assert_eq!(store.compute_quorum_load_shedding_percentage(&merged), 90);
+
+    // Without the overlay, only the persisted value is visible.
+    assert_eq!(store.get_quorum_load_shedding_percentage().unwrap(), 10);
 }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -155,3 +155,72 @@ async fn test_compute_quorum_load_shedding_percentage_uses_overlay() {
     // Without the overlay, only the persisted value is visible.
     assert_eq!(store.get_quorum_load_shedding_percentage().unwrap(), 10);
 }
+/// `load_overload_notifications` must return the same notification map
+/// whether a given authority's latest reported percentage lives in the
+/// persisted `authority_overload_notifications` DBMap or in a still-queued
+/// `ConsensusCommitOutput` inside `ConsensusOutputQuarantine`. The "logical
+/// state" of overload notifications is the union of (a) everything flushed to
+/// disk so far and (b) everything processed but not yet flushed; the read
+/// path must surface that union, not just (a).
+///
+/// This invariance under the disk/queue split is what makes the
+/// post-consensus drop decision deterministic: the same set of notifications
+/// fed into `compute_quorum_load_shedding_percentage` regardless of where the
+/// flush boundary happens to fall when the read is taken.
+///
+/// The test puts the same authority's value first in (a), then in (b), then
+/// back in (a) (mirroring what a fresh start sees after a queued commit has
+/// been flushed). All three reads must agree, and the derived
+/// `get_quorum_load_shedding_percentage` must match.
+#[tokio::test]
+async fn test_load_overload_notifications_invariant_under_disk_queue_split() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let authority_name = store.name;
+
+    // Disk holds an earlier value for the authority.
+    flush_overload_notification(&store, authority_name, 30);
+    assert_eq!(
+        store.load_overload_notifications().unwrap().get(&authority_name).copied(),
+        Some(30),
+    );
+
+    // A later commit has been processed and its output is sitting in the
+    // quarantine queue, *not* yet flushed. This is the common steady-state
+    // condition while consensus runs ahead of the checkpoint executor —
+    // potentially many commits queue up before any of them flush.
+    let mut later = ConsensusCommitOutput::default();
+    later.record_overload_notification(authority_name, 80);
+    later.set_default_commit_stats_for_testing();
+    store.push_consensus_output_for_tests(later);
+
+    // The read that drives the post-consensus drop decision must see the
+    // queued value, not the stale on-disk one.
+    let from_queue = store
+        .load_overload_notifications()
+        .unwrap()
+        .get(&authority_name)
+        .copied();
+    assert_eq!(
+        from_queue,
+        Some(80),
+        "queued notifications must be visible via load_overload_notifications",
+    );
+
+    // Now the same logical state sits fully on disk (as it would after the
+    // queued commit drains to RocksDB). The read must produce the same
+    // notification map as before.
+    flush_overload_notification(&store, authority_name, 80);
+    let from_disk = store
+        .load_overload_notifications()
+        .unwrap()
+        .get(&authority_name)
+        .copied();
+    assert_eq!(
+        from_queue, from_disk,
+        "load_overload_notifications must be invariant under the disk/queue split",
+    );
+
+    // The derived quorum percentage must agree with the union view.
+    assert_eq!(store.get_quorum_load_shedding_percentage().unwrap(), 80);
+}

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -12,7 +12,9 @@ use tokio::time::timeout;
 use typed_store::rocks::DBBatch;
 
 use crate::authority::{
-    authority_per_epoch_store::{AuthorityPerEpochStore, consensus_quarantine::ConsensusCommitOutput},
+    authority_per_epoch_store::{
+        AuthorityPerEpochStore, consensus_quarantine::ConsensusCommitOutput,
+    },
     test_authority_builder::TestAuthorityBuilder,
 };
 

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -9,7 +9,9 @@ use tokio::time::timeout;
 use typed_store::rocks::DBBatch;
 
 use crate::authority::{
-    authority_per_epoch_store::{AuthorityPerEpochStore, consensus_quarantine::ConsensusCommitOutput},
+    authority_per_epoch_store::{
+        AuthorityPerEpochStore, consensus_quarantine::ConsensusCommitOutput,
+    },
     test_authority_builder::TestAuthorityBuilder,
 };
 

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -4,10 +4,31 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use iota_types::base_types::TransactionDigest;
+use iota_types::base_types::{AuthorityName, TransactionDigest};
 use tokio::time::timeout;
+use typed_store::rocks::DBBatch;
 
-use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::authority::{
+    authority_per_epoch_store::{AuthorityPerEpochStore, consensus_quarantine::ConsensusCommitOutput},
+    test_authority_builder::TestAuthorityBuilder,
+};
+
+/// Records an overload notification through the same path
+/// `process_consensus_transaction` uses: buffer it in `ConsensusCommitOutput`
+/// and flush via `write_to_batch`. This is the only sanctioned way to populate
+/// `authority_overload_notifications` outside the consensus loop.
+fn flush_overload_notification(
+    store: &AuthorityPerEpochStore,
+    authority: AuthorityName,
+    percentage: u8,
+) {
+    let mut output = ConsensusCommitOutput::new(0);
+    output.record_overload_notification(authority, percentage);
+    output.set_default_commit_stats_for_testing();
+    let mut batch: DBBatch = store.db_batch_for_test();
+    output.write_to_batch(store, &mut batch).unwrap();
+    batch.write().unwrap();
+}
 
 #[tokio::test]
 async fn test_notify_read_executed_transactions_to_checkpoint() {
@@ -64,8 +85,9 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
 }
 
 /// Persisted overload notifications must round-trip through
-/// `record_overload_notification_v1` -> `load_overload_notifications`.
-/// Re-recording overwrites the previous percentage.
+/// `ConsensusCommitOutput::record_overload_notification` (flushed via
+/// `write_to_batch`) -> `load_overload_notifications`. Re-recording in a
+/// subsequent commit overwrites the previous percentage.
 #[tokio::test]
 async fn test_load_overload_notifications_round_trip() {
     let authority_state = TestAuthorityBuilder::new().build().await;
@@ -77,7 +99,7 @@ async fn test_load_overload_notifications_round_trip() {
         "no notifications recorded yet",
     );
 
-    store.record_overload_notification_v1(&me, 25).unwrap();
+    flush_overload_notification(&store, me, 25);
     assert_eq!(
         store
             .load_overload_notifications()
@@ -87,8 +109,9 @@ async fn test_load_overload_notifications_round_trip() {
         Some(25),
     );
 
-    // A subsequent record from the same authority overwrites the prior value.
-    store.record_overload_notification_v1(&me, 75).unwrap();
+    // A subsequent commit's recorder call from the same authority overwrites
+    // the prior value once flushed.
+    flush_overload_notification(&store, me, 75);
     assert_eq!(
         store
             .load_overload_notifications()
@@ -122,7 +145,7 @@ async fn test_compute_quorum_load_shedding_percentage_uses_overlay() {
 
     // Persist a different value and confirm the overlay wins, mirroring the
     // last-writer-wins behavior of the pre-pass merge step.
-    store.record_overload_notification_v1(&me, 10).unwrap();
+    flush_overload_notification(&store, me, 10);
     let mut merged = store.load_overload_notifications().unwrap();
     merged.insert(me, 90);
     assert_eq!(store.compute_quorum_load_shedding_percentage(&merged), 90);

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -241,3 +241,72 @@ async fn test_compute_quorum_load_shedding_percentage_uses_overlay() {
     // Without the overlay, only the persisted value is visible.
     assert_eq!(store.get_quorum_load_shedding_percentage().unwrap(), 10);
 }
+/// `load_overload_notifications` must return the same notification map
+/// whether a given authority's latest reported percentage lives in the
+/// persisted `authority_overload_notifications` DBMap or in a still-queued
+/// `ConsensusCommitOutput` inside `ConsensusOutputQuarantine`. The "logical
+/// state" of overload notifications is the union of (a) everything flushed to
+/// disk so far and (b) everything processed but not yet flushed; the read
+/// path must surface that union, not just (a).
+///
+/// This invariance under the disk/queue split is what makes the
+/// post-consensus drop decision deterministic: the same set of notifications
+/// fed into `compute_quorum_load_shedding_percentage` regardless of where the
+/// flush boundary happens to fall when the read is taken.
+///
+/// The test puts the same authority's value first in (a), then in (b), then
+/// back in (a) (mirroring what a fresh start sees after a queued commit has
+/// been flushed). All three reads must agree, and the derived
+/// `get_quorum_load_shedding_percentage` must match.
+#[tokio::test]
+async fn test_load_overload_notifications_invariant_under_disk_queue_split() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let authority_name = store.name;
+
+    // Disk holds an earlier value for the authority.
+    flush_overload_notification(&store, authority_name, 30);
+    assert_eq!(
+        store.load_overload_notifications().unwrap().get(&authority_name).copied(),
+        Some(30),
+    );
+
+    // A later commit has been processed and its output is sitting in the
+    // quarantine queue, *not* yet flushed. This is the common steady-state
+    // condition while consensus runs ahead of the checkpoint executor —
+    // potentially many commits queue up before any of them flush.
+    let mut later = ConsensusCommitOutput::default();
+    later.record_overload_notification(authority_name, 80);
+    later.set_default_commit_stats_for_testing();
+    store.push_consensus_output_for_tests(later);
+
+    // The read that drives the post-consensus drop decision must see the
+    // queued value, not the stale on-disk one.
+    let from_queue = store
+        .load_overload_notifications()
+        .unwrap()
+        .get(&authority_name)
+        .copied();
+    assert_eq!(
+        from_queue,
+        Some(80),
+        "queued notifications must be visible via load_overload_notifications",
+    );
+
+    // Now the same logical state sits fully on disk (as it would after the
+    // queued commit drains to RocksDB). The read must produce the same
+    // notification map as before.
+    flush_overload_notification(&store, authority_name, 80);
+    let from_disk = store
+        .load_overload_notifications()
+        .unwrap()
+        .get(&authority_name)
+        .copied();
+    assert_eq!(
+        from_queue, from_disk,
+        "load_overload_notifications must be invariant under the disk/queue split",
+    );
+
+    // The derived quorum percentage must agree with the union view.
+    assert_eq!(store.get_quorum_load_shedding_percentage().unwrap(), 80);
+}

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -258,10 +258,13 @@ async fn test_compute_quorum_load_shedding_percentage_uses_overlay() {
 /// fed into `compute_quorum_load_shedding_percentage` regardless of where the
 /// flush boundary happens to fall when the read is taken.
 ///
-/// The test puts the same authority's value first in (a), then in (b), then
-/// back in (a) (mirroring what a fresh start sees after a queued commit has
-/// been flushed). All three reads must agree, and the derived
-/// `get_quorum_load_shedding_percentage` must match.
+/// The test reads a value through path (b) — a queued, not-yet-flushed commit —
+/// and through path (a) — held fully on disk with an empty quarantine, on a
+/// second independent authority that models the freshly started / drained
+/// state. Both reads must agree, and the derived
+/// `get_quorum_load_shedding_percentage` must match. A single authority can't
+/// test path (a) cleanly: its queued entry lingers, making the read a tautology
+/// of disk overlaid by the identical queued value.
 #[tokio::test]
 async fn test_load_overload_notifications_invariant_under_disk_queue_split() {
     let authority_state = TestAuthorityBuilder::new().build().await;
@@ -301,20 +304,31 @@ async fn test_load_overload_notifications_invariant_under_disk_queue_split() {
         "queued notifications must be visible via load_overload_notifications",
     );
 
-    // Now the same logical state sits fully on disk (as it would after the
-    // queued commit drains to RocksDB). The read must produce the same
-    // notification map as before.
-    flush_overload_notification(&store, authority_name, 80);
-    let from_disk = store
+    // The other end of the split: the same logical state held fully on disk
+    // with nothing queued, as a freshly started authority sees it once the
+    // queued commit has drained. A second, independent authority — empty
+    // quarantine — with 80 persisted must read back the same value as the
+    // queued case above. (Reusing the first authority would not test this:
+    // its queued entry lingers, so the read would be disk(80)
+    // overlaid by queue(80).)
+    let fresh_state = TestAuthorityBuilder::new().build().await;
+    let fresh_store = fresh_state.epoch_store_for_testing();
+    let fresh_authority = fresh_store.name;
+    flush_overload_notification(&fresh_store, fresh_authority, 80);
+
+    let from_disk = fresh_store
         .load_overload_notifications()
         .unwrap()
-        .get(&authority_name)
+        .get(&fresh_authority)
         .copied();
     assert_eq!(
         from_queue, from_disk,
         "load_overload_notifications must be invariant under the disk/queue split",
     );
 
-    // The derived quorum percentage must agree with the union view.
-    assert_eq!(store.get_quorum_load_shedding_percentage().unwrap(), 80);
+    // The derived quorum percentage must agree with the disk-only view.
+    assert_eq!(
+        fresh_store.get_quorum_load_shedding_percentage().unwrap(),
+        80,
+    );
 }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -7,10 +7,31 @@ use std::{
     time::{Duration, Instant},
 };
 
-use iota_types::base_types::TransactionDigest;
+use iota_types::base_types::{AuthorityName, TransactionDigest};
 use tokio::time::timeout;
+use typed_store::rocks::DBBatch;
 
-use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::authority::{
+    authority_per_epoch_store::{AuthorityPerEpochStore, consensus_quarantine::ConsensusCommitOutput},
+    test_authority_builder::TestAuthorityBuilder,
+};
+
+/// Records an overload notification through the same path
+/// `process_consensus_transaction` uses: buffer it in `ConsensusCommitOutput`
+/// and flush via `write_to_batch`. This is the only sanctioned way to populate
+/// `authority_overload_notifications` outside the consensus loop.
+fn flush_overload_notification(
+    store: &AuthorityPerEpochStore,
+    authority: AuthorityName,
+    percentage: u8,
+) {
+    let mut output = ConsensusCommitOutput::new(0);
+    output.record_overload_notification(authority, percentage);
+    output.set_default_commit_stats_for_testing();
+    let mut batch: DBBatch = store.db_batch_for_test();
+    output.write_to_batch(store, &mut batch).unwrap();
+    batch.write().unwrap();
+}
 
 #[tokio::test]
 async fn test_notify_read_executed_transactions_to_checkpoint() {
@@ -150,8 +171,9 @@ async fn wait_for_transactions_in_checkpoint_times_out_without_notify() {
 }
 
 /// Persisted overload notifications must round-trip through
-/// `record_overload_notification_v1` -> `load_overload_notifications`.
-/// Re-recording overwrites the previous percentage.
+/// `ConsensusCommitOutput::record_overload_notification` (flushed via
+/// `write_to_batch`) -> `load_overload_notifications`. Re-recording in a
+/// subsequent commit overwrites the previous percentage.
 #[tokio::test]
 async fn test_load_overload_notifications_round_trip() {
     let authority_state = TestAuthorityBuilder::new().build().await;
@@ -163,7 +185,7 @@ async fn test_load_overload_notifications_round_trip() {
         "no notifications recorded yet",
     );
 
-    store.record_overload_notification_v1(&me, 25).unwrap();
+    flush_overload_notification(&store, me, 25);
     assert_eq!(
         store
             .load_overload_notifications()
@@ -173,8 +195,9 @@ async fn test_load_overload_notifications_round_trip() {
         Some(25),
     );
 
-    // A subsequent record from the same authority overwrites the prior value.
-    store.record_overload_notification_v1(&me, 75).unwrap();
+    // A subsequent commit's recorder call from the same authority overwrites
+    // the prior value once flushed.
+    flush_overload_notification(&store, me, 75);
     assert_eq!(
         store
             .load_overload_notifications()
@@ -208,7 +231,7 @@ async fn test_compute_quorum_load_shedding_percentage_uses_overlay() {
 
     // Persist a different value and confirm the overlay wins, mirroring the
     // last-writer-wins behavior of the pre-pass merge step.
-    store.record_overload_notification_v1(&me, 10).unwrap();
+    flush_overload_notification(&store, me, 10);
     let mut merged = store.load_overload_notifications().unwrap();
     merged.insert(me, 90);
     assert_eq!(store.compute_quorum_load_shedding_percentage(&merged), 90);

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use iota_types::base_types::TransactionDigest;
 use tokio::time::timeout;
@@ -61,4 +61,72 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
     assert_eq!(result[0].unwrap(), checkpoint_sequence_1);
     assert_eq!(result[1].unwrap(), checkpoint_sequence_2);
     assert_eq!(result[2].unwrap(), checkpoint_sequence_2);
+}
+
+/// Persisted overload notifications must round-trip through
+/// `record_overload_notification_v1` -> `load_overload_notifications`.
+/// Re-recording overwrites the previous percentage.
+#[tokio::test]
+async fn test_load_overload_notifications_round_trip() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+
+    assert!(
+        store.load_overload_notifications().unwrap().is_empty(),
+        "no notifications recorded yet",
+    );
+
+    store.record_overload_notification_v1(&me, 25).unwrap();
+    assert_eq!(
+        store
+            .load_overload_notifications()
+            .unwrap()
+            .get(&me)
+            .copied(),
+        Some(25),
+    );
+
+    // A subsequent record from the same authority overwrites the prior value.
+    store.record_overload_notification_v1(&me, 75).unwrap();
+    assert_eq!(
+        store
+            .load_overload_notifications()
+            .unwrap()
+            .get(&me)
+            .copied(),
+        Some(75),
+    );
+}
+
+/// `compute_quorum_load_shedding_percentage` must read the percentile from
+/// the supplied map without consulting the DB. With a single-authority test
+/// committee the 2f+1 quorum value is just that authority's reported value
+/// (or 0 when absent). This is the same code path used to apply in-batch
+/// `OverloadNotificationV1` overrides on top of the persisted map before
+/// dropping user transactions.
+#[tokio::test]
+async fn test_compute_quorum_load_shedding_percentage_uses_overlay() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+
+    // Empty overlay -> 0%.
+    let empty: HashMap<_, _> = HashMap::new();
+    assert_eq!(store.compute_quorum_load_shedding_percentage(&empty), 0);
+
+    // Overlay-only value is reflected without touching the DB.
+    let mut overlay = HashMap::new();
+    overlay.insert(me, 60);
+    assert_eq!(store.compute_quorum_load_shedding_percentage(&overlay), 60);
+
+    // Persist a different value and confirm the overlay wins, mirroring the
+    // last-writer-wins behavior of the pre-pass merge step.
+    store.record_overload_notification_v1(&me, 10).unwrap();
+    let mut merged = store.load_overload_notifications().unwrap();
+    merged.insert(me, 90);
+    assert_eq!(store.compute_quorum_load_shedding_percentage(&merged), 90);
+
+    // Without the overlay, only the persisted value is visible.
+    assert_eq!(store.get_quorum_load_shedding_percentage().unwrap(), 10);
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -167,6 +167,7 @@ pub struct ValidatorComponents {
     /// Handle for the soft-lock expiry sweep task. The task self-terminates
     /// via a `Weak` reference; this handle exists purely for ownership clarity.
     soft_lock_sweep_handle: JoinHandle<()>,
+    overload_notifier_handle: Option<JoinHandle<()>>,
     consensus_manager: ConsensusManager,
     consensus_store_pruner: ConsensusStorePruner,
     consensus_adapter: Arc<ConsensusAdapter>,
@@ -290,6 +291,51 @@ impl IotaNode {
             ServerVersion::new("iota-node", "unknown"),
         )
         .await
+    }
+
+    /// Starts a background task that polls the authority's load shedding
+    /// percentage and broadcasts changes to other validators via consensus.
+    /// Returns the task handle if the feature flag is enabled, or `None`
+    /// otherwise.
+    fn start_overload_notifier(
+        config: &NodeConfig,
+        state: Arc<AuthorityState>,
+        epoch_store: Arc<AuthorityPerEpochStore>,
+        consensus_adapter: Arc<ConsensusAdapter>,
+    ) -> Option<JoinHandle<()>> {
+        if !epoch_store.protocol_config().post_consensus_load_shedding() {
+            return None;
+        }
+
+        let poll_interval = config.authority_overload_config.overload_monitor_interval;
+        let authority_name = state.name;
+
+        Some(spawn_monitored_task!(async move {
+            let mut last_notified_percentage: u32 = state
+                .overload_info
+                .load_shedding_percentage
+                .load(std::sync::atomic::Ordering::Relaxed);
+            loop {
+                tokio::time::sleep(poll_interval).await;
+                let current = state
+                    .overload_info
+                    .load_shedding_percentage
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                if current != last_notified_percentage {
+                    last_notified_percentage = current;
+                    let transaction = ConsensusTransaction::new_overload_notification_v1(
+                        authority_name,
+                        current as u8,
+                    );
+                    if let Err(e) = consensus_adapter.submit(transaction, None, &epoch_store) {
+                        tracing::warn!(
+                            "Failed to submit overload notification to consensus: {:?}",
+                            e
+                        );
+                    }
+                }
+            }
+        }))
     }
 
     pub async fn start_async(
@@ -1377,11 +1423,19 @@ impl IotaNode {
         info!("Spawning checkpoint service");
         let checkpoint_service_tasks = checkpoint_service.spawn().await;
 
+        let overload_notifier_handle = Self::start_overload_notifier(
+            config,
+            state.clone(),
+            epoch_store.clone(),
+            consensus_adapter.clone(),
+        );
+
         Ok(ValidatorComponents {
             validator_server_handle,
             validator_overload_monitor_handle,
             consensus_queue_overload_monitor_handle,
             soft_lock_sweep_handle,
+            overload_notifier_handle,
             consensus_manager,
             consensus_store_pruner,
             consensus_adapter,
@@ -1875,6 +1929,7 @@ impl IotaNode {
                 validator_overload_monitor_handle,
                 consensus_queue_overload_monitor_handle,
                 soft_lock_sweep_handle,
+                overload_notifier_handle,
                 consensus_manager,
                 consensus_store_pruner,
                 consensus_adapter,
@@ -1886,6 +1941,11 @@ impl IotaNode {
             }) = validator_components_lock_guard.take()
             {
                 info!("Reconfiguring the validator.");
+                // Cancel the old overload notifier task so a new one can be
+                // started for the next epoch.
+                if let Some(handle) = overload_notifier_handle {
+                    handle.abort();
+                }
                 // Cancel the old checkpoint service tasks.
                 // Waiting for checkpoint builder to finish gracefully is not possible, because
                 // it may wait on transactions while consensus on peers have

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -301,7 +301,7 @@ impl IotaNode {
         epoch_store: Arc<AuthorityPerEpochStore>,
         consensus_adapter: Arc<ConsensusAdapter>,
     ) -> Option<JoinHandle<()>> {
-        if !epoch_store.protocol_config().post_consensus_load_shedding() {
+        if !epoch_store.protocol_config().enable_white_flag_flow() {
             return None;
         }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -167,6 +167,7 @@ pub struct ValidatorComponents {
     /// Handle for the soft-lock expiry sweep task. The task self-terminates
     /// via a `Weak` reference; this handle exists purely for ownership clarity.
     soft_lock_sweep_handle: JoinHandle<()>,
+    overload_notifier_handle: Option<JoinHandle<()>>,
     consensus_manager: ConsensusManager,
     consensus_store_pruner: ConsensusStorePruner,
     consensus_adapter: Arc<ConsensusAdapter>,
@@ -288,6 +289,51 @@ impl IotaNode {
             ServerVersion::new("iota-node", "unknown"),
         )
         .await
+    }
+
+    /// Starts a background task that polls the authority's load shedding
+    /// percentage and broadcasts changes to other validators via consensus.
+    /// Returns the task handle if the feature flag is enabled, or `None`
+    /// otherwise.
+    fn start_overload_notifier(
+        config: &NodeConfig,
+        state: Arc<AuthorityState>,
+        epoch_store: Arc<AuthorityPerEpochStore>,
+        consensus_adapter: Arc<ConsensusAdapter>,
+    ) -> Option<JoinHandle<()>> {
+        if !epoch_store.protocol_config().post_consensus_load_shedding() {
+            return None;
+        }
+
+        let poll_interval = config.authority_overload_config.overload_monitor_interval;
+        let authority_name = state.name;
+
+        Some(spawn_monitored_task!(async move {
+            let mut last_notified_percentage: u32 = state
+                .overload_info
+                .load_shedding_percentage
+                .load(std::sync::atomic::Ordering::Relaxed);
+            loop {
+                tokio::time::sleep(poll_interval).await;
+                let current = state
+                    .overload_info
+                    .load_shedding_percentage
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                if current != last_notified_percentage {
+                    last_notified_percentage = current;
+                    let transaction = ConsensusTransaction::new_overload_notification_v1(
+                        authority_name,
+                        current as u8,
+                    );
+                    if let Err(e) = consensus_adapter.submit(transaction, None, &epoch_store) {
+                        tracing::warn!(
+                            "Failed to submit overload notification to consensus: {:?}",
+                            e
+                        );
+                    }
+                }
+            }
+        }))
     }
 
     pub async fn start_async(
@@ -1363,11 +1409,19 @@ impl IotaNode {
         info!("Spawning checkpoint service");
         let checkpoint_service_tasks = checkpoint_service.spawn().await;
 
+        let overload_notifier_handle = Self::start_overload_notifier(
+            config,
+            state.clone(),
+            epoch_store.clone(),
+            consensus_adapter.clone(),
+        );
+
         Ok(ValidatorComponents {
             validator_server_handle,
             validator_overload_monitor_handle,
             consensus_queue_overload_monitor_handle,
             soft_lock_sweep_handle,
+            overload_notifier_handle,
             consensus_manager,
             consensus_store_pruner,
             consensus_adapter,
@@ -1862,6 +1916,7 @@ impl IotaNode {
                 validator_overload_monitor_handle,
                 consensus_queue_overload_monitor_handle,
                 soft_lock_sweep_handle,
+                overload_notifier_handle,
                 consensus_manager,
                 consensus_store_pruner,
                 consensus_adapter,
@@ -1873,6 +1928,11 @@ impl IotaNode {
             }) = validator_components_lock_guard.take()
             {
                 info!("Reconfiguring the validator.");
+                // Cancel the old overload notifier task so a new one can be
+                // started for the next epoch.
+                if let Some(handle) = overload_notifier_handle {
+                    handle.abort();
+                }
                 // Cancel the old checkpoint service tasks.
                 // Waiting for checkpoint builder to finish gracefully is not possible, because
                 // it may wait on transactions while consensus on peers have

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -311,13 +311,13 @@ impl IotaNode {
         Some(spawn_monitored_task!(async move {
             let mut last_notified_percentage: u32 = state
                 .overload_info
-                .load_shedding_percentage
+                .local_load_shedding_percentage
                 .load(std::sync::atomic::Ordering::Relaxed);
             loop {
                 tokio::time::sleep(poll_interval).await;
                 let current = state
                     .overload_info
-                    .load_shedding_percentage
+                    .local_load_shedding_percentage
                     .load(std::sync::atomic::Ordering::Relaxed);
                 if current != last_notified_percentage {
                     last_notified_percentage = current;

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -311,10 +311,10 @@ impl IotaNode {
         let authority_name = state.name;
 
         Some(spawn_monitored_task!(async move {
-            let mut last_notified_percentage: u32 = state
-                .overload_info
-                .local_load_shedding_percentage
-                .load(std::sync::atomic::Ordering::Relaxed);
+            // Seed from the percentage this authority last broadcasted
+            let mut last_notified_percentage: u32 = epoch_store
+                .load_overload_notification(&authority_name)
+                .unwrap_or(0) as u32;
             loop {
                 tokio::time::sleep(poll_interval).await;
                 let current = state

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -303,7 +303,7 @@ impl IotaNode {
         epoch_store: Arc<AuthorityPerEpochStore>,
         consensus_adapter: Arc<ConsensusAdapter>,
     ) -> Option<JoinHandle<()>> {
-        if !epoch_store.protocol_config().post_consensus_load_shedding() {
+        if !epoch_store.protocol_config().enable_white_flag_flow() {
             return None;
         }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -313,13 +313,13 @@ impl IotaNode {
         Some(spawn_monitored_task!(async move {
             let mut last_notified_percentage: u32 = state
                 .overload_info
-                .load_shedding_percentage
+                .local_load_shedding_percentage
                 .load(std::sync::atomic::Ordering::Relaxed);
             loop {
                 tokio::time::sleep(poll_interval).await;
                 let current = state
                     .overload_info
-                    .load_shedding_percentage
+                    .local_load_shedding_percentage
                     .load(std::sync::atomic::Ordering::Relaxed);
                 if current != last_notified_percentage {
                     last_notified_percentage = current;

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/iota-swarm-config/tests/snapshot_tests.rs
 expression: network_config
+snapshot_kind: text
 ---
 validator_configs:
   - authority-key-pair:
@@ -90,6 +91,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
@@ -188,6 +190,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
@@ -286,6 +289,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
@@ -384,6 +388,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
@@ -482,6 +487,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
@@ -580,6 +586,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
@@ -678,6 +685,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -106,9 +106,8 @@ impl Debug for ConsensusTransactionKey {
             Self::OverloadNotificationV1(name, percentage) => {
                 write!(
                     f,
-                    "OverloadNotificationV1({:?}, {:?})",
-                    name.concise(),
-                    percentage
+                    "OverloadNotificationV1({:?}, {percentage:?})",
+                    name.concise()
                 )
             }
         }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -56,7 +56,7 @@ pub enum ConsensusTransactionKey {
     ),
     /// White flag user transaction key (by transaction digest).
     UserTransaction(TransactionDigest),
-    OverloadNotificationV1(AuthorityName, u8),
+    OverloadNotificationV1(AuthorityName, u64 /* generation */),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -98,10 +98,10 @@ impl Debug for ConsensusTransactionKey {
                 )
             }
             Self::UserTransaction(digest) => write!(f, "UserTransaction({digest:?})"),
-            Self::OverloadNotificationV1(name, percentage) => {
+            Self::OverloadNotificationV1(name, generation) => {
                 write!(
                     f,
-                    "OverloadNotificationV1({:?}, {percentage:?})",
+                    "OverloadNotificationV1({:?}, gen={generation:?})",
                     name.concise()
                 )
             }
@@ -247,7 +247,11 @@ pub enum ConsensusTransactionKind {
     /// directly to consensus without pre-consensus object locking.
     /// Conflicts are resolved post-consensus.
     UserTransactionV1(Box<Transaction>),
-    OverloadNotificationV1(AuthorityName, u8),
+    OverloadNotificationV1(
+        AuthorityName,
+        u64, // generation
+        u8,  // percentage
+    ),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -565,14 +569,28 @@ impl ConsensusTransaction {
         authority: AuthorityName,
         load_shedding_percentage: u8,
     ) -> Self {
+        // Wall-clock millis-since-epoch is used purely as a unique-per-submission
+        // disambiguator in the consensus transaction key, mirroring
+        // `AuthorityCapabilitiesV1::new`, because `consensus_message_processed`
+        // dedups by key for the full epoch.
+        // The receive side uses the percentage value directly; the generation is only
+        // for key uniqueness, not for ordering (consensus already orders deliveries).
+        let generation: u64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("IOTA did not exist prior to 1970")
+            .as_millis()
+            .try_into()
+            .expect("This build of iota is not supported in the year 500,000,000");
         let mut hasher = DefaultHasher::new();
         authority.hash(&mut hasher);
+        generation.hash(&mut hasher);
         load_shedding_percentage.hash(&mut hasher);
         let tracking_id = hasher.finish().to_le_bytes();
         Self {
             tracking_id,
             kind: ConsensusTransactionKind::OverloadNotificationV1(
                 authority,
+                generation,
                 load_shedding_percentage,
             ),
         }
@@ -628,8 +646,8 @@ impl ConsensusTransaction {
             ConsensusTransactionKind::UserTransactionV1(tx) => {
                 ConsensusTransactionKey::UserTransaction(*tx.digest())
             }
-            ConsensusTransactionKind::OverloadNotificationV1(authority, percentage) => {
-                ConsensusTransactionKey::OverloadNotificationV1(*authority, *percentage)
+            ConsensusTransactionKind::OverloadNotificationV1(authority, generation, _) => {
+                ConsensusTransactionKey::OverloadNotificationV1(*authority, *generation)
             }
         }
     }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -61,6 +61,7 @@ pub enum ConsensusTransactionKey {
     ),
     /// White flag user transaction key (by transaction digest).
     UserTransaction(TransactionDigest),
+    OverloadNotificationV1(AuthorityName, u8),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -102,6 +103,14 @@ impl Debug for ConsensusTransactionKey {
                 )
             }
             Self::UserTransaction(digest) => write!(f, "UserTransaction({digest:?})"),
+            Self::OverloadNotificationV1(name, percentage) => {
+                write!(
+                    f,
+                    "OverloadNotificationV1({:?}, {:?})",
+                    name.concise(),
+                    percentage
+                )
+            }
         }
     }
 }
@@ -248,6 +257,7 @@ pub enum ConsensusTransactionKind {
     /// directly to consensus without pre-consensus object locking.
     /// Conflicts are resolved post-consensus.
     UserTransactionV1(Box<Transaction>),
+    OverloadNotificationV1(AuthorityName, u8),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -588,6 +598,23 @@ impl ConsensusTransaction {
         }
     }
 
+    pub fn new_overload_notification_v1(
+        authority: AuthorityName,
+        load_shedding_percentage: u8,
+    ) -> Self {
+        let mut hasher = DefaultHasher::new();
+        authority.hash(&mut hasher);
+        load_shedding_percentage.hash(&mut hasher);
+        let tracking_id = hasher.finish().to_le_bytes();
+        Self {
+            tracking_id,
+            kind: ConsensusTransactionKind::OverloadNotificationV1(
+                authority,
+                load_shedding_percentage,
+            ),
+        }
+    }
+
     pub fn get_tracking_id(&self) -> u64 {
         (&self.tracking_id[..])
             .read_u64::<BigEndian>()
@@ -637,6 +664,9 @@ impl ConsensusTransaction {
             }
             ConsensusTransactionKind::UserTransactionV1(tx) => {
                 ConsensusTransactionKey::UserTransaction(*tx.digest())
+            }
+            ConsensusTransactionKind::OverloadNotificationV1(authority, percentage) => {
+                ConsensusTransactionKey::OverloadNotificationV1(*authority, *percentage)
             }
         }
     }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -101,9 +101,8 @@ impl Debug for ConsensusTransactionKey {
             Self::OverloadNotificationV1(name, percentage) => {
                 write!(
                     f,
-                    "OverloadNotificationV1({:?}, {:?})",
-                    name.concise(),
-                    percentage
+                    "OverloadNotificationV1({:?}, {percentage:?})",
+                    name.concise()
                 )
             }
         }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -56,6 +56,7 @@ pub enum ConsensusTransactionKey {
     ),
     /// White flag user transaction key (by transaction digest).
     UserTransaction(TransactionDigest),
+    OverloadNotificationV1(AuthorityName, u8),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -97,6 +98,14 @@ impl Debug for ConsensusTransactionKey {
                 )
             }
             Self::UserTransaction(digest) => write!(f, "UserTransaction({digest:?})"),
+            Self::OverloadNotificationV1(name, percentage) => {
+                write!(
+                    f,
+                    "OverloadNotificationV1({:?}, {:?})",
+                    name.concise(),
+                    percentage
+                )
+            }
         }
     }
 }
@@ -239,6 +248,7 @@ pub enum ConsensusTransactionKind {
     /// directly to consensus without pre-consensus object locking.
     /// Conflicts are resolved post-consensus.
     UserTransactionV1(Box<Transaction>),
+    OverloadNotificationV1(AuthorityName, u8),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -552,6 +562,23 @@ impl ConsensusTransaction {
         }
     }
 
+    pub fn new_overload_notification_v1(
+        authority: AuthorityName,
+        load_shedding_percentage: u8,
+    ) -> Self {
+        let mut hasher = DefaultHasher::new();
+        authority.hash(&mut hasher);
+        load_shedding_percentage.hash(&mut hasher);
+        let tracking_id = hasher.finish().to_le_bytes();
+        Self {
+            tracking_id,
+            kind: ConsensusTransactionKind::OverloadNotificationV1(
+                authority,
+                load_shedding_percentage,
+            ),
+        }
+    }
+
     pub fn get_tracking_id(&self) -> u64 {
         (&self.tracking_id[..])
             .read_u64::<BigEndian>()
@@ -601,6 +628,9 @@ impl ConsensusTransaction {
             }
             ConsensusTransactionKind::UserTransactionV1(tx) => {
                 ConsensusTransactionKey::UserTransaction(*tx.digest())
+            }
+            ConsensusTransactionKind::OverloadNotificationV1(authority, percentage) => {
+                ConsensusTransactionKey::OverloadNotificationV1(*authority, *percentage)
             }
         }
     }


### PR DESCRIPTION
# Description of change

Adds a post-consensus load shedding path for the certificate-less (white-flag) flow. Validators now broadcast their measured load shedding percentage to peers via a new consensus transaction, and each validator deterministically drops user transactions during post-consensus categorization based on the stake-weighted quorum percentile of those load shedding percentages — so the entire committee sheds the same set of transactions in the same round.

Prior to white-flag changes, the load shedding percentage was only used locally and was based on execution queue latency. There was also a transactions manager queue based threshold and writeback cache threshold above which everything was dropped. Now the previous latency based load shedding percentage is combined with a transaction manager queue and writeback cache based load shedding percentage, and all the dropping for these is done after consensus.

## How the change has been tested

Stess testing detailed in #11203 

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes