### PR TITLE
feat(consensus): commit Optimistic-metastate acks in linearizer

### DIFF
--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -101,8 +101,8 @@ impl BaseCommitter {
             .into_iter()
             .filter(|l| self.enough_leader_support(certifying_round, l))
             .map(|leader_block| {
-                let metastate = self.determine_metastate_direct(&leader_block);
-                LeaderStatus::Commit(leader_block, metastate)
+                let (metastate, strong_voters) = self.determine_metastate_direct(&leader_block);
+                LeaderStatus::Commit(leader_block, metastate, strong_voters)
             })
             .collect();
 
@@ -130,7 +130,7 @@ impl BaseCommitter {
         for anchor in anchors {
             tracing::trace!("[{self}] Trying to indirect-decide {slot} using anchor {anchor}",);
             match anchor {
-                LeaderStatus::Commit(anchor, _) => {
+                LeaderStatus::Commit(anchor, _, _) => {
                     return self.decide_leader_from_anchor(anchor, slot);
                 }
                 LeaderStatus::Skip(..) => (),
@@ -313,10 +313,13 @@ impl BaseCommitter {
         // classify the metastate in the same walk. When the flag is off we
         // stick to the cheap regular-certificate-only check.
         let starfish_speed = self.context.protocol_config.consensus_starfish_speed();
-        let mut certified_leader_blocks: Vec<(VerifiedBlockHeader, Option<CommitMetastate>)> =
-            Vec::new();
+        let mut certified_leader_blocks: Vec<(
+            VerifiedBlockHeader,
+            Option<CommitMetastate>,
+            Vec<AuthorityIndex>,
+        )> = Vec::new();
         for leader_block in leader_blocks {
-            let (any_cert, metastate) = if starfish_speed {
+            let (any_cert, metastate, strong_voters) = if starfish_speed {
                 let (vote_refs, strong_vote_refs) =
                     self.vote_and_strong_vote_refs_for_leader(&leader_block);
                 let mut any_cert = false;
@@ -342,16 +345,21 @@ impl BaseCommitter {
                 } else {
                     None
                 };
-                (any_cert, metastate)
+                let strong_voters = if any_strong {
+                    strong_vote_refs.iter().map(|r| r.author).collect()
+                } else {
+                    Vec::new()
+                };
+                (any_cert, metastate, strong_voters)
             } else {
                 let mut all_votes = HashMap::new();
                 let any_cert = potential_certificates.iter().any(|potential_certificate| {
                     self.is_certificate(potential_certificate, &leader_block, &mut all_votes)
                 });
-                (any_cert, None)
+                (any_cert, None, Vec::new())
             };
             if any_cert {
-                certified_leader_blocks.push((leader_block, metastate));
+                certified_leader_blocks.push((leader_block, metastate, strong_voters));
             }
         }
 
@@ -362,8 +370,8 @@ impl BaseCommitter {
         }
 
         match certified_leader_blocks.pop() {
-            Some((certified_leader_block, metastate)) => {
-                LeaderStatus::Commit(certified_leader_block, metastate)
+            Some((certified_leader_block, metastate, strong_voters)) => {
+                LeaderStatus::Commit(certified_leader_block, metastate, strong_voters)
             }
             None => LeaderStatus::Skip(leader_slot),
         }
@@ -443,23 +451,26 @@ impl BaseCommitter {
 
     /// Direct-commit metastate: StrongQC quorum → `Optimistic`, strong-blame
     /// quorum → `Standard`, else `Pending`. `None` when the flag is off.
+    /// The returned `Vec<AuthorityIndex>` carries the leader's strong-voter
+    /// authorities for the Optimistic case (used by the linearizer to seed
+    /// the per-ref ack tracker); empty otherwise.
     fn determine_metastate_direct(
         &self,
         leader_block: &VerifiedBlockHeader,
-    ) -> Option<CommitMetastate> {
+    ) -> (Option<CommitMetastate>, Vec<AuthorityIndex>) {
         if !self.context.protocol_config.consensus_starfish_speed() {
-            return None;
+            return (None, Vec::new());
         }
 
-        if self.has_strong_qc_quorum(leader_block) {
-            return Some(CommitMetastate::Optimistic);
+        if let Some(strong_voters) = self.strong_qc_quorum(leader_block) {
+            return (Some(CommitMetastate::Optimistic), strong_voters);
         }
 
         if self.has_strong_blame_quorum(leader_block) {
-            return Some(CommitMetastate::Standard);
+            return (Some(CommitMetastate::Standard), Vec::new());
         }
 
-        Some(CommitMetastate::Pending)
+        (Some(CommitMetastate::Pending), Vec::new())
     }
 
     /// `(vote_refs, strong_vote_refs)` at r+1 for `leader_block`, built in a
@@ -489,8 +500,9 @@ impl BaseCommitter {
         (vote_refs, strong_vote_refs)
     }
 
-    /// 2f+1 StrongQCs at `r+2` for `leader_block`.
-    fn has_strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
+    /// `Some(strong-voter authorities)` when 2f+1 StrongQCs exist at `r+2`
+    /// for `leader_block`; `None` otherwise.
+    fn strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> Option<Vec<AuthorityIndex>> {
         let voting_round = leader_block.round() + 1;
         let certifying_round = leader_block.round() + 2;
 
@@ -514,10 +526,10 @@ impl BaseCommitter {
             if self.is_strong_certificate(decision_block, &strong_vote_refs)
                 && strong_qc_stake_aggregator.add(authority, &self.context.committee)
             {
-                return true;
+                return Some(strong_vote_refs.iter().map(|r| r.author).collect());
             }
         }
-        false
+        None
     }
 
     /// True if `potential_certificate` carries a StrongQC for the leader

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -950,6 +950,14 @@ impl Display for CommitMetastate {
     }
 }
 
+/// Test helper: pair each leader with `None` metastate.
+#[cfg(test)]
+pub(crate) fn with_no_metastate(
+    blocks: Vec<VerifiedBlockHeader>,
+) -> Vec<(VerifiedBlockHeader, Option<CommitMetastate>)> {
+    blocks.into_iter().map(|b| (b, None)).collect()
+}
+
 /// Per-commit properties that can be regenerated from past values, and do not
 /// need to be part of the Commit struct.
 /// Only the latest version is needed for recovery, but more versions are stored

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -976,7 +976,11 @@ impl Display for CommitMetastate {
 #[cfg(test)]
 pub(crate) fn with_no_metastate(
     blocks: Vec<VerifiedBlockHeader>,
-) -> Vec<(VerifiedBlockHeader, Option<CommitMetastate>, Vec<AuthorityIndex>)> {
+) -> Vec<(
+    VerifiedBlockHeader,
+    Option<CommitMetastate>,
+    Vec<AuthorityIndex>,
+)> {
     blocks.into_iter().map(|b| (b, None, Vec::new())).collect()
 }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -885,11 +885,13 @@ impl DecidedLeader {
         }
     }
 
-    // Converts to committed block if the decision is to commit. Returns None
-    // otherwise.
-    pub(crate) fn into_committed_block(self) -> Option<VerifiedBlockHeader> {
+    // Converts a Commit decision into the committed block plus its metastate.
+    // Returns None for Skip.
+    pub(crate) fn into_committed_block(
+        self,
+    ) -> Option<(VerifiedBlockHeader, Option<CommitMetastate>)> {
         match self {
-            Self::Commit(block, _) => Some(block),
+            Self::Commit(block, metastate) => Some((block, metastate)),
             Self::Skip(_) => None,
         }
     }

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -813,9 +813,18 @@ pub(crate) enum Decision {
 }
 
 /// The status of a leader slot from the direct and indirect commit rules.
+///
+/// `Commit(_, Some(Optimistic), strong_voters)` carries the r+1 authorities
+/// whose strong votes attest data availability for the leader and its
+/// acknowledgments; the linearizer feeds them to the per-ref ack tracker.
+/// Empty for every other case.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum LeaderStatus {
-    Commit(VerifiedBlockHeader, Option<CommitMetastate>),
+    Commit(
+        VerifiedBlockHeader,
+        Option<CommitMetastate>,
+        Vec<AuthorityIndex>,
+    ),
     Skip(Slot),
     Undecided(Slot),
 }
@@ -823,7 +832,7 @@ pub(crate) enum LeaderStatus {
 impl LeaderStatus {
     pub(crate) fn round(&self) -> Round {
         match self {
-            Self::Commit(block, _) => block.round(),
+            Self::Commit(block, _, _) => block.round(),
             Self::Skip(leader) => leader.round,
             Self::Undecided(leader) => leader.round,
         }
@@ -832,7 +841,7 @@ impl LeaderStatus {
     /// Slot of the leader this status refers to.
     pub(crate) fn slot(&self) -> Slot {
         match self {
-            Self::Commit(block, _) => block.reference().into(),
+            Self::Commit(block, _, _) => block.reference().into(),
             Self::Skip(leader) | Self::Undecided(leader) => *leader,
         }
     }
@@ -841,7 +850,7 @@ impl LeaderStatus {
     /// and `Undecided` are non-final.
     pub(crate) fn is_final(&self) -> bool {
         match self {
-            Self::Commit(_, Some(CommitMetastate::Pending)) => false,
+            Self::Commit(_, Some(CommitMetastate::Pending), _) => false,
             Self::Commit(..) | Self::Skip(_) => true,
             Self::Undecided(_) => false,
         }
@@ -849,7 +858,9 @@ impl LeaderStatus {
 
     pub(crate) fn into_decided_leader(self) -> Option<DecidedLeader> {
         match self {
-            Self::Commit(block, metastate) => Some(DecidedLeader::Commit(block, metastate)),
+            Self::Commit(block, metastate, strong_voters) => {
+                Some(DecidedLeader::Commit(block, metastate, strong_voters))
+            }
             Self::Skip(slot) => Some(DecidedLeader::Skip(slot)),
             Self::Undecided(..) => None,
         }
@@ -859,8 +870,8 @@ impl LeaderStatus {
 impl Display for LeaderStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Commit(block, None) => write!(f, "Commit({})", block.reference()),
-            Self::Commit(block, Some(metastate)) => {
+            Self::Commit(block, None, _) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, Some(metastate), _) => {
                 write!(f, "Commit({},{metastate})", block.reference())
             }
             Self::Skip(slot) => write!(f, "Skip({slot})"),
@@ -872,7 +883,11 @@ impl Display for LeaderStatus {
 /// Decision of each leader slot.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum DecidedLeader {
-    Commit(VerifiedBlockHeader, Option<CommitMetastate>),
+    Commit(
+        VerifiedBlockHeader,
+        Option<CommitMetastate>,
+        Vec<AuthorityIndex>,
+    ),
     Skip(Slot),
 }
 
@@ -880,18 +895,24 @@ impl DecidedLeader {
     // Slot where the leader is decided.
     pub(crate) fn slot(&self) -> Slot {
         match self {
-            Self::Commit(block, _) => block.reference().into(),
+            Self::Commit(block, _, _) => block.reference().into(),
             Self::Skip(slot) => *slot,
         }
     }
 
-    // Converts a Commit decision into the committed block plus its metastate.
-    // Returns None for Skip.
+    // Converts a Commit decision into the committed block, metastate, and
+    // strong-voter authority set. Returns None for Skip.
     pub(crate) fn into_committed_block(
         self,
-    ) -> Option<(VerifiedBlockHeader, Option<CommitMetastate>)> {
+    ) -> Option<(
+        VerifiedBlockHeader,
+        Option<CommitMetastate>,
+        Vec<AuthorityIndex>,
+    )> {
         match self {
-            Self::Commit(block, metastate) => Some((block, metastate)),
+            Self::Commit(block, metastate, strong_voters) => {
+                Some((block, metastate, strong_voters))
+            }
             Self::Skip(_) => None,
         }
     }
@@ -899,7 +920,7 @@ impl DecidedLeader {
     #[cfg(test)]
     pub(crate) fn round(&self) -> Round {
         match self {
-            Self::Commit(block, _) => block.round(),
+            Self::Commit(block, _, _) => block.round(),
             Self::Skip(leader) => leader.round,
         }
     }
@@ -907,7 +928,7 @@ impl DecidedLeader {
     #[cfg(test)]
     pub(crate) fn authority(&self) -> AuthorityIndex {
         match self {
-            Self::Commit(block, _) => block.author(),
+            Self::Commit(block, _, _) => block.author(),
             Self::Skip(leader) => leader.authority,
         }
     }
@@ -916,8 +937,8 @@ impl DecidedLeader {
 impl Display for DecidedLeader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Commit(block, None) => write!(f, "Commit({})", block.reference()),
-            Self::Commit(block, Some(metastate)) => {
+            Self::Commit(block, None, _) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, Some(metastate), _) => {
                 write!(f, "Commit({},{metastate})", block.reference())
             }
             Self::Skip(slot) => write!(f, "Skip({slot})"),
@@ -950,12 +971,13 @@ impl Display for CommitMetastate {
     }
 }
 
-/// Test helper: pair each leader with `None` metastate.
+/// Test helper: pair each leader with `None` metastate and an empty
+/// strong-voter set.
 #[cfg(test)]
 pub(crate) fn with_no_metastate(
     blocks: Vec<VerifiedBlockHeader>,
-) -> Vec<(VerifiedBlockHeader, Option<CommitMetastate>)> {
-    blocks.into_iter().map(|b| (b, None)).collect()
+) -> Vec<(VerifiedBlockHeader, Option<CommitMetastate>, Vec<AuthorityIndex>)> {
+    blocks.into_iter().map(|b| (b, None, Vec::new())).collect()
 }
 
 /// Per-commit properties that can be regenerated from past values, and do not

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -636,13 +636,12 @@ mod tests {
     use super::*;
     use crate::{
         block_header::BlockRef,
+        commit::with_no_metastate,
         context::Context,
         dag_state::{DagState, DataSource},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
     };
-
-    use crate::commit::with_no_metastate;
 
     #[tokio::test]
     async fn test_handle_commit() {
@@ -685,7 +684,10 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (commits, _missing_transactions_refs) = observer
-            .handle_committed_leaders(with_no_metastate(leaders.clone()), CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(
+                with_no_metastate(leaders.clone()),
+                CommittedSubDagSource::Consensus,
+            )
             .unwrap();
 
         // Check commits are returned by CommitObserver::handle_commit is accurate
@@ -1266,7 +1268,10 @@ mod tests {
         // Commit first 3 leaders (rounds 1-3)
         // Each leader in the first 3 rounds has transactions from previous rounds
         let (_, _) = observer
-            .handle_committed_leaders(with_no_metastate(all_leaders[0..3].to_vec()), CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(
+                with_no_metastate(all_leaders[0..3].to_vec()),
+                CommittedSubDagSource::Consensus,
+            )
             .unwrap();
 
         // Count transactions: with 4 authorities and standard DAG, each commit includes
@@ -1307,7 +1312,10 @@ mod tests {
         // Process new blocks - they acknowledge transactions from rounds 5-6
         // plus transactions from recovered blocks (rounds 1-3)
         let (_commits_after, _) = observer_after_restart
-            .handle_committed_leaders(with_no_metastate(new_leaders), CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(
+                with_no_metastate(new_leaders),
+                CommittedSubDagSource::Consensus,
+            )
             .unwrap();
 
         // Count transactions from new commits: new leaders in rounds 7-8 will process

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -642,14 +642,7 @@ mod tests {
         test_dag_builder::DagBuilder,
     };
 
-    /// Pair every leader with `None` metastate to drive the historical
-    /// (Standard) sequencing path; existing tests don't exercise the
-    /// Optimistic ack-inclusion branch.
-    fn with_no_metastate(
-        blocks: Vec<VerifiedBlockHeader>,
-    ) -> Vec<(VerifiedBlockHeader, Option<CommitMetastate>)> {
-        blocks.into_iter().map(|b| (b, None)).collect()
-    }
+    use crate::commit::with_no_metastate;
 
     #[tokio::test]
     async fn test_handle_commit() {

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -18,7 +18,8 @@ use crate::{
     CommitConsumer, CommittedSubDag,
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
     commit::{
-        CommitAPI, CommitIndex, PendingSubDag, TrustedCommit, load_pending_subdag_from_store,
+        CommitAPI, CommitIndex, CommitMetastate, PendingSubDag, TrustedCommit,
+        load_pending_subdag_from_store,
     },
     commit_solidifier::CommitSolidifier,
     context::Context,
@@ -146,7 +147,7 @@ impl CommitObserver {
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn handle_committed_leaders(
         &mut self,
-        committed_leaders: Vec<VerifiedBlockHeader>,
+        committed_leaders: Vec<(VerifiedBlockHeader, Option<CommitMetastate>)>,
         source: CommittedSubDagSource,
     ) -> ConsensusResult<(
         Vec<PendingSubDag>,
@@ -641,6 +642,15 @@ mod tests {
         test_dag_builder::DagBuilder,
     };
 
+    /// Pair every leader with `None` metastate to drive the historical
+    /// (Standard) sequencing path; existing tests don't exercise the
+    /// Optimistic ack-inclusion branch.
+    fn with_no_metastate(
+        blocks: Vec<VerifiedBlockHeader>,
+    ) -> Vec<(VerifiedBlockHeader, Option<CommitMetastate>)> {
+        blocks.into_iter().map(|b| (b, None)).collect()
+    }
+
     #[tokio::test]
     async fn test_handle_commit() {
         telemetry_subscribers::init_for_testing();
@@ -682,7 +692,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (commits, _missing_transactions_refs) = observer
-            .handle_committed_leaders(leaders.clone(), CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(with_no_metastate(leaders.clone()), CommittedSubDagSource::Consensus)
             .unwrap();
 
         // Check commits are returned by CommitObserver::handle_commit is accurate
@@ -803,11 +813,13 @@ mod tests {
         let expected_last_processed_index: usize = 2;
         let (mut created_commits, _missing_transactions_refs) = observer
             .handle_committed_leaders(
-                leaders
-                    .clone()
-                    .into_iter()
-                    .take(expected_last_processed_index)
-                    .collect::<Vec<_>>(),
+                with_no_metastate(
+                    leaders
+                        .clone()
+                        .into_iter()
+                        .take(expected_last_processed_index)
+                        .collect::<Vec<_>>(),
+                ),
                 CommittedSubDagSource::Consensus,
             )
             .unwrap();
@@ -840,10 +852,12 @@ mod tests {
         created_commits.append(
             &mut observer
                 .handle_committed_leaders(
-                    leaders
-                        .into_iter()
-                        .skip(expected_last_processed_index)
-                        .collect::<Vec<_>>(),
+                    with_no_metastate(
+                        leaders
+                            .into_iter()
+                            .skip(expected_last_processed_index)
+                            .collect::<Vec<_>>(),
+                    ),
                     CommittedSubDagSource::Consensus,
                 )
                 .unwrap()
@@ -949,7 +963,7 @@ mod tests {
         // the consensus output channel.
         let expected_last_processed_index: usize = 10;
         let (created_commits, _missing_transactions_refs) = observer
-            .handle_committed_leaders(leaders, CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(with_no_metastate(leaders), CommittedSubDagSource::Consensus)
             .unwrap();
 
         // Check commits sent over consensus output channel is accurate
@@ -1044,7 +1058,7 @@ mod tests {
         assert_eq!(leaders.len(), num_rounds as usize);
 
         let _ = observer
-            .handle_committed_leaders(leaders, CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(with_no_metastate(leaders), CommittedSubDagSource::Consensus)
             .unwrap();
 
         // Drain the receiver to simulate consumer processing commits before crash.
@@ -1259,7 +1273,7 @@ mod tests {
         // Commit first 3 leaders (rounds 1-3)
         // Each leader in the first 3 rounds has transactions from previous rounds
         let (_, _) = observer
-            .handle_committed_leaders(all_leaders[0..3].to_vec(), CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(with_no_metastate(all_leaders[0..3].to_vec()), CommittedSubDagSource::Consensus)
             .unwrap();
 
         // Count transactions: with 4 authorities and standard DAG, each commit includes
@@ -1300,7 +1314,7 @@ mod tests {
         // Process new blocks - they acknowledge transactions from rounds 5-6
         // plus transactions from recovered blocks (rounds 1-3)
         let (_commits_after, _) = observer_after_restart
-            .handle_committed_leaders(new_leaders, CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(with_no_metastate(new_leaders), CommittedSubDagSource::Consensus)
             .unwrap();
 
         // Count transactions from new commits: new leaders in rounds 7-8 will process

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -147,7 +147,11 @@ impl CommitObserver {
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn handle_committed_leaders(
         &mut self,
-        committed_leaders: Vec<(VerifiedBlockHeader, Option<CommitMetastate>)>,
+        committed_leaders: Vec<(
+            VerifiedBlockHeader,
+            Option<CommitMetastate>,
+            Vec<AuthorityIndex>,
+        )>,
         source: CommittedSubDagSource,
     ) -> ConsensusResult<(
         Vec<PendingSubDag>,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1145,7 +1145,7 @@ impl Core {
                 sequenced_leaders.len(),
                 sequenced_leaders
                     .iter()
-                    .map(|b| b.reference().to_string())
+                    .map(|(b, _)| b.reference().to_string())
                     .join(",")
             );
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1145,7 +1145,7 @@ impl Core {
                 sequenced_leaders.len(),
                 sequenced_leaders
                     .iter()
-                    .map(|(b, _)| b.reference().to_string())
+                    .map(|(b, _, _)| b.reference().to_string())
                     .join(",")
             );
 

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -1394,4 +1394,73 @@ mod tests {
             );
         }
     }
+
+    #[tokio::test]
+    async fn test_optimistic_records_strong_voters_in_ack_tracker() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder
+            .layers(1..=5)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        let leader = dag_builder
+            .leader_block(5)
+            .expect("Leader at round 5 should exist");
+        let leader_ref = leader.reference();
+        let leader_ack_refs: Vec<BlockRef> = leader.acknowledgments().to_vec();
+
+        // Synthetic strong-voter set: exactly 2f+1 (= 3) authorities. These
+        // should land in the tracker as actual votes for the leader's ref and
+        // for every block the leader acknowledges, so that
+        // `get_transaction_ack_authors` returns them as fetch sources.
+        let strong_voters: BTreeSet<AuthorityIndex> = (0..3u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect();
+        let commits = linearizer.get_pending_sub_dags(vec![(
+            leader,
+            Some(CommitMetastate::Optimistic),
+            strong_voters.iter().copied().collect(),
+        )]);
+        assert_eq!(commits.len(), 1);
+
+        let ack_authors = linearizer
+            .get_transaction_ack_authors(commits[0].committed_transaction_refs.clone());
+
+        let leader_generic = ack_authors
+            .iter()
+            .find(|(r, _)| r.round() == leader_ref.round && r.author() == leader_ref.author)
+            .map(|(_, authors)| authors)
+            .expect("leader ref must be present in ack tracker");
+        assert!(
+            strong_voters.is_subset(leader_generic),
+            "leader ref tracker should record the strong-voter authorities; \
+             got {leader_generic:?}, expected superset of {strong_voters:?}"
+        );
+
+        for ack_ref in &leader_ack_refs {
+            let recorded = ack_authors
+                .iter()
+                .find(|(r, _)| r.round() == ack_ref.round && r.author() == ack_ref.author)
+                .map(|(_, authors)| authors)
+                .unwrap_or_else(|| panic!("ack ref {ack_ref:?} must be in tracker"));
+            assert!(
+                strong_voters.is_subset(recorded),
+                "ack ref {ack_ref:?} tracker should record the strong-voter authorities; \
+                 got {recorded:?}, expected superset of {strong_voters:?}"
+            );
+        }
+    }
 }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -1272,10 +1272,9 @@ mod tests {
         let leader_a = dag_builder
             .leader_block(4)
             .expect("Leader at round 4 should exist");
-        let target_ack = *leader_a
-            .acknowledgments()
-            .first()
-            .expect("L_a should have acks in fully-linked DAG");
+        let optimistic_set: Vec<BlockRef> = std::iter::once(leader_a.reference())
+            .chain(leader_a.acknowledgments().iter().copied())
+            .collect();
         let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
             refs.iter()
                 .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
@@ -1284,24 +1283,28 @@ mod tests {
         let commits_a =
             linearizer.get_pending_sub_dags(vec![(leader_a, Some(CommitMetastate::Optimistic))]);
         assert_eq!(commits_a.len(), 1);
-        assert!(
-            contains_block(&commits_a[0].committed_transaction_refs, &target_ack),
-            "Optimistic commit of L_a should include target_ack {target_ack:?}"
-        );
+        for block_ref in &optimistic_set {
+            assert!(
+                contains_block(&commits_a[0].committed_transaction_refs, block_ref),
+                "Optimistic commit of L_a should include {block_ref:?}"
+            );
+        }
 
         // Second commit: L_b at round 7 standardly. Its causal history
-        // accumulates 2f+1 acks for target_ack, but `mark_committed` from
-        // L_a's Optimistic commit must suppress the re-commit.
+        // accumulates 2f+1 acks for L_a's optimistically-committed refs, but
+        // `mark_committed` from L_a's commit must suppress the re-commit.
         let leader_b = dag_builder
             .leader_block(7)
             .expect("Leader at round 7 should exist");
         let commits_b = linearizer.get_pending_sub_dags(vec![(leader_b, None)]);
         assert_eq!(commits_b.len(), 1);
-        assert!(
-            !contains_block(&commits_b[0].committed_transaction_refs, &target_ack),
-            "Standard commit of L_b should NOT re-include target_ack {target_ack:?} \
-             already committed by L_a's Optimistic commit"
-        );
+        for block_ref in &optimistic_set {
+            assert!(
+                !contains_block(&commits_b[0].committed_transaction_refs, block_ref),
+                "Standard commit of L_b should NOT re-include {block_ref:?} \
+                 already committed by L_a's Optimistic commit"
+            );
+        }
 
         // Sanity: the standard flow still commits refs L_a never touched.
         let has_round_5_ref = commits_b[0]

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -1182,4 +1182,153 @@ mod tests {
         let err = median_timestamp_by_stake(&context, vec![block].into_iter()).unwrap_err();
         assert_eq!(err, "Total stake 1 < quorum threshold 3");
     }
+
+    #[tokio::test]
+    async fn test_optimistic_emits_leader_ref_and_acknowledgments() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder
+            .layers(1..=5)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        let leader = dag_builder
+            .leader_block(5)
+            .expect("Leader at round 5 should exist");
+        let leader_ref = leader.reference();
+        let leader_ack_refs: Vec<BlockRef> = leader.acknowledgments().to_vec();
+        assert!(
+            !leader_ack_refs.is_empty(),
+            "fully-linked round-5 leader should have acknowledgments"
+        );
+
+        let commits =
+            linearizer.get_pending_sub_dags(vec![(leader, Some(CommitMetastate::Optimistic))]);
+        assert_eq!(commits.len(), 1);
+        let optimistic_refs = &commits[0].committed_transaction_refs;
+        // Compare on (round, author): committed_transaction_refs may carry the
+        // BlockRef or TransactionRef variant depending on protocol config, but
+        // both expose round() and author() via GenericTransactionRefAPI.
+        let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
+            refs.iter()
+                .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
+        };
+
+        // Optimistic emits the leader's own ref.
+        assert!(
+            contains_block(optimistic_refs, &leader_ref),
+            "Optimistic should include leader's own ref {leader_ref:?}"
+        );
+
+        // Optimistic emits every ack of the leader.
+        for ack_ref in &leader_ack_refs {
+            assert!(
+                contains_block(optimistic_refs, ack_ref),
+                "Optimistic should include leader's ack ref {ack_ref:?}"
+            );
+        }
+
+        // Optimistic is additive over the standard flow: leader_ref + acks
+        // alone account for 1 + leader_ack_refs.len() refs, but the standard
+        // causal walk also emits round-(R-2) and earlier blocks that reach
+        // 2f+1 quorum. Strictly more than the optimistic-only contribution
+        // means the standard flow ran and was preserved.
+        assert!(
+            optimistic_refs.len() > 1 + leader_ack_refs.len(),
+            "Optimistic should additively include standard-flow refs; \
+             got {} refs, optimistic-only would give {}",
+            optimistic_refs.len(),
+            1 + leader_ack_refs.len()
+        );
+
+        // No-duplicate property is also enforced by the production assert at
+        // collect_sub_dag_and_commit (`assert_eq!(committed_transactions.len(),
+        // …HashSet…len())`); a regression there would panic this test.
+    }
+
+    #[tokio::test]
+    async fn test_optimistic_does_not_double_emit_across_sub_dags() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder
+            .layers(1..=7)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        // First commit: L_a at round 4 with Optimistic metastate. L_a's first
+        // ack (a round-3 block) is the target ref T whose tracker entry will
+        // be `mark_committed`'d.
+        let leader_a = dag_builder
+            .leader_block(4)
+            .expect("Leader at round 4 should exist");
+        let target_ack = *leader_a
+            .acknowledgments()
+            .first()
+            .expect("L_a should have acks in fully-linked DAG");
+        // Compare on (round, author): committed_transaction_refs may carry
+        // either GenericTransactionRef variant depending on protocol config.
+        let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
+            refs.iter()
+                .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
+        };
+
+        let commits_a =
+            linearizer.get_pending_sub_dags(vec![(leader_a, Some(CommitMetastate::Optimistic))]);
+        assert_eq!(commits_a.len(), 1);
+        assert!(
+            contains_block(&commits_a[0].committed_transaction_refs, &target_ack),
+            "Optimistic commit of L_a should emit target_ack {target_ack:?}"
+        );
+
+        // Second commit: L_b at round 7 with no metastate (standard flow).
+        // L_b's causal history accumulates 2f+1 acks for target_ack, but the
+        // `mark_committed` flag set by L_a's Optimistic commit must suppress
+        // re-emission.
+        let leader_b = dag_builder
+            .leader_block(7)
+            .expect("Leader at round 7 should exist");
+        let commits_b = linearizer.get_pending_sub_dags(vec![(leader_b, None)]);
+        assert_eq!(commits_b.len(), 1);
+        assert!(
+            !contains_block(&commits_b[0].committed_transaction_refs, &target_ack),
+            "Standard commit of L_b should NOT re-emit target_ack {target_ack:?} \
+             already emitted by L_a's Optimistic commit"
+        );
+
+        // Sanity: the standard flow still emits refs that L_a never touched.
+        // L_b's commit should produce non-empty round-5 refs (R_b - 2 = 5);
+        // these are blocks the optimistic path never marked committed.
+        let has_round_5_ref = commits_b[0]
+            .committed_transaction_refs
+            .iter()
+            .any(|r| r.round() == 5);
+        assert!(
+            has_round_5_ref,
+            "Standard commit of L_b should still emit round-5 refs"
+        );
+    }
 }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -80,6 +80,7 @@ impl Linearizer {
         &mut self,
         leader_block: VerifiedBlockHeader,
         metastate: Option<CommitMetastate>,
+        strong_voters: Vec<AuthorityIndex>,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
     ) -> (PendingSubDag, TrustedCommit) {
         let _s = self
@@ -140,8 +141,9 @@ impl Linearizer {
             })
             .collect::<Vec<BlockRef>>();
 
-        // Optimistic: commit the leader's ref and its acks, marking each in
-        // the tracker so neither path re-commits them.
+        // Optimistic: record the leader's r+1 strong-voters as acks for the
+        // leader's ref and each of its acknowledgments. Crossing 2f+1 commits
+        // the ref through the standard quorum path.
         if metastate == Some(CommitMetastate::Optimistic) {
             let leader_ref = leader_block.reference();
             let refs =
@@ -151,11 +153,13 @@ impl Linearizer {
                     .transactions_ack_tracker
                     .entry(block_ref)
                     .or_insert_with(StakeAggregator::<QuorumThreshold>::new);
-                if entry.reached_threshold(&self.context.committee) {
-                    continue;
+                let was_at_threshold = entry.reached_threshold(&self.context.committee);
+                for authority in &strong_voters {
+                    entry.add(*authority, &self.context.committee);
                 }
-                entry.mark_committed();
-                committed_transactions.push(block_ref);
+                if !was_at_threshold && entry.reached_threshold(&self.context.committee) {
+                    committed_transactions.push(block_ref);
+                }
             }
         }
 
@@ -288,7 +292,11 @@ impl Linearizer {
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn get_pending_sub_dags(
         &mut self,
-        committed_leaders: Vec<(VerifiedBlockHeader, Option<CommitMetastate>)>,
+        committed_leaders: Vec<(
+            VerifiedBlockHeader,
+            Option<CommitMetastate>,
+            Vec<AuthorityIndex>,
+        )>,
     ) -> Vec<PendingSubDag> {
         if committed_leaders.is_empty() {
             return vec![];
@@ -302,7 +310,9 @@ impl Linearizer {
 
         let mut pending_sub_dags = vec![];
 
-        for (i, (leader_block, metastate)) in committed_leaders.into_iter().enumerate() {
+        for (i, (leader_block, metastate, strong_voters)) in
+            committed_leaders.into_iter().enumerate()
+        {
             let reputation_scores_desc = if schedule_updated && i == 0 {
                 self.leader_schedule
                     .leader_swap_table
@@ -313,8 +323,12 @@ impl Linearizer {
                 vec![]
             };
 
-            let (sub_dag, commit) =
-                self.collect_sub_dag_and_commit(leader_block, metastate, reputation_scores_desc);
+            let (sub_dag, commit) = self.collect_sub_dag_and_commit(
+                leader_block,
+                metastate,
+                strong_voters,
+                reputation_scores_desc,
+            );
 
             // Buffer commit in dag state for persistence later.
             // This also updates the last committed rounds.
@@ -1214,8 +1228,16 @@ mod tests {
             "fully-linked round-5 leader should have acknowledgments"
         );
 
-        let commits =
-            linearizer.get_pending_sub_dags(vec![(leader, Some(CommitMetastate::Optimistic))]);
+        // Synthetic strong-voter set: every authority. Carries 2f+1 stake so
+        // the per-ref tracker reaches quorum once these votes are added.
+        let strong_voters: Vec<AuthorityIndex> = (0..num_authorities as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect();
+        let commits = linearizer.get_pending_sub_dags(vec![(
+            leader,
+            Some(CommitMetastate::Optimistic),
+            strong_voters,
+        )]);
         assert_eq!(commits.len(), 1);
         let optimistic_refs = &commits[0].committed_transaction_refs;
         let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
@@ -1280,8 +1302,14 @@ mod tests {
                 .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
         };
 
-        let commits_a =
-            linearizer.get_pending_sub_dags(vec![(leader_a, Some(CommitMetastate::Optimistic))]);
+        let strong_voters: Vec<AuthorityIndex> = (0..num_authorities as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect();
+        let commits_a = linearizer.get_pending_sub_dags(vec![(
+            leader_a,
+            Some(CommitMetastate::Optimistic),
+            strong_voters,
+        )]);
         assert_eq!(commits_a.len(), 1);
         for block_ref in &optimistic_set {
             assert!(
@@ -1292,11 +1320,12 @@ mod tests {
 
         // Second commit: L_b at round 7 standardly. Its causal history
         // accumulates 2f+1 acks for L_a's optimistically-committed refs, but
-        // `mark_committed` from L_a's commit must suppress the re-commit.
+        // the votes already recorded for L_a's commit must keep the per-ref
+        // tracker at threshold so the standard path skips re-commit.
         let leader_b = dag_builder
             .leader_block(7)
             .expect("Leader at round 7 should exist");
-        let commits_b = linearizer.get_pending_sub_dags(vec![(leader_b, None)]);
+        let commits_b = linearizer.get_pending_sub_dags(vec![(leader_b, None, vec![])]);
         assert_eq!(commits_b.len(), 1);
         for block_ref in &optimistic_set {
             assert!(
@@ -1344,8 +1373,8 @@ mod tests {
         let leader_ref = leader.reference();
         let leader_ack_refs: Vec<BlockRef> = leader.acknowledgments().to_vec();
 
-        let commits =
-            linearizer.get_pending_sub_dags(vec![(leader, Some(CommitMetastate::Standard))]);
+        let commits = linearizer
+            .get_pending_sub_dags(vec![(leader, Some(CommitMetastate::Standard), vec![])]);
         assert_eq!(commits.len(), 1);
         let standard_refs = &commits[0].committed_transaction_refs;
         let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -16,7 +16,9 @@ use crate::{
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, VerifiedBlockHeader,
     },
-    commit::{Commit, CommitAPI, PendingSubDag, TrustedCommit, sort_sub_dag_blocks},
+    commit::{
+        Commit, CommitAPI, CommitMetastate, PendingSubDag, TrustedCommit, sort_sub_dag_blocks,
+    },
     context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
@@ -77,6 +79,7 @@ impl Linearizer {
     fn collect_sub_dag_and_commit(
         &mut self,
         leader_block: VerifiedBlockHeader,
+        metastate: Option<CommitMetastate>,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
     ) -> (PendingSubDag, TrustedCommit) {
         let _s = self
@@ -123,7 +126,7 @@ impl Linearizer {
 
         // Collect all block references for transactions that reached quorum after
         // adding acknowledgments
-        let committed_transactions = to_commit
+        let mut committed_transactions = to_commit
             .iter()
             // Add the acknowledgments to the tracker and collect the ones that reached quorum.
             // This will return a vector of block references that reached the quorum threshold, so
@@ -136,6 +139,26 @@ impl Linearizer {
                 )
             })
             .collect::<Vec<BlockRef>>();
+
+        // Optimistic: emit the leader's ref and its acks, marking each in the
+        // tracker so neither path re-emits them.
+        if metastate == Some(CommitMetastate::Optimistic) {
+            let leader_ref = leader_block.reference();
+            let refs =
+                std::iter::once(leader_ref).chain(leader_block.acknowledgments().iter().copied());
+            for block_ref in refs {
+                let entry = self
+                    .transactions_ack_tracker
+                    .entry(block_ref)
+                    .or_insert_with(StakeAggregator::<QuorumThreshold>::new);
+                if entry.reached_threshold(&self.context.committee) {
+                    continue;
+                }
+                entry.mark_committed();
+                committed_transactions.push(block_ref);
+            }
+        }
+
         // Check that there are no duplicates in the committed transactions
         assert_eq!(
             committed_transactions.len(),
@@ -265,7 +288,7 @@ impl Linearizer {
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn get_pending_sub_dags(
         &mut self,
-        committed_leaders: Vec<VerifiedBlockHeader>,
+        committed_leaders: Vec<(VerifiedBlockHeader, Option<CommitMetastate>)>,
     ) -> Vec<PendingSubDag> {
         if committed_leaders.is_empty() {
             return vec![];
@@ -279,7 +302,7 @@ impl Linearizer {
 
         let mut pending_sub_dags = vec![];
 
-        for (i, leader_block) in committed_leaders.into_iter().enumerate() {
+        for (i, (leader_block, metastate)) in committed_leaders.into_iter().enumerate() {
             let reputation_scores_desc = if schedule_updated && i == 0 {
                 self.leader_schedule
                     .leader_swap_table
@@ -291,7 +314,7 @@ impl Linearizer {
             };
 
             let (sub_dag, commit) =
-                self.collect_sub_dag_and_commit(leader_block, reputation_scores_desc);
+                self.collect_sub_dag_and_commit(leader_block, metastate, reputation_scores_desc);
 
             // Buffer commit in dag state for persistence later.
             // This also updates the last committed rounds.
@@ -510,7 +533,7 @@ mod tests {
     use super::*;
     use crate::{
         CommitIndex, TestBlockHeader,
-        commit::{CommitDigest, WAVE_LENGTH},
+        commit::{CommitDigest, WAVE_LENGTH, with_no_metastate},
         context::Context,
         dag_state::DataSource,
         leader_schedule::{LeaderSchedule, LeaderSwapTable},
@@ -549,7 +572,7 @@ mod tests {
             .map(Option::unwrap)
             .collect::<Vec<_>>();
 
-        let commits = linearizer.get_pending_sub_dags(leaders.clone());
+        let commits = linearizer.get_pending_sub_dags(with_no_metastate(leaders.clone()));
         for (idx, subdag) in commits.into_iter().enumerate() {
             tracing::info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
@@ -631,7 +654,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Create some commits
-        let commits = linearizer.get_pending_sub_dags(leaders);
+        let commits = linearizer.get_pending_sub_dags(with_no_metastate(leaders));
         {
             // Write them in DagState
             let mut write = dag_state.write();
@@ -653,7 +676,7 @@ mod tests {
 
         // Now on the commits only the first one should contain the updated scores, the
         // other should be empty
-        let commits = linearizer.get_pending_sub_dags(leaders);
+        let commits = linearizer.get_pending_sub_dags(with_no_metastate(leaders));
         assert_eq!(commits.len(), 10);
         let scores = vec![
             (AuthorityIndex::new_for_test(1), 29),
@@ -766,7 +789,7 @@ mod tests {
             vec![],
         );
 
-        let commit = linearizer.get_pending_sub_dags(vec![leader.clone()]);
+        let commit = linearizer.get_pending_sub_dags(with_no_metastate(vec![leader.clone()]));
         assert_eq!(commit.len(), 1);
 
         let subdag = &commit[0];
@@ -860,7 +883,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         for (idx, leader) in leaders.iter().enumerate() {
-            let subdags = linearizer.get_pending_sub_dags(vec![leader.clone()]);
+            let subdags = linearizer.get_pending_sub_dags(with_no_metastate(vec![leader.clone()]));
             assert_eq!(subdags.len(), 1);
             let subdag = &subdags[0];
 
@@ -979,7 +1002,7 @@ mod tests {
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
-        linearizer.get_pending_sub_dags(leaders);
+        linearizer.get_pending_sub_dags(with_no_metastate(leaders));
         // Check that before eviction acknowledgements for all rounds up to num_rounds-2
         // are stored
         for round in 1..=num_rounds - 2 {

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -1448,4 +1448,98 @@ mod tests {
             );
         }
     }
+
+    /// A leader-ack that is not among the leader's ancestors never enters
+    /// the traversed-headers tracker, so the Optimistic path must not commit
+    /// it when `consensus_commit_transactions_only_for_traversed_headers` is
+    /// on.
+    #[tokio::test]
+    async fn test_optimistic_path_respects_traversed_headers_gate() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let (mut ctx, _) = Context::new_for_test(num_authorities);
+        ctx.protocol_config
+            .set_consensus_commit_transactions_only_for_traversed_headers_for_testing(true);
+        let context = Arc::new(ctx);
+
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let all_authorities: Vec<AuthorityIndex> = (0..num_authorities as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect();
+        // Pick an authority that is neither the local node (own_index = 0) nor
+        // the round-5 leader. Their round-3 block will be the orphaned ref.
+        let orphan_author = AuthorityIndex::new_for_test(2);
+
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder
+            .layers(1..=3)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        // Round 4: every authority builds, but no round-4 block references the
+        // orphan author's round-3 block as either ancestor or ack. The orphan's
+        // round-3 block stays in dag_state but is not in the transitive
+        // ancestry of any round-5 block.
+        dag_builder
+            .layers(4..=4)
+            .authorities(all_authorities.clone())
+            .skip_ancestor_links(vec![orphan_author])
+            .skip_acknowledgements(vec![orphan_author])
+            .build()
+            .persist_layers(dag_state.clone());
+
+        dag_builder
+            .layers(5..=5)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        let orphan_block = dag_builder
+            .block_headers(3..=3)
+            .into_iter()
+            .find(|b| b.author() == orphan_author)
+            .expect("orphan round-3 block should exist");
+        let orphan_ref = orphan_block.reference();
+
+        let leader_orig = dag_builder
+            .leader_block(5)
+            .expect("leader at round 5 should exist");
+        let leader_author = leader_orig.author();
+        let leader_ancestors: Vec<BlockRef> = leader_orig.ancestors().to_vec();
+        let mut modified_acks = leader_orig.acknowledgments().to_vec();
+        modified_acks.push(orphan_ref);
+        let leader_modified = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(5, leader_author.value() as u8)
+                .set_ancestors(leader_ancestors)
+                .set_acknowledgments(modified_acks)
+                .build(),
+        );
+        dag_state
+            .write()
+            .accept_block_header(leader_modified.clone(), DataSource::Test);
+
+        let subdags = linearizer.get_pending_sub_dags(vec![(
+            leader_modified,
+            Some(CommitMetastate::Optimistic),
+            all_authorities,
+        )]);
+        assert_eq!(subdags.len(), 1);
+
+        let contains_orphan = subdags[0]
+            .committed_transaction_refs
+            .iter()
+            .any(|r| r.round() == orphan_ref.round && r.author() == orphan_ref.author);
+        assert!(
+            !contains_orphan,
+            "Optimistic path must not commit a ref whose header is not traversed"
+        );
+    }
 }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -1212,11 +1212,8 @@ mod tests {
         ));
         let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder
-            .layers(1..=5)
-            .build()
-            .persist_layers(dag_state.clone());
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=5).build().persist_layers(dag_state);
 
         let leader = dag_builder
             .leader_block(5)
@@ -1284,11 +1281,8 @@ mod tests {
         ));
         let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder
-            .layers(1..=7)
-            .build()
-            .persist_layers(dag_state.clone());
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=7).build().persist_layers(dag_state);
 
         // First commit: L_a at round 4 with Optimistic metastate.
         let leader_a = dag_builder
@@ -1361,11 +1355,8 @@ mod tests {
         ));
         let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder
-            .layers(1..=5)
-            .build()
-            .persist_layers(dag_state.clone());
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=5).build().persist_layers(dag_state);
 
         let leader = dag_builder
             .leader_block(5)
@@ -1373,8 +1364,11 @@ mod tests {
         let leader_ref = leader.reference();
         let leader_ack_refs: Vec<BlockRef> = leader.acknowledgments().to_vec();
 
-        let commits = linearizer
-            .get_pending_sub_dags(vec![(leader, Some(CommitMetastate::Standard), vec![])]);
+        let commits = linearizer.get_pending_sub_dags(vec![(
+            leader,
+            Some(CommitMetastate::Standard),
+            vec![],
+        )]);
         assert_eq!(commits.len(), 1);
         let standard_refs = &commits[0].committed_transaction_refs;
         let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
@@ -1410,11 +1404,8 @@ mod tests {
         ));
         let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder
-            .layers(1..=5)
-            .build()
-            .persist_layers(dag_state.clone());
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=5).build().persist_layers(dag_state);
 
         let leader = dag_builder
             .leader_block(5)
@@ -1426,9 +1417,8 @@ mod tests {
         // should land in the tracker as actual votes for the leader's ref and
         // for every block the leader acknowledges, so that
         // `get_transaction_ack_authors` returns them as fetch sources.
-        let strong_voters: BTreeSet<AuthorityIndex> = (0..3u8)
-            .map(AuthorityIndex::new_for_test)
-            .collect();
+        let strong_voters: BTreeSet<AuthorityIndex> =
+            (0..3u8).map(AuthorityIndex::new_for_test).collect();
         let commits = linearizer.get_pending_sub_dags(vec![(
             leader,
             Some(CommitMetastate::Optimistic),
@@ -1436,8 +1426,8 @@ mod tests {
         )]);
         assert_eq!(commits.len(), 1);
 
-        let ack_authors = linearizer
-            .get_transaction_ack_authors(commits[0].committed_transaction_refs.clone());
+        let ack_authors =
+            linearizer.get_transaction_ack_authors(commits[0].committed_transaction_refs.clone());
 
         let leader_generic = ack_authors
             .iter()

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -1316,4 +1316,53 @@ mod tests {
             "Standard commit of L_b should still include round-5 refs"
         );
     }
+
+    #[tokio::test]
+    async fn test_standard_metastate_does_not_commit_leader_ref_or_acks() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder
+            .layers(1..=5)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        let leader = dag_builder
+            .leader_block(5)
+            .expect("Leader at round 5 should exist");
+        let leader_ref = leader.reference();
+        let leader_ack_refs: Vec<BlockRef> = leader.acknowledgments().to_vec();
+
+        let commits =
+            linearizer.get_pending_sub_dags(vec![(leader, Some(CommitMetastate::Standard))]);
+        assert_eq!(commits.len(), 1);
+        let standard_refs = &commits[0].committed_transaction_refs;
+        let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
+            refs.iter()
+                .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
+        };
+
+        // Standard metastate must not trigger the Optimistic shortcut.
+        assert!(
+            !contains_block(standard_refs, &leader_ref),
+            "Standard should not include leader's own ref {leader_ref:?}"
+        );
+        for ack_ref in &leader_ack_refs {
+            assert!(
+                !contains_block(standard_refs, ack_ref),
+                "Standard should not include leader's ack ref {ack_ref:?}"
+            );
+        }
+    }
 }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -146,20 +146,15 @@ impl Linearizer {
         // the ref through the standard quorum path.
         if metastate == Some(CommitMetastate::Optimistic) {
             let leader_ref = leader_block.reference();
-            let refs =
-                std::iter::once(leader_ref).chain(leader_block.acknowledgments().iter().copied());
-            for block_ref in refs {
-                let entry = self
-                    .transactions_ack_tracker
-                    .entry(block_ref)
-                    .or_insert_with(StakeAggregator::<QuorumThreshold>::new);
-                let was_at_threshold = entry.reached_threshold(&self.context.committee);
-                for authority in &strong_voters {
-                    entry.add(*authority, &self.context.committee);
-                }
-                if !was_at_threshold && entry.reached_threshold(&self.context.committee) {
-                    committed_transactions.push(block_ref);
-                }
+            let refs: Vec<BlockRef> = std::iter::once(leader_ref)
+                .chain(leader_block.acknowledgments().iter().copied())
+                .collect();
+            for strong_voter in &strong_voters {
+                committed_transactions.extend(self.add_committed_transaction_acks(
+                    leader_block.round() + 1,
+                    *strong_voter,
+                    refs.clone(),
+                ));
             }
         }
 

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -1479,7 +1479,7 @@ mod tests {
         // the round-5 leader. Their round-3 block will be the orphaned ref.
         let orphan_author = AuthorityIndex::new_for_test(2);
 
-        let mut dag_builder = DagBuilder::new(context.clone());
+        let mut dag_builder = DagBuilder::new(context);
         dag_builder
             .layers(1..=3)
             .build()

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -140,8 +140,8 @@ impl Linearizer {
             })
             .collect::<Vec<BlockRef>>();
 
-        // Optimistic: emit the leader's ref and its acks, marking each in the
-        // tracker so neither path re-emits them.
+        // Optimistic: commit the leader's ref and its acks, marking each in
+        // the tracker so neither path re-commits them.
         if metastate == Some(CommitMetastate::Optimistic) {
             let leader_ref = leader_block.reference();
             let refs =
@@ -1184,7 +1184,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_optimistic_emits_leader_ref_and_acknowledgments() {
+    async fn test_optimistic_commits_leader_ref_and_acknowledgments() {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
@@ -1218,21 +1218,18 @@ mod tests {
             linearizer.get_pending_sub_dags(vec![(leader, Some(CommitMetastate::Optimistic))]);
         assert_eq!(commits.len(), 1);
         let optimistic_refs = &commits[0].committed_transaction_refs;
-        // Compare on (round, author): committed_transaction_refs may carry the
-        // BlockRef or TransactionRef variant depending on protocol config, but
-        // both expose round() and author() via GenericTransactionRefAPI.
         let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
             refs.iter()
                 .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
         };
 
-        // Optimistic emits the leader's own ref.
+        // Optimistic commits the leader's own ref.
         assert!(
             contains_block(optimistic_refs, &leader_ref),
             "Optimistic should include leader's own ref {leader_ref:?}"
         );
 
-        // Optimistic emits every ack of the leader.
+        // Optimistic commits every ack of the leader.
         for ack_ref in &leader_ack_refs {
             assert!(
                 contains_block(optimistic_refs, ack_ref),
@@ -1240,11 +1237,7 @@ mod tests {
             );
         }
 
-        // Optimistic is additive over the standard flow: leader_ref + acks
-        // alone account for 1 + leader_ack_refs.len() refs, but the standard
-        // causal walk also emits round-(R-2) and earlier blocks that reach
-        // 2f+1 quorum. Strictly more than the optimistic-only contribution
-        // means the standard flow ran and was preserved.
+        // Optimistic is additive over the standard flow.
         assert!(
             optimistic_refs.len() > 1 + leader_ack_refs.len(),
             "Optimistic should additively include standard-flow refs; \
@@ -1252,14 +1245,10 @@ mod tests {
             optimistic_refs.len(),
             1 + leader_ack_refs.len()
         );
-
-        // No-duplicate property is also enforced by the production assert at
-        // collect_sub_dag_and_commit (`assert_eq!(committed_transactions.len(),
-        // …HashSet…len())`); a regression there would panic this test.
     }
 
     #[tokio::test]
-    async fn test_optimistic_does_not_double_emit_across_sub_dags() {
+    async fn test_optimistic_does_not_double_commit_across_sub_dags() {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
@@ -1279,9 +1268,7 @@ mod tests {
             .build()
             .persist_layers(dag_state.clone());
 
-        // First commit: L_a at round 4 with Optimistic metastate. L_a's first
-        // ack (a round-3 block) is the target ref T whose tracker entry will
-        // be `mark_committed`'d.
+        // First commit: L_a at round 4 with Optimistic metastate.
         let leader_a = dag_builder
             .leader_block(4)
             .expect("Leader at round 4 should exist");
@@ -1289,8 +1276,6 @@ mod tests {
             .acknowledgments()
             .first()
             .expect("L_a should have acks in fully-linked DAG");
-        // Compare on (round, author): committed_transaction_refs may carry
-        // either GenericTransactionRef variant depending on protocol config.
         let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
             refs.iter()
                 .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
@@ -1301,13 +1286,12 @@ mod tests {
         assert_eq!(commits_a.len(), 1);
         assert!(
             contains_block(&commits_a[0].committed_transaction_refs, &target_ack),
-            "Optimistic commit of L_a should emit target_ack {target_ack:?}"
+            "Optimistic commit of L_a should include target_ack {target_ack:?}"
         );
 
-        // Second commit: L_b at round 7 with no metastate (standard flow).
-        // L_b's causal history accumulates 2f+1 acks for target_ack, but the
-        // `mark_committed` flag set by L_a's Optimistic commit must suppress
-        // re-emission.
+        // Second commit: L_b at round 7 standardly. Its causal history
+        // accumulates 2f+1 acks for target_ack, but `mark_committed` from
+        // L_a's Optimistic commit must suppress the re-commit.
         let leader_b = dag_builder
             .leader_block(7)
             .expect("Leader at round 7 should exist");
@@ -1315,20 +1299,18 @@ mod tests {
         assert_eq!(commits_b.len(), 1);
         assert!(
             !contains_block(&commits_b[0].committed_transaction_refs, &target_ack),
-            "Standard commit of L_b should NOT re-emit target_ack {target_ack:?} \
-             already emitted by L_a's Optimistic commit"
+            "Standard commit of L_b should NOT re-include target_ack {target_ack:?} \
+             already committed by L_a's Optimistic commit"
         );
 
-        // Sanity: the standard flow still emits refs that L_a never touched.
-        // L_b's commit should produce non-empty round-5 refs (R_b - 2 = 5);
-        // these are blocks the optimistic path never marked committed.
+        // Sanity: the standard flow still commits refs L_a never touched.
         let has_round_5_ref = commits_b[0]
             .committed_transaction_refs
             .iter()
             .any(|r| r.round() == 5);
         assert!(
             has_round_5_ref,
-            "Standard commit of L_b should still emit round-5 refs"
+            "Standard commit of L_b should still include round-5 refs"
         );
     }
 }

--- a/crates/starfish/core/src/stake_aggregator.rs
+++ b/crates/starfish/core/src/stake_aggregator.rs
@@ -38,6 +38,11 @@ impl CommitteeThreshold for ValidityThreshold {
 pub(crate) struct StakeAggregator<T> {
     votes: BTreeSet<AuthorityIndex>,
     stake: Stake,
+    /// External marker that forces `reached_threshold` to return true
+    /// regardless of stake. Used by callers that have an out-of-band reason
+    /// to consider this aggregator settled (e.g. starfish-speed Optimistic
+    /// commits that bypass the 2f+1 ack-quorum).
+    committed: bool,
     _phantom: PhantomData<T>,
 }
 
@@ -46,6 +51,7 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
         Self {
             votes: Default::default(),
             stake: 0,
+            committed: false,
             _phantom: Default::default(),
         }
     }
@@ -57,7 +63,7 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
         if self.votes.insert(vote) {
             self.stake += committee.stake(vote);
         }
-        T::is_threshold(committee, self.stake)
+        self.reached_threshold(committee)
     }
 
     pub(crate) fn stake(&self) -> Stake {
@@ -69,7 +75,12 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
     }
 
     pub(crate) fn reached_threshold(&self, committee: &Committee) -> bool {
-        T::is_threshold(committee, self.stake)
+        self.committed || T::is_threshold(committee, self.stake)
+    }
+
+    /// Force `reached_threshold` to true without recording any votes.
+    pub(crate) fn mark_committed(&mut self) {
+        self.committed = true;
     }
 
     pub(crate) fn threshold(&self, committee: &Committee) -> Stake {
@@ -79,6 +90,7 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
     pub(crate) fn clear(&mut self) {
         self.votes.clear();
         self.stake = 0;
+        self.committed = false;
     }
 }
 

--- a/crates/starfish/core/src/stake_aggregator.rs
+++ b/crates/starfish/core/src/stake_aggregator.rs
@@ -38,11 +38,6 @@ impl CommitteeThreshold for ValidityThreshold {
 pub(crate) struct StakeAggregator<T> {
     votes: BTreeSet<AuthorityIndex>,
     stake: Stake,
-    /// External marker that forces `reached_threshold` to return true
-    /// regardless of stake. Used by callers that have an out-of-band reason
-    /// to consider this aggregator settled (e.g. starfish-speed Optimistic
-    /// commits that bypass the 2f+1 ack-quorum).
-    committed: bool,
     _phantom: PhantomData<T>,
 }
 
@@ -51,7 +46,6 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
         Self {
             votes: Default::default(),
             stake: 0,
-            committed: false,
             _phantom: Default::default(),
         }
     }
@@ -63,7 +57,7 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
         if self.votes.insert(vote) {
             self.stake += committee.stake(vote);
         }
-        self.reached_threshold(committee)
+        T::is_threshold(committee, self.stake)
     }
 
     pub(crate) fn stake(&self) -> Stake {
@@ -75,12 +69,7 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
     }
 
     pub(crate) fn reached_threshold(&self, committee: &Committee) -> bool {
-        self.committed || T::is_threshold(committee, self.stake)
-    }
-
-    /// Force `reached_threshold` to true without recording any votes.
-    pub(crate) fn mark_committed(&mut self) {
-        self.committed = true;
+        T::is_threshold(committee, self.stake)
     }
 
     pub(crate) fn threshold(&self, committee: &Committee) -> Stake {
@@ -90,7 +79,6 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
     pub(crate) fn clear(&mut self) {
         self.votes.clear();
         self.stake = 0;
-        self.committed = false;
     }
 }
 

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -237,7 +237,7 @@ async fn indirect_commit() {
     tracing::info!("Leader index wave 2: {leader_index_wave2}");
 
     let leader_status_wave_2 = committer.try_direct_decide(leader_wave2);
-    if let LeaderStatus::Commit(committed, _) = leader_status_wave_2.clone() {
+    if let LeaderStatus::Commit(committed, _, _) = leader_status_wave_2.clone() {
         tracing::info!("Direct committed leader at wave 2: {committed}");
     } else {
         panic!(
@@ -250,7 +250,7 @@ async fn indirect_commit() {
         [leader_status_wave_2].iter(),
     );
 
-    if let LeaderStatus::Commit(committed, _) = leader_status_wave1_indirect {
+    if let LeaderStatus::Commit(committed, _, _) = leader_status_wave1_indirect {
         tracing::info!("Indirect committed leader at wave 1: {committed}");
     } else {
         panic!(
@@ -304,7 +304,7 @@ async fn indirect_skip() {
     tracing::info!("Leader index wave 1: {leader_index}");
 
     let leader_status_wave1 = committer.try_direct_decide(leader);
-    if let LeaderStatus::Commit(committed, _) = leader_status_wave1 {
+    if let LeaderStatus::Commit(committed, _, _) = leader_status_wave1 {
         tracing::info!("Direct undecided leader at wave 1: {committed}");
     } else {
         panic!(
@@ -341,7 +341,7 @@ async fn indirect_skip() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_3.authority);
         decided_leaders.push(leader_status);
     } else {

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -602,9 +602,15 @@ async fn leader_status_is_final_classification() {
         .expect("round-1 block exists");
 
     let slot = Slot::new(3, AuthorityIndex::from(0u8));
-    assert!(!LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending), vec![]).is_final());
-    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic), vec![]).is_final());
-    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard), vec![]).is_final());
+    assert!(
+        !LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending), vec![]).is_final()
+    );
+    assert!(
+        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic), vec![]).is_final()
+    );
+    assert!(
+        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard), vec![]).is_final()
+    );
     assert!(LeaderStatus::Commit(block, None, vec![]).is_final());
     assert!(LeaderStatus::Skip(slot).is_final());
     assert!(!LeaderStatus::Undecided(slot).is_final());

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -69,7 +69,7 @@ fn assert_direct_commit_metastate(
     expected: Option<CommitMetastate>,
 ) {
     match committer.try_direct_decide(slot) {
-        LeaderStatus::Commit(_, metastate) => assert_eq!(metastate, expected),
+        LeaderStatus::Commit(_, metastate, _) => assert_eq!(metastate, expected),
         status => panic!("expected Commit, got {status}"),
     }
 }
@@ -375,7 +375,7 @@ async fn determine_metastate_pending_when_equivocating_strong_vote_is_filtered()
     );
 
     match committer.try_direct_decide(leader_slot) {
-        LeaderStatus::Commit(block, metastate) => {
+        LeaderStatus::Commit(block, metastate, _) => {
             assert_eq!(block.reference(), leader_a_ref);
             assert_eq!(metastate, Some(CommitMetastate::Pending));
         }
@@ -413,7 +413,7 @@ async fn determine_metastate_pending_when_equivocating_strong_blame_is_filtered(
     );
 
     match committer.try_direct_decide(leader_slot) {
-        LeaderStatus::Commit(block, metastate) => {
+        LeaderStatus::Commit(block, metastate, _) => {
             assert_eq!(block.reference(), leader_a_ref);
             assert_eq!(metastate, Some(CommitMetastate::Pending));
         }
@@ -518,10 +518,10 @@ async fn indirect_metastate_optimistic_when_anchor_path_contains_strong_qc() {
         .write()
         .accept_block_header(anchor.clone(), DataSource::Test);
 
-    let anchor_status = LeaderStatus::Commit(anchor, None);
+    let anchor_status = LeaderStatus::Commit(anchor, None, vec![]);
     let current = LeaderStatus::Undecided(leader_slot);
     match committer.try_indirect_decide(current, std::iter::once(&anchor_status)) {
-        LeaderStatus::Commit(block, metastate) => {
+        LeaderStatus::Commit(block, metastate, _) => {
             assert_eq!(block.reference().round, leader_slot.round);
             assert_eq!(block.reference().author, leader_slot.authority);
             assert_eq!(metastate, Some(CommitMetastate::Optimistic));
@@ -553,10 +553,10 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
         .write()
         .accept_block_header(anchor.clone(), DataSource::Test);
 
-    let anchor_status = LeaderStatus::Commit(anchor, None);
+    let anchor_status = LeaderStatus::Commit(anchor, None, vec![]);
     let current = LeaderStatus::Undecided(leader_slot);
     match committer.try_indirect_decide(current, std::iter::once(&anchor_status)) {
-        LeaderStatus::Commit(block, metastate) => {
+        LeaderStatus::Commit(block, metastate, _) => {
             assert_eq!(block.reference().round, leader_slot.round);
             assert_eq!(block.reference().author, leader_slot.authority);
             assert_eq!(metastate, Some(CommitMetastate::Standard));
@@ -575,10 +575,10 @@ async fn leader_status_is_final_classification() {
         .expect("round-1 block exists");
 
     let slot = Slot::new(3, AuthorityIndex::from(0u8));
-    assert!(!LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending)).is_final());
-    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic)).is_final());
-    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard)).is_final());
-    assert!(LeaderStatus::Commit(block, None).is_final());
+    assert!(!LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending), vec![]).is_final());
+    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic), vec![]).is_final());
+    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard), vec![]).is_final());
+    assert!(LeaderStatus::Commit(block, None, vec![]).is_final());
     assert!(LeaderStatus::Skip(slot).is_final());
     assert!(!LeaderStatus::Undecided(slot).is_final());
 }
@@ -610,7 +610,7 @@ fn round_3_metastate(
         .find(|d| d.slot() == slot)
         .expect("round-3 leader should be decided");
     match decided {
-        DecidedLeader::Commit(_, m) => *m,
+        DecidedLeader::Commit(_, m, _) => *m,
         other => panic!("expected round-3 Commit, got {other:?}"),
     }
 }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
@@ -195,6 +195,33 @@ async fn determine_metastate_optimistic_when_strong_qc_quorum() {
     // 2f+1 StrongQC quorum → Optimistic.
     let leader = build_metastate_dag(context, dag_state, &committer, [strong_vote(); 4]);
     assert_direct_commit_metastate(&committer, leader, Some(CommitMetastate::Optimistic));
+}
+
+#[tokio::test]
+async fn strong_qc_quorum_collects_strong_voter_authorities_from_dag() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // 3 strong votes + 1 strong blame: every r+2 certifier still observes a
+    // 2f+1 strong-vote quorum at r+1 (Optimistic), but the strong-voter list
+    // returned by `strong_qc_quorum` must contain exactly authors {0, 1, 2}
+    // and exclude the strong-blamer at author 3.
+    let blame = strong_blame();
+    let leader = build_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [strong_vote(), strong_vote(), strong_vote(), blame],
+    );
+
+    let strong_voters = match committer.try_direct_decide(leader) {
+        LeaderStatus::Commit(_, Some(CommitMetastate::Optimistic), strong_voters) => strong_voters,
+        other => panic!("expected Commit(Optimistic), got {other}"),
+    };
+    let collected: BTreeSet<AuthorityIndex> = strong_voters.into_iter().collect();
+    let expected: BTreeSet<AuthorityIndex> = (0..3u8).map(AuthorityIndex::from).collect();
+    assert_eq!(collected, expected);
 }
 
 #[tokio::test]

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -55,7 +55,7 @@ async fn try_direct_commit() {
         tracing::info!("Leader commit status: {leader_status}");
 
         if round < incomplete_wave_leader_round {
-            if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+            if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
                 assert_eq!(committed_block.author(), leader.authority)
             } else {
                 panic!("Expected a committed leader at round {round}")
@@ -99,7 +99,7 @@ async fn idempotence() {
     let leader_status = committer.try_direct_decide(leader);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref block, _) = leader_status {
+    if let LeaderStatus::Commit(ref block, _, _) = leader_status {
         assert_eq!(block.author(), leader.authority)
     } else {
         panic!("Expected a committed leader")
@@ -110,7 +110,7 @@ async fn idempotence() {
     let leader_status = committer.try_direct_decide(leader);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader.authority)
     } else {
         panic!("Expected a committed leader")
@@ -150,7 +150,7 @@ async fn multiple_direct_commit() {
         let leader_status = committer.try_direct_decide(leader);
         tracing::info!("Leader commit status: {leader_status}");
 
-        if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+        if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
             assert_eq!(committed_block.author(), leader.authority)
         } else {
             panic!("Expected a committed leader")
@@ -314,7 +314,7 @@ async fn indirect_commit() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_2.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -350,7 +350,7 @@ async fn indirect_commit() {
     );
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority)
     } else {
         panic!("Expected a committed leader")
@@ -436,7 +436,7 @@ async fn indirect_skip() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_3.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -483,7 +483,7 @@ async fn indirect_skip() {
     let leader_status = committer.try_direct_decide(leader_wave_1);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority);
     } else {
         panic!("Expected a committed leader")
@@ -736,7 +736,7 @@ async fn test_byzantine_direct_commit() {
     let leader_status = committer.try_direct_decide(leader_wave_4);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_4.authority);
     } else {
         panic!("Expected a committed leader")

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -33,7 +33,7 @@ async fn direct_commit() {
     assert_eq!(sequence.len(), 1);
 
     let leader_round_wave_0_pipeline_1 = committer.committers[1].leader_round(0);
-    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[0] {
         assert_eq!(block.round(), leader_round_wave_0_pipeline_1);
         assert_eq!(
             block.author(),
@@ -61,7 +61,7 @@ async fn idempotence() {
     assert_eq!(first_sequence.len(), 1);
     tracing::info!("Commit sequence: {first_sequence:#?}");
 
-    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
         assert_eq!(block.round(), leader_round_pipeline_1_wave_0);
         assert_eq!(
             block.author(),
@@ -76,7 +76,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
         assert_eq!(block.round(), leader_round_pipeline_1_wave_0);
         assert_eq!(
             block.author(),
@@ -122,7 +122,7 @@ async fn multiple_direct_commit() {
         tracing::info!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), 1);
-        if let DecidedLeader::Commit(ref block, _) = sequence[0] {
+        if let DecidedLeader::Commit(ref block, _, _) = sequence[0] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(
                 block.author(),
@@ -161,7 +161,7 @@ async fn direct_commit_late_call() {
     for (i, leader_block) in sequence.iter().enumerate() {
         // First sequenced leader should be in round 1.
         let leader_round = i as u32 + 1;
-        if let DecidedLeader::Commit(ref block, _) = leader_block {
+        if let DecidedLeader::Commit(ref block, _, _) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -415,7 +415,7 @@ async fn indirect_commit() {
 
     let committed_leader_round = 1;
     let leader = committer.get_leaders(committed_leader_round)[0];
-    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[0] {
         assert_eq!(block.round(), committed_leader_round);
         assert_eq!(block.author(), leader);
     } else {
@@ -499,7 +499,7 @@ async fn indirect_skip() {
         // First sequenced leader should be in round 1.
         let leader_round = i + 1;
         let leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block, _) = sequence[i as usize] {
+        if let DecidedLeader::Commit(ref block, _, _) = sequence[i as usize] {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -518,7 +518,7 @@ async fn indirect_skip() {
     for i in 4..=6 {
         let leader_round = i + 1;
         let leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block, _) = sequence[i as usize] {
+        if let DecidedLeader::Commit(ref block, _, _) = sequence[i as usize] {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -730,7 +730,7 @@ async fn test_byzantine_validator() {
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
-    if let DecidedLeader::Commit(ref block, _) = sequence[11] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[11] {
         assert_eq!(block.round(), leader_round_12);
         assert_eq!(block.author(), committer.get_leaders(leader_round_12)[0])
     } else {

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -61,7 +61,7 @@ async fn test_randomized_dag_all_direct_commit() {
         for (i, leader_block) in sequence.iter().enumerate() {
             // First sequenced leader should be in round 1.
             let leader_round = i as u32 + 1;
-            if let DecidedLeader::Commit(ref block, _) = leader_block {
+            if let DecidedLeader::Commit(ref block, _, _) = leader_block {
                 assert_eq!(block.round(), leader_round);
                 assert_eq!(
                     block.author(),

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -52,7 +52,7 @@ async fn direct_commit() {
     tracing::info!("Commit sequence: {sequence:#?}");
     // The decided leaders should be all from round 1 to round 5
     assert_eq!(sequence.len(), 5);
-    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[0] {
         assert_eq!(
             block.author(),
             test_setup
@@ -84,7 +84,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
     assert_eq!(first_sequence.len(), 1);
 
-    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), first_non_genesis_leader_round);
         assert_eq!(
             block.author(),
@@ -99,7 +99,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), first_non_genesis_leader_round);
         assert_eq!(
             block.author(),
@@ -132,7 +132,7 @@ async fn idempotence() {
     // Expect that all leaders between round 2 and round 5 are committed.
     // The last one is a block of leader from round 5
     assert_eq!(second_sequence.len(), 4);
-    if let DecidedLeader::Commit(ref block, _) = second_sequence[3] {
+    if let DecidedLeader::Commit(ref block, _, _) = second_sequence[3] {
         assert_eq!(block.round(), round_5);
         assert_eq!(block.author(), committer.get_leaders(round_5)[0]);
     } else {
@@ -164,7 +164,7 @@ async fn multiple_direct_commit() {
         let sequence = committer.try_decide(last_decided);
         tracing::info!("Commit sequence: {sequence:#?}");
         assert_eq!(sequence.len(), 3);
-        if let DecidedLeader::Commit(ref block, _) = sequence[2] {
+        if let DecidedLeader::Commit(ref block, _, _) = sequence[2] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -198,7 +198,7 @@ async fn direct_commit_late_call() {
     assert_eq!(sequence.len(), 3 * (num_waves - 1_usize));
     for (i, leader_block) in sequence.iter().enumerate() {
         let leader_round = committer.committers[(i + 1) % 3].leader_round((i as u32 + 1) / 3);
-        if let DecidedLeader::Commit(ref block, _) = leader_block {
+        if let DecidedLeader::Commit(ref block, _, _) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -394,7 +394,7 @@ async fn indirect_commit() {
         let leader_round =
             committer.committers[(idx + 1) % 3].leader_round(((idx + 1) / 3) as WaveNumber);
         let expected_leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block, _) = decided_leader {
+        if let DecidedLeader::Commit(ref block, _, _) = decided_leader {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), expected_leader);
         } else {
@@ -469,7 +469,7 @@ async fn indirect_skip() {
     assert_eq!(sequence.len(), 7);
 
     for (idx, decided_leader) in sequence.iter().enumerate() {
-        if let DecidedLeader::Commit(ref block, _) = decided_leader {
+        if let DecidedLeader::Commit(ref block, _, _) = decided_leader {
             assert_eq!(block.round(), (idx + 1) as Round);
             assert_eq!(
                 block.author(),
@@ -699,7 +699,7 @@ async fn test_byzantine_direct_commit() {
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
-    if let DecidedLeader::Commit(ref block, _) = sequence[11] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[11] {
         assert_eq!(block.author(), committer.get_leaders(round_12)[0])
     } else {
         panic!("Expected a committed leader")

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -86,8 +86,8 @@ impl UniversalCommitter {
                         tracing::debug!("Outcome of indirect rule: {indirect}");
                         decision = match (&status, &indirect) {
                             (
-                                LeaderStatus::Commit(_, Some(CommitMetastate::Pending)),
-                                LeaderStatus::Commit(_, Some(m)),
+                                LeaderStatus::Commit(_, Some(CommitMetastate::Pending), _),
+                                LeaderStatus::Commit(_, Some(m), _),
                             ) if *m != CommitMetastate::Pending => Decision::Upgraded,
                             _ => Decision::Indirect,
                         };
@@ -141,8 +141,8 @@ impl UniversalCommitter {
             Decision::Indirect => "indirect",
         };
         let status = match decided_leader {
-            DecidedLeader::Commit(_, None) => format!("{decision_str}-commit"),
-            DecidedLeader::Commit(_, Some(metastate)) => {
+            DecidedLeader::Commit(_, None, _) => format!("{decision_str}-commit"),
+            DecidedLeader::Commit(_, Some(metastate), _) => {
                 format!("{decision_str}-commit-{metastate}")
             }
             DecidedLeader::Skip(..) => format!("{decision_str}-skip"),


### PR DESCRIPTION
# Description of change

Branch the linearizer's sequencing on `CommitMetastate`. For `Optimistic` leaders, the leader's r+1 strong-voter authorities (carried alongside the metastate) are recorded as votes for the leader's ref and each entry in `leader_block.acknowledgments()` against the per-ref ack tracker, crossing the 2f+1 quorum and committing those refs through the standard quorum path. Cross-sub-dag dedup falls out of the existing quorum check, and `get_transaction_ack_authors` returns viable fetch sources for the optimistically-committed refs. `Standard` / `None` sequencing is unchanged.

Key pieces:

- **`Linearizer::collect_sub_dag_and_commit`** (`linearizer.rs`): new `(metastate, strong_voters)` parameters. For an Optimistic leader, the strong-voter votes for the leader's ref + acks are routed through `add_committed_transaction_acks`, crossing 2f+1 and committing those refs.
- **`BaseCommitter::strong_qc_quorum`** (`base_committer.rs`): now returns `Option<Vec<AuthorityIndex>>` so the strong-voter authority list is captured in the same walk that classifies Optimistic.
- **Tests** (`linearizer.rs`, `tests/base_committer_metastate_tests.rs`):
  - `test_optimistic_commits_leader_ref_and_acknowledgments`: leader's ref + every ack land in `committed_transaction_refs`, additively over the standard flow.
  - `test_optimistic_does_not_double_commit_across_sub_dags`: a later standard commit whose causal history accumulates 2f+1 acks for any of L_a's optimistically-committed refs does not re-commit them.
  - `test_standard_metastate_does_not_commit_leader_ref_or_acks`: `Some(CommitMetastate::Standard)` behaves like `None`.
  - `test_optimistic_records_strong_voters_in_ack_tracker`: after an Optimistic commit, `get_transaction_ack_authors` returns the strong-voter authorities for the leader's ref and every ack.
  - `test_optimistic_path_respects_traversed_headers_gate`: with `consensus_commit_transactions_only_for_traversed_headers` enabled, a leader-ack whose header is not in the traversed-headers tracker is not committed by the optimistic flow even after 2f+1 strong-voter votes.
  - `strong_qc_quorum_collects_strong_voter_authorities_from_dag`: real V2-block DAG with mixed strong-vote / strong-blame voters; verifies the authority list returned by `strong_qc_quorum` excludes the strong-blamer.

Recovery for the optimistic-path tracker state (replaying strong-voter votes after restart) is deferred to a follow-up PR that will branch off this one.

## Links to any relevant issues

Part of #11009
Fixes #11138

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
