### PR TITLE
feat: Replace `Owner` with SDK version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25#6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=40d39c7f67bb394274f9dd6ca1a4915a40427b90#40d39c7f67bb394274f9dd6ca1a4915a40427b90"
 dependencies = [
  "bip32",
  "bip39",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25#6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=40d39c7f67bb394274f9dd6ca1a4915a40427b90#40d39c7f67bb394274f9dd6ca1a4915a40427b90"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=77e51e5361bb81054187788d820c4f4da8a3ad6c#77e51e5361bb81054187788d820c4f4da8a3ad6c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0930fb35bc5db8fc6baa5f0829b3997bff02f99a#0930fb35bc5db8fc6baa5f0829b3997bff02f99a"
 dependencies = [
  "bip32",
  "bip39",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=77e51e5361bb81054187788d820c4f4da8a3ad6c#77e51e5361bb81054187788d820c4f4da8a3ad6c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0930fb35bc5db8fc6baa5f0829b3997bff02f99a#0930fb35bc5db8fc6baa5f0829b3997bff02f99a"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0930fb35bc5db8fc6baa5f0829b3997bff02f99a#0930fb35bc5db8fc6baa5f0829b3997bff02f99a"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25#6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25"
 dependencies = [
  "bip32",
  "bip39",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0930fb35bc5db8fc6baa5f0829b3997bff02f99a#0930fb35bc5db8fc6baa5f0829b3997bff02f99a"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25#6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,7 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0930fb35bc5db8fc6baa5f0829b3997bff02f99a", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,7 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "77e51e5361bb81054187788d820c4f4da8a3ad6c", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0930fb35bc5db8fc6baa5f0829b3997bff02f99a", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,7 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "40d39c7f67bb394274f9dd6ca1a4915a40427b90", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable.snap
@@ -46,7 +46,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 26:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable_rotate.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/immutable_rotate.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 23:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 20:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable_rotate.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/mutable_rotate.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 23:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/receive_object.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/receive_object.snap
@@ -21,7 +21,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 57:
 //# view-object 2,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: test::authenticate::AbstractAccount {
     id: iota::object::UID {
@@ -46,7 +46,7 @@ Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: iota, name:
 
 task 7, line 68:
 //# view-object 5,0
-Owner: Account Address ( a_account )
+Owner: Address(a_account)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/several_accounts.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/several_accounts.snap
@@ -42,7 +42,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 32:
 //# view-object 4,1
-Owner: Object ID: ( fake(4,2) )
+Owner: Object(fake(4,2))
 Version: 3
 Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Key, iota::authenticator_function::AuthenticatorFunctionRefV1<simple_abstract_account::abstract_account::AbstractAccount>> {
     id: iota::object::UID {
@@ -106,7 +106,7 @@ Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Ke
 
 task 7, line 34:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {
@@ -118,7 +118,7 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
 
 task 8, line 36:
 //# view-object 5,1
-Owner: Object ID: ( fake(5,2) )
+Owner: Object(fake(5,2))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Key, iota::authenticator_function::AuthenticatorFunctionRefV1<simple_abstract_account::abstract_account::AbstractAccount>> {
     id: iota::object::UID {
@@ -182,7 +182,7 @@ Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Ke
 
 task 9, line 38:
 //# view-object 5,2
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {
@@ -194,7 +194,7 @@ Contents: simple_abstract_account::abstract_account::AbstractAccount {
 
 task 10, line 40:
 //# view-object 6,1
-Owner: Object ID: ( fake(6,2) )
+Owner: Object(fake(6,2))
 Version: 5
 Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Key, iota::authenticator_function::AuthenticatorFunctionRefV1<simple_abstract_account::abstract_account::AbstractAccount>> {
     id: iota::object::UID {
@@ -258,7 +258,7 @@ Contents: iota::dynamic_field::Field<iota::account::AuthenticatorFunctionRefV1Ke
 
 task 11, line 42:
 //# view-object 6,2
-Owner: Shared( 5 )
+Owner: Shared(5)
 Version: 5
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/account/sponsor.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/account/sponsor.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 20:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 26:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/deny_list_v1.snap
@@ -14,7 +14,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, line 34:
 //# view-object 1,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: iota::coin::Coin<test_coin::regulated_coin::REGULATED_COIN> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 38:
 //# view-object 4,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: abstract_account_with_pub_key::abstract_account::AbstractAccount {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 44:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_digest.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_digest.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 38:
 //# view-object 4,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: abstract_account_with_pub_key::abstract_account::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_signature.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/ed25519_wrong_signature.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 38:
 //# view-object 4,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: abstract_account_with_pub_key::abstract_account::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/event.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/event.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 33:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {
@@ -48,7 +48,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 39:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/not_attached.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/not_attached.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 35:
 //# view-object 2,1
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: test::authenticate::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness_attack.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/randomness_attack.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 28:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/several_authenticators.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/several_authenticators.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 38:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 44:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 28:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 34:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple_fail.snap
+++ b/crates/iota-adapter-transactional-tests/tests/abstract_account/authenticator/simple_fail.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 28:
 //# view-object 4,2
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: simple_abstract_account::abstract_account::AbstractAccount {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/call/simple.snap
+++ b/crates/iota-adapter-transactional-tests/tests/call/simple.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 30:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: Test::M1::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/count_decremented.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/count_decremented.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 56:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -44,7 +44,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, lines 62-66:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {
@@ -62,7 +62,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, line 70:
 //# view-object 7,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: test::m::S {
     id: iota::object::UID {
@@ -85,7 +85,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 11, lines 76-80:
 //# view-object 7,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 7
 Contents: test::m::S {
     id: iota::object::UID {
@@ -103,7 +103,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 13, line 84:
 //# view-object 12,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 8
 Contents: test::m::S {
     id: iota::object::UID {
@@ -128,7 +128,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 16, line 90:
 //# view-object 12,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 10
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/count_decremented_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/count_decremented_v9.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 58:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -44,7 +44,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, lines 64-68:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {
@@ -62,7 +62,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, line 72:
 //# view-object 7,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: test::m::S {
     id: iota::object::UID {
@@ -85,7 +85,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 11, lines 78-82:
 //# view-object 7,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 7
 Contents: test::m::S {
     id: iota::object::UID {
@@ -103,7 +103,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 13, line 86:
 //# view-object 12,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 8
 Contents: test::m::S {
     id: iota::object::UID {
@@ -128,7 +128,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 16, line 92:
 //# view-object 12,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 10
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/delete_by_wrap.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/delete_by_wrap.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 44:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/delete_parent_invalid.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/delete_parent_invalid.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 39:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/delete_parent_valid.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/delete_parent_valid.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 63:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 76:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 68:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/freeze_parent_valid.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/freeze_parent_valid.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 68:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 71:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, lines 50-54:
 //# view-object 2,2
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -43,7 +43,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, lines 60-64:
 //# view-object 4,1
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {
@@ -66,7 +66,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 70:
 //# view-object 7,1
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 6
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 40:
 //# view-object 2,1
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/children/child_of_shared_object.snap
+++ b/crates/iota-adapter-transactional-tests/tests/children/child_of_shared_object.snap
@@ -38,7 +38,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 79:
 //# view-object 4,0
-Owner: Object ID: ( fake(5,0) )
+Owner: Object(fake(5,0))
 Version: 3
 Contents: t3::o3::Obj3 {
     id: iota::object::UID {
@@ -50,7 +50,7 @@ Contents: t3::o3::Obj3 {
 
 task 7, lines 81-83:
 //# view-object 5,1
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v1/coin_deny_and_undeny_sender.snap
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v1/coin_deny_and_undeny_sender.snap
@@ -15,7 +15,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, lines 50-52:
 //# view-object 1,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: iota::coin::DenyCapV1<test::regulated_coin::REGULATED_COIN> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v1/coin_deny_multiple_coin_types.snap
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v1/coin_deny_multiple_coin_types.snap
@@ -15,7 +15,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, lines 62-64:
 //# view-object 1,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: iota::coin::Coin<test::regulated_coin1::REGULATED_COIN1> {
     id: iota::object::UID {
@@ -30,7 +30,7 @@ Contents: iota::coin::Coin<test::regulated_coin1::REGULATED_COIN1> {
 
 task 3, lines 65-67:
 //# view-object 1,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: iota::coin::Coin<test::regulated_coin2::REGULATED_COIN2> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v1/delete_setting_object_same_epoch.snap
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v1/delete_setting_object_same_epoch.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 61:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 3
 Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -60,7 +60,7 @@ Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::
 
 task 5, lines 63-65:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::deny_list::GlobalPauseKey, iota::config::Setting<bool>> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v1/delete_setting_object_set_once.snap
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v1/delete_setting_object_set_once.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 61:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 3
 Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -60,7 +60,7 @@ Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::
 
 task 5, line 63:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::deny_list::GlobalPauseKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -106,7 +106,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 74:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 5
 Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -138,7 +138,7 @@ Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::
 
 task 10, line 76:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 6
 Contents: iota::dynamic_field::Field<iota::deny_list::GlobalPauseKey, iota::config::Setting<bool>> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v1/delete_setting_object_set_twice.snap
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v1/delete_setting_object_set_twice.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 61:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 3
 Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -60,7 +60,7 @@ Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::
 
 task 5, line 63:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::deny_list::GlobalPauseKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -106,7 +106,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 74:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 5
 Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -140,7 +140,7 @@ Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::
 
 task 10, line 76:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 6
 Contents: iota::dynamic_field::Field<iota::deny_list::GlobalPauseKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -188,7 +188,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 14, line 87:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 7
 Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::Setting<bool>> {
     id: iota::object::UID {
@@ -220,7 +220,7 @@ Contents: iota::dynamic_field::Field<iota::deny_list::AddressKey, iota::config::
 
 task 15, line 89:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 8
 Contents: iota::dynamic_field::Field<iota::deny_list::GlobalPauseKey, iota::config::Setting<bool>> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v1/send_many_coins_unregulated.snap
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v1/send_many_coins_unregulated.snap
@@ -15,7 +15,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, line 55:
 //# view-object 1,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: iota::coin::Coin<test::coin::COIN> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/load_old_object.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/load_old_object.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 37:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -41,7 +41,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, lines 42-45:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.snap
@@ -30,7 +30,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, lines 43-45:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.snap
@@ -32,7 +32,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 68:
 //# view-object 3,0
-Owner: Object ID: ( fake(4,0) )
+Owner: Object(fake(4,0))
 Version: 4
 Contents: test::m::Child {
     id: iota::object::UID {
@@ -52,7 +52,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 72:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: test::m::Child {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 68:
 //# view-object 2,4
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m1::Object {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m1::Object {
 
 task 4, lines 70-72:
 //# view-object 2,5
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 91:
 //# view-object 2,8
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m1::GreatGrandParent {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m1::GreatGrandParent {
 
 task 4, lines 93-95:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::GreatGrandParent {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 79:
 //# view-object 2,8
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m1::GreatGrandParent {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m1::GreatGrandParent {
 
 task 4, lines 81-83:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::GreatGrandParent {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof_v9.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 81:
 //# view-object 2,8
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m1::GreatGrandParent {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m1::GreatGrandParent {
 
 task 4, lines 83-85:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::GreatGrandParent {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_v9.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 93:
 //# view-object 2,8
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m1::GreatGrandParent {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m1::GreatGrandParent {
 
 task 4, lines 95-97:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::GreatGrandParent {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 55:
 //# view-object 2,4
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::Object {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m1::Object {
 
 task 4, lines 57-59:
 //# view-object 2,5
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m1::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof_v9.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 57:
 //# view-object 2,4
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::Object {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m1::Object {
 
 task 4, lines 59-61:
 //# view-object 2,5
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m1::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_v9.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 70:
 //# view-object 2,4
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: test::m1::Object {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m1::Object {
 
 task 4, lines 72-74:
 //# view-object 2,5
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/shared_object.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/shared_object.snap
@@ -31,7 +31,7 @@ Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 5, line 82:
 //# view-object 3,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 4
 Contents: test::m::Child {
     id: iota::object::UID {
@@ -49,7 +49,7 @@ Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: iota, name:
 
 task 7, line 86:
 //# view-object 3,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 4
 Contents: test::m::Child {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.snap
@@ -28,7 +28,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 46:
 //# view-object 3,0
-Owner: Object ID: ( fake(3,1) )
+Owner: Object(fake(3,1))
 Version: 3
 Contents: a::m::Obj {
     id: iota::object::UID {
@@ -66,7 +66,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 59:
 //# view-object 7,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 7
 Contents: a::m::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/wrap_object.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/wrap_object.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 44:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: a::m::Obj {
     id: iota::object::UID {
@@ -46,7 +46,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 51:
 //# view-object 5,2
-Owner: Object ID: ( fake(5,1) )
+Owner: Object(fake(5,1))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -76,7 +76,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 58:
 //# view-object 8,2
-Owner: Object ID: ( fake(8,0) )
+Owner: Object(fake(8,0))
 Version: 6
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.snap
@@ -38,7 +38,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 93:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: iota::dynamic_field::Field<u64, a::m::Counter> {
     id: iota::object::UID {
@@ -71,7 +71,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 99:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: iota::dynamic_field::Field<u64, a::m::Counter> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/enums/basic_enums.snap
+++ b/crates/iota-adapter-transactional-tests/tests/enums/basic_enums.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 36:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: Test::f::S {
     id: iota::object::UID {
@@ -35,7 +35,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 40:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: Test::f::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/enums/enums_upgrade.snap
+++ b/crates/iota-adapter-transactional-tests/tests/enums/enums_upgrade.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 36:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 2
 Contents: Test::f::S {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 40:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: Test::f::S {
     id: iota::object::UID {
@@ -59,7 +59,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 73:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: fake(1,0)::f::S {
     id: iota::object::UID {
@@ -79,7 +79,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 77:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: fake(1,0)::f::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/enums/enums_upgrade_add_variant.snap
+++ b/crates/iota-adapter-transactional-tests/tests/enums/enums_upgrade_add_variant.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 36:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 2
 Contents: Test::f::S {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 40:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: Test::f::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/iota/coin_transfer.snap
+++ b/crates/iota-adapter-transactional-tests/tests/iota/coin_transfer.snap
@@ -16,7 +16,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, line 13:
 //# view-object 1,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 2
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -37,7 +37,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 17:
 //# view-object 1,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -52,7 +52,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 5, line 19:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -71,7 +71,7 @@ Error: Error checking transaction input objects: Transaction was not signed by t
 
 task 7, line 23:
 //# view-object 1,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/iota/object_basics.snap
+++ b/crates/iota-adapter-transactional-tests/tests/iota/object_basics.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 72:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::object_basics::Object {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 76:
 //# view-object 2,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 3
 Contents: test::object_basics::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/iota/unwrap.snap
+++ b/crates/iota-adapter-transactional-tests/tests/iota/unwrap.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 73:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::object_basics::Object {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 79:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: test::object_basics::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/iota/unwrap_then_freeze.snap
+++ b/crates/iota-adapter-transactional-tests/tests/iota/unwrap_then_freeze.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 43:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::object_basics::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/child_of_child.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/child_of_child.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 73:
 //# view-object 2,3
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Obj {
     id: iota::object::UID {
@@ -41,7 +41,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 78:
 //# view-object 2,3
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::Obj {
     id: iota::object::UID {
@@ -61,7 +61,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 83-86:
 //# view-object 2,3
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 124:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -83,7 +83,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 129:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -145,7 +145,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 134-137:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 137:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -83,7 +83,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 142:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -145,7 +145,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 147-150:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_dof_enum.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_dof_enum.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 174:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -99,7 +99,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 179:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -177,7 +177,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 184-186:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_enums.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_enums.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 141:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -91,7 +91,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 146:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -161,7 +161,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 151-153:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 147:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -40,7 +40,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 152:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -59,7 +59,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 157-160:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::Parent {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child_enum.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child_enum.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 226:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -40,7 +40,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 231:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -59,7 +59,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 236-239:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::Parent {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 60:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
     id: iota::object::UID {
@@ -44,7 +44,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
 
 task 4, line 62:
 //# view-object 2,1
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
     id: iota::object::UID {
@@ -65,7 +65,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
 
 task 5, line 64:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Obj {
     id: iota::object::UID {
@@ -85,7 +85,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 71:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
     id: iota::object::UID {
@@ -106,7 +106,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
 
 task 8, line 73:
 //# view-object 2,1
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 3
 Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
     id: iota::object::UID {
@@ -127,7 +127,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
 
 task 9, lines 75-78:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child_enum.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child_enum.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 85:
 //# view-object 2,0
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Enum> {
     id: iota::object::UID {
@@ -44,7 +44,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Enum> {
 
 task 4, line 87:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Enum> {
     id: iota::object::UID {
@@ -65,7 +65,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Enum> {
 
 task 5, line 89:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Obj {
     id: iota::object::UID {
@@ -85,7 +85,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 96:
 //# view-object 2,0
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 3
 Contents: iota::dynamic_field::Field<u64, test::m::Enum> {
     id: iota::object::UID {
@@ -106,7 +106,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Enum> {
 
 task 8, line 98:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Enum> {
     id: iota::object::UID {
@@ -127,7 +127,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Enum> {
 
 task 9, lines 100-103:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/not_root_version.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/not_root_version.snap
@@ -34,7 +34,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, lines 66-69:
 //# view-object 2,0
-Owner: Account Address ( P1 )
+Owner: Address(P1)
 Version: 4
 Contents: test::m::A {
     id: iota::object::UID {
@@ -54,7 +54,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 75:
 //# view-object 6,0
-Owner: Object ID: ( fake(6,1) )
+Owner: Object(fake(6,1))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, u64> {
     id: iota::object::UID {
@@ -74,7 +74,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, lines 80-84:
 //# view-object 6,0
-Owner: Object ID: ( fake(6,1) )
+Owner: Object(fake(6,1))
 Version: 3
 Contents: iota::dynamic_field::Field<u64, u64> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, lines 61-64:
 //# view-object 2,0
-Owner: Account Address ( P1 )
+Owner: Address(P1)
 Version: 2
 Contents: test::m::A {
     id: iota::object::UID {
@@ -42,7 +42,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 70:
 //# view-object 4,0
-Owner: Object ID: ( fake(4,1) )
+Owner: Object(fake(4,1))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, u64> {
     id: iota::object::UID {
@@ -62,7 +62,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 75-78:
 //# view-object 4,0
-Owner: Object ID: ( fake(4,1) )
+Owner: Object(fake(4,1))
 Version: 3
 Contents: iota::dynamic_field::Field<u64, u64> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_df.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_df.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 81:
 //# view-object 2,0
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 4, line 83:
 //# view-object 2,1
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 2
 Contents: iota::dynamic_field::Field<u64, tto::M1::A> {
     id: iota::object::UID {
@@ -73,7 +73,7 @@ Contents: iota::dynamic_field::Field<u64, tto::M1::A> {
 
 task 5, line 85:
 //# view-object 2,2
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 2
 Contents: iota::dynamic_field::Field<u64, tto::M1::A> {
     id: iota::object::UID {
@@ -106,7 +106,7 @@ Contents: iota::dynamic_field::Field<u64, tto::M1::A> {
 
 task 6, line 87:
 //# view-object 2,3
-Owner: Object ID: ( fake(2,4) )
+Owner: Object(fake(2,4))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, tto::M1::A> {
     id: iota::object::UID {
@@ -135,7 +135,7 @@ Contents: iota::dynamic_field::Field<u64, tto::M1::A> {
 
 task 7, line 89:
 //# view-object 2,4
-Owner: Account Address ( fake(2,6) )
+Owner: Address(fake(2,6))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -157,7 +157,7 @@ Contents: tto::M1::A {
 
 task 8, line 91:
 //# view-object 2,5
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -188,7 +188,7 @@ Contents: tto::M1::A {
 
 task 9, line 93:
 //# view-object 2,6
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -210,7 +210,7 @@ Contents: tto::M1::A {
 
 task 10, lines 95-98:
 //# view-object 2,7
-Owner: Account Address ( fake(2,6) )
+Owner: Address(fake(2,6))
 Version: 2
 Contents: tto::M1::Wrapper<tto::M1::A> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_dof.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_dof.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 81:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,5) )
+Owner: Object(fake(2,5))
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 4, line 83:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,4) )
+Owner: Object(fake(2,4))
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -56,7 +56,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 5, line 85:
 //# view-object 2,2
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -74,7 +74,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 6, line 87:
 //# view-object 2,3
-Owner: Object ID: ( fake(2,4) )
+Owner: Object(fake(2,4))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, tto::M1::A> {
     id: iota::object::UID {
@@ -112,7 +112,7 @@ Contents: iota::dynamic_field::Field<u64, tto::M1::A> {
 
 task 7, line 89:
 //# view-object 2,4
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -133,7 +133,7 @@ Contents: tto::M1::A {
 
 task 8, line 91:
 //# view-object 2,5
-Owner: Account Address ( fake(2,7) )
+Owner: Address(fake(2,7))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -155,7 +155,7 @@ Contents: tto::M1::A {
 
 task 9, line 93:
 //# view-object 2,6
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -179,7 +179,7 @@ Contents: tto::M1::A {
 
 task 10, line 95:
 //# view-object 2,7
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -201,7 +201,7 @@ Contents: tto::M1::A {
 
 task 11, line 97:
 //# view-object 2,8
-Owner: Object ID: ( fake(2,1) )
+Owner: Object(fake(2,1))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -228,7 +228,7 @@ Contents: tto::M1::A {
 
 task 12, lines 99-102:
 //# view-object 2,9
-Owner: Account Address ( fake(2,7) )
+Owner: Address(fake(2,7))
 Version: 2
 Contents: tto::M1::Wrapper<tto::M1::A> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/receive_object_dof.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/receive_object_dof.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 63:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,3) )
+Owner: Object(fake(2,3))
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 4, line 65:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -51,7 +51,7 @@ Contents: tto::M1::A {
 
 task 5, line 67:
 //# view-object 2,3
-Owner: Account Address ( fake(2,2) )
+Owner: Address(fake(2,2))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -64,7 +64,7 @@ Contents: tto::M1::A {
 
 task 6, line 69:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -83,7 +83,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, lines 73-75:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,3) )
+Owner: Object(fake(2,3))
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -101,7 +101,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 9, line 76:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -114,7 +114,7 @@ Contents: tto::M1::A {
 
 task 10, line 78:
 //# view-object 2,3
-Owner: Object ID: ( fake(7,0) )
+Owner: Object(fake(7,0))
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -127,7 +127,7 @@ Contents: tto::M1::A {
 
 task 11, line 80:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -146,7 +146,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 13, lines 85-87:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,3) )
+Owner: Object(fake(2,3))
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -164,7 +164,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 14, line 88:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -177,7 +177,7 @@ Contents: tto::M1::A {
 
 task 15, line 90:
 //# view-object 2,3
-Owner: Object ID: ( fake(7,0) )
+Owner: Object(fake(7,0))
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -190,7 +190,7 @@ Contents: tto::M1::A {
 
 task 16, line 92:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/v0/child_of_child.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/v0/child_of_child.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 73:
 //# view-object 2,3
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Obj {
     id: iota::object::UID {
@@ -41,7 +41,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 78:
 //# view-object 2,3
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::Obj {
     id: iota::object::UID {
@@ -61,7 +61,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 83-86:
 //# view-object 2,3
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 124:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -83,7 +83,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 129:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -145,7 +145,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 134-137:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 137:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -83,7 +83,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 142:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -145,7 +145,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 147-150:
 //# view-object 2,8
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 147:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -40,7 +40,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 152:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -59,7 +59,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 157-160:
 //# view-object 2,9
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::Parent {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/v0/middle_version_less_than_child.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/v0/middle_version_less_than_child.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 60:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
     id: iota::object::UID {
@@ -44,7 +44,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
 
 task 4, line 62:
 //# view-object 2,1
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
     id: iota::object::UID {
@@ -65,7 +65,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
 
 task 5, line 64:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Obj {
     id: iota::object::UID {
@@ -85,7 +85,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 71:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
     id: iota::object::UID {
@@ -106,7 +106,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
 
 task 8, line 73:
 //# view-object 2,1
-Owner: Object ID: ( _ )
+Owner: Object(_)
 Version: 3
 Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
     id: iota::object::UID {
@@ -127,7 +127,7 @@ Contents: iota::dynamic_field::Field<u64, test::m::Obj> {
 
 task 9, lines 75-78:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/v0/not_root_version.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/v0/not_root_version.snap
@@ -34,7 +34,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, lines 66-69:
 //# view-object 2,0
-Owner: Account Address ( P1 )
+Owner: Address(P1)
 Version: 4
 Contents: test::m::A {
     id: iota::object::UID {
@@ -54,7 +54,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 75:
 //# view-object 6,0
-Owner: Object ID: ( fake(6,1) )
+Owner: Object(fake(6,1))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, u64> {
     id: iota::object::UID {
@@ -74,7 +74,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, lines 80-84:
 //# view-object 6,0
-Owner: Object ID: ( fake(6,1) )
+Owner: Object(fake(6,1))
 Version: 3
 Contents: iota::dynamic_field::Field<u64, u64> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.snap
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, lines 61-64:
 //# view-object 2,0
-Owner: Account Address ( P1 )
+Owner: Address(P1)
 Version: 2
 Contents: test::m::A {
     id: iota::object::UID {
@@ -42,7 +42,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 70:
 //# view-object 4,0
-Owner: Object ID: ( fake(4,1) )
+Owner: Object(fake(4,1))
 Version: 2
 Contents: iota::dynamic_field::Field<u64, u64> {
     id: iota::object::UID {
@@ -62,7 +62,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 75-78:
 //# view-object 4,0
-Owner: Object ID: ( fake(4,1) )
+Owner: Object(fake(4,1))
 Version: 3
 Contents: iota::dynamic_field::Field<u64, u64> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 27:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: iota::coin::Coin<test::fake::FAKE> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable/gas_coin_by_value.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/gas_coin_by_value.snap
@@ -14,7 +14,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, line 12:
 //# view-object 0,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 2
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable/make_vec_objects.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/make_vec_objects.snap
@@ -52,7 +52,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 71:
 //# view-object 5,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: test::m1::Pub {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 27:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: iota::coin::Coin<test::fake::FAKE> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable/private_transfer_valid.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/private_transfer_valid.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 19:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::Pub {
     id: iota::object::UID {
@@ -42,7 +42,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 25:
 //# view-object 4,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: test::m1::Pub {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable/split_coins.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/split_coins.snap
@@ -29,7 +29,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, lines 32-34:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -52,7 +52,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 39:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -67,7 +67,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 7, lines 41-44:
 //# view-object 5,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -90,7 +90,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 49:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -105,7 +105,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 10, line 51:
 //# view-object 8,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 5
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -120,7 +120,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 11, lines 53-55:
 //# view-object 8,1
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 5
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -144,7 +144,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 13, line 61:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 6
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -159,7 +159,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 14, line 63:
 //# view-object 12,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 6
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -174,7 +174,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 15, lines 65-68:
 //# view-object 12,1
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 6
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -199,7 +199,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 17, line 75:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 7
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -214,7 +214,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 18, line 77:
 //# view-object 16,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 7
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -229,7 +229,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 19, line 79:
 //# view-object 16,1
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 7
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable/split_coins_invalid.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/split_coins_invalid.snap
@@ -29,7 +29,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, lines 34-36:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable/transfer_objects.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable/transfer_objects.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, lines 38-40:
 //# view-object 0,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -46,7 +46,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, lines 46-48:
 //# view-object 4,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: test::m1::Pub {
     id: iota::object::UID {
@@ -70,7 +70,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 56-58:
 //# view-object 6,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 4
 Contents: test::m1::Pub {
     id: iota::object::UID {
@@ -96,7 +96,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 68:
 //# view-object 8,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 5
 Contents: test::m1::Cup<iota::object::ID> {
     id: iota::object::UID {
@@ -108,7 +108,7 @@ Contents: test::m1::Cup<iota::object::ID> {
 
 task 10, line 70:
 //# view-object 8,1
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 5
 Contents: test::m1::Cup<test::m1::Pub> {
     id: iota::object::UID {
@@ -120,7 +120,7 @@ Contents: test::m1::Cup<test::m1::Pub> {
 
 task 11, line 72:
 //# view-object 8,2
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 5
 Contents: test::m1::Pub {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/coin_limit.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/coin_limit.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 32:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 2
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -37,7 +37,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 4, lines 34-36:
 //# view-object 2,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m1::CoolMarker {
     id: iota::object::UID {
@@ -67,7 +67,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 50:
 //# view-object 6,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -82,7 +82,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 8, line 52:
 //# view-object 6,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -97,7 +97,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 9, line 54:
 //# view-object 6,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m1::CoolMarker {
     id: iota::object::UID {
@@ -109,7 +109,7 @@ Contents: test::m1::CoolMarker {
 
 task 10, line 56:
 //# view-object 6,3
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m1::CoolMarker {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec_shared.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec_shared.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 34:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 31:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: test::m1::Coin {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared_real_coin.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 22:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/receipt.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/receipt.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 32:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: test::m1::Witness {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.snap
@@ -36,7 +36,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, lines 31-33:
 //# view-object 4,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.snap
+++ b/crates/iota-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 27:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/publish/init.snap
+++ b/crates/iota-adapter-transactional-tests/tests/publish/init.snap
@@ -11,7 +11,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, line 22:
 //# view-object 1,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 2
 Contents: Test::M1::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/publish/publish_with_upgrade.snap
+++ b/crates/iota-adapter-transactional-tests/tests/publish/publish_with_upgrade.snap
@@ -11,7 +11,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, line 12:
 //# view-object 1,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 2
 Contents: iota::package::UpgradeCap {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/basic_receive.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/basic_receive.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 35:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 37-39:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -46,7 +46,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 42:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -58,7 +58,7 @@ Contents: tto::M1::A {
 
 task 7, lines 44-46:
 //# view-object 2,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/move_vec_receiving_types.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/move_vec_receiving_types.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 68:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, line 70:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -41,7 +41,7 @@ Contents: tto::M1::B {
 
 task 5, line 72:
 //# view-object 2,2
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -53,7 +53,7 @@ Contents: tto::M1::B {
 
 task 6, line 74:
 //# view-object 2,3
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::C {
     id: iota::object::UID {
@@ -65,7 +65,7 @@ Contents: tto::M1::C {
 
 task 7, lines 76-78:
 //# view-object 2,4
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::C {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/pass_receiver_immut_then_reuse.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/pass_receiver_immut_then_reuse.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 37:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 39-41:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/pass_receiver_mut_then_reuse.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/pass_receiver_mut_then_reuse.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 37:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 39-41:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 55:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 57-60:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_add_dof_and_mutate.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_add_dof_and_mutate.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 41:
 //# view-object 2,0
-Owner: Account Address ( fake(2,1) )
+Owner: Address(fake(2,1))
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -33,7 +33,7 @@ Contents: tto::M1::A {
 
 task 4, line 43:
 //# view-object 2,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -52,7 +52,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 47:
 //# view-object 2,0
-Owner: Object ID: ( fake(5,0) )
+Owner: Object(fake(5,0))
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -65,7 +65,7 @@ Contents: tto::M1::A {
 
 task 7, line 49:
 //# view-object 2,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -78,7 +78,7 @@ Contents: tto::M1::A {
 
 task 8, line 51:
 //# view-object 5,0
-Owner: Object ID: ( fake(2,1) )
+Owner: Object(fake(2,1))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -96,7 +96,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 9, line 53:
 //# view-object 5,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -114,7 +114,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 10, line 55:
 //# view-object 5,2
-Owner: Object ID: ( fake(5,1) )
+Owner: Object(fake(5,1))
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_and_abort.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_and_abort.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 35:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 37-39:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -46,7 +46,7 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 6, line 42:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -58,7 +58,7 @@ Contents: tto::M1::A {
 
 task 7, line 44:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_and_deleted.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_and_deleted.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 35:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 37-39:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 42:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_and_send_back.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_and_send_back.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 36:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 38-40:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -46,7 +46,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 43:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -58,7 +58,7 @@ Contents: tto::M1::A {
 
 task 7, lines 45-47:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 4
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_and_wrap.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_and_wrap.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 44:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 46-48:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -48,7 +48,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 51:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_by_ref.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_by_ref.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 44:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, line 46:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_by_value_flow_through.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_by_value_flow_through.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 33:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 35-37:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_dof_and_mutate.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_dof_and_mutate.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 39:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 4, line 41:
 //# view-object 2,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -51,7 +51,7 @@ Contents: tto::M1::A {
 
 task 5, line 43:
 //# view-object 2,2
-Owner: Account Address ( fake(2,1) )
+Owner: Address(fake(2,1))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -64,7 +64,7 @@ Contents: tto::M1::A {
 
 task 6, line 45:
 //# view-object 2,3
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -83,7 +83,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, line 49:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -101,7 +101,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 9, line 51:
 //# view-object 2,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -114,7 +114,7 @@ Contents: tto::M1::A {
 
 task 10, line 53:
 //# view-object 2,2
-Owner: Object ID: ( fake(7,0) )
+Owner: Object(fake(7,0))
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -127,7 +127,7 @@ Contents: tto::M1::A {
 
 task 11, line 55:
 //# view-object 2,3
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_duo_struct.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_duo_struct.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 49:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, line 51:
 //# view-object 2,1
-Owner: Account Address ( fake(2,2) )
+Owner: Address(fake(2,2))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -41,7 +41,7 @@ Contents: tto::M1::B {
 
 task 5, lines 53-55:
 //# view-object 2,2
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_invalid_param_ty.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_invalid_param_ty.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 46:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, line 48:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_invalid_type.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_invalid_type.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 35:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 37-39:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_many_move_vec.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_many_move_vec.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 82:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, line 84:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -41,7 +41,7 @@ Contents: tto::M1::B {
 
 task 5, line 86:
 //# view-object 2,2
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -53,7 +53,7 @@ Contents: tto::M1::B {
 
 task 6, line 88:
 //# view-object 2,3
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -65,7 +65,7 @@ Contents: tto::M1::B {
 
 task 7, lines 90-92:
 //# view-object 2,4
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -152,7 +152,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 17, line 141:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 12
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -164,7 +164,7 @@ Contents: tto::M1::A {
 
 task 18, line 143:
 //# view-object 2,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 12
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -176,7 +176,7 @@ Contents: tto::M1::B {
 
 task 19, line 145:
 //# view-object 2,2
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 12
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -188,7 +188,7 @@ Contents: tto::M1::B {
 
 task 20, line 147:
 //# view-object 2,3
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 12
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -200,7 +200,7 @@ Contents: tto::M1::B {
 
 task 21, line 149:
 //# view-object 2,4
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 12
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_multiple_times_in_row.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_multiple_times_in_row.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 43:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: tto::M1::A {
 
 task 5, lines 45-47:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -55,7 +55,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 50:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -67,7 +67,7 @@ Contents: tto::M1::A {
 
 task 8, lines 52-54:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 4
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_object_id.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_object_id.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 34:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, line 36:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -58,7 +58,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, line 46:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -70,7 +70,7 @@ Contents: tto::M1::A {
 
 task 9, line 48:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_object_owner.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_object_owner.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 33:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,2) )
+Owner: Object(fake(2,2))
 Version: 2
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 4, line 35:
 //# view-object 2,1
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -51,7 +51,7 @@ Contents: tto::M1::A {
 
 task 5, lines 37-39:
 //# view-object 2,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: tto::M1::A {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_return_object_dont_touch.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_return_object_dont_touch.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 34:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 36-38:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 6, line 42:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -59,7 +59,7 @@ Contents: tto::M1::A {
 
 task 7, line 44:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_return_object_then_transfer.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_return_object_then_transfer.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 34:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 36-38:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -48,7 +48,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 43:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -60,7 +60,7 @@ Contents: tto::M1::A {
 
 task 7, line 45:
 //# view-object 2,1
-Owner: Account Address ( tto )
+Owner: Address(tto)
 Version: 4
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/receive_ticket_coin_operations.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/receive_ticket_coin_operations.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 28:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 30-32:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -65,7 +65,7 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 9, line 45:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 7
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -77,7 +77,7 @@ Contents: tto::M1::A {
 
 task 10, line 47:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/shared_parent/basic_receive.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/shared_parent/basic_receive.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 35:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, line 37:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -46,7 +46,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 41:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -58,7 +58,7 @@ Contents: tto::M1::A {
 
 task 7, line 43:
 //# view-object 2,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/shared_parent/receive_dof_and_mutate.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/shared_parent/receive_dof_and_mutate.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 39:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,1) )
+Owner: Object(fake(2,1))
 Version: 3
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 4, line 41:
 //# view-object 2,1
-Owner: Account Address ( fake(2,3) )
+Owner: Address(fake(2,3))
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -51,7 +51,7 @@ Contents: tto::M1::A {
 
 task 5, line 43:
 //# view-object 2,2
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -64,7 +64,7 @@ Contents: tto::M1::A {
 
 task 6, line 45:
 //# view-object 2,3
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -83,7 +83,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, line 49:
 //# view-object 2,0
-Owner: Object ID: ( fake(2,1) )
+Owner: Object(fake(2,1))
 Version: 3
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -101,7 +101,7 @@ Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, i
 
 task 9, line 51:
 //# view-object 2,1
-Owner: Object ID: ( fake(7,0) )
+Owner: Object(fake(7,0))
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -114,7 +114,7 @@ Contents: tto::M1::A {
 
 task 10, line 53:
 //# view-object 2,2
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -127,7 +127,7 @@ Contents: tto::M1::A {
 
 task 11, line 55:
 //# view-object 2,3
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/shared_parent/receive_multiple_times_in_row.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/shared_parent/receive_multiple_times_in_row.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 44:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: tto::M1::A {
 
 task 5, lines 46-48:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -55,7 +55,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 51:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -67,7 +67,7 @@ Contents: tto::M1::A {
 
 task 8, lines 53-55:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 4
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/shared_parent/transfer_then_share.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/shared_parent/transfer_then_share.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 36:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, line 38:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {
@@ -46,7 +46,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 42:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 4
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -58,7 +58,7 @@ Contents: tto::M1::A {
 
 task 7, line 44:
 //# view-object 2,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/receive_object/take_receiver_then_try_to_reuse.snap
+++ b/crates/iota-adapter-transactional-tests/tests/receive_object/take_receiver_then_try_to_reuse.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 37:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 3
 Contents: tto::M1::A {
     id: iota::object::UID {
@@ -29,7 +29,7 @@ Contents: tto::M1::A {
 
 task 4, lines 39-41:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 3
 Contents: tto::M1::B {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/add_dynamic_field.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/add_dynamic_field.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 37:
 //# view-object 2,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: a::m::Obj {
     id: iota::object::UID {
@@ -44,7 +44,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 43:
 //# view-object 5,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: a::m::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/become_dynamic_field.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/become_dynamic_field.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 44:
 //# view-object 2,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: a::m::Inner {
     id: iota::object::UID {
@@ -43,7 +43,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 50:
 //# view-object 5,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: a::m::Inner {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/become_dynamic_object_field.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/become_dynamic_object_field.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 44:
 //# view-object 2,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: a::m::Inner {
     id: iota::object::UID {
@@ -43,7 +43,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 50:
 //# view-object 5,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: a::m::Inner {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, lines 41-43:
 //# view-object 3,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 48-50:
 //# view-object 6,0
-Owner: Shared( 6 )
+Owner: Shared(6)
 Version: 6
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 52:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -35,7 +35,7 @@ Contents: t2::o2::Obj2 {
 
 task 5, lines 54-56:
 //# view-object 3,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -61,7 +61,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, lines 63-65:
 //# view-object 7,0
-Owner: Shared( 6 )
+Owner: Shared(6)
 Version: 6
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 104:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -35,7 +35,7 @@ Contents: t2::o2::Obj2 {
 
 task 5, lines 106-108:
 //# view-object 3,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -129,7 +129,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 16, lines 160-163:
 //# view-object 15,0
-Owner: Shared( 14 )
+Owner: Shared(14)
 Version: 14
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 67:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -41,7 +41,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 5, lines 69-72:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -83,7 +83,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 10, line 85:
 //# view-object 7,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -98,7 +98,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 11, line 87:
 //# view-object 8,0
-Owner: Shared( 6 )
+Owner: Shared(6)
 Version: 6
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -113,7 +113,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 12, lines 89-91:
 //# view-object 9,0
-Owner: Shared( 7 )
+Owner: Shared(7)
 Version: 7
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -152,7 +152,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 17, line 104:
 //# view-object 14,0
-Owner: Shared( 8 )
+Owner: Shared(8)
 Version: 8
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -167,7 +167,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 18, line 106:
 //# view-object 15,0
-Owner: Shared( 9 )
+Owner: Shared(9)
 Version: 9
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -182,7 +182,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 19, lines 108-110:
 //# view-object 16,0
-Owner: Shared( 10 )
+Owner: Shared(10)
 Version: 10
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.snap
@@ -32,7 +32,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 71:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -47,7 +47,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 6, line 73:
 //# view-object 3,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -62,7 +62,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 7, lines 75-77:
 //# view-object 4,0
-Owner: Shared( 5 )
+Owner: Shared(5)
 Version: 5
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -132,7 +132,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 16, line 110:
 //# view-object 13,0
-Owner: Shared( 6 )
+Owner: Shared(6)
 Version: 6
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -147,7 +147,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 17, line 112:
 //# view-object 14,0
-Owner: Shared( 7 )
+Owner: Shared(7)
 Version: 7
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -162,7 +162,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 18, lines 114-116:
 //# view-object 15,0
-Owner: Shared( 8 )
+Owner: Shared(8)
 Version: 8
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 42:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -35,7 +35,7 @@ Contents: t2::o2::Obj2 {
 
 task 5, lines 44-46:
 //# view-object 3,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -61,7 +61,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, lines 53-55:
 //# view-object 7,0
-Owner: Shared( 6 )
+Owner: Shared(6)
 Version: 6
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.snap
@@ -23,7 +23,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 64:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -35,7 +35,7 @@ Contents: t2::o2::Obj2 {
 
 task 5, lines 66-68:
 //# view-object 3,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -84,7 +84,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 11, lines 90-92:
 //# view-object 10,0
-Owner: Shared( 9 )
+Owner: Shared(9)
 Version: 9
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/freeze.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/freeze.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 30:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/re_share.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/re_share.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 34:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -34,7 +34,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 38:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 4
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -51,7 +51,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 42:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 5
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -68,7 +68,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 46:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 6
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {
@@ -85,7 +85,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 11, line 50:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 7
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/transfer.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/transfer.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 29:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/upgrade.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/upgrade.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 41:
 //# view-object 2,3
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: t::m::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/shared/wrap.snap
+++ b/crates/iota-adapter-transactional-tests/tests/shared/wrap.snap
@@ -17,7 +17,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 33:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: t2::o2::Obj2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/transfer_object/does_not_have_store.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transfer_object/does_not_have_store.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 30:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -37,7 +37,7 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 5, lines 34-37:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -55,7 +55,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 41:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::Cup<test::m::S> {
     id: iota::object::UID {
@@ -72,7 +72,7 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 9, line 45:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: test::m::Cup<test::m::S> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/transfer_object/does_not_have_store_receive.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transfer_object/does_not_have_store_receive.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 82:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -32,7 +32,7 @@ Contents: test::m::Parent {
 
 task 4, line 84:
 //# view-object 2,1
-Owner: Account Address ( fake(2,0) )
+Owner: Address(fake(2,0))
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -58,7 +58,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 92:
 //# view-object 6,0
-Owner: Account Address ( fake(6,1) )
+Owner: Address(fake(6,1))
 Version: 4
 Contents: test::m::Cup<u64> {
     id: iota::object::UID {
@@ -70,7 +70,7 @@ Contents: test::m::Cup<u64> {
 
 task 8, line 94:
 //# view-object 6,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -97,7 +97,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 11, line 104:
 //# view-object 10,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 6
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -109,7 +109,7 @@ Contents: test::m::Parent {
 
 task 12, line 106:
 //# view-object 10,1
-Owner: Account Address ( fake(10,0) )
+Owner: Address(fake(10,0))
 Version: 6
 Contents: test::m::S {
     id: iota::object::UID {
@@ -144,7 +144,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 16, line 122:
 //# view-object 15,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 9
 Contents: test::m::Parent {
     id: iota::object::UID {
@@ -156,7 +156,7 @@ Contents: test::m::Parent {
 
 task 17, line 124:
 //# view-object 15,1
-Owner: Account Address ( fake(15,0) )
+Owner: Address(fake(15,0))
 Version: 9
 Contents: test::m::Store {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/transfer_object/has_store.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transfer_object/has_store.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 30:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: test::m::S {
     id: iota::object::UID {
@@ -37,7 +37,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, lines 34-37:
 //# view-object 2,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -55,7 +55,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 41:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: test::m::Cup<test::m::S> {
     id: iota::object::UID {
@@ -72,7 +72,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, line 45:
 //# view-object 6,0
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 5
 Contents: test::m::Cup<test::m::S> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/transfer_object/quasi_shared.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transfer_object/quasi_shared.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 30:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {
@@ -48,7 +48,7 @@ Error: Error checking transaction input objects: Object ObjectId("object(3,0)") 
 
 task 6, line 34:
 //# view-object 3,0
-Owner: Object ID: ( fake(2,0) )
+Owner: Object(fake(2,0))
 Version: 4
 Contents: iota::dynamic_field::Field<iota::dynamic_object_field::Wrapper<u64>, iota::object::ID> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/transfer_object/shared.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transfer_object/shared.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 32:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: test::m::S {
     id: iota::object::UID {
@@ -38,7 +38,7 @@ Contents: test::m::S {
 
 task 5, line 34:
 //# view-object 3,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: test::m::S2 {
     id: iota::object::UID {
@@ -60,7 +60,7 @@ Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 8, line 40:
 //# view-object 2,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 4
 Contents: test::m::S {
     id: iota::object::UID {
@@ -72,7 +72,7 @@ Contents: test::m::S {
 
 task 9, line 42:
 //# view-object 3,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 5
 Contents: test::m::S2 {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/transfer_object/transfer_coin.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transfer_object/transfer_coin.snap
@@ -14,7 +14,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 2, line 12:
 //# view-object 0,2
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
@@ -34,7 +34,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 16:
 //# view-object 0,2
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 3
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 44:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: a::m::S {
     id: iota::object::UID {
@@ -39,7 +39,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 48:
 //# view-object 4,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: a::m::T {
     id: iota::object::UID {
@@ -65,7 +65,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 52:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: a::m::S {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/dep_override.snap
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/dep_override.snap
@@ -62,7 +62,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 10, line 90:
 //# view-object 9,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: iota::object::UID {
@@ -81,7 +81,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 12, line 94:
 //# view-object 11,0
-Owner: Shared( 3 )
+Owner: Shared(3)
 Version: 3
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: iota::object::UID {
@@ -100,7 +100,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 14, lines 98-101:
 //# view-object 13,0
-Owner: Shared( 4 )
+Owner: Shared(4)
 Version: 4
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: iota::object::UID {
@@ -121,7 +121,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 16, line 106:
 //# view-object 15,0
-Owner: Shared( 10 )
+Owner: Shared(10)
 Version: 10
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: iota::object::UID {
@@ -134,7 +134,7 @@ Contents: Test_DepDepV1::DepDepM1::Obj {
 
 task 17, lines 108-113:
 //# view-object 15,1
-Owner: Shared( 10 )
+Owner: Shared(10)
 Version: 10
 Contents: Test_DepDepV1::DepDepM1::Obj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/friend_fun_changes.snap
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/friend_fun_changes.snap
@@ -43,7 +43,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 90:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: V0::base_module::Object {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/new_types.snap
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/new_types.snap
@@ -44,7 +44,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 79-81:
 //# view-object 6,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 2
 Contents: Test_DepV1::DepM1::DepObj {
     id: iota::object::UID {
@@ -64,7 +64,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 9, lines 86-89:
 //# view-object 6,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 7
 Contents: Test_DepV1::DepM1::DepObj {
     id: iota::object::UID {
@@ -84,7 +84,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 11, lines 94-97:
 //# view-object 6,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 8
 Contents: Test_DepV1::DepM1::DepObj {
     id: iota::object::UID {
@@ -104,7 +104,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 13, line 102:
 //# view-object 6,0
-Owner: Shared( 2 )
+Owner: Shared(2)
 Version: 9
 Contents: Test_DepV1::DepM1::DepObj {
     id: iota::object::UID {

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/type_names.snap
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/type_names.snap
@@ -74,7 +74,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 12, line 81:
 //# view-object 4,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: A0::m::Canary {
     id: iota::object::UID {
@@ -152,7 +152,7 @@ Contents: A0::m::Canary {
 
 task 13, line 83:
 //# view-object 5,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 6
 Contents: A0::m::Canary {
     id: iota::object::UID {
@@ -230,7 +230,7 @@ Contents: A0::m::Canary {
 
 task 14, line 85:
 //# view-object 6,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 7
 Contents: A0::m::Canary {
     id: iota::object::UID {
@@ -308,7 +308,7 @@ Contents: A0::m::Canary {
 
 task 15, line 87:
 //# view-object 7,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 8
 Contents: A0::m::Canary {
     id: iota::object::UID {
@@ -386,7 +386,7 @@ Contents: A0::m::Canary {
 
 task 16, line 89:
 //# view-object 8,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 9
 Contents: A0::m::Canary {
     id: iota::object::UID {
@@ -464,7 +464,7 @@ Contents: A0::m::Canary {
 
 task 17, line 91:
 //# view-object 9,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 10
 Contents: A0::m::Canary {
     id: iota::object::UID {
@@ -542,7 +542,7 @@ Contents: A0::m::Canary {
 
 task 18, line 93:
 //# view-object 10,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 11
 Contents: A0::m::Canary {
     id: iota::object::UID {
@@ -620,7 +620,7 @@ Contents: A0::m::Canary {
 
 task 19, line 95:
 //# view-object 11,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 12
 Contents: A0::m::Canary {
     id: iota::object::UID {

--- a/crates/iota-analytics-indexer/src/handlers/mod.rs
+++ b/crates/iota-analytics-indexer/src/handlers/mod.rs
@@ -68,7 +68,7 @@ fn get_owner_type(object: &Object) -> OwnerType {
 }
 
 fn get_owner_address(object: &Object) -> Option<String> {
-    object.owner.address().map(ToString::to_string)
+    object.owner.address_or_object().map(ToString::to_string)
 }
 
 // Helper class to track input object kind.

--- a/crates/iota-analytics-indexer/src/handlers/mod.rs
+++ b/crates/iota-analytics-indexer/src/handlers/mod.rs
@@ -63,7 +63,7 @@ fn get_owner_type(object: &Object) -> OwnerType {
         Owner::Object(_) => OwnerType::ObjectOwner,
         Owner::Shared { .. } => OwnerType::Shared,
         Owner::Immutable => OwnerType::Immutable,
-        _ => unimplemented!("a new enum variant was added and needs to be handled"),
+        _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
     }
 }
 

--- a/crates/iota-analytics-indexer/src/handlers/mod.rs
+++ b/crates/iota-analytics-indexer/src/handlers/mod.rs
@@ -52,29 +52,23 @@ pub trait AnalyticsHandler<S>: Worker<Message = (), Error = anyhow::Error> {
 
 fn initial_shared_version(object: &Object) -> Option<u64> {
     match object.owner {
-        Owner::Shared {
-            initial_shared_version,
-        } => Some(initial_shared_version.as_u64()),
+        Owner::Shared(initial_shared_version) => Some(initial_shared_version.as_u64()),
         _ => None,
     }
 }
 
 fn get_owner_type(object: &Object) -> OwnerType {
     match object.owner {
-        Owner::AddressOwner(_) => OwnerType::AddressOwner,
-        Owner::ObjectOwner(_) => OwnerType::ObjectOwner,
+        Owner::Address(_) => OwnerType::AddressOwner,
+        Owner::Object(_) => OwnerType::ObjectOwner,
         Owner::Shared { .. } => OwnerType::Shared,
         Owner::Immutable => OwnerType::Immutable,
+        _ => unimplemented!("a new enum variant was added and needs to be handled"),
     }
 }
 
 fn get_owner_address(object: &Object) -> Option<String> {
-    match object.owner {
-        Owner::AddressOwner(address) => Some(address.to_string()),
-        Owner::ObjectOwner(address) => Some(address.to_string()),
-        Owner::Shared { .. } => None,
-        Owner::Immutable => None,
-    }
+    object.owner.address().map(ToString::to_string)
 }
 
 // Helper class to track input object kind.

--- a/crates/iota-benchmark/src/bank.rs
+++ b/crates/iota-benchmark/src/bank.rs
@@ -145,7 +145,10 @@ impl BenchmarkBank {
             .map_err(Error::msg)?;
 
         init_coin.0 = updated_gas.0;
-        init_coin.1 = updated_gas.1.get_owner_address()?;
+        init_coin.1 = *updated_gas
+            .1
+            .address()
+            .ok_or_else(|| Error::msg("not an address or object owner"))?;
         init_coin.2 = self.primary_coin.2.clone();
 
         let address_map: HashMap<IotaAddress, Arc<AccountKeyPair>> = coin_configs
@@ -157,7 +160,9 @@ impl BenchmarkBank {
             .created()
             .into_iter()
             .map(|c| {
-                let address = c.1.get_owner_address()?;
+                let address =
+                    *c.1.address()
+                        .ok_or_else(|| Error::msg("not an address or object owner"))?;
                 let keypair = address_map
                     .get(&address)
                     .ok_or("Owner address missing in the address map")
@@ -197,14 +202,20 @@ impl BenchmarkBank {
 
         self.primary_coin = (
             updated_gas.0,
-            updated_gas.1.get_owner_address()?,
+            *updated_gas
+                .1
+                .address()
+                .ok_or_else(|| Error::msg("not an address or object owner"))?,
             self.primary_coin.2.clone(),
         );
 
         match effects.created().first() {
             Some(created_coin) => Ok((
                 created_coin.0,
-                created_coin.1.get_owner_address()?,
+                *created_coin
+                    .1
+                    .address()
+                    .ok_or_else(|| Error::msg("not an address or object owner"))?,
                 self.primary_coin.2.clone(),
             )),
             None => panic!("Failed to create initialization coin for workload."),

--- a/crates/iota-benchmark/src/bank.rs
+++ b/crates/iota-benchmark/src/bank.rs
@@ -147,7 +147,7 @@ impl BenchmarkBank {
         init_coin.0 = updated_gas.0;
         init_coin.1 = *updated_gas
             .1
-            .address()
+            .address_or_object()
             .ok_or_else(|| Error::msg("not an address or object owner"))?;
         init_coin.2 = self.primary_coin.2.clone();
 
@@ -161,7 +161,7 @@ impl BenchmarkBank {
             .into_iter()
             .map(|c| {
                 let address =
-                    *c.1.address()
+                    *c.1.address_or_object()
                         .ok_or_else(|| Error::msg("not an address or object owner"))?;
                 let keypair = address_map
                     .get(&address)
@@ -204,7 +204,7 @@ impl BenchmarkBank {
             updated_gas.0,
             *updated_gas
                 .1
-                .address()
+                .address_or_object()
                 .ok_or_else(|| Error::msg("not an address or object owner"))?,
             self.primary_coin.2.clone(),
         );
@@ -214,7 +214,7 @@ impl BenchmarkBank {
                 created_coin.0,
                 *created_coin
                     .1
-                    .address()
+                    .address_or_object()
                     .ok_or_else(|| Error::msg("not an address or object owner"))?,
                 self.primary_coin.2.clone(),
             )),

--- a/crates/iota-benchmark/src/benchmark_setup.rs
+++ b/crates/iota-benchmark/src/benchmark_setup.rs
@@ -214,12 +214,7 @@ impl Env {
         let keystore_path = Some(&keystore_path)
             .filter(|s| !s.is_empty())
             .map(PathBuf::from)
-            .ok_or_else(|| {
-                anyhow!(format!(
-                    "Failed to find keypair at path: {}",
-                    &keystore_path
-                ))
-            })?;
+            .ok_or_else(|| anyhow!("Failed to find keypair at path: {}", &keystore_path))?;
 
         let current_gas = if use_fullnode_for_execution {
             // Go through fullnode to get the current gas object.
@@ -242,7 +237,10 @@ impl Env {
                 primary_gas_obj.id()
             );
 
-            let primary_gas_account = primary_gas_obj.owner.get_owner_address()?;
+            let primary_gas_account = *primary_gas_obj
+                .owner
+                .address()
+                .ok_or_else(|| anyhow!("Not an address or object owner"))?;
 
             let keypair = Arc::new(get_ed25519_keypair_from_keystore(
                 keystore_path,
@@ -260,7 +258,7 @@ impl Env {
 
             for obj in genesis.objects().iter() {
                 let owner = &obj.owner;
-                if let Owner::AddressOwner(addr) = owner {
+                if let Owner::Address(addr) = owner {
                     if *addr == primary_gas_owner_addr.into() {
                         genesis_gas_objects.push(obj.clone());
                     }
@@ -273,7 +271,10 @@ impl Env {
                 .clone();
 
             let current_gas_object = proxy.get_object(genesis_gas_obj.id()).await?;
-            let current_gas_account = current_gas_object.owner.get_owner_address()?;
+            let current_gas_account = *current_gas_object
+                .owner
+                .address()
+                .ok_or_else(|| anyhow::anyhow!("Not an address or object owner"))?;
 
             let keypair = Arc::new(get_ed25519_keypair_from_keystore(
                 keystore_path,

--- a/crates/iota-benchmark/src/benchmark_setup.rs
+++ b/crates/iota-benchmark/src/benchmark_setup.rs
@@ -239,7 +239,7 @@ impl Env {
 
             let primary_gas_account = *primary_gas_obj
                 .owner
-                .address()
+                .address_or_object()
                 .ok_or_else(|| anyhow!("Not an address or object owner"))?;
 
             let keypair = Arc::new(get_ed25519_keypair_from_keystore(
@@ -273,7 +273,7 @@ impl Env {
             let current_gas_object = proxy.get_object(genesis_gas_obj.id()).await?;
             let current_gas_account = *current_gas_object
                 .owner
-                .address()
+                .address_or_object()
                 .ok_or_else(|| anyhow::anyhow!("Not an address or object owner"))?;
 
             let keypair = Arc::new(get_ed25519_keypair_from_keystore(

--- a/crates/iota-benchmark/src/in_memory_wallet.rs
+++ b/crates/iota-benchmark/src/in_memory_wallet.rs
@@ -88,7 +88,7 @@ impl InMemoryWallet {
     /// Apply updates from `effects` to `self`
     pub fn update(&mut self, effects: &ExecutionEffects) {
         for (obj, owner) in effects.mutated().into_iter().chain(effects.created()) {
-            if let Owner::AddressOwner(a) = owner {
+            if let Owner::Address(a) = owner {
                 if let Some(account) = self.accounts.get_mut(&a) {
                     account.add_or_update(obj);
                 } // else, doesn't belong to an account we can spend from, we

--- a/crates/iota-benchmark/src/lib.rs
+++ b/crates/iota-benchmark/src/lib.rs
@@ -121,10 +121,7 @@ impl ExecutionEffects {
     }
 
     pub fn sender(&self) -> IotaAddress {
-        match self.gas_object().1 {
-            Owner::AddressOwner(a) => a,
-            Owner::ObjectOwner(_) | Owner::Shared { .. } | Owner::Immutable => unreachable!(), /* owner of gas object is always an address */
-        }
+        *self.gas_object().1.as_address()
     }
 
     pub fn is_ok(&self) -> bool {

--- a/crates/iota-benchmark/src/workloads/abstract_account/utils.rs
+++ b/crates/iota-benchmark/src/workloads/abstract_account/utils.rs
@@ -289,7 +289,7 @@ pub async fn mint_owned_coins_to_address(
         *init_coin = update_gas_from_effects(init_coin, &effects)?;
 
         for (r, o) in effects.created().into_iter() {
-            if matches!(o, Owner::AddressOwner(a) if a == recipient) {
+            if matches!(o, Owner::Address(a) if a == recipient) {
                 minted.push(r);
             }
         }
@@ -374,7 +374,15 @@ pub fn update_gas_from_effects(current: &Gas, effects: &ExecutionEffects) -> Res
         .find(|(r, _)| r.object_id == current.0.object_id)
         .ok_or_else(|| anyhow::anyhow!("init coin not found in mutated effects"))?;
 
-    Ok((updated.0, updated.1.get_owner_address()?, current.2.clone()))
+    // TODO: ok_or_else was added during a rebase, please check!
+    Ok((
+        updated.0,
+        *updated
+            .1
+            .address()
+            .ok_or_else(|| anyhow::anyhow!("not an address owner"))?,
+        current.2.clone(),
+    ))
 }
 
 /// If the object is not a Move object — returns None.

--- a/crates/iota-benchmark/src/workloads/abstract_account/utils.rs
+++ b/crates/iota-benchmark/src/workloads/abstract_account/utils.rs
@@ -374,13 +374,12 @@ pub fn update_gas_from_effects(current: &Gas, effects: &ExecutionEffects) -> Res
         .find(|(r, _)| r.object_id == current.0.object_id)
         .ok_or_else(|| anyhow::anyhow!("init coin not found in mutated effects"))?;
 
-    // TODO: ok_or_else was added during a rebase, please check!
     Ok((
         updated.0,
         *updated
             .1
             .address()
-            .ok_or_else(|| anyhow::anyhow!("not an address owner"))?,
+            .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?,
         current.2.clone(),
     ))
 }

--- a/crates/iota-benchmark/src/workloads/abstract_account/utils.rs
+++ b/crates/iota-benchmark/src/workloads/abstract_account/utils.rs
@@ -378,7 +378,7 @@ pub fn update_gas_from_effects(current: &Gas, effects: &ExecutionEffects) -> Res
         updated.0,
         *updated
             .1
-            .address()
+            .address_or_object()
             .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?,
         current.2.clone(),
     ))

--- a/crates/iota-benchmark/src/workloads/batch_payment.rs
+++ b/crates/iota-benchmark/src/workloads/batch_payment.rs
@@ -72,7 +72,7 @@ impl Payload for BatchPaymentTestPayload {
         self.state.update(effects);
         if self.num_payments == 0 {
             for (coin_obj, owner) in effects.created().into_iter().chain(effects.mutated()) {
-                if let Owner::AddressOwner(addr) = owner {
+                if let Owner::Address(addr) = owner {
                     self.state.account_mut(&addr).unwrap().gas = coin_obj;
                 } else {
                     unreachable!("Initial payment should only send to addresses")

--- a/crates/iota-benchmark/src/workloads/randomized_transaction.rs
+++ b/crates/iota-benchmark/src/workloads/randomized_transaction.rs
@@ -504,10 +504,7 @@ impl Workload<dyn Payload> for RandomizedTransactionWorkload {
                 .get_object(ObjectID::RANDOMNESS_STATE)
                 .await
                 .expect("Failed to get randomness object");
-            let Owner::Shared {
-                initial_shared_version,
-            } = obj.owner()
-            else {
+            let Owner::Shared(initial_shared_version) = obj.owner() else {
                 panic!("randomness object must be shared");
             };
             self.randomness_initial_shared_version = Some(*initial_shared_version);

--- a/crates/iota-benchmark/src/workloads/randomness.rs
+++ b/crates/iota-benchmark/src/workloads/randomness.rs
@@ -192,10 +192,7 @@ impl Workload<dyn Payload> for RandomnessWorkload {
                 .get_object(ObjectID::RANDOMNESS_STATE)
                 .await
                 .expect("Failed to get randomness object");
-            let Owner::Shared {
-                initial_shared_version,
-            } = obj.owner()
-            else {
+            let Owner::Shared(initial_shared_version) = obj.owner() else {
                 panic!("randomness object must be shared");
             };
             self.randomness_initial_shared_version = Some(*initial_shared_version);

--- a/crates/iota-cluster-test/src/lib.rs
+++ b/crates/iota-cluster-test/src/lib.rs
@@ -248,7 +248,7 @@ impl TestContext {
                 .iter()
                 .map(|coin_info| {
                     ObjectChecker::new(coin_info.id)
-                        .owner(Owner::AddressOwner(owner))
+                        .owner(Owner::Address(owner))
                         .check_into_gas_coin(self.get_fullnode_client())
                 })
                 .collect::<Vec<_>>(),

--- a/crates/iota-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/iota-cluster-test/src/test_case/coin_index_test.rs
@@ -67,11 +67,11 @@ impl TestCaseImpl for CoinIndexTest {
         let balance_change = response.balance_changes.unwrap();
         let owner_balance = balance_change
             .iter()
-            .find(|b| b.owner == Owner::AddressOwner(account))
+            .find(|b| b.owner == Owner::Address(account))
             .unwrap();
         let recipient_balance = balance_change
             .iter()
-            .find(|b| b.owner != Owner::AddressOwner(account))
+            .find(|b| b.owner != Owner::Address(account))
             .unwrap();
         let Balance {
             coin_object_count,
@@ -95,7 +95,7 @@ impl TestCaseImpl for CoinIndexTest {
             ..
         } = client
             .coin_read_api()
-            .get_balance(recipient_balance.owner.get_owner_address().unwrap(), None)
+            .get_balance(*recipient_balance.owner.address().unwrap(), None)
             .await?;
         assert_eq!(coin_object_count, 1);
         assert!(recipient_balance.amount > 0);
@@ -124,7 +124,7 @@ impl TestCaseImpl for CoinIndexTest {
             .await?;
 
         let balance_change = &response.balance_changes.unwrap()[0];
-        assert_eq!(balance_change.owner, Owner::AddressOwner(account));
+        assert_eq!(balance_change.owner, Owner::Address(account));
 
         let Balance {
             coin_object_count,
@@ -184,8 +184,8 @@ impl TestCaseImpl for CoinIndexTest {
             .find(|b| b.coin_type.to_string().contains("MANAGED"))
             .unwrap();
 
-        assert_eq!(iota_balance_change.owner, Owner::AddressOwner(account));
-        assert_eq!(managed_balance_change.owner, Owner::AddressOwner(account));
+        assert_eq!(iota_balance_change.owner, Owner::Address(account));
+        assert_eq!(managed_balance_change.owner, Owner::Address(account));
 
         let Balance { total_balance, .. } =
             client.coin_read_api().get_balance(account, None).await?;
@@ -650,7 +650,7 @@ async fn publish_managed_coin_package(
         .iter()
         .find(|change| {
             matches!(change, ObjectChange::Created {
-            owner: Owner::AddressOwner(_),
+            owner: Owner::Address(_),
             object_type,
             ..
         } if object_type.is_treasury_cap())

--- a/crates/iota-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/iota-cluster-test/src/test_case/coin_index_test.rs
@@ -95,7 +95,7 @@ impl TestCaseImpl for CoinIndexTest {
             ..
         } = client
             .coin_read_api()
-            .get_balance(*recipient_balance.owner.address().unwrap(), None)
+            .get_balance(*recipient_balance.owner.address_or_object().unwrap(), None)
             .await?;
         assert_eq!(coin_object_count, 1);
         assert!(recipient_balance.amount > 0);

--- a/crates/iota-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/iota-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -54,7 +54,7 @@ impl TestCaseImpl for CoinMergeSplitTest {
                 .iter()
                 .map(|coin_ref| {
                     ObjectChecker::new(coin_ref.reference.object_id)
-                        .owner(Owner::AddressOwner(signer))
+                        .owner(Owner::Address(signer))
                         .check_into_gas_coin(ctx.get_fullnode_client())
                 })
                 .collect::<Vec<_>>(),
@@ -85,7 +85,7 @@ impl TestCaseImpl for CoinMergeSplitTest {
                 .iter()
                 .map(|obj_id| {
                     ObjectChecker::new(*obj_id)
-                        .owner(Owner::AddressOwner(signer))
+                        .owner(Owner::Address(signer))
                         .deleted()
                         .check(ctx.get_fullnode_client())
                 })
@@ -101,7 +101,7 @@ impl TestCaseImpl for CoinMergeSplitTest {
             *primary_coin.id()
         );
         let primary_after_merge = ObjectChecker::new(primary_coin_id)
-            .owner(Owner::AddressOwner(ctx.get_wallet_address()))
+            .owner(Owner::Address(ctx.get_wallet_address()))
             .check_into_gas_coin(ctx.get_fullnode_client())
             .await;
         assert_eq!(

--- a/crates/iota-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/iota-cluster-test/src/test_case/native_transfer_test.rs
@@ -91,22 +91,22 @@ impl NativeTransferTest {
         );
         // Order of balance change is not fixed so need to check who's balance come
         // first. this make sure recipient always come first
-        if balance_changes[0].owner.get_owner_address().unwrap() == signer {
+        if *balance_changes[0].owner.address().unwrap() == signer {
             balance_changes.reverse()
         }
         BalanceChangeChecker::new()
-            .owner(Owner::AddressOwner(recipient))
+            .owner(Owner::Address(recipient))
             .coin_type("0x2::iota::IOTA")
             .check(&balance_changes.remove(0));
         BalanceChangeChecker::new()
-            .owner(Owner::AddressOwner(signer))
+            .owner(Owner::Address(signer))
             .coin_type("0x2::iota::IOTA")
             .check(&balance_changes.remove(0));
         // Verify fullnode observes the txn
         ctx.let_fullnode_sync(vec![response.digest], 5).await;
 
         let _ = ObjectChecker::new(obj_to_transfer_id)
-            .owner(Owner::AddressOwner(recipient))
+            .owner(Owner::Address(recipient))
             .check(ctx.get_fullnode_client())
             .await;
     }

--- a/crates/iota-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/iota-cluster-test/src/test_case/native_transfer_test.rs
@@ -91,7 +91,7 @@ impl NativeTransferTest {
         );
         // Order of balance change is not fixed so need to check who's balance come
         // first. this make sure recipient always come first
-        if *balance_changes[0].owner.address().unwrap() == signer {
+        if *balance_changes[0].owner.address_or_object().unwrap() == signer {
             balance_changes.reverse()
         }
         BalanceChangeChecker::new()

--- a/crates/iota-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/iota-cluster-test/src/test_case/shared_object_test.rs
@@ -65,20 +65,13 @@ impl TestCaseImpl for SharedCounterTest {
             .mutated()
             .iter()
             .find_map(|obj| {
-                let Owner::Shared {
-                    initial_shared_version,
-                } = obj.owner
-                else {
-                    return None;
-                };
-
-                if obj.reference.object_id == counter_ref.object_id
-                    && initial_shared_version == counter_ref.version
-                {
-                    Some(obj.reference.version)
-                } else {
-                    None
-                }
+                obj.owner
+                    .as_shared_opt()
+                    .and_then(|initial_shared_version| {
+                        (obj.reference.object_id == counter_ref.object_id
+                            && *initial_shared_version == counter_ref.version)
+                            .then_some(obj.reference.version)
+                    })
             })
             .unwrap_or_else(|| panic!("expect obj {} in mutated", counter_ref.object_id));
 
@@ -86,9 +79,7 @@ impl TestCaseImpl for SharedCounterTest {
         ctx.let_fullnode_sync(vec![response.digest], 5).await;
 
         let counter_object = ObjectChecker::new(counter_ref.object_id)
-            .owner(Owner::Shared {
-                initial_shared_version: counter_ref.version,
-            })
+            .owner(Owner::Shared(counter_ref.version))
             .check_into_object(ctx.get_fullnode_client())
             .await;
 

--- a/crates/iota-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/iota-cluster-test/src/test_case/shared_object_test.rs
@@ -65,13 +65,10 @@ impl TestCaseImpl for SharedCounterTest {
             .mutated()
             .iter()
             .find_map(|obj| {
-                obj.owner
-                    .as_shared_opt()
-                    .and_then(|initial_shared_version| {
-                        (obj.reference.object_id == counter_ref.object_id
-                            && *initial_shared_version == counter_ref.version)
-                            .then_some(obj.reference.version)
-                    })
+                let initial_shared_version = obj.owner.as_shared_opt()?;
+                (obj.reference.object_id == counter_ref.object_id
+                    && *initial_shared_version == counter_ref.version)
+                    .then_some(obj.reference.version)
             })
             .unwrap_or_else(|| panic!("expect obj {} in mutated", counter_ref.object_id));
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1928,7 +1928,7 @@ impl AuthorityState {
                     gas_object_id,
                     SIMULATION_GAS_COIN_VALUE,
                 ),
-                Owner::AddressOwner(sender),
+                Owner::Address(sender),
                 TransactionDigest::GENESIS_MARKER,
             );
             let gas_object_ref = gas_object.compute_object_reference();
@@ -2128,7 +2128,7 @@ impl AuthorityState {
                     ObjectID::MAX,
                     SIMULATION_GAS_COIN_VALUE,
                 ),
-                Owner::AddressOwner(transaction.gas_data().owner),
+                Owner::Address(transaction.gas_data().owner),
                 TransactionDigest::GENESIS_MARKER,
             );
             let mock_gas_object_ref = mock_gas_object.compute_object_reference();
@@ -2561,9 +2561,9 @@ impl AuthorityState {
             match self.get_owner_at_version(&object_ref.object_id, *old_version).unwrap_or_else(
                 |e| panic!("tx_digest={tx_digest:?}, error processing object owner index, cannot find owner for object {:?} at version {old_version:?}. Err: {e:?}",object_ref.object_id)
             ) {
-                Owner::AddressOwner(addr) => deleted_owners.push((addr, object_ref.object_id)),
-                Owner::ObjectOwner(object_id) => {
-                    deleted_dynamic_fields.push((ObjectID::from(object_id), object_ref.object_id))
+                Owner::Address(addr) => deleted_owners.push((addr, object_ref.object_id)),
+                Owner::Object(object_id) => {
+                    deleted_dynamic_fields.push((object_id, object_ref.object_id))
                 }
                 _ => {}
             }
@@ -2594,19 +2594,17 @@ impl AuthorityState {
                 };
                 if old_object.owner != owner {
                     match old_object.owner {
-                        Owner::AddressOwner(addr) => {
+                        Owner::Address(addr) => {
                             deleted_owners.push((addr, *id));
                         }
-                        Owner::ObjectOwner(object_id) => {
-                            deleted_dynamic_fields.push((ObjectID::from(object_id), *id))
-                        }
+                        Owner::Object(object_id) => deleted_dynamic_fields.push((object_id, *id)),
                         _ => {}
                     }
                 }
             }
 
             match owner {
-                Owner::AddressOwner(addr) => {
+                Owner::Address(addr) => {
                     // TODO: We can remove the object fetching after we added ObjectType to
                     // TransactionEffects
                     let new_object = written.get(id).unwrap_or_else(
@@ -2639,7 +2637,7 @@ impl AuthorityState {
                         },
                     ));
                 }
-                Owner::ObjectOwner(owner) => {
+                Owner::Object(owner) => {
                     let new_object = written.get(id).unwrap_or_else(
                         || panic!("tx_digest={tx_digest:?}, error processing object owner index, written does not contain object {id:?}")
                     );
@@ -2664,7 +2662,7 @@ impl AuthorityState {
                             // Skip indexing for non dynamic field objects.
                             continue;
                         };
-                    new_dynamic_fields.push(((ObjectID::from(owner), *id), df_info))
+                    new_dynamic_fields.push(((owner, *id), df_info))
                 }
                 _ => {}
             }
@@ -3238,11 +3236,11 @@ impl AuthorityState {
             .type_layout_resolver(Box::new(self.get_backing_package_store().as_ref()));
         for o in genesis_objects.iter() {
             match o.owner {
-                Owner::AddressOwner(addr) => new_owners.push((
+                Owner::Address(addr) => new_owners.push((
                     (addr, o.id()),
                     ObjectInfo::new(&o.compute_object_reference(), o),
                 )),
-                Owner::ObjectOwner(object_id) => {
+                Owner::Object(object_id) => {
                     let id = o.id();
                     let info = match self.try_create_dynamic_field_info(
                         o,
@@ -3269,7 +3267,7 @@ impl AuthorityState {
                         }
                         Err(e) => return Err(e),
                     };
-                    new_dynamic_fields.push(((ObjectID::from(object_id), id), info));
+                    new_dynamic_fields.push(((object_id, id), info));
                 }
                 _ => {}
             }

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -203,11 +203,8 @@ pub async fn init_state_with_ids_and_versions<
 ) -> Arc<AuthorityState> {
     let state = TestAuthorityBuilder::new().build().await;
     for (address, object_id, version) in objects {
-        let obj = Object::with_id_owner_version_for_testing(
-            object_id,
-            version,
-            Owner::AddressOwner(address),
-        );
+        let obj =
+            Object::with_id_owner_version_for_testing(object_id, version, Owner::Address(address));
         state.insert_genesis_object(obj).await;
     }
     state

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -269,7 +269,7 @@ mod tests {
         executable_transaction::{
             CertificateProof, ExecutableTransaction, VerifiedExecutableTransaction,
         },
-        object::{Object, Owner},
+        object::Object,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         transaction::{ObjectArg, SenderSignedData, VerifiedTransaction},
     };
@@ -285,13 +285,10 @@ mod tests {
     async fn test_assign_versions_from_consensus_basic() {
         let shared_object = Object::shared_for_testing();
         let id = shared_object.id();
-        let init_shared_version = match shared_object.owner {
-            Owner::Shared {
-                initial_shared_version,
-                ..
-            } => initial_shared_version,
-            _ => panic!("expected shared object"),
-        };
+        let init_shared_version = shared_object
+            .owner
+            .into_shared_opt()
+            .expect("expected shared object");
         let authority = TestAuthorityBuilder::new()
             .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()
@@ -426,20 +423,14 @@ mod tests {
         let shared_object_2 = Object::shared_for_testing();
         let id1 = shared_object_1.id();
         let id2 = shared_object_2.id();
-        let init_shared_version_1 = match shared_object_1.owner {
-            Owner::Shared {
-                initial_shared_version,
-                ..
-            } => initial_shared_version,
-            _ => panic!("expected shared object"),
-        };
-        let init_shared_version_2 = match shared_object_2.owner {
-            Owner::Shared {
-                initial_shared_version,
-                ..
-            } => initial_shared_version,
-            _ => panic!("expected shared object"),
-        };
+        let init_shared_version_1 = shared_object_1
+            .owner
+            .into_shared_opt()
+            .expect("expected shared object");
+        let init_shared_version_2 = shared_object_2
+            .owner
+            .into_shared_opt()
+            .expect("expected shared object");
         let authority = TestAuthorityBuilder::new()
             .with_starting_objects(&[shared_object_1.clone(), shared_object_2.clone()])
             .build()
@@ -599,13 +590,10 @@ mod tests {
     async fn test_assign_versions_from_effects() {
         let shared_object = Object::shared_for_testing();
         let id = shared_object.id();
-        let init_shared_version = match shared_object.owner {
-            Owner::Shared {
-                initial_shared_version,
-                ..
-            } => initial_shared_version,
-            _ => panic!("expected shared object"),
-        };
+        let init_shared_version = shared_object
+            .owner
+            .into_shared_opt()
+            .expect("expected shared object");
         let authority = TestAuthorityBuilder::new()
             .with_starting_objects(std::slice::from_ref(&shared_object))
             .build()

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -1303,7 +1303,7 @@ macro_rules! implement_storage_traits {
                 };
 
                 let parent = *parent;
-                if child_object.owner != Owner::ObjectOwner(parent.into()) {
+                if child_object.owner != Owner::Object(parent.into()) {
                     return Err(IotaError::InvalidChildObjectAccess {
                         object: *child,
                         given_parent: parent,
@@ -1336,7 +1336,7 @@ macro_rules! implement_storage_traits {
                 // These two cases must remain indisguishable to the caller otherwise we risk
                 // forks in transaction replay due to possible reordering of
                 // transactions during replay.
-                if recv_object.owner != Owner::AddressOwner((*owner).into())
+                if recv_object.owner != Owner::Address((*owner).into())
                     || self.try_have_received_object_at_version(
                         receiving_object_id,
                         receive_object_at_version,

--- a/crates/iota-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
@@ -223,9 +223,7 @@ async fn test_wait_for_object_impl<C: NotifyReadTestCache>(cache: Arc<C>) {
             let object = Object::with_id_owner_version_for_testing(
                 object_id,
                 SequenceNumber::from(0),
-                Owner::Shared {
-                    initial_shared_version: version,
-                },
+                Owner::Shared(version),
             );
             cache.write_object_for_testing(object);
         }
@@ -245,9 +243,7 @@ async fn test_wait_for_object_impl<C: NotifyReadTestCache>(cache: Arc<C>) {
             let object = Object::with_id_owner_version_for_testing(
                 object_id,
                 version,
-                Owner::Shared {
-                    initial_shared_version: version,
-                },
+                Owner::Shared(version),
             );
             cache.write_object_for_testing(object);
         }
@@ -338,7 +334,7 @@ async fn test_receiving_object_higher_version_impl(cache: &impl NotifyReadTestCa
     let object = Object::with_id_owner_version_for_testing(
         object_id,
         higher_version,
-        Owner::AddressOwner(IotaAddress::ZERO),
+        Owner::Address(IotaAddress::ZERO),
     );
 
     // Write higher version to cache

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -189,7 +189,7 @@ impl Scenario {
         let (owner, _) = deterministic_random_account_key();
         Object::new_move(
             MoveObject::new_gas_coin(OBJECT_START_VERSION, id, 100),
-            Owner::AddressOwner(owner),
+            Owner::Address(owner),
             TransactionDigest::ZERO,
         )
     }
@@ -215,7 +215,7 @@ impl Scenario {
         let id = ObjectID::random();
         Object::new_move(
             MoveObject::new_gas_coin(OBJECT_START_VERSION, id, 100),
-            Owner::ObjectOwner(owner.into()),
+            Owner::Object(owner),
             TransactionDigest::ZERO,
         )
     }
@@ -1230,7 +1230,7 @@ async fn latest_object_cache_race_test() {
                 let object = Object::with_id_owner_version_for_testing(
                     object_id,
                     version,
-                    Owner::AddressOwner(owner),
+                    Owner::Address(owner),
                 );
 
                 cache.write_object_entry(&object_id, version, object.into());
@@ -1271,7 +1271,7 @@ async fn latest_object_cache_race_test() {
                 let object = Object::with_id_owner_version_for_testing(
                     object_id,
                     latest_version,
-                    Owner::AddressOwner(owner),
+                    Owner::Address(owner),
                 );
 
                 // because we obtained the ticket before reading the object, we will not write a
@@ -1412,7 +1412,7 @@ async fn concurrent_latest_object_cache_race_test() {
         let object = Object::with_id_owner_version_for_testing(
             object_id,
             write_version,
-            Owner::AddressOwner(owner),
+            Owner::Address(owner),
         );
 
         cache.write_object_entry(&object_id, write_version, object.into());
@@ -1461,7 +1461,7 @@ async fn concurrent_latest_object_cache_race_test() {
         let object = Object::with_id_owner_version_for_testing(
             object_id,
             latest_version,
-            Owner::AddressOwner(owner),
+            Owner::Address(owner),
         );
 
         // preempt the reader to update the latest version and invalidate the cache
@@ -1534,7 +1534,7 @@ async fn concurrent_latest_object_cache_collision_test() {
         let object = Object::with_id_owner_version_for_testing(
             object_id,
             *write_version,
-            Owner::AddressOwner(owner),
+            Owner::Address(owner),
         );
 
         cache.write_object_entry(&object_id, *write_version, object.into());
@@ -1570,7 +1570,7 @@ async fn concurrent_latest_object_cache_collision_test() {
         let object2 = Object::with_id_owner_version_for_testing(
             object2_id,
             latest2_version,
-            Owner::AddressOwner(owner2),
+            Owner::Address(owner2),
         );
 
         // preempt the reader

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -729,7 +729,9 @@ impl IndexStoreTables {
                         )?;
                     }
                     Owner::Shared { .. } | Owner::Immutable => {}
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 }
             }
 
@@ -752,7 +754,9 @@ impl IndexStoreTables {
                             }
                         }
                         Owner::Shared { .. } | Owner::Immutable => {}
-                        _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                        _ => unimplemented!(
+                            "a new Owner enum variant was added and needs to be handled"
+                        ),
                     }
                 }
 
@@ -769,7 +773,9 @@ impl IndexStoreTables {
                         }
                     }
                     Owner::Shared { .. } | Owner::Immutable => {}
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 }
             }
 
@@ -1269,7 +1275,7 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
                 }
             }
             Owner::Shared { .. } | Owner::Immutable => {}
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
 
         // Look for CoinMetadata<T> and TreasuryCap<T> objects

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -716,19 +716,20 @@ impl IndexStoreTables {
             // determine changes from removed objects
             for removed_object in tx.removed_objects_pre_version() {
                 match removed_object.owner() {
-                    Owner::AddressOwner(address) => {
+                    Owner::Address(address) => {
                         // owner: delete old entry
                         if let Some((owner_key, _)) = make_owner_key(*address, removed_object) {
                             batch.delete_batch(&self.owner, [owner_key])?;
                         }
                     }
-                    Owner::ObjectOwner(object_id) => {
+                    Owner::Object(object_id) => {
                         batch.delete_batch(
                             &self.dynamic_field,
                             [DynamicFieldKey::new(*object_id, removed_object.id())],
                         )?;
                     }
                     Owner::Shared { .. } | Owner::Immutable => {}
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 }
             }
 
@@ -736,14 +737,13 @@ impl IndexStoreTables {
             for (object, old_object) in tx.changed_objects() {
                 if let Some(old_object) = old_object {
                     match old_object.owner() {
-                        Owner::AddressOwner(address) => {
+                        Owner::Address(address) => {
                             // owner: delete old entry
                             if let Some((owner_key, _)) = make_owner_key(*address, old_object) {
                                 batch.delete_batch(&self.owner, [owner_key])?;
                             }
                         }
-
-                        Owner::ObjectOwner(object_id) => {
+                        Owner::Object(object_id) => {
                             if old_object.owner() != object.owner() {
                                 batch.delete_batch(
                                     &self.dynamic_field,
@@ -751,24 +751,25 @@ impl IndexStoreTables {
                                 )?;
                             }
                         }
-
                         Owner::Shared { .. } | Owner::Immutable => {}
+                        _ => unimplemented!("a new enum variant was added and needs to be handled"),
                     }
                 }
 
                 match object.owner() {
-                    Owner::AddressOwner(owner) => {
+                    Owner::Address(owner) => {
                         if let Some((owner_key, owner_info)) = make_owner_key(*owner, object) {
                             batch.insert_batch(&self.owner, [(owner_key, owner_info)])?;
                         }
                     }
-                    Owner::ObjectOwner(parent) => {
+                    Owner::Object(parent) => {
                         if should_index_dynamic_field(object) {
                             let field_key = DynamicFieldKey::new(*parent, object.id());
                             batch.insert_batch(&self.dynamic_field, [(field_key, ())])?;
                         }
                     }
                     Owner::Shared { .. } | Owner::Immutable => {}
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 }
             }
 
@@ -1253,23 +1254,22 @@ impl<'a> ParMakeLiveObjectIndexer for GrpcParLiveObjectSetIndexer<'a> {
 impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
     fn index_object(&mut self, object: Object) -> Result<(), StorageError> {
         match object.owner {
-            Owner::AddressOwner(owner) => {
+            Owner::Address(owner) => {
                 if let Some((owner_key, owner_info)) = make_owner_key(owner, &object) {
                     self.batch
                         .insert_batch(&self.tables.owner, [(owner_key, owner_info)])?;
                 }
             }
-
             // Dynamic Field Index
-            Owner::ObjectOwner(parent) => {
+            Owner::Object(parent) => {
                 if should_index_dynamic_field(&object) {
                     let field_key = DynamicFieldKey::new(parent, object.id());
                     self.batch
                         .insert_batch(&self.tables.dynamic_field, [(field_key, ())])?;
                 }
             }
-
             Owner::Shared { .. } | Owner::Immutable => {}
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
 
         // Look for CoinMetadata<T> and TreasuryCap<T> objects

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -674,8 +674,7 @@ impl IndexStore {
             &self.tables.transactions_to_addr,
             mutated_objects.filter_map(|(_, owner)| {
                 owner
-                    .get_address_owner_address()
-                    .ok()
+                    .into_address_opt()
                     .map(|addr| ((addr, sequence), digest))
             }),
         )?;
@@ -1747,7 +1746,7 @@ mod tests {
                     version: object.version(),
                     digest: object.digest(),
                     type_: ObjectType::Struct(object.type_().unwrap().clone()),
-                    owner: Owner::AddressOwner(address),
+                    owner: Owner::Address(address),
                     previous_transaction: object.previous_transaction,
                 },
             ));

--- a/crates/iota-core/src/transaction_outputs.rs
+++ b/crates/iota-core/src/transaction_outputs.rs
@@ -100,7 +100,7 @@ impl TransactionOutputs {
             .into_iter()
             .filter_map(|(id, ((version, digest), owner))| {
                 owner
-                    .is_address_owned()
+                    .is_address()
                     .then_some(ObjectRef::new(id, version, digest))
             })
             .chain(received_objects)

--- a/crates/iota-core/src/unit_tests/auth_unit_test_utils.rs
+++ b/crates/iota-core/src/unit_tests/auth_unit_test_utils.rs
@@ -105,7 +105,7 @@ pub async fn publish_package_on_single_authority(
         .data()
         .created()
         .iter()
-        .find(|c| matches!(c.1, Owner::AddressOwner(..)))
+        .find(|c| matches!(c.1, Owner::Address(..)))
         .unwrap()
         .0;
     Ok((*effects.transaction_digest(), (package_id, cap_object)))
@@ -135,7 +135,7 @@ pub async fn upgrade_package_on_single_authority(
         package_id,
         modules,
         package.get_published_dependencies_ids(),
-        (upgrade_cap, Owner::AddressOwner(sender)),
+        (upgrade_cap, Owner::Address(sender)),
         UpgradePolicy::COMPATIBLE,
         digest,
         rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -98,16 +98,15 @@ impl TestCallArg {
     async fn call_arg_from_id(object_id: ObjectID, state: &AuthorityState) -> ObjectArg {
         let object = state.get_object(&object_id).await.unwrap();
         match &object.owner {
-            Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
+            Owner::Address(_) | Owner::Object(_) | Owner::Immutable => {
                 ObjectArg::ImmOrOwnedObject(object.compute_object_reference())
             }
-            Owner::Shared {
-                initial_shared_version,
-            } => ObjectArg::SharedObject {
+            Owner::Shared(initial_shared_version) => ObjectArg::SharedObject {
                 id: object_id,
                 initial_shared_version: *initial_shared_version,
                 mutable: true,
             },
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
 }
@@ -154,9 +153,7 @@ async fn construct_shared_object_transaction_with_sequence_number(
                 .try_as_move_mut()
                 .unwrap()
                 .increment_version_to(initial_shared_version);
-            shared_object.owner = Owner::Shared {
-                initial_shared_version,
-            };
+            shared_object.owner = Owner::Shared(initial_shared_version);
         }
         shared_object.previous_transaction = TransactionDigest::GENESIS_MARKER;
         (shared_object_id, shared_object)
@@ -447,7 +444,7 @@ async fn test_dev_inspect_unowned_object() {
     let created_object_id = effects.created()[0].0.object_id;
     let created_object = validator.get_object(&created_object_id).await.unwrap();
     assert!(alice != bob);
-    assert_eq!(created_object.owner, Owner::AddressOwner(bob));
+    assert_eq!(created_object.owner, Owner::Address(bob));
 
     // alice uses the object with dev inspect, despite not being the owner
     let DevInspectResults {
@@ -1097,7 +1094,7 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
     let gas_object = Object::with_id_owner_version_for_testing(
         gas_object_id,
         SequenceNumber::MAX_VALID_EXCL - 1,
-        Owner::AddressOwner(sender),
+        Owner::Address(sender),
     );
     let gas_object_ref = gas_object.compute_object_reference();
     validator.insert_genesis_object(gas_object.clone()).await;
@@ -3166,7 +3163,7 @@ async fn test_transfer_iota_no_amount() {
     assert!(effects.status().is_ok());
     assert!(effects.mutated_excluding_gas().is_empty());
     assert!(gas_ref.version < effects.gas_object().0.version);
-    assert_eq!(effects.gas_object().1, Owner::AddressOwner(recipient));
+    assert_eq!(effects.gas_object().1, Owner::Address(recipient));
     let new_balance = iota_types::gas::get_gas_balance(
         &authority_state.get_object(&gas_object_id).await.unwrap(),
     )
@@ -3207,14 +3204,14 @@ async fn test_transfer_iota_with_amount() {
     assert!(effects.status().is_ok());
     assert!(effects.mutated_excluding_gas().is_empty());
     assert_eq!(effects.created().len(), 1);
-    assert_eq!(effects.created()[0].1, Owner::AddressOwner(recipient));
+    assert_eq!(effects.created()[0].1, Owner::Address(recipient));
     let new_gas = authority_state
         .get_object(&effects.created()[0].0.object_id)
         .await
         .unwrap();
     assert_eq!(iota_types::gas::get_gas_balance(&new_gas).unwrap(), 500);
     assert!(gas_ref.version < effects.gas_object().0.version);
-    assert_eq!(effects.gas_object().1, Owner::AddressOwner(sender));
+    assert_eq!(effects.gas_object().1, Owner::Address(sender));
     let new_balance = iota_types::gas::get_gas_balance(
         &authority_state.get_object(&gas_object_id).await.unwrap(),
     )
@@ -3262,7 +3259,7 @@ async fn test_store_revert_transfer_iota() {
 
     assert_eq!(
         cache.get_object(&gas_object_id).unwrap().owner,
-        Owner::AddressOwner(sender),
+        Owner::Address(sender),
     );
     assert_eq!(
         cache
@@ -3724,11 +3721,11 @@ async fn test_store_revert_add_ofield() {
     assert_eq!(outer.version(), outer_v1.version);
 
     let field = cache.get_object(&field_v0.object_id).unwrap();
-    assert_eq!(field.owner, Owner::ObjectOwner(outer_v0.object_id.into()));
+    assert_eq!(field.owner, Owner::Object(outer_v0.object_id));
 
     let inner = cache.get_object(&inner_v0.object_id).unwrap();
     assert_eq!(inner.version(), inner_v1.version);
-    assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.object_id.into()));
+    assert_eq!(inner.owner, Owner::Object(field_v0.object_id));
 
     reconfig_api.revert_state_update(&add_digest);
 
@@ -3743,7 +3740,7 @@ async fn test_store_revert_add_ofield() {
 
     let inner = cache.get_object(&inner_v0.object_id).unwrap();
     assert_eq!(inner.version(), inner_v0.version);
-    assert_eq!(inner.owner, Owner::AddressOwner(sender));
+    assert_eq!(inner.owner, Owner::Address(sender));
 }
 
 #[tokio::test]
@@ -3850,7 +3847,7 @@ async fn test_store_revert_remove_ofield() {
     assert_eq!(outer.version(), outer_v2.version);
 
     let inner = cache.get_object(&inner_v0.object_id).unwrap();
-    assert_eq!(inner.owner, Owner::AddressOwner(sender));
+    assert_eq!(inner.owner, Owner::Address(sender));
     assert_eq!(inner.version(), inner_v2.version);
 
     reconfig_api.revert_state_update(&remove_ofield_digest);
@@ -3861,10 +3858,10 @@ async fn test_store_revert_remove_ofield() {
     assert_eq!(outer.version(), outer_v1.version);
 
     let field = cache.get_object(&field_v0.object_id).unwrap();
-    assert_eq!(field.owner, Owner::ObjectOwner(outer_v0.object_id.into()));
+    assert_eq!(field.owner, Owner::Object(outer_v0.object_id));
 
     let inner = cache.get_object(&inner_v0.object_id).unwrap();
-    assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.object_id.into()));
+    assert_eq!(inner.owner, Owner::Object(field_v0.object_id));
     assert_eq!(inner.version(), inner_v1.version);
 }
 
@@ -4596,9 +4593,7 @@ async fn prepare_authority_and_shared_object_cert()
     let shared_object_id = ObjectID::random();
     let shared_object = {
         let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
-        let owner = Owner::Shared {
-            initial_shared_version: obj.version(),
-        };
+        let owner = Owner::Shared(obj.version());
         Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
     };
     let initial_shared_version = shared_object.version();
@@ -4683,9 +4678,7 @@ async fn test_consensus_commit_prologue_generation() {
     let shared_object_id = ObjectID::random();
     let shared_object = {
         let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
-        let owner = Owner::Shared {
-            initial_shared_version: obj.version(),
-        };
+        let owner = Owner::Shared(obj.version());
         Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
     };
     let initial_shared_version = shared_object.version();
@@ -4783,9 +4776,7 @@ async fn test_consensus_message_processed() {
     let shared_object = {
         use iota_types::object::MoveObject;
         let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
-        let owner = Owner::Shared {
-            initial_shared_version: obj.version(),
-        };
+        let owner = Owner::Shared(obj.version());
         Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
     };
     let initial_shared_version = shared_object.version();
@@ -6191,9 +6182,7 @@ fn create_shared_objects(num: u32) -> Vec<Object> {
         let shared_object_id = ObjectID::random();
         let shared_object = {
             let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
-            let owner = Owner::Shared {
-                initial_shared_version: obj.version(),
-            };
+            let owner = Owner::Shared(obj.version());
             Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
         };
         objects.push(shared_object);
@@ -6449,12 +6438,12 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
         Object::with_id_owner_version_for_testing(
             ObjectID::random(),
             1.into(),
-            Owner::AddressOwner(sender),
+            Owner::Address(sender),
         ),
         Object::with_id_owner_version_for_testing(
             ObjectID::random(),
             2.into(),
-            Owner::AddressOwner(sender),
+            Owner::Address(sender),
         ),
     ];
 

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -106,7 +106,7 @@ impl TestCallArg {
                 initial_shared_version: *initial_shared_version,
                 mutable: true,
             },
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
 }

--- a/crates/iota-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/batch_transaction_tests.rs
@@ -86,14 +86,14 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
         effects
             .created()
             .iter()
-            .all(|(_, owner)| owner == &Owner::AddressOwner(sender))
+            .all(|(_, owner)| owner == &Owner::Address(sender))
     );
     // N of the objects should now be owned by recipient.
     assert_eq!(
         effects
             .mutated()
             .iter()
-            .filter(|(_, owner)| owner == &Owner::AddressOwner(recipient))
+            .filter(|(_, owner)| owner == &Owner::Address(recipient))
             .count(),
         N
     );

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -354,10 +354,7 @@ async fn test_execution_with_dependencies() {
             .await;
     executed_owned_certs.push(cert);
     let (mut shared_counter_ref, owner) = effects2.created()[0];
-    let shared_counter_initial_version = if let Owner::Shared {
-        initial_shared_version,
-    } = owner
-    {
+    let shared_counter_initial_version = if let Owner::Shared(initial_shared_version) = owner {
         // Because the gas object used has version 2, the initial lamport timestamp of
         // the shared counter is 3.
         assert_eq!(initial_shared_version, 3);
@@ -533,10 +530,7 @@ async fn test_per_object_overload() {
         .pop()
         .unwrap();
     let (shared_counter_ref, owner) = create_counter_effects.created()[0];
-    let Owner::Shared {
-        initial_shared_version: shared_counter_initial_version,
-    } = owner
-    else {
+    let Owner::Shared(shared_counter_initial_version) = owner else {
         panic!("Not a shared object! {shared_counter_ref:?} {owner:?}");
     };
 
@@ -661,10 +655,7 @@ async fn test_txn_age_overload() {
         .pop()
         .unwrap();
     let (shared_counter_ref, owner) = create_counter_effects.created()[0];
-    let Owner::Shared {
-        initial_shared_version: shared_counter_initial_version,
-    } = owner
-    else {
+    let Owner::Shared(shared_counter_initial_version) = owner else {
         panic!("Not a shared object! {shared_counter_ref:?} {owner:?}");
     };
 

--- a/crates/iota-core/src/unit_tests/gas_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_tests.rs
@@ -663,9 +663,7 @@ async fn test_invalid_gas_owners() {
         )
         .await,
         UserInputError::GasObjectNotOwnedObject {
-            owner: Owner::Shared {
-                initial_shared_version: OBJECT_START_VERSION
-            }
+            owner: Owner::Shared(OBJECT_START_VERSION)
         }
     );
     assert_eq!(
@@ -691,7 +689,7 @@ async fn test_invalid_gas_owners() {
         )
         .await,
         UserInputError::GasObjectNotOwnedObject {
-            owner: Owner::ObjectOwner(gas_object3.object_id.into())
+            owner: Owner::Object(gas_object3.object_id)
         }
     );
     assert!(matches!(

--- a/crates/iota-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_integration_tests.rs
@@ -354,11 +354,8 @@ async fn test_object_owning_another_object() {
         .find(|(object_ref, _)| object_ref.object_id == child_id)
         .unwrap();
     // Check that the child is now owned by the parent.
-    let field_id = match child_effect.1 {
-        Owner::ObjectOwner(field_id) => field_id.into(),
-        Owner::Shared { .. } | Owner::Immutable | Owner::AddressOwner(_) => panic!(),
-    };
-    let field_object = authority.get_object(&field_id).await.unwrap();
+    let field_id = child_effect.1.as_object();
+    let field_object = authority.get_object(field_id).await.unwrap();
     assert_eq!(field_object.owner, parent_id);
 
     // Mutate the child directly will now fail because we need the parent to
@@ -493,7 +490,7 @@ async fn test_create_then_delete_parent_child() {
     let parent = effects
         .created()
         .iter()
-        .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+        .find(|(_, owner)| matches!(owner, Owner::Address(_)))
         .unwrap()
         .0;
 
@@ -562,7 +559,7 @@ async fn test_create_then_delete_parent_child_wrap() {
     let parent = effects
         .created()
         .iter()
-        .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+        .find(|(_, owner)| matches!(owner, Owner::Address(_)))
         .unwrap()
         .0;
 
@@ -659,7 +656,7 @@ async fn test_remove_child_when_no_prior_version_exists() {
     let parent = effects
         .created()
         .iter()
-        .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+        .find(|(_, owner)| matches!(owner, Owner::Address(_)))
         .unwrap()
         .0;
 
@@ -3022,7 +3019,7 @@ pub async fn build_and_publish_test_package_with_upgrade_cap(
     let upgrade_cap = effects
         .created()
         .into_iter()
-        .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+        .find(|(_, owner)| matches!(owner, Owner::Address(_)))
         .unwrap();
 
     (package.0, upgrade_cap.0)
@@ -3040,7 +3037,7 @@ pub async fn collect_packages_and_upgrade_caps(
         .collect();
     let mut caps = HashMap::new();
     for (obj_ref, owner) in effects.created() {
-        if !matches!(owner, Owner::AddressOwner(_)) {
+        if !matches!(owner, Owner::Address(_)) {
             continue;
         }
         let cap = authority.get_object(&obj_ref.object_id).await.unwrap();

--- a/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
@@ -90,7 +90,7 @@ async fn test_publishing_with_unpublished_deps() {
     // Check that calling the function does what we expect
     assert!(matches!(
         owner,
-        Owner::Shared { initial_shared_version: initial } if initial == v
+        Owner::Shared(initial) if initial == v
     ));
 }
 

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -227,7 +227,7 @@ impl UpgradeStateRunner {
         let cap = effects
             .created()
             .into_iter()
-            .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+            .find(|(_, owner)| matches!(owner, Owner::Address(_)))
             .unwrap();
 
         (package.0, cap.0)
@@ -409,7 +409,7 @@ async fn test_upgrade_introduces_type_then_uses_it() {
     let created = effects
         .created()
         .into_iter()
-        .find_map(|(b, owner)| matches!(owner, Owner::AddressOwner(_)).then_some(b))
+        .find_map(|(b, owner)| matches!(owner, Owner::Address(_)).then_some(b))
         .unwrap();
 
     let b = runner
@@ -1211,7 +1211,7 @@ async fn test_upgraded_types_in_one_txn() {
     let created_b = effects
         .created()
         .into_iter()
-        .find_map(|(b, owner)| matches!(owner, Owner::AddressOwner(_)).then_some(b))
+        .find_map(|(b, owner)| matches!(owner, Owner::Address(_)).then_some(b))
         .unwrap();
 
     // Create an instance of the type introduced at version 3 using function from
@@ -1228,7 +1228,7 @@ async fn test_upgraded_types_in_one_txn() {
     let created_c = effects
         .created()
         .into_iter()
-        .find_map(|(c, owner)| matches!(owner, Owner::AddressOwner(_)).then_some(c))
+        .find_map(|(c, owner)| matches!(owner, Owner::Address(_)).then_some(c))
         .unwrap();
 
     // modify objects created of types introduced at versions 2 and 3 and emit

--- a/crates/iota-core/src/unit_tests/pay_iota_tests.rs
+++ b/crates/iota-core/src/unit_tests/pay_iota_tests.rs
@@ -190,9 +190,18 @@ async fn test_pay_iota_success_one_input_coin() -> anyhow::Result<()> {
         .await
         .unwrap();
 
-    let addr1 = effects.created()[0].1.get_owner_address()?;
-    let addr2 = effects.created()[1].1.get_owner_address()?;
-    let addr3 = effects.created()[2].1.get_owner_address()?;
+    let addr1 = *effects.created()[0]
+        .1
+        .address()
+        .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
+    let addr2 = *effects.created()[1]
+        .1
+        .address()
+        .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
+    let addr3 = *effects.created()[2]
+        .1
+        .address()
+        .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
     let coin_val1 = *recipient_amount_map
         .get(&addr1)
         .ok_or(IotaError::InvalidAddress)?;
@@ -261,8 +270,14 @@ async fn test_pay_iota_success_multiple_input_coins() -> anyhow::Result<()> {
         .get_object(&created_obj_id2)
         .await
         .unwrap();
-    let addr1 = effects.created()[0].1.get_owner_address()?;
-    let addr2 = effects.created()[1].1.get_owner_address()?;
+    let addr1 = *effects.created()[0]
+        .1
+        .address()
+        .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
+    let addr2 = *effects.created()[1]
+        .1
+        .address()
+        .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
     let coin_val1 = *recipient_amount_map
         .get(&addr1)
         .ok_or(IotaError::InvalidAddress)?;

--- a/crates/iota-core/src/unit_tests/pay_iota_tests.rs
+++ b/crates/iota-core/src/unit_tests/pay_iota_tests.rs
@@ -192,15 +192,15 @@ async fn test_pay_iota_success_one_input_coin() -> anyhow::Result<()> {
 
     let addr1 = *effects.created()[0]
         .1
-        .address()
+        .address_or_object()
         .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
     let addr2 = *effects.created()[1]
         .1
-        .address()
+        .address_or_object()
         .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
     let addr3 = *effects.created()[2]
         .1
-        .address()
+        .address_or_object()
         .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
     let coin_val1 = *recipient_amount_map
         .get(&addr1)
@@ -272,11 +272,11 @@ async fn test_pay_iota_success_multiple_input_coins() -> anyhow::Result<()> {
         .unwrap();
     let addr1 = *effects.created()[0]
         .1
-        .address()
+        .address_or_object()
         .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
     let addr2 = *effects.created()[1]
         .1
-        .address()
+        .address_or_object()
         .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?;
     let coin_val1 = *recipient_amount_map
         .get(&addr1)

--- a/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
@@ -125,7 +125,7 @@ async fn transaction_manager_basics() {
     let gas_object_new = Object::with_id_owner_version_for_testing(
         ObjectID::random(),
         0.into(),
-        Owner::AddressOwner(owner),
+        Owner::Address(owner),
     );
     let transaction = make_transaction(gas_object_new.clone(), vec![]);
     let tx_start_time = Instant::now();
@@ -398,11 +398,8 @@ async fn transaction_manager_receiving_notify_commit() {
     let obj_id = ObjectID::random();
     let object_arguments: Vec<_> = (0..10)
         .map(|i| {
-            let object = Object::with_id_owner_version_for_testing(
-                obj_id,
-                i.into(),
-                Owner::AddressOwner(owner),
-            );
+            let object =
+                Object::with_id_owner_version_for_testing(obj_id, i.into(), Owner::Address(owner));
             // Every other transaction receives the object, and we create a run of multiple
             // receives in a row at the beginning to test that the TM doesn't
             // get stuck in either configuration of: ImmOrOwnedObject =>
@@ -493,9 +490,9 @@ async fn transaction_manager_receiving_object_ready_notifications() {
 
     let obj_id = ObjectID::random();
     let receiving_object_new0 =
-        Object::with_id_owner_version_for_testing(obj_id, 0.into(), Owner::AddressOwner(owner));
+        Object::with_id_owner_version_for_testing(obj_id, 0.into(), Owner::Address(owner));
     let receiving_object_new1 =
-        Object::with_id_owner_version_for_testing(obj_id, 1.into(), Owner::AddressOwner(owner));
+        Object::with_id_owner_version_for_testing(obj_id, 1.into(), Owner::Address(owner));
     let receiving_object_arg0 =
         ObjectArg::Receiving(receiving_object_new0.compute_object_reference());
     let receive_object_transaction0 = make_transaction(
@@ -581,9 +578,9 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
 
     let obj_id = ObjectID::random();
     let receiving_object_new0 =
-        Object::with_id_owner_version_for_testing(obj_id, 0.into(), Owner::AddressOwner(owner));
+        Object::with_id_owner_version_for_testing(obj_id, 0.into(), Owner::Address(owner));
     let receiving_object_new1 =
-        Object::with_id_owner_version_for_testing(obj_id, 1.into(), Owner::AddressOwner(owner));
+        Object::with_id_owner_version_for_testing(obj_id, 1.into(), Owner::Address(owner));
     let receiving_object_arg0 =
         ObjectArg::Receiving(receiving_object_new0.compute_object_reference());
     let receive_object_transaction0 = make_transaction(
@@ -686,7 +683,7 @@ async fn transaction_manager_receiving_object_ready_if_current_version_greater()
     let receiving_object = Object::with_id_owner_version_for_testing(
         ObjectID::random(),
         10.into(),
-        Owner::AddressOwner(owner),
+        Owner::Address(owner),
     );
     gas_objects.push(receiving_object.clone());
     let state = init_state_with_objects(gas_objects.clone()).await;
@@ -702,12 +699,12 @@ async fn transaction_manager_receiving_object_ready_if_current_version_greater()
     let receiving_object_new0 = Object::with_id_owner_version_for_testing(
         receiving_object.id(),
         0.into(),
-        Owner::AddressOwner(owner),
+        Owner::Address(owner),
     );
     let receiving_object_new1 = Object::with_id_owner_version_for_testing(
         receiving_object.id(),
         1.into(),
-        Owner::AddressOwner(owner),
+        Owner::Address(owner),
     );
     let receiving_object_arg0 =
         ObjectArg::Receiving(receiving_object_new0.compute_object_reference());

--- a/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
@@ -257,7 +257,7 @@ impl TestRunner {
 fn get_parent_and_child(
     created: Vec<(ObjectRef, Owner)>,
 ) -> ((ObjectRef, Owner), (ObjectRef, Owner)) {
-    // make sure there is an object with an `AddressOwner` who matches the object ID
+    // make sure there is an object with an `Address` who matches the object ID
     // of another object.
     let created_addrs: HashSet<_> = created
         .iter()
@@ -266,7 +266,7 @@ fn get_parent_and_child(
     let (child, parent_id) = created
         .iter()
         .find_map(|child @ (_, owner)| match owner {
-            Owner::AddressOwner(j) if created_addrs.contains(&ObjectID::from(*j)) => {
+            Owner::Address(j) if created_addrs.contains(&ObjectID::from(*j)) => {
                 Some((child, (*j).into()))
             }
             _ => None,
@@ -321,7 +321,7 @@ async fn test_tto_transfer() {
         for (obj_ref, owner) in effects.mutated().iter() {
             if obj_ref.object_id == child.0 .object_id {
                 // Child should be sent to 0x0
-                assert_eq!(owner, &Owner::AddressOwner(IotaAddress::ZERO));
+                assert_eq!(owner, &Owner::Address(IotaAddress::ZERO));
                 // It's version should be bumped as well
                 assert!(obj_ref.version > child.0.version);
             }
@@ -424,7 +424,7 @@ async fn test_tto_invalid_receiving_arguments() {
         let object_owned = *effects
             .created()
             .iter()
-            .find(|(_, owner)| matches!(owner, Owner::ObjectOwner(_)))
+            .find(|(_, owner)| matches!(owner, Owner::Object(_)))
             .unwrap();
 
         #[expect(clippy::type_complexity)]
@@ -768,7 +768,7 @@ async fn test_tto_unwrap_transfer() {
         // The now-unwrapped object should be sent to 0x0
         assert_eq!(
             effects.unwrapped()[0].1,
-            Owner::AddressOwner(IotaAddress::ZERO)
+            Owner::Address(IotaAddress::ZERO)
         );
 
         // Receiving object ID is deleted
@@ -1132,7 +1132,7 @@ async fn test_tto_valid_dependencies() {
         for (obj_ref, owner) in effects.mutated().iter() {
             if obj_ref.object_id == child.0 .object_id {
                 // Child should be sent to 0x0
-                assert_eq!(owner, &Owner::AddressOwner(IotaAddress::ZERO));
+                assert_eq!(owner, &Owner::Address(IotaAddress::ZERO));
                 // It's version should be bumped as well
                 assert!(obj_ref.version > child.0.version);
                 // The child should be the max version
@@ -1659,9 +1659,9 @@ async fn receive_and_dof_interleave() {
         let owned = *effects
             .created()
             .iter()
-            .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+            .find(|(_, owner)| matches!(owner, Owner::Address(_)))
             .unwrap();
-        let Owner::Shared { initial_shared_version }= shared.1 else { unreachable!() };
+        let Owner::Shared(initial_shared_version) = shared.1 else { unreachable!() };
 
         let init_digest = effects.transaction_digest();
 

--- a/crates/iota-core/src/verify_indexes.rs
+++ b/crates/iota-core/src/verify_indexes.rs
@@ -29,7 +29,7 @@ pub fn verify_indexes(store: &dyn GlobalStateHashStore, indexes: Arc<IndexStore>
         let LiveObject::Normal(object) = object else {
             continue;
         };
-        let Owner::AddressOwner(owner) = object.owner else {
+        let Owner::Address(owner) = object.owner else {
             continue;
         };
 

--- a/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
@@ -344,7 +344,7 @@ mod add_stake {
             let staked_amount =
                 object.get_total_iota(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
             assert_eq!(staked_amount, self.stake_amount);
-            assert_eq!(object.owner.get_owner_address().unwrap(), self.sender);
+            assert_eq!(*object.owner.address().unwrap(), self.sender);
             runner.display_effects(effects);
         }
 

--- a/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
@@ -344,7 +344,7 @@ mod add_stake {
             let staked_amount =
                 object.get_total_iota(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
             assert_eq!(staked_amount, self.stake_amount);
-            assert_eq!(*object.owner.address().unwrap(), self.sender);
+            assert_eq!(*object.owner.address_or_object().unwrap(), self.sender);
             runner.display_effects(effects);
         }
 

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -78,7 +78,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     let object_read = fullnode.state().get_object_read(&transferred_object)?;
     let object = object_read.into_object()?;
 
-    assert_eq!(object.owner.get_owner_address().unwrap(), receiver);
+    assert_eq!(*object.owner.address().unwrap(), receiver);
 
     Ok(())
 }
@@ -416,7 +416,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     // let events_by_recipient = node
     // .state()
     // .query_events(
-    // EventQuery::Recipient(Owner::AddressOwner(receiver)),
+    // EventQuery::Recipient(Owner::Address(receiver)),
     // None,
     // 100,
     // false,
@@ -1011,13 +1011,13 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
         get_past_obj_read_from_node(node, object_id, object_ref_v2.version).await?;
     assert_eq!(read_ref_v2, object_ref_v2);
     assert_eq!(read_obj_v2, object_v2);
-    assert_eq!(read_obj_v2.owner, Owner::AddressOwner(recipient));
+    assert_eq!(read_obj_v2.owner, Owner::Address(recipient));
 
     let (read_ref_v1, read_obj_v1, _) =
         get_past_obj_read_from_node(node, object_id, object_ref_v1.version).await?;
     assert_eq!(read_ref_v1, object_ref_v1);
     assert_eq!(read_obj_v1, object_v1);
-    assert_eq!(read_obj_v1.owner, Owner::AddressOwner(sender));
+    assert_eq!(read_obj_v1.owner, Owner::Address(sender));
 
     let too_high_version = SequenceNumber::lamport_increment([object_ref_v3.version]).unwrap();
 

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -78,7 +78,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     let object_read = fullnode.state().get_object_read(&transferred_object)?;
     let object = object_read.into_object()?;
 
-    assert_eq!(*object.owner.address().unwrap(), receiver);
+    assert_eq!(*object.owner.address_or_object().unwrap(), receiver);
 
     Ok(())
 }

--- a/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
@@ -547,7 +547,7 @@ async fn list_owned_objects_tto_indexing() {
         .created()
         .iter()
         .find_map(|(obj_ref, owner)| match owner {
-            Owner::AddressOwner(addr) if *addr == sender => Some(*obj_ref),
+            Owner::Address(addr) if *addr == sender => Some(*obj_ref),
             _ => None,
         })
         .expect("start should create an `A` object owned by the sender");

--- a/crates/iota-e2e-tests/tests/per_epoch_config_stress_tests.rs
+++ b/crates/iota-e2e-tests/tests/per_epoch_config_stress_tests.rs
@@ -271,7 +271,7 @@ async fn create_test_env() -> TestEnv {
         } else if object.is_coin() {
             coin_id = Some(object_id);
             coin_type = object.coin_type_maybe();
-            coin_owner = Some(created.owner.get_address_owner_address().unwrap());
+            coin_owner = Some(*created.owner.as_address());
         } else if object.type_().unwrap().is_coin_deny_cap_v1() {
             deny_cap = Some(object_id);
         }

--- a/crates/iota-e2e-tests/tests/shared_objects_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/shared_objects_version_tests.rs
@@ -112,14 +112,7 @@ async fn shared_object_not_found() {
 }
 
 fn is_shared_at(owner: &Owner, version: SequenceNumber) -> bool {
-    if let Owner::Shared {
-        initial_shared_version,
-    } = owner
-    {
-        &version == initial_shared_version
-    } else {
-        false
-    }
+    matches!(owner, Owner::Shared(initial_shared_version) if *initial_shared_version == version)
 }
 
 struct TestEnvironment {
@@ -167,7 +160,7 @@ impl TestEnvironment {
 
         *fx.created()
             .iter()
-            .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+            .find(|(_, owner)| matches!(owner, Owner::Address(_)))
             .expect("Owned object created")
     }
 

--- a/crates/iota-e2e-tests/tests/transfer_to_object_tests.rs
+++ b/crates/iota-e2e-tests/tests/transfer_to_object_tests.rs
@@ -94,7 +94,7 @@ async fn delete_of_object_with_reconfiguration_receive_of_new_parent_and_old_chi
 }
 
 fn get_parent_and_child(created: Vec<(ObjectRef, Owner)>) -> (ObjectRef, ObjectRef) {
-    // make sure there is an object with an `AddressOwner` who matches the object ID
+    // make sure there is an object with an `Address` who matches the object ID
     // of another object.
     let created_addrs: HashSet<_> = created
         .iter()
@@ -103,7 +103,7 @@ fn get_parent_and_child(created: Vec<(ObjectRef, Owner)>) -> (ObjectRef, ObjectR
     let (child, parent_id) = created
         .iter()
         .find_map(|child @ (_, owner)| match owner {
-            Owner::AddressOwner(j) if created_addrs.contains(&ObjectID::from(*j)) => {
+            Owner::Address(j) if created_addrs.contains(&ObjectID::from(*j)) => {
                 Some((child, (*j).into()))
             }
             _ => None,

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -791,7 +791,7 @@ impl SimpleFaucet {
 
             // Insert the coins into the map based on the destination address
             address_coins_map
-                .entry(*owner.address().unwrap())
+                .entry(*owner.address_or_object().unwrap())
                 .or_default()
                 .push(coin_obj_ref);
         });

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -391,9 +391,7 @@ impl SimpleFaucet {
         let gas_obj = self.get_coin(coin_id).await?;
         info!(?coin_id, "Reading gas coin object: {gas_obj:?}");
         Ok(gas_obj.and_then(|(owner_opt, coin)| match owner_opt {
-            Some(Owner::AddressOwner(owner_addr)) if owner_addr == self.active_address => {
-                Some(coin)
-            }
+            Some(Owner::Address(owner_addr)) if owner_addr == self.active_address => Some(coin),
             _ => None,
         }))
     }
@@ -793,7 +791,7 @@ impl SimpleFaucet {
 
             // Insert the coins into the map based on the destination address
             address_coins_map
-                .entry(owner.get_owner_address().unwrap())
+                .entry(*owner.address().unwrap())
                 .or_default()
                 .push(coin_obj_ref);
         });

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -77,7 +77,7 @@ test-outputs = ["dep:iota-sdk-crypto"]
 
 [target.'cfg(not(msim))'.dependencies]
 # iota-sdk-crypto is only used when compiling test-outputs feature
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25", optional = true, features = ["ed25519", "mnemonic"] }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "40d39c7f67bb394274f9dd6ca1a4915a40427b90", optional = true, features = ["ed25519", "mnemonic"] }
 
 [[example]]
 name = "snapshot_add_test_outputs"

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -77,7 +77,7 @@ test-outputs = ["dep:iota-sdk-crypto"]
 
 [target.'cfg(not(msim))'.dependencies]
 # iota-sdk-crypto is only used when compiling test-outputs feature
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "77e51e5361bb81054187788d820c4f4da8a3ad6c", optional = true, features = ["ed25519", "mnemonic"] }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0930fb35bc5db8fc6baa5f0829b3997bff02f99a", optional = true, features = ["ed25519", "mnemonic"] }
 
 [[example]]
 name = "snapshot_add_test_outputs"

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -77,7 +77,7 @@ test-outputs = ["dep:iota-sdk-crypto"]
 
 [target.'cfg(not(msim))'.dependencies]
 # iota-sdk-crypto is only used when compiling test-outputs feature
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0930fb35bc5db8fc6baa5f0829b3997bff02f99a", optional = true, features = ["ed25519", "mnemonic"] }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25", optional = true, features = ["ed25519", "mnemonic"] }
 
 [[example]]
 name = "snapshot_add_test_outputs"

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -685,7 +685,7 @@ impl Builder {
                     let timelock_staked_iota_object_id = timelock_staked_iota_objects
                         .iter()
                         .find(|(_k, (o, s))| {
-                            let Owner::AddressOwner(owner) = &o.owner else {
+                            let Owner::Address(owner) = &o.owner else {
                                 panic!("gas object owner must be address owner");
                             };
                             *owner == allocation.recipient_address
@@ -700,7 +700,7 @@ impl Builder {
                         .unwrap();
                     assert_eq!(
                         timelock_staked_iota_object.0.owner,
-                        Owner::AddressOwner(allocation.recipient_address)
+                        Owner::Address(allocation.recipient_address)
                     );
                     assert_eq!(
                         timelock_staked_iota_object.1.principal(),
@@ -712,7 +712,7 @@ impl Builder {
                     let staked_iota_object_id = staked_iota_objects
                         .iter()
                         .find(|(_k, (o, s))| {
-                            let Owner::AddressOwner(owner) = &o.owner else {
+                            let Owner::Address(owner) = &o.owner else {
                                 panic!("gas object owner must be address owner");
                             };
                             *owner == allocation.recipient_address
@@ -725,7 +725,7 @@ impl Builder {
                         staked_iota_objects.remove(&staked_iota_object_id).unwrap();
                     assert_eq!(
                         staked_iota_object.0.owner,
-                        Owner::AddressOwner(allocation.recipient_address)
+                        Owner::Address(allocation.recipient_address)
                     );
                     assert_eq!(staked_iota_object.1.principal(), allocation.amount_nanos);
                     assert_eq!(staked_iota_object.1.pool_id(), staking_pool_id);
@@ -735,7 +735,7 @@ impl Builder {
                 let gas_object_id = gas_objects
                     .iter()
                     .find(|(_k, (o, g))| {
-                        if let Owner::AddressOwner(owner) = &o.owner {
+                        if let Owner::Address(owner) = &o.owner {
                             *owner == allocation.recipient_address
                                 && g.value() == allocation.amount_nanos
                         } else {
@@ -747,7 +747,7 @@ impl Builder {
                 let gas_object = gas_objects.remove(&gas_object_id).unwrap();
                 assert_eq!(
                     gas_object.0.owner,
-                    Owner::AddressOwner(allocation.recipient_address)
+                    Owner::Address(allocation.recipient_address)
                 );
                 assert_eq!(gas_object.1.value(), allocation.amount_nanos,);
             }
@@ -1311,10 +1311,7 @@ fn create_genesis_transaction(
                     o.decrement_version_to(SequenceNumber::MIN_VALID_INCL);
                 }
 
-                if let Owner::Shared {
-                    initial_shared_version,
-                } = &mut object.owner
-                {
+                if let Owner::Shared(initial_shared_version) = &mut object.owner {
                     *initial_shared_version = SequenceNumber::MIN_VALID_INCL;
                 }
 

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -318,9 +318,9 @@ impl Extend<Object> for MigrationObjects {
             } else {
                 continue;
             };
-            let owner = object
+            let owner = *object
                 .owner
-                .get_owner_address()
+                .as_address_opt()
                 .expect("timelocks should have an address owner");
             owner_object_map
                 .entry(owner)
@@ -513,7 +513,7 @@ mod tests {
             .map(|move_object| {
                 Object::new_from_genesis(
                     Data::Move(move_object),
-                    Owner::AddressOwner(address),
+                    Owner::Address(address),
                     tx_context.digest(),
                 )
             });
@@ -557,7 +557,7 @@ mod tests {
             .map(|move_object| {
                 Object::new_from_genesis(
                     Data::Move(move_object),
-                    Owner::AddressOwner(owner),
+                    Owner::Address(owner),
                     tx_context.digest(),
                 )
             })

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/alias.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/alias.rs
@@ -157,10 +157,10 @@ fn alias_migration_with_full_features() {
         &bcs::to_bytes(ALIAS_DYNAMIC_OBJECT_FIELD_KEY).unwrap(),
     )
     .unwrap();
-    assert_eq!(alias_object.owner, Owner::ObjectOwner(alias_owner.into()));
+    assert_eq!(alias_object.owner, Owner::Object(alias_owner));
 
     let alias_output_owner =
-        Owner::AddressOwner(stardust_to_iota_address(stardust_alias.governor_address()).unwrap());
+        Owner::Address(stardust_to_iota_address(stardust_alias.governor_address()).unwrap());
     assert_eq!(alias_output_object.owner, alias_output_owner);
 }
 

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/executor.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/executor.rs
@@ -105,10 +105,7 @@ fn create_bag_with_pt() {
         .filter(|object| object.is_child_object())
         .collect::<Vec<_>>();
     assert_eq!(tokens.len(), 1);
-    assert_eq!(
-        tokens[0].owner,
-        Owner::ObjectOwner((*bag.id.object_id()).into())
-    );
+    assert_eq!(tokens[0].owner, Owner::Object(*bag.id.object_id()));
     let token_as_df = tokens[0].to_rust::<Field<String, Balance>>().unwrap();
     // Verify name
     let expected_name = coin_type_tag.to_canonical_string(false);

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/foundry.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/foundry.rs
@@ -149,7 +149,7 @@ fn foundry_with_simple_metadata() -> Result<()> {
         .as_coin_maybe()
         .expect("should be a coin object");
     assert_eq!(
-        coin_object.owner.get_owner_address().unwrap().to_string(),
+        coin_object.owner.address().unwrap().to_string(),
         alias_id.to_string()
     );
     assert_eq!(coin.balance, Balance::new(1_000_000));
@@ -238,7 +238,7 @@ fn foundry_with_special_metadata() -> Result<()> {
         .as_coin_maybe()
         .expect("should be a coin object");
     assert_eq!(
-        coin_object.owner.get_owner_address().unwrap().to_string(),
+        coin_object.owner.address().unwrap().to_string(),
         alias_id.to_string()
     );
     assert_eq!(coin.balance, Balance::new(1_000_000));
@@ -310,7 +310,7 @@ fn coin_ownership() -> Result<()> {
 
     // Check the owner of the coin object.
     assert_eq!(
-        coin_object.owner.get_owner_address().unwrap().to_string(),
+        coin_object.owner.address().unwrap().to_string(),
         alias_id.to_string()
     );
 
@@ -360,7 +360,7 @@ fn create_gas_coin() -> Result<()> {
 
     // Check if the owner of the gas coin is the package object.
     assert_eq!(
-        gas_coin_object.owner.get_owner_address().unwrap(),
+        *gas_coin_object.owner.address().unwrap(),
         stardust_to_iota_address(alias_address).unwrap()
     );
 

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/foundry.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/foundry.rs
@@ -149,7 +149,7 @@ fn foundry_with_simple_metadata() -> Result<()> {
         .as_coin_maybe()
         .expect("should be a coin object");
     assert_eq!(
-        coin_object.owner.address().unwrap().to_string(),
+        coin_object.owner.address_or_object().unwrap().to_string(),
         alias_id.to_string()
     );
     assert_eq!(coin.balance, Balance::new(1_000_000));
@@ -238,7 +238,7 @@ fn foundry_with_special_metadata() -> Result<()> {
         .as_coin_maybe()
         .expect("should be a coin object");
     assert_eq!(
-        coin_object.owner.address().unwrap().to_string(),
+        coin_object.owner.address_or_object().unwrap().to_string(),
         alias_id.to_string()
     );
     assert_eq!(coin.balance, Balance::new(1_000_000));
@@ -310,7 +310,7 @@ fn coin_ownership() -> Result<()> {
 
     // Check the owner of the coin object.
     assert_eq!(
-        coin_object.owner.address().unwrap().to_string(),
+        coin_object.owner.address_or_object().unwrap().to_string(),
         alias_id.to_string()
     );
 
@@ -360,7 +360,7 @@ fn create_gas_coin() -> Result<()> {
 
     // Check if the owner of the gas coin is the package object.
     assert_eq!(
-        *gas_coin_object.owner.address().unwrap(),
+        *gas_coin_object.owner.address_or_object().unwrap(),
         stardust_to_iota_address(alias_address).unwrap()
     );
 

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/mod.rs
@@ -95,7 +95,7 @@ fn create_foundry(
 }
 
 /// Test that an Object owned by another Object (not to be confused with
-/// Owner::ObjectOwner) can be received by the owning object. This means aliases
+/// Owner::Object) can be received by the owning object. This means aliases
 /// owned by aliases, aliases owned by NFTs, etc.
 ///
 /// The PTB sends the extracted assets to the null address since they must be

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/nft.rs
@@ -186,10 +186,10 @@ fn nft_migration_with_full_features() {
         &bcs::to_bytes(NFT_DYNAMIC_OBJECT_FIELD_KEY).unwrap(),
     )
     .unwrap();
-    assert_eq!(nft_object.owner, Owner::ObjectOwner(nft_owner.into()));
+    assert_eq!(nft_object.owner, Owner::Object(nft_owner));
 
     let nft_output_owner =
-        Owner::AddressOwner(stardust_to_iota_address(stardust_nft.address()).unwrap());
+        Owner::Address(stardust_to_iota_address(stardust_nft.address()).unwrap());
     assert_eq!(nft_output_object.owner, nft_output_owner);
 }
 

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/alias.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/alias.rs
@@ -61,17 +61,14 @@ pub(super) fn verify_alias_output(
     )?;
 
     // Alias Owner
-    let expected_alias_owner = Owner::ObjectOwner(
-        derive_dynamic_field_id(
-            created_output_obj.id(),
-            &DynamicFieldInfo::dynamic_object_field_wrapper(
-                ALIAS_DYNAMIC_OBJECT_FIELD_KEY_TYPE.parse::<TypeTag>()?,
-            )
-            .into(),
-            &bcs::to_bytes(ALIAS_DYNAMIC_OBJECT_FIELD_KEY)?,
-        )?
+    let expected_alias_owner = Owner::Object(derive_dynamic_field_id(
+        created_output_obj.id(),
+        &DynamicFieldInfo::dynamic_object_field_wrapper(
+            ALIAS_DYNAMIC_OBJECT_FIELD_KEY_TYPE.parse::<TypeTag>()?,
+        )
         .into(),
-    );
+        &bcs::to_bytes(ALIAS_DYNAMIC_OBJECT_FIELD_KEY)?,
+    )?);
 
     ensure!(
         created_alias_obj.owner == expected_alias_owner,

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/foundry.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/foundry.rs
@@ -69,7 +69,7 @@ pub(super) fn verify_foundry_output(
         .ok_or_else(|| anyhow!("expected a native token coin"))?;
 
     // The minted native token coin should be owned by `0x0`
-    let expected_owner = Owner::AddressOwner(IotaAddress::ZERO);
+    let expected_owner = Owner::Address(IotaAddress::ZERO);
     ensure!(
         native_token_coin_obj.owner == expected_owner,
         "native token coin owner mismatch: found {}, expected {}",

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/nft.rs
@@ -76,17 +76,14 @@ pub(super) fn verify_nft_output(
     }
 
     // NFT Owner
-    let expected_nft_owner = Owner::ObjectOwner(
-        derive_dynamic_field_id(
-            created_output_obj.id(),
-            &DynamicFieldInfo::dynamic_object_field_wrapper(
-                NFT_DYNAMIC_OBJECT_FIELD_KEY_TYPE.parse::<TypeTag>()?,
-            )
-            .into(),
-            &bcs::to_bytes(NFT_DYNAMIC_OBJECT_FIELD_KEY)?,
-        )?
+    let expected_nft_owner = Owner::Object(derive_dynamic_field_id(
+        created_output_obj.id(),
+        &DynamicFieldInfo::dynamic_object_field_wrapper(
+            NFT_DYNAMIC_OBJECT_FIELD_KEY_TYPE.parse::<TypeTag>()?,
+        )
         .into(),
-    );
+        &bcs::to_bytes(NFT_DYNAMIC_OBJECT_FIELD_KEY)?,
+    )?);
 
     ensure!(
         created_nft_obj.owner == expected_nft_owner,

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/util.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/util.rs
@@ -338,9 +338,7 @@ pub(super) fn verify_address_owner(
 }
 
 pub(super) fn verify_shared_object(obj: &Object, name: &str) -> Result<()> {
-    let expected_owner = Owner::Shared {
-        initial_shared_version: Default::default(),
-    };
+    let expected_owner = Owner::Shared(Default::default());
     ensure!(
         obj.owner.is_shared(),
         "{name} shared owner mismatch: found {}, expected {}",

--- a/crates/iota-genesis-builder/src/stardust/types/address.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address.rs
@@ -21,5 +21,5 @@ pub fn stardust_to_iota_address(
 pub fn stardust_to_iota_address_owner(
     stardust_address: impl Into<Address>,
 ) -> anyhow::Result<Owner> {
-    stardust_to_iota_address(stardust_address.into()).map(Owner::AddressOwner)
+    stardust_to_iota_address(stardust_address.into()).map(Owner::Address)
 }

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -90,7 +90,7 @@ impl AddressSwapMap {
         if let Some(addr) = self.destination_address(&address) {
             address = addr;
         }
-        Ok(Owner::AddressOwner(address))
+        Ok(Owner::Address(address))
     }
 
     /// Converts a [`StardustAddress`] to an [`Owner`] by first
@@ -107,7 +107,7 @@ impl AddressSwapMap {
         if let Some(addr) = self.swap_destination_address(&address) {
             address = addr;
         }
-        Ok(Owner::AddressOwner(address))
+        Ok(Owner::Address(address))
     }
 
     /// Converts a [`StardustAddress`] to an [`IotaAddress`] and

--- a/crates/iota-genesis-builder/src/stardust/types/coin_kind.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/coin_kind.rs
@@ -111,7 +111,7 @@ mod tests {
             native_tokens: Default::default(),
         };
         output.to_genesis_object(
-            Owner::AddressOwner(IotaAddress::ZERO),
+            Owner::Address(IotaAddress::ZERO),
             &ProtocolConfig::get_for_min_version(),
             &TxContext::random_for_testing_only(),
             1.into(),

--- a/crates/iota-genesis-builder/src/stardust/types/output/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/output/basic.rs
@@ -51,7 +51,7 @@ pub fn create_coin(
         )?
     };
     // Resolve ownership
-    let owner = Owner::AddressOwner(owner);
+    let owner = Owner::Address(owner);
     Ok(Object::new_from_genesis(
         Data::Move(move_object),
         owner,
@@ -162,11 +162,9 @@ impl BasicOutputExt for BasicOutput {
         };
         // Resolve ownership
         let owner = if self.expiration.is_some() {
-            Owner::Shared {
-                initial_shared_version: version,
-            }
+            Owner::Shared(version)
         } else {
-            Owner::AddressOwner(owner)
+            Owner::Address(owner)
         };
         Ok(Object::new_from_genesis(
             Data::Move(move_object),

--- a/crates/iota-genesis-builder/src/stardust/types/output/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/output/nft.rs
@@ -344,11 +344,9 @@ impl NftOutputExt for NftOutput {
         };
 
         let owner = if self.expiration.is_some() {
-            Owner::Shared {
-                initial_shared_version: version,
-            }
+            Owner::Shared(version)
         } else {
-            Owner::AddressOwner(owner)
+            Owner::Address(owner)
         };
 
         let move_nft_output_object = Object::new_from_genesis(

--- a/crates/iota-genesis-builder/src/stardust/types/vested_reward.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/vested_reward.rs
@@ -132,7 +132,7 @@ pub fn to_genesis_object(
 
     Ok(Object::new_from_genesis(
         Data::Move(move_object),
-        Owner::AddressOwner(owner),
+        Owner::Address(owner),
         tx_context.digest(),
     ))
 }

--- a/crates/iota-graphql-e2e-tests/tests/call/owned_objects.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/owned_objects.snap
@@ -29,7 +29,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 66:
 //# view-object 3,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: Test::M1::Object {
     id: iota::object::UID {

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -39,7 +39,7 @@ Contents: iota_system::validator_cap::UnverifiedValidatorOperationCap {
 
 task 5, line 34:
 //# view-object 0,1
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 4
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -26,7 +26,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 234000, storage
 
 task 4, line 32:
 //# view-object 0,0
-Owner: Account Address ( validator_0 )
+Owner: Address(validator_0)
 Version: 1
 Contents: iota_system::validator_cap::UnverifiedValidatorOperationCap {
     id: iota::object::UID {
@@ -54,7 +54,7 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
 
 task 6, line 36:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: Test::M1::Object {
     id: iota::object::UID {
@@ -67,7 +67,7 @@ Contents: Test::M1::Object {
 
 task 7, line 38:
 //# view-object 3,0
-Owner: Account Address ( validator_0 )
+Owner: Address(validator_0)
 Version: 4
 Contents: Test::M1::Object {
     id: iota::object::UID {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 60:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -39,7 +39,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 64:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -58,7 +58,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 68:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: Test::M1::Parent {
     id: iota::object::UID {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 89:
 //# view-object 2,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -34,7 +34,7 @@ Contents: Test::M1::Parent {
 
 task 4, line 91:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: Test::M1::Child {
     id: iota::object::UID {
@@ -55,7 +55,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 6, line 97:
 //# view-object 2,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -67,7 +67,7 @@ Contents: Test::M1::Parent {
 
 task 7, line 99:
 //# view-object 2,0
-Owner: Object ID: ( fake(5,0) )
+Owner: Object(fake(5,0))
 Version: 3
 Contents: Test::M1::Child {
     id: iota::object::UID {
@@ -141,7 +141,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 11, line 171:
 //# view-object 2,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -153,7 +153,7 @@ Contents: Test::M1::Parent {
 
 task 12, line 173:
 //# view-object 2,0
-Owner: Object ID: ( fake(5,0) )
+Owner: Object(fake(5,0))
 Version: 4
 Contents: Test::M1::Child {
     id: iota::object::UID {
@@ -351,7 +351,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 17, line 282:
 //# view-object 2,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -363,7 +363,7 @@ Contents: Test::M1::Parent {
 
 task 18, line 284:
 //# view-object 2,0
-Owner: Object ID: ( fake(5,0) )
+Owner: Object(fake(5,0))
 Version: 4
 Contents: Test::M1::Child {
     id: iota::object::UID {
@@ -580,7 +580,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 22, line 343:
 //# view-object 2,1
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 6
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -592,7 +592,7 @@ Contents: Test::M1::Parent {
 
 task 23, line 345:
 //# view-object 2,0
-Owner: Object ID: ( fake(5,0) )
+Owner: Object(fake(5,0))
 Version: 4
 Contents: Test::M1::Child {
     id: iota::object::UID {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.snap
@@ -20,7 +20,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 50:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 2
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -39,7 +39,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 54:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 3
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -57,7 +57,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 58:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -144,7 +144,7 @@ Response: {
 
 task 10, line 112:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 4
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -162,7 +162,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 12, line 116:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 5
 Contents: Test::M1::Parent {
     id: iota::object::UID {
@@ -180,7 +180,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 14, line 120:
 //# view-object 2,0
-Owner: Account Address ( A )
+Owner: Address(A)
 Version: 6
 Contents: Test::M1::Parent {
     id: iota::object::UID {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/performance/many_objects.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/performance/many_objects.snap
@@ -158,7 +158,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 8, line 91:
 //# view-object 2,498
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 4
 Contents: Test::M1::Object {
     id: iota::object::UID {
@@ -171,7 +171,7 @@ Contents: Test::M1::Object {
 
 task 9, line 93:
 //# view-object 2,497
-Owner: Account Address ( B )
+Owner: Address(B)
 Version: 5
 Contents: Test::M1::Object {
     id: iota::object::UID {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.snap
@@ -68,7 +68,7 @@ Epoch advanced: 1
 
 task 10, line 41:
 //# view-object 3,1
-Owner: Account Address ( C )
+Owner: Address(C)
 Version: 3
 Contents: iota_system::staking_pool::StakedIota {
     id: iota::object::UID {
@@ -87,7 +87,7 @@ Contents: iota_system::staking_pool::StakedIota {
 
 task 11, line 43:
 //# view-object 7,0
-Owner: Account Address ( C )
+Owner: Address(C)
 Version: 5
 Contents: iota_system::staking_pool::StakedIota {
     id: iota::object::UID {

--- a/crates/iota-graphql-e2e-tests/tests/owner/root_version.snap
+++ b/crates/iota-graphql-e2e-tests/tests/owner/root_version.snap
@@ -45,7 +45,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, lines 107-109:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 7
 Contents: P0::M::O {
     id: iota::object::UID {
@@ -90,7 +90,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 12, line 123:
 //# view-object 2,0
-Owner: Account Address ( _ )
+Owner: Address(_)
 Version: 11
 Contents: P0::M::O {
     id: iota::object::UID {

--- a/crates/iota-graphql-rpc/src/types/balance_change.rs
+++ b/crates/iota-graphql-rpc/src/types/balance_change.rs
@@ -4,7 +4,6 @@
 
 use async_graphql::*;
 use iota_json_rpc_types::BalanceChange as StoredBalanceChange;
-use iota_types::object::Owner as NativeOwner;
 
 use crate::{
     error::Error,
@@ -23,17 +22,11 @@ pub(crate) struct BalanceChange {
 impl BalanceChange {
     /// The address or object whose balance has changed.
     async fn owner(&self) -> Option<Owner> {
-        use NativeOwner as O;
-
-        match self.stored.owner {
-            O::AddressOwner(addr) | O::ObjectOwner(addr) => Some(Owner {
-                address: IotaAddress::from(addr),
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
-                root_version: None,
-            }),
-
-            O::Shared { .. } | O::Immutable => None,
-        }
+        self.stored.owner.address().map(|addr| Owner {
+            address: IotaAddress::from(*addr),
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
+            root_version: None,
+        })
     }
 
     /// The inner type of the coin whose balance has changed (e.g.

--- a/crates/iota-graphql-rpc/src/types/balance_change.rs
+++ b/crates/iota-graphql-rpc/src/types/balance_change.rs
@@ -22,7 +22,7 @@ pub(crate) struct BalanceChange {
 impl BalanceChange {
     /// The address or object whose balance has changed.
     async fn owner(&self) -> Option<Owner> {
-        self.stored.owner.address().map(|addr| Owner {
+        self.stored.owner.address_or_object().map(|addr| Owner {
             address: IotaAddress::from(*addr),
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             root_version: None,

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -30,7 +30,7 @@ use super::{
     iota_address::IotaAddress,
     move_object::{MoveObject, MoveObjectImpl},
     move_value::MoveValue,
-    object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus},
+    object::{self, Object, ObjectFilter, ObjectImpl, ObjectStatus},
     owner::OwnerImpl,
     stake::StakedIota,
     string_input::impl_string_input,
@@ -44,6 +44,7 @@ use crate::{
     consistency::{View, build_objects_query},
     data::{Db, DbConnection, QueryExecutor},
     error::Error,
+    types::object::ObjectOwner,
 };
 
 /// Represents the "core" of the name service (e.g. the on-chain registry and

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -664,7 +664,7 @@ impl ObjectImpl<'_> {
             O::Shared(initial_shared_version) => Some(ObjectOwner::Shared(Shared {
                 initial_shared_version: initial_shared_version.as_u64().into(),
             })),
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
 

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -638,7 +638,7 @@ impl ObjectImpl<'_> {
         let native = self.0.native_impl()?;
 
         match native.owner {
-            O::AddressOwner(address) => {
+            O::Address(address) => {
                 let address = IotaAddress::from(address);
                 Some(ObjectOwner::Address(AddressOwner {
                     owner: Some(Owner {
@@ -649,7 +649,7 @@ impl ObjectImpl<'_> {
                 }))
             }
             O::Immutable => Some(ObjectOwner::Immutable(Immutable { dummy: None })),
-            O::ObjectOwner(address) => {
+            O::Object(address) => {
                 let parent = Object::query(
                     ctx,
                     address.into(),
@@ -661,11 +661,10 @@ impl ObjectImpl<'_> {
 
                 Some(ObjectOwner::Parent(Box::new(Parent { parent })))
             }
-            O::Shared {
-                initial_shared_version,
-            } => Some(ObjectOwner::Shared(Shared {
+            O::Shared(initial_shared_version) => Some(ObjectOwner::Shared(Shared {
                 initial_shared_version: initial_shared_version.as_u64().into(),
             })),
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
 

--- a/crates/iota-grpc-server/src/state_service/get_coin_info.rs
+++ b/crates/iota-grpc-server/src/state_service/get_coin_info.rs
@@ -88,7 +88,7 @@ pub(crate) fn get_coin_info(
             // to mint, so supply is fixed.
             let supply_state = match &object.owner {
                 iota_types::object::Owner::Immutable => SupplyState::Fixed,
-                iota_types::object::Owner::AddressOwner(addr)
+                iota_types::object::Owner::Address(addr)
                     if *addr == iota_types::base_types::IotaAddress::ZERO =>
                 {
                     SupplyState::Fixed

--- a/crates/iota-grpc-server/src/transaction_filter.rs
+++ b/crates/iota-grpc-server/src/transaction_filter.rs
@@ -362,7 +362,7 @@ impl TransactionFilter {
                 .mutated()
                 .iter()
                 .chain(item.effects.unwrapped().iter())
-                .any(|(_, owner)| matches!(owner, Owner::AddressOwner(addr) if *addr == *a)),
+                .any(|(_, owner)| matches!(owner, Owner::Address(addr) if *addr == *a)),
 
             TransactionFilter::AffectedObject(o) => item
                 .effects

--- a/crates/iota-grpc-server/tests/batching_stream.rs
+++ b/crates/iota-grpc-server/tests/batching_stream.rs
@@ -50,7 +50,7 @@ fn create_large_object(padding_bytes_len: usize) -> (ObjectID, Object) {
     .unwrap();
     let obj = Object::new_move(
         move_obj,
-        Owner::AddressOwner(owner),
+        Owner::Address(owner),
         TransactionDigest::GENESIS_MARKER,
     );
     (id, obj)

--- a/crates/iota-grpc-server/tests/list_owned_objects.rs
+++ b/crates/iota-grpc-server/tests/list_owned_objects.rs
@@ -49,7 +49,7 @@ fn make_gas_coin(owner: IotaAddress, object_id: ObjectID, balance: u64) -> Objec
     .unwrap();
     Object::new_move(
         move_obj,
-        Owner::AddressOwner(owner),
+        Owner::Address(owner),
         TransactionDigest::GENESIS_MARKER,
     )
 }
@@ -72,7 +72,7 @@ fn make_large_gas_coin(
     .unwrap();
     Object::new_move(
         move_obj,
-        Owner::AddressOwner(owner),
+        Owner::Address(owner),
         TransactionDigest::GENESIS_MARKER,
     )
 }

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -454,7 +454,7 @@ impl PrimaryWorker {
             .all_changed_objects()
             .into_iter()
             .filter_map(|(_object_ref, owner, _write_kind)| match owner {
-                Owner::AddressOwner(address) => Some(address),
+                Owner::Address(address) => Some(address),
                 _ => None,
             })
             .unique()

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -690,7 +690,7 @@ mod tests {
         let owner = IotaAddress::STD;
 
         let object = ObjectInner {
-            owner: Owner::AddressOwner(owner),
+            owner: Owner::Address(owner),
             data,
             previous_transaction: TransactionDigest::GENESIS_MARKER,
             storage_rebate: 0,

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -311,7 +311,7 @@ pub fn owner_to_owner_info(owner: &Owner) -> (OwnerType, Option<IotaAddress>) {
         Owner::Object(object_id) => (OwnerType::Object, Some(*object_id.as_address())),
         Owner::Shared { .. } => (OwnerType::Shared, None),
         Owner::Immutable => (OwnerType::Immutable, None),
-        _ => unimplemented!("a new enum variant was added and needs to be handled"),
+        _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
     }
 }
 

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -307,10 +307,11 @@ impl TryFrom<i16> for OwnerType {
 // Returns owner_type, owner_address
 pub fn owner_to_owner_info(owner: &Owner) -> (OwnerType, Option<IotaAddress>) {
     match owner {
-        Owner::AddressOwner(address) => (OwnerType::Address, Some(*address)),
-        Owner::ObjectOwner(address) => (OwnerType::Object, Some(*address)),
+        Owner::Address(address) => (OwnerType::Address, Some(*address)),
+        Owner::Object(object_id) => (OwnerType::Object, Some(*object_id.as_address())),
         Owner::Shared { .. } => (OwnerType::Shared, None),
         Owner::Immutable => (OwnerType::Immutable, None),
+        _ => unimplemented!("a new enum variant was added and needs to be handled"),
     }
 }
 

--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -72,10 +72,7 @@ fn transfer_object() {
             .await
             .unwrap();
 
-        assert_eq!(
-            transferred_object.owner(),
-            Some(Owner::AddressOwner(receiver))
-        );
+        assert_eq!(transferred_object.owner(), Some(Owner::Address(receiver)));
     });
 }
 
@@ -835,7 +832,7 @@ async fn create_cluster_with_timelocked_iota(
         .unwrap()
     };
     let timelock_iota = ObjectInner {
-        owner: Owner::AddressOwner(address),
+        owner: Owner::Address(address),
         data: Data::Move(timelock_iota),
         previous_transaction: TransactionDigest::GENESIS_MARKER,
         storage_rebate: 0,

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -271,7 +271,7 @@ fn dev_inspect_transaction_block() {
             .find_map(|obj| (obj.reference.object_id == object_ref.object_id).then_some(obj.owner))
             .unwrap();
 
-        assert_eq!(owner, Owner::AddressOwner(receiver));
+        assert_eq!(owner, Owner::Address(receiver));
 
         let latest_checkpoint_seq_number = client
             .get_latest_checkpoint_sequence_number()
@@ -298,7 +298,7 @@ fn dev_inspect_transaction_block() {
         );
         assert_eq!(
             actual_object_data.owner.unwrap(),
-            Owner::AddressOwner(sender),
+            Owner::Address(sender),
             "the initial owner of the object should not change"
         );
     });
@@ -374,7 +374,7 @@ fn execute_transaction_block() {
             })
             .unwrap();
 
-        assert_eq!(owner, Owner::AddressOwner(receiver));
+        assert_eq!(owner, Owner::Address(receiver));
 
         let actual_object_info = client
             .get_object(
@@ -387,7 +387,7 @@ fn execute_transaction_block() {
         assert_eq!(actual_object_info.data.as_ref().unwrap().version, seq_num);
         assert_eq!(
             actual_object_info.data.unwrap().owner.unwrap(),
-            Owner::AddressOwner(receiver)
+            Owner::Address(receiver)
         );
     });
 }
@@ -1419,10 +1419,7 @@ fn move_view_function_call() {
             .find_map(|change| match change {
                 ObjectChange::Created {
                     object_id,
-                    owner:
-                        Owner::Shared {
-                            initial_shared_version,
-                        },
+                    owner: Owner::Shared(initial_shared_version),
                     ..
                 } => Some((object_id, initial_shared_version)),
                 _ => None,

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -522,7 +522,7 @@ async fn test_timelocked_staking() -> Result<(), anyhow::Error> {
         .unwrap()
     };
     let timelock_iota = ObjectInner {
-        owner: Owner::AddressOwner(address),
+        owner: Owner::Address(address),
         data: Data::Move(timelock_iota),
         previous_transaction: TransactionDigest::GENESIS_MARKER,
         storage_rebate: 0,
@@ -677,7 +677,7 @@ async fn test_timelocked_unstaking() -> Result<(), anyhow::Error> {
         .unwrap()
     };
     let timelock_iota = ObjectInner {
-        owner: Owner::AddressOwner(address),
+        owner: Owner::Address(address),
         data: Data::Move(timelock_iota),
         previous_transaction: TransactionDigest::GENESIS_MARKER,
         storage_rebate: 0,

--- a/crates/iota-json-rpc-tests/tests/indexer_api.rs
+++ b/crates/iota-json-rpc-tests/tests/indexer_api.rs
@@ -72,7 +72,7 @@ async fn test_nft_display_object() -> Result<(), anyhow::Error> {
         .unwrap()
     };
     let nft_object = ObjectInner {
-        owner: Owner::AddressOwner(address),
+        owner: Owner::Address(address),
         data: Data::Move(nft_move_object),
         previous_transaction: TransactionDigest::GENESIS_MARKER,
         storage_rebate: 0,

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -467,7 +467,7 @@ async fn get_object_info() -> Result<(), anyhow::Error> {
             )
             .await?;
         assert!(
-            matches!(rpc_obj, IotaObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && object.owner.unwrap().get_owner_address()? == address)
+            matches!(rpc_obj, IotaObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && *object.owner.unwrap().address().unwrap() == address)
         );
     }
     Ok(())

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -467,7 +467,7 @@ async fn get_object_info() -> Result<(), anyhow::Error> {
             )
             .await?;
         assert!(
-            matches!(rpc_obj, IotaObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && *object.owner.unwrap().address().unwrap() == address)
+            matches!(rpc_obj, IotaObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && *object.owner.unwrap().address_or_object().unwrap() == address)
         );
     }
     Ok(())

--- a/crates/iota-json-rpc-tests/tests/transaction_builder_api.rs
+++ b/crates/iota-json-rpc-tests/tests/transaction_builder_api.rs
@@ -138,9 +138,9 @@ async fn test_transfer_iota() -> Result<(), anyhow::Error> {
     // let amount_to_transfer = i128::from(amount_to_transfer);
     let expected_sender_balance_change = -amount_to_transfer - gas_usage;
     let balance_changes = tx_response.balance_changes.unwrap();
-    assert_eq!(balance_changes[0].owner, Owner::AddressOwner(address));
+    assert_eq!(balance_changes[0].owner, Owner::Address(address));
     assert_eq!(balance_changes[0].amount, expected_sender_balance_change);
-    assert_eq!(balance_changes[1].owner, Owner::AddressOwner(other_address));
+    assert_eq!(balance_changes[1].owner, Owner::Address(other_address));
     assert_eq!(balance_changes[1].amount, amount_to_transfer);
 
     Ok(())
@@ -191,9 +191,9 @@ async fn test_pay() -> Result<(), anyhow::Error> {
 
     let expected_sender_balance_change = -amount_to_transfer - gas_usage;
     let balance_changes = tx_response.balance_changes.unwrap();
-    assert_eq!(balance_changes[0].owner, Owner::AddressOwner(address));
+    assert_eq!(balance_changes[0].owner, Owner::Address(address));
     assert_eq!(balance_changes[0].amount, expected_sender_balance_change);
-    assert_eq!(balance_changes[1].owner, Owner::AddressOwner(other_address));
+    assert_eq!(balance_changes[1].owner, Owner::Address(other_address));
     assert_eq!(balance_changes[1].amount, amount_to_transfer);
 
     Ok(())
@@ -248,11 +248,11 @@ async fn test_pay_iota() -> Result<(), anyhow::Error> {
 
     let expected_sender_balance_change = -recipient_1_amount - recipient_2_amount - gas_usage;
     let balance_changes = tx_response.balance_changes.unwrap();
-    assert_eq!(balance_changes[0].owner, Owner::AddressOwner(address));
+    assert_eq!(balance_changes[0].owner, Owner::Address(address));
     assert_eq!(balance_changes[0].amount, expected_sender_balance_change);
-    assert_eq!(balance_changes[1].owner, Owner::AddressOwner(recipient_1));
+    assert_eq!(balance_changes[1].owner, Owner::Address(recipient_1));
     assert_eq!(balance_changes[1].amount, recipient_1_amount);
-    assert_eq!(balance_changes[2].owner, Owner::AddressOwner(recipient_2));
+    assert_eq!(balance_changes[2].owner, Owner::Address(recipient_2));
     assert_eq!(balance_changes[2].amount, recipient_2_amount);
 
     Ok(())
@@ -302,9 +302,9 @@ async fn test_pay_all_iota() -> Result<(), anyhow::Error> {
 
     let expected_recipient_balance_change = total_balance - gas_usage;
     let balance_changes = tx_response.balance_changes.unwrap();
-    assert_eq!(balance_changes[0].owner, Owner::AddressOwner(address));
+    assert_eq!(balance_changes[0].owner, Owner::Address(address));
     assert_eq!(balance_changes[0].amount, -total_balance);
-    assert_eq!(balance_changes[1].owner, Owner::AddressOwner(recipient));
+    assert_eq!(balance_changes[1].owner, Owner::Address(recipient));
     assert_eq!(balance_changes[1].amount, expected_recipient_balance_change);
 
     Ok(())
@@ -640,7 +640,7 @@ async fn test_batch_transaction() -> Result<(), anyhow::Error> {
             .unwrap();
         assert_eq!(
             transferred_object.owner(),
-            Some(Owner::AddressOwner(other_address))
+            Some(Owner::Address(other_address))
         );
     }
 

--- a/crates/iota-json-rpc-tests/tests/write_api.rs
+++ b/crates/iota-json-rpc-tests/tests/write_api.rs
@@ -73,7 +73,7 @@ async fn test_dev_inspect_transaction_block() -> Result<(), anyhow::Error> {
         .unwrap();
     assert_eq!(
         tx_effect_obj_reassigned.owner,
-        Owner::AddressOwner(other_address)
+        Owner::Address(other_address)
     );
 
     let actual_object_info = http_client
@@ -89,7 +89,7 @@ async fn test_dev_inspect_transaction_block() -> Result<(), anyhow::Error> {
 
     assert_eq!(
         actual_object_info.data.unwrap().owner.unwrap(),
-        Owner::AddressOwner(address)
+        Owner::Address(address)
     );
 
     Ok(())

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -1343,10 +1343,10 @@ impl IotaObjectDataFilter {
                 matches!(&object.type_, ObjectType::Struct(s) if &ObjectID::from(s.address()) == p)
             }
             IotaObjectDataFilter::AddressOwner(a) => {
-                matches!(object.owner, Owner::AddressOwner(addr) if &addr == a)
+                matches!(object.owner, Owner::Address(addr) if &addr == a)
             }
             IotaObjectDataFilter::ObjectOwner(o) => {
-                matches!(object.owner, Owner::ObjectOwner(addr) if addr == IotaAddress::from(*o))
+                matches!(object.owner, Owner::Object(addr) if &addr == o)
             }
             IotaObjectDataFilter::ObjectId(id) => &object.object_id == id,
             IotaObjectDataFilter::ObjectIds(ids) => ids.contains(&object.object_id),

--- a/crates/iota-json-rpc-types/src/iota_owner.rs
+++ b/crates/iota-json-rpc-types/src/iota_owner.rs
@@ -98,7 +98,7 @@ impl From<Owner> for OwnerSchema {
                 initial_shared_version,
             },
             Owner::Immutable => OwnerSchema::Immutable,
-            _ => unreachable!("a new Owner enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_owner.rs
+++ b/crates/iota-json-rpc-types/src/iota_owner.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_types::{
-    base_types::{IotaAddress, SequenceNumber},
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
     object::Owner,
 };
 use schemars::JsonSchema;
@@ -92,14 +92,13 @@ impl std::fmt::Display for OwnerSchema {
 impl From<Owner> for OwnerSchema {
     fn from(value: Owner) -> Self {
         match value {
-            Owner::AddressOwner(address) => OwnerSchema::AddressOwner(address),
-            Owner::ObjectOwner(object_id) => OwnerSchema::ObjectOwner(object_id),
-            Owner::Shared {
-                initial_shared_version,
-            } => OwnerSchema::Shared {
+            Owner::Address(address) => OwnerSchema::AddressOwner(address),
+            Owner::Object(object_id) => OwnerSchema::ObjectOwner(*object_id.as_address()),
+            Owner::Shared(initial_shared_version) => OwnerSchema::Shared {
                 initial_shared_version,
             },
             Owner::Immutable => OwnerSchema::Immutable,
+            _ => unreachable!("a new Owner enum variant was added and needs to be handled"),
         }
     }
 }
@@ -107,13 +106,11 @@ impl From<Owner> for OwnerSchema {
 impl From<OwnerSchema> for Owner {
     fn from(value: OwnerSchema) -> Self {
         match value {
-            OwnerSchema::AddressOwner(address) => Owner::AddressOwner(address),
-            OwnerSchema::ObjectOwner(object_id) => Owner::ObjectOwner(object_id),
+            OwnerSchema::AddressOwner(address) => Owner::Address(address),
+            OwnerSchema::ObjectOwner(address) => Owner::Object(ObjectID::from(address)),
             OwnerSchema::Shared {
                 initial_shared_version,
-            } => Owner::Shared {
-                initial_shared_version,
-            },
+            } => Owner::Shared(initial_shared_version),
             OwnerSchema::Immutable => Owner::Immutable,
         }
     }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -456,7 +456,7 @@ pub fn get_new_package_upgrade_cap_from_response(
             .iter()
             .find(|change| {
                 matches!(change, ObjectChange::Created {
-                    owner: Owner::AddressOwner(_),
+                    owner: Owner::Address(_),
                     object_type,
                     ..
                 } if object_type.is_upgrade_cap())
@@ -991,7 +991,7 @@ impl IotaTransactionBlockEffects {
             transaction_digest,
             status,
             gas_object: OwnedObjectRef {
-                owner: Owner::AddressOwner(IotaAddress::random()),
+                owner: Owner::Address(IotaAddress::random()),
                 reference: iota_types::base_types::random_object_ref(),
             },
             executed_epoch: 0,
@@ -2714,7 +2714,7 @@ impl Filter<EffectsWithInput> for TransactionFilter {
             TransactionFilter::ToAddress(a) => {
                 let mutated: &[OwnedObjectRef] = item.effects.mutated();
                 mutated.iter().chain(item.effects.unwrapped().iter()).any(|oref: &OwnedObjectRef| {
-                    matches!(oref.owner, Owner::AddressOwner(owner) if owner == *a)
+                    matches!(oref.owner, Owner::Address(owner) if owner == *a)
                 })
             }
             TransactionFilter::FromAndToAddress { from, to } => {

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -329,7 +329,7 @@ impl RpcExampleProvider {
                         )
                         .unwrap(),
                     ),
-                    owner: Some(Owner::AddressOwner(IotaAddress::from(ObjectID::new(
+                    owner: Some(Owner::Address(IotaAddress::from(ObjectID::new(
                         self.rng.gen(),
                     )))),
                     previous_transaction: Some(TransactionDigest::new(self.rng.gen())),
@@ -373,7 +373,7 @@ impl RpcExampleProvider {
                 )
                 .unwrap(),
             ),
-            owner: Some(Owner::AddressOwner(IotaAddress::from(ObjectID::new(
+            owner: Some(Owner::Address(IotaAddress::from(ObjectID::new(
                 self.rng.gen(),
             )))),
             previous_transaction: Some(TransactionDigest::new(self.rng.gen())),
@@ -473,7 +473,7 @@ impl RpcExampleProvider {
                 version: Default::default(),
                 digest: ObjectDigest::new(self.rng.gen()),
                 type_: Some(ObjectType::Struct(MoveObjectType::gas_coin())),
-                owner: Some(Owner::AddressOwner(owner)),
+                owner: Some(Owner::Address(owner)),
                 previous_transaction: Some(TransactionDigest::new(self.rng.gen())),
                 storage_rebate: None,
                 display: None,
@@ -702,7 +702,7 @@ impl RpcExampleProvider {
         let tx_digest = tx.digest();
         let object_change = ObjectChange::Transferred {
             sender: signer,
-            recipient: Owner::AddressOwner(recipient),
+            recipient: Owner::Address(recipient),
             object_type: parse_iota_struct_tag("0x2::example::Object").unwrap(),
             object_id: object_ref.object_id,
             version: object_ref.version,
@@ -734,11 +734,11 @@ impl RpcExampleProvider {
                     created: vec![],
                     mutated: vec![
                         OwnedObjectRef {
-                            owner: Owner::AddressOwner(signer),
+                            owner: Owner::Address(signer),
                             reference: gas_ref,
                         },
                         OwnedObjectRef {
-                            owner: Owner::AddressOwner(recipient),
+                            owner: Owner::Address(recipient),
                             reference: object_ref,
                         },
                     ],
@@ -747,7 +747,7 @@ impl RpcExampleProvider {
                     unwrapped_then_deleted: vec![],
                     wrapped: vec![],
                     gas_object: OwnedObjectRef {
-                        owner: Owner::ObjectOwner(signer),
+                        owner: Owner::Object(ObjectID::from(signer)),
                         reference: gas_ref,
                     },
                     events_digest: Some(TransactionEventsDigest::new(self.rng.gen())),
@@ -1217,7 +1217,7 @@ impl RpcExampleProvider {
                 )
                 .unwrap(),
             ),
-            owner: Some(Owner::AddressOwner(IotaAddress::from(ObjectID::new(
+            owner: Some(Owner::Address(IotaAddress::from(ObjectID::new(
                 self.rng.gen(),
             )))),
             previous_transaction: Some(TransactionDigest::new(self.rng.gen())),
@@ -1267,7 +1267,7 @@ impl RpcExampleProvider {
             .map(|_| {
                 IotaObjectResponse::new_with_data(IotaObjectData {
                     content: None,
-                    owner: Some(Owner::AddressOwner(owner)),
+                    owner: Some(Owner::Address(owner)),
                     previous_transaction: Some(TransactionDigest::new(self.rng.gen())),
                     storage_rebate: Some(100),
                     object_id: ObjectID::new(self.rng.gen()),
@@ -1486,7 +1486,7 @@ impl RpcExampleProvider {
                     )
                     .unwrap(),
                 ),
-                owner: Some(Owner::AddressOwner(IotaAddress::from(ObjectID::new(
+                owner: Some(Owner::Address(IotaAddress::from(ObjectID::new(
                     self.rng.gen(),
                 )))),
                 previous_transaction: Some(TransactionDigest::new(self.rng.gen())),
@@ -1506,7 +1506,7 @@ impl RpcExampleProvider {
                     )
                     .unwrap(),
                 ),
-                owner: Some(Owner::AddressOwner(IotaAddress::from(ObjectID::new(
+                owner: Some(Owner::Address(IotaAddress::from(ObjectID::new(
                     self.rng.gen(),
                 )))),
                 previous_transaction: Some(TransactionDigest::new(self.rng.gen())),

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -2226,7 +2226,7 @@ impl ChildObjectResolver for LocalExec {
                 )));
             }
             let parent = *parent;
-            if child_object.owner != Owner::ObjectOwner(parent.into()) {
+            if child_object.owner != Owner::Object(parent) {
                 return Err(IotaError::InvalidChildObjectAccess {
                     object: *child,
                     given_parent: parent,
@@ -2273,7 +2273,7 @@ impl ChildObjectResolver for LocalExec {
                     {receive_object_at_version} but expected the version to be == {receive_object_at_version}"
                 )));
             }
-            if recv_object.owner != Owner::AddressOwner((*owner).into()) {
+            if recv_object.owner != Owner::Address((*owner).into()) {
                 return Ok(None);
             }
             Ok(Some(recv_object))

--- a/crates/iota-sdk/examples/utils.rs
+++ b/crates/iota-sdk/examples/utils.rs
@@ -163,7 +163,11 @@ pub async fn request_tokens_from_faucet(
             .await?;
 
         if owner.owner().is_some() {
-            let owner_address = owner.owner().unwrap().get_owner_address()?;
+            let owner_address = *owner
+                .owner()
+                .unwrap()
+                .address()
+                .ok_or_else(|| anyhow::anyhow!("owner is not an address or object"))?;
             if owner_address == address {
                 break;
             }

--- a/crates/iota-sdk/examples/utils.rs
+++ b/crates/iota-sdk/examples/utils.rs
@@ -166,7 +166,7 @@ pub async fn request_tokens_from_faucet(
             let owner_address = *owner
                 .owner()
                 .unwrap()
-                .address()
+                .address_or_object()
                 .ok_or_else(|| anyhow::anyhow!("owner is not an address or object"))?;
             if owner_address == address {
                 break;

--- a/crates/iota-sdk/src/wallet_context.rs
+++ b/crates/iota-sdk/src/wallet_context.rs
@@ -225,10 +225,11 @@ impl WalletContext {
             .get_object_with_options(*id, IotaObjectDataOptions::new().with_owner())
             .await?
             .into_object()?;
-        Ok(object
+        Ok(*object
             .owner
             .ok_or_else(|| anyhow!("Owner field is None"))?
-            .get_owner_address()?)
+            .address()
+            .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?)
     }
 
     /// Get the address that owns the object, if an [`ObjectID`] is provided.

--- a/crates/iota-sdk/src/wallet_context.rs
+++ b/crates/iota-sdk/src/wallet_context.rs
@@ -228,7 +228,7 @@ impl WalletContext {
         Ok(*object
             .owner
             .ok_or_else(|| anyhow!("Owner field is None"))?
-            .address()
+            .address_or_object()
             .ok_or_else(|| anyhow::anyhow!("not an address or object owner"))?)
     }
 

--- a/crates/iota-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/iota-single-node-benchmark/src/benchmark_context.rs
@@ -130,12 +130,7 @@ impl BenchmarkContext {
             let (owner, root_object) = effects
                 .created()
                 .into_iter()
-                .filter_map(|(oref, owner)| {
-                    owner
-                        .get_address_owner_address()
-                        .ok()
-                        .map(|owner| (owner, oref))
-                })
+                .filter_map(|(oref, owner)| owner.as_address_opt().map(|owner| (*owner, oref)))
                 .next()
                 .unwrap();
             root_objects.insert(owner, root_object);

--- a/crates/iota-single-node-benchmark/src/mock_storage.rs
+++ b/crates/iota-single-node-benchmark/src/mock_storage.rs
@@ -145,9 +145,7 @@ impl ChildObjectResolver for InMemoryObjectStore {
         child_version_upper_bound: SequenceNumber,
     ) -> IotaResult<Option<Object>> {
         Ok(self.try_get_object(child)?.and_then(|o| {
-            if o.version() <= child_version_upper_bound
-                && o.owner == Owner::ObjectOwner((*parent).into())
-            {
+            if o.version() <= child_version_upper_bound && o.owner == Owner::Object(*parent) {
                 Some(o)
             } else {
                 None

--- a/crates/iota-source-validation-service/tests/tests.rs
+++ b/crates/iota-source-validation-service/tests/tests.rs
@@ -82,7 +82,7 @@ async fn test_end_to_end() -> anyhow::Result<()> {
     let cap = effects
         .created()
         .iter()
-        .find(|refe| matches!(refe.owner, Owner::AddressOwner(_)))
+        .find(|refe| matches!(refe.owner, Owner::Address(_)))
         .unwrap();
 
     // Set up source service config to watch the upgrade cap.

--- a/crates/iota-surfer/src/surfer_state.rs
+++ b/crates/iota-surfer/src/surfer_state.rs
@@ -264,7 +264,7 @@ impl SurferState {
                     // means we should already have it in
                     // the inventory.
                 }
-                _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
             }
             if obj_ref.object_id == self.gas_object.object_id {
                 self.gas_object = obj_ref;

--- a/crates/iota-surfer/src/surfer_state.rs
+++ b/crates/iota-surfer/src/surfer_state.rs
@@ -216,7 +216,7 @@ impl SurferState {
     #[tracing::instrument(skip_all, fields(surfer_id = self.id))]
     async fn process_tx_effects(&mut self, effects: &IotaTransactionBlockEffects) {
         for (owned_ref, write_kind) in effects.all_changed_objects() {
-            if matches!(owned_ref.owner, Owner::ObjectOwner(_)) {
+            if matches!(owned_ref.owner, Owner::Object(_)) {
                 // For object owned objects, we don't need to do anything.
                 // We also cannot read them because in the case of shared objects, there can be
                 // races and the child object may no longer exist.
@@ -242,7 +242,7 @@ impl SurferState {
                         .or_default()
                         .push(obj_ref);
                 }
-                Owner::AddressOwner(address) => {
+                Owner::Address(address) => {
                     if address == self.address {
                         self.owned_objects
                             .entry(struct_tag)
@@ -250,10 +250,8 @@ impl SurferState {
                             .insert(obj_ref);
                     }
                 }
-                Owner::ObjectOwner(_) => (),
-                Owner::Shared {
-                    initial_shared_version,
-                } => {
+                Owner::Object(_) => (),
+                Owner::Shared(initial_shared_version) => {
                     if write_kind != WriteKind::Mutate {
                         self.shared_objects
                             .write()
@@ -266,6 +264,7 @@ impl SurferState {
                     // means we should already have it in
                     // the inventory.
                 }
+                _ => unimplemented!("a new enum variant was added and needs to be handled"),
             }
             if obj_ref.object_id == self.gas_object.object_id {
                 self.gas_object = obj_ref;

--- a/crates/iota-surfer/src/surfer_task.rs
+++ b/crates/iota-surfer/src/surfer_task.rs
@@ -68,9 +68,7 @@ impl SurferTask {
                                     .or_default()
                                     .push(obj_ref);
                             }
-                            Owner::Shared {
-                                initial_shared_version,
-                            } => {
+                            Owner::Shared(initial_shared_version) => {
                                 shared_objects
                                     .write()
                                     .await
@@ -78,7 +76,7 @@ impl SurferTask {
                                     .or_default()
                                     .push((obj_ref.object_id, initial_shared_version));
                             }
-                            Owner::AddressOwner(address) => {
+                            Owner::Address(address) => {
                                 if let Some((gas_object, owned_objects)) =
                                     accounts.get_mut(&address)
                                 {
@@ -92,7 +90,10 @@ impl SurferTask {
                                     }
                                 }
                             }
-                            Owner::ObjectOwner(_) => (),
+                            Owner::Object(_) => (),
+                            _ => unimplemented!(
+                                "a new enum variant was added and needs to be handled"
+                            ),
                         }
                     }
                 }

--- a/crates/iota-test-transaction-builder/src/lib.rs
+++ b/crates/iota-test-transaction-builder/src/lib.rs
@@ -653,10 +653,7 @@ pub async fn emit_new_random_u128(
         .owner
         .expect("Expect Randomness object to have an owner");
 
-    let Owner::Shared {
-        initial_shared_version,
-    } = random_obj_owner
-    else {
+    let Owner::Shared(initial_shared_version) = random_obj_owner else {
         panic!("Expect Randomness to be shared object")
     };
     let random_call_arg = CallArg::Object(ObjectArg::SharedObject {

--- a/crates/iota-transaction-builder/src/package.rs
+++ b/crates/iota-transaction-builder/src/package.rs
@@ -82,12 +82,8 @@ impl TransactionBuilder {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
             let capability_arg = match capability_owner {
-                Owner::AddressOwner(_) => {
-                    ObjectArg::ImmOrOwnedObject(upgrade_capability.object_ref())
-                }
-                Owner::Shared {
-                    initial_shared_version,
-                } => ObjectArg::SharedObject {
+                Owner::Address(_) => ObjectArg::ImmOrOwnedObject(upgrade_capability.object_ref()),
+                Owner::Shared(initial_shared_version) => ObjectArg::SharedObject {
                     id: upgrade_capability.object_ref().object_id,
                     initial_shared_version,
                     mutable: true,
@@ -97,9 +93,10 @@ impl TransactionBuilder {
                 }
                 // If the capability is owned by an object, then the module defining the owning
                 // object gets to decide how the upgrade capability should be used.
-                Owner::ObjectOwner(_) => {
+                Owner::Object(_) => {
                     bail!("Upgrade capability controlled by object");
                 }
+                _ => unimplemented!("a new enum variant was added and needs to be handled"),
             };
             builder.obj(capability_arg).unwrap();
             let upgrade_arg = builder.pure(upgrade_policy).unwrap();

--- a/crates/iota-transaction-builder/src/package.rs
+++ b/crates/iota-transaction-builder/src/package.rs
@@ -96,7 +96,7 @@ impl TransactionBuilder {
                 Owner::Object(_) => {
                     bail!("Upgrade capability controlled by object");
                 }
-                _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
             };
             builder.obj(capability_arg).unwrap();
             let upgrade_arg = builder.pure(upgrade_policy).unwrap();

--- a/crates/iota-transaction-builder/src/utils.rs
+++ b/crates/iota-transaction-builder/src/utils.rs
@@ -119,16 +119,15 @@ impl TransactionBuilder {
             return Ok(ObjectArg::Receiving(obj_ref));
         }
         Ok(match owner {
-            Owner::Shared {
-                initial_shared_version,
-            } => ObjectArg::SharedObject {
+            Owner::Shared(initial_shared_version) => ObjectArg::SharedObject {
                 id,
                 initial_shared_version,
                 mutable: is_mutable_ref,
             },
-            Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
+            Owner::Address(_) | Owner::Object(_) | Owner::Immutable => {
                 ObjectArg::ImmOrOwnedObject(obj_ref)
             }
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         })
     }
 

--- a/crates/iota-transaction-builder/src/utils.rs
+++ b/crates/iota-transaction-builder/src/utils.rs
@@ -127,7 +127,7 @@ impl TransactionBuilder {
             Owner::Address(_) | Owner::Object(_) | Owner::Immutable => {
                 ObjectArg::ImmOrOwnedObject(obj_ref)
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         })
     }
 

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -425,7 +425,9 @@ mod checked {
                         }
                         .into()
                     ),
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 };
             }
 
@@ -637,7 +639,9 @@ mod checked {
                         // specifies it as an owned object. This is inconsistent.
                         return Err(UserInputError::NotSharedObject);
                     }
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 };
             }
             InputObjectKind::SharedMoveObject {
@@ -702,7 +706,9 @@ mod checked {
                             UserInputError::SharedObjectStartingVersionMismatch
                         )
                     }
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 }
             }
         };
@@ -793,7 +799,9 @@ mod checked {
                         // specifies it as an owned object. This is inconsistent.
                         return Err(UserInputError::NotSharedObject);
                     }
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 };
             }
             InputObjectKind::SharedMoveObject {
@@ -831,7 +839,9 @@ mod checked {
                             UserInputError::SharedObjectStartingVersionMismatch
                         )
                     }
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 }
             }
         };

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -354,7 +354,7 @@ mod checked {
                 continue;
             };
 
-            if !(object.owner.is_address_owned()
+            if !(object.owner.is_address()
                 && object.version() == object_ref.version
                 && object.digest() == object_ref.digest)
             {
@@ -389,7 +389,7 @@ mod checked {
                 );
 
                 match object.owner {
-                    Owner::AddressOwner(_) => {
+                    Owner::Address(_) => {
                         debug_assert!(
                             false,
                             "Receiving object {:?} is invalid but we expect it should be valid. {:?}",
@@ -409,11 +409,11 @@ mod checked {
                             .into()
                         )
                     }
-                    Owner::ObjectOwner(owner) => {
+                    Owner::Object(owner) => {
                         fp_bail!(
                             UserInputError::InvalidChildObjectArgument {
                                 child_id: object.id(),
-                                parent_id: owner.into(),
+                                parent_id: owner,
                             }
                             .into()
                         )
@@ -425,6 +425,7 @@ mod checked {
                         }
                         .into()
                     ),
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 };
             }
 
@@ -613,7 +614,7 @@ mod checked {
                     Owner::Immutable => {
                         // Nothing else to check for Immutable.
                     }
-                    Owner::AddressOwner(actual_owner) => {
+                    Owner::Address(actual_owner) => {
                         // Check the owner is correct.
                         fp_ensure!(
                             owner == &actual_owner,
@@ -625,10 +626,10 @@ mod checked {
                             }
                         );
                     }
-                    Owner::ObjectOwner(owner) => {
+                    Owner::Object(owner) => {
                         return Err(UserInputError::InvalidChildObjectArgument {
                             child_id: object.id(),
-                            parent_id: owner.into(),
+                            parent_id: owner,
                         });
                     }
                     Owner::Shared { .. } => {
@@ -636,6 +637,7 @@ mod checked {
                         // specifies it as an owned object. This is inconsistent.
                         return Err(UserInputError::NotSharedObject);
                     }
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 };
             }
             InputObjectKind::SharedMoveObject {
@@ -690,18 +692,17 @@ mod checked {
                 );
 
                 match object.owner {
-                    Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
+                    Owner::Address(_) | Owner::Object(_) | Owner::Immutable => {
                         // When someone locks an object as shared it must be shared already.
                         return Err(UserInputError::NotSharedObject);
                     }
-                    Owner::Shared {
-                        initial_shared_version: actual_initial_shared_version,
-                    } => {
+                    Owner::Shared(actual_initial_shared_version) => {
                         fp_ensure!(
                             input_initial_shared_version == actual_initial_shared_version,
                             UserInputError::SharedObjectStartingVersionMismatch
                         )
                     }
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 }
             }
         };
@@ -777,12 +778,12 @@ mod checked {
                     Owner::Immutable => {
                         // Nothing else to check for Immutable.
                     }
-                    Owner::AddressOwner { .. } => {
+                    Owner::Address { .. } => {
                         return Err(UserInputError::AddressOwnedIsInMoveAuthenticatorInput {
                             object_id: object.id(),
                         });
                     }
-                    Owner::ObjectOwner { .. } => {
+                    Owner::Object { .. } => {
                         return Err(UserInputError::ObjectOwnedIsInMoveAuthenticatorInput {
                             object_id: object.id(),
                         });
@@ -792,6 +793,7 @@ mod checked {
                         // specifies it as an owned object. This is inconsistent.
                         return Err(UserInputError::NotSharedObject);
                     }
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 };
             }
             InputObjectKind::SharedMoveObject {
@@ -819,18 +821,17 @@ mod checked {
                 );
 
                 match object.owner {
-                    Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
+                    Owner::Address(_) | Owner::Object(_) | Owner::Immutable => {
                         // When someone locks an object as shared it must be shared already.
                         return Err(UserInputError::NotSharedObject);
                     }
-                    Owner::Shared {
-                        initial_shared_version: actual_initial_shared_version,
-                    } => {
+                    Owner::Shared(actual_initial_shared_version) => {
                         fp_ensure!(
                             input_initial_shared_version == actual_initial_shared_version,
                             UserInputError::SharedObjectStartingVersionMismatch
                         )
                     }
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 }
             }
         };

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -555,10 +555,7 @@ impl IotaValue {
     ) -> anyhow::Result<ObjectArg> {
         let obj = Self::resolve_object(fake_id, version, test_adapter)?;
         let id = obj.id();
-        if let Owner::Shared {
-            initial_shared_version,
-        } = obj.owner
-        {
+        if let Owner::Shared(initial_shared_version) = obj.owner {
             Ok(ObjectArg::SharedObject {
                 id,
                 initial_shared_version,
@@ -577,17 +574,16 @@ impl IotaValue {
         let obj = Self::resolve_object(fake_id, version, test_adapter)?;
         let id = obj.id();
         match obj.owner {
-            Owner::Shared {
-                initial_shared_version,
-            } => Ok(ObjectArg::SharedObject {
+            Owner::Shared(initial_shared_version) => Ok(ObjectArg::SharedObject {
                 id,
                 initial_shared_version,
                 mutable: true,
             }),
-            Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Immutable => {
+            Owner::Address(_) | Owner::Object(_) | Owner::Immutable => {
                 let obj_ref = obj.compute_object_reference();
                 Ok(ObjectArg::ImmOrOwnedObject(obj_ref))
             }
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
 

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -583,7 +583,7 @@ impl IotaValue {
                 let obj_ref = obj.compute_object_reference();
                 Ok(ObjectArg::ImmOrOwnedObject(obj_ref))
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
 

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -220,13 +220,16 @@ impl SimulatorStore for PersistedStore {
     }
 
     fn owned_objects(&self, owner: IotaAddress) -> Box<dyn Iterator<Item = Object> + '_> {
-        Box::new(self.read_write.live_objects
-            .safe_iter()
-            .map(|result| result.expect("rocksdb iteration failed"))
-            .flat_map(|(id, version)| self.get_object_at_version(&id, version))
-            .filter(
-                move |object| matches!(object.owner, Owner::AddressOwner(addr) if addr == owner),
-            ))
+        Box::new(
+            self.read_write
+                .live_objects
+                .safe_iter()
+                .map(|result| result.expect("rocksdb iteration failed"))
+                .flat_map(|(id, version)| self.get_object_at_version(&id, version))
+                .filter(
+                    move |object| matches!(object.owner, Owner::Address(addr) if addr == owner),
+                ),
+        )
     }
 
     fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {
@@ -372,7 +375,7 @@ impl ChildObjectResolver for PersistedStore {
         };
 
         let parent = *parent;
-        if child_object.owner != Owner::ObjectOwner(parent.into()) {
+        if child_object.owner != Owner::Object(parent) {
             return Err(IotaError::InvalidChildObjectAccess {
                 object: *child,
                 given_parent: parent,
@@ -401,7 +404,7 @@ impl ChildObjectResolver for PersistedStore {
             None => return Ok(None),
             Some(obj) => obj,
         };
-        if recv_object.owner != Owner::AddressOwner((*owner).into()) {
+        if recv_object.owner != Owner::Address((*owner).into()) {
             return Ok(None);
         }
 

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -18,7 +18,7 @@ use crate::{
     dynamic_field::{DOFWrapper, get_dynamic_field_from_store},
     error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInputResult},
     id::{ID, UID},
-    object::{Object, Owner},
+    object::Object,
     storage::{DenyListResult, ObjectStore},
     transaction::{CheckedInputObjects, ReceivingObjects},
 };
@@ -128,13 +128,13 @@ pub fn check_coin_deny_list_v1_during_execution(
         let Some(coin_type) = obj.coin_type_maybe() else {
             continue;
         };
-        let Ok(owner) = obj.owner.get_address_owner_address() else {
+        let Some(owner) = obj.owner.as_address_opt() else {
             continue;
         };
         new_coin_owners
             .entry(coin_type.to_canonical_string(false))
             .or_insert_with(BTreeSet::new)
-            .insert(owner);
+            .insert(*owner);
     }
     let num_non_gas_coin_owners = new_coin_owners.values().map(|v| v.len() as u64).sum();
     let new_regulated_coin_owners = new_coin_owners
@@ -236,11 +236,10 @@ pub fn get_deny_list_root_object(object_store: &dyn ObjectStore) -> Option<Objec
 
 pub fn get_deny_list_obj_initial_shared_version(object_store: &dyn ObjectStore) -> SequenceNumber {
     get_deny_list_root_object(object_store)
-        .map(|obj| match obj.owner {
-            Owner::Shared {
-                initial_shared_version,
-            } => initial_shared_version,
-            _ => unreachable!("Deny list object must be shared"),
+        .map(|obj| {
+            obj.owner
+                .into_shared_opt()
+                .expect("Deny list object must be shared")
         })
         .expect("Deny list object must exist")
 }

--- a/crates/iota-types/src/effects/effects_v1.rs
+++ b/crates/iota-types/src/effects/effects_v1.rs
@@ -299,7 +299,7 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
         } else {
             (
                 ObjectRef::new(ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
-                Owner::AddressOwner(IotaAddress::ZERO),
+                Owner::Address(IotaAddress::ZERO),
             )
         }
     }
@@ -347,15 +347,11 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
                 EffectsObjectChange {
                     input_state: ObjectIn::Exist((
                         (obj_ref.version, obj_ref.digest),
-                        Owner::Shared {
-                            initial_shared_version: OBJECT_START_VERSION,
-                        },
+                        Owner::Shared(OBJECT_START_VERSION),
                     )),
                     output_state: ObjectOut::ObjectWrite((
                         obj_ref.digest,
-                        Owner::Shared {
-                            initial_shared_version: obj_ref.version,
-                        },
+                        Owner::Shared(obj_ref.version),
                     )),
                     id_operation: IDOperation::None,
                 },
@@ -382,11 +378,11 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
             EffectsObjectChange {
                 input_state: ObjectIn::Exist((
                     (obj_ref.version, obj_ref.digest),
-                    Owner::AddressOwner(IotaAddress::ZERO),
+                    Owner::Address(IotaAddress::ZERO),
                 )),
                 output_state: ObjectOut::ObjectWrite((
                     obj_ref.digest,
-                    Owner::AddressOwner(IotaAddress::ZERO),
+                    Owner::Address(IotaAddress::ZERO),
                 )),
                 id_operation: IDOperation::None,
             },
@@ -399,7 +395,7 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
             EffectsObjectChange {
                 input_state: ObjectIn::Exist((
                     (obj_ref.version, obj_ref.digest),
-                    Owner::AddressOwner(IotaAddress::ZERO),
+                    Owner::Address(IotaAddress::ZERO),
                 )),
                 output_state: ObjectOut::NotExist,
                 id_operation: IDOperation::Deleted,
@@ -571,7 +567,7 @@ impl TransactionEffectsV1 {
         }
         // Make sure that gas object exists in changed_objects.
         let (_, owner) = self.gas_object();
-        assert!(matches!(owner, Owner::AddressOwner(_)));
+        assert!(matches!(owner, Owner::Address(_)));
 
         for (id, _) in &self.unchanged_shared_objects {
             assert!(

--- a/crates/iota-types/src/effects/test_effects_builder.rs
+++ b/crates/iota-types/src/effects/test_effects_builder.rs
@@ -149,12 +149,12 @@ impl TestEffectsBuilder {
                         EffectsObjectChange {
                             input_state: ObjectIn::Exist((
                                 (oref.version, oref.digest),
-                                Owner::AddressOwner(sender),
+                                Owner::Address(sender),
                             )),
                             output_state: ObjectOut::ObjectWrite((
                                 // Digest must change with a mutation.
                                 ObjectDigest::MAX,
-                                Owner::AddressOwner(sender),
+                                Owner::Address(sender),
                             )),
                             id_operation: IDOperation::None,
                         },
@@ -176,16 +176,12 @@ impl TestEffectsBuilder {
                                     .unwrap_or(initial_shared_version),
                                 ObjectDigest::MIN,
                             ),
-                            Owner::Shared {
-                                initial_shared_version: *initial_shared_version,
-                            },
+                            Owner::Shared(*initial_shared_version),
                         )),
                         output_state: ObjectOut::ObjectWrite((
                             // Digest must change with a mutation.
                             ObjectDigest::MAX,
-                            Owner::Shared {
-                                initial_shared_version: *initial_shared_version,
-                            },
+                            Owner::Shared(*initial_shared_version),
                         )),
                         id_operation: IDOperation::None,
                     },
@@ -210,7 +206,7 @@ impl TestEffectsBuilder {
                             EffectsObjectChange {
                                 input_state: ObjectIn::Exist((
                                     (version, ObjectDigest::random()),
-                                    Owner::AddressOwner(sender),
+                                    Owner::Address(sender),
                                 )),
                                 output_state: ObjectOut::ObjectWrite((
                                     ObjectDigest::random(),
@@ -227,7 +223,7 @@ impl TestEffectsBuilder {
                     EffectsObjectChange {
                         input_state: ObjectIn::Exist((
                             (version, ObjectDigest::random()),
-                            Owner::AddressOwner(sender),
+                            Owner::Address(sender),
                         )),
                         output_state: ObjectOut::NotExist,
                         id_operation: IDOperation::Deleted,
@@ -240,7 +236,7 @@ impl TestEffectsBuilder {
                     EffectsObjectChange {
                         input_state: ObjectIn::Exist((
                             (version, ObjectDigest::random()),
-                            Owner::AddressOwner(sender),
+                            Owner::Address(sender),
                         )),
                         output_state: ObjectOut::NotExist,
                         id_operation: IDOperation::None,

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -420,9 +420,6 @@ pub enum IotaError {
     #[error("Error checking transaction object: {error}")]
     IotaObjectResponse { error: IotaObjectResponseError },
 
-    #[error("Expecting a single owner, shared ownership found")]
-    UnexpectedOwnerType,
-
     #[error("There are already {queue_len} transactions pending, above threshold of {threshold}")]
     TooManyTransactionsPendingExecution { queue_len: usize, threshold: usize },
 

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -138,10 +138,7 @@ impl ExecutionResultsV1 {
             // Note, this only works because shared objects must be created as
             // shared (not created as owned in one transaction and later
             // converted to shared in another).
-            if let Owner::Shared {
-                initial_shared_version,
-            } = &mut obj.owner
-            {
+            if let Owner::Shared(initial_shared_version) = &mut obj.owner {
                 if self.created_object_ids.contains(id) {
                     assert_eq!(
                         *initial_shared_version,
@@ -152,9 +149,9 @@ impl ExecutionResultsV1 {
                 }
 
                 // Update initial_shared_version for reshared objects
-                if let Some(Owner::Shared {
-                    initial_shared_version: previous_initial_shared_version,
-                }) = input_objects.get(id).map(|obj| &obj.owner)
+                if let Some(previous_initial_shared_version) = input_objects
+                    .get(id)
+                    .and_then(|obj| obj.owner.as_shared_opt())
                 {
                     debug_assert!(!self.created_object_ids.contains(id));
                     debug_assert!(!self.deleted_object_ids.contains(id));

--- a/crates/iota-types/src/in_memory_storage.rs
+++ b/crates/iota-types/src/in_memory_storage.rs
@@ -49,7 +49,7 @@ impl ChildObjectResolver for InMemoryStorage {
             Some(obj) => obj,
         };
         let parent = *parent;
-        if child_object.owner != Owner::ObjectOwner(parent.into()) {
+        if child_object.owner != Owner::Object(parent) {
             return Err(IotaError::InvalidChildObjectAccess {
                 object: *child,
                 given_parent: parent,
@@ -76,7 +76,7 @@ impl ChildObjectResolver for InMemoryStorage {
             None => return Ok(None),
             Some(obj) => obj,
         };
-        if recv_object.owner != Owner::AddressOwner((*owner).into()) {
+        if recv_object.owner != Owner::Address((*owner).into()) {
             return Ok(None);
         }
 

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -30,9 +30,7 @@ use iota_sdk_types::{
     },
     gas::GasCostSummary,
     move_core::{Identifier, StructTag, TypeParseError, TypeTag},
-    object::{
-        GenesisObject, MovePackage, MoveStruct, Object, ObjectData, Owner, TypeOrigin, UpgradeInfo,
-    },
+    object::{GenesisObject, MovePackage, MoveStruct, Object, ObjectData, TypeOrigin, UpgradeInfo},
     object_id::ObjectId,
     transaction::{
         Argument, CancelledTransaction, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,
@@ -84,7 +82,7 @@ impl TryFrom<crate::object::Object> for Object {
     fn try_from(value: crate::object::Object) -> Result<Self, Self::Error> {
         Self {
             data: value.data.clone().try_into()?,
-            owner: value.owner.into(),
+            owner: value.owner,
             previous_transaction: value.previous_transaction,
             storage_rebate: value.storage_rebate,
         }
@@ -98,7 +96,7 @@ impl TryFrom<Object> for crate::object::Object {
     fn try_from(value: Object) -> Result<Self, Self::Error> {
         Self::from(ObjectInner {
             data: value.data.try_into()?,
-            owner: value.owner.into(),
+            owner: value.owner,
             previous_transaction: value.previous_transaction,
             storage_rebate: value.storage_rebate,
         })
@@ -361,7 +359,7 @@ impl TryFrom<crate::transaction::TransactionKind> for TransactionKind {
                                 match data.try_into() {
                                     Ok(data) => Ok(GenesisObject {
                                         data,
-                                        owner: owner.into(),
+                                        owner,
                                     }),
                                     Err(e) => Err(e),
                                 }
@@ -448,7 +446,7 @@ impl TryFrom<TransactionKind> for crate::transaction::TransactionKind {
                             match obj.data.try_into() {
                                 Ok(data) => Ok(crate::transaction::GenesisObject::RawObject {
                                     data,
-                                    owner: obj.owner.into(),
+                                    owner: obj.owner,
                                 }),
                                 Err(e) => Err(e),
                             }
@@ -764,17 +762,14 @@ impl TryFrom<crate::effects::TransactionEffects> for TransactionEffects {
                                     ObjectIn::Data {
                                         version,
                                         digest,
-                                        owner: owner.into(),
+                                        owner,
                                     }
                                 }
                             },
                             output_state: match change.output_state {
                                 crate::effects::ObjectOut::NotExist => ObjectOut::Missing,
                                 crate::effects::ObjectOut::ObjectWrite((digest, owner)) => {
-                                    ObjectOut::ObjectWrite {
-                                        digest,
-                                        owner: owner.into(),
-                                    }
+                                    ObjectOut::ObjectWrite { digest, owner }
                                 }
                                 crate::effects::ObjectOut::PackageWrite((seq, digest)) => {
                                     ObjectOut::PackageWrite {
@@ -869,7 +864,7 @@ impl TryFrom<TransactionEffects> for crate::effects::TransactionEffects {
                                                 owner,
                                             } => crate::effects::ObjectIn::Exist((
                                                 (version, digest),
-                                                owner.into(),
+                                                owner,
                                             )),
                                             _ => unimplemented!("a new enum variant was added and needs to be handled"),
                                         },
@@ -880,7 +875,7 @@ impl TryFrom<TransactionEffects> for crate::effects::TransactionEffects {
                                             ObjectOut::ObjectWrite { digest, owner } => {
                                                 crate::effects::ObjectOut::ObjectWrite((
                                                     digest,
-                                                    owner.into(),
+                                                    owner,
                                                 ))
                                             }
                                             ObjectOut::PackageWrite { version, digest } => {
@@ -1899,33 +1894,6 @@ impl<const T: bool> From<ValidatorAggregatedSignature>
             signature: crate::crypto::AggregateAuthoritySignature::from_bytes(signature.as_bytes())
                 .unwrap(),
             signers_map: bitmap,
-        }
-    }
-}
-
-impl From<crate::object::Owner> for Owner {
-    fn from(value: crate::object::Owner) -> Self {
-        match value {
-            crate::object::Owner::AddressOwner(address) => Self::Address(address),
-            crate::object::Owner::ObjectOwner(object_id) => Self::Object(object_id.into()),
-            crate::object::Owner::Shared {
-                initial_shared_version,
-            } => Self::Shared(initial_shared_version),
-            crate::object::Owner::Immutable => Self::Immutable,
-        }
-    }
-}
-
-impl From<Owner> for crate::object::Owner {
-    fn from(value: Owner) -> Self {
-        match value {
-            Owner::Address(address) => crate::object::Owner::AddressOwner(address),
-            Owner::Object(object_id) => crate::object::Owner::ObjectOwner(object_id.into()),
-            Owner::Shared(initial_shared_version) => crate::object::Owner::Shared {
-                initial_shared_version,
-            },
-            Owner::Immutable => crate::object::Owner::Immutable,
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
 }

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use iota_protocol_config::ProtocolConfig;
+pub use iota_sdk_types::Owner;
 use iota_sdk_types::{StructTag, TypeTag};
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::{layout::TypeLayoutBuilder, module_cache::GetModule};
@@ -451,102 +452,6 @@ impl Data {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Copy, Deserialize, Serialize, Hash, Ord, PartialOrd)]
-#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
-pub enum Owner {
-    /// Object is exclusively owned by a single address, and is mutable.
-    AddressOwner(IotaAddress),
-    /// Object is exclusively owned by a single object, and is mutable.
-    /// The object ID is converted to IotaAddress as IotaAddress is universal.
-    ObjectOwner(IotaAddress),
-    /// Object is shared, can be used by any address, and is mutable.
-    Shared {
-        /// The version at which the object became shared
-        initial_shared_version: SequenceNumber,
-    },
-    /// Object is immutable, and hence ownership doesn't matter.
-    Immutable,
-}
-
-impl Owner {
-    // NOTE: only return address of AddressOwner, otherwise return error,
-    // ObjectOwner's address is converted from object id, thus we will skip it.
-    pub fn get_address_owner_address(&self) -> IotaResult<IotaAddress> {
-        match self {
-            Self::AddressOwner(address) => Ok(*address),
-            Self::Shared { .. } | Self::Immutable | Self::ObjectOwner(_) => {
-                Err(IotaError::UnexpectedOwnerType)
-            }
-        }
-    }
-
-    // NOTE: this function will return address of both AddressOwner and ObjectOwner,
-    // address of ObjectOwner is converted from object id, even though the type is
-    // IotaAddress.
-    pub fn get_owner_address(&self) -> IotaResult<IotaAddress> {
-        match self {
-            Self::AddressOwner(address) | Self::ObjectOwner(address) => Ok(*address),
-            Self::Shared { .. } | Self::Immutable => Err(IotaError::UnexpectedOwnerType),
-        }
-    }
-
-    pub fn is_immutable(&self) -> bool {
-        matches!(self, Owner::Immutable)
-    }
-
-    pub fn is_address_owned(&self) -> bool {
-        matches!(self, Owner::AddressOwner(_))
-    }
-
-    pub fn is_child_object(&self) -> bool {
-        matches!(self, Owner::ObjectOwner(_))
-    }
-
-    pub fn is_shared(&self) -> bool {
-        matches!(self, Owner::Shared { .. })
-    }
-}
-
-impl PartialEq<IotaAddress> for Owner {
-    fn eq(&self, other: &IotaAddress) -> bool {
-        match self {
-            Self::AddressOwner(address) => address == other,
-            Self::ObjectOwner(_) | Self::Shared { .. } | Self::Immutable => false,
-        }
-    }
-}
-
-impl PartialEq<ObjectID> for Owner {
-    fn eq(&self, other: &ObjectID) -> bool {
-        let other_id: IotaAddress = (*other).into();
-        match self {
-            Self::ObjectOwner(id) => id == &other_id,
-            Self::AddressOwner(_) | Self::Shared { .. } | Self::Immutable => false,
-        }
-    }
-}
-
-impl Display for Owner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::AddressOwner(address) => {
-                write!(f, "Account Address ( {address} )")
-            }
-            Self::ObjectOwner(address) => {
-                write!(f, "Object ID: ( {address} )")
-            }
-            Self::Immutable => {
-                write!(f, "Immutable")
-            }
-            Self::Shared {
-                initial_shared_version,
-            } => {
-                write!(f, "Shared( {initial_shared_version} )")
-            }
-        }
-    }
-}
-
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 #[serde(rename = "Object")]
 pub struct ObjectInner {
@@ -717,11 +622,11 @@ impl ObjectInner {
     }
 
     pub fn is_address_owned(&self) -> bool {
-        self.owner.is_address_owned()
+        self.owner.is_address()
     }
 
     pub fn is_child_object(&self) -> bool {
-        self.owner.is_child_object()
+        self.owner.is_object()
     }
 
     pub fn is_shared(&self) -> bool {
@@ -729,7 +634,7 @@ impl ObjectInner {
     }
 
     pub fn get_single_owner(&self) -> Option<IotaAddress> {
-        self.owner.get_owner_address().ok()
+        self.owner.address().copied()
     }
 
     // It's a common pattern to retrieve both the owner and object ID
@@ -844,7 +749,7 @@ impl ObjectInner {
 
     /// Change the owner of `self` to `new_owner`.
     pub fn transfer(&mut self, new_owner: IotaAddress) {
-        self.owner = Owner::AddressOwner(new_owner);
+        self.owner = Owner::Address(new_owner);
     }
 
     /// Get a `MoveStructLayout` for `self`.
@@ -926,9 +831,7 @@ impl Object {
     pub fn shared_for_testing() -> Object {
         let id = ObjectID::random();
         let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, id, 10);
-        let owner = Owner::Shared {
-            initial_shared_version: obj.version(),
-        };
+        let owner = Owner::Shared(obj.version());
         Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
     }
 
@@ -939,7 +842,7 @@ impl Object {
             contents: GasCoin::new(id, gas).to_bcs_bytes(),
         });
         ObjectInner {
-            owner: Owner::AddressOwner(owner),
+            owner: Owner::Address(owner),
             data,
             previous_transaction: TransactionDigest::GENESIS_MARKER,
             storage_rebate: 0,
@@ -984,7 +887,7 @@ impl Object {
             contents: GasCoin::new(id, GAS_VALUE_FOR_TESTING).to_bcs_bytes(),
         });
         ObjectInner {
-            owner: Owner::ObjectOwner(owner.into()),
+            owner: Owner::Object(owner),
             data,
             previous_transaction: TransactionDigest::GENESIS_MARKER,
             storage_rebate: 0,
@@ -1026,7 +929,7 @@ impl Object {
         let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, ObjectID::random(), value);
         Object::new_move(
             obj,
-            Owner::AddressOwner(owner),
+            Owner::Address(owner),
             TransactionDigest::GENESIS_MARKER,
         )
     }
@@ -1206,7 +1109,7 @@ mod tests {
             GasCoin::new_for_testing_with_id(ObjectID::ZERO, 123).to_object(OBJECT_START_VERSION);
         let o = Object::new_move(
             g,
-            Owner::AddressOwner(IotaAddress::ZERO),
+            Owner::Address(IotaAddress::ZERO),
             TransactionDigest::ZERO,
         );
         let bytes = bcs::to_bytes(&o).unwrap();

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -634,7 +634,7 @@ impl ObjectInner {
     }
 
     pub fn get_single_owner(&self) -> Option<IotaAddress> {
-        self.owner.address().copied()
+        self.owner.address_or_object().copied()
     }
 
     // It's a common pattern to retrieve both the owner and object ID

--- a/crates/iota-types/src/randomness_state.rs
+++ b/crates/iota-types/src/randomness_state.rs
@@ -10,7 +10,6 @@ use crate::{
     IOTA_FRAMEWORK_ADDRESS,
     base_types::{Identifier, ObjectID, SequenceNumber},
     error::{IotaError, IotaResult},
-    object::Owner,
     storage::ObjectStore,
 };
 
@@ -28,11 +27,10 @@ pub fn get_randomness_state_obj_initial_shared_version(
 ) -> IotaResult<SequenceNumber> {
     object_store
         .try_get_object(&ObjectID::RANDOMNESS_STATE)?
-        .map(|obj| match obj.owner {
-            Owner::Shared {
-                initial_shared_version,
-            } => initial_shared_version,
-            _ => unreachable!("Randomness state object must be shared"),
+        .map(|obj| {
+            obj.owner
+                .into_shared_opt()
+                .expect("Randomness state object must be shared")
         })
         .ok_or(IotaError::Storage(
             "Randomness state object not found".to_string(),

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -172,7 +172,7 @@ impl<T: Storage + ChildObjectResolver> StorageView for T {}
 /// An abstraction of the (possibly distributed) store for objects. This
 /// API only allows for the retrieval of objects, not any state changes
 pub trait ChildObjectResolver {
-    /// `child` must have an `Object` ownership equal to `owner`.
+    /// `child` must have an `Object` ownership equal to `parent`.
     fn read_child_object(
         &self,
         parent: &ObjectID,

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -172,7 +172,7 @@ impl<T: Storage + ChildObjectResolver> StorageView for T {}
 /// An abstraction of the (possibly distributed) store for objects. This
 /// API only allows for the retrieval of objects, not any state changes
 pub trait ChildObjectResolver {
-    /// `child` must have an `ObjectOwner` ownership equal to `owner`.
+    /// `child` must have an `Object` ownership equal to `owner`.
     fn read_child_object(
         &self,
         parent: &ObjectID,
@@ -180,7 +180,7 @@ pub trait ChildObjectResolver {
         child_version_upper_bound: SequenceNumber,
     ) -> IotaResult<Option<Object>>;
 
-    /// `receiving_object_id` must have an `AddressOwner` ownership equal to
+    /// `receiving_object_id` must have an `Address` ownership equal to
     /// `owner`. `get_object_received_at_version` must be the exact version
     /// at which the object will be received, and it cannot have been
     /// previously received at that version. NB: An object not existing at

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -173,9 +173,7 @@ impl TestCheckpointDataBuilder {
     pub fn create_shared_object(self, object_idx: u64) -> Self {
         self.create_coin_object_with_owner(
             object_idx,
-            Owner::Shared {
-                initial_shared_version: SequenceNumber::MIN_VALID_INCL,
-            },
+            Owner::Shared(SequenceNumber::MIN_VALID_INCL),
             GAS_VALUE_FOR_TESTING,
             GAS::type_tag(),
         )
@@ -208,7 +206,7 @@ impl TestCheckpointDataBuilder {
     ) -> Self {
         self.create_coin_object_with_owner(
             object_idx,
-            Owner::AddressOwner(Self::derive_address(owner_idx)),
+            Owner::Address(Self::derive_address(owner_idx)),
             balance,
             coin_type,
         )
@@ -266,7 +264,7 @@ impl TestCheckpointDataBuilder {
     pub fn transfer_object(self, object_idx: u64, recipient_idx: u8) -> Self {
         self.change_object_owner(
             object_idx,
-            Owner::AddressOwner(Self::derive_address(recipient_idx)),
+            Owner::Address(Self::derive_address(recipient_idx)),
         )
     }
 
@@ -436,10 +434,7 @@ impl TestCheckpointDataBuilder {
         }
 
         for (id, input) in &shared_inputs {
-            let &Owner::Shared {
-                initial_shared_version,
-            } = input.object.owner()
-            else {
+            let &Owner::Shared(initial_shared_version) = input.object.owner() else {
                 panic!("Accessing a non-shared object as shared");
             };
 
@@ -797,8 +792,7 @@ mod tests {
                 .created()
                 .iter()
                 .any(|(object_ref, owner)| object_ref.object_id == created_obj_id
-                    && owner.get_owner_address().unwrap()
-                        == TestCheckpointDataBuilder::derive_address(0))
+                    && owner.address().unwrap() == &TestCheckpointDataBuilder::derive_address(0))
         );
     }
 
@@ -924,8 +918,7 @@ mod tests {
                 .mutated()
                 .iter()
                 .any(|(object_ref, owner)| object_ref.object_id == obj_id
-                    && owner.get_owner_address().unwrap()
-                        == TestCheckpointDataBuilder::derive_address(1))
+                    && owner.address().unwrap() == &TestCheckpointDataBuilder::derive_address(1))
         );
     }
 

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -792,7 +792,8 @@ mod tests {
                 .created()
                 .iter()
                 .any(|(object_ref, owner)| object_ref.object_id == created_obj_id
-                    && owner.address().unwrap() == &TestCheckpointDataBuilder::derive_address(0))
+                    && owner.address_or_object().unwrap()
+                        == &TestCheckpointDataBuilder::derive_address(0))
         );
     }
 
@@ -918,7 +919,8 @@ mod tests {
                 .mutated()
                 .iter()
                 .any(|(object_ref, owner)| object_ref.object_id == obj_id
-                    && owner.address().unwrap() == &TestCheckpointDataBuilder::derive_address(1))
+                    && owner.address_or_object().unwrap()
+                        == &TestCheckpointDataBuilder::derive_address(1))
         );
     }
 

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1934,10 +1934,8 @@ impl TransactionData {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
             let capability_arg = match capability_owner {
-                Owner::AddressOwner(_) => ObjectArg::ImmOrOwnedObject(upgrade_capability),
-                Owner::Shared {
-                    initial_shared_version,
-                } => ObjectArg::SharedObject {
+                Owner::Address(_) => ObjectArg::ImmOrOwnedObject(upgrade_capability),
+                Owner::Shared(initial_shared_version) => ObjectArg::SharedObject {
                     id: upgrade_capability.object_id,
                     initial_shared_version,
                     mutable: true,
@@ -1947,9 +1945,10 @@ impl TransactionData {
                 }
                 // If the capability is owned by an object, then the module defining the owning
                 // object gets to decide how the upgrade capability should be used.
-                Owner::ObjectOwner(_) => {
+                Owner::Object(_) => {
                     bail!("Upgrade capability controlled by object");
                 }
+                _ => unimplemented!("a new enum variant was added and needs to be handled"),
             };
             builder.obj(capability_arg).unwrap();
             let upgrade_arg = builder.pure(upgrade_policy).unwrap();

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1948,7 +1948,7 @@ impl TransactionData {
                 Owner::Object(_) => {
                     bail!("Upgrade capability controlled by object");
                 }
-                _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
             };
             builder.obj(capability_arg).unwrap();
             let upgrade_arg = builder.pure(upgrade_policy).unwrap();

--- a/crates/iota-types/src/unit_tests/base_types_tests.rs
+++ b/crates/iota-types/src/unit_tests/base_types_tests.rs
@@ -32,10 +32,8 @@ use crate::{
 
 #[test]
 fn test_bcs_enum() {
-    let address = Owner::AddressOwner(IotaAddress::random());
-    let shared = Owner::Shared {
-        initial_shared_version: 1.into(),
-    };
+    let address = Owner::Address(IotaAddress::random());
+    let shared = Owner::Shared(1.into());
 
     let address_ser = bcs::to_bytes(&address).unwrap();
     let shared_ser = bcs::to_bytes(&shared).unwrap();

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -132,20 +132,19 @@ impl<'a> Resolver<'a> for ToObject {
         // Depending on the ownership of the object, we resolve it to different types of
         // object arguments for the transaction.
         let obj_arg = match owner {
-            Owner::AddressOwner(_) if self.is_receiving => ObjectArg::Receiving(object_ref),
-            Owner::Immutable | Owner::AddressOwner(_) => ObjectArg::ImmOrOwnedObject(object_ref),
-            Owner::Shared {
-                initial_shared_version,
-            } => ObjectArg::SharedObject {
+            Owner::Address(_) if self.is_receiving => ObjectArg::Receiving(object_ref),
+            Owner::Immutable | Owner::Address(_) => ObjectArg::ImmOrOwnedObject(object_ref),
+            Owner::Shared(initial_shared_version) => ObjectArg::SharedObject {
                 id: object_ref.object_id,
                 initial_shared_version,
                 mutable: self.is_mut,
             },
-            Owner::ObjectOwner(_) => {
+            Owner::Object(_) => {
                 error!(loc => help: {
                     "{obj_id} is an object-owned object, you can only use immutable, shared, or owned objects here."
                 }, "Cannot use an object-owned object as an argument")
             }
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         };
         // Insert the correct object arg that we built above into the transaction.
         builder.ptb.obj(obj_arg).map_err(|e| err!(loc, "{e}"))

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -144,7 +144,7 @@ impl<'a> Resolver<'a> for ToObject {
                     "{obj_id} is an object-owned object, you can only use immutable, shared, or owned objects here."
                 }, "Cannot use an object-owned object as an argument")
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         };
         // Insert the correct object arg that we built above into the transaction.
         builder.ptb.obj(obj_arg).map_err(|e| err!(loc, "{e}"))

--- a/crates/iota/src/signing.rs
+++ b/crates/iota/src/signing.rs
@@ -201,10 +201,7 @@ pub(crate) async fn get_shared_object_version(
     }
     let object = object_response.data.expect("missing object data");
 
-    if let Some(iota_types::object::Owner::Shared {
-        initial_shared_version,
-    }) = object.owner
-    {
+    if let Some(iota_types::object::Owner::Shared(initial_shared_version)) = object.owner {
         Ok(initial_shared_version)
     } else {
         bail!("signer_address {signer_address} is not a shared object")

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -504,7 +504,7 @@ async fn get_cap_object_ref(
         let cap_obj_ref = resp
             .object_ref_if_exists()
             .unwrap_or_else(|| panic!("OperationCap {cap_object_id} does not exist"));
-        if owner != Owner::AddressOwner(context.active_address()?) {
+        if owner != Owner::Address(context.active_address()?) {
             anyhow::bail!(
                 "OperationCap {} is not owned by the sender address {} but {:?}",
                 summary.operation_cap_id,

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -2868,14 +2868,14 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         panic!();
     };
 
-    let (gas, obj) = if *mut_obj1.owner.unwrap().address().unwrap() == address {
+    let (gas, obj) = if *mut_obj1.owner.unwrap().address_or_object().unwrap() == address {
         (mut_obj1, mut_obj2)
     } else {
         (mut_obj2, mut_obj1)
     };
 
-    assert_eq!(*gas.owner.unwrap().address().unwrap(), address);
-    assert_eq!(*obj.owner.unwrap().address().unwrap(), recipient);
+    assert_eq!(*gas.owner.unwrap().address_or_object().unwrap(), address);
+    assert_eq!(*obj.owner.unwrap().address_or_object().unwrap(), recipient);
 
     let object_refs = client
         .read_api()
@@ -3940,7 +3940,7 @@ async fn test_get_owned_objects_owned_by_address_and_check_pagination() -> Resul
     // assert that all the objects_returned are owned by the address
     for resp in &object_responses.data {
         let obj_owner = resp.object().unwrap().owner.unwrap();
-        assert_eq!(*obj_owner.address().unwrap(), address)
+        assert_eq!(*obj_owner.address_or_object().unwrap(), address)
     }
     // assert that has next page is false
     assert!(!object_responses.has_next_page);

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -248,7 +248,7 @@ async fn publish_package(
     let cap = effects
         .created()
         .iter()
-        .find(|refe| matches!(refe.owner, Owner::AddressOwner(_)))
+        .find(|refe| matches!(refe.owner, Owner::Address(_)))
         .unwrap();
 
     Ok((package_a.reference.object_id, cap.reference.object_id))
@@ -1549,12 +1549,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
             let created = response.effects.unwrap().created().to_vec();
             let owners: BTreeSet<ObjectID> = created
                 .iter()
-                .flat_map(|refe| {
-                    refe.owner
-                        .get_address_owner_address()
-                        .ok()
-                        .map(|x| x.into())
-                })
+                .flat_map(|refe| refe.owner.as_address_opt().copied().map(|x| x.into()))
                 .collect();
             let child = created
                 .iter()
@@ -1692,12 +1687,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
             let created = response.effects.unwrap().created().to_vec();
             let owners: BTreeSet<ObjectID> = created
                 .iter()
-                .flat_map(|refe| {
-                    refe.owner
-                        .get_address_owner_address()
-                        .ok()
-                        .map(|x| x.into())
-                })
+                .flat_map(|refe| refe.owner.as_address_opt().copied().map(|x| x.into()))
                 .collect();
             let child = created
                 .iter()
@@ -1835,12 +1825,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
             let created = response.effects.unwrap().created().to_vec();
             let owners: BTreeSet<ObjectID> = created
                 .iter()
-                .flat_map(|refe| {
-                    refe.owner
-                        .get_address_owner_address()
-                        .ok()
-                        .map(|x| x.into())
-                })
+                .flat_map(|refe| refe.owner.as_address_opt().copied().map(|x| x.into()))
                 .collect();
             let child = created
                 .iter()
@@ -2375,7 +2360,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     let cap = effects
         .created()
         .iter()
-        .find(|refe| matches!(refe.owner, Owner::AddressOwner(_)))
+        .find(|refe| matches!(refe.owner, Owner::Address(_)))
         .unwrap();
 
     // Hacky for now: we need to add the correct `published-at` field to the Move
@@ -2525,7 +2510,7 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
     let cap = effects
         .created()
         .iter()
-        .find(|refe| matches!(refe.owner, Owner::AddressOwner(_)))
+        .find(|refe| matches!(refe.owner, Owner::Address(_)))
         .unwrap();
 
     // We will upgrade the package in a `tmp_dir` using the `Move.lock` resulting
@@ -2691,7 +2676,7 @@ async fn test_package_management_on_upgrade_command_conflict() -> Result<(), any
     let cap = effects
         .created()
         .iter()
-        .find(|refe| matches!(refe.owner, Owner::AddressOwner(_)))
+        .find(|refe| matches!(refe.owner, Owner::Address(_)))
         .unwrap();
 
     // Set up a temporary working directory  for upgrading.
@@ -2883,14 +2868,14 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         panic!();
     };
 
-    let (gas, obj) = if mut_obj1.owner.unwrap().get_owner_address().unwrap() == address {
+    let (gas, obj) = if *mut_obj1.owner.unwrap().address().unwrap() == address {
         (mut_obj1, mut_obj2)
     } else {
         (mut_obj2, mut_obj1)
     };
 
-    assert_eq!(gas.owner.unwrap().get_owner_address().unwrap(), address);
-    assert_eq!(obj.owner.unwrap().get_owner_address().unwrap(), recipient);
+    assert_eq!(*gas.owner.unwrap().address().unwrap(), address);
+    assert_eq!(*obj.owner.unwrap().address().unwrap(), recipient);
 
     let object_refs = client
         .read_api()
@@ -3955,10 +3940,7 @@ async fn test_get_owned_objects_owned_by_address_and_check_pagination() -> Resul
     // assert that all the objects_returned are owned by the address
     for resp in &object_responses.data {
         let obj_owner = resp.object().unwrap().owner.unwrap();
-        assert_eq!(
-            obj_owner.get_owner_address().unwrap().to_string(),
-            address.to_string()
-        )
+        assert_eq!(*obj_owner.address().unwrap(), address)
     }
     // assert that has next page is false
     assert!(!object_responses.has_next_page);

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -208,7 +208,7 @@ impl EpochState {
         let mock_gas_id = if transaction.gas().is_empty() {
             let mock_gas_object = Object::new_move(
                 MoveObject::new_gas_coin(1.into(), ObjectID::MAX, SIMULATION_GAS_COIN_VALUE),
-                Owner::AddressOwner(transaction.gas_data().owner),
+                Owner::Address(transaction.gas_data().owner),
                 TransactionDigest::GENESIS_MARKER,
             );
             let mock_gas_object_ref = mock_gas_object.compute_object_reference();

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -170,9 +170,7 @@ impl InMemoryStore {
         self.live_objects
             .iter()
             .flat_map(|(id, version)| self.get_object_at_version(id, *version))
-            .filter(
-                move |object| matches!(object.owner, Owner::AddressOwner(addr) if addr == owner),
-            )
+            .filter(move |object| matches!(object.owner, Owner::Address(addr) if addr == owner))
     }
 
     pub fn update_last_checkpoint_by_epoch(
@@ -301,7 +299,7 @@ impl ChildObjectResolver for InMemoryStore {
         };
 
         let parent = *parent;
-        if child_object.owner != Owner::ObjectOwner(parent.into()) {
+        if child_object.owner != Owner::Object(parent) {
             return Err(IotaError::InvalidChildObjectAccess {
                 object: *child,
                 given_parent: parent,
@@ -331,7 +329,7 @@ impl ChildObjectResolver for InMemoryStore {
             None => return Ok(None),
             Some(obj) => obj,
         };
-        if recv_object.owner != Owner::AddressOwner((*owner).into()) {
+        if recv_object.owner != Owner::Address((*owner).into()) {
             return Ok(None);
         }
 

--- a/crates/transaction-fuzzer/src/lib.rs
+++ b/crates/transaction-fuzzer/src/lib.rs
@@ -56,9 +56,7 @@ fn generate_random_gas_data(
     let gas_coin_owners = gas_coin_owners
         .iter()
         .map(|o| match o {
-            Owner::ObjectOwner(_) | Owner::AddressOwner(_) if owned_by_sender => {
-                Owner::AddressOwner(sender)
-            }
+            Owner::Object(_) | Owner::Address(_) if owned_by_sender => Owner::Address(sender),
             _ => *o,
         })
         .collect::<Vec<_>>();

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -19,7 +19,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -875,6 +875,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,7 +1087,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1186,6 +1195,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-str"
@@ -1316,6 +1331,15 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1475,7 +1499,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468 0.6.0",
  "zeroize",
 ]
@@ -1486,7 +1510,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468 0.7.0",
  "zeroize",
 ]
@@ -1621,9 +1645,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1899,7 +1934,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "signature 2.2.0",
  "static_assertions",
  "thiserror 1.0.69",
@@ -1929,7 +1964,7 @@ dependencies = [
  "itertools 0.10.5",
  "rand 0.8.6",
  "serde",
- "sha3",
+ "sha3 0.10.9",
  "tap",
  "tracing",
  "typenum",
@@ -2570,6 +2605,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3387,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=23fb07a1ac138d045c61158c6623d79189ccde7e#23fb07a1ac138d045c61158c6623d79189ccde7e"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25#6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3852,6 +3896,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -4388,7 +4442,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.11.0",
  "smallvec",
 ]
 
@@ -6515,7 +6569,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -7485,7 +7549,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4.3"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0930fb35bc5db8fc6baa5f0829b3997bff02f99a" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4.3"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "40d39c7f67bb394274f9dd6ca1a4915a40427b90" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4.3"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "77e51e5361bb81054187788d820c4f4da8a3ad6c" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0930fb35bc5db8fc6baa5f0829b3997bff02f99a" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -17,6 +17,6 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "40d39c7f67bb394274f9dd6ca1a4915a40427b90" }
 iota-types = { path = "../../../crates/iota-types" }
 move-core-types = { path = "../../../external-crates/move/crates/move-core-types" }

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -17,6 +17,6 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0930fb35bc5db8fc6baa5f0829b3997bff02f99a" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25" }
 iota-types = { path = "../../../crates/iota-types" }
 move-core-types = { path = "../../../external-crates/move/crates/move-core-types" }

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -17,6 +17,6 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "77e51e5361bb81054187788d820c4f4da8a3ad6c" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0930fb35bc5db8fc6baa5f0829b3997bff02f99a" }
 iota-types = { path = "../../../crates/iota-types" }
 move-core-types = { path = "../../../external-crates/move/crates/move-core-types" }

--- a/examples/tic-tac-toe/cli/src/client.rs
+++ b/examples/tic-tac-toe/cli/src/client.rs
@@ -144,10 +144,7 @@ impl Client {
 
         // (4) Check whether the game has ended or not.
         let mut builder = ProgrammableTransactionBuilder::new();
-        let g = if let Owner::Shared {
-            initial_shared_version,
-        } = owner
-        {
+        let g = if let Owner::Shared(initial_shared_version) = owner {
             builder.obj(ObjectArg::SharedObject {
                 id,
                 initial_shared_version,
@@ -346,10 +343,7 @@ impl Client {
     pub async fn delete_shared_game(&mut self, game: &game::Shared, owner: Owner) -> Result<()> {
         let player = self.wallet.active_address()?;
 
-        let Owner::Shared {
-            initial_shared_version,
-        } = owner
-        else {
+        let Owner::Shared(initial_shared_version) = owner else {
             bail!("Game is not shared");
         };
 
@@ -426,10 +420,7 @@ impl Client {
     ) -> Result<()> {
         let player = self.wallet.active_address()?;
 
-        let Owner::Shared {
-            initial_shared_version,
-        } = owner
-        else {
+        let Owner::Shared(initial_shared_version) = owner else {
             bail!("Game is not shared");
         };
 

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -647,8 +647,7 @@ mod checked {
             obj: ObjectValue,
             addr: IotaAddress,
         ) -> Result<(), ExecutionError> {
-            self.additional_transfers
-                .push((Owner::AddressOwner(addr), obj));
+            self.additional_transfers.push((Owner::Address(addr), obj));
             Ok(())
         }
 
@@ -1451,13 +1450,14 @@ mod checked {
             "override_as_immutable should only be set for shared objects"
         );
         let is_mutable_input = match obj.owner {
-            Owner::AddressOwner(_) => true,
+            Owner::Address(_) => true,
             Owner::Shared { .. } => !override_as_immutable,
             Owner::Immutable => false,
-            Owner::ObjectOwner(_) => {
+            Owner::Object(_) => {
                 // protected by transaction input checker
-                invariant_violation!("ObjectOwner objects cannot be input")
+                invariant_violation!("Object-owned objects cannot be inputs")
             }
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         };
         let owner = obj.owner;
         let version = obj.version();

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -1457,7 +1457,7 @@ mod checked {
                 // protected by transaction input checker
                 invariant_violation!("Object-owned objects cannot be inputs")
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         };
         let owner = obj.owner;
         let version = obj.version();

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -588,7 +588,9 @@ impl TemporaryStore<'_> {
                     Owner::Object(_parent) => {
                         unreachable!("Input objects must be address owned, shared, or immutable")
                     }
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 }
             })
             .filter(|id| {
@@ -655,7 +657,9 @@ impl TemporaryStore<'_> {
                         );
                         continue;
                     }
-                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                    _ => {
+                        unimplemented!("a new Owner enum variant was added and needs to be handled")
+                    }
                 }
             };
             // we now assume the object is authenticated and must check the parent

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -242,7 +242,7 @@ impl<'backing> TemporaryStore<'backing> {
                 // This is because this could be "spoofed" by loading a dynamic object field.
                 let loaded_via_receive = obj_meta.version == receiving_object.version
                     && obj_meta.digest == receiving_object.digest
-                    && obj_meta.owner.is_address_owned();
+                    && obj_meta.owner.is_address();
                 if loaded_via_receive {
                     transaction_dependencies.insert(obj_meta.previous_transaction);
                 }
@@ -567,7 +567,7 @@ impl TemporaryStore<'_> {
                     return None;
                 }
                 match &obj.owner {
-                    Owner::AddressOwner(a) => {
+                    Owner::Address(a) => {
                         assert!(sender == a, "Input object not owned by sender");
                         Some(id)
                     }
@@ -585,9 +585,10 @@ impl TemporaryStore<'_> {
                         // us from catching this.
                         None
                     }
-                    Owner::ObjectOwner(_parent) => {
+                    Owner::Object(_parent) => {
                         unreachable!("Input objects must be address owned, shared, or immutable")
                     }
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 }
             })
             .filter(|id| {
@@ -628,8 +629,8 @@ impl TemporaryStore<'_> {
                     )
                 };
                 match &old_obj.owner {
-                    Owner::ObjectOwner(parent) => ObjectID::from(*parent),
-                    Owner::AddressOwner(parent) => {
+                    Owner::Object(parent) => *parent,
+                    Owner::Address(parent) => {
                         // For Receiving<_> objects, the address owner is actually an object.
                         // If it was actually an address, we should have caught it as an input and
                         // it would already have been in authenticated_for_mutation
@@ -654,6 +655,7 @@ impl TemporaryStore<'_> {
                         );
                         continue;
                     }
+                    _ => unimplemented!("a new enum variant was added and needs to be handled"),
                 }
             };
             // we now assume the object is authenticated and must check the parent

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs
@@ -802,7 +802,7 @@ fn check_circular_ownership(
                 }
                 object_owner_map.insert(id, new_owner);
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
     Ok(())

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs
@@ -661,14 +661,12 @@ impl ObjectRuntimeState {
                     debug_assert!(!self.transfers.contains_key(&child));
                     debug_assert!(!self.new_ids.contains(&child));
                     debug_assert!(loaded_child_objects.contains_key(&child));
-                    self.transfers
-                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
+                    self.transfers.insert(child, (Owner::Object(parent), ty, v));
                 }
 
                 Op::New(v) => {
                     debug_assert!(!self.transfers.contains_key(&child));
-                    self.transfers
-                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
+                    self.transfers.insert(child, (Owner::Object(parent), ty, v));
                 }
 
                 Op::Delete => {
@@ -741,8 +739,7 @@ impl ObjectRuntimeState {
                                 || !self.new_ids.contains(&child)
                         );
                         // Mark the mutation of the new value and/or parent.
-                        self.transfers
-                            .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
+                        self.transfers.insert(child, (Owner::Object(parent), ty, v));
                     }
                 }
             } else {
@@ -787,9 +784,9 @@ fn check_circular_ownership(
     for (id, recipient) in transfers {
         object_owner_map.remove(&id);
         match recipient {
-            Owner::AddressOwner(_) | Owner::Shared { .. } | Owner::Immutable => (),
-            Owner::ObjectOwner(new_owner) => {
-                let new_owner: ObjectID = new_owner.into();
+            Owner::Address(_) | Owner::Shared { .. } | Owner::Immutable => (),
+            Owner::Object(new_owner) => {
+                let new_owner: ObjectID = new_owner;
                 let mut cur = new_owner;
                 loop {
                     if cur == id {
@@ -805,6 +802,7 @@ fn check_circular_ownership(
                 }
                 object_owner_map.insert(id, new_owner);
             }
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
     Ok(())

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
@@ -164,7 +164,7 @@ macro_rules! fetch_child_object_unbounded {
                         ),
                     ));
                 }
-                _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
             };
             match &object.data {
                 Data::Package(_) => {

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
@@ -144,7 +144,7 @@ macro_rules! fetch_child_object_unbounded {
             // guard against bugs in `read_child_object`: if it returns a child object such
             // that C.parent != parent, we raise an invariant violation
             match &object.owner {
-                Owner::ObjectOwner(id) => {
+                Owner::Object(id) => {
                     if ObjectID::from(*id) != $parent {
                         return Err(PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(
                             format!(
@@ -154,7 +154,7 @@ macro_rules! fetch_child_object_unbounded {
                         ));
                     }
                 }
-                Owner::AddressOwner(_) | Owner::Immutable | Owner::Shared { .. } => {
+                Owner::Address(_) | Owner::Immutable | Owner::Shared { .. } => {
                     return Err(PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(
                         format!(
                             "Bad owner for {}. \
@@ -164,6 +164,7 @@ macro_rules! fetch_child_object_unbounded {
                         ),
                     ));
                 }
+                _ => unimplemented!("a new enum variant was added and needs to be handled"),
             };
             match &object.data {
                 Data::Package(_) => {
@@ -201,7 +202,7 @@ impl Inner<'_> {
             // object such that C.parent != parent, we raise an invariant
             // violation since that should be checked by
             // `receive_object_at_version`.
-            if object.owner != Owner::AddressOwner(owner.into()) {
+            if object.owner != Owner::Address(owner.into()) {
                 return Err(
                     PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(format!(
                         "Bad owner for {child}. \

--- a/iota-execution/latest/iota-move-natives/src/test_scenario.rs
+++ b/iota-execution/latest/iota-move-natives/src/test_scenario.rs
@@ -246,7 +246,7 @@ pub fn end_transaction(
                     .or_default()
                     .insert(id);
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
 
@@ -860,7 +860,7 @@ fn transaction_effects(
             )),
             Owner::Shared { .. } => shared.push(AccountAddress::new(id.into_bytes())),
             Owner::Immutable => frozen.push(AccountAddress::new(id.into_bytes())),
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
 

--- a/iota-execution/latest/iota-move-natives/src/test_scenario.rs
+++ b/iota-execution/latest/iota-move-natives/src/test_scenario.rs
@@ -222,7 +222,7 @@ pub fn end_transaction(
             written.push(id);
         }
         match owner {
-            Owner::AddressOwner(a) => {
+            Owner::Address(a) => {
                 inventories
                     .address_inventories
                     .entry(a)
@@ -231,7 +231,7 @@ pub fn end_transaction(
                     .or_default()
                     .insert(id);
             }
-            Owner::ObjectOwner(_) => (),
+            Owner::Object(_) => (),
             Owner::Shared { .. } => {
                 inventories
                     .shared_inventory
@@ -246,6 +246,7 @@ pub fn end_transaction(
                     .or_default()
                     .insert(id);
             }
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
 
@@ -407,7 +408,7 @@ pub fn take_from_address_by_id(
         &mut inventories.taken,
         &mut object_runtime.state.input_objects,
         id,
-        Owner::AddressOwner(account),
+        Owner::Address(account),
     );
     Ok(match res {
         Ok(value) => NativeResult::ok(legacy_test_cost(), smallvec![value]),
@@ -476,7 +477,7 @@ pub fn was_taken_from_address(
     let was_taken = inventories
         .taken
         .get(&id)
-        .map(|owner| owner == &Owner::AddressOwner(account))
+        .map(|owner| owner == &Owner::Address(account))
         .unwrap_or(false);
     Ok(NativeResult::ok(
         legacy_test_cost(),
@@ -590,7 +591,7 @@ pub fn take_shared_by_id(
         &mut inventories.taken,
         &mut object_runtime.state.input_objects,
         id,
-        Owner::Shared { initial_shared_version: /* dummy */ SequenceNumber::default() },
+        Owner::Shared(Default::default()),
     );
     Ok(match res {
         Ok(value) => NativeResult::ok(legacy_test_cost(), smallvec![value]),
@@ -695,7 +696,7 @@ pub fn allocate_receiving_ticket_for_object(
             DynamicallyLoadedObjectMetadata {
                 version: SequenceNumber::default(),
                 digest: ObjectDigest::MIN,
-                owner: Owner::AddressOwner(*owner),
+                owner: Owner::Address(*owner),
                 storage_rebate: 0,
                 previous_transaction: TransactionDigest::default(),
             },
@@ -705,7 +706,7 @@ pub fn allocate_receiving_ticket_for_object(
 
     let object = Object::new_move(
         move_object,
-        Owner::AddressOwner(*owner),
+        Owner::Address(*owner),
         TransactionDigest::default(),
     );
 
@@ -849,16 +850,17 @@ fn transaction_effects(
     let mut frozen = vec![];
     for (id, owner) in transferred {
         match owner {
-            Owner::AddressOwner(a) => transferred_to_account.push((
+            Owner::Address(a) => transferred_to_account.push((
                 pack_id(AccountAddress::new(id.into_bytes())),
                 Value::address(AccountAddress::new(a.into_bytes())),
             )),
-            Owner::ObjectOwner(o) => transferred_to_object.push((
+            Owner::Object(o) => transferred_to_object.push((
                 pack_id(AccountAddress::new(id.into_bytes())),
                 pack_id(AccountAddress::new(o.into_bytes())),
             )),
             Owner::Shared { .. } => shared.push(AccountAddress::new(id.into_bytes())),
             Owner::Immutable => frozen.push(AccountAddress::new(id.into_bytes())),
+            _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
 

--- a/iota-execution/latest/iota-move-natives/src/transfer.rs
+++ b/iota-execution/latest/iota-move-natives/src/transfer.rs
@@ -173,7 +173,7 @@ pub fn transfer_internal(
     let recipient = pop_arg!(args, AccountAddress);
     let obj = args.pop_back().unwrap();
 
-    let owner = Owner::AddressOwner(IotaAddress::new(recipient.into_bytes()));
+    let owner = Owner::Address(IotaAddress::new(recipient.into_bytes()));
     object_runtime_transfer(context, owner, ty, obj)?;
     let cost = context.gas_used();
     Ok(NativeResult::ok(cost, smallvec![]))
@@ -251,9 +251,7 @@ pub fn share_object(
         context,
         // Dummy version, to be filled with the correct initial version when the effects of the
         // transaction are written to storage.
-        Owner::Shared {
-            initial_shared_version: SequenceNumber::default(),
-        },
+        Owner::Shared(Default::default()),
         ty,
         obj,
     )?;


### PR DESCRIPTION
This PR is part of the ongoing effort to consolidate blockchain types in the
canonical `iota-rust-sdk`. Types that are needed by both clients/SDK consumers
and the node should live in `iota-rust-sdk` and be imported from there, instead
of being defined twice (once in `iota-types`, once in the SDK).

This PR replaces `Owner` (previously defined in `iota-types`) with the
SDK version from `iota-sdk-types`. To keep the diff small and avoid touching
every call site, the SDK type is re-exported from `iota-types` under the
original name `Owner`, so most existing imports continue to work
unchanged.

## Notes

The SDK `Owner` enum has different variant names and shapes than the previous
`iota-types` version, so call sites that pattern-match on variants or call the
old helper methods had to be updated:

- `Owner::AddressOwner(addr)` → `Owner::Address(addr)`
- `Owner::ObjectOwner(addr)` → `Owner::Object(object_id)` (now wraps an
  `ObjectId` rather than an `IotaAddress`)
- `Owner::Shared { initial_shared_version }` →
  `Owner::Shared(initial_shared_version)` (tuple variant)
- `Owner::Immutable` is unchanged.

Helper methods were renamed/replaced to match the SDK API:

- `is_address_owned()` → `is_address()`
- `is_child_object()` → `is_object()`
- `get_owner_address()` → `address_or_object()`
- `get_address_owner_address()` → `as_address_opt()`

The SDK enum is `#[non_exhaustive]`, so exhaustive matches now include a
catch-all arm.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: `Owner` is now displayed using the SDK's `Display` impl
  (`Address(<addr>)`, `Object(<id>)`, `Shared(<v>)`, `Immutable`) instead of
  the previous `Account Address ( <addr> )` / `Object ID: ( <id> )` /
  `Shared( <v> )` formatting.
- [x] Rust SDK: `iota_types::object::Owner` is now a re-export of
  `iota_sdk_types::Owner`. Variant names and shapes changed
  (`AddressOwner`/`ObjectOwner`/`Shared { .. }` →
  `Address`/`Object`/`Shared(..)`), helper methods were renamed
  (`is_address_owned` → `is_address`, `is_child_object` → `is_object`,
  `get_owner_address` → `address_or_object`), and the enum is now
  `#[non_exhaustive]`.
- [ ] gRPC:
