### PR TITLE
feat(transaction-orchestrator): [cherry-pick] Run transaction validity checks in transaction orchestrator already (#11335)

### DIFF
--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -246,6 +246,12 @@ where
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
     ) -> Result<(VerifiedTransaction, QuorumDriverResponse), QuorumDriverError> {
+        // Reject malformed transactions before any code path inspects shared
+        // inputs or `MoveAuthenticator`
+        request
+            .transaction
+            .validity_check(epoch_store.protocol_config(), epoch_store.epoch())
+            .map_err(QuorumDriverError::InvalidTransaction)?;
         let transaction = epoch_store
             .verify_transaction(request.transaction.clone())
             .map_err(QuorumDriverError::InvalidUserSignature)?;

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -12,15 +12,17 @@ use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
 };
 use iota_test_transaction_builder::{
-    batch_make_transfer_transactions, make_staking_transaction, make_transfer_iota_transaction,
+    TestTransactionBuilder, batch_make_transfer_transactions, make_staking_transaction,
+    make_transfer_iota_transaction,
 };
 use iota_types::{
     effects::TransactionEffectsAPI,
+    error::IotaError,
     quorum_driver_types::{
         ExecuteTransactionRequestType, ExecuteTransactionRequestV1, ExecuteTransactionResponseV1,
         FinalizedEffects, IsTransactionExecutedLocally, QuorumDriverError,
     },
-    transaction::Transaction,
+    transaction::{Transaction, TransactionDataAPI, TransactionExpiration},
 };
 use test_cluster::TestClusterBuilder;
 use tokio::time::timeout;
@@ -416,4 +418,46 @@ async fn execute_transaction_v1_staking_transaction() -> Result<(), anyhow::Erro
     assert_eq!(expected_output_objects, actual_output_objects_received);
 
     Ok(())
+}
+
+// Submitting a transaction whose expiration epoch lies in the past must be
+// rejected by the orchestrator's `validity_check` before it ever reaches the
+// quorum driver. The expected surface error is `InvalidTransaction`, carrying
+// the inner `IotaError::TransactionExpired`.
+#[sim_test]
+async fn test_orchestrator_rejects_expired_transaction() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+
+    // Advance to epoch >= 1 so a transaction marked as expiring at epoch 0
+    // is past its expiration window.
+    test_cluster.force_new_epoch().await;
+
+    let context = &test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.iota_node;
+    let orchestrator = handle.with(|n| n.transaction_orchestrator().as_ref().unwrap().clone());
+
+    let (sender, gas_object) = context.get_one_gas_object().await.unwrap().unwrap();
+    let gas_price = context.get_reference_gas_price().await.unwrap();
+    let mut data = TestTransactionBuilder::new(sender, gas_object, gas_price)
+        .transfer_iota(Some(1), sender)
+        .build();
+    *data.expiration_mut_for_testing() = TransactionExpiration::Epoch(0);
+    let txn = context.sign_transaction(&data);
+
+    let err = orchestrator
+        .execute_transaction_block(
+            ExecuteTransactionRequestV1::new(txn),
+            ExecuteTransactionRequestType::WaitForEffectsCert,
+            None,
+        )
+        .await
+        .expect_err("expired transaction must be rejected by the orchestrator");
+
+    assert!(
+        matches!(
+            err,
+            QuorumDriverError::InvalidTransaction(IotaError::TransactionExpired)
+        ),
+        "expected InvalidTransaction(TransactionExpired), got {err:?}"
+    );
 }

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -293,6 +293,16 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RpcError {
                 };
                 RpcError::new(Code::InvalidArgument, message)
             }
+            InvalidTransaction(err) => {
+                let message = {
+                    let err = match err {
+                        IotaError::UserInput { error } => error.to_string(),
+                        _ => err.to_string(),
+                    };
+                    format!("Invalid transaction: {err}")
+                };
+                RpcError::new(Code::InvalidArgument, message)
+            }
             QuorumDriverInternal(err) => RpcError::new(Code::Internal, err.to_string()),
             ObjectsDoubleUsed { conflicting_txes } => {
                 let new_map = conflicting_txes

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -161,6 +161,7 @@ impl From<Error> for RpcError {
 
                 match err {
                     QuorumDriverError::InvalidUserSignature { .. }
+                    | QuorumDriverError::InvalidTransaction { .. }
                     | QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures
                     | QuorumDriverError::NonRecoverableTransactionError { .. } => {
                         let error_object = ErrorObject::owned::<()>(

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -40,6 +40,8 @@ pub enum QuorumDriverError {
     QuorumDriverInternal(IotaError),
     #[error("Invalid user signature: {0}.")]
     InvalidUserSignature(IotaError),
+    #[error("Invalid transaction: {0}.")]
+    InvalidTransaction(IotaError),
     #[error(
         "Failed to sign transaction by a quorum of validators because of locked objects: {conflicting_txes:?}"
     )]
@@ -78,6 +80,9 @@ impl QuorumDriverError {
         match self {
             QuorumDriverError::InvalidUserSignature(err) => {
                 format!("Invalid user signature: {err}")
+            }
+            QuorumDriverError::InvalidTransaction(err) => {
+                format!("Invalid transaction: {err}")
             }
             QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {
                 "The transaction is already finalized but with different user signatures"


### PR DESCRIPTION
# Description of change

User transactions are validated on fullnodes before being sent to validators via the transaction orchestrator.
