### PR TITLE
feat(starfish): bound block commit votes

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1490,6 +1490,14 @@ impl ProtocolConfig {
         }
     }
 
+    pub fn max_commit_votes_per_block(&self, committee_size: usize) -> usize {
+        if self.consensus_block_restrictions() {
+            committee_size
+        } else {
+            100
+        }
+    }
+
     pub fn variant_nodes(&self) -> bool {
         self.feature_flags.variant_nodes
     }

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -140,6 +140,16 @@ impl BlockVerifier for SignedBlockVerifier {
                     max: max_acknowledgments,
                 });
             }
+            let max_commit_votes = self
+                .context
+                .protocol_config
+                .max_commit_votes_per_block(committee.size());
+            if block.commit_votes().len() > max_commit_votes {
+                return Err(ConsensusError::TooManyCommitVotes {
+                    count: block.commit_votes().len(),
+                    max: max_commit_votes,
+                });
+            }
         }
         let gc_depth = self.context.protocol_config.gc_depth();
         let min_ref_round = self.context.min_ref_round(block.round());
@@ -449,6 +459,20 @@ pub(crate) mod test {
             assert!(matches!(
                 verifier.verify(&signed_block),
                 Err(ConsensusError::TooManyAcknowledgments { .. })
+            ));
+        }
+
+        // Block with too many commit votes.
+        {
+            let committee_size = 4u32;
+            let commit_votes = (0..=committee_size)
+                .map(|i| crate::commit::CommitVote::new(i, crate::commit::CommitDigest::MIN))
+                .collect::<Vec<_>>();
+            let block = test_block.clone().set_commit_votes(commit_votes).build();
+            let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::TooManyCommitVotes { .. })
             ));
         }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -55,10 +55,6 @@ use crate::{
     },
 };
 
-// Maximum number of commit votes to include in a block.
-// TODO: Move to protocol config, and verify in BlockVerifier.
-const MAX_COMMIT_VOTES_PER_BLOCK: usize = 100;
-
 pub(crate) struct Core {
     context: Arc<Context>,
     /// The consumer to use in order to pull transactions to be included for the
@@ -881,10 +877,11 @@ impl Core {
         }
 
         // Consume the commit votes to be included.
-        let commit_votes = self
-            .dag_state
-            .write()
-            .take_commit_votes(MAX_COMMIT_VOTES_PER_BLOCK);
+        let max_commit_votes = self
+            .context
+            .protocol_config
+            .max_commit_votes_per_block(self.context.committee.size());
+        let commit_votes = self.dag_state.write().take_commit_votes(max_commit_votes);
 
         // Get current timestamp and record drift but don't enforce ancestor timestamp
         // checks.

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -145,6 +145,9 @@ pub(crate) enum ConsensusError {
     #[error("Too many acknowledgments in the block: {count} > {max}")]
     TooManyAcknowledgments { count: usize, max: usize },
 
+    #[error("Too many commit votes in the block: {count} > {max}")]
+    TooManyCommitVotes { count: usize, max: usize },
+
     #[error(
         "Acknowledgment's round ({acknowledgment}) should be lower than the block's round ({block})"
     )]


### PR DESCRIPTION
# Description of change

Under the `consensus_block_restrictions` flag, the number of commit votes per block is bounded by `committee_size` both at proposal time and in the block verifier. Replaces the hardcoded `MAX_COMMIT_VOTES_PER_BLOCK = 100` constant with `ProtocolConfig::max_commit_votes_per_block`.

Adds `ConsensusError::TooManyCommitVotes`.

Stacked on top of #11382. 

## Links to any relevant issues

Fixes #11363
Part of #11323

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes