### PR TITLE
feat(cli): support Move authenticator as gas sponsor

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3886,19 +3886,10 @@ async fn create_move_authenticator_signature(
     auth_call_args: Option<&Vec<String>>,
     auth_type_args: Option<&Vec<String>>,
 ) -> Result<GenericSignature, anyhow::Error> {
-    let auth_info = fetch_auth_info(client, address).await?;
-
-    let (type_args, json_args) = process_auth_args(auth_call_args, auth_type_args, address)?;
-
-    let call_args = resolve_auth_call_args(
-        client,
-        auth_info.value.package,
-        &auth_info.value.module,
-        &auth_info.value.function,
-        &type_args,
-        json_args,
-    )
-    .await?;
+    let (call_args, type_args) =
+        build_auth_args_for_signing(client, address, auth_call_args, auth_type_args)
+            .await?
+            .ok_or_else(|| anyhow!("auth args are required to create a MoveAuthenticator"))?;
 
     let initial_shared_version = get_shared_object_version(client, &address).await?;
 

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3343,6 +3343,11 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
         !serialize_unsigned_transaction || !serialize_signed_transaction,
         "Cannot specify both flags: --serialize-unsigned-transaction and --serialize-signed-transaction."
     );
+    ensure!(
+        gas_sponsor.is_some()
+            || (sponsor_auth_call_args.is_none() && sponsor_auth_type_args.is_none()),
+        "--sponsor-auth-call-args and --sponsor-auth-type-args require --gas-sponsor."
+    );
     let gas_price = if let Some(gas_price) = gas_price {
         gas_price
     } else {
@@ -3753,7 +3758,7 @@ pub(crate) async fn build_auth_args_for_signing(
     address: IotaAddress,
     auth_call_args: Option<&Vec<String>>,
     auth_type_args: Option<&Vec<String>>,
-) -> Result<Option<(Vec<CallArg>, Vec<TypeInput>)>, anyhow::Error> {
+) -> Result<Option<(Vec<CallArg>, Vec<TypeTag>)>, anyhow::Error> {
     if auth_call_args.is_none() && auth_type_args.is_none() {
         return Ok(None);
     }
@@ -3769,10 +3774,7 @@ pub(crate) async fn build_auth_args_for_signing(
         json_args,
     )
     .await?;
-    Ok(Some((
-        call_args,
-        type_args.into_iter().map(TypeInput::from).collect(),
-    )))
+    Ok(Some((call_args, type_args)))
 }
 
 /// Resolves authentication call arguments, removing the signer arg added by

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -680,12 +680,21 @@ pub struct TxProcessingArgs {
     #[arg(long, required = false, num_args = 0.., value_parser = parse_display_option, default_value = "input,effects,events,object_changes,balance_changes")]
     pub display: HashSet<DisplayOption>,
     /// Auth input objects or primitive values for the Move authenticate
-    /// function
+    /// function of the sender.
     #[arg(long, num_args = 1..)]
     pub auth_call_args: Option<Vec<String>>,
-    /// Auth type arguments for the Move authenticate function
+    /// Auth type arguments for the Move authenticate function of the sender.
     #[arg(long, num_args = 1..)]
     pub auth_type_args: Option<Vec<String>>,
+    /// Auth input objects or primitive values for the Move authenticate
+    /// function of the gas sponsor. Use this when the sponsor is an abstract
+    /// account that must be authenticated via a `MoveAuthenticator`.
+    #[arg(long, num_args = 1..)]
+    pub sponsor_auth_call_args: Option<Vec<String>>,
+    /// Auth type arguments for the Move authenticate function of the gas
+    /// sponsor.
+    #[arg(long, num_args = 1..)]
+    pub sponsor_auth_type_args: Option<Vec<String>>,
 }
 
 impl TxProcessingArgs {
@@ -3327,6 +3336,8 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
         display,
         auth_call_args,
         auth_type_args,
+        sponsor_auth_call_args,
+        sponsor_auth_type_args,
     } = processing;
     ensure!(
         !serialize_unsigned_transaction || !serialize_signed_transaction,
@@ -3430,33 +3441,30 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
     } else if tx_digest {
         Ok(IotaClientCommandResult::ComputeTransactionDigest(tx_data))
     } else {
-        let auth_args = if auth_call_args.is_some() || auth_type_args.is_some() {
-            let auth_info = fetch_auth_info(&client, signer).await?;
-            let (type_args, json_args) =
-                process_auth_args(auth_call_args.as_ref(), auth_type_args.as_ref(), signer)?;
-            let call_args = resolve_auth_call_args(
-                &client,
-                auth_info.value.package,
-                &auth_info.value.module,
-                &auth_info.value.function,
-                &type_args,
-                json_args,
-            )
-            .await?;
-            Some((call_args, type_args))
-        } else {
-            None
-        };
+        let sender_auth_args = build_auth_args_for_signing(
+            &client,
+            signer,
+            auth_call_args.as_ref(),
+            auth_type_args.as_ref(),
+        )
+        .await?;
 
         let signature =
-            sign_transaction(context, &tx_data, &tx_data.sender(), auth_args.clone()).await?;
+            sign_transaction(context, &tx_data, &tx_data.sender(), sender_auth_args).await?;
 
         let mut signatures = vec![signature];
 
         if let Some(gas_sponsor) = gas_sponsor {
             if gas_sponsor != signer {
+                let sponsor_auth_args = build_auth_args_for_signing(
+                    &client,
+                    gas_sponsor,
+                    sponsor_auth_call_args.as_ref(),
+                    sponsor_auth_type_args.as_ref(),
+                )
+                .await?;
                 let signature =
-                    sign_transaction(context, &tx_data, &gas_sponsor, auth_args).await?;
+                    sign_transaction(context, &tx_data, &gas_sponsor, sponsor_auth_args).await?;
 
                 signatures.push(signature);
             }
@@ -3734,8 +3742,41 @@ async fn select_coins_for_amount(
     Ok(coins)
 }
 
-/// Resolves authentication call arguments, removing the signer arg added by the
-/// VM.
+/// Builds a `MoveAuthenticator` auth-args tuple for the given signer address.
+///
+/// Returns `None` when no `--auth-call-args` / `--auth-type-args` are provided.
+/// Fetches the `AuthenticatorFunctionRefV1` bound to `address` so the correct
+/// package/module/function is resolved per signer — required for abstract
+/// accounts acting as either sender or gas sponsor.
+pub(crate) async fn build_auth_args_for_signing(
+    client: &IotaClient,
+    address: IotaAddress,
+    auth_call_args: Option<&Vec<String>>,
+    auth_type_args: Option<&Vec<String>>,
+) -> Result<Option<(Vec<CallArg>, Vec<TypeInput>)>, anyhow::Error> {
+    if auth_call_args.is_none() && auth_type_args.is_none() {
+        return Ok(None);
+    }
+
+    let auth_info = fetch_auth_info(client, address).await?;
+    let (type_args, json_args) = process_auth_args(auth_call_args, auth_type_args, address)?;
+    let call_args = resolve_auth_call_args(
+        client,
+        auth_info.value.package,
+        &auth_info.value.module,
+        &auth_info.value.function,
+        &type_args,
+        json_args,
+    )
+    .await?;
+    Ok(Some((
+        call_args,
+        type_args.into_iter().map(TypeInput::from).collect(),
+    )))
+}
+
+/// Resolves authentication call arguments, removing the signer arg added by
+/// the VM.
 pub(crate) async fn resolve_auth_call_args(
     client: &IotaClient,
     package: ObjectID,

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3343,11 +3343,6 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
         !serialize_unsigned_transaction || !serialize_signed_transaction,
         "Cannot specify both flags: --serialize-unsigned-transaction and --serialize-signed-transaction."
     );
-    ensure!(
-        gas_sponsor.is_some()
-            || (sponsor_auth_call_args.is_none() && sponsor_auth_type_args.is_none()),
-        "--sponsor-auth-call-args and --sponsor-auth-type-args require --gas-sponsor."
-    );
     let gas_price = if let Some(gas_price) = gas_price {
         gas_price
     } else {
@@ -3357,6 +3352,12 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
     let client = context.get_client().await?;
 
     let signer = sender.unwrap_or(signer);
+
+    ensure!(
+        gas_sponsor.is_some_and(|s| s != signer)
+            || (sponsor_auth_call_args.is_none() && sponsor_auth_type_args.is_none()),
+        "--sponsor-auth-call-args and --sponsor-auth-type-args require --gas-sponsor with an address different from the sender."
+    );
 
     if dev_inspect {
         return execute_dev_inspect(

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -132,6 +132,10 @@ fn extract_auth_args(args: &[String]) -> Result<ExtractedAuthArgs, Error> {
             }
         };
 
+        if slot.is_some() {
+            bail!("Duplicate {arg} found");
+        }
+
         let mut values = Vec::new();
         while let Some(next) = iter.peek() {
             if next.starts_with("--") {
@@ -140,8 +144,8 @@ fn extract_auth_args(args: &[String]) -> Result<ExtractedAuthArgs, Error> {
             values.push(iter.next().unwrap().clone());
         }
 
-        if slot.is_some() {
-            bail!("Duplicate {arg} found");
+        if values.is_empty() {
+            bail!("{arg} requires at least one value");
         }
         *slot = Some(values);
     }

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -121,33 +121,29 @@ fn extract_auth_args(args: &[String]) -> Result<ExtractedAuthArgs, Error> {
     let mut iter = args.iter().peekable();
 
     while let Some(arg) = iter.next() {
-        match arg.as_str() {
-            "--auth-call-args"
-            | "--auth-type-args"
-            | "--sponsor-auth-call-args"
-            | "--sponsor-auth-type-args" => {
-                let mut values = Vec::new();
-                while let Some(next) = iter.peek() {
-                    if next.starts_with("--") {
-                        break;
-                    }
-                    values.push(iter.next().unwrap().clone());
-                }
-
-                let slot = match arg.as_str() {
-                    "--auth-call-args" => &mut auth_call_args,
-                    "--auth-type-args" => &mut auth_type_args,
-                    "--sponsor-auth-call-args" => &mut sponsor_auth_call_args,
-                    "--sponsor-auth-type-args" => &mut sponsor_auth_type_args,
-                    _ => unreachable!(),
-                };
-                if slot.is_some() {
-                    bail!("Duplicate {arg} found");
-                }
-                *slot = Some(values);
+        let slot = match arg.as_str() {
+            "--auth-call-args" => &mut auth_call_args,
+            "--auth-type-args" => &mut auth_type_args,
+            "--sponsor-auth-call-args" => &mut sponsor_auth_call_args,
+            "--sponsor-auth-type-args" => &mut sponsor_auth_type_args,
+            _ => {
+                remaining_args.push(arg.clone());
+                continue;
             }
-            _ => remaining_args.push(arg.clone()),
+        };
+
+        let mut values = Vec::new();
+        while let Some(next) = iter.peek() {
+            if next.starts_with("--") {
+                break;
+            }
+            values.push(iter.next().unwrap().clone());
         }
+
+        if slot.is_some() {
+            bail!("Duplicate {arg} found");
+        }
+        *slot = Some(values);
     }
 
     Ok(ExtractedAuthArgs {

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -96,24 +96,36 @@ impl std::fmt::Display for PTBCommandResult {
 
 /// Result of extracting auth arguments from the initial PTB args.
 struct ExtractedAuthArgs {
-    /// The auth call arguments (values for `--auth-call-args`).
+    /// The auth call arguments for the sender (values for `--auth-call-args`).
     auth_call_args: Option<Vec<String>>,
-    /// The auth type arguments (values for `--auth-type-args`).
+    /// The auth type arguments for the sender (values for `--auth-type-args`).
     auth_type_args: Option<Vec<String>>,
+    /// The auth call arguments for the gas sponsor (values for
+    /// `--sponsor-auth-call-args`).
+    sponsor_auth_call_args: Option<Vec<String>>,
+    /// The auth type arguments for the gas sponsor (values for
+    /// `--sponsor-auth-type-args`).
+    sponsor_auth_type_args: Option<Vec<String>>,
     /// The remaining args after auth arguments are removed.
     remaining_args: Vec<String>,
 }
 
-/// Extracts `--auth-call-args` and `--auth-type-args` from the given args.
+/// Extracts `--auth-call-args`, `--auth-type-args`, `--sponsor-auth-call-args`
+/// and `--sponsor-auth-type-args` from the given args.
 fn extract_auth_args(args: &[String]) -> Result<ExtractedAuthArgs, Error> {
     let mut auth_call_args = None;
     let mut auth_type_args = None;
+    let mut sponsor_auth_call_args = None;
+    let mut sponsor_auth_type_args = None;
     let mut remaining_args = Vec::new();
     let mut iter = args.iter().peekable();
 
     while let Some(arg) = iter.next() {
         match arg.as_str() {
-            "--auth-call-args" | "--auth-type-args" => {
+            "--auth-call-args"
+            | "--auth-type-args"
+            | "--sponsor-auth-call-args"
+            | "--sponsor-auth-type-args" => {
                 let mut values = Vec::new();
                 while let Some(next) = iter.peek() {
                     if next.starts_with("--") {
@@ -122,17 +134,17 @@ fn extract_auth_args(args: &[String]) -> Result<ExtractedAuthArgs, Error> {
                     values.push(iter.next().unwrap().clone());
                 }
 
-                if arg == "--auth-call-args" {
-                    if auth_call_args.is_some() {
-                        bail!("Duplicate --auth-call-args found");
-                    }
-                    auth_call_args = Some(values);
-                } else {
-                    if auth_type_args.is_some() {
-                        bail!("Duplicate --auth-type-args found");
-                    }
-                    auth_type_args = Some(values);
+                let slot = match arg.as_str() {
+                    "--auth-call-args" => &mut auth_call_args,
+                    "--auth-type-args" => &mut auth_type_args,
+                    "--sponsor-auth-call-args" => &mut sponsor_auth_call_args,
+                    "--sponsor-auth-type-args" => &mut sponsor_auth_type_args,
+                    _ => unreachable!(),
+                };
+                if slot.is_some() {
+                    bail!("Duplicate {arg} found");
                 }
+                *slot = Some(values);
             }
             _ => remaining_args.push(arg.clone()),
         }
@@ -141,6 +153,8 @@ fn extract_auth_args(args: &[String]) -> Result<ExtractedAuthArgs, Error> {
     Ok(ExtractedAuthArgs {
         auth_call_args,
         auth_type_args,
+        sponsor_auth_call_args,
+        sponsor_auth_type_args,
         remaining_args,
     })
 }
@@ -156,6 +170,8 @@ impl PTB {
         let extracted = extract_auth_args(&self.args)?;
         let auth_call_args = extracted.auth_call_args;
         let auth_type_args = extracted.auth_type_args;
+        let sponsor_auth_call_args = extracted.sponsor_auth_call_args;
+        let sponsor_auth_type_args = extracted.sponsor_auth_type_args;
 
         if extracted.remaining_args.is_empty() {
             return Ok(PTBCommandResult::Help { long: false });
@@ -274,6 +290,8 @@ impl PTB {
             display: self.display,
             auth_call_args,
             auth_type_args,
+            sponsor_auth_call_args,
+            sponsor_auth_type_args,
         };
 
         let gas_payment = client.transaction_builder().input_refs(&gas).await?;
@@ -577,10 +595,18 @@ pub fn ptb_description() -> clap::Command {
         ))
         .arg(arg!(
             --"auth-call-args"
-            "Auth input objects or primitive values for the Move authenticate function"
+            "Auth input objects or primitive values for the Move authenticate function of the sender"
         ))
         .arg(arg!(
             --"auth-type-args"
-            "Auth type arguments for the Move authenticate function"
+            "Auth type arguments for the Move authenticate function of the sender"
+        ))
+        .arg(arg!(
+            --"sponsor-auth-call-args"
+            "Auth input objects or primitive values for the Move authenticate function of the gas sponsor"
+        ))
+        .arg(arg!(
+            --"sponsor-auth-type-args"
+            "Auth type arguments for the Move authenticate function of the gas sponsor"
         ))
 }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -554,6 +554,11 @@ async fn test_ptb_publish() -> Result<(), anyhow::Error> {
     let mut package_path = PathBuf::from(TEST_DATA_DIR);
     package_path.push("ptb_complex_args_test_functions");
 
+    // Drop any stale `Move.lock` left behind by a prior publish — its
+    // `published-id` would rewrite module addresses away from 0x0 and fail
+    // this publish. `Move.lock` is gitignored, so this is always safe.
+    let _ = fs::remove_file(package_path.join("Move.lock"));
+
     let publish_ptb_string = format!(
         r#"
          --move-call iota::tx_context::sender
@@ -586,6 +591,10 @@ async fn test_ptb_publish_upgrade() -> Result<(), anyhow::Error> {
     package_path.push("ptb_complex_args_test_functions");
     let mut package_path_2 = PathBuf::from(TEST_DATA_DIR);
     package_path_2.push("clever_errors");
+
+    // Drop stale `Move.lock`s from prior publishes; see `test_ptb_publish`.
+    let _ = fs::remove_file(package_path.join("Move.lock"));
+    let _ = fs::remove_file(package_path_2.join("Move.lock"));
 
     let publish_ptb_string = format!(
         r#"

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -6673,10 +6673,9 @@ async fn test_move_authenticator_nested_vec() -> Result<(), anyhow::Error> {
 }
 
 /// Tests that the CLI can execute a sponsored transaction where the gas
-/// sponsor is an abstract account authenticated via a `MoveAuthenticator`
-/// (the feature enabled by PR #10947 / issue #11087). The sender is a regular
-/// keystore address; the sponsor's auth args are supplied via the new
-/// `--sponsor-auth-call-args` flag.
+/// sponsor is an abstract account authenticated via a `MoveAuthenticator`.
+/// The sender is a regular keystore address; the sponsor's auth args are
+/// supplied via the new `--sponsor-auth-call-args` flag.
 #[sim_test]
 async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new()

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -6761,3 +6761,102 @@ async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+/// Tests that the CLI can execute a sponsored transaction where both the
+/// sender AND the gas sponsor are abstract accounts authenticated via a
+/// `MoveAuthenticator`. The sender's auth args are supplied via
+/// `--auth-call-args` and the sponsor's via `--sponsor-auth-call-args`.
+#[sim_test]
+async fn test_move_authenticator_sender_and_sponsor() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let publisher = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+    let context = &mut test_cluster.wallet;
+
+    // Publish the `account` example package twice — each publication produces
+    // a distinct shared `Account` with its own authenticator function ref.
+    let sender_aa = setup_move_authenticator_account(
+        context,
+        rgp,
+        publisher,
+        "examples/move/account",
+        "account",
+        "authenticate",
+        2_000_000_000,
+    )
+    .await?;
+    let sponsor_aa = setup_move_authenticator_account(
+        context,
+        rgp,
+        publisher,
+        "examples/move/account",
+        "account",
+        "authenticate",
+        2_000_000_000,
+    )
+    .await?;
+    assert_ne!(sender_aa, sponsor_aa);
+
+    // Both AA addresses must be in the keystore so the CLI can build their
+    // `MoveAuthenticator` signatures.
+    IotaClientCommands::AddAccount {
+        alias: None,
+        address: sender_aa.into(),
+    }
+    .execute(context)
+    .await?;
+    IotaClientCommands::AddAccount {
+        alias: None,
+        address: sponsor_aa.into(),
+    }
+    .execute(context)
+    .await?;
+
+    // Sponsored PTB splitting a nano off the sponsor's gas and transferring it
+    // to `recipient`. Sender is authenticated via `--auth-call-args`, sponsor
+    // via `--sponsor-auth-call-args`.
+    let ptb_resp = IotaClientCommands::PTB(PTB {
+        args: vec![
+            "--split-coins".to_string(),
+            "gas".to_string(),
+            "[1]".to_string(),
+            "--assign".to_string(),
+            "coin".to_string(),
+            "--transfer-objects".to_string(),
+            "[coin]".to_string(),
+            format!("@{recipient}"),
+            "--sender".to_string(),
+            format!("@{sender_aa}"),
+            "--gas-sponsor".to_string(),
+            format!("@{sponsor_aa}"),
+            "--gas-budget".to_string(),
+            (rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER).to_string(),
+            "--auth-call-args".to_string(),
+            "hello".to_string(),
+            "--sponsor-auth-call-args".to_string(),
+            "hello".to_string(),
+        ],
+        display: HashSet::new(),
+    })
+    .execute(context)
+    .await?;
+
+    let IotaClientCommandResult::TransactionBlock(tx) = ptb_resp else {
+        panic!("Expected TransactionBlock result, got {ptb_resp:?}");
+    };
+    let effects = tx.effects.as_ref().unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "Sponsored tx with MoveAuthenticator sender and sponsor should succeed: {:?}",
+        effects.status()
+    );
+    let tx_block = tx.transaction.as_ref().expect("transaction block");
+    assert_eq!(tx_block.data.sender(), &IotaAddress::from(sender_aa));
+    assert_eq!(tx_block.data.gas_data().owner, IotaAddress::from(sponsor_aa));
+
+    Ok(())
+}

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -6376,6 +6376,7 @@ async fn setup_move_authenticator_account(
     let mut build_config = BuildConfig::new_for_testing().config;
     build_config.lock_file = Some(package_path.join("Move.lock"));
 
+    // Publish the account package
     let resp = IotaClientCommands::Publish {
         package_path,
         build_config,
@@ -6394,6 +6395,7 @@ async fn setup_move_authenticator_account(
     .execute(context)
     .await?;
 
+    // Extract IDs from publish response
     let IotaClientCommandResult::TransactionBlock(response) = resp else {
         anyhow::bail!("Expected TransactionBlock from Publish");
     };
@@ -6430,6 +6432,7 @@ async fn setup_move_authenticator_account(
         })
         .expect("package metadata created");
 
+    // Link auth
     IotaClientCommands::Call {
         package: package_id,
         module: module.to_string(),
@@ -6451,6 +6454,7 @@ async fn setup_move_authenticator_account(
     .execute(context)
     .await?;
 
+    // Send funds to account
     let transfer_resp = IotaClientCommands::PTB(PTB {
         args: vec![
             "--split-coins".to_string(),

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4,7 +4,6 @@
 
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::FileExt;
-use std::str::FromStr;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     env,
@@ -12,7 +11,8 @@ use std::{
     fs::{self, read_dir},
     io::{self, Read, Seek, SeekFrom, Write as IoWrite},
     path::{Path, PathBuf},
-    str, thread,
+    str::{self, FromStr},
+    thread,
     time::Duration,
 };
 

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -6751,3 +6751,198 @@ async fn test_move_authenticator_nested_vec() -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+/// Tests that the CLI can execute a sponsored transaction where the gas
+/// sponsor is an abstract account authenticated via a `MoveAuthenticator`
+/// (the feature enabled by PR #10947 / issue #11087). The sender is a regular
+/// keystore address; the sponsor's auth args are supplied via the new
+/// `--sponsor-auth-call-args` flag.
+#[sim_test]
+async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let publisher = test_cluster.get_address_0();
+    let sender = test_cluster.get_address_1();
+    let recipient = test_cluster.get_address_2();
+    let context = &mut test_cluster.wallet;
+
+    let client = context.get_client().await?;
+    let gas_obj_id = client
+        .read_api()
+        .get_owned_objects(publisher, None, None, None)
+        .await?
+        .data
+        .first()
+        .unwrap()
+        .object()
+        .unwrap()
+        .object_id;
+
+    // Publish the `account` example package. It shares a single Account object
+    // that will act as our sponsor AA.
+    let package_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("examples/move/account");
+    let mut build_config = BuildConfig::new_for_testing().config;
+    build_config.lock_file = Some(package_path.join("Move.lock"));
+    let resp = IotaClientCommands::Publish {
+        package_path,
+        build_config,
+        skip_dependency_verification: false,
+        with_unpublished_dependencies: false,
+        verify_deps: true,
+        payment: PaymentArgs {
+            gas: vec![gas_obj_id],
+        },
+        gas_data: GasDataArgs {
+            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let IotaClientCommandResult::TransactionBlock(response) = resp else {
+        panic!("Expected TransactionBlock");
+    };
+    let object_changes = response.object_changes.as_ref().unwrap();
+    let account_address = object_changes
+        .iter()
+        .find_map(|oc| match oc {
+            ObjectChange::Created {
+                object_type,
+                object_id,
+                ..
+            } if object_type.to_string().ends_with("::account::Account") => Some(*object_id),
+            _ => None,
+        })
+        .unwrap();
+    let package_id = object_changes
+        .iter()
+        .find_map(|oc| match oc {
+            ObjectChange::Published { package_id, .. } => Some(*package_id),
+            _ => None,
+        })
+        .unwrap();
+    let metadata_id = object_changes
+        .iter()
+        .find_map(|oc| match oc {
+            ObjectChange::Created {
+                object_type,
+                object_id,
+                ..
+            } if object_type.to_string() == "0x2::package_metadata::PackageMetadataV1" => {
+                Some(*object_id)
+            }
+            _ => None,
+        })
+        .unwrap();
+
+    // Bind the account to its authenticator function.
+    IotaClientCommands::Call {
+        package: package_id,
+        module: "account".to_string(),
+        function: "link_auth".to_string(),
+        type_args: vec![],
+        args: vec![
+            IotaJsonValue::from_str(&account_address.to_string()).unwrap(),
+            IotaJsonValue::from_str(&metadata_id.to_string()).unwrap(),
+            IotaJsonValue::from_str("\"account\"").unwrap(),
+            IotaJsonValue::from_str("\"authenticate\"").unwrap(),
+        ],
+        payment: PaymentArgs::default(),
+        gas_data: GasDataArgs {
+            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    // Fund the sponsor AA so it can pay for gas.
+    let transfer_resp = IotaClientCommands::PTB(PTB {
+        args: vec![
+            "--split-coins".to_string(),
+            "gas".to_string(),
+            "[2000000000]".to_string(),
+            "--assign".to_string(),
+            "coin".to_string(),
+            "--transfer-objects".to_string(),
+            "[coin]".to_string(),
+            format!("@{account_address}"),
+        ],
+        display: HashSet::new(),
+    })
+    .execute(context)
+    .await?;
+    assert!(matches!(
+        transfer_resp,
+        IotaClientCommandResult::TransactionBlock(ref tx) if tx.effects.as_ref().unwrap().status().is_ok()
+    ));
+
+    // Add the AA address to the keystore so the CLI can look it up when
+    // building the sponsor's `MoveAuthenticator` signature.
+    IotaClientCommands::AddAccount {
+        alias: None,
+        address: account_address.into(),
+    }
+    .execute(context)
+    .await?;
+
+    // Find an object owned by `sender` that we can transfer.
+    let sender_obj = client
+        .read_api()
+        .get_owned_objects(sender, None, None, None)
+        .await?
+        .data
+        .into_iter()
+        .next()
+        .unwrap()
+        .object()
+        .unwrap()
+        .object_id;
+
+    // Transfer a sender-owned object to `recipient`, sponsored by the AA.
+    // The sender signs with a regular key; the sponsor is authenticated via
+    // the new `--sponsor-auth-call-args` flag.
+    let transfer_resp = IotaClientCommands::Transfer {
+        to: KeyIdentity::Address(recipient),
+        object_id: sender_obj,
+        payment: PaymentArgs::default(),
+        gas_data: GasDataArgs {
+            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
+            gas_sponsor: Some(account_address.into()),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs {
+            sender: Some(sender),
+            sponsor_auth_call_args: Some(vec!["hello".to_string()]),
+            ..Default::default()
+        },
+    }
+    .execute(context)
+    .await?;
+
+    let IotaClientCommandResult::TransactionBlock(tx) = transfer_resp else {
+        panic!("Expected TransactionBlock result, got {transfer_resp:?}");
+    };
+    let effects = tx.effects.as_ref().unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "Sponsored transfer with MoveAuthenticator sponsor should succeed: {:?}",
+        effects.status()
+    );
+    let tx_block = tx.transaction.as_ref().expect("transaction block");
+    assert_eq!(tx_block.data.gas_data().owner, account_address.into());
+    assert_eq!(tx_block.data.sender(), &sender);
+
+    Ok(())
+}

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -6342,20 +6342,23 @@ async fn test_ptb_gas_coins_smashing() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[sim_test]
-async fn test_move_authenticator() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new()
-        .with_num_validators(1)
-        .build()
-        .await;
-    let rgp = test_cluster.get_reference_gas_price().await;
-    let sender_address = test_cluster.get_address_0();
-    let context = &mut test_cluster.wallet;
-
+/// Publishes a Move-authenticator example package, links its authenticator
+/// function, and funds the resulting shared `Account` object with
+/// `fund_amount` nanos. Returns the shared `Account`'s `ObjectID`, whose bytes
+/// are the abstract-account address.
+async fn setup_move_authenticator_account(
+    context: &mut WalletContext,
+    rgp: u64,
+    publisher: IotaAddress,
+    package_relative_path: &str,
+    module: &str,
+    function: &str,
+    fund_amount: u64,
+) -> Result<ObjectID, anyhow::Error> {
     let client = context.get_client().await?;
     let gas_obj_id = client
         .read_api()
-        .get_owned_objects(sender_address, None, None, None)
+        .get_owned_objects(publisher, None, None, None)
         .await?
         .data
         .first()
@@ -6364,15 +6367,15 @@ async fn test_move_authenticator() -> Result<(), anyhow::Error> {
         .unwrap()
         .object_id;
 
-    // Publish the account package
     let package_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
         .parent()
         .unwrap()
         .parent()
         .unwrap()
-        .join("examples/move/account");
+        .join(package_relative_path);
     let mut build_config = BuildConfig::new_for_testing().config;
     build_config.lock_file = Some(package_path.join("Move.lock"));
+
     let resp = IotaClientCommands::Publish {
         package_path,
         build_config,
@@ -6391,9 +6394,8 @@ async fn test_move_authenticator() -> Result<(), anyhow::Error> {
     .execute(context)
     .await?;
 
-    // Extract IDs from publish response
     let IotaClientCommandResult::TransactionBlock(response) = resp else {
-        panic!("Expected TransactionBlock");
+        anyhow::bail!("Expected TransactionBlock from Publish");
     };
     let object_changes = response.object_changes.as_ref().unwrap();
     let account_address = object_changes
@@ -6406,14 +6408,14 @@ async fn test_move_authenticator() -> Result<(), anyhow::Error> {
             } if object_type.to_string().ends_with("::account::Account") => Some(*object_id),
             _ => None,
         })
-        .unwrap();
+        .expect("account object created");
     let package_id = object_changes
         .iter()
         .find_map(|oc| match oc {
             ObjectChange::Published { package_id, .. } => Some(*package_id),
             _ => None,
         })
-        .unwrap();
+        .expect("package published");
     let metadata_id = object_changes
         .iter()
         .find_map(|oc| match oc {
@@ -6426,19 +6428,18 @@ async fn test_move_authenticator() -> Result<(), anyhow::Error> {
             }
             _ => None,
         })
-        .unwrap();
+        .expect("package metadata created");
 
-    // Link auth
     IotaClientCommands::Call {
         package: package_id,
-        module: "account".to_string(),
+        module: module.to_string(),
         function: "link_auth".to_string(),
         type_args: vec![],
         args: vec![
             IotaJsonValue::from_str(&account_address.to_string()).unwrap(),
             IotaJsonValue::from_str(&metadata_id.to_string()).unwrap(),
-            IotaJsonValue::from_str("\"account\"").unwrap(),
-            IotaJsonValue::from_str("\"authenticate\"").unwrap(),
+            IotaJsonValue::from_str(&format!("\"{module}\"")).unwrap(),
+            IotaJsonValue::from_str(&format!("\"{function}\"")).unwrap(),
         ],
         payment: PaymentArgs::default(),
         gas_data: GasDataArgs {
@@ -6450,12 +6451,11 @@ async fn test_move_authenticator() -> Result<(), anyhow::Error> {
     .execute(context)
     .await?;
 
-    // Send funds to account
     let transfer_resp = IotaClientCommands::PTB(PTB {
         args: vec![
             "--split-coins".to_string(),
             "gas".to_string(),
-            "[2000000000]".to_string(),
+            format!("[{fund_amount}]"),
             "--assign".to_string(),
             "coin".to_string(),
             "--transfer-objects".to_string(),
@@ -6470,6 +6470,30 @@ async fn test_move_authenticator() -> Result<(), anyhow::Error> {
         transfer_resp,
         IotaClientCommandResult::TransactionBlock(ref tx) if tx.effects.as_ref().unwrap().status().is_ok()
     ));
+
+    Ok(account_address)
+}
+
+#[sim_test]
+async fn test_move_authenticator() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let sender_address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    let account_address = setup_move_authenticator_account(
+        context,
+        rgp,
+        sender_address,
+        "examples/move/account",
+        "account",
+        "authenticate",
+        2_000_000_000,
+    )
+    .await?;
 
     // Add and switch to account
     IotaClientCommands::AddAccount {
@@ -6579,124 +6603,16 @@ async fn test_move_authenticator_nested_vec() -> Result<(), anyhow::Error> {
     let sender_address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
-    let client = context.get_client().await?;
-    let gas_obj_id = client
-        .read_api()
-        .get_owned_objects(sender_address, None, None, None)
-        .await?
-        .data
-        .first()
-        .unwrap()
-        .object()
-        .unwrap()
-        .object_id;
-
-    // Publish the account_multi_auth package
-    let package_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("examples/move/abstract_iota_accounts/account_multi_auth");
-    let mut build_config = BuildConfig::new_for_testing().config;
-    build_config.lock_file = Some(package_path.join("Move.lock"));
-    let resp = IotaClientCommands::Publish {
-        package_path,
-        build_config,
-        skip_dependency_verification: false,
-        with_unpublished_dependencies: false,
-        verify_deps: true,
-        payment: PaymentArgs {
-            gas: vec![gas_obj_id],
-        },
-        gas_data: GasDataArgs {
-            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
-            ..Default::default()
-        },
-        processing: TxProcessingArgs::default(),
-    }
-    .execute(context)
+    let account_address = setup_move_authenticator_account(
+        context,
+        rgp,
+        sender_address,
+        "examples/move/abstract_iota_accounts/account_multi_auth",
+        "account",
+        "authenticate",
+        2_000_000_000,
+    )
     .await?;
-
-    // Extract IDs from publish response
-    let IotaClientCommandResult::TransactionBlock(response) = resp else {
-        panic!("Expected TransactionBlock");
-    };
-    let object_changes = response.object_changes.as_ref().unwrap();
-    let account_address = object_changes
-        .iter()
-        .find_map(|oc| match oc {
-            ObjectChange::Created {
-                object_type,
-                object_id,
-                ..
-            } if object_type.to_string().ends_with("::account::Account") => Some(*object_id),
-            _ => None,
-        })
-        .unwrap();
-    let package_id = object_changes
-        .iter()
-        .find_map(|oc| match oc {
-            ObjectChange::Published { package_id, .. } => Some(*package_id),
-            _ => None,
-        })
-        .unwrap();
-    let metadata_id = object_changes
-        .iter()
-        .find_map(|oc| match oc {
-            ObjectChange::Created {
-                object_type,
-                object_id,
-                ..
-            } if object_type.to_string() == "0x2::package_metadata::PackageMetadataV1" => {
-                Some(*object_id)
-            }
-            _ => None,
-        })
-        .unwrap();
-
-    // Link auth
-    IotaClientCommands::Call {
-        package: package_id,
-        module: "account".to_string(),
-        function: "link_auth".to_string(),
-        type_args: vec![],
-        args: vec![
-            IotaJsonValue::from_str(&account_address.to_string()).unwrap(),
-            IotaJsonValue::from_str(&metadata_id.to_string()).unwrap(),
-            IotaJsonValue::from_str("\"account\"").unwrap(),
-            IotaJsonValue::from_str("\"authenticate\"").unwrap(),
-        ],
-        payment: PaymentArgs::default(),
-        gas_data: GasDataArgs {
-            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
-            ..Default::default()
-        },
-        processing: TxProcessingArgs::default(),
-    }
-    .execute(context)
-    .await?;
-
-    // Send funds to account
-    let transfer_resp = IotaClientCommands::PTB(PTB {
-        args: vec![
-            "--split-coins".to_string(),
-            "gas".to_string(),
-            "[2000000000]".to_string(),
-            "--assign".to_string(),
-            "coin".to_string(),
-            "--transfer-objects".to_string(),
-            "[coin]".to_string(),
-            format!("@{account_address}"),
-        ],
-        display: HashSet::new(),
-    })
-    .execute(context)
-    .await?;
-    assert!(matches!(
-        transfer_resp,
-        IotaClientCommandResult::TransactionBlock(ref tx) if tx.effects.as_ref().unwrap().status().is_ok()
-    ));
 
     // Add and switch to account
     IotaClientCommands::AddAccount {
@@ -6769,124 +6685,18 @@ async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
     let recipient = test_cluster.get_address_2();
     let context = &mut test_cluster.wallet;
 
-    let client = context.get_client().await?;
-    let gas_obj_id = client
-        .read_api()
-        .get_owned_objects(publisher, None, None, None)
-        .await?
-        .data
-        .first()
-        .unwrap()
-        .object()
-        .unwrap()
-        .object_id;
-
-    // Publish the `account` example package. It shares a single Account object
-    // that will act as our sponsor AA.
-    let package_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("examples/move/account");
-    let mut build_config = BuildConfig::new_for_testing().config;
-    build_config.lock_file = Some(package_path.join("Move.lock"));
-    let resp = IotaClientCommands::Publish {
-        package_path,
-        build_config,
-        skip_dependency_verification: false,
-        with_unpublished_dependencies: false,
-        verify_deps: true,
-        payment: PaymentArgs {
-            gas: vec![gas_obj_id],
-        },
-        gas_data: GasDataArgs {
-            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
-            ..Default::default()
-        },
-        processing: TxProcessingArgs::default(),
-    }
-    .execute(context)
+    // Publish the `account` example package and fund the resulting shared
+    // Account so it can act as the sponsor.
+    let account_address = setup_move_authenticator_account(
+        context,
+        rgp,
+        publisher,
+        "examples/move/account",
+        "account",
+        "authenticate",
+        2_000_000_000,
+    )
     .await?;
-
-    let IotaClientCommandResult::TransactionBlock(response) = resp else {
-        panic!("Expected TransactionBlock");
-    };
-    let object_changes = response.object_changes.as_ref().unwrap();
-    let account_address = object_changes
-        .iter()
-        .find_map(|oc| match oc {
-            ObjectChange::Created {
-                object_type,
-                object_id,
-                ..
-            } if object_type.to_string().ends_with("::account::Account") => Some(*object_id),
-            _ => None,
-        })
-        .unwrap();
-    let package_id = object_changes
-        .iter()
-        .find_map(|oc| match oc {
-            ObjectChange::Published { package_id, .. } => Some(*package_id),
-            _ => None,
-        })
-        .unwrap();
-    let metadata_id = object_changes
-        .iter()
-        .find_map(|oc| match oc {
-            ObjectChange::Created {
-                object_type,
-                object_id,
-                ..
-            } if object_type.to_string() == "0x2::package_metadata::PackageMetadataV1" => {
-                Some(*object_id)
-            }
-            _ => None,
-        })
-        .unwrap();
-
-    // Bind the account to its authenticator function.
-    IotaClientCommands::Call {
-        package: package_id,
-        module: "account".to_string(),
-        function: "link_auth".to_string(),
-        type_args: vec![],
-        args: vec![
-            IotaJsonValue::from_str(&account_address.to_string()).unwrap(),
-            IotaJsonValue::from_str(&metadata_id.to_string()).unwrap(),
-            IotaJsonValue::from_str("\"account\"").unwrap(),
-            IotaJsonValue::from_str("\"authenticate\"").unwrap(),
-        ],
-        payment: PaymentArgs::default(),
-        gas_data: GasDataArgs {
-            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
-            ..Default::default()
-        },
-        processing: TxProcessingArgs::default(),
-    }
-    .execute(context)
-    .await?;
-
-    // Fund the sponsor AA so it can pay for gas.
-    let transfer_resp = IotaClientCommands::PTB(PTB {
-        args: vec![
-            "--split-coins".to_string(),
-            "gas".to_string(),
-            "[2000000000]".to_string(),
-            "--assign".to_string(),
-            "coin".to_string(),
-            "--transfer-objects".to_string(),
-            "[coin]".to_string(),
-            format!("@{account_address}"),
-        ],
-        display: HashSet::new(),
-    })
-    .execute(context)
-    .await?;
-    assert!(matches!(
-        transfer_resp,
-        IotaClientCommandResult::TransactionBlock(ref tx) if tx.effects.as_ref().unwrap().status().is_ok()
-    ));
 
     // Add the AA address to the keystore so the CLI can look it up when
     // building the sponsor's `MoveAuthenticator` signature.
@@ -6898,7 +6708,9 @@ async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
     .await?;
 
     // Find an object owned by `sender` that we can transfer.
-    let sender_obj = client
+    let sender_obj = context
+        .get_client()
+        .await?
         .read_api()
         .get_owned_objects(sender, None, None, None)
         .await?

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -6475,6 +6475,15 @@ async fn setup_move_authenticator_account(
         IotaClientCommandResult::TransactionBlock(ref tx) if tx.effects.as_ref().unwrap().status().is_ok()
     ));
 
+    // Add the AA to the keystore so the CLI can build `MoveAuthenticator`
+    // signatures for it.
+    IotaClientCommands::AddAccount {
+        alias: None,
+        address: account_address.into(),
+    }
+    .execute(context)
+    .await?;
+
     Ok(account_address)
 }
 
@@ -6499,13 +6508,7 @@ async fn test_move_authenticator() -> Result<(), anyhow::Error> {
     )
     .await?;
 
-    // Add and switch to account
-    IotaClientCommands::AddAccount {
-        alias: None,
-        address: account_address.into(),
-    }
-    .execute(context)
-    .await?;
+    // Switch to the AA so subsequent commands treat it as the active address.
     IotaClientCommands::Switch {
         address: Some(IotaAddress::from(account_address).into()),
         env: None,
@@ -6618,13 +6621,7 @@ async fn test_move_authenticator_nested_vec() -> Result<(), anyhow::Error> {
     )
     .await?;
 
-    // Add and switch to account
-    IotaClientCommands::AddAccount {
-        alias: None,
-        address: account_address.into(),
-    }
-    .execute(context)
-    .await?;
+    // Switch to the AA so subsequent commands treat it as the active address.
     IotaClientCommands::Switch {
         address: Some(IotaAddress::from(account_address).into()),
         env: None,
@@ -6699,15 +6696,6 @@ async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
         "authenticate",
         2_000_000_000,
     )
-    .await?;
-
-    // Add the AA address to the keystore so the CLI can look it up when
-    // building the sponsor's `MoveAuthenticator` signature.
-    IotaClientCommands::AddAccount {
-        alias: None,
-        address: account_address.into(),
-    }
-    .execute(context)
     .await?;
 
     // Find an object owned by `sender` that we can transfer.
@@ -6800,21 +6788,6 @@ async fn test_move_authenticator_sender_and_sponsor() -> Result<(), anyhow::Erro
     )
     .await?;
     assert_ne!(sender_aa, sponsor_aa);
-
-    // Both AA addresses must be in the keystore so the CLI can build their
-    // `MoveAuthenticator` signatures.
-    IotaClientCommands::AddAccount {
-        alias: None,
-        address: sender_aa.into(),
-    }
-    .execute(context)
-    .await?;
-    IotaClientCommands::AddAccount {
-        alias: None,
-        address: sponsor_aa.into(),
-    }
-    .execute(context)
-    .await?;
 
     // Sponsored PTB splitting a nano off the sponsor's gas and transferring it
     // to `recipient`. Sender is authenticated via `--auth-call-args`, sponsor

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -6348,7 +6348,6 @@ async fn test_ptb_gas_coins_smashing() -> Result<(), anyhow::Error> {
 /// are the abstract-account address.
 async fn setup_move_authenticator_account(
     context: &mut WalletContext,
-    rgp: u64,
     publisher: IotaAddress,
     package_relative_path: &str,
     module: &str,
@@ -6386,10 +6385,7 @@ async fn setup_move_authenticator_account(
         payment: PaymentArgs {
             gas: vec![gas_obj_id],
         },
-        gas_data: GasDataArgs {
-            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
-            ..Default::default()
-        },
+        gas_data: GasDataArgs::default(),
         processing: TxProcessingArgs::default(),
     }
     .execute(context)
@@ -6445,10 +6441,7 @@ async fn setup_move_authenticator_account(
             IotaJsonValue::from_str(&format!("\"{function}\"")).unwrap(),
         ],
         payment: PaymentArgs::default(),
-        gas_data: GasDataArgs {
-            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
-            ..Default::default()
-        },
+        gas_data: GasDataArgs::default(),
         processing: TxProcessingArgs::default(),
     }
     .execute(context)
@@ -6493,13 +6486,11 @@ async fn test_move_authenticator() -> Result<(), anyhow::Error> {
         .with_num_validators(1)
         .build()
         .await;
-    let rgp = test_cluster.get_reference_gas_price().await;
     let sender_address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
     let account_address = setup_move_authenticator_account(
         context,
-        rgp,
         sender_address,
         "examples/move/account",
         "account",
@@ -6606,13 +6597,11 @@ async fn test_move_authenticator_nested_vec() -> Result<(), anyhow::Error> {
         .with_num_validators(1)
         .build()
         .await;
-    let rgp = test_cluster.get_reference_gas_price().await;
     let sender_address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
     let account_address = setup_move_authenticator_account(
         context,
-        rgp,
         sender_address,
         "examples/move/abstract_iota_accounts/account_multi_auth",
         "account",
@@ -6679,7 +6668,6 @@ async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
         .with_num_validators(1)
         .build()
         .await;
-    let rgp = test_cluster.get_reference_gas_price().await;
     let publisher = test_cluster.get_address_0();
     let sender = test_cluster.get_address_1();
     let recipient = test_cluster.get_address_2();
@@ -6689,7 +6677,6 @@ async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
     // Account so it can act as the sponsor.
     let account_address = setup_move_authenticator_account(
         context,
-        rgp,
         publisher,
         "examples/move/account",
         "account",
@@ -6721,7 +6708,6 @@ async fn test_move_authenticator_as_sponsor() -> Result<(), anyhow::Error> {
         object_id: sender_obj,
         payment: PaymentArgs::default(),
         gas_data: GasDataArgs {
-            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             gas_sponsor: Some(account_address.into()),
             ..Default::default()
         },
@@ -6760,7 +6746,6 @@ async fn test_move_authenticator_sender_and_sponsor() -> Result<(), anyhow::Erro
         .with_num_validators(1)
         .build()
         .await;
-    let rgp = test_cluster.get_reference_gas_price().await;
     let publisher = test_cluster.get_address_0();
     let recipient = test_cluster.get_address_1();
     let context = &mut test_cluster.wallet;
@@ -6769,7 +6754,6 @@ async fn test_move_authenticator_sender_and_sponsor() -> Result<(), anyhow::Erro
     // a distinct shared `Account` with its own authenticator function ref.
     let sender_aa = setup_move_authenticator_account(
         context,
-        rgp,
         publisher,
         "examples/move/account",
         "account",
@@ -6779,7 +6763,6 @@ async fn test_move_authenticator_sender_and_sponsor() -> Result<(), anyhow::Erro
     .await?;
     let sponsor_aa = setup_move_authenticator_account(
         context,
-        rgp,
         publisher,
         "examples/move/account",
         "account",
@@ -6806,8 +6789,6 @@ async fn test_move_authenticator_sender_and_sponsor() -> Result<(), anyhow::Erro
             format!("@{sender_aa}"),
             "--gas-sponsor".to_string(),
             format!("@{sponsor_aa}"),
-            "--gas-budget".to_string(),
-            (rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER).to_string(),
             "--auth-call-args".to_string(),
             "hello".to_string(),
             "--sponsor-auth-call-args".to_string(),
@@ -6829,7 +6810,10 @@ async fn test_move_authenticator_sender_and_sponsor() -> Result<(), anyhow::Erro
     );
     let tx_block = tx.transaction.as_ref().expect("transaction block");
     assert_eq!(tx_block.data.sender(), &IotaAddress::from(sender_aa));
-    assert_eq!(tx_block.data.gas_data().owner, IotaAddress::from(sponsor_aa));
+    assert_eq!(
+        tx_block.data.gas_data().owner,
+        IotaAddress::from(sponsor_aa)
+    );
 
     Ok(())
 }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4,7 +4,6 @@
 
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::FileExt;
-#[cfg(not(msim))]
 use std::str::FromStr;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},


### PR DESCRIPTION
## Description of change

Allow the CLI to sign a sponsored transaction where the gas sponsor is an
abstract account authenticated via a `MoveAuthenticator`. Previously, the
sender's `--auth-call-args` / `--auth-type-args` were reused for the sponsor,
which resolved the wrong `AuthenticatorFunctionRefV1` and prepended the
sender's address into the sponsor's auth args.

Introduces dedicated `--sponsor-auth-call-args` / `--sponsor-auth-type-args`
flags on `TxProcessingArgs` (and the PTB command), and a `build_auth_args_for_signing`
helper that fetches the authenticator info per signer. This enables the
regular-sender / AA-sponsor and AA-sender / AA-sponsor flows unlocked by
the protocol-level work in #10947.

## Links to any relevant issues

Closes #11087 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

Also in devnet, move auth sponsor only: https://explorer.iota.org/txblock/CSDXM56jBpR9DJqHvR23XajQezkUiKRT1TNAHTgiSfBi?network=devnet
Move auth sponsor and sender: https://explorer.iota.org/txblock/6H4bLGQ7oHkWH1WVK4zs3qUCSQTdRsPpZTxnKndoqfh3?network=devnet
```bash
#!/usr/bin/env bash
# Manual reproduction of `test_move_authenticator_sender_and_sponsor`
# from iota/crates/iota/tests/cli_tests.rs
#
# Publishes the `account` example package twice to get two distinct
# MoveAuthenticator-backed Accounts, then runs a PTB where one AA is the
# sender and the other is the gas sponsor.

set -euo pipefail

iota client switch --env devnet >/dev/null

PKG_PATH="/home/t/Desktop/iota/iota/examples/move/account"
GAS_BUDGET_PUBLISH=1000000000
GAS_BUDGET_TX=200000000
FUND_AMOUNT=2000000000

need() { command -v "$1" >/dev/null || { echo "missing dep: $1" >&2; exit 1; }; }
need iota
need jq

say() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }

##########################################################
# setup_aa — publish pkg, link_auth, fund, add-account   #
# prints the resulting Account address to stdout         #
##########################################################
setup_aa() {
  local publish_json package_id account_id metadata_id
  publish_json=$(iota client publish "$PKG_PATH" \
    --gas-budget "$GAS_BUDGET_PUBLISH" \
    --json)

  package_id=$(echo "$publish_json" | jq -r '
    .objectChanges[] | select(.type == "published") | .packageId')
  account_id=$(echo "$publish_json" | jq -r '
    .objectChanges[]
    | select(.type == "created")
    | select(.objectType | endswith("::account::Account"))
    | .objectId')
  metadata_id=$(echo "$publish_json" | jq -r '
    .objectChanges[]
    | select(.type == "created")
    | select(.objectType == "0x2::package_metadata::PackageMetadataV1")
    | .objectId')

  [ -n "$package_id" ] && [ -n "$account_id" ] && [ -n "$metadata_id" ] \
    || { echo "failed to extract IDs from publish output" >&2; return 1; }

  iota client call \
    --package "$package_id" \
    --module account \
    --function link_auth \
    --args "$account_id" "$metadata_id" '"account"' '"authenticate"' \
    --gas-budget "$GAS_BUDGET_TX" >/dev/null

  iota client ptb \
    --split-coins gas "[$FUND_AMOUNT]" \
    --assign coin \
    --transfer-objects "[coin]" "@$account_id" \
    --gas-budget "$GAS_BUDGET_TX" >/dev/null

  iota client add-account "$account_id" >/dev/null || true

  echo "$account_id"
}

#################################################
# 1. Ensure ≥2 keypair addresses (publisher+rcp) #
#################################################
say "Ensuring at least 2 keypair addresses in keystore"
keypair_count() {
  iota client addresses --json | jq '[.addresses[] | select(.[2] == "keypair")] | length'
}
while [ "$(keypair_count)" -lt 2 ]; do
  iota client new-address ed25519 >/dev/null
done

ADDRS_JSON=$(iota client addresses --json)
PUBLISHER=$(echo "$ADDRS_JSON" | jq -r '[.addresses[] | select(.[2] == "keypair")][0][1]')
RECIPIENT=$(echo "$ADDRS_JSON" | jq -r '[.addresses[] | select(.[2] == "keypair")][1][1]')
echo "PUBLISHER=$PUBLISHER"
echo "RECIPIENT=$RECIPIENT"

###############################
# 2. Fund PUBLISHER + RECIPIENT #
###############################
say "Funding PUBLISHER and RECIPIENT via faucet"
for A in "$PUBLISHER" "$RECIPIENT"; do
  iota client faucet --address "$A" >/dev/null || true
done
sleep 3

iota client switch --address "$PUBLISHER" >/dev/null

#############################################################
# 3. Set up two independent AAs (sender_aa and sponsor_aa)  #
#############################################################
say "Setting up sender_aa (first publish of $PKG_PATH)"
SENDER_AA=$(setup_aa)
echo "SENDER_AA=$SENDER_AA"

say "Setting up sponsor_aa (second publish of $PKG_PATH)"
SPONSOR_AA=$(setup_aa)
echo "SPONSOR_AA=$SPONSOR_AA"

[ "$SENDER_AA" != "$SPONSOR_AA" ] \
  || { echo "sender_aa and sponsor_aa must differ" >&2; exit 1; }

#############################################################
# 4. Sponsored PTB: sender_aa splits 1 nano from sponsor_aa  #
#    gas and transfers it to RECIPIENT.                      #
#############################################################
say "Sponsored PTB: sender=$SENDER_AA, gas-sponsor=$SPONSOR_AA, recipient=$RECIPIENT"
iota client ptb \
  --split-coins gas "[1]" \
  --assign coin \
  --transfer-objects "[coin]" "@$RECIPIENT" \
  --sender "@$SENDER_AA" \
  --gas-sponsor "@$SPONSOR_AA" \
  --gas-budget "$GAS_BUDGET_TX" \
  --auth-call-args hello \
  --sponsor-auth-call-args hello

say "Done."
```

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: support Move authenticator as gas sponsor
- [ ] Rust SDK:
- [ ] gRPC:
