### PR TITLE
feat(starfish): bound block-header acknowledgments

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 25;
+pub const MAX_PROTOCOL_VERSION: u64 = 26;
 
 /// Protocol version that IIP8 took effect.
 pub const PROTOCOL_VERSION_IIP8: u64 = 20;
@@ -141,6 +141,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             Enable additional borrow checks.
 // Version 25: Deprecate zkLogin related parameters since zkLogin is no longer
 //             supported.
+// Version 26: Enable consensus block restrictions in devnet — bound the block
+// header             size for a given committee size.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -463,6 +465,11 @@ struct FeatureFlags {
     // commits and transactions.
     #[serde(skip_serializing_if = "is_false")]
     consensus_fast_commit_sync: bool,
+
+    // If true, enables consensus block restrictions: bounds the block header size for
+    // a given committee size.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_block_restrictions: bool,
 
     // If true, enable `TxContext` Move API to go native.
     #[serde(skip_serializing_if = "is_false")]
@@ -1477,6 +1484,14 @@ impl ProtocolConfig {
         self.consensus_max_acknowledgments_per_block.unwrap_or(400)
     }
 
+    pub fn max_acknowledgments_per_block(&self, committee_size: usize) -> usize {
+        if self.consensus_block_restrictions() {
+            2 * committee_size
+        } else {
+            self.consensus_max_acknowledgments_per_block_or_default() as usize
+        }
+    }
+
     pub fn variant_nodes(&self) -> bool {
         self.feature_flags.variant_nodes
     }
@@ -1663,6 +1678,10 @@ impl ProtocolConfig {
             "consensus_fast_commit_sync requires consensus_commit_transactions_only_for_traversed_headers to be enabled"
         );
         res
+    }
+
+    pub fn consensus_block_restrictions(&self) -> bool {
+        self.feature_flags.consensus_block_restrictions
     }
 
     pub fn move_native_tx_context(&self) -> bool {
@@ -2743,6 +2762,12 @@ impl ProtocolConfig {
                     cfg.max_jwk_votes_per_validator_per_epoch = None;
                     cfg.max_age_of_jwk_in_epochs = None;
                 }
+                26 => {
+                    if chain != Chain::Testnet && chain != Chain::Mainnet {
+                        // Bound block header size for a given committee size in devnet.
+                        cfg.feature_flags.consensus_block_restrictions = true;
+                    }
+                }
 
                 // Use this template when making changes:
                 //
@@ -2972,6 +2997,10 @@ impl ProtocolConfig {
 
     pub fn set_consensus_fast_commit_sync_for_testing(&mut self, val: bool) {
         self.feature_flags.consensus_fast_commit_sync = val;
+    }
+
+    pub fn set_consensus_block_restrictions_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_block_restrictions = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_26.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_26.snap
@@ -1,0 +1,325 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 26
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  pass_validator_scores_to_advance_epoch: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_26.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_26.snap
@@ -1,0 +1,333 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 26
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
+  pass_validator_scores_to_advance_epoch: true
+  calculate_validator_scores: true
+  consensus_fast_commit_sync: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_auth_gas: 250000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 100
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+scorer_version: 1
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_26.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_26.snap
@@ -1,0 +1,345 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 26
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  enable_poseidon: true
+  enable_group_ops_native_function_msm: true
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  enable_vdf: true
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  accept_passkey_in_multisig: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
+  enable_move_authentication_for_sponsor: true
+  pass_validator_scores_to_advance_epoch: true
+  calculate_validator_scores: true
+  adjust_rewards_by_score: true
+  pass_calculated_validator_scores_to_advance_epoch: true
+  consensus_fast_commit_sync: true
+  consensus_block_restrictions: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_auth_gas: 250000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 100
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+scorer_version: 1
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -128,6 +128,18 @@ impl BlockVerifier for SignedBlockVerifier {
                 quorum: committee.quorum_threshold(),
             });
         }
+        if self.context.protocol_config.consensus_block_restrictions() {
+            let max_acknowledgments = self
+                .context
+                .protocol_config
+                .max_acknowledgments_per_block(committee.size());
+            if block.acknowledgments().len() > max_acknowledgments {
+                return Err(ConsensusError::TooManyAcknowledgments {
+                    count: block.acknowledgments().len(),
+                    max: max_acknowledgments,
+                });
+            }
+        }
         for acknowledgment in block.acknowledgments() {
             ConsensusError::quick_validation_authority_indices(
                 &[acknowledgment.author],
@@ -378,6 +390,32 @@ pub(crate) mod test {
             assert!(matches!(
                 verifier.verify(&signed_block),
                 Err(ConsensusError::TooManyAncestors(_, _))
+            ));
+        }
+
+        // Block with too many acknowledgments.
+        {
+            let committee_size = 4u8;
+            let max_acknowledgments = 2 * committee_size;
+            // Build acknowledgments at rounds (1..) that don't overlap with the
+            // ancestors above (rounds 7 and 9).
+            let acknowledgments = (0..=max_acknowledgments)
+                .map(|i| {
+                    BlockRef::new(
+                        (i / committee_size + 1) as u32,
+                        AuthorityIndex::new_for_test(i % committee_size),
+                        BlockHeaderDigest::MIN,
+                    )
+                })
+                .collect::<Vec<_>>();
+            let block = test_block
+                .clone()
+                .set_acknowledgments(acknowledgments)
+                .build();
+            let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::TooManyAcknowledgments { .. })
             ));
         }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -852,11 +852,14 @@ impl Core {
 
         // Consume the acknowledgments about transaction data availability for past
         // blocks to be included.
-        let acknowledgments = self.dag_state.write().take_acknowledgments(
-            self.context
-                .protocol_config
-                .consensus_max_acknowledgments_per_block_or_default() as usize,
-        );
+        let max_acknowledgments = self
+            .context
+            .protocol_config
+            .max_acknowledgments_per_block(self.context.committee.size());
+        let acknowledgments = self
+            .dag_state
+            .write()
+            .take_acknowledgments(max_acknowledgments);
 
         self.context
             .metrics
@@ -1879,11 +1882,11 @@ mod test {
             }
         }
 
-        // Second set dummy acknowledgments in DagState. First 200 acknowledgments are
-        // from eligible round; the rest are from the clock round, thereby they
-        // will not be taken when creating a block
+        // Second set dummy acknowledgments in DagState. First `num_acks`
+        // acknowledgments are from an eligible round; the rest are from the
+        // clock round, thereby they will not be taken when creating a block.
         let mut acknowledgments = vec![];
-        let num_acks = 200;
+        let num_acks = 2 * context.committee.size();
         let mut num_pending_acks = 0;
         let mut rng = &mut rand::thread_rng();
         loop {

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -142,6 +142,9 @@ pub(crate) enum ConsensusError {
     #[error("Too many ancestors in the block: {0} > {1}")]
     TooManyAncestors(usize, usize),
 
+    #[error("Too many acknowledgments in the block: {count} > {max}")]
+    TooManyAcknowledgments { count: usize, max: usize },
+
     #[error("Merkle tree has no root (empty shard list)")]
     EmptyMerkleTree,
 


### PR DESCRIPTION
# Description of change

Introduces the `consensus_block_restrictions` protocol-config feature flag (enabled in devnet at protocol v26). Under the flag, the number of acknowledgments per block is bounded by `2 * committee_size` both at proposal time and in the block verifier. Centralizes the cap in `ProtocolConfig::max_acknowledgments_per_block(committee_size)`.

## Links to any relevant issues

Fixes #11361
Part of #11323

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes