### PR TITLE
feat(starfish): bound acknowledgments and verify ancestor/ack round-gap

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1294,7 +1294,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "25",
+              "maxSupportedProtocolVersion": "26",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_passkey_in_multisig": false,
@@ -1306,6 +1306,7 @@
                 "congestion_control_min_free_execution_slot": false,
                 "congestion_limit_overshoot_in_gas_price_feedback_mechanism": false,
                 "consensus_batched_block_sync": false,
+                "consensus_block_restrictions": false,
                 "consensus_commit_transactions_only_for_traversed_headers": false,
                 "consensus_distributed_vote_scoring_strategy": false,
                 "consensus_fast_commit_sync": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -464,6 +464,11 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     consensus_fast_commit_sync: bool,
 
+    // If true, enables consensus block restrictions: bounds the block header size for
+    // a given committee size.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_block_restrictions: bool,
+
     // If true, enable `TxContext` Move API to go native.
     #[serde(skip_serializing_if = "is_false")]
     move_native_tx_context: bool,
@@ -1477,6 +1482,14 @@ impl ProtocolConfig {
         self.consensus_max_acknowledgments_per_block.unwrap_or(400)
     }
 
+    pub fn max_acknowledgments_per_block(&self, committee_size: usize) -> usize {
+        if self.consensus_block_restrictions() {
+            2 * committee_size
+        } else {
+            self.consensus_max_acknowledgments_per_block_or_default() as usize
+        }
+    }
+
     pub fn variant_nodes(&self) -> bool {
         self.feature_flags.variant_nodes
     }
@@ -1663,6 +1676,10 @@ impl ProtocolConfig {
             "consensus_fast_commit_sync requires consensus_commit_transactions_only_for_traversed_headers to be enabled"
         );
         res
+    }
+
+    pub fn consensus_block_restrictions(&self) -> bool {
+        self.feature_flags.consensus_block_restrictions
     }
 
     pub fn move_native_tx_context(&self) -> bool {
@@ -2972,6 +2989,10 @@ impl ProtocolConfig {
 
     pub fn set_consensus_fast_commit_sync_for_testing(&mut self, val: bool) {
         self.feature_flags.consensus_fast_commit_sync = val;
+    }
+
+    pub fn set_consensus_block_restrictions_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_block_restrictions = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 25;
+pub const MAX_PROTOCOL_VERSION: u64 = 26;
 
 /// Protocol version that IIP8 took effect.
 pub const PROTOCOL_VERSION_IIP8: u64 = 20;
@@ -2759,6 +2759,13 @@ impl ProtocolConfig {
                     cfg.check_zklogin_issuer_cost_base = None;
                     cfg.max_jwk_votes_per_validator_per_epoch = None;
                     cfg.max_age_of_jwk_in_epochs = None;
+                }
+                26 => {
+                    if chain != Chain::Mainnet {
+                        // Enable consensus block restrictions on testnet/devnet to bound
+                        // header size by committee size.
+                        cfg.feature_flags.consensus_block_restrictions = true;
+                    }
                 }
 
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_26.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_26.snap
@@ -1,0 +1,325 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 26
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  pass_validator_scores_to_advance_epoch: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_26.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_26.snap
@@ -1,0 +1,334 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 26
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
+  pass_validator_scores_to_advance_epoch: true
+  calculate_validator_scores: true
+  consensus_fast_commit_sync: true
+  consensus_block_restrictions: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_auth_gas: 250000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 100
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+scorer_version: 1
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_26.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_26.snap
@@ -1,0 +1,345 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 26
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  enable_poseidon: true
+  enable_group_ops_native_function_msm: true
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  enable_vdf: true
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  accept_passkey_in_multisig: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
+  enable_move_authentication_for_sponsor: true
+  pass_validator_scores_to_advance_epoch: true
+  calculate_validator_scores: true
+  adjust_rewards_by_score: true
+  pass_calculated_validator_scores_to_advance_epoch: true
+  consensus_fast_commit_sync: true
+  consensus_block_restrictions: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_auth_gas: 250000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 100
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+scorer_version: 1
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 25
+  protocol_version: 26
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
 accounts:

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,12 +3,12 @@ source: crates/iota-swarm-config/tests/snapshot_tests.rs
 expression: genesis.iota_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 25
+protocol_version: 26
 system_state_version: 1
 iota_treasury_cap:
   inner:
     id:
-      id: "0xb8998632ae8a032c760cb0adb6c316e218cafc8dd813d3bc7fafde61d038ac07"
+      id: "0x7b8c9ddbbb9b68e8fc0341c5c2d255b9f210c121244bc8354088d57ab0ccde55"
     total_supply:
       value: "751500000000000000"
 validators:
@@ -244,13 +244,13 @@ validators:
         next_epoch_primary_address: ~
         extra_fields:
           id:
-            id: "0xd3e4fa6a5f289ad77fb4578e49c4a86a6e47d400635f6529a21d29cbd5553e18"
+            id: "0xb604678b75df7ec0ddd02a8be8aa6e31ca4843d5c6a93be72464cdeed94d4fe8"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x257a41cd6dd3be58c7f096ca6ed382a703f787ac4b9891d37dead96f7002ce8d"
+      operation_cap_id: "0x3b291588d918aad1ba879c03f63f8caae59958b7a53788f4eea03d7270f40c52"
       gas_price: 1000
       staking_pool:
-        id: "0xc1d25a1cf8f56ec720db62aed27835c5e14a80dbdb62643cfa7f3492a8225196"
+        id: "0xbfafbdd17a9c85082faf5e998ac121634bb77eabe181dacbba36e149e815aa5b"
         activation_epoch: 0
         deactivation_epoch: ~
         iota_balance: 1500000000000000
@@ -258,14 +258,14 @@ validators:
           value: 0
         pool_token_balance: 1500000000000000
         exchange_rates:
-          id: "0xdca62922c1e163d0d1135082dac9e3880c985fd7a9a8340580829b6d5a25e3af"
+          id: "0x5f2e28ddaa4dfc6c3b68af73be7e4e129c6be52cc91bc4c836ba0b242cbef54a"
           size: 1
         pending_stake: 0
         pending_total_iota_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xb75d05bc8ed9d360980627def318bce6060d888c45bcf80d93cc9a5ac0b307da"
+            id: "0xd7b13e20bbded2ea5a668d1998def92035ab559ac23903ea5af33d18054ab466"
           size: 0
       commission_rate: 200
       next_epoch_stake: 1500000000000000
@@ -273,27 +273,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x99ddf7650c06eca33e7f8fb0185f2991cc91045ca023e28bceb860947c38cd7e"
+          id: "0xd44e0e87d7f11c3fcf7f3420266bbeeb4cd26503e722875f2f02a938acceb2ed"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xeec348c886b3692c44f4cd3dfaa1cf2349cfaaae9050fe95c10aaedf6abfe508"
+      id: "0x5258de65f4e79464a887153005062bb2a42a6983beace8b93fb4c666004bbb96"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xcee897c6cdd2c0c55b2efde2bb6e208301ec470aaebc2eac497ed16ff3655b65"
+    id: "0x11f780ef5046ec0af2de199eda410e2f0ccc8d37b7a22ddc5433cd5f8bc38574"
     size: 1
   inactive_validators:
-    id: "0x6b558c616c564bf13f7c228e0cd18d4c65cc628d5ffabff745679fe47f5295b3"
+    id: "0xa3491f6602503639ed5efab5754f1f133b1d53664537b7604879baf21a7e9586"
     size: 0
   validator_candidates:
-    id: "0xed7c0b0a6f87e3f3bfd38252b86b817cb665dd1d69846379786e8dd2f79882c4"
+    id: "0xac46fca67a3786220159ff16714e55ab8862e1b51984455a1695e97999838926"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xa5e7041c28fd8a5026715912c11e4ef0b1acd95764aaf97d845b65c3ac224b0a"
+      id: "0x13f623e9799ad5db831d5eac7114ad49e289514377299a7ea9f5dff80842eebe"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -310,7 +310,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x02117867e7d6ba84ead539cb69411085ba9122bd35ed49a0e5f4e713e7a432d1"
+      id: "0x78501d21f843d7a95dada8f4f22e61c7aea3190d927529a3330d18a8046c343a"
     size: 0
 iota_system_admin_cap:
   dummy_field: false
@@ -327,5 +327,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xa67f882bf47f870f07ce6929ddce511afa7541e6f199ccdd6274fcd74a7017a5"
+    id: "0x2c29469414eecd7d91a3f38f9b758c922fa89477ecbecebb0db133d78e093abe"
   size: 0

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -128,6 +128,19 @@ impl BlockVerifier for SignedBlockVerifier {
                 quorum: committee.quorum_threshold(),
             });
         }
+        let block_restrictions = self.context.protocol_config.consensus_block_restrictions();
+        if block_restrictions {
+            let max_acknowledgments = self
+                .context
+                .protocol_config
+                .max_acknowledgments_per_block(committee.size());
+            if block.acknowledgments().len() > max_acknowledgments {
+                return Err(ConsensusError::TooManyAcknowledgments {
+                    count: block.acknowledgments().len(),
+                    max: max_acknowledgments,
+                });
+            }
+        }
         for acknowledgment in block.acknowledgments() {
             ConsensusError::quick_validation_authority_indices(
                 &[acknowledgment.author],
@@ -378,6 +391,32 @@ pub(crate) mod test {
             assert!(matches!(
                 verifier.verify(&signed_block),
                 Err(ConsensusError::TooManyAncestors(_, _))
+            ));
+        }
+
+        // Block with too many acknowledgments.
+        {
+            let committee_size = 4u8;
+            let max_acknowledgments = 2 * committee_size;
+            // Build acknowledgments at rounds (1..) that don't overlap with the
+            // ancestors above (rounds 7 and 9).
+            let acknowledgments = (0..=max_acknowledgments)
+                .map(|i| {
+                    BlockRef::new(
+                        (i / committee_size + 1) as u32,
+                        AuthorityIndex::new_for_test(i % committee_size),
+                        BlockHeaderDigest::MIN,
+                    )
+                })
+                .collect::<Vec<_>>();
+            let block = test_block
+                .clone()
+                .set_acknowledgments(acknowledgments)
+                .build();
+            let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::TooManyAcknowledgments { .. })
             ));
         }
 

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -141,13 +141,32 @@ impl BlockVerifier for SignedBlockVerifier {
                 });
             }
         }
+        let gc_depth = self.context.protocol_config.gc_depth();
+        let min_ref_round = self.context.min_ref_round(block.round());
         for acknowledgment in block.acknowledgments() {
             ConsensusError::quick_validation_authority_indices(
                 &[acknowledgment.author],
                 committee,
             )?;
+            if block_restrictions {
+                if acknowledgment.round >= block.round() {
+                    return Err(ConsensusError::InvalidAcknowledgmentRound {
+                        acknowledgment: acknowledgment.round,
+                        block: block.round(),
+                    });
+                }
+                if acknowledgment.round < min_ref_round {
+                    return Err(ConsensusError::AcknowledgmentRoundTooOld {
+                        acknowledgment: acknowledgment.round,
+                        block: block.round(),
+                        gc_depth,
+                    });
+                }
+            }
         }
 
+        let check_ancestor_lower_bound =
+            block_restrictions && self.context.protocol_config.consensus_fast_commit_sync();
         let mut seen_ancestors = vec![false; committee.size()];
         let mut parent_stakes = 0;
         for (i, ancestor) in block.ancestors().iter().enumerate() {
@@ -165,6 +184,16 @@ impl BlockVerifier for SignedBlockVerifier {
                 return Err(ConsensusError::InvalidAncestorRound {
                     ancestor: ancestor.round,
                     block: block.round(),
+                });
+            }
+            // Skip the gc_depth lower bound for the author's own ancestor
+            // (i == 0): the proposer always includes its last proposed block
+            // regardless of gap so a recovered node can catch up.
+            if check_ancestor_lower_bound && i > 0 && ancestor.round < min_ref_round {
+                return Err(ConsensusError::AncestorRoundTooOld {
+                    ancestor: ancestor.round,
+                    block: block.round(),
+                    gc_depth,
                 });
             }
             if ancestor.round == GENESIS_ROUND && !self.genesis.contains(ancestor) {
@@ -243,7 +272,10 @@ pub(crate) mod test {
 
     #[tokio::test]
     async fn test_verify_block() {
-        let (context, keypairs) = Context::new_for_test(4);
+        let (mut context, keypairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_block_restrictions_for_testing(true);
         let context = Arc::new(context);
         let authority_2_protocol_keypair = &keypairs[2].1;
         let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
@@ -477,6 +509,99 @@ pub(crate) mod test {
                 verifier.verify(&signed_block),
                 Err(ConsensusError::DuplicatedAncestorsAuthority(_))
             ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_block_round_gap() {
+        let (mut context, keypairs) = Context::new_for_test(4);
+        // Small gc_depth so we can construct violations without huge round
+        // numbers. consensus_fast_commit_sync must be on for the ancestor
+        // lower-bound check to fire.
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(5);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(true);
+        context
+            .protocol_config
+            .set_consensus_block_restrictions_for_testing(true);
+        let context = Arc::new(context);
+        let authority_2_protocol_keypair = &keypairs[2].1;
+        let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+
+        let test_block = TestBlockHeader::new(10, 2).set_ancestors(vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+            BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+        ]);
+
+        // Acknowledgment at the block's round.
+        {
+            let block = test_block
+                .clone()
+                .set_acknowledgments(vec![BlockRef::new(
+                    10,
+                    AuthorityIndex::new_for_test(0),
+                    BlockHeaderDigest::MIN,
+                )])
+                .build();
+            let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::InvalidAcknowledgmentRound { .. })
+            ));
+        }
+
+        // Acknowledgment older than gc_depth (block 10 - gc_depth 5 = 5).
+        {
+            let block = test_block
+                .clone()
+                .set_acknowledgments(vec![BlockRef::new(
+                    4,
+                    AuthorityIndex::new_for_test(0),
+                    BlockHeaderDigest::MIN,
+                )])
+                .build();
+            let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::AcknowledgmentRoundTooOld { .. })
+            ));
+        }
+
+        // Non-own ancestor older than gc_depth.
+        {
+            let block = test_block
+                .clone()
+                .set_ancestors(vec![
+                    BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+                    BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+                    BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+                    BlockRef::new(2, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+                ])
+                .build();
+            let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::AncestorRoundTooOld { .. })
+            ));
+        }
+
+        // Author's own ancestor older than gc_depth is allowed (catch-up).
+        {
+            let block = test_block
+                .set_ancestors(vec![
+                    BlockRef::new(2, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+                    BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+                    BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+                    BlockRef::new(9, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+                ])
+                .build();
+            let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
+            verifier.verify(&signed_block).unwrap();
         }
     }
 }

--- a/crates/starfish/core/src/context.rs
+++ b/crates/starfish/core/src/context.rs
@@ -14,7 +14,10 @@ use tokio::time::Instant;
 
 #[cfg(test)]
 use crate::metrics::test_metrics;
-use crate::{block_header::BlockTimestampMs, metrics::Metrics};
+use crate::{
+    block_header::{BlockTimestampMs, Round},
+    metrics::Metrics,
+};
 
 /// Context contains per-epoch configuration and metrics shared by all
 /// components of this authority.
@@ -59,6 +62,12 @@ impl Context {
 
     pub(crate) fn authority_hostname(&self, authority: AuthorityIndex) -> &str {
         self.committee.authority(authority).hostname.as_str()
+    }
+
+    /// Lower bound (inclusive) on the round of an acknowledgment or non-own
+    /// ancestor of a block at `block_round`.
+    pub(crate) fn min_ref_round(&self, block_round: Round) -> Round {
+        block_round.saturating_sub(self.protocol_config.gc_depth())
     }
 
     /// Create a test context with a committee of given size and even stake

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1318,17 +1318,7 @@ impl Core {
         if !self.context.protocol_config.consensus_fast_commit_sync() {
             return GENESIS_ROUND;
         }
-        let gc_depth = self.context.protocol_config.gc_depth();
-        let depth = if self
-            .leaders(clock_round)
-            .iter()
-            .any(|slot| slot.authority == self.context.own_index)
-        {
-            gc_depth
-        } else {
-            gc_depth.saturating_sub(1)
-        };
-        clock_round.saturating_sub(depth)
+        self.context.min_ref_round(clock_round)
     }
 
     /// Returns the 1st leader of the round.
@@ -2082,12 +2072,8 @@ mod test {
     ///   1. `saturating_sub` clamps small `clock_round`s to `0`, so the
     ///      strict-`<` filter in `ancestors_to_propose` self-disables there and
     ///      genesis/quorum-round ancestors can never be accidentally dropped.
-    ///   2. Well above `gc_depth`, the returned value is either `clock_round -
-    ///      gc_depth` (leader at `clock_round`, uses its own commit's
-    ///      `gc_round`) or `clock_round - (gc_depth - 1)` (non- leader, uses
-    ///      the tighter `gc_round` of the leader at `clock_round + 1`). These
-    ///      are the only two valid outcomes; any other value would indicate a
-    ///      regression in the leader-awareness or the depth arithmetic.
+    ///   2. Well above `gc_depth`, the helper returns `clock_round - gc_depth`
+    ///      (matching `Context::min_ref_round` and the verifier's bound).
     ///   3. When the `consensus_fast_commit_sync` protocol flag is off the
     ///      helper returns `GENESIS_ROUND = 0` unconditionally — the filter
     ///      becomes a no-op, preserving backwards compatibility on networks
@@ -2120,38 +2106,14 @@ mod test {
             );
         }
 
-        // (2) Well above gc_depth, the value is either the leader bound
-        // (clock_round - gc_depth) or the non-leader bound
-        // (clock_round - (gc_depth - 1)). We sample multiple rounds to
-        // cover both leader and non-leader cases given an arbitrary schedule.
-        let leader_bound = |r: Round| r - gc_depth;
-        let non_leader_bound = |r: Round| r - (gc_depth - 1);
-        let mut saw_leader = false;
-        let mut saw_non_leader = false;
+        // (2) Well above gc_depth, the value is exactly clock_round - gc_depth.
         for clock_round in (gc_depth + 2)..(gc_depth + 20) {
-            let got = core.min_ancestor_round(clock_round);
-            let l = leader_bound(clock_round);
-            let nl = non_leader_bound(clock_round);
-            assert!(
-                got == l || got == nl,
-                "min_ancestor_round({clock_round}) = {got}; \
-                 expected leader={l} or non-leader={nl} (gc_depth={gc_depth})"
+            assert_eq!(
+                core.min_ancestor_round(clock_round),
+                clock_round - gc_depth,
+                "min_ancestor_round({clock_round}) should be clock_round - gc_depth (gc_depth={gc_depth})",
             );
-            if got == l {
-                saw_leader = true;
-            }
-            if got == nl {
-                saw_non_leader = true;
-            }
         }
-        // Over a window of ~gc_depth rounds we expect the leader schedule to
-        // put us in both the leader and non-leader position at least once.
-        assert!(
-            saw_leader && saw_non_leader,
-            "expected to observe both leader (gc_depth) and non-leader \
-             (gc_depth - 1) bounds over the sampled range; \
-             saw_leader={saw_leader}, saw_non_leader={saw_non_leader}",
-        );
 
         // (3) Flag off → no-op. Build a fresh fixture with the flag disabled
         // and confirm the helper returns GENESIS_ROUND for a round well

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -852,11 +852,14 @@ impl Core {
 
         // Consume the acknowledgments about transaction data availability for past
         // blocks to be included.
-        let acknowledgments = self.dag_state.write().take_acknowledgments(
-            self.context
-                .protocol_config
-                .consensus_max_acknowledgments_per_block_or_default() as usize,
-        );
+        let max_acknowledgments = self
+            .context
+            .protocol_config
+            .max_acknowledgments_per_block(self.context.committee.size());
+        let acknowledgments = self
+            .dag_state
+            .write()
+            .take_acknowledgments(max_acknowledgments);
 
         self.context
             .metrics
@@ -1879,11 +1882,11 @@ mod test {
             }
         }
 
-        // Second set dummy acknowledgments in DagState. First 200 acknowledgments are
-        // from eligible round; the rest are from the clock round, thereby they
-        // will not be taken when creating a block
+        // Second set dummy acknowledgments in DagState. First `num_acks`
+        // acknowledgments are from an eligible round; the rest are from the
+        // clock round, thereby they will not be taken when creating a block.
         let mut acknowledgments = vec![];
-        let num_acks = 200;
+        let num_acks = 2 * context.committee.size();
         let mut num_pending_acks = 0;
         let mut rng = &mut rand::thread_rng();
         loop {

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -142,6 +142,9 @@ pub(crate) enum ConsensusError {
     #[error("Too many ancestors in the block: {0} > {1}")]
     TooManyAncestors(usize, usize),
 
+    #[error("Too many acknowledgments in the block: {count} > {max}")]
+    TooManyAcknowledgments { count: usize, max: usize },
+
     #[error("Merkle tree has no root (empty shard list)")]
     EmptyMerkleTree,
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -145,6 +145,29 @@ pub(crate) enum ConsensusError {
     #[error("Too many acknowledgments in the block: {count} > {max}")]
     TooManyAcknowledgments { count: usize, max: usize },
 
+    #[error(
+        "Acknowledgment's round ({acknowledgment}) should be lower than the block's round ({block})"
+    )]
+    InvalidAcknowledgmentRound { acknowledgment: Round, block: Round },
+
+    #[error(
+        "Acknowledgment is older than gc_depth: block {block}, acknowledgment {acknowledgment}, gc_depth {gc_depth}"
+    )]
+    AcknowledgmentRoundTooOld {
+        acknowledgment: Round,
+        block: Round,
+        gc_depth: u32,
+    },
+
+    #[error(
+        "Ancestor is older than gc_depth: block {block}, ancestor {ancestor}, gc_depth {gc_depth}"
+    )]
+    AncestorRoundTooOld {
+        ancestor: Round,
+        block: Round,
+        gc_depth: u32,
+    },
+
     #[error("Merkle tree has no root (empty shard list)")]
     EmptyMerkleTree,
 


### PR DESCRIPTION
# Description of change

Introduces the `consensus_block_restrictions` protocol-config feature flag (plumbed only — defaults to off for now). Under the flag, two block-header constraints become active:

1. **Acknowledgments cap.** The number of acknowledgments per block is bounded both at proposal time and in the block verifier. Centralized in `ProtocolConfig::max_acknowledgments_per_block(committee_size)`.
2. **Ancestor/acknowledgment round-gap check.** The block verifier rejects blocks whose acknowledgments fall outside `[block.round - gc_depth, block.round)`. When `consensus_fast_commit_sync` is also enabled, non-own ancestors must additionally be at round `>= block.round - gc_depth`; the author's own ancestor at index 0 stays exempt so a recovered node can still catch up after a long absence.

Adds `ConsensusError::TooManyAcknowledgments`, `InvalidAcknowledgmentRound`, `AcknowledgmentRoundTooOld`, and `AncestorRoundTooOld`.

## Links to any relevant issues

Fixes #11361
Fixes #11367
Part of #11323

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Introduces the `consensus_block_restrictions` feature flag. When enabled, the block verifier and proposer enforce per-block caps and round-gap constraints on block-header fields so that block-header size is bounded for a given committee size.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC: