### PR TITLE
chore: Revert some Identifier changes from "Replace Identifier, StructTag and TypeTag with SDK versions (#10075)" (#11355)

### DIFF
--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -18,7 +18,7 @@ use iota_package_management::{
     system_package_versions::{SYSTEM_GIT_REPO, SystemPackagesVersion},
 };
 use iota_types::{
-    base_types::{Identifier, IotaAddress, ObjectID},
+    base_types::{IotaAddress, ObjectID},
     error::{IotaError, IotaResult},
     move_package::{
         FnInfo, FnInfoKey, FnInfoMap, IotaAttribute, MovePackage, RuntimeModuleMetadata,
@@ -372,8 +372,8 @@ fn fill_metadata(package: &mut MoveCompiledPackage, fn_info_map: &FnInfoMap) -> 
         let mut runtime_metadata = RuntimeModuleMetadata::default();
         for fn_def in &module.function_defs {
             let fn_handle = module.function_handle_at(fn_def.function);
-            let fn_name = Identifier::new_unchecked(module.identifier_at(fn_handle.name).as_str());
-            if let Some(version) = get_authenticator_version_from_fun(&fn_name, module, fn_info_map)
+            let fn_name = module.identifier_at(fn_handle.name);
+            if let Some(version) = get_authenticator_version_from_fun(fn_name.as_str(), module, fn_info_map)
             {
                 runtime_metadata.add_function_attribute(
                     fn_name.to_string(),

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -373,7 +373,8 @@ fn fill_metadata(package: &mut MoveCompiledPackage, fn_info_map: &FnInfoMap) -> 
         for fn_def in &module.function_defs {
             let fn_handle = module.function_handle_at(fn_def.function);
             let fn_name = module.identifier_at(fn_handle.name);
-            if let Some(version) = get_authenticator_version_from_fun(fn_name.as_str(), module, fn_info_map)
+            if let Some(version) =
+                get_authenticator_version_from_fun(fn_name.as_str(), module, fn_info_map)
             {
                 runtime_metadata.add_function_attribute(
                     fn_name.to_string(),

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -628,7 +628,7 @@ impl UpgradeReceipt {
 }
 
 /// Checks if a function is annotated with one of the test-related annotations
-pub fn is_test_fun(name: &Identifier, module: &CompiledModule, fn_info_map: &FnInfoMap) -> bool {
+pub fn is_test_fun(name: &str, module: &CompiledModule, fn_info_map: &FnInfoMap) -> bool {
     let fn_name = name.to_string();
     let mod_handle = module.self_handle();
     let mod_addr = IotaAddress::new(
@@ -649,7 +649,7 @@ pub fn is_test_fun(name: &Identifier, module: &CompiledModule, fn_info_map: &FnI
 }
 
 pub fn get_authenticator_version_from_fun(
-    name: &Identifier,
+    name: &str,
     module: &CompiledModule,
     fn_info_map: &FnInfoMap,
 ) -> Option<u8> {

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -629,7 +629,6 @@ impl UpgradeReceipt {
 
 /// Checks if a function is annotated with one of the test-related annotations
 pub fn is_test_fun(name: &str, module: &CompiledModule, fn_info_map: &FnInfoMap) -> bool {
-    let fn_name = name.to_string();
     let mod_handle = module.self_handle();
     let mod_addr = IotaAddress::new(
         module
@@ -638,7 +637,7 @@ pub fn is_test_fun(name: &str, module: &CompiledModule, fn_info_map: &FnInfoMap)
     );
     let mod_name = module.name().to_string();
     let fn_info_key = FnInfoKey {
-        fn_name,
+        fn_name: name.to_string(),
         mod_name,
         mod_addr,
     };
@@ -653,7 +652,6 @@ pub fn get_authenticator_version_from_fun(
     module: &CompiledModule,
     fn_info_map: &FnInfoMap,
 ) -> Option<u8> {
-    let fn_name = name.to_string();
     let mod_handle = module.self_handle();
     let mod_addr = IotaAddress::from(
         module
@@ -662,7 +660,7 @@ pub fn get_authenticator_version_from_fun(
     );
     let mod_name = module.name().to_string();
     let fn_info_key = FnInfoKey {
-        fn_name,
+        fn_name: name.to_string(),
         mod_name,
         mod_addr,
     };

--- a/iota-execution/latest/iota-adapter/src/execution_value.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_value.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_types::{
-    base_types::{Identifier, IotaAddress, ObjectID, SequenceNumber},
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
     coin::Coin,
     error::{ExecutionError, ExecutionErrorKind, IotaError},
     execution_status::CommandArgumentError,
@@ -12,7 +12,7 @@ use iota_types::{
     transfer::Receiving,
 };
 use move_binary_format::file_format::AbilitySet;
-use move_core_types::resolver::ResourceResolver;
+use move_core_types::{identifier::IdentStr, resolver::ResourceResolver};
 use move_vm_types::loaded_data::runtime_types::Type;
 use serde::Deserialize;
 
@@ -75,8 +75,8 @@ pub enum UsageKind {
 pub enum CommandKind<'a> {
     MoveCall {
         package: ObjectID,
-        module: &'a Identifier,
-        function: &'a Identifier,
+        module: &'a IdentStr,
+        function: &'a IdentStr,
     },
     MakeMoveVec,
     TransferObjects,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -1122,7 +1122,7 @@ mod checked {
         pub(crate) fn execute_function_bypass_visibility(
             &mut self,
             module: &ModuleId,
-            function_name: &Identifier,
+            function_name: &IdentStr,
             ty_args: Vec<Type>,
             args: Vec<impl Borrow<[u8]>>,
             tracer: &mut Option<MoveTraceBuilder>,
@@ -1131,7 +1131,7 @@ mod checked {
             let mut data_store = IotaDataStore::new(&self.linkage_view, &self.new_packages);
             self.vm.get_runtime().execute_function_bypass_visibility(
                 module,
-                IdentStr::new(function_name.as_str()).unwrap(),
+                function_name,
                 ty_args,
                 args,
                 &mut data_store,
@@ -1148,13 +1148,13 @@ mod checked {
         pub(crate) fn load_function(
             &mut self,
             module_id: &ModuleId,
-            function_name: &Identifier,
+            function_name: &IdentStr,
             type_arguments: &[Type],
         ) -> VMResult<LoadedFunctionInstantiation> {
             let mut data_store = IotaDataStore::new(&self.linkage_view, &self.new_packages);
             self.vm.get_runtime().load_function(
                 module_id,
-                IdentStr::new(function_name.as_str()).unwrap(),
+                function_name,
                 type_arguments,
                 &mut data_store,
             )

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -1464,8 +1464,7 @@ mod checked {
     ) -> Result<(), ExecutionError> {
         let module_addr = module_id.address();
         let module_name = module_id.name();
-        if module_addr.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
-            && module_name == EVENT_MODULE
+        if module_addr.as_ref() == IotaAddress::FRAMEWORK.as_bytes() && module_name == EVENT_MODULE
         {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::NonEntryFunctionInvoked,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -17,7 +17,6 @@ mod checked {
     use iota_move_natives::object_runtime::ObjectRuntime;
     use iota_protocol_config::ProtocolConfig;
     use iota_types::{
-        IOTA_FRAMEWORK_ADDRESS,
         auth_context,
         base_types::{
             IotaAddress, MoveLegacyTxContext, MoveObjectType, ObjectID,
@@ -1465,14 +1464,16 @@ mod checked {
     ) -> Result<(), ExecutionError> {
         let module_addr = module_id.address();
         let module_name = module_id.name();
-        if *module_addr == IOTA_FRAMEWORK_ADDRESS && module_name == EVENT_MODULE {
+        if module_addr.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
+            && module_name == EVENT_MODULE
+        {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::NonEntryFunctionInvoked,
                 format!("Cannot directly call functions in iota::{EVENT_MODULE}"),
             ));
         }
 
-        if *module_addr == IOTA_FRAMEWORK_ADDRESS
+        if module_addr.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
             && module_name == TRANSFER_MODULE
             && PRIVATE_TRANSFER_FUNCTIONS.contains(&function)
         {
@@ -1486,7 +1487,7 @@ mod checked {
             ));
         }
 
-        if *module_addr == IOTA_FRAMEWORK_ADDRESS
+        if module_addr.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
             && module_name == ACCOUNT_MODULE
             && PRIVATE_ACCOUNT_FUNCTIONS.contains(&function)
         {
@@ -1798,7 +1799,7 @@ mod checked {
             invariant_violation!("Loaded struct not found")
         };
         let (module_addr, module_name, struct_name) = get_datatype_ident(&s);
-        let is_tx_context_type = *module_addr == IOTA_FRAMEWORK_ADDRESS
+        let is_tx_context_type = module_addr.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
             && module_name == ident_str!("tx_context")
             && struct_name == ident_str!("TxContext");
         Ok(if is_tx_context_type {

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -17,9 +17,10 @@ mod checked {
     use iota_move_natives::object_runtime::ObjectRuntime;
     use iota_protocol_config::ProtocolConfig;
     use iota_types::{
+        IOTA_FRAMEWORK_ADDRESS,
         auth_context,
         base_types::{
-            Identifier, IotaAddress, MoveLegacyTxContext, MoveObjectType, ObjectID,
+            IotaAddress, MoveLegacyTxContext, MoveObjectType, ObjectID,
             RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, StructTag, TxContext,
             TxContextKind, TypeTag,
         },
@@ -59,8 +60,8 @@ mod checked {
         normalized,
     };
     use move_core_types::{
-        account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
-        u256::U256,
+        account_address::AccountAddress, ident_str, identifier::IdentStr,
+        language_storage::ModuleId, u256::U256,
     };
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::{
@@ -356,12 +357,9 @@ mod checked {
                 }
 
                 let original_address = context.set_link_context(package)?;
-                let storage_id = ModuleId::new(AccountAddress::new(package.into_bytes()), unsafe {
-                    move_core_types::identifier::Identifier::new_unchecked(module.as_str())
-                });
-                let runtime_id = ModuleId::new(original_address, unsafe {
-                    move_core_types::identifier::Identifier::new_unchecked(module.as_str())
-                });
+                let storage_id =
+                    ModuleId::new(AccountAddress::new(package.into_bytes()), module.clone());
+                let runtime_id = ModuleId::new(original_address, module);
                 let return_values = execute_move_call::<Mode>(
                     context,
                     &mut argument_updates,
@@ -408,7 +406,7 @@ mod checked {
         argument_updates: &mut Mode::ArgumentUpdates,
         storage_id: &ModuleId,
         runtime_id: &ModuleId,
-        function: &Identifier,
+        function: &IdentStr,
         type_arguments: Vec<Type>,
         arguments: Vec<Arg>,
         is_init: bool,
@@ -1049,7 +1047,7 @@ mod checked {
     fn vm_move_call(
         context: &mut ExecutionContext<'_, '_, '_>,
         module_id: &ModuleId,
-        function: &Identifier,
+        function: &IdentStr,
         type_arguments: Vec<Type>,
         tx_context_kind: TxContextKind,
         has_auth_context: bool,
@@ -1185,7 +1183,7 @@ mod checked {
         let modules_to_init = modules.iter().filter_map(|module| {
             for fdef in &module.function_defs {
                 let fhandle = module.function_handle_at(fdef.function);
-                let fname = Identifier::new_unchecked(module.identifier_at(fhandle.name).as_str());
+                let fname = module.identifier_at(fhandle.name);
                 if fname == INIT_FN_NAME {
                     return Some(module.self_id());
                 }
@@ -1202,7 +1200,7 @@ mod checked {
                 // for some reason, then we would need to perform relocation here.
                 &module_id,
                 &module_id,
-                &INIT_FN_NAME,
+                INIT_FN_NAME,
                 vec![],
                 vec![],
                 // is_init
@@ -1261,7 +1259,7 @@ mod checked {
     fn check_visibility_and_signature<Mode: ExecutionMode>(
         context: &mut ExecutionContext<'_, '_, '_>,
         module_id: &ModuleId,
-        function: &Identifier,
+        function: &IdentStr,
         type_arguments: &[Type],
         from_init: bool,
     ) -> Result<LoadedFunctionInfo, ExecutionError> {
@@ -1300,7 +1298,7 @@ mod checked {
         };
 
         // entry on init is banned, so ban invoking it
-        if !from_init && function == &INIT_FN_NAME {
+        if !from_init && function == INIT_FN_NAME {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::NonEntryFunctionInvoked,
                 "Cannot call 'init'",
@@ -1318,7 +1316,7 @@ mod checked {
             (Visibility::Public, false) => FunctionKind::NonEntry,
             (Visibility::Private, false) if from_init => {
                 assert_invariant!(
-                    function == &INIT_FN_NAME,
+                    function == INIT_FN_NAME,
                     "module init specified non-init function"
                 );
                 FunctionKind::Init
@@ -1392,7 +1390,7 @@ mod checked {
     fn check_non_entry_signature<Mode: ExecutionMode>(
         context: &mut ExecutionContext<'_, '_, '_>,
         _module_id: &ModuleId,
-        _function: &Identifier,
+        _function: &IdentStr,
         signature: &LoadedFunctionInstantiation,
     ) -> Result<Vec<ValueKind>, ExecutionError> {
         signature
@@ -1462,22 +1460,21 @@ mod checked {
     fn check_private_generics(
         _context: &mut ExecutionContext,
         module_id: &ModuleId,
-        function: &Identifier,
+        function: &IdentStr,
         _type_arguments: &[Type],
     ) -> Result<(), ExecutionError> {
-        let module_ident = (
-            IotaAddress::new(module_id.address().into_bytes()),
-            Identifier::new_unchecked(module_id.name().as_str()),
-        );
-        if module_ident == (IotaAddress::FRAMEWORK, EVENT_MODULE) {
+        let module_addr = module_id.address();
+        let module_name = module_id.name();
+        if *module_addr == IOTA_FRAMEWORK_ADDRESS && module_name == EVENT_MODULE {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::NonEntryFunctionInvoked,
                 format!("Cannot directly call functions in iota::{EVENT_MODULE}"),
             ));
         }
 
-        if module_ident == (IotaAddress::FRAMEWORK, TRANSFER_MODULE)
-            && PRIVATE_TRANSFER_FUNCTIONS.contains(function)
+        if *module_addr == IOTA_FRAMEWORK_ADDRESS
+            && module_name == TRANSFER_MODULE
+            && PRIVATE_TRANSFER_FUNCTIONS.contains(&function)
         {
             let msg = format!(
                 "Cannot directly call iota::{TRANSFER_MODULE}::{function}. \
@@ -1489,8 +1486,9 @@ mod checked {
             ));
         }
 
-        if module_ident == (IotaAddress::FRAMEWORK, ACCOUNT_MODULE)
-            && PRIVATE_ACCOUNT_FUNCTIONS.contains(function)
+        if *module_addr == IOTA_FRAMEWORK_ADDRESS
+            && module_name == ACCOUNT_MODULE
+            && PRIVATE_ACCOUNT_FUNCTIONS.contains(&function)
         {
             let msg = format!("Cannot directly call iota::{ACCOUNT_MODULE}::{function}.");
             return Err(ExecutionError::new_with_source(
@@ -1515,7 +1513,7 @@ mod checked {
     fn build_move_args<Mode: ExecutionMode>(
         context: &mut ExecutionContext<'_, '_, '_>,
         module_id: &ModuleId,
-        function: &Identifier,
+        function: &IdentStr,
         function_kind: FunctionKind,
         signature: &LoadedFunctionInstantiation,
         args: &[Arg],
@@ -1575,7 +1573,7 @@ mod checked {
         let mut serialized_args = Vec::with_capacity(num_args);
         let command_kind = CommandKind::MoveCall {
             package: ObjectID::new(module_id.address().into_bytes()),
-            module: &Identifier::new_unchecked(module_id.name().as_str()),
+            module: module_id.name(),
             function,
         };
         // an init function can have one or two arguments, with the last one always
@@ -1739,9 +1737,9 @@ mod checked {
     fn to_identifier(
         context: &mut ExecutionContext<'_, '_, '_>,
         ident: String,
-    ) -> Result<Identifier, ExecutionError> {
+    ) -> Result<move_core_types::identifier::Identifier, ExecutionError> {
         if context.protocol_config.validate_identifier_inputs() {
-            Identifier::new(ident).map_err(|e| {
+            move_core_types::identifier::Identifier::new(ident).map_err(|e| {
                 ExecutionError::new_with_source(
                     ExecutionErrorKind::VMInvariantViolation,
                     e.to_string(),
@@ -1749,7 +1747,7 @@ mod checked {
             })
         } else {
             // SAFETY: Preserving existing behaviour for identifier deserialization.
-            Ok(Identifier::new_unchecked(&ident))
+            Ok(unsafe { move_core_types::identifier::Identifier::new_unchecked(ident) })
         }
     }
 
@@ -1800,9 +1798,9 @@ mod checked {
             invariant_violation!("Loaded struct not found")
         };
         let (module_addr, module_name, struct_name) = get_datatype_ident(&s);
-        let is_tx_context_type = module_addr.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
-            && module_name.as_str() == Identifier::TX_CONTEXT_MODULE.as_str()
-            && struct_name.as_str() == Identifier::TX_CONTEXT.as_str();
+        let is_tx_context_type = *module_addr == IOTA_FRAMEWORK_ADDRESS
+            && module_name == ident_str!("tx_context")
+            && struct_name == ident_str!("TxContext");
         Ok(if is_tx_context_type {
             if is_mut {
                 TxContextKind::Mutable

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -19,7 +19,7 @@ mod checked {
     use iota_types::{
         auth_context,
         base_types::{
-            IotaAddress, MoveLegacyTxContext, MoveObjectType, ObjectID,
+            Identifier, IotaAddress, MoveLegacyTxContext, MoveObjectType, ObjectID,
             RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, StructTag, TxContext,
             TxContextKind, TypeTag,
         },
@@ -59,8 +59,8 @@ mod checked {
         normalized,
     };
     use move_core_types::{
-        account_address::AccountAddress, ident_str, identifier::IdentStr,
-        language_storage::ModuleId, u256::U256,
+        account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+        u256::U256,
     };
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::{
@@ -1800,8 +1800,8 @@ mod checked {
         };
         let (module_addr, module_name, struct_name) = get_datatype_ident(&s);
         let is_tx_context_type = module_addr.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
-            && module_name == ident_str!("tx_context")
-            && struct_name == ident_str!("TxContext");
+            && module_name.as_str() == Identifier::TX_CONTEXT_MODULE.as_str()
+            && struct_name.as_str() == Identifier::TX_CONTEXT.as_str();
         Ok(if is_tx_context_type {
             if is_mut {
                 TxContextKind::Mutable

--- a/iota-execution/latest/iota-move-natives/src/lib.rs
+++ b/iota-execution/latest/iota-move-natives/src/lib.rs
@@ -12,6 +12,7 @@ use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     annotated_value as A,
     gas_algebra::InternalGas,
+    identifier::Identifier,
     language_storage::{StructTag, TypeTag},
     runtime_value as R,
     vm_status::StatusCode,
@@ -1315,8 +1316,8 @@ pub fn all_natives(silent: bool, protocol_config: &ProtocolConfig) -> NativeFunc
             .map(|(module_name, func_name, func)| {
                 (
                     IOTA_FRAMEWORK_ADDRESS,
-                    move_core_types::identifier::Identifier::new(module_name).unwrap(),
-                    move_core_types::identifier::Identifier::new(func_name).unwrap(),
+                    Identifier::new(module_name).unwrap(),
+                    Identifier::new(func_name).unwrap(),
                     func,
                 )
             });
@@ -1331,8 +1332,8 @@ pub fn all_natives(silent: bool, protocol_config: &ProtocolConfig) -> NativeFunc
         .map(|(module_name, func_name, func)| {
             (
                 IOTA_SYSTEM_ADDRESS,
-                move_core_types::identifier::Identifier::new(module_name).unwrap(),
-                move_core_types::identifier::Identifier::new(func_name).unwrap(),
+                Identifier::new(module_name).unwrap(),
+                Identifier::new(func_name).unwrap(),
                 func,
             )
         })

--- a/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
@@ -14,12 +14,12 @@ use iota_types::{
     is_object_struct, is_primitive_strict,
     transfer::Receiving,
 };
-use move_core_types::identifier::IdentStr;
 use move_binary_format::{
     CompiledModule,
     file_format::{AbilitySet, SignatureToken, Visibility},
 };
 use move_bytecode_utils::format_signature_token;
+use move_core_types::identifier::IdentStr;
 
 use crate::verification_failure;
 

--- a/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
@@ -9,11 +9,12 @@
 /// authenticator function.
 use iota_types::{
     auth_context::{AuthContext, AuthContextKind},
-    base_types::{Identifier, TxContext, TxContextKind},
+    base_types::{TxContext, TxContextKind},
     error::ExecutionError,
     is_object_struct, is_primitive_strict,
     transfer::Receiving,
 };
+use move_core_types::identifier::IdentStr;
 use move_binary_format::{
     CompiledModule,
     file_format::{AbilitySet, SignatureToken, Visibility},
@@ -37,7 +38,7 @@ use crate::verification_failure;
 /// - TxContext has to be an immutable reference
 pub fn verify_authenticate_func_v1(
     module: &CompiledModule,
-    function_identifier: Identifier,
+    function_identifier: &IdentStr,
 ) -> Result<(), ExecutionError> {
     let module_name = module.name();
 

--- a/iota-execution/latest/iota-verifier/src/entry_points_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/entry_points_verifier.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_types::{
-    base_types::{IotaAddress, TxContext, TxContextKind},
+    base_types::{Identifier, IotaAddress, TxContext, TxContextKind},
     clock::Clock,
     error::ExecutionError,
     is_object, is_object_vector, is_primitive,
@@ -16,7 +16,6 @@ use move_binary_format::{
     file_format::{AbilitySet, Bytecode, FunctionDefinition, SignatureToken, Visibility},
 };
 use move_bytecode_utils::format_signature_token;
-use move_core_types::ident_str;
 
 use crate::{INIT_FN_NAME, verification_failure};
 
@@ -164,8 +163,8 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
             module.self_id(),
             INIT_FN_NAME,
             IotaAddress::FRAMEWORK,
-            ident_str!("tx_context"),
-            ident_str!("TxContext"),
+            Identifier::TX_CONTEXT_MODULE,
+            Identifier::TX_CONTEXT,
             format_signature_token(module, &parameters[0]),
         ))
     }

--- a/iota-execution/latest/iota-verifier/src/entry_points_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/entry_points_verifier.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_types::{
-    base_types::{Identifier, IotaAddress, TxContext, TxContextKind},
+    IOTA_FRAMEWORK_ADDRESS,
+    base_types::{TxContext, TxContextKind},
     clock::Clock,
     error::ExecutionError,
     is_object, is_object_vector, is_primitive,
@@ -16,6 +17,7 @@ use move_binary_format::{
     file_format::{AbilitySet, Bytecode, FunctionDefinition, SignatureToken, Visibility},
 };
 use move_bytecode_utils::format_signature_token;
+use move_core_types::ident_str;
 
 use crate::{INIT_FN_NAME, verification_failure};
 
@@ -47,10 +49,10 @@ pub fn verify_module(
 
     for func_def in &module.function_defs {
         let handle = module.function_handle_at(func_def.function);
-        let name = Identifier::new_unchecked(module.identifier_at(handle.name).as_str());
+        let name = module.identifier_at(handle.name);
 
         // allow calling init function in the test code
-        if !is_test_fun(&name, module, fn_info_map) {
+        if !is_test_fun(name.as_str(), module, fn_info_map) {
             verify_init_not_called(module, func_def).map_err(verification_failure)?;
         }
 
@@ -90,7 +92,7 @@ fn verify_init_not_called(
             _ => None,
         })
         .try_for_each(|(idx, fhandle)| {
-            let name = Identifier::new_unchecked(module.identifier_at(fhandle.name).as_str());
+            let name = module.identifier_at(fhandle.name);
             if name == INIT_FN_NAME {
                 Err(format!(
                     "{}::{} at offset {}. Cannot call a module's '{}' function from another Move function",
@@ -162,9 +164,9 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
             but found {5}",
             module.self_id(),
             INIT_FN_NAME,
-            IotaAddress::FRAMEWORK,
-            Identifier::TX_CONTEXT_MODULE,
-            Identifier::TX_CONTEXT,
+            IOTA_FRAMEWORK_ADDRESS,
+            ident_str!("tx_context"),
+            ident_str!("TxContext"),
             format_signature_token(module, &parameters[0]),
         ))
     }

--- a/iota-execution/latest/iota-verifier/src/entry_points_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/entry_points_verifier.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_types::{
-    IOTA_FRAMEWORK_ADDRESS,
-    base_types::{TxContext, TxContextKind},
+    base_types::{IotaAddress, TxContext, TxContextKind},
     clock::Clock,
     error::ExecutionError,
     is_object, is_object_vector, is_primitive,
@@ -164,7 +163,7 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
             but found {5}",
             module.self_id(),
             INIT_FN_NAME,
-            IOTA_FRAMEWORK_ADDRESS,
+            IotaAddress::FRAMEWORK,
             ident_str!("tx_context"),
             ident_str!("TxContext"),
             format_signature_token(module, &parameters[0]),

--- a/iota-execution/latest/iota-verifier/src/lib.rs
+++ b/iota-execution/latest/iota-verifier/src/lib.rs
@@ -14,13 +14,10 @@ pub mod private_generics;
 pub mod runtime_module_metadata;
 pub mod struct_with_key_verifier;
 
-use iota_types::{
-    base_types::Identifier,
-    error::{ExecutionError, ExecutionErrorKind},
-};
-use move_core_types::vm_status::StatusCode;
+use iota_types::error::{ExecutionError, ExecutionErrorKind};
+use move_core_types::{ident_str, identifier::IdentStr, vm_status::StatusCode};
 
-pub const INIT_FN_NAME: Identifier = Identifier::from_static("init");
+pub const INIT_FN_NAME: &IdentStr = ident_str!("init");
 pub const TEST_SCENARIO_MODULE_NAME: &str = "test_scenario";
 
 fn verification_failure(error: String) -> ExecutionError {

--- a/iota-execution/latest/iota-verifier/src/one_time_witness_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/one_time_witness_verifier.rs
@@ -22,6 +22,7 @@
 //! - it is never instantiated anywhere in its defining module
 use iota_types::{
     IOTA_FRAMEWORK_ADDRESS,
+    base_types::IotaAddress,
     error::ExecutionError,
     move_package::{FnInfoMap, is_test_fun},
 };
@@ -187,7 +188,7 @@ fn verify_init_single_param(
              single field of type bool",
             module.self_id(),
             INIT_FN_NAME,
-            IOTA_FRAMEWORK_ADDRESS,
+            IotaAddress::FRAMEWORK,
             ident_str!("tx_context"),
             ident_str!("TxContext"),
             module.self_id(),

--- a/iota-execution/latest/iota-verifier/src/one_time_witness_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/one_time_witness_verifier.rs
@@ -22,7 +22,6 @@
 //! - it is never instantiated anywhere in its defining module
 use iota_types::{
     IOTA_FRAMEWORK_ADDRESS,
-    base_types::{Identifier, IotaAddress},
     error::ExecutionError,
     move_package::{FnInfoMap, is_test_fun},
 };
@@ -84,7 +83,7 @@ pub fn verify_module(
     }
     for fn_def in &module.function_defs {
         let fn_handle = module.function_handle_at(fn_def.function);
-        let fn_name = Identifier::new_unchecked(module.identifier_at(fn_handle.name).as_str());
+        let fn_name = module.identifier_at(fn_handle.name);
         if fn_name == INIT_FN_NAME {
             if let Some((candidate_name, candidate_handle, _)) = one_time_witness_candidate {
                 // only verify if init function conforms to one-time witness type requirements
@@ -102,7 +101,7 @@ pub fn verify_module(
             // one-time witness type candidate and if instantiation does not
             // happen in test code
 
-            if !is_test_fun(&fn_name, module, fn_info_map) {
+            if !is_test_fun(fn_name.as_str(), module, fn_info_map) {
                 verify_no_instantiations(module, fn_def, candidate_name, def)
                     .map_err(verification_failure)?;
             }
@@ -188,9 +187,9 @@ fn verify_init_single_param(
              single field of type bool",
             module.self_id(),
             INIT_FN_NAME,
-            IotaAddress::FRAMEWORK,
-            Identifier::TX_CONTEXT_MODULE,
-            Identifier::TX_CONTEXT,
+            IOTA_FRAMEWORK_ADDRESS,
+            ident_str!("tx_context"),
+            ident_str!("TxContext"),
             module.self_id(),
             module.self_id().name().as_str().to_uppercase(),
         ));

--- a/iota-execution/latest/iota-verifier/src/one_time_witness_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/one_time_witness_verifier.rs
@@ -22,7 +22,7 @@
 //! - it is never instantiated anywhere in its defining module
 use iota_types::{
     IOTA_FRAMEWORK_ADDRESS,
-    base_types::IotaAddress,
+    base_types::{Identifier, IotaAddress},
     error::ExecutionError,
     move_package::{FnInfoMap, is_test_fun},
 };
@@ -189,8 +189,8 @@ fn verify_init_single_param(
             module.self_id(),
             INIT_FN_NAME,
             IotaAddress::FRAMEWORK,
-            ident_str!("tx_context"),
-            ident_str!("TxContext"),
+            Identifier::TX_CONTEXT_MODULE,
+            Identifier::TX_CONTEXT,
             module.self_id(),
             module.self_id().name().as_str().to_uppercase(),
         ));

--- a/iota-execution/latest/iota-verifier/src/private_generics.rs
+++ b/iota-execution/latest/iota-verifier/src/private_generics.rs
@@ -102,12 +102,12 @@ fn verify_function(view: &CompiledModule, fdef: &FunctionDefinition) -> Result<(
             let mhandle = view.module_handle_at(fhandle.module);
 
             let type_arguments = &view.signature_at(*type_parameters).0;
-            let (maddr, mname) = addr_module(view, mhandle);
-            if maddr == IotaAddress::FRAMEWORK && mname == TRANSFER_MODULE {
+            let ident = addr_module(view, mhandle);
+            if ident == (IotaAddress::FRAMEWORK, TRANSFER_MODULE) {
                 verify_private_transfer_module_functions(view, fhandle, type_arguments)?
-            } else if maddr == IotaAddress::FRAMEWORK && mname == EVENT_MODULE {
+            } else if ident == (IotaAddress::FRAMEWORK, EVENT_MODULE) {
                 verify_private_event_emit(view, fhandle, type_arguments)?
-            } else if maddr == IotaAddress::FRAMEWORK && mname == ACCOUNT_MODULE {
+            } else if ident == (IotaAddress::FRAMEWORK, ACCOUNT_MODULE) {
                 verify_private_account_module_functions(view, fhandle, type_arguments)?
             }
         }
@@ -121,8 +121,7 @@ fn verify_private_transfer_module_functions(
     type_arguments: &[SignatureToken],
 ) -> Result<(), String> {
     let self_handle = view.module_handle_at(view.self_handle_idx());
-    let (self_addr, self_name) = addr_module(view, self_handle);
-    if self_addr == IotaAddress::FRAMEWORK && self_name == TRANSFER_MODULE {
+    if addr_module(view, self_handle) == (IotaAddress::FRAMEWORK, TRANSFER_MODULE) {
         return Ok(());
     }
     let fident = view.identifier_at(fhandle.name);
@@ -163,8 +162,7 @@ fn verify_private_account_module_functions(
     type_arguments: &[SignatureToken],
 ) -> Result<(), String> {
     let self_handle = view.module_handle_at(view.self_handle_idx());
-    let (self_addr, self_name) = addr_module(view, self_handle);
-    if self_addr == IotaAddress::FRAMEWORK && self_name == ACCOUNT_MODULE {
+    if addr_module(view, self_handle) == (IotaAddress::FRAMEWORK, ACCOUNT_MODULE) {
         return Ok(());
     }
     let fident = view.identifier_at(fhandle.name);

--- a/iota-execution/latest/iota-verifier/src/private_generics.rs
+++ b/iota-execution/latest/iota-verifier/src/private_generics.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_types::{
-    base_types::{Identifier, IotaAddress},
+    base_types::IotaAddress,
     error::ExecutionError,
 };
 use move_binary_format::{
@@ -14,43 +14,43 @@ use move_binary_format::{
     },
 };
 use move_bytecode_utils::format_signature_token;
-use move_core_types::identifier::IdentStr;
+use move_core_types::{ident_str, identifier::IdentStr};
 
 use crate::{TEST_SCENARIO_MODULE_NAME, verification_failure};
 
-pub const TRANSFER_MODULE: Identifier = Identifier::from_static("transfer");
-pub const ACCOUNT_MODULE: Identifier = Identifier::from_static("account");
-pub const EVENT_MODULE: Identifier = Identifier::from_static("event");
-pub const EVENT_FUNCTION: Identifier = Identifier::from_static("emit");
-pub const GET_EVENTS_TEST_FUNCTION: Identifier = Identifier::from_static("events_by_type");
-pub const PUBLIC_TRANSFER_FUNCTIONS: [Identifier; 5] = [
-    Identifier::from_static("public_transfer"),
-    Identifier::from_static("public_freeze_object"),
-    Identifier::from_static("public_share_object"),
-    Identifier::from_static("public_receive"),
-    Identifier::from_static("receiving_object_id"),
+pub const TRANSFER_MODULE: &IdentStr = ident_str!("transfer");
+pub const ACCOUNT_MODULE: &IdentStr = ident_str!("account");
+pub const EVENT_MODULE: &IdentStr = ident_str!("event");
+pub const EVENT_FUNCTION: &IdentStr = ident_str!("emit");
+pub const GET_EVENTS_TEST_FUNCTION: &IdentStr = ident_str!("events_by_type");
+pub const PUBLIC_TRANSFER_FUNCTIONS: &[&IdentStr] = &[
+    ident_str!("public_transfer"),
+    ident_str!("public_freeze_object"),
+    ident_str!("public_share_object"),
+    ident_str!("public_receive"),
+    ident_str!("receiving_object_id"),
 ];
-pub const PRIVATE_TRANSFER_FUNCTIONS: [Identifier; 4] = [
-    Identifier::from_static("transfer"),
-    Identifier::from_static("freeze_object"),
-    Identifier::from_static("share_object"),
-    Identifier::from_static("receive"),
+pub const PRIVATE_TRANSFER_FUNCTIONS: &[&IdentStr] = &[
+    ident_str!("transfer"),
+    ident_str!("freeze_object"),
+    ident_str!("share_object"),
+    ident_str!("receive"),
 ];
-pub const TRANSFER_IMPL_FUNCTIONS: [Identifier; 4] = [
-    Identifier::from_static("transfer_impl"),
-    Identifier::from_static("freeze_object_impl"),
-    Identifier::from_static("share_object_impl"),
-    Identifier::from_static("receive_impl"),
+pub const TRANSFER_IMPL_FUNCTIONS: &[&IdentStr] = &[
+    ident_str!("transfer_impl"),
+    ident_str!("freeze_object_impl"),
+    ident_str!("share_object_impl"),
+    ident_str!("receive_impl"),
 ];
 
-pub const PUBLIC_ACCOUNT_FUNCTIONS: [Identifier; 2] = [
-    Identifier::from_static("borrow_auth_function_ref_v1"),
-    Identifier::from_static("has_auth_function_ref_v1"),
+pub const PUBLIC_ACCOUNT_FUNCTIONS: &[&IdentStr] = &[
+    ident_str!("borrow_auth_function_ref_v1"),
+    ident_str!("has_auth_function_ref_v1"),
 ];
-pub const PRIVATE_ACCOUNT_FUNCTIONS: [Identifier; 3] = [
-    Identifier::from_static("create_account_v1"),
-    Identifier::from_static("create_immutable_account_v1"),
-    Identifier::from_static("rotate_auth_function_ref_v1"),
+pub const PRIVATE_ACCOUNT_FUNCTIONS: &[&IdentStr] = &[
+    ident_str!("create_account_v1"),
+    ident_str!("create_immutable_account_v1"),
+    ident_str!("rotate_auth_function_ref_v1"),
 ];
 
 /// All transfer functions (the functions in `iota::transfer`) are "private" in
@@ -65,7 +65,7 @@ pub const PRIVATE_ACCOUNT_FUNCTIONS: [Identifier; 3] = [
 /// - `T` must be a type declared in the current module
 pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
     if module.address().as_ref() == IotaAddress::FRAMEWORK.as_bytes()
-        && module.name() == IdentStr::new(TEST_SCENARIO_MODULE_NAME).unwrap()
+        && module.name().as_str() == TEST_SCENARIO_MODULE_NAME
     {
         // exclude test_module which is a test-only module in the IOTA framework which
         // "emulates" transactional execution and needs to allow test code to
@@ -102,12 +102,12 @@ fn verify_function(view: &CompiledModule, fdef: &FunctionDefinition) -> Result<(
             let mhandle = view.module_handle_at(fhandle.module);
 
             let type_arguments = &view.signature_at(*type_parameters).0;
-            let ident = addr_module(view, mhandle);
-            if ident == (IotaAddress::FRAMEWORK, TRANSFER_MODULE) {
+            let (maddr, mname) = addr_module(view, mhandle);
+            if maddr == IotaAddress::FRAMEWORK && mname == TRANSFER_MODULE {
                 verify_private_transfer_module_functions(view, fhandle, type_arguments)?
-            } else if ident == (IotaAddress::FRAMEWORK, EVENT_MODULE) {
+            } else if maddr == IotaAddress::FRAMEWORK && mname == EVENT_MODULE {
                 verify_private_event_emit(view, fhandle, type_arguments)?
-            } else if ident == (IotaAddress::FRAMEWORK, ACCOUNT_MODULE) {
+            } else if maddr == IotaAddress::FRAMEWORK && mname == ACCOUNT_MODULE {
                 verify_private_account_module_functions(view, fhandle, type_arguments)?
             }
         }
@@ -121,10 +121,11 @@ fn verify_private_transfer_module_functions(
     type_arguments: &[SignatureToken],
 ) -> Result<(), String> {
     let self_handle = view.module_handle_at(view.self_handle_idx());
-    if addr_module(view, self_handle) == (IotaAddress::FRAMEWORK, TRANSFER_MODULE) {
+    let (self_addr, self_name) = addr_module(view, self_handle);
+    if self_addr == IotaAddress::FRAMEWORK && self_name == TRANSFER_MODULE {
         return Ok(());
     }
-    let fident = Identifier::new_unchecked(view.identifier_at(fhandle.name).as_str());
+    let fident = view.identifier_at(fhandle.name);
     // public transfer functions require `store` and have no additional rules
     if PUBLIC_TRANSFER_FUNCTIONS.contains(&fident) {
         return Ok(());
@@ -162,10 +163,11 @@ fn verify_private_account_module_functions(
     type_arguments: &[SignatureToken],
 ) -> Result<(), String> {
     let self_handle = view.module_handle_at(view.self_handle_idx());
-    if addr_module(view, self_handle) == (IotaAddress::FRAMEWORK, ACCOUNT_MODULE) {
+    let (self_addr, self_name) = addr_module(view, self_handle);
+    if self_addr == IotaAddress::FRAMEWORK && self_name == ACCOUNT_MODULE {
         return Ok(());
     }
-    let fident = Identifier::new_unchecked(view.identifier_at(fhandle.name).as_str());
+    let fident = view.identifier_at(fhandle.name);
     // public account functions have no additional rules
     if PUBLIC_ACCOUNT_FUNCTIONS.contains(&fident) {
         return Ok(());
@@ -202,11 +204,11 @@ fn verify_private_event_emit(
     type_arguments: &[SignatureToken],
 ) -> Result<(), String> {
     let fident = view.identifier_at(fhandle.name);
-    if fident.as_str() == GET_EVENTS_TEST_FUNCTION.as_str() {
+    if fident == GET_EVENTS_TEST_FUNCTION {
         // test-only function with no params--no need to verify
         return Ok(());
     }
-    if fident.as_str() != EVENT_FUNCTION.as_str() {
+    if fident != EVENT_FUNCTION {
         debug_assert!(false, "unknown event function {fident}");
         return Err(format!("Calling unknown event function, {fident}"));
     };
@@ -257,11 +259,8 @@ fn is_defined_in_current_module(view: &CompiledModule, type_arg: &SignatureToken
     }
 }
 
-fn addr_module(view: &CompiledModule, mhandle: &ModuleHandle) -> (IotaAddress, Identifier) {
+fn addr_module<'a>(view: &'a CompiledModule, mhandle: &ModuleHandle) -> (IotaAddress, &'a IdentStr) {
     let maddr = view.address_identifier_at(mhandle.address);
     let mident = view.identifier_at(mhandle.name);
-    (
-        IotaAddress::new(maddr.into_bytes()),
-        Identifier::new(mident.as_str()).unwrap(),
-    )
+    (IotaAddress::new(maddr.into_bytes()), mident)
 }

--- a/iota-execution/latest/iota-verifier/src/private_generics.rs
+++ b/iota-execution/latest/iota-verifier/src/private_generics.rs
@@ -2,10 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::{
-    base_types::IotaAddress,
-    error::ExecutionError,
-};
+use iota_types::{base_types::IotaAddress, error::ExecutionError};
 use move_binary_format::{
     CompiledModule,
     file_format::{
@@ -257,7 +254,10 @@ fn is_defined_in_current_module(view: &CompiledModule, type_arg: &SignatureToken
     }
 }
 
-fn addr_module<'a>(view: &'a CompiledModule, mhandle: &ModuleHandle) -> (IotaAddress, &'a IdentStr) {
+fn addr_module<'a>(
+    view: &'a CompiledModule,
+    mhandle: &ModuleHandle,
+) -> (IotaAddress, &'a IdentStr) {
     let maddr = view.address_identifier_at(mhandle.address);
     let mident = view.identifier_at(mhandle.name);
     (IotaAddress::new(maddr.into_bytes()), mident)

--- a/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
+++ b/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
@@ -11,7 +11,6 @@
 use std::collections::BTreeSet;
 
 use iota_types::{
-    base_types::Identifier,
     error::ExecutionError,
     move_package::{IotaAttribute, RuntimeModuleMetadata, RuntimeModuleMetadataWrapper},
 };
@@ -80,14 +79,14 @@ fn verify_runtime_metadata(
                     match attr.version {
                         1 => {
                             // Version 1: verify that the function is a valid authenticator
-                            verify_authenticate_func_v1(
-                                module,
-                                Identifier::new(fn_name.clone()).map_err(|err| {
-                                    verification_failure(format!(
-                                        "Failed to read function name: {err}",
-                                    ))
-                                })?,
-                            )?;
+                            let ident =
+                                move_core_types::identifier::Identifier::new(fn_name.clone())
+                                    .map_err(|err| {
+                                        verification_failure(format!(
+                                            "Failed to read function name: {err}",
+                                        ))
+                                    })?;
+                            verify_authenticate_func_v1(module, &ident)?;
                         }
                         _ => {
                             return Err(verification_failure(format!(

--- a/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
+++ b/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
@@ -15,6 +15,7 @@ use iota_types::{
     move_package::{IotaAttribute, RuntimeModuleMetadata, RuntimeModuleMetadataWrapper},
 };
 use move_binary_format::{file_format::CompiledModule, file_format_common::IOTA_METADATA_KEY};
+use move_core_types::identifier::Identifier;
 
 use crate::{authenticator_verifier::verify_authenticate_func_v1, verification_failure};
 
@@ -79,14 +80,14 @@ fn verify_runtime_metadata(
                     match attr.version {
                         1 => {
                             // Version 1: verify that the function is a valid authenticator
-                            let ident =
-                                move_core_types::identifier::Identifier::new(fn_name.clone())
-                                    .map_err(|err| {
-                                        verification_failure(format!(
-                                            "Failed to read function name: {err}",
-                                        ))
-                                    })?;
-                            verify_authenticate_func_v1(module, &ident)?;
+                            verify_authenticate_func_v1(
+                                module,
+                                &Identifier::new(fn_name.clone()).map_err(|err| {
+                                    verification_failure(format!(
+                                        "Failed to read function name: {err}",
+                                    ))
+                                })?,
+                            )?;
                         }
                         _ => {
                             return Err(verification_failure(format!(

--- a/iota-execution/latest/iota-verifier/src/struct_with_key_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/struct_with_key_verifier.rs
@@ -8,8 +8,7 @@
 //! - The first field has type `iota::object::UID`
 
 use iota_types::{
-    IOTA_FRAMEWORK_ADDRESS,
-    base_types::StructTag,
+    base_types::{IotaAddress, StructTag},
     error::ExecutionError,
     fp_ensure,
 };
@@ -68,7 +67,7 @@ fn verify_key_structs(module: &CompiledModule) -> Result<(), ExecutionError> {
         let uid_type_module_name = module.identifier_at(uid_type_module.name);
         fp_ensure!(
             uid_type_struct_name == ident_str!("UID")
-                && *uid_type_module_address == IOTA_FRAMEWORK_ADDRESS
+                && uid_type_module_address.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
                 && uid_type_module_name == ident_str!("object"),
             verification_failure(format!(
                 "First field of struct {name} must be of type {}, \

--- a/iota-execution/latest/iota-verifier/src/struct_with_key_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/struct_with_key_verifier.rs
@@ -8,12 +8,11 @@
 //! - The first field has type `iota::object::UID`
 
 use iota_types::{
-    base_types::{IotaAddress, StructTag},
+    base_types::{Identifier, IotaAddress, StructTag},
     error::ExecutionError,
     fp_ensure,
 };
 use move_binary_format::file_format::{CompiledModule, SignatureToken};
-use move_core_types::ident_str;
 
 use crate::verification_failure;
 
@@ -66,9 +65,9 @@ fn verify_key_structs(module: &CompiledModule) -> Result<(), ExecutionError> {
         let uid_type_module_address = module.address_identifier_at(uid_type_module.address);
         let uid_type_module_name = module.identifier_at(uid_type_module.name);
         fp_ensure!(
-            uid_type_struct_name == ident_str!("UID")
+            uid_type_struct_name.as_str() == Identifier::UID.as_str()
                 && uid_type_module_address.as_ref() == IotaAddress::FRAMEWORK.as_bytes()
-                && uid_type_module_name == ident_str!("object"),
+                && uid_type_module_name.as_str() == Identifier::OBJECT_MODULE.as_str(),
             verification_failure(format!(
                 "First field of struct {name} must be of type {}, \
                 {uid_type_module_address}::{uid_type_module_name}::{uid_type_struct_name} type found",

--- a/iota-execution/latest/iota-verifier/src/struct_with_key_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/struct_with_key_verifier.rs
@@ -8,11 +8,13 @@
 //! - The first field has type `iota::object::UID`
 
 use iota_types::{
-    base_types::{Identifier, ObjectID, StructTag},
+    IOTA_FRAMEWORK_ADDRESS,
+    base_types::StructTag,
     error::ExecutionError,
     fp_ensure,
 };
 use move_binary_format::file_format::{CompiledModule, SignatureToken};
+use move_core_types::ident_str;
 
 use crate::verification_failure;
 
@@ -65,9 +67,9 @@ fn verify_key_structs(module: &CompiledModule) -> Result<(), ExecutionError> {
         let uid_type_module_address = module.address_identifier_at(uid_type_module.address);
         let uid_type_module_name = module.identifier_at(uid_type_module.name);
         fp_ensure!(
-            uid_type_struct_name.as_str() == Identifier::UID.as_str()
-                && uid_type_module_address.as_ref() == ObjectID::FRAMEWORK.as_bytes()
-                && uid_type_module_name.as_str() == Identifier::OBJECT_MODULE.as_str(),
+            uid_type_struct_name == ident_str!("UID")
+                && *uid_type_module_address == IOTA_FRAMEWORK_ADDRESS
+                && uid_type_module_name == ident_str!("object"),
             verification_failure(format!(
                 "First field of struct {name} must be of type {}, \
                 {uid_type_module_address}::{uid_type_module_name}::{uid_type_struct_name} type found",


### PR DESCRIPTION
# Description of change

- Reverts the move_core_types::identifier::IdentStr/Identifier → iota_sdk_types::Identifier replacement inside iota-execution, keeping SDK Identifier only at boundary points where types cross crate boundaries (e.g., Command::move_call construction, Event::new)
- Internal functions, constants, and comparisons use move_core_types IdentStr directly, eliminating unnecessary conversions at the Move VM boundary
- Changes is_test_fun and get_authenticator_version_from_fun in iota_types::move_package to accept &str instead of &Identifier, since they only need the string value
- StructTag, TypeTag, and ObjectID SDK replacements from the original commit are intentionally kept, as they are needed by external types (Event, MoveObjectType, execution results)