### PR TITLE
feat(github): disable depandabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       - "/external-crates/move"
     schedule:
       interval: "daily"
+    # Disable version update PRs, keep security alerts
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
We update the dependencies manually
Opened again as the original PR was merged to a wrong branch