### PR TITLE
chore: cleanup tokio feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,7 +366,7 @@ test-fuzz = "3.0.4"
 thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim
 # Do not upgrade without updating https://github.com/iotaledger/iota-sim first
-tokio = "1.49.0"
+tokio = { version = "1.49.0", features = ["parking_lot"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
 tokio-stream = { version = "0.1.17", features = ["sync", "net"] }
 tokio-util = "0.7.17"

--- a/crates/iota-analytics-indexer/Cargo.toml
+++ b/crates/iota-analytics-indexer/Cargo.toml
@@ -28,7 +28,7 @@ strum.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-archival/Cargo.toml
+++ b/crates/iota-archival/Cargo.toml
@@ -20,7 +20,7 @@ prometheus.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-authority-aggregation/Cargo.toml
+++ b/crates/iota-authority-aggregation/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 # external dependencies
 futures.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-aws-orchestrator/Cargo.toml
+++ b/crates/iota-aws-orchestrator/Cargo.toml
@@ -28,7 +28,7 @@ russh = { version = "0.59", default-features = false, features = ["ring", "rsa",
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/iota-benchmark/Cargo.toml
+++ b/crates/iota-benchmark/Cargo.toml
@@ -33,7 +33,7 @@ serde_json.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 sysinfo.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
 tokio-util.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-build-cache-server/Cargo.toml
+++ b/crates/iota-build-cache-server/Cargo.toml
@@ -23,7 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "fs", "time"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/iota-cluster-test/Cargo.toml
+++ b/crates/iota-cluster-test/Cargo.toml
@@ -20,7 +20,7 @@ regex.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 tracing.workspace = true
 uuid.workspace = true
 

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -54,7 +54,7 @@ strum_macros.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "net", "tracing"] }
 tokio-stream.workspace = true
 tracing.workspace = true
 twox-hash = "1.6"
@@ -103,6 +103,7 @@ pretty_assertions.workspace = true
 rstest.workspace = true
 serde-reflection.workspace = true
 serde_yaml.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tower.workspace = true
 
 # internal dependencies

--- a/crates/iota-cost/Cargo.toml
+++ b/crates/iota-cost/Cargo.toml
@@ -13,7 +13,7 @@ bcs.workspace = true
 insta.workspace = true
 serde.workspace = true
 strum.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 # internal dependencies
 iota-config.workspace = true

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -24,7 +24,7 @@ serde_json.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "fs"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true

--- a/crates/iota-data-ingestion/Cargo.toml
+++ b/crates/iota-data-ingestion/Cargo.toml
@@ -24,7 +24,7 @@ rustls.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
 tokio-util.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-faucet/Cargo.toml
+++ b/crates/iota-faucet/Cargo.toml
@@ -23,7 +23,7 @@ serde.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "net"] }
 tonic.workspace = true
 tower.workspace = true
 tower-http.workspace = true

--- a/crates/iota-framework-snapshot/Cargo.toml
+++ b/crates/iota-framework-snapshot/Cargo.toml
@@ -23,7 +23,7 @@ iota-types.workspace = true
 
 [dev-dependencies]
 # external dependencies
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 # internal dependencies
 iota-common.workspace = true

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -37,7 +37,7 @@ serde_with.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true

--- a/crates/iota-indexer-builder/Cargo.toml
+++ b/crates/iota-indexer-builder/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 anyhow.workspace = true
 async-trait.workspace = true
 prometheus.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 tokio-util.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -40,7 +40,7 @@ strum_macros.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "net"] }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 toml.workspace = true

--- a/crates/iota-json-rpc-tests/Cargo.toml
+++ b/crates/iota-json-rpc-tests/Cargo.toml
@@ -21,7 +21,7 @@ jsonrpsee.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 reqwest.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-json-rpc/Cargo.toml
+++ b/crates/iota-json-rpc/Cargo.toml
@@ -34,7 +34,7 @@ signature.workspace = true
 statrs = "0.17.1"
 tap.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tower.workspace = true
 tower-http.workspace = true

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -15,7 +15,7 @@ clap.workspace = true
 iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", tag = "v0.1.0" }
 serde.workspace = true
 strum.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-light-client/Cargo.toml
+++ b/crates/iota-light-client/Cargo.toml
@@ -30,7 +30,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "sync"] }
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/iota-localnet/Cargo.toml
+++ b/crates/iota-localnet/Cargo.toml
@@ -21,7 +21,7 @@ prometheus.workspace = true
 rand.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/iota-metric-checker/Cargo.toml
+++ b/crates/iota-metric-checker/Cargo.toml
@@ -20,7 +20,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 strum.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-metrics-push-client/Cargo.toml
+++ b/crates/iota-metrics-push-client/Cargo.toml
@@ -14,7 +14,7 @@ prometheus.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 snap.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-metrics/Cargo.toml
+++ b/crates/iota-metrics/Cargo.toml
@@ -26,7 +26,7 @@ simple-server-timing-header = "0.1.1"
 sysinfo.workspace = true
 tap.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net"] }
 tracing.workspace = true
 uuid.workspace = true
 

--- a/crates/iota-move/Cargo.toml
+++ b/crates/iota-move/Cargo.toml
@@ -14,7 +14,7 @@ colored.workspace = true
 once_cell.workspace = true
 prometheus.workspace = true
 serde_yaml.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-network/Cargo.toml
+++ b/crates/iota-network/Cargo.toml
@@ -23,7 +23,7 @@ prometheus.workspace = true
 rand.workspace = true
 serde.workspace = true
 tap.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tonic.workspace = true
 tower.workspace = true
 tracing.workspace = true

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -30,7 +30,7 @@ prometheus.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 tap.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "signal", "net"] }
 tokio-util.workspace = true
 tonic.workspace = true
 tower.workspace = true

--- a/crates/iota-open-rpc/Cargo.toml
+++ b/crates/iota-open-rpc/Cargo.toml
@@ -23,7 +23,7 @@ clap.workspace = true
 fastcrypto.workspace = true
 pretty_assertions.workspace = true
 rand.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 # internal dependencies
 iota-json.workspace = true

--- a/crates/iota-package-resolver/Cargo.toml
+++ b/crates/iota-package-resolver/Cargo.toml
@@ -12,7 +12,6 @@ async-trait.workspace = true
 bcs.workspace = true
 lru.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
 
 # internal dependencies
 iota-types.workspace = true
@@ -28,6 +27,7 @@ move-core-types.workspace = true
 hyper.workspace = true
 insta.workspace = true
 serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
 tower.workspace = true
 
 # internal dependencies

--- a/crates/iota-proxy/Cargo.toml
+++ b/crates/iota-proxy/Cargo.toml
@@ -33,7 +33,7 @@ serde.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
 snap.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time"] }
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true

--- a/crates/iota-replay/Cargo.toml
+++ b/crates/iota-replay/Cargo.toml
@@ -33,7 +33,7 @@ similar = "2.4.0"
 tabled.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-rpc-loadgen/Cargo.toml
+++ b/crates/iota-rpc-loadgen/Cargo.toml
@@ -19,7 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 shellexpand.workspace = true
 strum.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -24,7 +24,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-single-node-benchmark/Cargo.toml
+++ b/crates/iota-single-node-benchmark/Cargo.toml
@@ -16,7 +16,7 @@ prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-snapshot/Cargo.toml
+++ b/crates/iota-snapshot/Cargo.toml
@@ -21,7 +21,7 @@ num_enum.workspace = true
 object_store.workspace = true
 prometheus.workspace = true
 serde.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tokio-stream.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-storage/Cargo.toml
+++ b/crates/iota-storage/Cargo.toml
@@ -40,7 +40,7 @@ serde_json.workspace = true
 strum.workspace = true
 tap.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full", "tracing"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "tracing"] }
 tracing.workspace = true
 url.workspace = true
 zstd = "0.13"

--- a/crates/iota-storage/Cargo.toml
+++ b/crates/iota-storage/Cargo.toml
@@ -58,6 +58,7 @@ typed-store.workspace = true
 anyhow.workspace = true
 once_cell.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 # internal dependencies
 iota-common.workspace = true

--- a/crates/iota-surfer/Cargo.toml
+++ b/crates/iota-surfer/Cargo.toml
@@ -13,7 +13,7 @@ clap.workspace = true
 futures.workspace = true
 indexmap.workspace = true
 rand.workspace = true
-tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "tracing"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-swarm/Cargo.toml
+++ b/crates/iota-swarm/Cargo.toml
@@ -17,7 +17,7 @@ prometheus.workspace = true
 rand.workspace = true
 tap.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 tonic-health.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-synthetic-ingestion/Cargo.toml
+++ b/crates/iota-synthetic-ingestion/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 # external dependencies
 anyhow.workspace = true
 clap.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-tool/Cargo.toml
+++ b/crates/iota-tool/Cargo.toml
@@ -39,7 +39,7 @@ serde_json.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-transactional-test-runner/Cargo.toml
+++ b/crates/iota-transactional-test-runner/Cargo.toml
@@ -26,7 +26,7 @@ once_cell.workspace = true
 rand.workspace = true
 regex.workspace = true
 tempfile.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 # internal dependencies
 iota-common.workspace = true

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -43,7 +43,7 @@ signature.workspace = true
 strum.workspace = true
 tabled.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/simulacrum-server/Cargo.toml
+++ b/crates/simulacrum-server/Cargo.toml
@@ -18,7 +18,7 @@ clap.workspace = true
 http.workspace = true
 rand.workspace = true
 serde.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal"] }
 tokio-util.workspace = true
 tower.workspace = true
 tower-http.workspace = true

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -36,7 +36,7 @@ serde.workspace = true
 strum_macros.workspace = true
 tap.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net"] }
 tokio-rustls.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -64,6 +64,7 @@ typed-store.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 # internal dependencies
 telemetry-subscribers.workspace = true

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -33,7 +33,7 @@ prost = "0.13"
 rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
 tonic = { version = "0.12.3" }
 tracing.workspace = true
 tracing-appender = "0.2.2"

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -15,7 +15,7 @@ anyhow.workspace = true
 futures.workspace = true
 jsonrpsee.workspace = true
 rand.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -16,7 +16,7 @@ once_cell.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
 rand.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -25,7 +25,7 @@ rocksdb = { version = "0.24.0", default-features = false, features = ["snappy", 
 serde.workspace = true
 tap.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full", "test-util"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing.workspace = true
 
 # internal dependencies
@@ -40,6 +40,7 @@ once_cell.workspace = true
 rand.workspace = true
 rstest.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 uint = "0.9"
 
 # Most packages should depend on iota-simulator instead of directly on msim, but for typed-store


### PR DESCRIPTION
# Description of change

The `full` feature flag is used all over the codebase, even though the following features are never used in any crate:
```
io-std
io-util
process
```

Also the `"test-util"` was moved to `dev-dependencies` if needed.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes