### PR TITLE
fix(graphql): make test_transaction_execution robust to skipped optimistic indexing

### DIFF
--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -466,8 +466,9 @@ mod tests {
             }
             "#;
 
-        let response_fields =
-            format!("effects {{ transactionBlock {{ {tx_block_gql_fields} }} }} errors");
+        let response_fields = format!(
+            "effects {{ checkpoint {{ sequenceNumber }} transactionBlock {{ {tx_block_gql_fields} }} }} errors"
+        );
 
         let tx = cluster.build_transfer_iota_for_test().await;
         let signed_tx = cluster.sign_transaction(&tx);
@@ -531,7 +532,11 @@ mod tests {
         assert_eq!(mutation_tx_data, immediate_tx_data);
         assert_eq!(immediate_tx_data, checkpointed_tx_data);
 
-        // Check that optimistic indexing happened
+        // The mutation response carries a checkpoint only when optimistic
+        // indexing was skipped and the executor fell back to checkpointed reads.
+        let optimistically_indexed =
+            execute_transaction_block_res["effects"]["checkpoint"].is_null();
+
         let digest_bytes = Base58::decode(digest).unwrap();
         let pool = cluster.indexer_store.blocking_cp();
 
@@ -543,10 +548,18 @@ mod tests {
         })
         .unwrap();
 
-        assert_eq!(
-            count, 1,
-            "Transaction should be present in optimistic_transactions table"
-        );
+        if optimistically_indexed {
+            assert_eq!(
+                count, 1,
+                "Transaction should be present in optimistic_transactions table"
+            );
+        } else {
+            assert_eq!(
+                count, 0,
+                "Transaction should NOT be present in optimistic_transactions table \
+                 when optimistic indexing was skipped"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description of change

When the optimistic indexer skips a transaction (e.g. because its dependencies are not yet indexed), the executor falls back to checkpointed reads and the mutation response carries a checkpoint. In that case the optimistic_transactions table will not contain the transaction, so assert the opposite instead of unconditionally expecting the row.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11354

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

