### PR TITLE
feat(ci): remove apt install / upgrade / update from workflows

### DIFF
--- a/.github/workflows/_move_ide.yml
+++ b/.github/workflows/_move_ide.yml
@@ -64,11 +64,6 @@ jobs:
       - name: Install dependencies (emulate a display so VS Code can be started)
         working-directory: ./external-crates/move/crates/move-analyzer/editors/code
         run: |
-          sudo apt install libgtk-3-0 -y
-          sudo apt-get install -y xvfb x11-apps x11-xkb-utils libx11-6 libx11-xcb1
-          sudo add-apt-repository ppa:kisak/kisak-mesa -y
-          sudo apt update
-          sudo apt upgrade -y
           npm install && npm install --save-dev @types/node @types/semver
 
       - name: Build move-analyzer

--- a/.github/workflows/release_move_ide.yml
+++ b/.github/workflows/release_move_ide.yml
@@ -135,7 +135,6 @@ jobs:
           npm install
           npm install --save-dev @types/node @types/semver
           npm install -g vsce
-          sudo apt install zsh -y
 
       - name: Build and publish VS Code extension with move-analyzer binaries
         working-directory: external-crates/move/crates/move-analyzer/editors/code/


### PR DESCRIPTION
The steps from the workflows that use `apt` have been moved into the Dockerfile of the Gihub Runner image