### PR TITLE
feat(iota-rest-kv): add object before version support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,7 +4499,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
- "tonic-build 0.14.2",
+ "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
  "url",
@@ -5902,17 +5902,18 @@ dependencies = [
 [[package]]
 name = "iota-bigtable"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=265bc250c7772a3703ed965c9542f61d35f54821#265bc250c7772a3703ed965c9542f61d35f54821"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?tag=v0.1.0#da30081e1b3fbd162cc00fa723a03837d89c4a58"
 dependencies = [
  "gcp_auth",
  "http 1.4.0",
  "prometheus",
- "prost 0.13.3",
- "prost-types 0.13.3",
+ "prost 0.14.1",
+ "prost-types 0.14.1",
  "serde",
  "thiserror 2.0.18",
- "tonic 0.13.1",
- "tonic-build 0.13.1",
+ "tonic 0.14.2",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -7363,7 +7364,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tonic 0.14.2",
- "tonic-build 0.14.2",
+ "tonic-build",
  "tower 0.4.13",
  "tracing",
 ]
@@ -7584,7 +7585,7 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.108",
- "tonic-build 0.14.2",
+ "tonic-build",
  "tonic-prost-build",
  "walkdir",
 ]
@@ -7720,6 +7721,7 @@ dependencies = [
  "bin-version",
  "bytes",
  "clap",
+ "futures",
  "iota-config",
  "iota-kvstore",
  "iota-storage",
@@ -14103,7 +14105,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.18",
  "tonic 0.14.2",
- "tonic-build 0.14.2",
+ "tonic-build",
  "tonic-prost",
  "tonic-rustls",
  "tower 0.4.13",
@@ -15089,37 +15091,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "axum 0.8.8",
- "base64 0.22.1",
- "bytes",
- "h2 0.4.12",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.3",
- "rustls-native-certs",
- "socket2 0.5.7",
- "tokio",
- "tokio-rustls 0.26.2",
- "tokio-stream",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
@@ -15150,20 +15121,6 @@ dependencies = [
  "tracing",
  "webpki-roots 1.0.4",
  "zstd",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build 0.13.3",
- "prost-types 0.13.3",
- "quote",
- "syn 2.0.108",
 ]
 
 [[package]]
@@ -15215,7 +15172,7 @@ dependencies = [
  "quote",
  "syn 2.0.108",
  "tempfile",
- "tonic-build 0.14.2",
+ "tonic-build",
 ]
 
 [[package]]

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
-iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "265bc250c7772a3703ed965c9542f61d35f54821" }
+iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", tag = "v0.1.0" }
 serde.workspace = true
 strum.workspace = true
 tokio.workspace = true

--- a/crates/iota-rest-kv/Cargo.toml
+++ b/crates/iota-rest-kv/Cargo.toml
@@ -16,6 +16,7 @@ base64-url.workspace = true
 bcs.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["env"] }
+futures.workspace = true
 object_store.workspace = true
 rustls.workspace = true
 serde.workspace = true

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -10,6 +10,7 @@ use std::{
 
 use anyhow::Result;
 use bytes::Bytes;
+use futures::{StreamExt, TryStreamExt, stream};
 use iota_kvstore::{
     BigTableClient, Cell,
     client::{
@@ -19,14 +20,21 @@ use iota_kvstore::{
         TRANSACTION_COLUMN_QUALIFIER, TRANSACTION_TO_CHECKPOINT, TRANSACTIONS_TABLE,
         raw_object_key,
     },
-    proto::bigtable::v2::{RowFilter, row_filter::Filter},
+    proto::bigtable::v2::{
+        RowFilter,
+        row_filter::Filter,
+        row_range::{EndKey, StartKey},
+    },
 };
-use iota_storage::http_key_value_store::Key;
-use iota_types::effects::TransactionEvents;
+use iota_storage::http_key_value_store::{ItemType, Key};
+use iota_types::{effects::TransactionEvents, storage::ObjectKey};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
-use crate::errors::ApiError;
+use crate::errors::{ApiError, RangeKeyBoundError};
+
+/// The maximum number of concurrent futures allowed when scanning BigTableDB.
+const MAX_CONCURRENT_FUTURES: usize = 100;
 
 /// Configuration for the [`KvStoreClient`] used to access data from BigTableDB
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -81,6 +89,22 @@ impl KvStoreClient {
         })
     }
 
+    /// Builds a [`RowFilter`] that matches only cells whose column qualifier
+    /// equals `column_qualifier` exactly.
+    ///
+    /// Internally the filter is implemented as a regex anchored with `^` and
+    /// `$` to enforce an exact byte match of the provided
+    /// `column_qualifier`, preventing partial or substring matches against
+    /// other columns whose qualifiers happen to contain `column_qualifier`
+    /// as a prefix, suffix, or substring.
+    fn column_qualifier_filter(column_qualifier: &str) -> RowFilter {
+        RowFilter {
+            filter: Some(Filter::ColumnQualifierRegexFilter(
+                format!("^{column_qualifier}$").into_bytes(),
+            )),
+        }
+    }
+
     /// Get the elapsed time from which the service was instantiated.
     pub fn get_uptime(&self) -> Duration {
         self.start_time.elapsed()
@@ -90,7 +114,7 @@ impl KvStoreClient {
     ///
     /// Based on the provided [`Key`] fetch the data from BigTableDB.
     pub async fn get(&self, key: Key) -> Result<Option<Bytes>, ApiError> {
-        let results = self.multi_get(vec![key]).await?;
+        let results = self.get_items(vec![key]).await?;
         Ok(results.into_iter().next().unwrap_or(None))
     }
 
@@ -104,49 +128,37 @@ impl KvStoreClient {
     ///
     /// All keys must be of the same type, otherwise [`ApiError::BadRequest`] is
     /// returned.
-    pub async fn multi_get(&self, keys: Vec<Key>) -> Result<Vec<Option<Bytes>>, ApiError> {
+    pub async fn get_items(&self, keys: Vec<Key>) -> Result<Vec<Option<Bytes>>, ApiError> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
 
-        let mut client = self.bigtable_client.clone();
-
         // Use the first key to determine the type - all keys should be of the same type
         match keys.first().expect("emptiness was checked earlier") {
             Key::Transaction(_) => {
-                let digests = Self::extract_keys(&keys, |k| match k {
+                let digests = extract_keys(&keys, |k| match k {
                     Key::Transaction(digest) => Some(*digest),
                     _ => None,
                 })?;
 
                 let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
-                multi_get_cell(
-                    &mut client,
-                    TRANSACTIONS_TABLE,
-                    keys,
-                    TRANSACTION_COLUMN_QUALIFIER,
-                )
-                .await
+                self.fetch_from_bigtable(TRANSACTIONS_TABLE, keys, TRANSACTION_COLUMN_QUALIFIER)
+                    .await
             }
             Key::TransactionEffects(_) => {
-                let digests = Self::extract_keys(&keys, |k| match k {
+                let digests = extract_keys(&keys, |k| match k {
                     Key::TransactionEffects(digest) => Some(*digest),
                     _ => None,
                 })?;
 
                 let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
-                multi_get_cell(
-                    &mut client,
-                    TRANSACTIONS_TABLE,
-                    keys,
-                    EFFECTS_COLUMN_QUALIFIER,
-                )
-                .await
+                self.fetch_from_bigtable(TRANSACTIONS_TABLE, keys, EFFECTS_COLUMN_QUALIFIER)
+                    .await
             }
             Key::CheckpointContents(_) => {
-                let seq_nums = Self::extract_keys(&keys, |k| match k {
+                let seq_nums = extract_keys(&keys, |k| match k {
                     Key::CheckpointContents(seq_num) => Some(*seq_num),
                     _ => None,
                 })?;
@@ -156,8 +168,7 @@ impl KvStoreClient {
                     .map(|sq| Some(sq.to_be_bytes().to_vec()))
                     .collect();
 
-                multi_get_cell(
-                    &mut client,
+                self.fetch_from_bigtable(
                     CHECKPOINTS_TABLE,
                     keys,
                     CHECKPOINT_CONTENTS_COLUMN_QUALIFIER,
@@ -165,7 +176,7 @@ impl KvStoreClient {
                 .await
             }
             Key::CheckpointSummary(_) => {
-                let seq_nums = Self::extract_keys(&keys, |k| match k {
+                let seq_nums = extract_keys(&keys, |k| match k {
                     Key::CheckpointSummary(seq_num) => Some(*seq_num),
                     _ => None,
                 })?;
@@ -175,8 +186,7 @@ impl KvStoreClient {
                     .map(|sq| Some(sq.to_be_bytes().to_vec()))
                     .collect();
 
-                multi_get_cell(
-                    &mut client,
+                self.fetch_from_bigtable(
                     CHECKPOINTS_TABLE,
                     keys,
                     CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
@@ -184,7 +194,7 @@ impl KvStoreClient {
                 .await
             }
             Key::CheckpointSummaryByDigest(_) => {
-                let checkpoint_digests = Self::extract_keys(&keys, |k| match k {
+                let checkpoint_digests = extract_keys(&keys, |k| match k {
                     Key::CheckpointSummaryByDigest(checkpoint_digest) => Some(*checkpoint_digest),
                     _ => None,
                 })?;
@@ -194,26 +204,21 @@ impl KvStoreClient {
                     .map(|digest| Some(digest.inner().to_vec()))
                     .collect::<Vec<Option<Vec<u8>>>>();
 
-                fetch_checkpoint_summary_by_digests(&mut client, digest_keys).await
+                self.checkpoint_summary_by_digests(digest_keys).await
             }
             Key::TransactionToCheckpoint(_) => {
-                let digests = Self::extract_keys(&keys, |k| match k {
+                let digests = extract_keys(&keys, |k| match k {
                     Key::TransactionToCheckpoint(digest) => Some(*digest),
                     _ => None,
                 })?;
 
                 let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
-                multi_get_cell(
-                    &mut client,
-                    TRANSACTIONS_TABLE,
-                    keys,
-                    TRANSACTION_TO_CHECKPOINT,
-                )
-                .await
+                self.fetch_from_bigtable(TRANSACTIONS_TABLE, keys, TRANSACTION_TO_CHECKPOINT)
+                    .await
             }
             Key::ObjectKey(_) => {
-                let object_keys = Self::extract_keys(&keys, |k| match k {
+                let object_keys = extract_keys(&keys, |k| match k {
                     Key::ObjectKey(object_key) => Some(*object_key),
                     _ => None,
                 })?;
@@ -223,23 +228,20 @@ impl KvStoreClient {
                     .map(|key| Some(raw_object_key(key)))
                     .collect();
 
-                multi_get_cell(&mut client, OBJECTS_TABLE, keys, DEFAULT_COLUMN_QUALIFIER).await
+                self.fetch_from_bigtable(OBJECTS_TABLE, keys, DEFAULT_COLUMN_QUALIFIER)
+                    .await
             }
             Key::EventsByTransactionDigest(_) => {
-                let digests = Self::extract_keys(&keys, |k| match k {
+                let digests = extract_keys(&keys, |k| match k {
                     Key::EventsByTransactionDigest(digest) => Some(*digest),
                     _ => None,
                 })?;
 
                 let keys = digests.iter().map(|tx| Some(tx.inner().to_vec())).collect();
 
-                let response = multi_get_cell(
-                    &mut client,
-                    TRANSACTIONS_TABLE,
-                    keys,
-                    EVENTS_COLUMN_QUALIFIER,
-                )
-                .await?;
+                let response = self
+                    .fetch_from_bigtable(TRANSACTIONS_TABLE, keys, EVENTS_COLUMN_QUALIFIER)
+                    .await?;
 
                 Ok(response
                     .into_iter()
@@ -257,113 +259,256 @@ impl KvStoreClient {
         .map_err(Into::into)
     }
 
-    /// Extracts specific key type from a general [`Key`] type.
+    /// Fetch multiple values from a BigTable table with a specific key and
+    /// column qualifier.
     ///
-    /// Takes:
-    /// - `keys`: The list of keys to extract from
-    /// - `extractor`: Function that returns Some(extracted_value) for the
-    ///   target variant, None otherwise
+    /// Keys wrapped in `Option<Vec<u8>>` allow chaining multiple queries: the
+    /// result from one `fetch_from_bigtable` (which contains `None` for missing
+    /// keys) can be directly passed as input to the next call. `None` keys
+    /// are skipped in the query but preserve their position in the result.
     ///
-    /// Returns a vector of extracted values. Returns [`ApiError::BadRequest`]
-    /// if any extraction returns None value.
-    fn extract_keys<T, F>(keys: &[Key], extractor: F) -> Result<Vec<T>, ApiError>
-    where
-        F: Fn(&Key) -> Option<T>,
-    {
-        keys.iter()
-            .map(|k| {
-                extractor(k).ok_or_else(|| {
-                    ApiError::BadRequest("all keys should be of the same type".to_string())
-                })
-            })
-            .collect()
-    }
-}
+    /// The result's length is guaranteed to match the input `keys` length. Each
+    /// position in the result corresponds to the key at the same position in
+    /// the input. This allows the caller to easily determine which
+    /// requested keys have data:
+    /// - `Some(value)` at index `i` means `key[i]` exists and has data
+    /// - `None` at index `i` means `key[i]` was not found or has no matching
+    ///   data
+    async fn fetch_from_bigtable(
+        &self,
+        table_name: &str,
+        keys: Vec<Option<Vec<u8>>>,
+        column_qualifier: &str,
+    ) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
+        let mut client = self.bigtable_client.clone();
+        // pre-allocate results with None. Matching cells will replace None with
+        // Some(value), and unmatched keys will remain None.
+        let mut results = vec![None; keys.len()];
 
-/// Fetch multiple values from a BigTable table with a specific key and column
-/// qualifier.
-///
-/// Keys wrapped in `Option<Vec<u8>>` allow chaining multiple queries: the
-/// result from one `multi_get_cell` (which contains `None` for missing keys)
-/// can be directly passed as input to the next call. `None` keys are skipped in
-/// the query but preserve their position in the result.
-///
-/// The result's length is guaranteed to match the input `keys` length. Each
-/// position in the result corresponds to the key at the same position in the
-/// input. This allows the caller to easily determine which requested keys have
-/// data:
-/// - `Some(value)` at index `i` means `key[i]` exists and has data
-/// - `None` at index `i` means `key[i]` was not found or has no matching data
-async fn multi_get_cell(
-    client: &mut BigTableClient,
-    table_name: &str,
-    keys: Vec<Option<Vec<u8>>>,
-    column_qualifier: &str,
-) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
-    // pre-allocate results with None. Matching cells will replace None with
-    // Some(value), and unmatched keys will remain None.
-    let mut results = vec![None; keys.len()];
+        let key_to_index = keys
+            .iter()
+            .enumerate()
+            .filter_map(|(index, key)| key.as_ref().map(|k| (k.clone(), index)))
+            .collect::<HashMap<Vec<u8>, usize>>();
 
-    let key_to_index = keys
-        .iter()
-        .enumerate()
-        .filter_map(|(index, key)| key.as_ref().map(|k| (k.clone(), index)))
-        .collect::<HashMap<Vec<u8>, usize>>();
-
-    // create the exact match filter
-    // We use ^ and $ to ensure it's an exact byte match, not a substring match.
-    let exact_column_filter = RowFilter {
-        filter: Some(Filter::ColumnQualifierRegexFilter(
-            format!("^{column_qualifier}$").into_bytes(),
-        )),
-    };
-
-    for row in client
-        .multi_get(
-            table_name,
-            key_to_index.keys().cloned().collect(),
-            Some(exact_column_filter),
-        )
-        .await?
-    {
-        for Cell { name, value } in row.cells {
-            let cell_name = std::str::from_utf8(&name)?;
-            if cell_name == column_qualifier {
-                if let Some(&index) = key_to_index.get(&row.key) {
-                    results[index] = Some(Bytes::from(value));
+        for row in client
+            .multi_get(
+                table_name,
+                key_to_index.keys().cloned().collect(),
+                Some(Self::column_qualifier_filter(column_qualifier)),
+            )
+            .await?
+        {
+            for Cell { name, value } in row.cells {
+                let cell_name = std::str::from_utf8(&name)?;
+                if cell_name == column_qualifier {
+                    if let Some(&index) = key_to_index.get(&row.key) {
+                        results[index] = Some(Bytes::from(value));
+                    }
+                } else {
+                    error!("unexpected column {cell_name:?} in {table_name} table")
                 }
-            } else {
-                error!("unexpected column {cell_name:?} in checkpoints table")
             }
         }
+
+        Ok(results)
     }
 
-    Ok(results)
+    /// Fetch multiple checkpoint summaries by its checkpoint digest.
+    async fn checkpoint_summary_by_digests(
+        &self,
+        keys: Vec<Option<Vec<u8>>>,
+    ) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
+        let sequence_numbers = self
+            .fetch_from_bigtable(CHECKPOINTS_BY_DIGEST_TABLE, keys, DEFAULT_COLUMN_QUALIFIER)
+            .await?;
+
+        let seq_numbers_keys = sequence_numbers
+            .into_iter()
+            .map(|bytes| bytes.map(|b| b.to_vec()))
+            .collect::<Vec<Option<Vec<u8>>>>();
+
+        self.fetch_from_bigtable(
+            CHECKPOINTS_TABLE,
+            seq_numbers_keys,
+            CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
+        )
+        .await
+    }
+
+    /// Performs a single reverse range scan against the objects table and
+    /// returns the bytes of the highest stored version that is **strictly
+    /// less than** the version encoded in [`ObjectRangeKeyBound::end_key`].
+    ///
+    /// Returns `None` if no version below the requested one exists for that
+    /// object (or if the object is not stored at all).
+    pub async fn object_before_version(
+        &self,
+        range: ObjectRangeKeyBound,
+    ) -> Result<Option<Bytes>, anyhow::Error> {
+        if range.is_empty() {
+            return Ok(None);
+        }
+
+        let mut client = self.bigtable_client.clone();
+
+        let reversed = true;
+        let rows_limit = 1;
+        let rows = client
+            .range_scan(
+                OBJECTS_TABLE,
+                Some(range.start_key),
+                Some(range.end_key),
+                rows_limit,
+                reversed,
+                Some(Self::column_qualifier_filter(DEFAULT_COLUMN_QUALIFIER)),
+            )
+            .await?;
+
+        let Some(row) = rows.into_iter().next() else {
+            return Ok(None);
+        };
+
+        let mut value = None;
+        for Cell {
+            name,
+            value: cell_value,
+        } in row.cells
+        {
+            // little optimization, comparing bytes is cheaper than converting it to utf8
+            // string and do string comparison.
+            if name == DEFAULT_COLUMN_QUALIFIER.as_bytes() {
+                value = Some(Bytes::from(cell_value));
+            } else {
+                let cell_name = std::str::from_utf8(&name)?;
+                error!("unexpected column {cell_name:?} in {OBJECTS_TABLE} table");
+            }
+        }
+        Ok(value)
+    }
+
+    /// Gets multiple objects returning the latest version strictly less than
+    /// the requested version values as [`Vec`]<[`Option`]<[`Bytes`]>> from the
+    /// kv store.
+    ///
+    /// Based on the provided [`ObjectsBeforeVersionRequest`] fetch the data
+    /// from BigTableDB. Returns a vector of the same length and order as
+    /// the input keys. Each entry is `Some(bytes)` if the key was found, or
+    /// `None` if not found.
+    pub async fn objects_before_version(
+        &self,
+        req: ObjectsBeforeVersionRequest,
+    ) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
+        let req = req.into_inner();
+
+        // `multiget_max_items` bounds the size of an incoming request, but it is
+        // an operator-configurable value. Concurrency is capped independently via
+        // `MAX_CONCURRENT_FUTURES` so that increasing the request limit does not
+        // proportionally increase the number of concurrent BigTable calls per request.
+        let max_buffered_concurrent_futures = req.len().clamp(1, MAX_CONCURRENT_FUTURES);
+
+        stream::iter(req.into_iter())
+            .map(|range| self.object_before_version(range))
+            .buffered(max_buffered_concurrent_futures)
+            .try_collect::<Vec<Option<Bytes>>>()
+            .await
+    }
 }
 
-/// Fetch multiple checkpoint summaries by its checkpoint digest.
-async fn fetch_checkpoint_summary_by_digests(
-    client: &mut BigTableClient,
-    keys: Vec<Option<Vec<u8>>>,
-) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
-    let sequence_numbers = multi_get_cell(
-        client,
-        CHECKPOINTS_BY_DIGEST_TABLE,
-        keys,
-        DEFAULT_COLUMN_QUALIFIER,
-    )
-    .await?;
+/// Extracts specific key type from a general [`Key`] type.
+///
+/// Takes:
+/// - `keys`: The list of keys to extract from
+/// - `extractor`: Function that returns Some(extracted_value) for the target
+///   variant, None otherwise
+///
+/// Returns a vector of extracted values. Returns [`ApiError::BadRequest`]
+/// if any extraction returns None value.
+fn extract_keys<T, F>(keys: &[Key], extractor: F) -> Result<Vec<T>, ApiError>
+where
+    F: Fn(&Key) -> Option<T>,
+{
+    keys.iter()
+        .map(|k| {
+            extractor(k).ok_or_else(|| {
+                ApiError::BadRequest("all keys should be of the same type".to_string())
+            })
+        })
+        .collect()
+}
 
-    let seq_numbers_keys = sequence_numbers
+/// Represents a range of keys for a single object the BigTableDB is allowed to
+/// scan.
+pub(crate) struct ObjectRangeKeyBound {
+    start_key: StartKey,
+    end_key: EndKey,
+}
+
+impl ObjectRangeKeyBound {
+    /// Returns `true` if the range contains no rows.
+    fn is_empty(&self) -> bool {
+        match (&self.start_key, &self.end_key) {
+            (StartKey::StartKeyClosed(start), EndKey::EndKeyClosed(end)) => start > end,
+            (
+                StartKey::StartKeyClosed(start) | StartKey::StartKeyOpen(start),
+                EndKey::EndKeyClosed(end) | EndKey::EndKeyOpen(end),
+            ) => start >= end,
+        }
+    }
+}
+
+impl TryFrom<Key> for ObjectRangeKeyBound {
+    type Error = RangeKeyBoundError;
+
+    fn try_from(key: Key) -> Result<Self, Self::Error> {
+        let Key::ObjectKey(object_key) = key else {
+            return Err(RangeKeyBoundError::UnexpectedItemType {
+                expected: ItemType::Object,
+                detail: "range key must be an ObjectKey".into(),
+            });
+        };
+        Ok(object_key.into())
+    }
+}
+
+impl From<ObjectKey> for ObjectRangeKeyBound {
+    fn from(value: ObjectKey) -> Self {
+        let obj_id = value.0;
+        ObjectRangeKeyBound {
+            start_key: StartKey::StartKeyClosed(raw_object_key(&ObjectKey::min_for_id(&obj_id))),
+            end_key: EndKey::EndKeyOpen(raw_object_key(&value)),
+        }
+    }
+}
+
+/// Represents a request to fetch objects before a given version.
+///
+/// This struct expects that all keys in the input vector are of type
+/// [`Key::ObjectKey`] in the [`TryFrom`] implementation.
+pub(crate) struct ObjectsBeforeVersionRequest(Vec<ObjectRangeKeyBound>);
+
+impl ObjectsBeforeVersionRequest {
+    fn into_inner(self) -> Vec<ObjectRangeKeyBound> {
+        self.0
+    }
+}
+
+impl TryFrom<Vec<Key>> for ObjectsBeforeVersionRequest {
+    type Error = RangeKeyBoundError;
+
+    fn try_from(keys: Vec<Key>) -> Result<Self, Self::Error> {
+        let object_range_keys = extract_keys(&keys, |k| match k {
+            Key::ObjectKey(object_key) => Some(*object_key),
+            _ => None,
+        })
+        .map_err(|e| RangeKeyBoundError::UnexpectedItemType {
+            expected: ItemType::Object,
+            detail: e.to_string(),
+        })?
         .into_iter()
-        .map(|bytes| bytes.map(|b| b.to_vec()))
-        .collect::<Vec<Option<Vec<u8>>>>();
+        .map(ObjectRangeKeyBound::from)
+        .collect();
 
-    multi_get_cell(
-        client,
-        CHECKPOINTS_TABLE,
-        seq_numbers_keys,
-        CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
-    )
-    .await
+        Ok(ObjectsBeforeVersionRequest(object_range_keys))
+    }
 }

--- a/crates/iota-rest-kv/src/errors.rs
+++ b/crates/iota-rest-kv/src/errors.rs
@@ -8,6 +8,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use iota_storage::http_key_value_store::ItemType;
 use serde::Serialize;
 use thiserror::Error;
 
@@ -52,4 +53,16 @@ impl IntoResponse for ApiError {
 pub(crate) struct ErrorResponse {
     error_code: String,
     error_message: String,
+}
+
+#[derive(Error, Debug)]
+pub enum RangeKeyBoundError {
+    #[error("expected `{expected}` item type: {detail}")]
+    UnexpectedItemType { expected: ItemType, detail: String },
+}
+
+impl From<RangeKeyBoundError> for ApiError {
+    fn from(err: RangeKeyBoundError) -> Self {
+        ApiError::BadRequest(err.to_string())
+    }
 }

--- a/crates/iota-rest-kv/src/routes/kv_store.rs
+++ b/crates/iota-rest-kv/src/routes/kv_store.rs
@@ -40,10 +40,9 @@ pub(crate) struct BeforeVersion {
 /// # Query Parameters
 ///
 /// * `before_version` (optional, default `false`): only valid when `item_type`
-///   is [`ItemType::Object`](iota_storage::http_key_value_store::ItemType::Object).
-///   When `true`, returns the latest stored version strictly less than the
-///   version encoded in the key. Returns `400 Bad Request` if used with any
-///   other [`ItemType`](iota_storage::http_key_value_store::ItemType).
+///   is [`ItemType::Object`]. When `true`, returns the latest stored version
+///   strictly less than the version encoded in the key. Returns `400 Bad
+///   Request` if used with any other [`ItemType`].
 ///
 /// # Returns
 ///
@@ -92,10 +91,9 @@ pub async fn data_as_bytes(
 /// # Query Parameters
 ///
 /// * `before_version` (optional, default `false`): only valid when `item_type`
-///   is [`ItemType::Object`](iota_storage::http_key_value_store::ItemType::Object).
-///   When `true`, returns the latest stored version strictly less than the
-///   version encoded in each key. Returns `400 Bad Request` if used with any
-///   other [`ItemType`](iota_storage::http_key_value_store::ItemType).
+///   is [`ItemType::Object`]. When `true`, returns the latest stored version
+///   strictly less than the version encoded in each key. Returns `400 Bad
+///   Request` if used with any other [`ItemType`].
 ///
 /// # Request Body
 ///

--- a/crates/iota-rest-kv/src/routes/kv_store.rs
+++ b/crates/iota-rest-kv/src/routes/kv_store.rs
@@ -3,37 +3,76 @@
 use axum::{
     Json,
     body::Body,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use iota_storage::http_key_value_store::{ItemType, Key};
 use serde::Deserialize;
 
-use crate::{errors::ApiError, extractors::ExtractPath, types::SharedRestServerAppState};
+use crate::{
+    bigtable::{ObjectRangeKeyBound, ObjectsBeforeVersionRequest},
+    errors::ApiError,
+    extractors::ExtractPath,
+    types::SharedRestServerAppState,
+};
+
+const BEFORE_VERSION_REQUIRES_OB_ERROR_MSG: &str =
+    "`before_version` query parameter is only valid for `ob` item types";
 
 /// Request payload for multi_get_objects_post containing list of keys.
 #[derive(Deserialize, Debug)]
-pub struct MultiGetRequest {
+pub(crate) struct MultiGetRequest {
     /// List of base64url-encoded keys to retrieve.
-    pub keys: Vec<String>,
+    pub(crate) keys: Vec<String>,
+}
+
+/// Extracts the `?before_version` query parameter
+#[derive(Deserialize, Debug, Default)]
+pub(crate) struct BeforeVersion {
+    #[serde(default)]
+    pub(crate) before_version: bool,
 }
 
 /// Retrieves data associated with a given key from the KV store as raw
 /// [`Bytes`](bytes::Bytes).
 ///
+/// # Query Parameters
+///
+/// * `before_version` (optional, default `false`): only valid when `item_type`
+///   is [`ItemType::Object`](iota_storage::http_key_value_store::ItemType::Object).
+///   When `true`, returns the latest stored version strictly less than the
+///   version encoded in the key. Returns `400 Bad Request` if used with any
+///   other [`ItemType`](iota_storage::http_key_value_store::ItemType).
+///
 /// # Returns
 ///
 /// * If the key exists, the data is returned as a [`Bytes`](bytes::Bytes)
 ///   stream with a `200 OK` status code.
-/// * If the key does not exist, a `204 No Content` status code is returned with
+/// * If the key does not exist, a `404 Not Found` status code is returned with
 ///   an empty body.
 /// * If an error occurs while interacting with the KV store, an `500 internal
 ///   server error` is returned.
 pub async fn data_as_bytes(
-    ExtractPath(key): ExtractPath,
     State(app_state): State<SharedRestServerAppState>,
+    ExtractPath(key): ExtractPath,
+    Query(BeforeVersion { before_version }): Query<BeforeVersion>,
 ) -> Result<impl IntoResponse, ApiError> {
+    if before_version {
+        let range = ObjectRangeKeyBound::try_from(key)
+            .map_err(|_| ApiError::BadRequest(BEFORE_VERSION_REQUIRES_OB_ERROR_MSG.into()))?;
+
+        let response = app_state
+            .kv_store_client
+            .object_before_version(range)
+            .await?;
+
+        return Ok(response.map_or_else(
+            || (StatusCode::NOT_FOUND, Body::empty()).into_response(),
+            |bytes| bytes.into_response(),
+        ));
+    }
+
     app_state
         .kv_store_client
         .get(key)
@@ -49,6 +88,14 @@ pub async fn data_as_bytes(
 /// # Path Parameters
 ///
 /// - `item_type`: The type of items to get (e.g., "cs", "cc", "tx")
+///
+/// # Query Parameters
+///
+/// * `before_version` (optional, default `false`): only valid when `item_type`
+///   is [`ItemType::Object`](iota_storage::http_key_value_store::ItemType::Object).
+///   When `true`, returns the latest stored version strictly less than the
+///   version encoded in each key. Returns `400 Bad Request` if used with any
+///   other [`ItemType`](iota_storage::http_key_value_store::ItemType).
 ///
 /// # Request Body
 ///
@@ -71,20 +118,19 @@ pub async fn data_as_bytes(
 ///   The vector has the same length and order as the `keys` list in the request
 ///   body. Each entry is `Some(bytes)` if the key was found, or `None` if the
 ///   key was not found.
-/// * If no keys are provided or the number of keys exceeds the configured
-///   `multiget_max_items` limit, a `400 bad request error` is returned.
+///  * If no keys are provided or the number of keys exceeds the configured
+///    `multiget_max_items` limit, a `400 bad request error` is returned.
 /// * If the keys cannot be parsed, a `400 bad request error` is returned.
-/// * If heterogenous key types are requested (e.g. checkpoints by sequence id
-///   and by digest), a `400 bad request error` is returned.
 /// * If an error occurs while interacting with the KV store, an `500 internal
 ///   server error` is returned.
 pub async fn multi_get_data(
-    Path(item_type): Path<ItemType>,
     State(app_state): State<SharedRestServerAppState>,
+    Path(item_type): Path<ItemType>,
+    Query(BeforeVersion { before_version }): Query<BeforeVersion>,
     Json(payload): Json<MultiGetRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     if payload.keys.is_empty() {
-        return Err(ApiError::BadRequest("no keys provided".to_string()));
+        return Err(ApiError::BadRequest("no keys provided".into()));
     }
 
     if payload.keys.len() > app_state.multiget_max_items.get() {
@@ -105,7 +151,16 @@ pub async fn multi_get_data(
         })
         .collect::<Result<Vec<Key>, ApiError>>()?;
 
-    let results = app_state.kv_store_client.multi_get(keys).await?;
+    let results = if before_version {
+        let request = ObjectsBeforeVersionRequest::try_from(keys)
+            .map_err(|_| ApiError::BadRequest(BEFORE_VERSION_REQUIRES_OB_ERROR_MSG.into()))?;
+        app_state
+            .kv_store_client
+            .objects_before_version(request)
+            .await?
+    } else {
+        app_state.kv_store_client.get_items(keys).await?
+    };
 
     let bcs_data = bcs::to_bytes(&results).map_err(|_| ApiError::InternalServerError)?;
     Ok(bcs_data.into_response())


### PR DESCRIPTION
# Description of change

Adds an optional `?before_version=<bool>` query parameter to the object retrieval routes of `iota-rest-kv`. When `true`, the server returns the highest stored object version **strictly less than** the version encoded in the request key, instead of the exact-version match.

This unblocks callers that know the `ObjectID` but not the exact version (e.g. resolving a past object state) from using the REST KV store. Previously only exact-version lookups were possible.

### Implementation details

-  **Query parameter over dedicated route.** The existing routes are generic over `item_type` (`/{item_type}` and `/{item_type}/{key}`). Adding a dedicated route for this one retrieval mode would introduce an object-only special case in an otherwise uniform route table. Expressing the mode as an optional query parameter keeps the routes generic and makes the feature backward-compatible by default. This also aligns with common REST guidance: the resource is the same (`/ob/{key}` or `/ob`), only the retrieval mode changes, which is the canonical use case for a query parameter rather than a new path.
- **Validation in a custom extractor.** A `BeforeVersionQuery` extractor reads the flag and, when `true`, enforces that the item type is `ob`. Everything else is rejected with `400 Bad Request` before the handler runs. This keeps route handlers focused on business logic.
- **Supported routes.** Both `GET /{item_type}/{key}` and `POST /{item_type}` accept the parameter. When absent it defaults to `false`, so existing callers are unaffected.
-  **Batch semantics.** The response is a BCS-serialized `Vec<Option<Bytes>>` that preserves the order of the input `keys`. `Some(bytes)` is the highest version strictly below the requested one; `None` means not found.
- **Edge case.** `before_version=true` with a key at version 0 returns `None`.
-  **BigTable scan.** Implemented as a single reverse `range_scan` on the objects table with `rows_limit = 1`. The scan is bounded to a single object by setting the start key (inclusive) to `(object_id, version = 0)` and the end key (exclusive) to `(object_id, requested_version)`. The lower bound prevents the scan from spilling into the previous `object_id`.

## Links to any relevant issues

fixes #11304 

## How the change has been tested

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Manual tests for `BeforeVersionQuery` (valid/invalid item types, absent parameter, default value) using testnet bigtable instance.
- For testing we picked the `Clock` object, since it's always mutated and has lots of versions to work with.

```shell
# POST
curl --location 'http://0.0.0.0:3555/ob?before_version=true' \
--header 'Content-Type: application/json' \
--data '{
    "keys": [
        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYnAQAAAAAAAA",
        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYmAQAAAAAAAA"
    ]
}'
```

```shell
# GET
curl --location 'http://0.0.0.0:3555/ob/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYnAQAAAAAAAA?before_version=true'
```
- Extractor validation of the `before_version=true` with an item type which is not an `ob` one.
```shell
curl --location 'http://0.0.0.0:3555/tx/Y1OOIQeD_oRmu8-7E2yFbqrboSrprUKBu0-HTMAo_Ek?before_version=true'
```
Response
```json
{
    "error_code": "400",
    "error_message": "bad request: `before_version` query parameter is only valid for `ob` item types"
}

```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the normal operation of the indexer, thus no further tests were conducted.
