### PR TITLE
fix(json-rpc): Populate balance-changes object cache with input objects

### DIFF
--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -49,7 +49,7 @@ use tonic::{
     metadata::{Ascii, MetadataValue},
     transport::server::TcpConnectInfo,
 };
-use tracing::{Instrument, debug, error, error_span, info, trace_span};
+use tracing::{Instrument, debug, error, error_span, info, trace_span, warn};
 
 use crate::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
@@ -695,11 +695,29 @@ impl ValidatorService {
 
                 let input_objects = include_input_objects
                     .then(|| self.state.get_transaction_input_objects(&effects))
-                    .and_then(Result::ok);
+                    .and_then(|res| {
+                        res.map_err(|e| {
+                            warn!(
+                                tx_digest = ?effects.transaction_digest(),
+                                error = ?e,
+                                "Failed to load transaction input objects requested by client",
+                            )
+                        })
+                        .ok()
+                    });
 
                 let output_objects = include_output_objects
                     .then(|| self.state.get_transaction_output_objects(&effects))
-                    .and_then(Result::ok);
+                    .and_then(|res| {
+                        res.map_err(|e| {
+                            warn!(
+                                tx_digest = ?effects.transaction_digest(),
+                                error = ?e,
+                                "Failed to load transaction output objects requested by client",
+                            )
+                        })
+                        .ok()
+                    });
 
                 let signed_effects = self.state.sign_effects(effects, epoch_store)?;
                 epoch_store.insert_tx_cert_sig(certificate.digest(), certificate.auth_sig())?;

--- a/crates/iota-json-rpc/src/balance_changes.rs
+++ b/crates/iota-json-rpc/src/balance_changes.rs
@@ -186,6 +186,31 @@ impl<P> ObjectProviderCache<P> {
         }
     }
 
+    #[instrument(level = "trace", skip_all)]
+    pub fn insert_objects_into_cache(&mut self, objects: Vec<Object>) {
+        let object_cache = self.object_cache.get_mut();
+        let last_version_cache = self.last_version_cache.get_mut();
+
+        for object in objects {
+            let object_id = object.id();
+            let version = object.version();
+
+            let key = (object_id, version);
+            object_cache.insert(key, object.clone());
+
+            match last_version_cache.get_mut(&key) {
+                Some(existing_seq_number) => {
+                    if version > *existing_seq_number {
+                        *existing_seq_number = version
+                    }
+                }
+                None => {
+                    last_version_cache.insert(key, version);
+                }
+            }
+        }
+    }
+
     pub fn new_with_cache(
         provider: P,
         written_objects: BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
@@ -205,37 +230,6 @@ impl<P> ObjectProviderCache<P> {
                 }
                 None => {
                     last_version_cache.insert(key, object_ref.1);
-                }
-            }
-        }
-
-        Self {
-            object_cache: RwLock::new(object_cache),
-            last_version_cache: RwLock::new(last_version_cache),
-            provider,
-        }
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    pub fn new_with_output_objects(provider: P, output_objects: Vec<Object>) -> Self {
-        let mut object_cache = BTreeMap::new();
-        let mut last_version_cache = BTreeMap::new();
-
-        for object in output_objects {
-            let object_id = object.id();
-            let version = object.version();
-
-            let key = (object_id, version);
-            object_cache.insert(key, object.clone());
-
-            match last_version_cache.get_mut(&key) {
-                Some(existing_seq_number) => {
-                    if version > *existing_seq_number {
-                        *existing_seq_number = version
-                    }
-                }
-                None => {
-                    last_version_cache.insert(key, version);
                 }
             }
         }

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -227,7 +227,13 @@ impl TransactionExecutionApi {
             None
         };
 
-        let object_cache = if opts.show_balance_changes || opts.show_object_changes {
+        // Skip cache (and downstream balance/object_changes) when the validator
+        // returned no input/output objects — e.g. the already-executed early-return.
+        // Without this guard, cache misses fall through to a provider lookup that
+        // races with local state and returns "version higher than latest".
+        let object_cache = if (opts.show_balance_changes || opts.show_object_changes)
+            && (response.input_objects.is_some() || response.output_objects.is_some())
+        {
             let mut object_cache = ObjectProviderCache::new(self.state.clone());
             if let Some(input_objects) = response.input_objects {
                 object_cache.insert_objects_into_cache(input_objects);

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -227,10 +227,14 @@ impl TransactionExecutionApi {
             None
         };
 
-        let object_cache = {
-            response.output_objects.map(|output_objects| {
-                ObjectProviderCache::new_with_output_objects(self.state.clone(), output_objects)
-            })
+        let object_cache = match (response.input_objects, response.output_objects) {
+            (Some(input_objects), Some(output_objects)) => {
+                let mut object_cache = ObjectProviderCache::new(self.state.clone());
+                object_cache.insert_objects_into_cache(input_objects);
+                object_cache.insert_objects_into_cache(output_objects);
+                Some(object_cache)
+            }
+            _ => None,
         };
 
         let balance_changes = match &object_cache {

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -227,14 +227,17 @@ impl TransactionExecutionApi {
             None
         };
 
-        let object_cache = match (response.input_objects, response.output_objects) {
-            (Some(input_objects), Some(output_objects)) => {
-                let mut object_cache = ObjectProviderCache::new(self.state.clone());
+        let object_cache = if opts.show_balance_changes || opts.show_object_changes {
+            let mut object_cache = ObjectProviderCache::new(self.state.clone());
+            if let Some(input_objects) = response.input_objects {
                 object_cache.insert_objects_into_cache(input_objects);
-                object_cache.insert_objects_into_cache(output_objects);
-                Some(object_cache)
             }
-            _ => None,
+            if let Some(output_objects) = response.output_objects {
+                object_cache.insert_objects_into_cache(output_objects);
+            }
+            Some(object_cache)
+        } else {
+            None
         };
 
         let balance_changes = match &object_cache {


### PR DESCRIPTION
# Description of change

- Port the fix from upstream commit: https://github.com/MystenLabs/sui/commit/cc13b433d65b9171e544c407d6703e6ec816e718
  -  Pre-populate the cache with both `response.input_objects` and `response.output_objects`. 
- Log discarded errors from `get_transaction_input_objects` / `get_transaction_output_objects` in `authority_server.rs`. 
- Port the follow-up fix upstream commit: https://github.com/MystenLabs/sui/commit/c34b812822ff7cef93ddab8a5ef91c2948bbb93c (The test is skipped)
  - Create the `ObjectProviderCache` when `show_balance_changes` or `show_object_changes` is requested, instead of only when both `input_objects` and `output_objects` are Some.
  - We do not have the bug that the upstream found bc we don't support address-balance-backed transactions with no coin inputs, so the `input_objects` is always Some. We still port the fix because it could still happen if we failed to load the input objects from the local store is reachable not via "no coin inputs" but via a transient store read failure.


## Test plan

End-to-end stress test against local network with `fullnode-1`'s `iota-node` binary hot-swapped between this branch and `6bb98867b7` (the commit before the fix), following the testing flow as the issue described. CLI temporarily patched to use `WaitForEffectsCert` because the default `WaitForLocalExecution` masks the race entirely:

  | Fullnode | Concurrent shared-object increments | Successful | -32602 errors |
  |---|---|---|---|
  | `6bb98867b7`  | 90 | 2 | **88** |
  | `6bb98867b7` (rerun) | 80 | 1 | **79** |
  | this branch | 80 | 80 | **0** |
  | this branch (rerun) | 80 | 80 | **0** |

  Sample pre-fix error (the symptom from the issue):
  ```
  ErrorObject { code: InvalidParams, message: "Could not find the referenced object
  ObjectId(\"0x6af8…\") as the asked version Version(2234) is higher than the latest
  Version(2227)", data: None }
  ```


## Links to any relevant issues

Fixes #10977.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: Fixed "Could not find the referenced object" errors in balance/object changes for concurrent shared-object transactions.
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC: