### PR TITLE
fix(node): Remove deprecated `ignore_range_deletions` from ReadWriteOptions

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -837,7 +837,7 @@ fn owned_object_locked_transactions_table_default_config() -> DBOptions {
             .optimize_for_write_throughput()
             .optimize_for_read(read_size_from_env(ENV_VAR_LOCKS_BLOCK_CACHE_SIZE).unwrap_or(1024))
             .options,
-        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(false),
+        rw_options: ReadWriteOptions::default(),
     }
 }
 

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -212,12 +212,11 @@ impl AuthorityStorePruner {
 
         // Instead of using range deletes, we
         // need to do a scan of all the keys for the deleted objects and then do
-        // point deletes to delete all the existing keys. This is because to improve
-        // read performance, we set `ignore_range_deletions` on all read
-        // options, and using range delete to delete tombstones may leak object
-        // (imagine a tombstone is compacted away, but earlier version is still not).
-        // Using point deletes guarantees that all earlier versions are deleted
-        // in the database.
+        // point deletes to delete all the existing keys. This is because using
+        // range delete to delete tombstones may leak objects (imagine a tombstone
+        // is compacted away, but earlier version is still not). Using point
+        // deletes guarantees that all earlier versions are deleted in the
+        // database.
         if !object_tombstones_to_prune.is_empty() {
             let mut object_keys_to_delete = vec![];
             for ObjectKey(object_id, seq_number) in object_tombstones_to_prune {

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -633,7 +633,7 @@ fn live_owned_object_markers_table_config(db_options: DBOptions) -> DBOptions {
             .optimize_for_write_throughput()
             .optimize_for_read(read_size_from_env(ENV_VAR_LOCKS_BLOCK_CACHE_SIZE).unwrap_or(1024))
             .options,
-        rw_options: db_options.rw_options.set_ignore_range_deletions(false),
+        rw_options: db_options.rw_options,
     }
 }
 

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -897,14 +897,9 @@ impl DBBatch {
     }
 
     /// Deletes a range of keys between `from` (inclusive) and `to`
-    /// (non-inclusive) by writing a range delete tombstone in the db map
-    /// If the DBMap is configured with ignore_range_deletions set to false,
-    /// the effect of this write will be visible immediately i.e. you won't
-    /// see old values when you do a lookup or scan. But if it is configured
-    /// with ignore_range_deletions set to true, the old value are visible until
-    /// compaction actually deletes them which will happen sometime after. By
-    /// default ignore_range_deletions is set to true on a DBMap (unless it is
-    /// overridden in the config), so please use this function with caution
+    /// (non-inclusive) by writing a range delete tombstone in the db map.
+    /// The effect of this write is visible immediately, i.e. you won't see
+    /// old values when you do a lookup or scan.
     pub fn schedule_delete_range<K: Serialize, V>(
         &mut self,
         db: &DBMap<K, V>,
@@ -1128,14 +1123,9 @@ where
         Ok(())
     }
 
-    /// Writes a range delete tombstone to delete all entries in the db map
-    /// If the DBMap is configured with ignore_range_deletions set to false,
-    /// the effect of this write will be visible immediately i.e. you won't
-    /// see old values when you do a lookup or scan. But if it is configured
-    /// with ignore_range_deletions set to true, the old value are visible until
-    /// compaction actually deletes them which will happen sometime after. By
-    /// default ignore_range_deletions is set to true on a DBMap (unless it is
-    /// overridden in the config), so please use this function with caution
+    /// Writes a range delete tombstone to delete all entries in the db map.
+    /// The effect of this write is visible immediately, i.e. you won't see
+    /// old values when you do a lookup or scan.
     #[instrument(level = "trace", skip_all, err)]
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -34,10 +34,8 @@ const DEFAULT_TARGET_FILE_SIZE_BASE_MB: usize = 128;
 const ENV_VAR_DISABLE_BLOB_STORAGE: &str = "DISABLE_BLOB_STORAGE";
 const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
 
-// TODO: Remove ReadWriteOptions because `ignore_range_deletions` is deprecated in RocksDB 10.2.1 and has no effect. There is no need to keep this struct or its boolean flag. (trackin issue: https://github.com/iotaledger/iota/issues/11042)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ReadWriteOptions {
-    pub ignore_range_deletions: bool,
     /// When set, debug log the hash of the key and value bytes when inserting
     /// to this table.
     pub log_value_hash: bool,
@@ -45,29 +43,12 @@ pub struct ReadWriteOptions {
 
 impl ReadWriteOptions {
     pub fn readopts(&self) -> ReadOptions {
-        let mut readopts = ReadOptions::default();
-        #[allow(deprecated)]
-        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
-        readopts
-    }
-
-    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
-        self.ignore_range_deletions = ignore;
-        self
+        ReadOptions::default()
     }
 
     pub fn set_log_value_hash(mut self, log_value_hash: bool) -> Self {
         self.log_value_hash = log_value_hash;
         self
-    }
-}
-
-impl Default for ReadWriteOptions {
-    fn default() -> Self {
-        Self {
-            ignore_range_deletions: true,
-            log_value_hash: false,
-        }
     }
 }
 

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -425,7 +425,7 @@ async fn test_delete_batch() {
 #[tokio::test]
 async fn test_delete_range() {
     let tmp_dir = iota_common::tempdir();
-    let options = ReadWriteOptions::default().set_ignore_range_deletions(false);
+    let options = ReadWriteOptions::default();
     let db: DBMap<i32, String> = DBMap::reopen(
         &open_rocksdb(tmp_dir.path(), &[rocksdb::DEFAULT_COLUMN_FAMILY_NAME]),
         None,


### PR DESCRIPTION
# Description of change

Remove `ignore_range_deletions` flag from ReadWriteOptions, because RocksDB deprecated `set_ignore_range_deletions`.

## Links to any relevant issues

Closes #11042 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

