### PR TITLE
feat!: Replace `RandomnessStateUpdate` with SDK version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=45c8ec1bacee8679f4a0ec2a1a220a3bb782d214#45c8ec1bacee8679f4a0ec2a1a220a3bb782d214"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=77e51e5361bb81054187788d820c4f4da8a3ad6c#77e51e5361bb81054187788d820c4f4da8a3ad6c"
 dependencies = [
  "bip32",
  "bip39",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=45c8ec1bacee8679f4a0ec2a1a220a3bb782d214#45c8ec1bacee8679f4a0ec2a1a220a3bb782d214"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=77e51e5361bb81054187788d820c4f4da8a3ad6c#77e51e5361bb81054187788d820c4f4da8a3ad6c"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,7 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "45c8ec1bacee8679f4a0ec2a1a220a3bb782d214", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "77e51e5361bb81054187788d820c4f4da8a3ad6c", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -309,7 +309,7 @@ impl RandomnessManager {
             used_messages: OnceCell::new(),
             confirmations: BTreeMap::new(),
             dkg_output: OnceCell::new(),
-            next_randomness_round: RandomnessRound(0),
+            next_randomness_round: RandomnessRound::new(0),
             highest_completed_round: Arc::new(Mutex::new(highest_completed_round)),
         };
         let dkg_output = tables
@@ -377,22 +377,21 @@ impl RandomnessManager {
             .randomness_next_round
             .get(&SINGLETON_KEY)
             .expect("typed_store should not fail")
-            .unwrap_or(RandomnessRound(0));
+            .unwrap_or(RandomnessRound::new(0));
         info!(
             "random beacon: starting from next_randomness_round={}",
-            rm.next_randomness_round.0
+            rm.next_randomness_round
         );
         let first_incomplete_round = highest_completed_round
             .map(|r| r + 1)
-            .unwrap_or(RandomnessRound(0));
+            .unwrap_or(RandomnessRound::new(0));
         if first_incomplete_round < rm.next_randomness_round {
             info!(
-                "random beacon: resuming generation for randomness rounds from {} to {}",
-                first_incomplete_round,
+                "random beacon: resuming generation for randomness rounds from {first_incomplete_round} to {}",
                 rm.next_randomness_round - 1,
             );
-            for r in first_incomplete_round.0..rm.next_randomness_round.0 {
-                network_handle.send_partial_signatures(committee.epoch(), RandomnessRound(r));
+            for r in first_incomplete_round.value()..rm.next_randomness_round.value() {
+                network_handle.send_partial_signatures(committee.epoch(), RandomnessRound::new(r));
             }
         }
 

--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -838,15 +838,11 @@ PublicKey:
           TUPLEARRAY:
             CONTENT: U8
             SIZE: 33
-RandomnessRound:
-  NEWTYPESTRUCT: U64
 RandomnessStateUpdate:
   STRUCT:
     - epoch: U64
-    - randomness_round:
-        TYPENAME: RandomnessRound
-    - random_bytes:
-        SEQ: U8
+    - randomness_round: U64
+    - random_bytes: BYTES
     - randomness_obj_initial_shared_version: U64
 SenderSignedData:
   NEWTYPESTRUCT:

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -17,7 +17,7 @@ use iota_storage::blob::{Blob, BlobEncoding};
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber},
     committee::EpochId,
-    crypto::{KeypairTraits, RandomnessRound},
+    crypto::KeypairTraits,
     digests::ObjectDigest,
     effects::TransactionEffects,
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
@@ -438,7 +438,7 @@ async fn basic_flow_with_custom_callback() {
     let tx_data = TransactionData::new(
         TransactionKind::RandomnessStateUpdate(RandomnessStateUpdate {
             epoch: 0,
-            randomness_round: RandomnessRound::new(0),
+            randomness_round: 0.into(),
             random_bytes: vec![],
             randomness_obj_initial_shared_version: SequenceNumber::default(),
         }),

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -77,7 +77,7 @@ test-outputs = ["dep:iota-sdk-crypto"]
 
 [target.'cfg(not(msim))'.dependencies]
 # iota-sdk-crypto is only used when compiling test-outputs feature
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "45c8ec1bacee8679f4a0ec2a1a220a3bb782d214", optional = true, features = ["ed25519", "mnemonic"] }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "77e51e5361bb81054187788d820c4f4da8a3ad6c", optional = true, features = ["ed25519", "mnemonic"] }
 
 [[example]]
 name = "snapshot_add_test_outputs"

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -26,7 +26,7 @@ impl RandomnessStateUpdateTransaction {
 
     /// Randomness round of the update.
     async fn randomness_round(&self) -> UInt53 {
-        self.native.randomness_round.0.into()
+        self.native.randomness_round.value().into()
     }
 
     /// Updated random bytes, encoded as Base64.

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -563,7 +563,7 @@ impl IotaTransactionBlockKind {
             TransactionKind::RandomnessStateUpdate(update) => {
                 Ok(Self::RandomnessStateUpdate(IotaRandomnessStateUpdate {
                     epoch: update.epoch,
-                    randomness_round: update.randomness_round.0,
+                    randomness_round: update.randomness_round.value(),
                     random_bytes: update.random_bytes,
                 }))
             }

--- a/crates/iota-network/src/randomness/metrics.rs
+++ b/crates/iota-network/src/randomness/metrics.rs
@@ -39,9 +39,12 @@ impl Metrics {
 
     pub fn record_completed_round(&self, round: RandomnessRound) {
         if let Some(inner) = &self.0 {
-            inner
-                .highest_round_generated
-                .set(inner.highest_round_generated.get().max(round.0 as i64));
+            inner.highest_round_generated.set(
+                inner
+                    .highest_round_generated
+                    .get()
+                    .max(round.value() as i64),
+            );
         }
     }
 

--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -368,7 +368,7 @@ impl RandomnessEventLoop {
         self.highest_requested_round = self.highest_requested_round.split_off(&new_epoch);
         self.round_request_time = self
             .round_request_time
-            .split_off(&(new_epoch, RandomnessRound(0)));
+            .split_off(&(new_epoch, RandomnessRound::new(0)));
         self.received_partial_sigs.clear();
         self.completed_sigs.clear();
         self.highest_completed_round = self.highest_completed_round.split_off(&new_epoch);
@@ -443,7 +443,7 @@ impl RandomnessEventLoop {
 
         if epoch == self.epoch {
             self.remove_partial_sigs_in_range((
-                Bound::Included((RandomnessRound(0), PeerId([0; 32]))),
+                Bound::Included((RandomnessRound::new(0), PeerId([0; 32]))),
                 Bound::Excluded((round + 1, PeerId([0; 32]))),
             ));
             self.completed_sigs = self.completed_sigs.split_off(&(round + 1));
@@ -495,7 +495,7 @@ impl RandomnessEventLoop {
         // If sigs are for a future epoch, we can't fully verify them without DKG
         // output. Save them for later use.
         if epoch != self.epoch || self.peer_share_ids.is_none() {
-            if round.0 >= self.config.max_partial_sigs_rounds_ahead() {
+            if round.value() >= self.config.max_partial_sigs_rounds_ahead() {
                 debug!("skipping received partial sigs for future epoch, round too far ahead",);
                 return;
             }
@@ -528,10 +528,10 @@ impl RandomnessEventLoop {
         // round, whichever is greater.
         let last_completed_signature = self.completed_sigs.last_key_value().map(|(r, _)| *r);
         let last_completed_round = std::cmp::max(last_completed_signature, highest_completed_round)
-            .unwrap_or(RandomnessRound(0));
-        if round.0
+            .unwrap_or(RandomnessRound::new(0));
+        if round.value()
             >= last_completed_round
-                .0
+                .value()
                 .saturating_add(self.config.max_partial_sigs_rounds_ahead())
         {
             debug!(
@@ -856,17 +856,17 @@ impl RandomnessEventLoop {
             if let Some(highest_completed_round) = self.highest_completed_round.get(&self.epoch) {
                 highest_completed_round.checked_add(1).unwrap()
             } else {
-                RandomnessRound(0)
+                RandomnessRound::new(0)
             },
             self.send_tasks
                 .last_key_value()
                 .map(|(r, _)| r.checked_add(1).unwrap())
-                .unwrap_or(RandomnessRound(0)),
+                .unwrap_or(RandomnessRound::new(0)),
         );
 
         let mut rounds_to_aggregate = Vec::new();
-        for round in start_round.0..=highest_requested_round.0 {
-            let round = RandomnessRound(round);
+        for round in start_round.value()..=highest_requested_round.value() {
+            let round = RandomnessRound::new(round);
 
             if self.send_tasks.len() >= self.config.max_partial_sigs_concurrent_sends() {
                 break; // limit concurrent tasks
@@ -1024,12 +1024,12 @@ impl RandomnessEventLoop {
         let highest_requested_round = self
             .highest_requested_round
             .get(&self.epoch)
-            .map(|r| r.0)
+            .map(|r| r.value())
             .unwrap_or(0);
         let highest_completed_round = self
             .highest_completed_round
             .get(&self.epoch)
-            .map(|r| r.0)
+            .map(|r| r.value())
             .unwrap_or(0);
         let num_rounds_pending =
             highest_requested_round.saturating_sub(highest_completed_round) as i64;

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -73,7 +73,7 @@ async fn test_multiple_epochs() {
                 .try_into()
                 .unwrap(),
         );
-        handle.send_partial_signatures(0, RandomnessRound(0));
+        handle.send_partial_signatures(0, RandomnessRound::new(0));
         handle.update_epoch(
             0,
             authority_info.clone(),
@@ -85,22 +85,22 @@ async fn test_multiple_epochs() {
     for rx in randomness_rxs.iter_mut() {
         let (epoch, round, bytes) = rx.recv().await.unwrap();
         assert_eq!(0, epoch);
-        assert_eq!(0, round.0);
+        assert_eq!(0, round.value());
         assert_ne!(0, bytes.len());
     }
 
     // Test a few more rounds. Generation of rounds in epoch 1 should block until
     // epoch is updated.
     for (_authority, handle) in handles.iter() {
-        handle.complete_round(0, RandomnessRound(0));
-        handle.send_partial_signatures(0, RandomnessRound(1));
-        handle.send_partial_signatures(1, RandomnessRound(0));
-        handle.send_partial_signatures(1, RandomnessRound(1));
+        handle.complete_round(0, RandomnessRound::new(0));
+        handle.send_partial_signatures(0, RandomnessRound::new(1));
+        handle.send_partial_signatures(1, RandomnessRound::new(0));
+        handle.send_partial_signatures(1, RandomnessRound::new(1));
     }
     for rx in randomness_rxs.iter_mut() {
         let (epoch, round, bytes) = rx.recv().await.unwrap();
         assert_eq!(0, epoch);
-        assert_eq!(1, round.0);
+        assert_eq!(1, round.value());
         assert_ne!(0, bytes.len());
         assert!(rx.try_recv().is_err()); // there should not be anything else
         // ready yet
@@ -137,8 +137,8 @@ async fn test_multiple_epochs() {
         rounds_seen.insert(round);
         assert_ne!(0, bytes.len());
     }
-    assert!(rounds_seen.contains(&RandomnessRound(0)));
-    assert!(rounds_seen.contains(&RandomnessRound(1)));
+    assert!(rounds_seen.contains(&RandomnessRound::new(0)));
+    assert!(rounds_seen.contains(&RandomnessRound::new(1)));
 }
 
 #[sim_test]
@@ -196,7 +196,7 @@ async fn test_record_own_partial_sigs() {
                 .try_into()
                 .unwrap(),
         );
-        handle.send_partial_signatures(0, RandomnessRound(0));
+        handle.send_partial_signatures(0, RandomnessRound::new(0));
         handle.update_epoch(
             0,
             authority_info.clone(),
@@ -209,7 +209,7 @@ async fn test_record_own_partial_sigs() {
         if i < 2 {
             let (epoch, round, bytes) = rx.recv().await.unwrap();
             assert_eq!(0, epoch);
-            assert_eq!(0, round.0);
+            assert_eq!(0, round.value());
             assert_ne!(0, bytes.len());
         } else {
             assert!(rx.try_recv().is_err());
@@ -274,7 +274,7 @@ async fn test_receive_full_sig() {
                 .try_into()
                 .unwrap(),
         );
-        handle.send_partial_signatures(0, RandomnessRound(0));
+        handle.send_partial_signatures(0, RandomnessRound::new(0));
         handle.update_epoch(
             0,
             authority_info.clone(),
@@ -286,7 +286,7 @@ async fn test_receive_full_sig() {
     for rx in randomness_rxs[..7].iter_mut() {
         let (epoch, round, bytes) = rx.recv().await.unwrap();
         assert_eq!(0, epoch);
-        assert_eq!(0, round.0);
+        assert_eq!(0, round.value());
         assert_ne!(0, bytes.len());
     }
     // Authority 7 shouldn't have the completed sig, since it's disconnected.
@@ -297,7 +297,7 @@ async fn test_receive_full_sig() {
     networks[7].connect(networks[0].local_addr()).await.unwrap();
     let (epoch, round, bytes) = randomness_rxs[7].recv().await.unwrap();
     assert_eq!(0, epoch);
-    assert_eq!(0, round.0);
+    assert_eq!(0, round.value());
     assert_ne!(0, bytes.len());
 }
 
@@ -354,19 +354,19 @@ async fn test_restart_recovery() {
                 .try_into()
                 .unwrap(),
         );
-        handle.send_partial_signatures(0, RandomnessRound(1_000_000));
+        handle.send_partial_signatures(0, RandomnessRound::new(1_000_000));
         handle.update_epoch(
             0,
             authority_info.clone(),
             mock_dkg_output,
             committee.validity_threshold().try_into().unwrap(),
-            Some(RandomnessRound(999_999)),
+            Some(RandomnessRound::new(999_999)),
         );
     }
     for rx in randomness_rxs.iter_mut() {
         let (epoch, round, bytes) = rx.recv().await.unwrap();
         assert_eq!(0, epoch);
-        assert_eq!(1_000_000, round.0);
+        assert_eq!(1_000_000, round.value());
         assert_ne!(0, bytes.len());
     }
 }
@@ -430,7 +430,7 @@ async fn test_byzantine_peer_handling() {
                 .try_into()
                 .unwrap(),
         );
-        handle.send_partial_signatures(0, RandomnessRound(0));
+        handle.send_partial_signatures(0, RandomnessRound::new(0));
         handle.update_epoch(
             0,
             authority_info.clone(),
@@ -447,7 +447,7 @@ async fn test_byzantine_peer_handling() {
             .await
             .expect("Validators (2, 3) should receive randomness in epoch 0, round 0");
         assert_eq!(0, epoch);
-        assert_eq!(0, round.0);
+        assert_eq!(0, round.value());
         assert_ne!(0, bytes.len());
     }
     for rx in &mut randomness_rxs[..2] {
@@ -467,7 +467,7 @@ async fn test_byzantine_peer_handling() {
                 .try_into()
                 .unwrap(),
         );
-        handle.send_partial_signatures(1, RandomnessRound(0));
+        handle.send_partial_signatures(1, RandomnessRound::new(0));
         handle.update_epoch(
             1,
             authority_info.clone(),
@@ -483,7 +483,7 @@ async fn test_byzantine_peer_handling() {
             .await
             .expect("Validators (0, 1) should receive randomness in epoch 1, round 0");
         assert_eq!(1, epoch);
-        assert_eq!(0, round.0);
+        assert_eq!(0, round.value());
         assert_ne!(0, bytes.len());
     }
     for rx in &mut randomness_rxs[2..] {

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -359,7 +359,7 @@ async fn randomness_partial_sigs(
     state
         .node
         .randomness_handle()
-        .admin_get_partial_signatures(RandomnessRound(round), tx);
+        .admin_get_partial_signatures(RandomnessRound::new(round), tx);
 
     let sigs = match rx.await {
         Ok(sigs) => sigs,
@@ -410,7 +410,12 @@ async fn randomness_inject_partial_sigs(
     state
         .node
         .randomness_handle()
-        .admin_inject_partial_signatures(authority_name, RandomnessRound(round), sigs, tx_result);
+        .admin_inject_partial_signatures(
+            authority_name,
+            RandomnessRound::new(round),
+            sigs,
+            tx_result,
+        );
 
     match rx_result.await {
         Ok(Ok(())) => (StatusCode::OK, "partial signatures injected\n".to_string()),
@@ -443,7 +448,7 @@ async fn randomness_inject_full_sig(
 
     let (tx_result, rx_result) = oneshot::channel();
     state.node.randomness_handle().admin_inject_full_signature(
-        RandomnessRound(round),
+        RandomnessRound::new(round),
         sig,
         tx_result,
     );

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -732,7 +732,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 let latest_epoch = self.try_get_latest_epoch_id()?;
                 let tx = VerifiedTransaction::new_randomness_state_update(
                     latest_epoch,
-                    RandomnessRound(randomness_round),
+                    RandomnessRound::new(randomness_round),
                     random_bytes,
                     SequenceNumber::from_u64(randomness_initial_version),
                 );

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -8,7 +8,7 @@
 
 use std::{
     collections::BTreeMap,
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{Debug, Display, Formatter},
     hash::{Hash, Hasher},
     str::FromStr,
 };
@@ -42,6 +42,7 @@ use fastcrypto::{
         Secp256r1SignatureAsBytes,
     },
 };
+pub use iota_sdk_types::RandomnessRound;
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
 use rand::{
     SeedableRng,
@@ -1783,60 +1784,3 @@ pub type RandomnessSignature = fastcrypto_tbls::types::Signature;
 pub type RandomnessPartialSignature = fastcrypto_tbls::tbls::PartialSignature<RandomnessSignature>;
 pub type RandomnessPrivateKey =
     fastcrypto_tbls::ecies_v1::PrivateKey<fastcrypto::groups::bls12381::G2Element>;
-
-/// Round number of generated randomness.
-#[derive(Clone, Copy, Hash, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RandomnessRound(pub u64);
-
-impl Display for RandomnessRound {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::ops::Add for RandomnessRound {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        Self(self.0 + other.0)
-    }
-}
-
-impl std::ops::Add<u64> for RandomnessRound {
-    type Output = Self;
-    fn add(self, other: u64) -> Self {
-        Self(self.0 + other)
-    }
-}
-
-impl std::ops::Sub for RandomnessRound {
-    type Output = Self;
-    fn sub(self, other: Self) -> Self {
-        Self(self.0 - other.0)
-    }
-}
-
-impl std::ops::Sub<u64> for RandomnessRound {
-    type Output = Self;
-    fn sub(self, other: u64) -> Self {
-        Self(self.0 - other)
-    }
-}
-
-impl RandomnessRound {
-    pub fn new(round: u64) -> Self {
-        Self(round)
-    }
-
-    pub fn checked_add(self, rhs: u64) -> Option<Self> {
-        self.0.checked_add(rhs).map(Self)
-    }
-
-    pub fn signature_message(&self) -> Vec<u8> {
-        "random_beacon round "
-            .as_bytes()
-            .iter()
-            .cloned()
-            .chain(bcs::to_bytes(&self.0).expect("serialization should not fail"))
-            .collect()
-    }
-}

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -409,7 +409,7 @@ impl TryFrom<crate::transaction::TransactionKind> for TransactionKind {
             InternalTxnKind::RandomnessStateUpdate(randomness_state_update) => {
                 TransactionKind::RandomnessStateUpdate(RandomnessStateUpdate {
                     epoch: randomness_state_update.epoch,
-                    randomness_round: randomness_state_update.randomness_round.0,
+                    randomness_round: randomness_state_update.randomness_round,
                     random_bytes: randomness_state_update.random_bytes,
                     randomness_obj_initial_shared_version: randomness_state_update
                         .randomness_obj_initial_shared_version,
@@ -499,9 +499,7 @@ impl TryFrom<TransactionKind> for crate::transaction::TransactionKind {
             TransactionKind::RandomnessStateUpdate(randomness_state_update) => {
                 Self::RandomnessStateUpdate(crate::transaction::RandomnessStateUpdate {
                     epoch: randomness_state_update.epoch,
-                    randomness_round: crate::crypto::RandomnessRound(
-                        randomness_state_update.randomness_round,
-                    ),
+                    randomness_round: randomness_state_update.randomness_round,
                     random_bytes: randomness_state_update.random_bytes,
                     randomness_obj_initial_shared_version: randomness_state_update
                         .randomness_obj_initial_shared_version,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -17,6 +17,7 @@ use anyhow::bail;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::{encoding::Base64, hash::HashFunction};
 use iota_protocol_config::ProtocolConfig;
+pub use iota_sdk_types::RandomnessStateUpdate;
 use iota_sdk_types::{
     Identifier, ObjectId, TypeTag,
     crypto::{Intent, IntentMessage, IntentScope},
@@ -315,26 +316,6 @@ impl GenesisObject {
         match self {
             GenesisObject::RawObject { data, .. } => data.id(),
         }
-    }
-}
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct RandomnessStateUpdate {
-    /// Epoch of the randomness state update transaction
-    pub epoch: u64,
-    /// Randomness round of the update
-    pub randomness_round: RandomnessRound,
-    /// Updated random bytes
-    pub random_bytes: Vec<u8>,
-    /// The initial version of the randomness object that it was shared at.
-    pub randomness_obj_initial_shared_version: SequenceNumber,
-    // to version this struct, do not add new fields. Instead, add a RandomnessStateUpdateV2 to
-    // TransactionKind.
-}
-
-impl RandomnessStateUpdate {
-    pub fn randomness_obj_initial_shared_version(&self) -> SequenceNumber {
-        self.randomness_obj_initial_shared_version
     }
 }
 
@@ -1475,7 +1456,7 @@ impl TransactionKind {
             Self::RandomnessStateUpdate(update) => {
                 vec![InputObjectKind::SharedMoveObject {
                     id: ObjectID::RANDOMNESS_STATE,
-                    initial_shared_version: update.randomness_obj_initial_shared_version(),
+                    initial_shared_version: update.randomness_obj_initial_shared_version,
                     mutable: true,
                 }]
             }

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4.3"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "45c8ec1bacee8679f4a0ec2a1a220a3bb782d214" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "77e51e5361bb81054187788d820c4f4da8a3ad6c" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -17,6 +17,6 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "45c8ec1bacee8679f4a0ec2a1a220a3bb782d214" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "77e51e5361bb81054187788d820c4f4da8a3ad6c" }
 iota-types = { path = "../../../crates/iota-types" }
 move-core-types = { path = "../../../external-crates/move/crates/move-core-types" }


### PR DESCRIPTION
This PR is part of the ongoing effort to consolidate blockchain types in the
canonical `iota-rust-sdk`. Types that are needed by both clients/SDK consumers
and the node should live in `iota-rust-sdk` and be imported from there, instead
of being defined twice (once in `iota-types`, once in the SDK).

This PR replaces `RandomnessStateUpdate` and `RandomnessRound` (previously
defined in `iota-types`) with the SDK versions from `iota-sdk-types`. To keep
the diff small and avoid touching every call site, the SDK types are
re-exported from `iota-types` under their original names
(`crate::transaction::RandomnessStateUpdate` and
`crate::crypto::RandomnessRound`), so most existing imports continue to work
unchanged.

## Summary

The SDK's `RandomnessRound` is no longer a tuple struct, so call sites that
relied on tuple-field access (`round.0`) or tuple construction
(`RandomnessRound(n)`) have been updated to use `RandomnessRound::new(n)` and
`round.value()`.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: `RandomnessStateUpdate` and `RandomnessRound` are now defined
  in `iota-sdk-types` and re-exported from `iota-types`. `RandomnessRound` is
  no longer a tuple struct — use `RandomnessRound::new(n)` to construct and
  `round.value()` to access the inner `u64` instead of `RandomnessRound(n)` /
  `round.0`.
- [ ] gRPC:
