### PR TITLE
feat!: Replace `AuthenticatorStateUpdateV1` with the SDK version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,6 +375,7 @@ tonic = { version = "0.14", features = ["zstd", "transport"] }
 tonic-build = "0.14"
 tonic-health = "0.14"
 tonic-prost = "0.14"
+tonic-rustls = "0.3.0"
 tower = { version = "0.4.12", features = ["util", "timeout", "load-shed", "limit"] }
 tower-http = { version = "0.5", features = ["cors", "timeout", "trace", "set-header", "propagate-header"] }
 tracing = "0.1.44"

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25#6fa3e8d214550eb0e657e5ebd9ae6e7b920b1c25"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6e087404235c995f3d50c0975eb388347516d295#6e087404235c995f3d50c0975eb388347516d295"
 dependencies = [
  "base64ct",
  "bcs",


### PR DESCRIPTION
This PR is part of the ongoing effort to consolidate blockchain types in the
canonical `iota-rust-sdk`. Types that are needed by both clients/SDK consumers
and the node should live in `iota-rust-sdk` and be imported from there, instead
of being defined twice (once in `iota-types`, once in the SDK).

This PR replaces `AuthenticatorStateUpdateV1` (previously defined in `iota-types`) with the SDK version from `iota-sdk-types`. To keep the diff small and avoid touching every call site, the SDK type is re-exported from `iota-types` under the
original name `AuthenticatorStateUpdateV1`, so most existing imports continue to work unchanged.
