### PR TITLE
feat(iota-indexer): add fallback support for object before version

### DIFF
--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -163,6 +163,9 @@ pub enum IndexerError {
     #[error("historical fallback storage error: {0}")]
     HistoricalFallbackStorageError(String),
 
+    #[error("historical fallback input error: {0}")]
+    HistoricalFallbackInput(String),
+
     #[error("Missing data due to pruning: `{0}`")]
     DataPruned(String),
 

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -596,20 +596,15 @@ impl KeyValueStoreClient for HttpRestKVClient {
         object_refs: &[(ObjectID, SequenceNumber)],
         before_version: bool,
     ) -> IndexerResult<Vec<Option<Object>>> {
-        let fetches = if before_version {
-            let keys = object_refs
-                .iter()
-                .map(|(object_id, version)| ObjectKey(*object_id, *version))
-                .collect::<Vec<ObjectKey>>();
+        let keys = object_refs
+            .iter()
+            .map(|(object_id, version)| ObjectKey(*object_id, *version));
 
+        let fetches = if before_version {
+            let keys = keys.collect::<Vec<ObjectKey>>();
             self.multi_fetch_objects_before_version(&keys).await?
         } else {
-            let keys = object_refs
-                .iter()
-                .map(|(object_id, version)| Key::ObjectKey(ObjectKey(*object_id, *version)))
-                .collect::<Vec<_>>();
-
-            self.multi_fetch(keys).await?
+            self.multi_fetch(keys.map(Key::ObjectKey).collect()).await?
         };
 
         let objects = fetches

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -6,7 +6,10 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use futures::stream::{self, StreamExt};
+use futures::{
+    TryStreamExt,
+    stream::{self, StreamExt},
+};
 use iota_storage::http_key_value_store::{ItemType, Key};
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
@@ -121,6 +124,7 @@ pub(crate) trait KeyValueStoreClient {
     async fn multi_get_objects(
         &self,
         object_refs: &[(ObjectID, SequenceNumber)],
+        before_version: bool,
     ) -> IndexerResult<Vec<Option<Object>>>;
 }
 
@@ -133,6 +137,13 @@ pub(crate) struct HttpRestKVClient {
     /// Maximum number of concurrent batch requests
     max_concurrent_batches: usize,
     cache: MokaCache<Key, Bytes>,
+    /// Cache for before-version lookups, keyed by `ObjectKey`.
+    ///
+    /// Kept separate from `cache` because the cached value is the object at
+    /// some earlier version, not the exact-version match that `cache` stores.
+    /// Mixing them under the same key would let before-version results serve
+    /// exact-version requests (or vice versa).
+    cache_object_before_version: MokaCache<ObjectKey, Bytes>,
     metrics: HistoricalFallbackClientMetrics,
 }
 
@@ -162,6 +173,10 @@ impl HttpRestKVClient {
             .time_to_idle(CACHE_TIME_TO_IDLE)
             .build();
 
+        let cache_object_before_version = MokaCacheBuilder::new(cache_size)
+            .time_to_idle(CACHE_TIME_TO_IDLE)
+            .build();
+
         Ok(Self {
             base_url,
             client,
@@ -169,6 +184,7 @@ impl HttpRestKVClient {
             max_concurrent_batches,
             metrics,
             cache,
+            cache_object_before_version,
         })
     }
 
@@ -188,7 +204,7 @@ impl HttpRestKVClient {
 
         for (index, key) in keys.iter().enumerate() {
             if let Some(bytes) = self.cache.get(key) {
-                trace!("found cached data for url: {key:?}, len: {}", bytes.len());
+                trace!("found cached data for key: {key:?}, len: {}", bytes.len());
                 self.metrics.record_cache_hit(key.item_type());
                 results[index] = Some(bytes);
             } else {
@@ -210,12 +226,12 @@ impl HttpRestKVClient {
             .collect::<Result<Vec<MultiGetRequest>, IndexerError>>()?;
 
         let mut fetch_batch_stream = stream::iter(missing_chunks)
-            .map(|chunk| async move { self.fetch_batch(chunk).await })
+            .map(|chunk| self.fetch_batch(chunk))
             .buffered(self.max_concurrent_batches);
 
         let mut fetched_results = Vec::with_capacity(missing.len());
-        while let Some(batch_result) = fetch_batch_stream.next().await {
-            fetched_results.extend(batch_result?);
+        while let Some(batch_result) = fetch_batch_stream.try_next().await? {
+            fetched_results.extend(batch_result);
         }
 
         // process fetched results: for each missing key that was successfully fetched
@@ -260,6 +276,109 @@ impl HttpRestKVClient {
         let bytes = resp.bytes().await?;
         bcs::from_bytes::<Vec<Option<Bytes>>>(&bytes).map_err(|e| {
             IndexerError::Serde(format!("failed to deserialize multi_get response: {e:?}"))
+        })
+    }
+
+    async fn multi_fetch_objects_before_version(
+        &self,
+        keys: &[ObjectKey],
+    ) -> IndexerResult<Vec<Option<Bytes>>> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // pre-allocate results with None. Cache hits will replace None with
+        // Some(value), and cache misses will remain None until we fetch them
+        // from the REST API.
+        let mut results = vec![None; keys.len()];
+        // track keys that missed the cache, preserving their original positions.
+        // Each entry is a tuple of (key, original_index) so we can merge fetched data
+        // back into the correct position in the results vector.
+        let mut missing = Vec::with_capacity(keys.len());
+
+        for (index, key) in keys.iter().enumerate() {
+            if let Some(bytes) = self.cache_object_before_version.get(key) {
+                trace!("found cached data for key: {key:?}, len: {}", bytes.len());
+                self.metrics.record_cache_object_before_version_hit();
+                results[index] = Some(bytes);
+            } else {
+                self.metrics.record_cache_object_before_version_miss();
+                missing.push((*key, index));
+            }
+        }
+
+        if missing.is_empty() {
+            return Ok(results);
+        }
+
+        let missing_chunks = missing
+            .chunks(self.batch_size)
+            .map(|chunk| {
+                let keys = chunk
+                    .iter()
+                    .map(|(key, _)| Key::ObjectKey(*key))
+                    .collect::<Vec<Key>>();
+                MultiGetRequest::try_from(keys.as_slice())
+            })
+            .collect::<Result<Vec<MultiGetRequest>, IndexerError>>()?;
+
+        let mut stream = stream::iter(missing_chunks)
+            .map(|chunk| self.fetch_objects_before_version_batch(chunk))
+            .buffered(self.max_concurrent_batches);
+
+        let mut fetched_results = Vec::with_capacity(missing.len());
+        while let Some(batch) = stream.try_next().await? {
+            fetched_results.extend(batch);
+        }
+
+        // process fetched results: for each missing key that was successfully fetched
+        // that has non empty bytes, update the cache with the new data and
+        // populate the corresponding slot in results at original index
+        // position.
+        for (fetch_result, (key, index)) in fetched_results.into_iter().zip(missing) {
+            if let Some(bytes) = fetch_result.filter(|b| !b.is_empty()) {
+                self.cache_object_before_version.insert(key, bytes.clone());
+                results[index] = Some(bytes);
+            }
+        }
+
+        Ok(results)
+    }
+
+    async fn fetch_objects_before_version_batch(
+        &self,
+        request: MultiGetRequest,
+    ) -> IndexerResult<Vec<Option<Bytes>>> {
+        let mut url = self.base_url.join(&request.item_type.to_string())?;
+        url.query_pairs_mut().append_pair("before_version", "true");
+
+        trace!(
+            "fetching batch of {} keys from url: {url}",
+            request.keys.len()
+        );
+
+        let resp = self.client.post(url.clone()).json(&request).send().await?;
+
+        trace!(
+            "got response {} for url: {url}, len: {:?}",
+            resp.status(),
+            resp.headers()
+                .get(CONTENT_LENGTH)
+                .unwrap_or(&HeaderValue::from_static("0"))
+        );
+
+        if !resp.status().is_success() {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "object_before_version request failed with status: {}",
+                resp.status()
+            )));
+        }
+
+        let bytes = resp.bytes().await?;
+        bcs::from_bytes::<Vec<Option<Bytes>>>(&bytes).map_err(|e| {
+            IndexerError::Serde(format!(
+                "failed to deserialize before_version response: {e:?}"
+            ))
         })
     }
 }
@@ -475,19 +594,29 @@ impl KeyValueStoreClient for HttpRestKVClient {
     async fn multi_get_objects(
         &self,
         object_refs: &[(ObjectID, SequenceNumber)],
+        before_version: bool,
     ) -> IndexerResult<Vec<Option<Object>>> {
-        let keys = object_refs
-            .iter()
-            .map(|(object_id, version)| Key::ObjectKey(ObjectKey(*object_id, *version)))
-            .collect::<Vec<_>>();
+        let fetches = if before_version {
+            let keys = object_refs
+                .iter()
+                .map(|(object_id, version)| ObjectKey(*object_id, *version))
+                .collect::<Vec<ObjectKey>>();
 
-        let fetches = self.multi_fetch(keys).await?;
+            self.multi_fetch_objects_before_version(&keys).await?
+        } else {
+            let keys = object_refs
+                .iter()
+                .map(|(object_id, version)| Key::ObjectKey(ObjectKey(*object_id, *version)))
+                .collect::<Vec<_>>();
+
+            self.multi_fetch(keys).await?
+        };
 
         let objects = fetches
             .iter()
             .zip(object_refs.iter())
             .map(|(fetch, object_ref)| fetch.as_ref().and_then(|bytes| deser(object_ref, bytes)))
-            .collect::<Vec<_>>();
+            .collect();
 
         Ok(objects)
     }

--- a/crates/iota-indexer/src/historical_fallback/metrics.rs
+++ b/crates/iota-indexer/src/historical_fallback/metrics.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_storage::http_key_value_store::ItemType;
-use prometheus::{IntCounterVec, Registry, register_int_counter_vec_with_registry};
+use prometheus::{
+    IntCounter, IntCounterVec, Registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry,
+};
 
 #[derive(Clone)]
 pub struct HistoricalFallbackClientMetrics {
     pub(crate) cache_hits: IntCounterVec,
     pub(crate) cache_misses: IntCounterVec,
+    pub(crate) cache_object_before_version_hits: IntCounter,
+    pub(crate) cache_object_before_version_misses: IntCounter,
 }
 
 impl HistoricalFallbackClientMetrics {
@@ -27,6 +32,18 @@ impl HistoricalFallbackClientMetrics {
                 registry,
             )
             .unwrap(),
+            cache_object_before_version_hits: register_int_counter_with_registry!(
+                "historical_fallback_cache_object_before_version_hits",
+                "Historical fallback cache object before version hits",
+                registry,
+            )
+            .unwrap(),
+            cache_object_before_version_misses: register_int_counter_with_registry!(
+                "historical_fallback_cache_object_before_version_misses",
+                "Historical fallback cache object before version misses",
+                registry,
+            )
+            .unwrap(),
         }
     }
 
@@ -40,5 +57,13 @@ impl HistoricalFallbackClientMetrics {
         self.cache_misses
             .with_label_values(&[item_type.to_string()])
             .inc();
+    }
+
+    pub(crate) fn record_cache_object_before_version_hit(&self) {
+        self.cache_object_before_version_hits.inc();
+    }
+
+    pub(crate) fn record_cache_object_before_version_miss(&self) {
+        self.cache_object_before_version_misses.inc();
     }
 }

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -99,8 +99,8 @@ impl HistoricalFallbackReader {
             .collect::<Vec<(ObjectID, SequenceNumber)>>();
 
         let (raw_input_objects, raw_output_objects) = tokio::try_join!(
-            self.client.multi_get_objects(&input_object_keys),
-            self.client.multi_get_objects(&output_object_keys),
+            self.client.multi_get_objects(&input_object_keys, false),
+            self.client.multi_get_objects(&output_object_keys, false),
         )?;
 
         let input_objects = raw_input_objects
@@ -342,29 +342,14 @@ impl HistoricalFallbackReader {
     ///
     /// - If `before_version` is `false`, it looks for the exact version.
     /// - If `true`, it finds the latest version before the given one.
-    ///
-    /// # Note
-    ///
-    /// Currently only supports `before_version = false`.
-    ///
-    /// Support for `before_version = true` will be added once range scan is
-    /// implemented on the KV REST API.
     pub(crate) async fn objects(
         &self,
         object_refs: &[(ObjectID, SequenceNumber)],
         before_version: bool,
     ) -> IndexerResult<Vec<Option<StoredObject>>> {
-        if before_version {
-            // TODO: Implement once range scan is available on KV REST API
-            // For now, we cannot determine the correct previous version without it due to
-            // non-contiguous object versioning:
-            // https://docs.iota.org/developer/iota-101/objects/versioning#move-objects.
-            return Ok(vec![None; object_refs.len()]);
-        }
-
         let stored_objects = self
             .client
-            .multi_get_objects(object_refs)
+            .multi_get_objects(object_refs, before_version)
             .await?
             .into_iter()
             .map(|obj| obj.map(StoredObject::from))


### PR DESCRIPTION
# Description of change

When the indexer's database is pruned, the JSON-RPC `iota_tryGetPastObject` call cannot resolve object versions that no longer exist locally. This PR extends the `iota-indexer` historical fallback client to use the REST KV store's new `before_version=true` query parameter when fetching objects, so past versions can be served from BigTable when local data has been pruned.

### Implementation details

- **New signature for the fallback client.** `HttpRestKVClient::multi_get_objects` now takes an extra `before_version: bool` argument. When `true`, each requested `(object_id, version)` is resolved to the highest stored version strictly less than the requested one, instead of an exact match.
- **Cache isolation.** Before-version lookups use a dedicated `MokaCache<ObjectKey, Bytes>` so that exact-match and before-version results cannot collide in the same cache entry.

## Links to any relevant issues

fixes #11053 

## How the change has been tested


Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

End-to-end verification against a local BigTable emulator with objects seeded at versions 0, 1, 2, 5 for the same `ObjectID` (gaps at 3 and 4 intentional; the test also probes version 10 to cover requests above the highest stored version).

1.  Start a local BigTable emulator. See `crates/iota-kvstore/README.md` for setup.
1.  Run `iota-rest-kv` against the emulator with the following `config.yaml`:
```yaml
# Remote KV Store REST API config
#
# The Rest Api address
server-address: "0.0.0.0:3555"

instance-id: "iota"
column-family: "iota"
timeout-secs: 60
emulator-host: "localhost:8086"
```

```shell
$(gcloud beta emulators bigtable env-init)
cargo r -- --config config.yaml
```
3. Run the verification test to assert `before_version` behavior across the seeded versions and the intentional gaps.
```rust
/// Verifies that `multi_get_objects` with `before_version = true` returns, for
/// each requested `(object_id, version)`, the highest stored version strictly
/// less than the requested one, including across gaps in the stored version
/// sequence.
///
/// Assumes a local `iota-rest-kv` server is reachable and has versions
/// 0, 1, 2 and 5 seeded for `TEST_OBJECT_ID`.
#[tokio::test]
async fn get_objects_before_version() {
    std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost:8086");
    let mut client = BigTableClient::new_local("iota", "iota").await.unwrap();

    let id = ObjectID::random();
    let owner = Owner::AddressOwner(IotaAddress::random_for_testing_only());

    let objs = &[
        &Object::with_id_owner_version_for_testing(id, SequenceNumber::from_u64(0), owner),
        &Object::with_id_owner_version_for_testing(id, SequenceNumber::from_u64(1), owner),
        &Object::with_id_owner_version_for_testing(id, SequenceNumber::from_u64(2), owner),
        &Object::with_id_owner_version_for_testing(id, SequenceNumber::from_u64(5), owner),
    ];

    client.save_objects(objs).await.unwrap();

    const REST_KV_URL: &str = "http://127.0.0.1:3555";

    let client = HttpRestKVClient::new(
        REST_KV_URL,
        // max_concurrent_requests
        100,
        // multiget_batch_size
        100,
        // request_timeout_secs
        10,
        HistoricalFallbackClientMetrics::new(&prometheus::default_registry()),
    )
    .unwrap();

    // (requested_version, expected version returned, or None if no prior exists)
    let cases: &[(u64, Option<u64>)] = &[
        (0, None), // no version strictly < 0
        (1, Some(0)),
        (2, Some(1)),
        (5, Some(2)), // 3 and 4 are gaps
        (10, Some(5)),
    ];

    let requests: Vec<_> = cases
        .iter()
        .map(|(v, _)| (id, SequenceNumber::from_u64(*v)))
        .collect();

    let before_version = true;
    let results = client
        .multi_get_objects(&requests, before_version)
        .await
        .expect("multi_get_objects should succeed");

    assert_eq!(results.len(), cases.len());
    for ((requested, expected), got) in cases.iter().zip(results.iter()) {
        let got_version = got.as_ref().map(|obj| obj.version().value());
        assert_eq!(
            got_version, *expected,
            "before_version for requested v{requested}: expected {expected:?}, got {got_version:?}",
        );
    }
}

```


### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: JSON-RPC supports fetching objects before a requested version from the fallback KV storage when the indexer database does not contain the requested version due to pruning.

