### PR TITLE
chore(ci): update actions

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -35,7 +35,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Detect Changes
       uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       id: diff

--- a/.github/workflows/_cargo_deny.yml
+++ b/.github/workflows/_cargo_deny.yml
@@ -17,12 +17,12 @@ jobs:
     name: cargo deny (bans, licenses, sources)
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check bans licenses sources --hide-inclusion-graph
 
   advisories:
     name: cargo deny (advisories)
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check advisories --hide-inclusion-graph

--- a/.github/workflows/_docs_lint.yml
+++ b/.github/workflows/_docs_lint.yml
@@ -16,9 +16,9 @@ jobs:
     name: Lint documentation
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Spell Check Docs
-        uses: crate-ci/typos@945d407a5fc9097f020969446a16f581612ab4df # v1.24.5
+        uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83 # v1.45.1
         with:
           files: ./docs/content
 

--- a/.github/workflows/_docusaurus.yml
+++ b/.github/workflows/_docusaurus.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: self-hosted-x64
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - name: Install Nodejs
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/_docusaurus.yml
+++ b/.github/workflows/_docusaurus.yml
@@ -20,12 +20,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
-      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - name: Install Nodejs
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
-          cache: "pnpm"
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - name: Enable corepack
         run: corepack enable
       - name: Install dependencies

--- a/.github/workflows/_execution_cut.yml
+++ b/.github/workflows/_execution_cut.yml
@@ -16,7 +16,7 @@ jobs:
     name: cutting a new execution layer
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Make cut
         run: ./scripts/execution_layer.py cut for_ci_test

--- a/.github/workflows/_move_ide.yml
+++ b/.github/workflows/_move_ide.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.iota_repo_ref || github.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
@@ -52,12 +52,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.iota_repo_ref || github.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
@@ -98,12 +98,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.iota_repo_ref || github.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -57,8 +57,8 @@ jobs:
     outputs:
       components: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           list-files: "json"
@@ -71,8 +71,8 @@ jobs:
     outputs:
       components: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           list-files: "json"

--- a/.github/workflows/_rust_examples.yml
+++ b/.github/workflows/_rust_examples.yml
@@ -38,7 +38,7 @@ jobs:
   lint-examples:
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check examples
         # Set the globstar opt here to enable recursive glob.

--- a/.github/workflows/_rust_lints.yml
+++ b/.github/workflows/_rust_lints.yml
@@ -43,7 +43,7 @@ jobs:
     if: (!cancelled() && inputs.isRust)
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check Rust formatting
         run: cargo +nightly-2026-01-07 ci-fmt
 
@@ -61,7 +61,7 @@ jobs:
     if: (!cancelled() && inputs.isRust)
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check Cargo.toml format and sorting and consolidate dependencies
         run: |
           pushd "scripts/cargo_sort"
@@ -97,7 +97,7 @@ jobs:
       - rustfmt
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # See '.cargo/config' for list of enabled/disabled clippy lints
       - name: Check Clippy Lints

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -89,7 +89,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup db
         run: |
@@ -160,7 +160,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup db
         run: |
@@ -217,7 +217,7 @@ jobs:
       fail-fast: false
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Cargo Udeps
         run: cargo +nightly-2026-01-07 ci-udeps ${{ matrix.flags }}
@@ -249,7 +249,7 @@ jobs:
           - [self-hosted-x64]
       fail-fast: false
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: benchmark (smoke)
         run: |

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -20,7 +20,7 @@ jobs:
     if: (!cancelled() && !failure())
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload mainnet split cluster logs on failure
         if: failure()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mainnet-split-cluster-logs-${{ github.run_id }}
           path: /tmp/mainnet-split-cluster-${{ github.run_id }}/logs/
@@ -45,7 +45,7 @@ jobs:
     if: (!cancelled() && !failure())
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload testnet split cluster logs on failure
         if: failure()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testnet-split-cluster-logs-${{ github.run_id }}
           path: /tmp/testnet-split-cluster-${{ github.run_id }}/logs/

--- a/.github/workflows/_split_cluster_sync_check.yml
+++ b/.github/workflows/_split_cluster_sync_check.yml
@@ -20,7 +20,7 @@ jobs:
     if: (!cancelled() && !failure())
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Run split cluster sync check script
@@ -31,7 +31,7 @@ jobs:
           scripts/compatibility/split-cluster-sync-check.sh origin/mainnet ${{ github.sha }}
       - name: Upload mainnet split cluster sync logs on failure
         if: failure()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mainnet-split-cluster-sync-logs-${{ github.run_id }}
           path: /tmp/mainnet-split-cluster-sync-${{ github.run_id }}/logs/
@@ -39,7 +39,7 @@ jobs:
           if-no-files-found: warn
       - name: Upload mainnet split cluster sync metrics on failure
         if: failure()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mainnet-split-cluster-sync-metrics-${{ github.run_id }}
           path: /tmp/mainnet-split-cluster-sync-${{ github.run_id }}/metrics/
@@ -50,7 +50,7 @@ jobs:
     if: (!cancelled() && !failure())
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Run split cluster sync check script
@@ -61,7 +61,7 @@ jobs:
           scripts/compatibility/split-cluster-sync-check.sh origin/testnet ${{ github.sha }}
       - name: Upload testnet split cluster sync logs on failure
         if: failure()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testnet-split-cluster-sync-logs-${{ github.run_id }}
           path: /tmp/testnet-split-cluster-sync-${{ github.run_id }}/logs/
@@ -69,7 +69,7 @@ jobs:
           if-no-files-found: warn
       - name: Upload testnet split cluster sync metrics on failure
         if: failure()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testnet-split-cluster-sync-metrics-${{ github.run_id }}
           path: /tmp/testnet-split-cluster-sync-${{ github.run_id }}/metrics/

--- a/.github/workflows/_typos.yml
+++ b/.github/workflows/_typos.yml
@@ -13,9 +13,9 @@ jobs:
     if: (!cancelled() && !failure())
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check spelling
-        uses: crate-ci/typos@945d407a5fc9097f020969446a16f581612ab4df # v1.24.5
+        uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83 # v1.45.1
         with:
           config: ./.typos.toml

--- a/.github/workflows/cargo_llvm_cov.yml
+++ b/.github/workflows/cargo_llvm_cov.yml
@@ -46,12 +46,12 @@ jobs:
       CARGO_NET_RETRY: 10
       RUSTUP_MAX_RETRIES: 10
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.branch-or-commit || github.ref }}
 
       - name: Set Swap Space
-        uses: actionhippie/swap-space@73376950a0019f8e1f6a3d3d2673fe2aed74ae17 # v1.0.2
+        uses: actionhippie/swap-space@0cffa893f224708cfb6b011690d8ba819d69c10f # v1.1.0
         with:
           size: 256G
 
@@ -148,7 +148,7 @@ jobs:
           sed --in-place "s#${{ github.workspace }}#.#g" lcov.info
 
       - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@cfd0633edbd2411b532b808ba7a8b5e04f76d2c8 # v2.3.4
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: target/lcov.info

--- a/.github/workflows/crate_docs.yml
+++ b/.github/workflows/crate_docs.yml
@@ -17,7 +17,7 @@ jobs:
     if: (!cancelled() && !failure())
     steps:
       - name: Checkout sources
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate documentation
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
@@ -26,7 +26,7 @@ jobs:
           args: --workspace --exclude "iota-benchmark" --no-deps
 
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -30,7 +30,7 @@ jobs:
       isExternalCrates: ${{ steps.diff.outputs.isExternalCrates }}
       isStarfishSynchronization: ${{ steps.diff.outputs.isStarfishSynchronization }}
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Detect Changes (diff)
         uses: "./.github/actions/diffs"
         id: diff
@@ -42,7 +42,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
           cd scripts/release_notes
           ./run.sh check-pr ${{ github.event.pull_request.number }}
@@ -54,7 +54,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check dprint formatting
         run: dprint check
 
@@ -71,7 +71,7 @@ jobs:
     if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     runs-on: [self-hosted-x64]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run license check
         run: cargo ci-license

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,15 +9,15 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
   team-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: equitybee/team-label-action@732147c0a9129eb90b16261d14860954fe5ce42a # v1.0.3
         with:
           repo-token: ${{ secrets.TEAM_LABELER_TOKEN }}

--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -16,11 +16,11 @@ jobs:
       LYCHEE_OUT: ./lychee/links-report
     steps:
       ## Check out code using Git
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check all links at *.md and doc files
         id: lychee
-        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1.10.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: ${{ env.LYCHEE_OUT }}
@@ -45,7 +45,7 @@ jobs:
           labels: broken-links
 
       - name: Create or update report
-        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: Link checker report
           content-filepath: ${{ env.LYCHEE_OUT }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,7 +129,7 @@ jobs:
       CONSENSUS_PROTOCOL: mysticeti
 
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.IOTA_REF }}
 
@@ -149,7 +149,7 @@ jobs:
       CONSENSUS_PROTOCOL: starfish
 
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.IOTA_REF }}
 

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
           types: |
             feat

--- a/.github/workflows/preview_wiki.yml
+++ b/.github/workflows/preview_wiki.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -65,7 +65,7 @@ jobs:
         working-directory: ./docs/site
 
       - name: Update PR with Deployment URL
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           fi
 
       - name: Check out ${{ needs.generate-tag.outputs.iota_ref }}
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ needs.generate-tag.outputs.iota_ref }}
@@ -145,11 +145,11 @@ jobs:
 
       - name: Install protoc (Windows)
         if: ${{ matrix.os_type == 'windows-x86_64' }}
-        uses: taiki-e/install-action@protoc
+        uses: taiki-e/install-action@c2316dd9f137fd4debf7defea65ed68c0d463be4 # protoc
 
       - name: Install protoc (MacOS arm64)
         if: ${{ matrix.os_type == 'macos-arm64' }}
-        uses: taiki-e/install-action@protoc
+        uses: taiki-e/install-action@c2316dd9f137fd4debf7defea65ed68c0d463be4 # protoc
 
       - name: Remove unused apps (MacOS arm64)
         if: ${{ matrix.os_type == 'macos-arm64' }}
@@ -192,7 +192,7 @@ jobs:
           tar -cvzf ./tmp/${{ steps.create-artifact.outputs.artifact_name }}.tgz -C ${{ env.TMP_BUILD_DIR }} .
 
       - name: Upload artifacts for ${{ matrix.os_type }} platform
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.create-artifact.outputs.artifact_name }}
           if-no-files-found: error
@@ -201,7 +201,7 @@ jobs:
 
       - name: Attach artifacts to ${{ needs.generate-tag.outputs.iota_ref }} release in GH
         if: ${{ github.event_name == 'release' }}
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ needs.generate-tag.outputs.iota_ref }}
           files: |
@@ -216,7 +216,7 @@ jobs:
     needs: generate-tag
     steps:
       - name: Check out ${{ needs.generate-tag.outputs.iota_ref }}
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ needs.generate-tag.outputs.iota_ref }}
@@ -250,7 +250,7 @@ jobs:
           cat ${{ env.RELEASE_NOTES_FILE }}
 
       - name: Add release notes to ${{ needs.generate-tag.outputs.iota_ref }} release in GH
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ needs.generate-tag.outputs.iota_ref }}
           body_path: ${{ env.RELEASE_NOTES_FILE }}
@@ -275,7 +275,7 @@ jobs:
         shell: bash
         run: |
           echo iota_tag="$(echo ${{ github.ref }} | sed s/'refs\/tags\/'//)" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get binary checksums
         uses: thewh1teagle/checksum@6577963a29f57d780d12a2e5495601298ba739d1 # v2
         with:

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare Environment Variables
         run: |
@@ -130,23 +130,23 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.DOCKER_IMAGE }}
 
       - name: Login to Docker Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build and push by digest
         id: build-image
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ${{ env.DOCKER_FILE }}
@@ -165,7 +165,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ github.sha }}-${{ matrix.image }}-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -186,25 +186,25 @@ jobs:
           echo "DOCKER_IMAGE=iotaledger/${{ matrix.image }}" >> $GITHUB_ENV
 
       - name: Download digests
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-${{ github.sha }}-${{ matrix.image }}-*
           merge-multiple: true
 
       - name: Login to Docker Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.DOCKER_IMAGE }}
           # mapping semver tags to networks

--- a/.github/workflows/release_fullnode_docker_setup.yml
+++ b/.github/workflows/release_fullnode_docker_setup.yml
@@ -84,7 +84,7 @@ jobs:
         network: ${{ fromJson(needs.determine-ref-and-networks.outputs.iota_networks) }}
     steps:
       - name: Check out ${{ needs.determine-ref-and-networks.outputs.iota_ref }}
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ needs.determine-ref-and-networks.outputs.iota_ref }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload artifact to workflow run
         if: github.event_name != 'release'
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.vars.outputs.archive_name }}
           if-no-files-found: error
@@ -139,6 +139,6 @@ jobs:
 
       - name: Attach artifact to ${{ needs.determine-ref-and-networks.outputs.iota_ref }} release in GH
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: ${{ steps.vars.outputs.target_dir }}/${{ steps.vars.outputs.archive_name }}

--- a/.github/workflows/release_move_ide.yml
+++ b/.github/workflows/release_move_ide.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set os/arch variables (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
@@ -99,7 +99,7 @@ jobs:
         run: ls -R ${{ env.TMP_BUILD_DIR }}
 
       - name: Upload move-analyzer binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.os }}-move-analyzer
           path: ${{ env.TMP_BUILD_DIR }}
@@ -111,12 +111,12 @@ jobs:
     runs-on: self-hosted-x64
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.iota_repo_ref || github.ref }}
 
       - name: Download move-analyzer binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
           path: "external-crates/move/crates/move-analyzer/editors/code/move-analyzer-binaries"
@@ -125,7 +125,7 @@ jobs:
         run: ls -R external-crates/move/crates/move-analyzer/editors/code/move-analyzer-binaries
 
       - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 

--- a/.github/workflows/release_wiki.yml
+++ b/.github/workflows/release_wiki.yml
@@ -13,15 +13,15 @@ jobs:
   wiki-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 180

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Tag
         uses: julbme/gh-action-manage-tag@8daf6387badea2c6b8f989bd0f82b5a9ef1d84e6 # v1.0.1

--- a/.github/workflows/upload-docs-to-aws.yml
+++ b/.github/workflows/upload-docs-to-aws.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build Rust documentation
         run: UPDATE=1 cargo test --manifest-path crates/iota-framework/Cargo.toml
 
       # ----------- Build TypeScript and GraphQL Docs with pnpm -----------
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
@@ -41,7 +41,7 @@ jobs:
 
       # ----------- Configure AWS Credentials -----------
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_IOTA_WIKI }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_IOTA_WIKI }}


### PR DESCRIPTION
# Description of change

I updated all actions and pinned them (manually checked) to their latest version.

`peaceiris/actions-gh-pages` still uses v20 unfortunately.

This will fix most of the node v20 deprecation warnings.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes