### PR TITLE
feat(iota-benchmark): resilience bench implementation

### DIFF
--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -403,7 +403,8 @@ pub struct BenchmarkParametersGenerator<T> {
     num_shared_counters: Option<usize>,
     /// Path for the benchmark stats metadata to be downloaded after the run
     benchmark_stats_path: Option<String>,
-    /// Override max_auth_gas in protocol config at genesis (see BenchmarkParameters).
+    /// Override max_auth_gas in protocol config at genesis (see
+    /// BenchmarkParameters).
     genesis_max_auth_gas: Option<u64>,
 }
 

--- a/crates/iota-aws-orchestrator/src/benchmark.rs
+++ b/crates/iota-aws-orchestrator/src/benchmark.rs
@@ -137,6 +137,9 @@ pub struct BenchmarkParameters<T> {
     /// Stress server threads used for AA workload (bench keeps the old
     /// hardcoded behavior).
     pub stress_num_server_threads: u64,
+    /// Rate mode passed to the resilience-bench injector: "exact" drops missed
+    /// ticks (steady controlled load) or "flow" catches up (max throughput).
+    pub stress_rate_mode: String,
     /// Flag indicating whether nodes should advertise their internal or public
     /// IP address for inter-node communication. When running the simulation
     /// in multiple regions, nodes need to use their public IPs to correctly
@@ -169,6 +172,11 @@ pub struct BenchmarkParameters<T> {
     /// Optional path to benchmark stats metadata for downloading stats after
     /// the run.
     pub benchmark_stats_path: Option<String>,
+    /// Override max_auth_gas in the protocol config at genesis.
+    /// When set, injects IOTA_PROTOCOL_CONFIG_OVERRIDE_max_auth_gas=VALUE into
+    /// the genesis environment so that each experiment can use a different cap
+    /// without rebuilding the binary.
+    pub genesis_max_auth_gas: Option<u64>,
 }
 
 impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
@@ -189,6 +197,7 @@ impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
             stress_in_flight_ratio: 10,
             stress_num_client_threads: 8,
             stress_num_server_threads: 8,
+            stress_rate_mode: "exact".to_string(),
             use_internal_ip_address: true,
             latency_topology: Some(TopologyLayout::Mainnet),
             perturbation_spec: PerturbationSpec::None,
@@ -201,6 +210,7 @@ impl<T: BenchmarkType> Default for BenchmarkParameters<T> {
             num_shared_counters: None,
             benchmark_dir: PathBuf::default(),
             benchmark_stats_path: None,
+            genesis_max_auth_gas: None,
         }
     }
 }
@@ -253,6 +263,7 @@ impl<T> BenchmarkParameters<T> {
         stress_in_flight_ratio: u64,
         stress_num_client_threads: u64,
         stress_num_server_threads: u64,
+        stress_rate_mode: String,
         use_internal_ip_address: bool,
         latency_topology: Option<TopologyLayout>,
         perturbation_spec: PerturbationSpec,
@@ -265,6 +276,7 @@ impl<T> BenchmarkParameters<T> {
         num_shared_counters: Option<usize>,
         benchmark_dir: PathBuf,
         benchmark_stats_path: Option<String>,
+        genesis_max_auth_gas: Option<u64>,
     ) -> Self {
         Self {
             benchmark_type,
@@ -282,6 +294,7 @@ impl<T> BenchmarkParameters<T> {
             stress_in_flight_ratio,
             stress_num_client_threads,
             stress_num_server_threads,
+            stress_rate_mode,
             use_internal_ip_address,
 
             latency_topology,
@@ -295,6 +308,7 @@ impl<T> BenchmarkParameters<T> {
             num_shared_counters,
             benchmark_dir,
             benchmark_stats_path,
+            genesis_max_auth_gas,
         }
     }
 }
@@ -365,6 +379,8 @@ pub struct BenchmarkParametersGenerator<T> {
     /// Stress threads used for AA.
     stress_num_client_threads: u64,
     stress_num_server_threads: u64,
+    /// Rate mode for the resilience-bench injector ("exact" or "flow").
+    stress_rate_mode: String,
 
     /// The topology of private network latencies, RandomGeographical,
     /// RandomClustered, HardCodedClustered, or Mainnet
@@ -387,6 +403,8 @@ pub struct BenchmarkParametersGenerator<T> {
     num_shared_counters: Option<usize>,
     /// Path for the benchmark stats metadata to be downloaded after the run
     benchmark_stats_path: Option<String>,
+    /// Override max_auth_gas in protocol config at genesis (see BenchmarkParameters).
+    genesis_max_auth_gas: Option<u64>,
 }
 
 impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
@@ -423,6 +441,7 @@ impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
                 self.stress_in_flight_ratio,
                 self.stress_num_client_threads,
                 self.stress_num_server_threads,
+                self.stress_rate_mode.clone(),
                 self.use_internal_ip_address,
                 self.latency_topology.clone(),
                 self.perturbation_spec.clone(),
@@ -435,6 +454,7 @@ impl<T: BenchmarkType> Iterator for BenchmarkParametersGenerator<T> {
                 self.num_shared_counters,
                 PathBuf::default(),
                 self.benchmark_stats_path.clone(),
+                self.genesis_max_auth_gas,
             )
         })
     }
@@ -491,7 +511,9 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
             aa_split_amount: 1_000,
             stress_num_client_threads: 8,
             stress_num_server_threads: 8,
+            stress_rate_mode: "exact".to_string(),
             benchmark_stats_path: None,
+            genesis_max_auth_gas: None,
         }
     }
 
@@ -532,6 +554,11 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
 
     pub fn with_stress_server_threads(mut self, stress_num_server_threads: u64) -> Self {
         self.stress_num_server_threads = stress_num_server_threads;
+        self
+    }
+
+    pub fn with_stress_rate_mode(mut self, stress_rate_mode: String) -> Self {
+        self.stress_rate_mode = stress_rate_mode;
         self
     }
 
@@ -600,6 +627,11 @@ impl<T: BenchmarkType> BenchmarkParametersGenerator<T> {
 
     pub fn with_benchmark_stats_path(mut self, path: Option<String>) -> Self {
         self.benchmark_stats_path = path;
+        self
+    }
+
+    pub fn with_genesis_max_auth_gas(mut self, max_auth_gas: u64) -> Self {
+        self.genesis_max_auth_gas = Some(max_auth_gas);
         self
     }
 

--- a/crates/iota-aws-orchestrator/src/main.rs
+++ b/crates/iota-aws-orchestrator/src/main.rs
@@ -118,6 +118,12 @@ pub enum Operation {
         #[arg(long, default_value = "8", global = true)]
         stress_num_server_threads: u64,
 
+        /// Rate mode for the stress client ("exact" or "flow").
+        /// "flow" catches up on missed ticks and is recommended for high-QPS
+        /// workloads where timer resolution would otherwise cap throughput.
+        #[arg(long, default_value = "exact", global = true)]
+        stress_rate_mode: String,
+
         /// The committee size to deploy.
         #[arg(long, value_name = "INT")]
         committee: usize,
@@ -245,6 +251,13 @@ pub enum Operation {
         /// after the run
         #[arg(long, value_name = "/home/ubuntu/benchmark_stats.json", global = true)]
         benchmark_stats_path: Option<String>,
+
+        /// Override max_auth_gas in the protocol config at genesis.
+        /// Injects IOTA_PROTOCOL_CONFIG_OVERRIDE_max_auth_gas into the genesis
+        /// environment, allowing different auth-gas caps without rebuilding.
+        /// Requires a full genesis re-run (new testbed or --force-genesis).
+        #[arg(long, global = true)]
+        genesis_max_auth_gas: Option<u64>,
     },
 
     /// Print a summary of the specified measurements collection.
@@ -512,9 +525,11 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             stress_in_flight_ratio,
             stress_num_client_threads,
             stress_num_server_threads,
+            stress_rate_mode,
             shared_counter_hotness_factor,
             num_shared_counters,
             benchmark_stats_path,
+            genesis_max_auth_gas,
         } => {
             // Create a new orchestrator to instruct the testbed.
             let username = testbed.username();
@@ -612,6 +627,7 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             .with_stress_in_flight_ratio(stress_in_flight_ratio)
             .with_stress_client_threads(stress_num_client_threads)
             .with_stress_server_threads(stress_num_server_threads)
+            .with_stress_rate_mode(stress_rate_mode)
             .with_benchmark_stats_path(benchmark_stats_path.clone());
 
             if let Some(factor) = shared_counter_hotness_factor {
@@ -619,6 +635,9 @@ async fn run<C: ServerProviderClient>(settings: Settings, client: C, opts: Opts)
             }
             if let Some(counters) = num_shared_counters {
                 generator = generator.with_num_shared_counters(counters);
+            }
+            if let Some(max_auth_gas) = genesis_max_auth_gas {
+                generator = generator.with_genesis_max_auth_gas(max_auth_gas);
             }
 
             Orchestrator::new(

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -24,6 +24,25 @@ pub enum IotaBenchmarkType {
     SharedObjectsRatio(u16),
     /// Benchmark for Abstract Account functionality.
     AbstractAccountBench,
+    /// Resilience benchmark: one injector client sends targeted fault traffic
+    /// directly to the focal validator via DirectValidatorProxy while the
+    /// remaining client instances send honest baseline traffic via quorum.
+    ///
+    /// `fault_scenario` is passed verbatim to `--fault-scenario` (e.g.
+    /// `"auth-compute-heavy"` or `"std-invalid"`).
+    /// `injection_qps` is the TPS sent to the focal validator.
+    /// `focal_validator` selects the focal node; accepted forms:
+    ///   - an IPv4 address (e.g. `"3.124.187.12"`) — recommended for remote
+    ///     benchmarks; matched against genesis network addresses unambiguously.
+    ///   - a 0-based integer index into the BLS-key-sorted committee BTreeMap.
+    ///   - a key-prefix substring (e.g. `"8dcff6"`).
+    /// The `load` field of `BenchmarkParameters` is used as the total honest
+    /// baseline TPS split across all non-injector client instances.
+    ResilienceBench {
+        fault_scenario: String,
+        injection_qps: usize,
+        focal_validator: String,
+    },
 }
 
 impl Default for IotaBenchmarkType {
@@ -37,6 +56,14 @@ impl std::fmt::Debug for IotaBenchmarkType {
         match self {
             Self::SharedObjectsRatio(shared_objects_ratio) => write!(f, "{shared_objects_ratio}"),
             Self::AbstractAccountBench => write!(f, "abstract_account_bench"),
+            Self::ResilienceBench {
+                fault_scenario,
+                injection_qps,
+                focal_validator,
+            } => write!(
+                f,
+                "resilience_bench_{fault_scenario}_{injection_qps}tps_v{focal_validator}"
+            ),
         }
     }
 }
@@ -48,6 +75,14 @@ impl std::fmt::Display for IotaBenchmarkType {
                 write!(f, "bench ({}% shared objects)", shared_objects_ratio)
             }
             Self::AbstractAccountBench => write!(f, "abstract-account-bench"),
+            Self::ResilienceBench {
+                fault_scenario,
+                injection_qps,
+                focal_validator,
+            } => write!(
+                f,
+                "resilience-bench ({fault_scenario} @ {injection_qps} TPS → validator {focal_validator})"
+            ),
         }
     }
 }
@@ -63,10 +98,38 @@ impl FromStr for IotaBenchmarkType {
             return Ok(Self::SharedObjectsRatio(n.min(100)));
         }
 
+        // resilience-bench:<fault_scenario>:<injection_qps>:<focal_validator>
+        // focal_validator may be an integer index, an IPv4 address, or a key
+        // prefix — it is passed verbatim to the stress binary's
+        // --focal-validator flag.  IPv4 addresses contain dots and colons, so
+        // we use splitn(4, ':') only for the first three fields and take the
+        // remainder as the focal_validator string.
+        if s.trim().starts_with("resilience-bench:") {
+            let parts: Vec<&str> = s.trim().splitn(4, ':').collect();
+            if parts.len() == 4 {
+                let fault_scenario = parts[1].to_string();
+                let injection_qps = parts[2].parse::<usize>().map_err(|_| {
+                    format!("Invalid injection_qps '{}' in resilience-bench spec", parts[2])
+                })?;
+                let focal_validator = parts[3].to_string();
+                return Ok(Self::ResilienceBench {
+                    fault_scenario,
+                    injection_qps,
+                    focal_validator,
+                });
+            }
+            return Err(format!(
+                "Invalid resilience-bench spec '{s}'. \
+                 Expected: resilience-bench:<fault_scenario>:<injection_qps>:<focal_validator>"
+            ));
+        }
+
         match v.as_str() {
             "abstract-account-bench" => Ok(Self::AbstractAccountBench),
             _ => Err(format!(
-                "Unknown benchmark type '{s}'. Expected 0..=100 or abstract-account-bench"
+                "Unknown benchmark type '{s}'. \
+                 Expected: 0..=100, abstract-account-bench, or \
+                 resilience-bench:<fault_scenario>:<injection_qps>:<focal_validator>"
             )),
         }
     }
@@ -148,11 +211,14 @@ impl IotaProtocol {
             return vec![];
         };
         // TRACE_FILTER values can be implemented as params as well. For now, we keep
-        // them fixed to trace handle_transaction and process_certificate which are the
-        // most relevant spans for benchmarks.
+        // them fixed to the most relevant spans for benchmarks:
+        //   handle_transaction   — AuthorityState tx processing (aa-super-heavy Move VM cost)
+        //   process_certificate  — certificate processing latency
+        //   verify_transaction   — signature verification (only signal for std-invalid, which
+        //                          is rejected before AuthorityState::handle_transaction runs)
         vec![
             format!("export OTEL_EXPORTER_OTLP_ENDPOINT={}", otel.otlp_endpoint),
-            "export TRACE_FILTER=[handle_transaction]=trace,[process_certificate]=trace"
+            "export TRACE_FILTER=[handle_transaction]=trace,[process_certificate]=trace,[verify_transaction]=trace"
                 .to_string(),
             format!(
                 "export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT={}",
@@ -216,14 +282,21 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
             parameters.additional_gas_accounts
         );
 
+        let mut genesis_setup: Vec<String> = vec![
+            // Set protocol config override to disable validator subsidies for benchmarks
+            "export IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1".to_string(),
+            "export IOTA_PROTOCOL_CONFIG_OVERRIDE_validator_target_reward=0".to_string(),
+            format!("mkdir -p {working_dir}"),
+        ];
+        if let Some(max_auth_gas) = parameters.genesis_max_auth_gas {
+            genesis_setup.push(format!(
+                "export IOTA_PROTOCOL_CONFIG_OVERRIDE_max_auth_gas={max_auth_gas}"
+            ));
+        }
+
         let iota_command = self.run_binary_command(
-            "iota",
-            &[
-                // Set protocol config override to disable validator subsidies for benchmarks
-                "export IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1",
-                "export IOTA_PROTOCOL_CONFIG_OVERRIDE_validator_target_reward=0",
-                &format!("mkdir -p {working_dir}")
-            ],
+            "iota-localnet",
+            &genesis_setup,
             &[
                 "genesis",
                 &format!("-f --working-dir {working_dir} --benchmark-ips {ips} --admin-interface-address=localhost:1337"),
@@ -279,6 +352,12 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     format!("export IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1"),
                     format!("export IOTA_PROTOCOL_CONFIG_OVERRIDE_validator_target_reward=0"),
                 ];
+
+                if let Some(max_auth_gas) = parameters.genesis_max_auth_gas {
+                    setup.push(format!(
+                        "export IOTA_PROTOCOL_CONFIG_OVERRIDE_max_auth_gas={max_auth_gas}"
+                    ));
+                }
 
                 if self.enable_flamegraph {
                     setup.push("export TRACE_FLAMEGRAPH=1".to_string());
@@ -378,7 +457,8 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
 
         let committee_size = parameters.nodes;
         let clients: Vec<_> = instances.into_iter().collect();
-        let load_share = parameters.load / clients.len();
+        let clients_len = clients.len();
+        let load_share = parameters.load / clients_len;
         let metrics_port = Self::CLIENT_METRICS_PORT;
         // Get gas keys for all validators and clients
         let gas_keys =
@@ -399,9 +479,19 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                 let client_threads = parameters.stress_num_client_threads;
                 let server_threads = parameters.stress_num_server_threads;
 
+                // For ResilienceBench baseline clients, use 150 transfer
+                // accounts so they can sustain 30+ TPS over a 420s run without
+                // account exhaustion. The injector (i=0) only needs 2 — its
+                // transactions always fail so there is no account churn.
+                // For other bench types keep the existing value of 2.
+                let transfer_accounts = match &parameters.benchmark_type {
+                    IotaBenchmarkType::ResilienceBench { .. } if i > 0 => 150,
+                    _ => 2,
+                };
+
                 let mut stress_args: Vec<String> = vec![
                     format!("--num-client-threads {client_threads} --num-server-threads {server_threads}"),
-                    "--local false --num-transfer-accounts 2".to_string(),
+                    format!("--local false --num-transfer-accounts {transfer_accounts}"),
                     format!("--genesis-blob-path {genesis} --keystore-path {keystore}"),
                     format!("--primary-gas-owner-id {gas_address}"),
                     // Run interval param
@@ -414,9 +504,9 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                     },
                 ];
 
-                match parameters.benchmark_type {
+                match &parameters.benchmark_type {
                     IotaBenchmarkType::SharedObjectsRatio(shared_objects_ratio) => {
-                        let transfer_objects = 100 - shared_objects_ratio;
+                        let transfer_objects = 100 - *shared_objects_ratio;
                         let hotness_factor = parameters.shared_counter_hotness_factor.unwrap_or(50);
                         stress_args.push("bench".to_string());
                         stress_args.push(format!("--target-qps {load_share}"));
@@ -439,6 +529,40 @@ impl ProtocolCommands<IotaBenchmarkType> for IotaProtocol {
                         stress_args.push(format!("--split-amount {}", parameters.aa_split_amount));
                         if parameters.should_fail {
                             stress_args.push("--should-fail".to_string());
+                        }
+                    }
+
+                    IotaBenchmarkType::ResilienceBench {
+                        fault_scenario,
+                        injection_qps,
+                        focal_validator,
+                    } => {
+                        if i == 0 {
+                            // Injector: targets the focal validator directly via
+                            // DirectValidatorProxy. stress.rs builds the proxy
+                            // from the genesis file when --local false and
+                            // resilience-bench subcommand are combined.
+                            // --baseline-qps 0: all honest traffic comes from
+                            // the separate baseline client instances.
+                            stress_args.push("resilience-bench".to_string());
+                            stress_args.push(format!("--fault-scenario {fault_scenario}"));
+                            stress_args.push(format!("--injection-qps {injection_qps}"));
+                            stress_args.push(format!("--num-workers {}", parameters.stress_num_workers));
+                            stress_args.push(format!("--in-flight-ratio {}", parameters.stress_in_flight_ratio));
+                            stress_args.push("--baseline-qps 0".to_string());
+                            stress_args.push(format!("--rate-mode {}", parameters.stress_rate_mode));
+                            stress_args.push(format!("--focal-validator {focal_validator}"));
+                        } else {
+                            // Baseline clients: honest TransferObject traffic
+                            // through the full quorum. Load is split evenly
+                            // across all baseline clients (clients.len()-1).
+                            let baseline_clients = clients_len.saturating_sub(1).max(1);
+                            let baseline_share = parameters.load / baseline_clients;
+                            stress_args.push("bench".to_string());
+                            stress_args.push(format!("--target-qps {baseline_share}"));
+                            stress_args.push(format!("--num-workers {}", parameters.stress_num_workers));
+                            stress_args.push(format!("--in-flight-ratio {}", parameters.stress_in_flight_ratio));
+                            stress_args.push("--transfer-object 100".to_string());
                         }
                     }
                 }
@@ -483,8 +607,8 @@ impl IotaProtocol {
             })
             .collect();
 
-        // `u64::MAX - 1` is the max total supply value acceptable by
-        // `iota::balance::increase_supply`
+        // `u64::MAX - 1` is the max total supply value accepted by
+        // `iota::balance::increase_supply` (strict less-than check in genesis_config)
         let genesis_config = GenesisConfig::new_for_benchmarks(
             &ips,
             parameters.epoch_duration_ms,
@@ -525,7 +649,7 @@ impl ProtocolMetrics for IotaProtocol {
         // From GenesisConfig we only need validators' `metrics_address` port which is
         // computed from validator's offset in `ips`. The values of (the rest
         // of) the arguments are irrelevant.
-        GenesisConfig::new_for_benchmarks(&ips, None, None, None, u64::MAX)
+        GenesisConfig::new_for_benchmarks(&ips, None, None, None, u64::MAX - 1)
             .validator_config_info
             .expect("No validator in genesis")
             .iter()

--- a/crates/iota-aws-orchestrator/src/protocol/iota.rs
+++ b/crates/iota-aws-orchestrator/src/protocol/iota.rs
@@ -36,6 +36,7 @@ pub enum IotaBenchmarkType {
     ///     benchmarks; matched against genesis network addresses unambiguously.
     ///   - a 0-based integer index into the BLS-key-sorted committee BTreeMap.
     ///   - a key-prefix substring (e.g. `"8dcff6"`).
+    ///
     /// The `load` field of `BenchmarkParameters` is used as the total honest
     /// baseline TPS split across all non-injector client instances.
     ResilienceBench {
@@ -109,7 +110,10 @@ impl FromStr for IotaBenchmarkType {
             if parts.len() == 4 {
                 let fault_scenario = parts[1].to_string();
                 let injection_qps = parts[2].parse::<usize>().map_err(|_| {
-                    format!("Invalid injection_qps '{}' in resilience-bench spec", parts[2])
+                    format!(
+                        "Invalid injection_qps '{}' in resilience-bench spec",
+                        parts[2]
+                    )
                 })?;
                 let focal_validator = parts[3].to_string();
                 return Ok(Self::ResilienceBench {
@@ -212,10 +216,11 @@ impl IotaProtocol {
         };
         // TRACE_FILTER values can be implemented as params as well. For now, we keep
         // them fixed to the most relevant spans for benchmarks:
-        //   handle_transaction   — AuthorityState tx processing (aa-super-heavy Move VM cost)
-        //   process_certificate  — certificate processing latency
-        //   verify_transaction   — signature verification (only signal for std-invalid, which
-        //                          is rejected before AuthorityState::handle_transaction runs)
+        //   handle_transaction   — AuthorityState tx processing (aa-super-heavy Move VM
+        // cost)   process_certificate  — certificate processing latency
+        //   verify_transaction   — signature verification (only signal for std-invalid,
+        // which                          is rejected before
+        // AuthorityState::handle_transaction runs)
         vec![
             format!("export OTEL_EXPORTER_OTLP_ENDPOINT={}", otel.otlp_endpoint),
             "export TRACE_FILTER=[handle_transaction]=trace,[process_certificate]=trace,[verify_transaction]=trace"

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -294,7 +294,7 @@ impl Settings {
     pub fn build_groups(&self) -> BuildGroups {
         let mut groups: BuildGroups = HashMap::new();
 
-        for name in ["iota", "iota-node", "stress"] {
+        for name in ["iota", "iota-localnet", "iota-node", "stress"] {
             let config = self.build_configs.get(name);
 
             let mut features = config.map(|c| c.features.clone()).unwrap_or_default();

--- a/crates/iota-benchmark/src/benchmark_setup.rs
+++ b/crates/iota-benchmark/src/benchmark_setup.rs
@@ -168,7 +168,10 @@ impl Env {
         ) {
             eprintln!("Warning: could not write gas info: {e}");
         } else {
-            eprintln!("Gas info written to {} (address / object-id)", gas_info_path.display());
+            eprintln!(
+                "Gas info written to {} (address / object-id)",
+                gas_info_path.display()
+            );
         }
 
         let proxy: Arc<dyn ValidatorProxy + Send + Sync> =

--- a/crates/iota-benchmark/src/benchmark_setup.rs
+++ b/crates/iota-benchmark/src/benchmark_setup.rs
@@ -42,6 +42,7 @@ pub struct BenchmarkSetup {
     pub shutdown_notifier: oneshot::Sender<()>,
     pub bank: BenchmarkBank,
     pub proxies: Vec<Arc<dyn ValidatorProxy + Send + Sync>>,
+    pub genesis: Option<iota_config::genesis::Genesis>,
 }
 
 impl Env {
@@ -135,6 +136,41 @@ impl Env {
         // Wait for the embedded reconfig observer.
         sleep(Duration::from_secs(5)).await;
         let (genesis, primary_gas) = genesis_recv.await.unwrap();
+
+        // Write genesis, keypair, and gas object ID to well-known paths so that
+        // a second stress process can connect to this cluster in remote mode.
+        let genesis_path = std::path::Path::new("/tmp/iota-bench-genesis.blob");
+        if let Err(e) = genesis.save(genesis_path) {
+            eprintln!("Warning: could not write genesis blob: {e}");
+        } else {
+            eprintln!("Genesis blob written to {}", genesis_path.display());
+        }
+
+        // Write keystore (base64-encoded keypair) for remote bench process.
+        let keystore_path = std::path::Path::new("/tmp/iota-bench.keystore");
+        {
+            use fastcrypto::traits::KeyPair as _;
+            use iota_types::crypto::{EncodeDecodeBase64, IotaKeyPair};
+            let kp = IotaKeyPair::Ed25519(keypair.copy());
+            let encoded = kp.encode_base64();
+            if let Err(e) = std::fs::write(keystore_path, format!("[\"{encoded}\"]")) {
+                eprintln!("Warning: could not write keystore: {e}");
+            } else {
+                eprintln!("Keystore written to {}", keystore_path.display());
+            }
+        }
+
+        // Write primary gas owner address for remote bench process.
+        let gas_info_path = std::path::Path::new("/tmp/iota-bench-gas.txt");
+        if let Err(e) = std::fs::write(
+            gas_info_path,
+            format!("{}\n{}\n", primary_gas_owner, primary_gas.0),
+        ) {
+            eprintln!("Warning: could not write gas info: {e}");
+        } else {
+            eprintln!("Gas info written to {} (address / object-id)", gas_info_path.display());
+        }
+
         let proxy: Arc<dyn ValidatorProxy + Send + Sync> =
             Arc::new(LocalValidatorAggregatorProxy::from_genesis(&genesis, registry, None).await);
         Ok(BenchmarkSetup {
@@ -142,6 +178,7 @@ impl Env {
             shutdown_notifier: shutdown_sender,
             bank: BenchmarkBank::new(proxy.clone(), (primary_gas, primary_gas_owner, keypair)),
             proxies: vec![proxy],
+            genesis: Some(genesis),
         })
     }
 
@@ -295,6 +332,9 @@ impl Env {
             shutdown_notifier: sender,
             bank: BenchmarkBank::new(proxy.clone(), current_gas),
             proxies,
+            // Expose genesis so ResilienceBench can build a DirectValidatorProxy
+            // targeting a specific node even when connecting to a remote cluster.
+            genesis: Some(genesis.clone()),
         })
     }
 }

--- a/crates/iota-benchmark/src/benchmark_setup.rs
+++ b/crates/iota-benchmark/src/benchmark_setup.rs
@@ -164,7 +164,7 @@ impl Env {
         let gas_info_path = std::path::Path::new("/tmp/iota-bench-gas.txt");
         if let Err(e) = std::fs::write(
             gas_info_path,
-            format!("{}\n{}\n", primary_gas_owner, primary_gas.0),
+            format!("{}\n{}\n", primary_gas_owner, primary_gas.object_id),
         ) {
             eprintln!("Warning: could not write gas info: {e}");
         } else {

--- a/crates/iota-benchmark/src/bin/stress.rs
+++ b/crates/iota-benchmark/src/bin/stress.rs
@@ -7,11 +7,12 @@ use std::{sync::Arc, time::Duration};
 use anyhow::{Context, Result, bail};
 use clap::*;
 use iota_benchmark::{
+    DirectValidatorProxy,
     benchmark_setup::Env,
     drivers::{
         BenchmarkCmp, BenchmarkMetadata, BenchmarkStats, bench_driver::BenchDriver, driver::Driver,
     },
-    options::Opts,
+    options::{Opts, RunSpec},
     system_state_observer::SystemStateObserver,
     workloads::workload_configuration::WorkloadConfiguration,
 };
@@ -140,7 +141,39 @@ async fn main() -> Result<()> {
             // otherwise summarized benchmark results are
             // published in the end
             let show_progress = interval.is_unbounded();
-            let driver = BenchDriver::new(opts.stat_collection_interval, stress_stat_collection);
+            let mut driver = BenchDriver::new(
+                opts.stat_collection_interval,
+                stress_stat_collection,
+                opts.run_spec.rate_mode(),
+            );
+
+            // For ResilienceBench, build a DirectValidatorProxy that pins all
+            // injection traffic (group 0) to the focal node's gRPC endpoint,
+            // and enable concurrent_groups so the baseline workload (group 1,
+            // quorum proxy) starts at the same time as the injection workload.
+            if let RunSpec::ResilienceBench { focal_validator, .. } = &opts.run_spec {
+                driver.concurrent_groups = true;
+                if let Some(genesis) = &bench_setup.genesis {
+                    match DirectValidatorProxy::from_genesis(genesis, focal_validator.as_str()) {
+                        Ok(proxy) => {
+                            driver.focal_proxy = Some(Arc::new(proxy));
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Could not build DirectValidatorProxy for focal_validator={:?}: {e:#}. \
+                                 Falling back to shared proxy pool.",
+                                focal_validator,
+                            );
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        "ResilienceBench: genesis not available (remote mode?). \
+                         DirectValidatorProxy not configured; injection traffic will use shared pool."
+                    );
+                }
+            }
+
             driver
                 .run(
                     bench_setup.proxies,

--- a/crates/iota-benchmark/src/drivers/bench_driver.rs
+++ b/crates/iota-benchmark/src/drivers/bench_driver.rs
@@ -52,6 +52,7 @@ use super::{BenchmarkStats, Interval, StressStats};
 use crate::{
     ExecutionEffects, ValidatorProxy,
     drivers::{HistogramWrapper, driver::Driver},
+    options::RateMode,
     system_state_observer::SystemStateObserver,
     workloads::{GroupID, WorkloadInfo, payload::Payload, workload::ExpectedFailureType},
 };
@@ -214,6 +215,7 @@ pub struct BenchWorker {
     pub proxy: Arc<dyn ValidatorProxy + Send + Sync>,
     pub group: u32,
     pub duration: Interval,
+    pub rate_mode: RateMode,
 }
 
 impl Debug for BenchWorker {
@@ -233,15 +235,32 @@ pub struct BenchDriver {
     pub stress_stat_collection: bool,
     pub start_time: Instant,
     pub token: CancellationToken,
+    pub rate_mode: RateMode,
+    /// When set, all group-0 workers use this proxy instead of a randomly
+    /// chosen one from the pool. Used by ResilienceBench to pin injection
+    /// traffic to a single focal node's gRPC endpoint.
+    pub focal_proxy: Option<Arc<dyn ValidatorProxy + Send + Sync>>,
+    /// When true, all benchmark groups start concurrently rather than
+    /// sequentially (group 0 finishes → group 1 starts).
+    /// Used by ResilienceBench so the baseline workload (group 1, quorum proxy)
+    /// runs alongside the injection workload (group 0, DirectValidatorProxy).
+    pub concurrent_groups: bool,
 }
 
 impl BenchDriver {
-    pub fn new(stat_collection_interval: u64, stress_stat_collection: bool) -> BenchDriver {
+    pub fn new(
+        stat_collection_interval: u64,
+        stress_stat_collection: bool,
+        rate_mode: RateMode,
+    ) -> BenchDriver {
         BenchDriver {
             stat_collection_interval,
             stress_stat_collection,
             start_time: Instant::now(),
             token: CancellationToken::new(),
+            rate_mode,
+            focal_proxy: None,
+            concurrent_groups: false,
         }
     }
     pub fn terminate(&self) {
@@ -301,6 +320,7 @@ impl BenchDriver {
                     proxy: proxy.clone(),
                     group: workload_info.workload_params.group,
                     duration: workload_info.workload_params.duration,
+                    rate_mode: self.rate_mode,
                 });
                 payloads = remaining;
                 qps -= target_qps;
@@ -349,18 +369,32 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
         let mut worker_id = 0;
         let mut num_workers = 0;
 
-        for (_, workloads) in workloads_by_group_id.iter() {
+        for (group_id, workloads) in workloads_by_group_id.iter() {
             let mut workers = vec![];
 
             for workload in workloads {
-                let proxy = proxies
-                    .choose(&mut rand::thread_rng())
-                    .context("Failed to get proxy for bench driver")?;
+                // Group 0 uses the focal proxy when one is configured (ResilienceBench),
+                // all other groups pick a proxy randomly from the pool.
+                let proxy = if *group_id == 0 {
+                    if let Some(ref ap) = self.focal_proxy {
+                        ap.clone()
+                    } else {
+                        proxies
+                            .choose(&mut rand::thread_rng())
+                            .context("Failed to get proxy for bench driver")?
+                            .clone()
+                    }
+                } else {
+                    proxies
+                        .choose(&mut rand::thread_rng())
+                        .context("Failed to get proxy for bench driver")?
+                        .clone()
+                };
                 workers.extend(
                     self.make_workers(
                         &mut worker_id,
                         workload,
-                        proxy.clone(),
+                        proxy,
                         system_state_observer.clone(),
                     )
                     .await,
@@ -390,6 +424,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
             metrics.clone(),
             total_benchmark_run_interval,
             stat_delay_micros,
+            self.concurrent_groups,
         )
         .await;
 
@@ -574,13 +609,14 @@ async fn spawn_workers_scheduler(
     metrics_cloned: Arc<BenchMetrics>,
     total_benchmark_run_interval: Interval,
     stat_delay_micros: u64,
+    concurrent_groups: bool,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         info!("Spawn up scheduler task...");
 
         let mut running_workers: JoinSet<Option<BenchWorker>> = JoinSet::new();
         let mut finished_workers = Vec::new();
-        let (tx_workers_to_run, mut rx_workers_to_run) = channel(1);
+        let (tx_workers_to_run, mut rx_workers_to_run) = channel(bench_workers.len().max(1));
 
         let mut check_interval = time::interval(Duration::from_millis(500));
         check_interval.set_missed_tick_behavior(time::MissedTickBehavior::Burst);
@@ -588,11 +624,20 @@ async fn spawn_workers_scheduler(
         // Set the total benchmark start time
         let total_benchmark_start_time = print_and_start_benchmark().await;
 
-        // Initially bootstrap the first tasks
-        tx_workers_to_run
-            .send(bench_workers.pop_front().unwrap())
-            .await
-            .expect("Should be able to send next workers to run");
+        if concurrent_groups {
+            while let Some(group) = bench_workers.pop_front() {
+                tx_workers_to_run
+                    .send(group)
+                    .await
+                    .expect("Should be able to send workers to run");
+            }
+        } else {
+            // Initially bootstrap the first tasks
+            tx_workers_to_run
+                .send(bench_workers.pop_front().unwrap())
+                .await
+                .expect("Should be able to send next workers to run");
+        }
 
         loop {
             tokio::select! {
@@ -745,7 +790,10 @@ async fn run_bench_worker(
 
     let mut latency_histogram = hdrhistogram::Histogram::<u64>::new_with_max(120_000, 3).unwrap();
     let mut request_interval = time::interval(Duration::from_micros(request_delay_micros));
-    request_interval.set_missed_tick_behavior(time::MissedTickBehavior::Burst);
+    request_interval.set_missed_tick_behavior(match worker.rate_mode {
+        RateMode::Exact => time::MissedTickBehavior::Skip,
+        RateMode::Flow => time::MissedTickBehavior::Burst,
+    });
     let mut stat_interval = time::interval(Duration::from_micros(stat_delay_micros));
 
     let mut retry_queue: VecDeque<RetryType> = VecDeque::new();

--- a/crates/iota-benchmark/src/lib.rs
+++ b/crates/iota-benchmark/src/lib.rs
@@ -584,19 +584,48 @@ pub struct DirectValidatorProxy {
 
 impl DirectValidatorProxy {
     /// Build a proxy targeting the focal validator selected by `selector`.
-    ///
-    /// `selector` is either:
-    /// - a decimal integer → 0-based index into the genesis committee order
-    /// - a key substring → matched against each validator's concise authority
-    ///   key (e.g. `"8dcff6"` matches `"k#8dcff6d1.."`).
     pub fn from_genesis(genesis: &Genesis, selector: &str) -> anyhow::Result<Self> {
         let (_, clients) =
             AuthorityAggregatorBuilder::from_genesis(genesis).build_network_clients();
         let committee = genesis.committee()?;
         let committee_size = committee.num_members();
 
-        let (resolved_idx, target_name, client) = if let Ok(idx) = selector.parse::<usize>() {
-            // Integer index: pick the nth entry in committee order.
+        let (resolved_idx, target_name, client) = if selector.contains('.') {
+            // This form is preferred for remote (AWS) benchmarks because the
+            // BTreeMap is sorted by BLS public-key bytes, which is independent
+            // of the genesis IP order — using an integer index would silently
+            // attack the wrong validator.
+            let network_committee = genesis.committee_with_network();
+            clients
+                .into_iter()
+                .enumerate()
+                .find(|(_, (name, _))| {
+                    network_committee
+                        .validators()
+                        .get(name)
+                        .map(|(_, meta)| meta.network_address.to_string().contains(selector))
+                        .unwrap_or(false)
+                })
+                .map(|(i, (name, client))| (i, name, client))
+                .ok_or_else(|| {
+                    let addrs: Vec<String> = network_committee
+                        .validators()
+                        .values()
+                        .map(|(_, m)| m.network_address.to_string())
+                        .collect();
+                    anyhow::anyhow!(
+                        "focal_validator IP {:?} did not match any validator network address. \
+                         Available: {:?} \
+                         (hint: pass the IP used in --benchmark-ips, e.g. '3.124.187.12')",
+                        selector,
+                        addrs,
+                    )
+                })?
+        } else if let Ok(idx) = selector.parse::<usize>() {
+            // Integer index: pick the nth entry in BTreeMap<AuthorityName> order.
+            // WARNING: this order is sorted by BLS key bytes and does NOT match
+            // the genesis IP list order.  Prefer the IP-based selector above for
+            // remote benchmarks.
             clients
                 .into_iter()
                 .enumerate()

--- a/crates/iota-benchmark/src/lib.rs
+++ b/crates/iota-benchmark/src/lib.rs
@@ -23,7 +23,7 @@ use futures::TryStreamExt;
 use iota_config::genesis::Genesis;
 use iota_core::{
     authority_aggregator::{AuthorityAggregator, AuthorityAggregatorBuilder},
-    authority_client::NetworkAuthorityClient,
+    authority_client::{AuthorityAPI, NetworkAuthorityClient},
     quorum_driver::{
         QuorumDriver, QuorumDriverHandler, QuorumDriverHandlerBuilder, QuorumDriverMetrics,
         reconfig_observer::ReconfigObserver,
@@ -35,7 +35,9 @@ use iota_json_rpc_types::{
 };
 use iota_sdk::{IotaClient, IotaClientBuilder, PagedFn};
 use iota_types::{
-    base_types::{AuthorityName, IotaAddress, ObjectID, ObjectRef, SequenceNumber},
+    base_types::{
+        AuthorityName, ConciseableName, IotaAddress, ObjectID, ObjectRef, SequenceNumber,
+    },
     committee::{Committee, EpochId},
     crypto::AuthorityStrongQuorumSignInfo,
     effects::{CertifiedTransactionEffects, TransactionEffectsAPI, TransactionEvents},
@@ -569,6 +571,136 @@ impl ValidatorProxy for FullNodeProxy {
             .iter_committee_members()
             .map(|v| v.iota_address)
             .collect())
+    }
+}
+
+/// A proxy that sends transactions directly to a single validator via its gRPC
+/// `handle_transaction` endpoint, bypassing quorum. Used by `ResilienceBench`
+/// to concentrate injection traffic on one focal node.
+pub struct DirectValidatorProxy {
+    client: NetworkAuthorityClient,
+    committee: Arc<Committee>,
+}
+
+impl DirectValidatorProxy {
+    /// Build a proxy targeting the focal validator selected by `selector`.
+    ///
+    /// `selector` is either:
+    /// - a decimal integer → 0-based index into the genesis committee order
+    /// - a key substring → matched against each validator's concise authority
+    ///   key (e.g. `"8dcff6"` matches `"k#8dcff6d1.."`).
+    pub fn from_genesis(genesis: &Genesis, selector: &str) -> anyhow::Result<Self> {
+        let (_, clients) =
+            AuthorityAggregatorBuilder::from_genesis(genesis).build_network_clients();
+        let committee = genesis.committee()?;
+        let committee_size = committee.num_members();
+
+        let (resolved_idx, target_name, client) = if let Ok(idx) = selector.parse::<usize>() {
+            // Integer index: pick the nth entry in committee order.
+            clients
+                .into_iter()
+                .enumerate()
+                .nth(idx)
+                .map(|(i, (name, client))| (i, name, client))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "focal_validator index {} out of range (committee size {})",
+                        idx,
+                        committee_size
+                    )
+                })?
+        } else {
+            // Key substring: find the first validator whose concise key contains
+            // the selector string (e.g. "8dcff6" matches "k#8dcff6d1..").
+            clients
+                .into_iter()
+                .enumerate()
+                .find(|(_, (name, _))| format!("{}", name.concise()).contains(selector))
+                .map(|(i, (name, client))| (i, name, client))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "focal_validator {:?} did not match any validator key \
+                         (hint: use a substring of the key printed as \
+                         'Metric address for validator <KEY>: ...' in the log)",
+                        selector
+                    )
+                })?
+        };
+
+        // Print the authority key so the monitoring scripts can correlate it
+        // with the metric address logged by benchmark_setup.rs.
+        // benchmark_setup.rs prints "Metric address for validator <CONCISE>: <ADDR>"
+        // using the same concise format, making the mapping unambiguous.
+        eprintln!(
+            "ResilienceBench focal node: validator_index={} authority={}",
+            resolved_idx,
+            target_name.concise(),
+        );
+
+        Ok(Self {
+            client,
+            committee: Arc::new(committee),
+        })
+    }
+}
+
+#[async_trait]
+impl ValidatorProxy for DirectValidatorProxy {
+    async fn get_object(&self, _object_id: ObjectID) -> Result<Object, anyhow::Error> {
+        unimplemented!(
+            "DirectValidatorProxy: object reads go through LocalValidatorAggregatorProxy during setup"
+        )
+    }
+
+    async fn get_owned_objects(
+        &self,
+        _account_address: IotaAddress,
+    ) -> Result<Vec<(u64, Object)>, anyhow::Error> {
+        unimplemented!(
+            "DirectValidatorProxy: object reads go through LocalValidatorAggregatorProxy during setup"
+        )
+    }
+
+    async fn get_latest_system_state_object(
+        &self,
+    ) -> Result<IotaSystemStateSummary, anyhow::Error> {
+        unimplemented!(
+            "DirectValidatorProxy: system state goes through LocalValidatorAggregatorProxy during setup"
+        )
+    }
+
+    /// Submits the transaction to the focal validator's handle_transaction
+    /// endpoint. Always returns Err because injected TXs are expected to fail.
+    async fn execute_transaction_block(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {
+        // Fire-and-forget: send to focal node, ignore the (error) response.
+        // Propagate the error so bench_driver counts it as a failed TX,
+        // which is the expected outcome for injection workloads.
+        let _ = self.client.handle_transaction(tx, None).await?;
+        // If the node somehow accepted it (unexpected for injection TXs),
+        // return an error anyway — DirectValidatorProxy never produces effects.
+        anyhow::bail!("DirectValidatorProxy: handle_transaction unexpectedly succeeded")
+    }
+
+    fn clone_committee(&self) -> Arc<Committee> {
+        self.committee.clone()
+    }
+
+    fn get_current_epoch(&self) -> EpochId {
+        self.committee.epoch
+    }
+
+    fn clone_new(&self) -> Box<dyn ValidatorProxy + Send + Sync> {
+        Box::new(Self {
+            client: self.client.clone(),
+            committee: self.committee.clone(),
+        })
+    }
+
+    async fn get_committee(&self) -> Result<Vec<IotaAddress>, anyhow::Error> {
+        unimplemented!(
+            "DirectValidatorProxy: committee address lookup not supported \
+             (only used by delegation workload, which ResilienceBench does not run)"
+        )
     }
 }
 

--- a/crates/iota-benchmark/src/options.rs
+++ b/crates/iota-benchmark/src/options.rs
@@ -11,6 +11,72 @@ use crate::{
     workloads::abstract_account::{AuthenticatorKind, TxPayloadObjType},
 };
 
+/// Fault scenario to inject into the target node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultScenario {
+    /// AA authenticator: plain ed25519_verify + assert.
+    /// Minimal AA variant — one verify, aborts immediately on invalid sig.
+    /// Submitted with `should_fail=true` so the client pays no IOTA tokens.
+    AuthBasic,
+    /// AA authenticator: ed25519 loop (no assert) + 122 BenchObject reads.
+    /// Submitted with `should_fail=true` — the validator exhausts
+    /// `max_auth_gas` regardless of signature validity; client pays no IOTA
+    /// tokens.
+    AuthComputeHeavy,
+    /// Standard TransferObject TX with a zeroed (invalid) Ed25519 signature.
+    /// Rejected at pre-consensus signature verification.
+    StdInvalid,
+}
+
+impl FromStr for FaultScenario {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auth-basic" | "authbasic" | "aa-ed25519" | "aaed25519" => Ok(FaultScenario::AuthBasic),
+            "auth-compute-heavy" | "authcomputeheavy" | "aa-super-heavy" | "aasuperheavy" => {
+                Ok(FaultScenario::AuthComputeHeavy)
+            }
+            "std-invalid" | "stdinvalid" => Ok(FaultScenario::StdInvalid),
+            _ => anyhow::bail!(
+                "unknown FaultScenario '{}' \
+                 (expected: auth-basic / aa-ed25519, auth-compute-heavy / aa-super-heavy, std-invalid)",
+                s
+            ),
+        }
+    }
+}
+
+/// Controls how the bench driver handles scheduling when it falls behind the
+/// target send rate (i.e. which [`tokio::time::MissedTickBehavior`] to use).
+///
+/// * `Flow`  (default) — `MissedTickBehavior::Burst`: fires all missed ticks
+///   immediately, allowing the driver to catch up. Good for throughput
+///   benchmarks where you want maximum offered load.
+/// * `Exact` — `MissedTickBehavior::Skip`: drops missed ticks, keeping the
+///   *offered load* at exactly the specified QPS.  Use this for DoS experiments
+///   where a precise, reproducible load level is required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RateMode {
+    /// Drop missed ticks — offered load stays at exactly the specified QPS.
+    Exact,
+    /// Burst through missed ticks — maximise offered load.
+    #[default]
+    Flow,
+}
+
+impl FromStr for RateMode {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "exact" => Ok(RateMode::Exact),
+            "flow" => Ok(RateMode::Flow),
+            _ => anyhow::bail!("unknown RateMode '{}' (expected: exact, flow)", s),
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "Stress Testing Framework")]
 pub struct Opts {
@@ -252,6 +318,56 @@ pub enum RunSpec {
         duration: Vec<Interval>,
     },
 
+    /// Resilience benchmark: one injection worker targets a single node while a
+    /// second worker maintains a baseline load through the full quorum.
+    ResilienceBench {
+        /// Fault scenario to inject into the focal node.
+        #[arg(long, default_value = "auth-compute-heavy")]
+        fault_scenario: FaultScenario,
+
+        /// Which validator to use as the focal node. Accepts either:
+        ///   - a 0-based integer index into the genesis committee order (e.g.
+        ///     `0`)
+        ///   - a key prefix that uniquely matches one validator's concise
+        ///     authority key as printed in the log (e.g. `8dcff6` matches
+        ///     `k#8dcff6d1..`)
+        /// Injection traffic is routed directly to that node's
+        /// `handle_transaction` endpoint, bypassing quorum.
+        #[arg(long, default_value = "0")]
+        focal_validator: String,
+
+        /// Target offered load (TPS) for the injection workload.
+        #[arg(long, default_value = "100")]
+        injection_qps: u64,
+
+        /// Target offered load (TPS) for the baseline workload
+        /// (TransferObject).
+        #[arg(long, default_value = "30")]
+        baseline_qps: u64,
+
+        /// How to handle missed ticks in the scheduler.
+        /// `exact` = drop missed ticks (steady load); `flow` = burst catch-up.
+        #[arg(long, default_value = "exact")]
+        rate_mode: RateMode,
+
+        /// Benchmark duration. Leave as "unbounded" and use `--run-duration`.
+        #[arg(long, default_value = "unbounded")]
+        duration: Interval,
+
+        // -- AA-specific (ignored when fault_scenario = std-invalid) --
+        /// Split amount used in OwnedObject AA transactions.
+        #[arg(long, default_value = "1000")]
+        split_amount: u64,
+
+        /// Concurrent worker tasks for the injection workload.
+        #[arg(long, default_value = "12")]
+        num_workers: u64,
+
+        /// In-flight pipeline depth ratio.
+        #[arg(long, default_value = "5")]
+        in_flight_ratio: u64,
+    },
+
     AbstractAccountBench {
         #[arg(long, default_value = "ed25519")]
         authenticator: AuthenticatorKind,
@@ -314,6 +430,16 @@ pub enum RunSpec {
 }
 
 impl RunSpec {
+    /// Returns the [`RateMode`] for this run spec.
+    /// Only `ResilienceBench` sets a non-default value; all other specs use
+    /// `Flow` (burst catch-up, the historical default).
+    pub fn rate_mode(&self) -> RateMode {
+        match self {
+            RunSpec::ResilienceBench { rate_mode, .. } => *rate_mode,
+            _ => RateMode::Flow,
+        }
+    }
+
     pub fn get_setup_info(&self) -> SetupInfo {
         match self {
             RunSpec::Bench {
@@ -347,6 +473,24 @@ impl RunSpec {
                 target_qps: target_qps.clone(),
                 workers: num_workers.clone(),
                 in_flight_ratio: in_flight_ratio.clone(),
+            },
+            RunSpec::ResilienceBench {
+                fault_scenario,
+                injection_qps,
+                baseline_qps,
+                num_workers,
+                in_flight_ratio,
+                rate_mode,
+                ..
+            } => SetupInfo {
+                test_type: "resilience_bench".to_string(),
+                scenario: format!(
+                    "fault_scenario={:?} injection_qps={} baseline_qps={} rate_mode={:?}",
+                    fault_scenario, injection_qps, baseline_qps, rate_mode,
+                ),
+                target_qps: vec![*injection_qps + *baseline_qps],
+                workers: vec![*num_workers + 4],
+                in_flight_ratio: vec![*in_flight_ratio],
             },
             RunSpec::AbstractAccountBench {
                 target_qps,

--- a/crates/iota-benchmark/src/options.rs
+++ b/crates/iota-benchmark/src/options.rs
@@ -331,6 +331,7 @@ pub enum RunSpec {
         ///   - a key prefix that uniquely matches one validator's concise
         ///     authority key as printed in the log (e.g. `8dcff6` matches
         ///     `k#8dcff6d1..`)
+        ///
         /// Injection traffic is routed directly to that node's
         /// `handle_transaction` endpoint, bypassing quorum.
         #[arg(long, default_value = "0")]

--- a/crates/iota-benchmark/src/workloads/abstract_account/payload.rs
+++ b/crates/iota-benchmark/src/workloads/abstract_account/payload.rs
@@ -315,6 +315,27 @@ fn build_move_auth_args(
                 auth_args.push(CallArg::ImmutableOrOwned(*obj));
             }
         }
+
+        AuthenticatorKind::SuperHeavy => {
+            let digest = tx_data.digest().into_inner();
+            let sig: Ed25519Signature = owner.1.sign(&digest);
+
+            let mut sig_bytes = sig.as_ref().to_vec();
+            if should_fail {
+                sig_bytes[0] ^= 0x01;
+            }
+
+            let hex_encoded = Hex::encode(sig_bytes)
+                .chars()
+                .take(Ed25519Signature::LENGTH * 2)
+                .collect::<String>();
+
+            auth_args.push(CallArg::Pure(bcs::to_bytes(&hex_encoded)?));
+
+            for obj in bench_objects.iter() {
+                auth_args.push(CallArg::Object(ObjectArg::ImmOrOwnedObject(*obj)));
+            }
+        }
     }
 
     Ok(auth_args)

--- a/crates/iota-benchmark/src/workloads/abstract_account/payload.rs
+++ b/crates/iota-benchmark/src/workloads/abstract_account/payload.rs
@@ -333,7 +333,7 @@ fn build_move_auth_args(
             auth_args.push(CallArg::Pure(bcs::to_bytes(&hex_encoded)?));
 
             for obj in bench_objects.iter() {
-                auth_args.push(CallArg::Object(ObjectArg::ImmOrOwnedObject(*obj)));
+                auth_args.push(CallArg::ImmutableOrOwned(*obj));
             }
         }
     }

--- a/crates/iota-benchmark/src/workloads/abstract_account/types.rs
+++ b/crates/iota-benchmark/src/workloads/abstract_account/types.rs
@@ -13,6 +13,8 @@ pub enum AuthenticatorKind {
     Ed25519Heavy,
     HelloWorld,
     MaxArgs125,
+    // Basically the same as MaxArgs125 + Ed25519Heavy.
+    SuperHeavy,
 }
 
 impl AuthenticatorKind {
@@ -22,16 +24,20 @@ impl AuthenticatorKind {
             AuthenticatorKind::Ed25519Heavy => "authenticate_ed25519_heavy",
             AuthenticatorKind::HelloWorld => "authenticate_hello_world",
             AuthenticatorKind::MaxArgs125 => "authenticate_max_args_125",
+            AuthenticatorKind::SuperHeavy => "authenticate_super_heavy",
         }
     }
 
     pub fn requires_bench_objects(&self) -> bool {
-        matches!(self, AuthenticatorKind::MaxArgs125)
+        matches!(
+            self,
+            AuthenticatorKind::MaxArgs125 | AuthenticatorKind::SuperHeavy
+        )
     }
 
     pub fn expected_bench_objects_count(&self) -> Option<usize> {
         match self {
-            AuthenticatorKind::MaxArgs125 => Some(122),
+            AuthenticatorKind::MaxArgs125 | AuthenticatorKind::SuperHeavy => Some(122),
             _ => None,
         }
     }
@@ -46,6 +52,7 @@ impl FromStr for AuthenticatorKind {
             "ed25519heavy" => Ok(AuthenticatorKind::Ed25519Heavy),
             "helloworld" => Ok(AuthenticatorKind::HelloWorld),
             "maxargs125" => Ok(AuthenticatorKind::MaxArgs125),
+            "superheavy" => Ok(AuthenticatorKind::SuperHeavy),
             _ => bail!("unknown AuthenticatorKind: {}", s),
         }
     }
@@ -58,6 +65,7 @@ impl std::fmt::Display for AuthenticatorKind {
             AuthenticatorKind::Ed25519Heavy => "ed25519heavy",
             AuthenticatorKind::HelloWorld => "helloworld",
             AuthenticatorKind::MaxArgs125 => "maxargs125",
+            AuthenticatorKind::SuperHeavy => "superheavy",
         };
         f.write_str(s)
     }

--- a/crates/iota-benchmark/src/workloads/expected_failure.rs
+++ b/crates/iota-benchmark/src/workloads/expected_failure.rs
@@ -135,11 +135,8 @@ impl ExpectedFailureWorkloadBuilder {
             };
             // Expected-failure transactions (e.g. InvalidSignature) are rejected
             // before execution so gas is never consumed — the same gas objects can
-            // be reused across all in-flight slots. Capping num_payloads to
-            // num_workers avoids allocating O(target_qps * in_flight_ratio) gas
-            // coins during setup, which can take minutes at high QPS and prevent
-            // the benchmark from starting within the run interval.
-            let num_payloads = num_workers.max(1);
+            // be reused across all in-flight slots.
+            let num_payloads = (num_workers * in_flight_ratio).max(1);
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
                 ExpectedFailureWorkloadBuilder {
                     expected_failure_cfg,

--- a/crates/iota-benchmark/src/workloads/expected_failure.rs
+++ b/crates/iota-benchmark/src/workloads/expected_failure.rs
@@ -133,10 +133,17 @@ impl ExpectedFailureWorkloadBuilder {
                 duration,
                 group,
             };
+            // Expected-failure transactions (e.g. InvalidSignature) are rejected
+            // before execution so gas is never consumed — the same gas objects can
+            // be reused across all in-flight slots. Capping num_payloads to
+            // num_workers avoids allocating O(target_qps * in_flight_ratio) gas
+            // coins during setup, which can take minutes at high QPS and prevent
+            // the benchmark from starting within the run interval.
+            let num_payloads = num_workers.max(1);
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
                 ExpectedFailureWorkloadBuilder {
                     expected_failure_cfg,
-                    num_payloads: max_ops,
+                    num_payloads,
                     num_transfer_accounts,
                 },
             ));

--- a/crates/iota-benchmark/src/workloads/expected_failure.rs
+++ b/crates/iota-benchmark/src/workloads/expected_failure.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use iota_core::test_utils::make_transfer_object_transaction;
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
-    crypto::{AccountKeyPair, Ed25519IotaSignature, get_key_pair},
+    crypto::{AccountKeyPair, ToFromBytes, get_key_pair},
     signature::GenericSignature,
     transaction::Transaction,
 };
@@ -50,13 +50,17 @@ impl ExpectedFailurePayload {
     fn create_failing_transaction(&self, mut tx: Transaction) -> Transaction {
         match self.failure_type {
             ExpectedFailureType::InvalidSignature => {
-                let signatures = tx.tx_signatures_mut_for_testing();
-                signatures.pop();
-                signatures.push(GenericSignature::Signature(
-                    iota_types::crypto::Signature::Ed25519IotaSignature(
-                        Ed25519IotaSignature::default(),
-                    ),
-                ));
+                // Bumping byte in position 1 (skipping position 0 because it is the flag)
+                // by 1 (mod 256) with a guaranteed-different value, makes it so that
+                // `from_bytes` still parses but verification fails at verify_authenticator
+                // (Ed25519 scalar multiply runs and rejects the corrupted scalar).
+                // The public key bytes are left intact so address derivation still matches
+                // the real sender, ensuring we reach Step 4 of signature verification.
+                for signature in tx.tx_signatures_mut_for_testing().iter_mut() {
+                    let mut bytes = signature.as_ref().to_vec();
+                    bytes[1] = bytes[1].wrapping_add(1);
+                    *signature = GenericSignature::from_bytes(&bytes).unwrap();
+                }
                 tx
             }
             ExpectedFailureType::Random => unreachable!(),
@@ -82,7 +86,10 @@ impl Payload for ExpectedFailurePayload {
             *gas_obj,
             self.transfer_from,
             keypair,
-            self.transfer_to,
+            // Use a fresh random address each call so every transaction has a unique
+            // digest. The tx is rejected at signature verification and never executes,
+            // so the recipient address has no effect on correctness.
+            IotaAddress::random_for_testing_only(),
             self.system_state_observer
                 .state
                 .borrow()

--- a/crates/iota-benchmark/src/workloads/expected_failure.rs
+++ b/crates/iota-benchmark/src/workloads/expected_failure.rs
@@ -34,7 +34,6 @@ pub struct ExpectedFailurePayload {
     failure_type: ExpectedFailureType,
     transfer_object: ObjectRef,
     transfer_from: IotaAddress,
-    transfer_to: IotaAddress,
     gas: Vec<Gas>,
     system_state_observer: Arc<SystemStateObserver>,
 }
@@ -89,7 +88,7 @@ impl Payload for ExpectedFailurePayload {
             // Use a fresh random address each call so every transaction has a unique
             // digest. The tx is rejected at signature verification and never executes,
             // so the recipient address has no effect on correctness.
-            IotaAddress::random_for_testing_only(),
+            IotaAddress::random(),
             self.system_state_observer
                 .state
                 .borrow()
@@ -268,12 +267,10 @@ impl Workload<dyn Payload> for ExpectedFailureWorkload {
         refs.iter()
             .map(|(g, t)| {
                 let from = t.1;
-                let to = g.iter().find(|x| x.1 != from).unwrap().1;
                 Box::new(ExpectedFailurePayload {
                     failure_type: self.expected_failure_cfg.failure_type,
                     transfer_object: t.0,
                     transfer_from: from,
-                    transfer_to: to,
                     gas: g.to_vec(),
                     system_state_observer: system_state_observer.clone(),
                 })

--- a/crates/iota-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/iota-benchmark/src/workloads/workload_configuration.rs
@@ -17,13 +17,15 @@ use super::{
 use crate::{
     bank::BenchmarkBank,
     drivers::Interval,
-    options::{Opts, RunSpec},
+    options::{FaultScenario, Opts, RunSpec},
     system_state_observer::SystemStateObserver,
     workloads::{
         ExpectedFailureType, GroupID, WorkloadBuilderInfo, WorkloadInfo,
-        abstract_account::AbstractAccountWorkloadBuilder,
-        batch_payment::BatchPaymentWorkloadBuilder, delegation::DelegationWorkloadBuilder,
-        shared_counter::SharedCounterWorkloadBuilder, slow::SlowWorkloadBuilder,
+        abstract_account::{AbstractAccountWorkloadBuilder, AuthenticatorKind, TxPayloadObjType},
+        batch_payment::BatchPaymentWorkloadBuilder,
+        delegation::DelegationWorkloadBuilder,
+        shared_counter::SharedCounterWorkloadBuilder,
+        slow::SlowWorkloadBuilder,
         transfer_object::TransferObjectWorkloadBuilder,
     },
 };
@@ -145,6 +147,107 @@ impl WorkloadConfiguration {
                 )
                 .await
             }
+            RunSpec::ResilienceBench {
+                fault_scenario,
+                focal_validator: _,
+                injection_qps,
+                baseline_qps,
+                rate_mode: _,
+                duration,
+                split_amount,
+                num_workers,
+                in_flight_ratio,
+            } => {
+                info!(
+                    "Resilience bench: fault_scenario={:?}, injection_qps={}, baseline_qps={}, \
+                     num_workers={}, in_flight_ratio={}, duration={:?}",
+                    fault_scenario,
+                    injection_qps,
+                    num_workers,
+                    in_flight_ratio,
+                    baseline_qps,
+                    duration,
+                );
+
+                // Group 0: injection workload — all traffic goes to the focal node
+                // (DirectValidatorProxy is wired in by stress.rs for group 0;
+                // falls back to the shared pool when not configured).
+                let injection_builder = match fault_scenario {
+                    FaultScenario::AuthBasic => AbstractAccountWorkloadBuilder::from(
+                        1.0,
+                        injection_qps,
+                        num_workers,
+                        in_flight_ratio,
+                        AuthenticatorKind::Ed25519,
+                        TxPayloadObjType::OwnedObject,
+                        split_amount,
+                        // should_fail=true: invalid signature; node runs one
+                        // ed25519_verify then aborts on assert.
+                        true,
+                        duration,
+                        0, // group 0 = focal node proxy
+                    ),
+                    FaultScenario::AuthComputeHeavy => AbstractAccountWorkloadBuilder::from(
+                        1.0,
+                        injection_qps,
+                        num_workers,
+                        in_flight_ratio,
+                        AuthenticatorKind::SuperHeavy,
+                        TxPayloadObjType::OwnedObject,
+                        split_amount,
+                        // should_fail=true: invalid signature; node exhausts
+                        // max_auth_gas regardless. Client pays no IOTA tokens.
+                        true,
+                        duration,
+                        0, // group 0 = focal node proxy
+                    ),
+                    FaultScenario::StdInvalid => ExpectedFailureWorkloadBuilder::from(
+                        1.0,
+                        injection_qps,
+                        num_workers,
+                        in_flight_ratio,
+                        opts.num_transfer_accounts,
+                        ExpectedFailurePayloadCfg {
+                            failure_type: ExpectedFailureType::InvalidSignature,
+                        },
+                        duration,
+                        0, // group 0 = focal node proxy
+                    ),
+                };
+
+                if injection_builder.is_none() {
+                    anyhow::bail!(
+                        "ResilienceBench produced no injection workload \
+                         (injection_qps={}, num_workers={}, in_flight_ratio={})",
+                        injection_qps,
+                        num_workers,
+                        in_flight_ratio,
+                    );
+                }
+
+                // Baseline workload — plain TransferObject through the full quorum
+                // (LocalValidatorAggregatorProxy). Group 1 ensures the scheduler
+                // picks a quorum proxy rather than the focal proxy (which is pinned
+                // to group 0 / DirectValidatorProxy).
+                let baseline_builder = TransferObjectWorkloadBuilder::from(
+                    1.0,
+                    baseline_qps,
+                    4, // 4 workers is ample for a 30–100 TPS baseline
+                    5,
+                    opts.num_transfer_accounts,
+                    duration,
+                    1, // group 1 = quorum proxy, runs concurrently with group 0
+                );
+
+                Self::build(
+                    vec![injection_builder, baseline_builder],
+                    bank,
+                    system_state_observer,
+                    opts.gas_request_chunk_size,
+                )
+                .await
+            }
+
             RunSpec::AbstractAccountBench {
                 authenticator,
                 should_fail,

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -1150,7 +1150,7 @@ mod test {
         };
 
         let bench_task = tokio::spawn(async move {
-            let driver = BenchDriver::new(5, false);
+            let driver = BenchDriver::new(5, false, Default::default());
 
             // Use 0 for unbounded
             let interval = Interval::Time(test_duration);

--- a/crates/iota-network-stack/src/metrics.rs
+++ b/crates/iota-network-stack/src/metrics.rs
@@ -35,11 +35,12 @@ pub trait MetricsCallbackProvider: Send + Sync + Clone + 'static {
     /// `grpc_status_code`: the grpc status code (see <https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc>)
     fn on_response(&self, path: String, latency: Duration, status: u16, grpc_status_code: Code);
 
-    /// Called when a gRPC request completes with a non-OK status code.
+    /// Called when a gRPC request fails at the transport/middleware level
+    /// (e.g. service panic, connection drop, timeout). gRPC application
+    /// errors (non-OK status codes) are NOT reported here — they are
+    /// already captured by [`on_response`](Self::on_response).
     /// The method path is not available at this layer (tower-http's
-    /// `on_failure` callback does not receive the response object);
-    /// implementations should record failure counts keyed by status code
-    /// only.
+    /// `on_failure` callback does not receive the response object).
     fn on_error(&self, _latency: Duration, _grpc_status_code: Code) {}
 
     /// Called when request call is started
@@ -111,10 +112,11 @@ impl<M: MetricsCallbackProvider> OnFailure<GrpcFailureClass> for MetricsHandler<
         latency: Duration,
         _span: &Span,
     ) {
-        let grpc_status_code = match failure_classification {
-            GrpcFailureClass::Code(code) => Code::from(code.get()),
-            GrpcFailureClass::Error(_) => Code::Internal,
-        };
-        self.metrics_provider.on_error(latency, grpc_status_code);
+        // Only count transport/middleware errors (GrpcFailureClass::Error).
+        // GrpcFailureClass::Code variants are gRPC application errors that
+        // on_response already records with full method-path context.
+        if let GrpcFailureClass::Error(_) = failure_classification {
+            self.metrics_provider.on_error(latency, Code::Internal);
+        }
     }
 }

--- a/crates/iota-network-stack/src/metrics.rs
+++ b/crates/iota-network-stack/src/metrics.rs
@@ -36,9 +36,10 @@ pub trait MetricsCallbackProvider: Send + Sync + Clone + 'static {
     fn on_response(&self, path: String, latency: Duration, status: u16, grpc_status_code: Code);
 
     /// Called when a gRPC request completes with a non-OK status code.
-    /// The method path is not available at this layer (tower-http's `on_failure`
-    /// callback does not receive the response object); implementations should
-    /// record failure counts keyed by status code only.
+    /// The method path is not available at this layer (tower-http's
+    /// `on_failure` callback does not receive the response object);
+    /// implementations should record failure counts keyed by status code
+    /// only.
     fn on_error(&self, _latency: Duration, _grpc_status_code: Code) {}
 
     /// Called when request call is started

--- a/crates/iota-network-stack/src/metrics.rs
+++ b/crates/iota-network-stack/src/metrics.rs
@@ -35,6 +35,12 @@ pub trait MetricsCallbackProvider: Send + Sync + Clone + 'static {
     /// `grpc_status_code`: the grpc status code (see <https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc>)
     fn on_response(&self, path: String, latency: Duration, status: u16, grpc_status_code: Code);
 
+    /// Called when a gRPC request completes with a non-OK status code.
+    /// The method path is not available at this layer (tower-http's `on_failure`
+    /// callback does not receive the response object); implementations should
+    /// record failure counts keyed by status code only.
+    fn on_error(&self, _latency: Duration, _grpc_status_code: Code) {}
+
     /// Called when request call is started
     fn on_start(&self, _path: &str) {}
 
@@ -100,10 +106,14 @@ impl<B, M: MetricsCallbackProvider> OnRequest<B> for MetricsHandler<M> {
 impl<M: MetricsCallbackProvider> OnFailure<GrpcFailureClass> for MetricsHandler<M> {
     fn on_failure(
         &mut self,
-        _failure_classification: GrpcFailureClass,
-        _latency: Duration,
+        failure_classification: GrpcFailureClass,
+        latency: Duration,
         _span: &Span,
     ) {
-        // just do nothing for now so we avoid printing unnecessary logs
+        let grpc_status_code = match failure_classification {
+            GrpcFailureClass::Code(code) => Code::from(code.get()),
+            GrpcFailureClass::Error(_) => Code::Internal,
+        };
+        self.metrics_provider.on_error(latency, grpc_status_code);
     }
 }

--- a/crates/iota-node/src/metrics.rs
+++ b/crates/iota-node/src/metrics.rs
@@ -48,9 +48,9 @@ impl IotaNodeMetrics {
 pub struct GrpcMetrics {
     inflight_requests: IntGaugeVec,
     num_requests: IntCounterVec,
-    /// Counts gRPC requests that completed with a non-OK status code, by status
-    /// code. The method path is not available in `on_failure` (tower-http
-    /// limitation), so failures are labelled by status code only.
+    /// Counts gRPC requests that failed at the transport/middleware level
+    /// (e.g. service panic, connection drop, timeout). gRPC application
+    /// errors are NOT counted here — they are already in `num_requests`.
     num_errors: IntCounterVec,
     request_latency: HistogramVec,
     /// Known gRPC method paths. Paths not in this set are labelled as `"SPAM"`
@@ -70,14 +70,14 @@ impl GrpcMetrics {
             .unwrap(),
             num_requests: register_int_counter_vec_with_registry!(
                 "authority_grpc_requests",
-                "Total authority gRPC requests that completed with OK status, per method and status code",
+                "Total authority gRPC requests per method and status code",
                 &["method", "status"],
                 registry,
             )
             .unwrap(),
             num_errors: register_int_counter_vec_with_registry!(
                 "authority_grpc_errors",
-                "Total authority gRPC requests that completed with a non-OK status code, by status code (method path not available at this layer)",
+                "Total authority gRPC transport/middleware failures by status code (service panics, connection drops, timeouts)",
                 &["status"],
                 registry,
             )

--- a/crates/iota-node/src/metrics.rs
+++ b/crates/iota-node/src/metrics.rs
@@ -48,6 +48,10 @@ impl IotaNodeMetrics {
 pub struct GrpcMetrics {
     inflight_requests: IntGaugeVec,
     num_requests: IntCounterVec,
+    /// Counts gRPC requests that completed with a non-OK status code, by status
+    /// code. The method path is not available in `on_failure` (tower-http
+    /// limitation), so failures are labelled by status code only.
+    num_errors: IntCounterVec,
     request_latency: HistogramVec,
     /// Known gRPC method paths. Paths not in this set are labelled as `"SPAM"`
     /// to prevent unbounded metric cardinality from arbitrary HTTP traffic.
@@ -66,8 +70,15 @@ impl GrpcMetrics {
             .unwrap(),
             num_requests: register_int_counter_vec_with_registry!(
                 "authority_grpc_requests",
-                "Total authority gRPC requests per method and status code",
+                "Total authority gRPC requests that completed with OK status, per method and status code",
                 &["method", "status"],
+                registry,
+            )
+            .unwrap(),
+            num_errors: register_int_counter_vec_with_registry!(
+                "authority_grpc_errors",
+                "Total authority gRPC requests that completed with a non-OK status code, by status code (method path not available at this layer)",
+                &["status"],
                 registry,
             )
             .unwrap(),
@@ -104,6 +115,12 @@ impl MetricsCallbackProvider for GrpcMetrics {
         self.request_latency
             .with_label_values(&[method])
             .observe(latency.as_secs_f64());
+    }
+
+    fn on_error(&self, _latency: Duration, grpc_status_code: Code) {
+        self.num_errors
+            .with_label_values(&[grpc_code_to_str(grpc_status_code)])
+            .inc();
     }
 
     fn on_start(&self, path: &str) {

--- a/examples/move/abstract_account_for_benchmarks/sources/abstract_account.move
+++ b/examples/move/abstract_account_for_benchmarks/sources/abstract_account.move
@@ -64,7 +64,7 @@ public fun authenticate_ed25519(
     );
 }
 
-/// Ed25519 signature authenticator.
+/// Ed25519 signature authenticator
 #[authenticator]
 public fun authenticate_ed25519_heavy(
     account: &AbstractAccount,
@@ -74,7 +74,58 @@ public fun authenticate_ed25519_heavy(
 ) {
     let mut i = 0;
     while (i < 5) {
-         ed25519::ed25519_verify(
+        ed25519::ed25519_verify(
+            &decode(signature),
+            account.borrow_public_key(),
+            ctx.digest(),
+        );
+        i = i + 1;
+    };
+}
+
+/// Super-heavy authenticator: combines max-budget crypto loop
+/// with 122 additional objects.
+#[authenticator]
+public fun authenticate_super_heavy(
+    account: &AbstractAccount,
+    signature: vector<u8>,
+    _o1: &BenchObject,   _o2: &BenchObject,   _o3: &BenchObject,   _o4: &BenchObject,
+    _o5: &BenchObject,   _o6: &BenchObject,   _o7: &BenchObject,   _o8: &BenchObject,
+    _o9: &BenchObject,   _o10: &BenchObject,  _o11: &BenchObject,  _o12: &BenchObject,
+    _o13: &BenchObject,  _o14: &BenchObject,  _o15: &BenchObject,  _o16: &BenchObject,
+    _o17: &BenchObject,  _o18: &BenchObject,  _o19: &BenchObject,  _o20: &BenchObject,
+    _o21: &BenchObject,  _o22: &BenchObject,  _o23: &BenchObject,  _o24: &BenchObject,
+    _o25: &BenchObject,  _o26: &BenchObject,  _o27: &BenchObject,  _o28: &BenchObject,
+    _o29: &BenchObject,  _o30: &BenchObject,  _o31: &BenchObject,  _o32: &BenchObject,
+    _o33: &BenchObject,  _o34: &BenchObject,  _o35: &BenchObject,  _o36: &BenchObject,
+    _o37: &BenchObject,  _o38: &BenchObject,  _o39: &BenchObject,  _o40: &BenchObject,
+    _o41: &BenchObject,  _o42: &BenchObject,  _o43: &BenchObject,  _o44: &BenchObject,
+    _o45: &BenchObject,  _o46: &BenchObject,  _o47: &BenchObject,  _o48: &BenchObject,
+    _o49: &BenchObject,  _o50: &BenchObject,  _o51: &BenchObject,  _o52: &BenchObject,
+    _o53: &BenchObject,  _o54: &BenchObject,  _o55: &BenchObject,  _o56: &BenchObject,
+    _o57: &BenchObject,  _o58: &BenchObject,  _o59: &BenchObject,  _o60: &BenchObject,
+    _o61: &BenchObject,  _o62: &BenchObject,  _o63: &BenchObject,  _o64: &BenchObject,
+    _o65: &BenchObject,  _o66: &BenchObject,  _o67: &BenchObject,  _o68: &BenchObject,
+    _o69: &BenchObject,  _o70: &BenchObject,  _o71: &BenchObject,  _o72: &BenchObject,
+    _o73: &BenchObject,  _o74: &BenchObject,  _o75: &BenchObject,  _o76: &BenchObject,
+    _o77: &BenchObject,  _o78: &BenchObject,  _o79: &BenchObject,  _o80: &BenchObject,
+    _o81: &BenchObject,  _o82: &BenchObject,  _o83: &BenchObject,  _o84: &BenchObject,
+    _o85: &BenchObject,  _o86: &BenchObject,  _o87: &BenchObject,  _o88: &BenchObject,
+    _o89: &BenchObject,  _o90: &BenchObject,  _o91: &BenchObject,  _o92: &BenchObject,
+    _o93: &BenchObject,  _o94: &BenchObject,  _o95: &BenchObject,  _o96: &BenchObject,
+    _o97: &BenchObject,  _o98: &BenchObject,  _o99: &BenchObject,  _o100: &BenchObject,
+    _o101: &BenchObject, _o102: &BenchObject, _o103: &BenchObject, _o104: &BenchObject,
+    _o105: &BenchObject, _o106: &BenchObject, _o107: &BenchObject, _o108: &BenchObject,
+    _o109: &BenchObject, _o110: &BenchObject, _o111: &BenchObject, _o112: &BenchObject,
+    _o113: &BenchObject, _o114: &BenchObject, _o115: &BenchObject, _o116: &BenchObject,
+    _o117: &BenchObject, _o118: &BenchObject, _o119: &BenchObject, _o120: &BenchObject,
+    _o121: &BenchObject, _o122: &BenchObject,
+    _: &AuthContext,
+    ctx: &TxContext,
+) {
+    let mut i: u256 = 0;
+    while (i < 100000000) {
+        ed25519::ed25519_verify(
             &decode(signature),
             account.borrow_public_key(),
             ctx.digest(),


### PR DESCRIPTION
# Description of change

Adds a benchmark mode that characterizes per-validator handling of high-cost transactions while the rest of the network sustains a baseline workload through quorum. Lets us measure the practical effect of `max_auth_gas` and related caps on validator throughput under realistic mixed traffic and validate that those caps behave as designed.

- **`DirectValidatorProxy`** (`iota-benchmark/src/lib.rs`): a new `ValidatorProxy` implementation that sends transactions straight to one validator's gRPC `handle_transaction` endpoint instead of going through quorum. Useful for measuring the cost of a workload on a single node in isolation.

- **Concurrent workload groups** (`bench_driver.rs`): adds `BenchDriver::concurrent_groups`. When set, all groups start in parallel rather than serially. Group 0 is pinned to the `DirectValidatorProxy` (the node under measurement); group 1 uses the shared quorum proxy pool for the steady-state baseline.

- **Workload profiles**:
  - `auth-basic` — minimal AA authenticator: one `ed25519_verify`.
  - `auth-compute-heavy` — new `SuperHeavy` AA authenticator: 122 BenchObject reads plus a long `ed25519_verify` loop.
  - `std-invalid` — standard TransferObject with a corrupted (still well-formed) Ed25519 signature. 

## Links to any relevant issues

Fixes #11269
