### PR TITLE
feat(consensus): seed ack tracker on recovery for optimistic commits

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1674,7 +1674,12 @@ impl ProtocolConfig {
     }
 
     pub fn consensus_starfish_speed(&self) -> bool {
-        self.feature_flags.consensus_starfish_speed
+        let res = self.feature_flags.consensus_starfish_speed;
+        assert!(
+            !res || self.consensus_fast_commit_sync(),
+            "consensus_starfish_speed requires consensus_fast_commit_sync to be enabled"
+        );
+        res
     }
 }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -61,11 +61,12 @@ pub(crate) type WaveNumber = u32;
 pub(crate) enum Commit {
     V1(CommitV1),
     V2(CommitV2),
+    V3(CommitV3),
 }
 
 impl Commit {
-    /// Create a new commit. The variant (V1 or V2) is determined by the
-    /// consensus_fast_commit_sync protocol flag.
+    /// Create a new commit. The variant (V1, V2, or V3) is determined by the
+    /// consensus_fast_commit_sync and consensus_starfish_speed protocol flags.
     pub(crate) fn new(
         context: &Arc<Context>,
         index: CommitIndex,
@@ -75,8 +76,33 @@ impl Commit {
         blocks: Vec<BlockRef>,
         committed_transactions: Vec<GenericTransactionRef>,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
+        is_optimistic: bool,
     ) -> Self {
-        if context.protocol_config.consensus_fast_commit_sync() {
+        if context.protocol_config.consensus_starfish_speed() {
+            debug!("Creating CommitV3 as consensus_starfish_speed is enabled");
+            // consensus_starfish_speed implies consensus_fast_commit_sync (asserted in
+            // protocol config), so all committed transactions are TransactionRefs.
+            let transaction_refs: Vec<TransactionRef> = committed_transactions
+                .into_iter()
+                .map(|gen_ref| match gen_ref {
+                    GenericTransactionRef::TransactionRef(tr) => tr,
+                    GenericTransactionRef::BlockRef(_) => {
+                        panic!("Expected TransactionRef when consensus_starfish_speed is enabled")
+                    }
+                })
+                .collect();
+
+            Commit::V3(CommitV3 {
+                index,
+                previous_digest,
+                timestamp_ms,
+                leader,
+                block_headers: blocks,
+                committed_transactions: transaction_refs,
+                reputation_scores_desc,
+                is_optimistic,
+            })
+        } else if context.protocol_config.consensus_fast_commit_sync() {
             debug!("Creating CommitV2 as consensus_fast_commit_sync is enabled");
             // Extract TransactionRefs from GenericTransactionRef
             let transaction_refs: Vec<TransactionRef> = committed_transactions
@@ -138,6 +164,7 @@ pub(crate) trait CommitAPI {
     fn block_headers(&self) -> &[BlockRef];
     fn committed_transactions(&self) -> Vec<GenericTransactionRef>;
     fn reputation_scores(&self) -> &[(AuthorityIndex, u64)];
+    fn is_optimistic(&self) -> bool;
 }
 
 /// Specifies one consensus commit.
@@ -199,6 +226,10 @@ impl CommitAPI for CommitV1 {
     fn reputation_scores(&self) -> &[(AuthorityIndex, u64)] {
         // CommitV1 does not have reputation scores
         &[]
+    }
+
+    fn is_optimistic(&self) -> bool {
+        false
     }
 }
 
@@ -265,6 +296,82 @@ impl CommitAPI for CommitV2 {
     fn reputation_scores(&self) -> &[(AuthorityIndex, u64)] {
         &self.reputation_scores_desc
     }
+
+    fn is_optimistic(&self) -> bool {
+        false
+    }
+}
+
+/// Specifies one consensus commit.
+/// It is stored on disk, so it does not contain blocks which are stored
+/// individually.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub(crate) struct CommitV3 {
+    /// Index of the commit.
+    /// First commit after genesis has an index of 1, then every next commit has
+    /// an index incremented by 1.
+    index: CommitIndex,
+    /// Digest of the previous commit.
+    /// Set to CommitDigest::MIN for the first commit after genesis.
+    previous_digest: CommitDigest,
+    /// Timestamp of the commit, max of the timestamp of the leader block and
+    /// previous Commit timestamp.
+    timestamp_ms: BlockTimestampMs,
+    /// A reference to the commit leader.
+    leader: BlockRef,
+    /// Refs to committed headers, in the commit order.
+    block_headers: Vec<BlockRef>,
+    /// Refs to transactions in blocks for which quorum of acknowledgments has
+    /// been collected in this and past commits.
+    committed_transactions: Vec<TransactionRef>,
+    /// Optional scores that are provided as part of the consensus output to
+    /// IOTA that can then be used by IOTA for future transaction submission to
+    /// consensus.
+    reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
+    /// True if the leader was committed via the StarfishSpeed Optimistic
+    /// metastate.
+    is_optimistic: bool,
+}
+
+impl CommitAPI for CommitV3 {
+    fn round(&self) -> Round {
+        self.leader.round
+    }
+
+    fn index(&self) -> CommitIndex {
+        self.index
+    }
+
+    fn previous_digest(&self) -> CommitDigest {
+        self.previous_digest
+    }
+
+    fn timestamp_ms(&self) -> BlockTimestampMs {
+        self.timestamp_ms
+    }
+
+    fn leader(&self) -> BlockRef {
+        self.leader
+    }
+
+    fn block_headers(&self) -> &[BlockRef] {
+        &self.block_headers
+    }
+
+    fn committed_transactions(&self) -> Vec<GenericTransactionRef> {
+        self.committed_transactions
+            .iter()
+            .map(|t| GenericTransactionRef::TransactionRef(*t))
+            .collect()
+    }
+
+    fn reputation_scores(&self) -> &[(AuthorityIndex, u64)] {
+        &self.reputation_scores_desc
+    }
+
+    fn is_optimistic(&self) -> bool {
+        self.is_optimistic
+    }
 }
 
 /// A commit is trusted when it is produced locally or certified by a quorum of
@@ -310,6 +417,7 @@ impl TrustedCommit {
             blocks,
             committed_transactions,
             vec![],
+            false,
         );
         let serialized = commit.serialize().unwrap();
         Self::new_trusted(commit, serialized)

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -346,10 +346,10 @@ impl CommitObserver {
                     );
                 }
 
-                // Re-seed the tracker for refs that were optimistically committed
-                // pre-restart so natural acks post-restart don't push them across
-                // 2f+1 again. Full committee is a conservative over-approximation;
-                // persisting the actual strong-voter set is a follow-up.
+                // Repopulate the ack tracker for transactions optimistically committed
+                // pre-restart so post-restart acks don't cross 2f+1 and re-commit them.
+                // The full committee is used as a conservative over-approximation of
+                // the actual acknowledging set.
                 if is_optimistic {
                     let leader_ref = pending_sub_dag.leader;
                     let leader_header = pending_sub_dag

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -1457,18 +1457,15 @@ mod tests {
         while receiver.try_recv().is_ok() {}
         drop(observer);
         let mut observer_after = CommitObserver::new(
-            context.clone(),
+            context,
             CommitConsumer::new(sender, 0),
             dag_state.clone(),
-            mem_store.clone(),
+            mem_store,
             leader_schedule,
         );
         while receiver.try_recv().is_ok() {}
 
-        builder
-            .layers(6..=8)
-            .build()
-            .persist_layers(dag_state.clone());
+        builder.layers(6..=8).build().persist_layers(dag_state);
         let later_leaders: Vec<_> = builder.leader_blocks(6..=8).into_iter().flatten().collect();
         let (later_commits, _) = observer_after
             .handle_committed_leaders(

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::{
     CommitConsumer, CommittedSubDag,
-    block_header::{BlockHeaderAPI, VerifiedBlockHeader},
+    block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
     commit::{
         CommitAPI, CommitIndex, CommitMetastate, PendingSubDag, TrustedCommit,
         load_pending_subdag_from_store,
@@ -326,6 +326,7 @@ impl CommitObserver {
         for commit in recovery_commits {
             // Recovery only needs headers/acks, so reputation scores are irrelevant here.
             let commit_index = commit.index();
+            let is_optimistic = commit.is_optimistic();
             let pending_sub_dag =
                 load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
 
@@ -343,6 +344,29 @@ impl CommitObserver {
                         authority_idx,
                         transaction_acknowledgments,
                     );
+                }
+
+                // Re-seed the tracker for refs that were optimistically committed
+                // pre-restart so natural acks post-restart don't push them across
+                // 2f+1 again. Full committee is a conservative over-approximation;
+                // persisting the actual strong-voter set is a follow-up.
+                if is_optimistic {
+                    let leader_ref = pending_sub_dag.leader;
+                    let leader_header = pending_sub_dag
+                        .headers
+                        .iter()
+                        .find(|h| h.reference() == leader_ref)
+                        .expect("leader header must be present in pending sub-dag");
+                    let refs: Vec<BlockRef> = std::iter::once(leader_ref)
+                        .chain(leader_header.acknowledgments().iter().copied())
+                        .collect();
+                    for (authority_idx, _) in self.context.committee.authorities() {
+                        let _ = self.linearizer.add_committed_transaction_acks(
+                            leader_header.round() + 1,
+                            authority_idx,
+                            refs.clone(),
+                        );
+                    }
                 }
             }
 
@@ -645,6 +669,7 @@ mod tests {
         dag_state::{DagState, DataSource},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
+        transaction_ref::GenericTransactionRefAPI,
     };
 
     #[tokio::test]
@@ -1331,5 +1356,200 @@ mod tests {
 
         // Verify that txs_after significantly exceeds txs_before
         assert!(txs_after >= txs_before * 4,);
+    }
+
+    /// Run the commit pipeline through a restart. With `starfish_speed` true,
+    /// L5 is committed Optimistically (full-committee strong-voters); with
+    /// false, L5 is committed standardly. Returns L5's ref, L5's acks, the
+    /// refs in L5's commit, and the refs across all post-restart commits.
+    async fn run_recovery_scenario(
+        starfish_speed: bool,
+    ) -> (
+        BlockRef,
+        Vec<BlockRef>,
+        Vec<GenericTransactionRef>,
+        Vec<GenericTransactionRef>,
+    ) {
+        let num_authorities = 4;
+
+        let mut protocol_config =
+            iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE();
+        protocol_config.set_consensus_starfish_speed_for_testing(starfish_speed);
+
+        let (committee, _keypairs) =
+            starfish_config::local_committee_and_keys(0, vec![1; num_authorities]);
+        let metrics = crate::metrics::test_metrics();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let clock = Arc::new(crate::context::Clock::default());
+        let context = Arc::new(Context::new(
+            0,
+            starfish_config::AuthorityIndex::new_for_test(0),
+            committee,
+            starfish_config::Parameters {
+                db_path: temp_dir.keep(),
+                ..Default::default()
+            },
+            protocol_config,
+            metrics,
+            clock,
+        ));
+
+        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            mem_store.clone(),
+        )));
+        let (sender, mut receiver) = unbounded_channel("consensus_output");
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
+            context.clone(),
+            dag_state.clone(),
+        ));
+
+        let mut observer = CommitObserver::new(
+            context.clone(),
+            CommitConsumer::new(sender.clone(), 0),
+            dag_state.clone(),
+            mem_store.clone(),
+            leader_schedule.clone(),
+        );
+
+        let mut builder = DagBuilder::new(context.clone());
+        builder
+            .layers(1..=5)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        let leaders_1_to_4: Vec<_> = builder
+            .leader_blocks(1..=4)
+            .into_iter()
+            .map(Option::unwrap)
+            .collect();
+        let l5 = builder
+            .leader_block(5)
+            .expect("leader at round 5 should exist");
+        let l5_ref = l5.reference();
+        let l5_acks: Vec<BlockRef> = l5.acknowledgments().to_vec();
+
+        observer
+            .handle_committed_leaders(
+                with_no_metastate(leaders_1_to_4),
+                CommittedSubDagSource::Consensus,
+            )
+            .unwrap();
+
+        let l5_meta = if starfish_speed {
+            let strong_voters: Vec<AuthorityIndex> = (0..num_authorities as u8)
+                .map(AuthorityIndex::new_for_test)
+                .collect();
+            vec![(l5, Some(CommitMetastate::Optimistic), strong_voters)]
+        } else {
+            with_no_metastate(vec![l5])
+        };
+        let (pre_commits, _) = observer
+            .handle_committed_leaders(l5_meta, CommittedSubDagSource::Consensus)
+            .unwrap();
+        let pre_refs = pre_commits
+            .last()
+            .expect("at least one commit")
+            .committed_transaction_refs
+            .clone();
+
+        while receiver.try_recv().is_ok() {}
+        drop(observer);
+        let mut observer_after = CommitObserver::new(
+            context.clone(),
+            CommitConsumer::new(sender, 0),
+            dag_state.clone(),
+            mem_store.clone(),
+            leader_schedule,
+        );
+        while receiver.try_recv().is_ok() {}
+
+        builder
+            .layers(6..=8)
+            .build()
+            .persist_layers(dag_state.clone());
+        let later_leaders: Vec<_> = builder.leader_blocks(6..=8).into_iter().flatten().collect();
+        let (later_commits, _) = observer_after
+            .handle_committed_leaders(
+                with_no_metastate(later_leaders),
+                CommittedSubDagSource::Consensus,
+            )
+            .unwrap();
+        let post_refs: Vec<GenericTransactionRef> = later_commits
+            .iter()
+            .flat_map(|c| c.committed_transaction_refs.iter().cloned())
+            .collect();
+
+        (l5_ref, l5_acks, pre_refs, post_refs)
+    }
+
+    /// With `consensus_starfish_speed` ON, L5 is committed Optimistically and
+    /// its ref + acks land in commit 5 (early); recovery seeding then
+    /// suppresses re-commit post-restart. With the flag OFF, L5 is
+    /// committed standardly: its ref + acks are NOT in commit 5 and appear
+    /// only later, when natural 2f+1 acks accumulate across post-restart
+    /// commits.
+    #[tokio::test]
+    async fn test_optimistic_vs_standard_recovery_timing() {
+        telemetry_subscribers::init_for_testing();
+
+        let (l5_ref_on, l5_acks_on, pre_on, post_on) = run_recovery_scenario(true).await;
+        let (l5_ref_off, l5_acks_off, pre_off, post_off) = run_recovery_scenario(false).await;
+
+        assert!(!l5_acks_on.is_empty(), "leader should have acks");
+        assert!(!l5_acks_off.is_empty(), "leader should have acks");
+
+        let contains = |refs: &[GenericTransactionRef], target: &BlockRef| -> bool {
+            refs.iter()
+                .any(|r| r.round() == target.round && r.author() == target.author)
+        };
+
+        // Flag ON: L5's ref + every ack land in L5's commit (early), and
+        // recovery seeding suppresses re-commit post-restart.
+        assert!(
+            contains(&pre_on, &l5_ref_on),
+            "ON: L5's commit should include L5_ref"
+        );
+        for ack in &l5_acks_on {
+            assert!(
+                contains(&pre_on, ack),
+                "ON: L5's commit should include L5_ack {ack:?}"
+            );
+        }
+        assert!(
+            !contains(&post_on, &l5_ref_on),
+            "ON: post-restart commits must NOT re-include L5_ref"
+        );
+        for ack in &l5_acks_on {
+            assert!(
+                !contains(&post_on, ack),
+                "ON: post-restart commits must NOT re-include L5_ack {ack:?}"
+            );
+        }
+
+        // Flag OFF: L5's ref + acks are NOT in L5's commit (no Optimistic
+        // pre-credit); they appear only in some later commit when 2f+1 acks
+        // accumulate naturally.
+        assert!(
+            !contains(&pre_off, &l5_ref_off),
+            "OFF: L5's commit must NOT include L5_ref"
+        );
+        for ack in &l5_acks_off {
+            assert!(
+                !contains(&pre_off, ack),
+                "OFF: L5's commit must NOT include L5_ack {ack:?}"
+            );
+        }
+        assert!(
+            contains(&post_off, &l5_ref_off),
+            "OFF: post-restart commits SHOULD include L5_ref once natural acks accumulate"
+        );
+        for ack in &l5_acks_off {
+            assert!(
+                contains(&post_off, ack),
+                "OFF: post-restart commits SHOULD include L5_ack {ack:?} once natural acks accumulate"
+            );
+        }
     }
 }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -207,6 +207,7 @@ impl Linearizer {
                 .collect::<Vec<BlockRef>>(),
             committed_transactions_refs,
             reputation_scores_desc.clone(),
+            metastate == Some(CommitMetastate::Optimistic),
         );
         let serialized = commit
             .serialize()


### PR DESCRIPTION
# Description of change

Persists an `is_optimistic` bit in commits when `consensus_starfish_speed` is on (new `CommitV3`) and re-seeds the linearizer's per-ref ack tracker from those bits during recovery, so refs that were optimistically committed pre-restart are not re-committed when natural acks accumulate post-restart. Also asserts that `consensus_starfish_speed` requires `consensus_fast_commit_sync`, mirroring the existing dependency check on the latter.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
