### PR TITLE
feat(starfish): pin StarfishSpeed strong votes/blames to leader authority

### DIFF
--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -421,9 +421,11 @@ impl BaseCommitter {
     }
 
     /// `(vote_refs, strong_vote_refs)` at r+1 for `leader_block`, built in a
-    /// single pass. Strong votes are a subset of votes; `is_strong_vote()`
-    /// alone is insufficient (a voter may flag itself strong while supporting
-    /// an equivocating leader).
+    /// single pass. Strong votes are a subset of votes; the strong-vote filter
+    /// also requires the voter's pinned leader (`strong_vote_leader`) to
+    /// match `leader_block.author()` — strong votes computed against a
+    /// different leader (e.g. before a schedule rotation) don't count toward
+    /// this leader's quorum.
     fn vote_and_strong_vote_refs_for_leader(
         &self,
         leader_block: &VerifiedBlockHeader,
@@ -439,7 +441,9 @@ impl BaseCommitter {
             if self.is_vote(voter, leader_block) {
                 let r = voter.reference();
                 vote_refs.insert(r);
-                if voter.is_strong_vote() {
+                if voter.is_strong_vote()
+                    && voter.strong_vote_leader() == Some(leader_block.author())
+                {
                     strong_vote_refs.insert(r);
                 }
             }
@@ -463,7 +467,11 @@ impl BaseCommitter {
 
         let strong_vote_refs: HashSet<BlockRef> = voters
             .into_iter()
-            .filter(|b| b.is_strong_vote() && self.is_vote(b, leader_block))
+            .filter(|b| {
+                b.is_strong_vote()
+                    && b.strong_vote_leader() == Some(leader_block.author())
+                    && self.is_vote(b, leader_block)
+            })
             .map(|b| b.reference())
             .collect();
 

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -538,8 +538,10 @@ impl BaseCommitter {
         (is_cert, is_strong)
     }
 
-    /// Check whether 2f+1 blocks at `r+1` both vote for `leader_block` and
-    /// carry `is_strong_blame() == true`.
+    /// Check whether 2f+1 blocks at `r+1` vote for `leader_block`, pin their
+    /// strong-blame to `leader_block.author()`, and carry
+    /// `is_strong_blame() == true`. Strong blames whose pinned leader doesn't
+    /// match are ignored — same misattribution rule as for strong votes.
     fn has_strong_blame_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
         let voting_round = leader_block.round() + 1;
         let voting_blocks = self
@@ -550,6 +552,9 @@ impl BaseCommitter {
         let mut strong_blame_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         for voting_block in &voting_blocks {
             if !voting_block.is_strong_blame() {
+                continue;
+            }
+            if voting_block.strong_vote_leader() != Some(leader_block.author()) {
                 continue;
             }
             if !self.is_vote(voting_block, leader_block) {

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -441,9 +441,7 @@ impl BaseCommitter {
             if self.is_vote(voter, leader_block) {
                 let r = voter.reference();
                 vote_refs.insert(r);
-                if voter.is_strong_vote()
-                    && voter.strong_vote_leader() == Some(leader_block.author())
-                {
+                if voter.is_strong_vote_for(leader_block.author()) {
                     strong_vote_refs.insert(r);
                 }
             }
@@ -468,9 +466,7 @@ impl BaseCommitter {
         let strong_vote_refs: HashSet<BlockRef> = voters
             .into_iter()
             .filter(|b| {
-                b.is_strong_vote()
-                    && b.strong_vote_leader() == Some(leader_block.author())
-                    && self.is_vote(b, leader_block)
+                b.is_strong_vote_for(leader_block.author()) && self.is_vote(b, leader_block)
             })
             .map(|b| b.reference())
             .collect();
@@ -551,10 +547,7 @@ impl BaseCommitter {
 
         let mut strong_blame_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         for voting_block in &voting_blocks {
-            if !voting_block.is_strong_blame() {
-                continue;
-            }
-            if voting_block.strong_vote_leader() != Some(leader_block.author()) {
+            if !voting_block.is_strong_blame_for(leader_block.author()) {
                 continue;
             }
             if !self.is_vote(voting_block, leader_block) {

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -111,7 +111,8 @@ pub trait BlockHeaderAPI {
     fn ancestors(&self) -> &[BlockRef];
     fn commit_votes(&self) -> &[CommitVote];
     fn transactions_commitment(&self) -> TransactionsCommitment;
-    fn strong_vote(&self) -> Option<AuthoritySet>;
+    fn strong_vote(&self) -> Option<StrongVote>;
+    fn strong_vote_leader(&self) -> Option<AuthorityIndex>;
     fn is_strong_vote(&self) -> bool;
     fn is_strong_blame(&self) -> bool;
 }
@@ -213,7 +214,11 @@ impl BlockHeaderAPI for BlockHeaderV1 {
     }
 
     // V1 blocks do not carry a strong vote; always returns None.
-    fn strong_vote(&self) -> Option<AuthoritySet> {
+    fn strong_vote(&self) -> Option<StrongVote> {
+        None
+    }
+
+    fn strong_vote_leader(&self) -> Option<AuthorityIndex> {
         None
     }
 
@@ -223,6 +228,26 @@ impl BlockHeaderAPI for BlockHeaderV1 {
 
     fn is_strong_blame(&self) -> bool {
         false
+    }
+}
+
+/// Strong-vote payload pinned to a specific leader authority. The producer
+/// records which leader the vote/blame is *for*, so consumers can reject votes
+/// whose pinned leader doesn't match the canonical leader they're evaluating.
+#[derive(Clone, Copy, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq, Debug)]
+pub struct StrongVote {
+    /// Authority of the leader at round - 1, per the producer's swap table at
+    /// block-creation time.
+    pub leader_authority: AuthorityIndex,
+    /// Bitmask of authorities whose data the producer was missing relative to
+    /// the pinned leader's data set. Empty = strong vote; non-empty = strong
+    /// blame.
+    pub missing: AuthoritySet,
+}
+
+impl StrongVote {
+    pub fn is_strong_vote(&self) -> bool {
+        self.missing.is_empty()
     }
 }
 
@@ -237,11 +262,10 @@ pub struct BlockHeaderV2 {
     overlap_end_index: u8,
     transactions_commitment: TransactionsCommitment,
     commit_votes: Vec<CommitVote>,
-    // Bitmask of authorities whose transaction data (announced by the leader)
-    // is not available. None means no vote. Some(empty) means all data is
-    // available (strong vote). Some(nonempty) means some data is missing
-    // (strong blame).
-    strong_vote: Option<AuthoritySet>,
+    // Strong-vote payload pinned to a specific leader. None = no vote;
+    // Some(StrongVote { missing: empty, .. }) = strong vote;
+    // Some(StrongVote { missing: nonempty, .. }) = strong blame.
+    strong_vote: Option<StrongVote>,
 }
 
 impl BlockHeaderV2 {
@@ -254,7 +278,7 @@ impl BlockHeaderV2 {
         acknowledgments: Vec<BlockRef>,
         commit_votes: Vec<CommitVote>,
         transactions_commitment: TransactionsCommitment,
-        strong_vote: Option<AuthoritySet>,
+        strong_vote: Option<StrongVote>,
     ) -> BlockHeaderV2 {
         let (references, overlap_start_index, overlap_end_index) =
             BlockHeader::compress_references(ancestors, acknowledgments);
@@ -328,16 +352,20 @@ impl BlockHeaderAPI for BlockHeaderV2 {
         self.transactions_commitment
     }
 
-    fn strong_vote(&self) -> Option<AuthoritySet> {
+    fn strong_vote(&self) -> Option<StrongVote> {
         self.strong_vote
     }
 
+    fn strong_vote_leader(&self) -> Option<AuthorityIndex> {
+        self.strong_vote.map(|sv| sv.leader_authority)
+    }
+
     fn is_strong_vote(&self) -> bool {
-        self.strong_vote.is_some_and(|s| s.is_empty())
+        self.strong_vote.is_some_and(|sv| sv.is_strong_vote())
     }
 
     fn is_strong_blame(&self) -> bool {
-        self.strong_vote.is_some_and(|s| !s.is_empty())
+        self.strong_vote.is_some_and(|sv| !sv.is_strong_vote())
     }
 }
 
@@ -405,10 +433,17 @@ impl BlockHeaderAPI for BlockHeader {
         }
     }
 
-    fn strong_vote(&self) -> Option<AuthoritySet> {
+    fn strong_vote(&self) -> Option<StrongVote> {
         match self {
             BlockHeader::V1(header) => header.strong_vote(),
             BlockHeader::V2(header) => header.strong_vote(),
+        }
+    }
+
+    fn strong_vote_leader(&self) -> Option<AuthorityIndex> {
+        match self {
+            BlockHeader::V1(header) => header.strong_vote_leader(),
+            BlockHeader::V2(header) => header.strong_vote_leader(),
         }
     }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -115,6 +115,16 @@ pub trait BlockHeaderAPI {
     fn strong_vote_leader(&self) -> Option<AuthorityIndex>;
     fn is_strong_vote(&self) -> bool;
     fn is_strong_blame(&self) -> bool;
+
+    /// True if this block is a strong vote pinned to `leader`.
+    fn is_strong_vote_for(&self, leader: AuthorityIndex) -> bool {
+        self.is_strong_vote() && self.strong_vote_leader() == Some(leader)
+    }
+
+    /// True if this block is a strong blame pinned to `leader`.
+    fn is_strong_blame_for(&self, leader: AuthorityIndex) -> bool {
+        self.is_strong_blame() && self.strong_vote_leader() == Some(leader)
+    }
 }
 
 #[derive(Clone, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -195,7 +195,7 @@ impl BlockVerifier for SignedBlockVerifier {
                 }
             }
             // Self-consistency: the pinned leader must appear in the block's
-            // ancestors at round-1. Independent of the verifier's swap table.
+            // ancestors at round-1.
             let leader_round = block.round().saturating_sub(1);
             if leader_round != GENESIS_ROUND {
                 let leader_seen = block

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -176,15 +176,37 @@ impl BlockVerifier for SignedBlockVerifier {
         }
 
         // Validate strong_vote field.
-        if let Some(authority_set) = block.strong_vote() {
+        if let Some(strong_vote) = block.strong_vote() {
             if !self.context.protocol_config.consensus_starfish_speed() {
                 return Err(ConsensusError::UnexpectedStrongVote);
             }
-            for authority_index in authority_set.iter() {
+            if !committee.is_valid_index(strong_vote.leader_authority) {
+                return Err(ConsensusError::InvalidStrongVoteAuthority {
+                    index: strong_vote.leader_authority,
+                    max: committee.size(),
+                });
+            }
+            for authority_index in strong_vote.missing.iter() {
                 if !committee.is_valid_index(authority_index) {
                     return Err(ConsensusError::InvalidStrongVoteAuthority {
                         index: authority_index,
                         max: committee.size(),
+                    });
+                }
+            }
+            // Self-consistency: the pinned leader must appear in the block's
+            // ancestors at round-1. Independent of the verifier's swap table.
+            let leader_round = block.round().saturating_sub(1);
+            if leader_round != GENESIS_ROUND {
+                let leader_seen = block
+                    .ancestors()
+                    .iter()
+                    .any(|r| r.round == leader_round && r.author == strong_vote.leader_authority);
+                if !leader_seen {
+                    return Err(ConsensusError::StrongVoteLeaderNotInAncestors {
+                        block_round: block.round(),
+                        leader_round,
+                        leader_authority: strong_vote.leader_authority,
                     });
                 }
             }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -23,7 +23,7 @@ use tokio::{
     sync::{broadcast, watch},
     time::Instant,
 };
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, info, instrument, trace, warn};
 
 #[cfg(test)]
 use crate::storage::Store;
@@ -822,7 +822,9 @@ impl Core {
         // Compute the strong_vote once; reused for readiness check 2 and
         // the block header below.
         let strong_vote = if self.context.protocol_config.consensus_starfish_speed() {
-            leader_header.as_ref().map(|h| self.compute_strong_vote(h))
+            leader_header
+                .as_ref()
+                .map(|h| Self::compute_strong_vote(&self.dag_state.read(), h))
         } else {
             None
         };
@@ -1350,21 +1352,12 @@ impl Core {
         included_ancestors
     }
 
-    /// Given a leader block header, computes the `StrongVote` payload for a
-    /// block voting on that leader: pins the leader's authority and records
-    /// the set of authorities (the leader itself and those it acknowledges)
-    /// whose transaction data is not locally available. An empty `missing`
-    /// set means a strong vote; a non-empty set means strong blame.
-    fn compute_strong_vote(&self, leader_header: &VerifiedBlockHeader) -> StrongVote {
-        if !self.context.protocol_config.consensus_starfish_speed() {
-            error!("compute_strong_vote called while consensus_starfish_speed is disabled");
-        }
-        Self::compute_strong_vote_for(&self.dag_state.read(), leader_header)
-    }
-
-    /// Static form of [`Self::compute_strong_vote`]: builds the `StrongVote`
-    /// payload from a borrowed `DagState`, no `Core` instance required.
-    pub(crate) fn compute_strong_vote_for(
+    /// Builds the `StrongVote` payload for a block voting on `leader_header`:
+    /// pins the leader's authority and records the set of authorities (the
+    /// leader itself and those it acknowledges) whose transaction data is not
+    /// locally available. An empty `missing` set means a strong vote; a
+    /// non-empty set means strong blame.
+    pub(crate) fn compute_strong_vote(
         dag_state: &DagState,
         leader_header: &VerifiedBlockHeader,
     ) -> StrongVote {

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -36,8 +36,8 @@ use crate::{
     authority_set::AuthoritySet,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockHeaderV2, BlockRef, BlockTimestampMs,
-        GENESIS_ROUND, Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
-        VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
+        GENESIS_ROUND, Round, SignedBlockHeader, Slot, StrongVote, TransactionsCommitment,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, CommitAPI, PendingSubDag},
@@ -795,11 +795,13 @@ impl Core {
             leader_header.as_ref()?;
 
             // Strong-vote readiness check 1 (StarfishSpeed only, bypassed on
-            // soft-timeout): 2f+1 strong votes at clock_round-1 for the leader
-            // at clock_round-2.
+            // soft-timeout): 2f+1 strong votes at clock_round-1 pinned to the
+            // leader at clock_round-2.
+            let prev_leader_round = quorum_round.saturating_sub(1);
             if !strong_vote_timed_out
                 && self.context.protocol_config.consensus_starfish_speed()
-                && !self.has_strong_vote_quorum(quorum_round)
+                && prev_leader_round > GENESIS_ROUND
+                && !self.has_strong_vote_quorum(quorum_round, self.first_leader(prev_leader_round))
             {
                 return None;
             }
@@ -825,13 +827,11 @@ impl Core {
 
         // Strong-vote readiness check 2 (StarfishSpeed only, bypassed on
         // soft-timeout): our block would itself be a strong vote for the
-        // leader at clock_round-1 (strong_vote is Some(empty)).
+        // leader at clock_round-1.
         if !reason.is_forced()
             && !strong_vote_timed_out
             && self.context.protocol_config.consensus_starfish_speed()
-            && !strong_vote
-                .as_ref()
-                .is_some_and(|missing| missing.is_empty())
+            && !strong_vote.as_ref().is_some_and(|sv| sv.is_strong_vote())
         {
             return None;
         }
@@ -1348,24 +1348,24 @@ impl Core {
         included_ancestors
     }
 
-    /// Given a leader block header, computes the `strong_vote` bitmask for
-    /// a block voting on that leader: the set of authorities (the leader
-    /// itself and those it acknowledges) whose transaction data is not
-    /// locally available. An empty set means a strong vote; a non-empty set
-    /// means strong blame.
-    fn compute_strong_vote(&self, leader_header: &VerifiedBlockHeader) -> AuthoritySet {
+    /// Given a leader block header, computes the `StrongVote` payload for a
+    /// block voting on that leader: pins the leader's authority and records
+    /// the set of authorities (the leader itself and those it acknowledges)
+    /// whose transaction data is not locally available. An empty `missing`
+    /// set means a strong vote; a non-empty set means strong blame.
+    fn compute_strong_vote(&self, leader_header: &VerifiedBlockHeader) -> StrongVote {
         if !self.context.protocol_config.consensus_starfish_speed() {
             error!("compute_strong_vote called while consensus_starfish_speed is disabled");
         }
         Self::compute_strong_vote_for(&self.dag_state.read(), leader_header)
     }
 
-    /// Static form of [`Self::compute_strong_vote`]: derives the missing-data
-    /// mask from a borrowed `DagState`, no `Core` instance required.
+    /// Static form of [`Self::compute_strong_vote`]: builds the `StrongVote`
+    /// payload from a borrowed `DagState`, no `Core` instance required.
     pub(crate) fn compute_strong_vote_for(
         dag_state: &DagState,
         leader_header: &VerifiedBlockHeader,
-    ) -> AuthoritySet {
+    ) -> StrongVote {
         let mut missing = AuthoritySet::new();
 
         let leader_ref = leader_header.reference();
@@ -1379,19 +1379,26 @@ impl Core {
             }
         }
 
-        missing
+        StrongVote {
+            leader_authority: leader_header.author(),
+            missing,
+        }
     }
 
-    /// Returns true when 2f+1 stake of blocks at `voting_round` have
-    /// `is_strong_vote() == true`. A block at round R with `is_strong_vote`
-    /// certifies the leader at R-1, so a quorum at `voting_round` certifies
-    /// the leader at `voting_round - 1`.
-    fn has_strong_vote_quorum(&self, voting_round: Round) -> bool {
+    /// Returns true when 2f+1 stake of blocks at `voting_round` carry a strong
+    /// vote pinned to `expected_leader`. A block at round R with
+    /// `is_strong_vote` certifies the leader at R-1, so a quorum at
+    /// `voting_round` certifies `expected_leader` at `voting_round - 1`.
+    /// Strong votes whose pinned leader doesn't match are ignored.
+    fn has_strong_vote_quorum(&self, voting_round: Round, expected_leader: AuthorityIndex) -> bool {
         let dag_state = self.dag_state.read();
         let blocks = dag_state.get_last_cached_block_header_per_authority(voting_round + 1);
         let mut strong_votes = StakeAggregator::<QuorumThreshold>::new();
         for (block, _equivocating) in &blocks {
-            if block.round() == voting_round && block.is_strong_vote() {
+            if block.round() == voting_round
+                && block.is_strong_vote()
+                && block.strong_vote_leader() == Some(expected_leader)
+            {
                 strong_votes.add(block.author(), &self.context.committee);
             }
         }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -795,15 +795,17 @@ impl Core {
             leader_header.as_ref()?;
 
             // Strong-vote readiness check 1 (StarfishSpeed only, bypassed on
-            // soft-timeout): 2f+1 strong votes at clock_round-1 pinned to the
-            // leader at clock_round-2.
-            let prev_leader_round = quorum_round.saturating_sub(1);
+            // soft-timeout): 2f+1 strong votes at quorum_round pinned to the
+            // leader at quorum_round - 1.
             if !strong_vote_timed_out
                 && self.context.protocol_config.consensus_starfish_speed()
-                && prev_leader_round > GENESIS_ROUND
-                && !self.has_strong_vote_quorum(quorum_round, self.first_leader(prev_leader_round))
+                && quorum_round > GENESIS_ROUND
             {
-                return None;
+                if let Some(prev_leader) = self.leader_header(quorum_round - 1) {
+                    if !self.has_strong_vote_quorum(quorum_round, prev_leader.author()) {
+                        return None;
+                    }
+                }
             }
 
             if Duration::from_millis(

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1390,10 +1390,7 @@ impl Core {
         let blocks = dag_state.get_last_cached_block_header_per_authority(voting_round + 1);
         let mut strong_votes = StakeAggregator::<QuorumThreshold>::new();
         for (block, _equivocating) in &blocks {
-            if block.round() == voting_round
-                && block.is_strong_vote()
-                && block.strong_vote_leader() == Some(expected_leader)
-            {
+            if block.round() == voting_round && block.is_strong_vote_for(expected_leader) {
                 strong_votes.add(block.author(), &self.context.committee);
             }
         }

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -323,6 +323,16 @@ pub(crate) enum ConsensusError {
 
     #[error("Block strong_vote contains invalid authority index {index}, committee size is {max}")]
     InvalidStrongVoteAuthority { index: AuthorityIndex, max: usize },
+
+    #[error(
+        "Block at round {block_round} carries strong_vote pinned to leader \
+         authority {leader_authority} but does not reference that leader at round {leader_round}"
+    )]
+    StrongVoteLeaderNotInAncestors {
+        block_round: Round,
+        leader_round: Round,
+        leader_authority: AuthorityIndex,
+    },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -845,13 +845,13 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
     let b_block = &r3_blocks[1];
     {
         let dag = dag_state.read();
-        assert!(Core::compute_strong_vote_for(&dag, a_block).is_strong_vote());
-        assert!(!Core::compute_strong_vote_for(&dag, b_block).is_strong_vote());
+        assert!(Core::compute_strong_vote(&dag, a_block).is_strong_vote());
+        assert!(!Core::compute_strong_vote(&dag, b_block).is_strong_vote());
     }
 
     let voter_strong_vote = {
         let dag = dag_state.read();
-        Core::compute_strong_vote_for(&dag, a_block)
+        Core::compute_strong_vote(&dag, a_block)
     };
     let r4_refs: Vec<BlockRef> = (0..4u8)
         .map(|author| {

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -755,6 +755,8 @@ async fn pending_leader_resolves_to_standard() {
     );
 }
 
+/// A strong vote computed against one leader must not be counted as evidence
+/// for a different canonical leader (e.g. across a leader-schedule swap).
 /// Asserts the StarfishSpeed safety invariant: every ref in
 /// `committed_transaction_refs` has locally-available transaction data.
 ///

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -755,22 +755,13 @@ async fn pending_leader_resolves_to_standard() {
     );
 }
 
-/// Optimistic-commit injects phantom acks: when the canonical leader at commit
-/// time differs from the leader the producers were "voting for" (e.g. block
-/// built before a schedule rotation, committed after), the strong-vote bytes
-/// — which carry no leader identity — get credited as acks for the canonical
-/// leader's `acknowledgments` set. The test sets up a single-validator view
-/// where:
-///   - The canonical leader of round 3 (per the post-rotation table) is
-///     authority 1, whose round-3 block has acks=[round-2 block from authority
-///     3].
-///   - That round-2 block's transaction data is *not* locally available.
-///   - Round-4 voters carry `strong_vote = Some(empty)`, consistent with the
-///     pre-rotation leader (different acks, all available).
-/// Optimistic linearization injects phantom acks for the canonical leader's
-/// ack set, committing the round-2 block via fictional 2f+1 evidence — even
-/// though no validator has its data. Asserts the system invariant
-/// "Z committed via Optimistic ⇒ ≥1 stake has Z's data" — fails by design.
+/// Asserts the StarfishSpeed safety invariant: every ref in
+/// `committed_transaction_refs` has locally-available transaction data.
+///
+/// Setup: round-3 leaders have asymmetric ack lists — A (auth 0) acks
+/// nothing; B (auth 1) acks `r2[3]`. Local data state covers everything
+/// except `r2[3]`. Round-4 voters cast strong votes computed against A.
+/// The committer's swap table designates B as canonical leader of round 3.
 #[tokio::test]
 async fn optimistic_commits_ref_without_actual_data_backing() {
     telemetry_subscribers::init_for_testing();
@@ -836,12 +827,8 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
         r3_blocks.push(block);
     }
 
-    // Mark transaction data as locally available for everything *except*
-    //   - r2[3] (the block in B's acks)
-    //   - r3[1..=3] (B, C, D themselves)
-    // The producer's data state covers A's set ({A, A.acks=∅}) cleanly, so
-    // `Core::compute_strong_vote_for(A_block)` returns `Some(empty)` — a
-    // legitimate strong vote for A.
+    // Mark transaction data available for everything except `r2[3]` and
+    // round-3 blocks other than A.
     for block in &r1_blocks {
         add_transactions_for(&dag_state, block);
     }
@@ -852,25 +839,14 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
     }
     add_transactions_for(&dag_state, &r3_blocks[0]);
 
-    // Sanity: with this data state, A is a legitimate strong-vote target; B
-    // is *not* (data for B itself and for `r2[3]` is missing).
     let a_block = &r3_blocks[0];
     let b_block = &r3_blocks[1];
     {
         let dag = dag_state.read();
-        assert!(
-            Core::compute_strong_vote_for(&dag, a_block).is_strong_vote(),
-            "producer should be able to legitimately strong-vote for A"
-        );
-        assert!(
-            !Core::compute_strong_vote_for(&dag, b_block).is_strong_vote(),
-            "producer should NOT be able to legitimately strong-vote for B"
-        );
+        assert!(Core::compute_strong_vote_for(&dag, a_block).is_strong_vote());
+        assert!(!Core::compute_strong_vote_for(&dag, b_block).is_strong_vote());
     }
 
-    // Build round-4 voters using the production strong-vote computation
-    // against A — this is what an honest validator on the pre-rotation table
-    // would produce.
     let voter_strong_vote = {
         let dag = dag_state.read();
         Core::compute_strong_vote_for(&dag, a_block)
@@ -900,9 +876,7 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
             .accept_block_header(block, DataSource::Test);
     }
 
-    // Force canonical leader of round 3 to authority 1 (B).
-    // Test mode: `elect_leader(3, 0)` returns `(3 + 0) % 4 = 3`. The swap
-    // table flags auth 3 as bad and remaps to auth 1.
+    // Swap table forcing canonical leader of round 3 to authority 1.
     let alt_table = LeaderSwapTable {
         good_nodes: vec![(
             auth_1,
@@ -948,17 +922,9 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
         });
     let p_data_available = dag_state.read().is_data_available(&r2_refs[3]);
 
-    // Safety invariant: a ref committed at this height must have its
-    // transaction data locally available. Pre-fix, the Optimistic phantom-ack
-    // injection commits B's ack target (`r2[3]`) without backing — assertion
-    // fails. Post-fix, voters' strong-votes pinned to A get filtered out at
-    // the committer's leader check, no Optimistic, no injection — invariant
-    // holds (vacuously: the ref is not committed at all).
     assert!(
         !p_committed || p_data_available,
-        "round-2 block from auth 3 (B's ack target) was committed via phantom \
-         acks: strong-vote bytes had been computed against leader A, got \
-         credited as acks for B's ack set, despite no validator having that \
-         block's transaction data"
+        "ref {:?} committed without locally-available transaction data",
+        r2_refs[3]
     );
 }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -13,7 +13,8 @@ use crate::{
     },
     block_header::{
         BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        TransactionsCommitment, VerifiedBlockHeader, VerifiedTransactions, genesis_block_headers,
+        StrongVote, TransactionsCommitment, VerifiedBlockHeader, VerifiedTransactions,
+        genesis_block_headers,
     },
     commit::{CommitMetastate, DecidedLeader, LeaderStatus},
     context::Context,
@@ -32,7 +33,7 @@ fn v2_block(
     round: Round,
     author: u8,
     ancestors: Vec<BlockRef>,
-    strong_vote: Option<AuthoritySet>,
+    strong_vote: Option<StrongVote>,
     timestamp_ms: BlockTimestampMs,
 ) -> VerifiedBlockHeader {
     let header = BlockHeaderV2::new(
@@ -55,7 +56,7 @@ fn v2_block_with_acks(
     author: u8,
     ancestors: Vec<BlockRef>,
     acks: Vec<BlockRef>,
-    strong_vote: Option<AuthoritySet>,
+    strong_vote: Option<StrongVote>,
     timestamp_ms: BlockTimestampMs,
 ) -> VerifiedBlockHeader {
     let header = BlockHeaderV2::new(
@@ -70,6 +71,18 @@ fn v2_block_with_acks(
         strong_vote,
     );
     VerifiedBlockHeader::new_for_test(BlockHeader::V2(header))
+}
+
+/// Wraps a "missing" mask into a `StrongVote` pinned to `leader_authority`.
+/// `None` passes through (no vote).
+fn pin_strong_vote(
+    leader_authority: AuthorityIndex,
+    missing: Option<AuthoritySet>,
+) -> Option<StrongVote> {
+    missing.map(|missing| StrongVote {
+        leader_authority,
+        missing,
+    })
 }
 
 /// Marks `header`'s transaction data as locally available, so
@@ -162,27 +175,33 @@ fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwL
     (ctx, dag_state)
 }
 
-/// Populate `dag_state` through round 5; round-4 voters carry the given
-/// `strong_vote` values. Returns the leader slot at round 3.
+/// Populate `dag_state` through round 5; round-4 voters carry strong-vote
+/// payloads pinned to the canonical round-3 leader. Returns the leader slot at
+/// round 3.
 fn build_metastate_dag(
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     committer: &crate::base_committer::BaseCommitter,
     voter_strong_votes: [Option<AuthoritySet>; 4],
 ) -> crate::block_header::Slot {
-    let round_3_refs = build_v2_layers(&context, &dag_state, None, committer.leader_round(1));
+    let leader_round = committer.leader_round(1);
+    let round_3_refs = build_v2_layers(&context, &dag_state, None, leader_round);
+    let leader_authority = committer
+        .elect_leader(leader_round)
+        .expect("should elect a leader")
+        .authority;
 
     // Round 4 (voting): each voter links to all round-3 blocks and carries the
-    // configured strong_vote.
+    // configured missing-mask, pinned to the canonical leader.
     let mut round_4_refs = Vec::new();
-    let voting_round = committer.leader_round(1) + 1;
-    for (author, strong_vote) in voter_strong_votes.into_iter().enumerate() {
+    let voting_round = leader_round + 1;
+    for (author, missing) in voter_strong_votes.into_iter().enumerate() {
         let author = author as u8;
         let block = v2_block(
             voting_round,
             author,
             round_3_refs.clone(),
-            strong_vote,
+            pin_strong_vote(leader_authority, missing),
             default_ts(voting_round, author),
         );
         round_4_refs.push(block.reference());
@@ -368,9 +387,11 @@ fn build_equivocating_metastate_dag(
         .accept_block_header(leader_b, DataSource::Test);
 
     // Round `voting_round`: each voter includes all non-leader round-3 blocks
-    // plus the chosen leader block, and carries the configured strong_vote.
+    // plus the chosen leader block, and carries the configured missing-mask
+    // pinned to the (shared) leader authority — the equivocating L_A and L_B
+    // share the same author.
     let mut round_4_refs = Vec::new();
-    for (author, (leader_choice, strong_vote)) in voter_config.into_iter().enumerate() {
+    for (author, (leader_choice, missing)) in voter_config.into_iter().enumerate() {
         let author = author as u8;
         let chosen_leader = match leader_choice {
             LeaderChoice::A => leader_a_ref,
@@ -382,7 +403,7 @@ fn build_equivocating_metastate_dag(
             voting_round,
             author,
             ancestors,
-            strong_vote,
+            pin_strong_vote(leader_slot.authority, missing),
             default_ts(voting_round, author),
         );
         round_4_refs.push(block.reference());
@@ -496,15 +517,19 @@ fn build_through_voting_round(
     let leader_round = committer.leader_round(1);
     let voting_round = leader_round + 1;
     let round_3_refs = build_v2_layers(context, dag_state, None, leader_round);
+    let leader_authority = committer
+        .elect_leader(leader_round)
+        .expect("should elect a leader")
+        .authority;
 
     let mut voter_refs = Vec::with_capacity(4);
-    for (author, strong_vote) in voter_strong_votes.into_iter().enumerate() {
+    for (author, missing) in voter_strong_votes.into_iter().enumerate() {
         let author = author as u8;
         let block = v2_block(
             voting_round,
             author,
             round_3_refs.clone(),
-            strong_vote,
+            pin_strong_vote(leader_authority, missing),
             default_ts(voting_round, author),
         );
         voter_refs.push(block.reference());
@@ -834,11 +859,11 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
     {
         let dag = dag_state.read();
         assert!(
-            Core::compute_strong_vote_for(&dag, a_block).is_empty(),
+            Core::compute_strong_vote_for(&dag, a_block).is_strong_vote(),
             "producer should be able to legitimately strong-vote for A"
         );
         assert!(
-            !Core::compute_strong_vote_for(&dag, b_block).is_empty(),
+            !Core::compute_strong_vote_for(&dag, b_block).is_strong_vote(),
             "producer should NOT be able to legitimately strong-vote for B"
         );
     }
@@ -905,22 +930,15 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
     let leader_b_slot = committer.elect_leader(3).expect("leader at round 3");
     assert_eq!(leader_b_slot.authority, auth_1);
 
-    let (block_b, strong_voters) = match committer.try_direct_decide(leader_b_slot) {
-        LeaderStatus::Commit(b, Some(CommitMetastate::Optimistic), sv) => (b, sv),
-        other => panic!("expected Optimistic Commit, got {other}"),
+    let (block_b, metastate, strong_voters) = match committer.try_direct_decide(leader_b_slot) {
+        LeaderStatus::Commit(b, m, sv) => (b, m, sv),
+        other => panic!("expected Commit at any metastate, got {other}"),
     };
 
     let mut linearizer = Linearizer::new(context, dag_state.clone(), alt_schedule);
-    let pending = linearizer.get_pending_sub_dags(vec![(
-        block_b,
-        Some(CommitMetastate::Optimistic),
-        strong_voters,
-    )]);
+    let pending = linearizer.get_pending_sub_dags(vec![(block_b, metastate, strong_voters)]);
     assert_eq!(pending.len(), 1);
 
-    // The Optimistic injection records each strong voter as acking
-    // {leader_ref, leader.acks}. With B.acks = [r2[3]], r2[3] crosses the
-    // 2f+1 threshold via these phantom acks and lands in committed_refs.
     let p_committed = pending[0]
         .committed_transaction_refs
         .iter()
@@ -928,18 +946,19 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
             GenericTransactionRef::BlockRef(br) => br.round == 2 && br.author == auth_3,
             GenericTransactionRef::TransactionRef(tr) => tr.round == 2 && tr.author == auth_3,
         });
-    assert!(
-        p_committed,
-        "round-2 block from auth 3 (B's ack target) should be committed via the \
-         Optimistic injection"
-    );
-
     let p_data_available = dag_state.read().is_data_available(&r2_refs[3]);
 
+    // Safety invariant: a ref committed at this height must have its
+    // transaction data locally available. Pre-fix, the Optimistic phantom-ack
+    // injection commits B's ack target (`r2[3]`) without backing — assertion
+    // fails. Post-fix, voters' strong-votes pinned to A get filtered out at
+    // the committer's leader check, no Optimistic, no injection — invariant
+    // holds (vacuously: the ref is not committed at all).
     assert!(
         !p_committed || p_data_available,
-        "Optimistic committed round-2 block from auth 3 via phantom acks: \
-         strong-vote bytes were leader-agnostic, got credited as acks for B's \
-         ack set, despite no validator having that block's transaction data"
+        "round-2 block from auth 3 (B's ack target) was committed via phantom \
+         acks: strong-vote bytes had been computed against leader A, got \
+         credited as acks for B's ack set, despite no validator having that \
+         block's transaction data"
     );
 }


### PR DESCRIPTION
# Description of change

Fixes the StarfishSpeed phantom-ack safety invariant violation demonstrated by the test on the base branch. Adds a `leader_authority` field to the `strong_vote` payload (`Option<StrongVote>` instead of `Option<AuthoritySet>`); committer-side filters in `vote_and_strong_vote_refs_for_leader`, `strong_qc_quorum`, and `has_strong_blame_quorum` now reject strong votes/blames whose pinned leader doesn't match the canonical leader being evaluated. Block verifier validates that the pinned leader appears in the block's ancestors (self-consistency check).

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
