### PR TITLE
feat(iota-data-ingestion-core): introduce fullnode gRPC filters

### DIFF
--- a/crates/iota-data-ingestion-core/src/config.rs
+++ b/crates/iota-data-ingestion-core/src/config.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration options for the ingestion framework.
+
+use std::path::PathBuf;
+
+use crate::{
+    IngestionLimit, ReaderOptions,
+    filters::fullnode::TransactionFilter,
+    reader::v2::{CheckpointReaderConfig, RemoteUrl},
+};
+
+/// Configuration options for the ingestion framework.
+#[derive(Clone, Default)]
+pub struct IngestionConfig {
+    /// Config the checkpoint reader behavior for downloading new checkpoints.
+    pub(crate) reader_options: ReaderOptions,
+    /// Local path for checkpoint ingestion. If not provided, checkpoints will
+    /// be ingested from a temporary directory.
+    pub(crate) ingestion_path: Option<PathBuf>,
+    /// Remote source for checkpoint data stream.
+    pub(crate) remote_store_url: Option<RemoteUrl>,
+    /// Determines when the ingestion process should stop.
+    pub(crate) ingestion_limit: Option<IngestionLimit>,
+    /// Filter applied to transactions within a checkpoint.
+    pub(crate) fullnode_transaction_filter: Option<TransactionFilter>,
+}
+
+impl From<CheckpointReaderConfig> for IngestionConfig {
+    fn from(config: CheckpointReaderConfig) -> Self {
+        Self {
+            reader_options: config.reader_options,
+            ingestion_path: config.ingestion_path,
+            remote_store_url: config.remote_store_url,
+            ..Default::default()
+        }
+    }
+}
+
+impl IngestionConfig {
+    pub fn new(reader_options: ReaderOptions) -> Self {
+        Self {
+            reader_options,
+            ..Default::default()
+        }
+    }
+
+    /// Sets the local path where checkpoints will be ingested from.
+    ///
+    /// If not provided, checkpoints will be ingested from a temporary
+    /// directory.
+    pub fn with_ingestion_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.ingestion_path = Some(path.into());
+        self
+    }
+
+    /// Sets the remote store URL for checkpoint to be downloaded from.
+    pub fn with_remote_store_url(mut self, url: RemoteUrl) -> Self {
+        self.remote_store_url = Some(url);
+        self
+    }
+
+    /// Adds an upper‑limit policy that determines when the ingestion
+    /// process should stop.
+    pub fn with_ingestion_limit(mut self, limit: IngestionLimit) -> Self {
+        self.ingestion_limit = Some(limit);
+        self
+    }
+
+    /// Enables server-side filtering of transactions within each checkpoint.
+    ///
+    /// When set, the remote source will only return checkpoints containing
+    /// transactions that match the provided [`TransactionFilter`].
+    ///
+    /// ### Connection Requirements
+    /// This is only supported for [`RemoteUrl::Fullnode`] connections.
+    pub fn with_fullnode_transaction_filter(mut self, filter: TransactionFilter) -> Self {
+        self.fullnode_transaction_filter = Some(filter);
+        self
+    }
+}

--- a/crates/iota-data-ingestion-core/src/errors.rs
+++ b/crates/iota-data-ingestion-core/src/errors.rs
@@ -25,7 +25,7 @@ pub enum IngestionError {
     #[error("grpc error: `{0}`")]
     Grpc(String),
 
-    #[error("Register at least one worker pool")]
+    #[error("register at least one worker pool")]
     EmptyWorkerPool,
 
     #[error("{component} shutdown error: `{msg}`")]
@@ -63,6 +63,9 @@ pub enum IngestionError {
 
     #[error(transparent)]
     Sdk(#[from] iota_types::iota_sdk_types_conversions::SdkTypeConversionError),
+
+    #[error("unsupported operation: `{0}`")]
+    Unsupported(String),
 }
 
 impl From<iota_grpc_types::proto::TryFromProtoError> for IngestionError {

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -16,8 +16,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
-    filters::fullnode::TransactionFilter,
+    DataIngestionMetrics, IngestionConfig, IngestionError, IngestionResult, ReaderOptions, Worker,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
     reader::v2::{CheckpointReader, CheckpointReaderConfig, RemoteUrl},
     worker_pool::{WorkerPool, WorkerPoolStatus},
@@ -159,7 +158,6 @@ pub struct IndexerExecutor<P> {
     metrics: DataIngestionMetrics,
     token: CancellationToken,
     shutdown_callback: Option<ShutdownCallback>,
-    fullnode_transaction_filter: Option<TransactionFilter>,
 }
 
 impl<P: ProgressStore> IndexerExecutor<P> {
@@ -180,7 +178,6 @@ impl<P: ProgressStore> IndexerExecutor<P> {
             metrics,
             token,
             shutdown_callback: None,
-            fullnode_transaction_filter: None,
         }
     }
 
@@ -242,17 +239,6 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         self.shutdown_when(move |checkpoint| limit.matches(checkpoint));
     }
 
-    /// Enables server-side filtering of transactions within each checkpoint.
-    ///
-    /// When set, the remote source will only return checkpoints containing
-    /// transactions that match the provided [`TransactionFilter`].
-    ///
-    /// ### Connection Requirements
-    /// This is only supported for [`RemoteUrl::Fullnode`] connections.
-    pub fn with_fullnode_transaction_filter(&mut self, filter: TransactionFilter) {
-        self.fullnode_transaction_filter = Some(filter);
-    }
-
     pub async fn update_watermark(
         &mut self,
         task_name: String,
@@ -276,15 +262,19 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     /// registered.
     pub async fn run_with_config(
         mut self,
-        config: CheckpointReaderConfig,
+        config: impl Into<IngestionConfig>,
     ) -> IngestionResult<ExecutorProgress> {
+        let config = config.into();
+
+        if let Some(limit) = config
+            .ingestion_limit
+            .filter(|_| self.shutdown_callback.is_none())
+        {
+            self.with_ingestion_limit(limit);
+        }
+
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
-        let checkpoint_reader = CheckpointReader::new(
-            reader_checkpoint_number,
-            config,
-            self.fullnode_transaction_filter.take(),
-        )
-        .await?;
+        let checkpoint_reader = CheckpointReader::new(reader_checkpoint_number, config).await?;
 
         self.run_executor_loop(reader_checkpoint_number, checkpoint_reader)
             .await

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -16,7 +16,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    DataIngestionMetrics, IngestionConfig, IngestionError, IngestionResult, ReaderOptions, Worker,
+    DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
+    config::CheckpointReaderConfigExt,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
     reader::v2::{CheckpointReader, CheckpointReaderConfig, RemoteUrl},
     worker_pool::{WorkerPool, WorkerPoolStatus},
@@ -262,7 +263,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     /// registered.
     pub async fn run_with_config(
         mut self,
-        config: impl Into<IngestionConfig>,
+        config: impl Into<CheckpointReaderConfigExt>,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
         let checkpoint_reader =

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -264,17 +264,9 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         mut self,
         config: impl Into<IngestionConfig>,
     ) -> IngestionResult<ExecutorProgress> {
-        let config = config.into();
-
-        if let Some(limit) = config
-            .ingestion_limit
-            .filter(|_| self.shutdown_callback.is_none())
-        {
-            self.with_ingestion_limit(limit);
-        }
-
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
-        let checkpoint_reader = CheckpointReader::new(reader_checkpoint_number, config).await?;
+        let checkpoint_reader =
+            CheckpointReader::new(reader_checkpoint_number, config.into()).await?;
 
         self.run_executor_loop(reader_checkpoint_number, checkpoint_reader)
             .await

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -17,6 +17,7 @@ use tracing::info;
 
 use crate::{
     DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
+    filters::fullnode::TransactionFilter,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
     reader::v2::{CheckpointReader, CheckpointReaderConfig, RemoteUrl},
     worker_pool::{WorkerPool, WorkerPoolStatus},
@@ -158,6 +159,7 @@ pub struct IndexerExecutor<P> {
     metrics: DataIngestionMetrics,
     token: CancellationToken,
     shutdown_callback: Option<ShutdownCallback>,
+    fullnode_transaction_filter: Option<TransactionFilter>,
 }
 
 impl<P: ProgressStore> IndexerExecutor<P> {
@@ -178,6 +180,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
             metrics,
             token,
             shutdown_callback: None,
+            fullnode_transaction_filter: None,
         }
     }
 
@@ -239,6 +242,17 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         self.shutdown_when(move |checkpoint| limit.matches(checkpoint));
     }
 
+    /// Enables server-side filtering of transactions within each checkpoint.
+    ///
+    /// When set, the remote source will only return checkpoints containing
+    /// transactions that match the provided [`TransactionFilter`].
+    ///
+    /// ### Connection Requirements
+    /// This is only supported for [`RemoteUrl::Fullnode`] connections.
+    pub fn with_fullnode_transaction_filter(&mut self, filter: TransactionFilter) {
+        self.fullnode_transaction_filter = Some(filter);
+    }
+
     pub async fn update_watermark(
         &mut self,
         task_name: String,
@@ -246,6 +260,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     ) -> IngestionResult<()> {
         self.progress_store.save(task_name, watermark).await
     }
+
     pub async fn read_watermark(
         &mut self,
         task_name: String,
@@ -264,7 +279,12 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         config: CheckpointReaderConfig,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
-        let checkpoint_reader = CheckpointReader::new(reader_checkpoint_number, config).await?;
+        let checkpoint_reader = CheckpointReader::new(
+            reader_checkpoint_number,
+            config,
+            self.fullnode_transaction_filter.take(),
+        )
+        .await?;
 
         self.run_executor_loop(reader_checkpoint_number, checkpoint_reader)
             .await

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -50,7 +50,7 @@ pub use executor::{
 use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
-pub use reader::ReaderOptions;
+pub use reader::{ReaderOptions, filters};
 pub use reducer::Reducer;
 pub use util::{create_remote_store_client, create_remote_store_client_with_ops};
 pub use worker_pool::WorkerPool;

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -24,7 +24,6 @@
 //! 3. [`IndexerExecutor`]: Orchestrates the shutdown of all worker pools and
 //!    and finalizes system termination.
 
-mod config;
 mod errors;
 mod executor;
 pub mod history;
@@ -51,12 +50,10 @@ pub use executor::{
 use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
-pub use reader::{ReaderOptions, filters};
+pub use reader::{IngestionConfig, ReaderOptions, filters};
 pub use reducer::Reducer;
 pub use util::{create_remote_store_client, create_remote_store_client_with_ops};
 pub use worker_pool::WorkerPool;
-
-pub use crate::config::IngestionConfig;
 
 /// Processes individual checkpoints and produces messages for optional batch
 /// processing.

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -24,6 +24,7 @@
 //! 3. [`IndexerExecutor`]: Orchestrates the shutdown of all worker pools and
 //!    and finalizes system termination.
 
+mod config;
 mod errors;
 mod executor;
 pub mod history;
@@ -54,6 +55,8 @@ pub use reader::{ReaderOptions, filters};
 pub use reducer::Reducer;
 pub use util::{create_remote_store_client, create_remote_store_client_with_ops};
 pub use worker_pool::WorkerPool;
+
+pub use crate::config::IngestionConfig;
 
 /// Processes individual checkpoints and produces messages for optional batch
 /// processing.

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -50,7 +50,7 @@ pub use executor::{
 use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
-pub use reader::{IngestionConfig, ReaderOptions, filters};
+pub use reader::{ReaderOptions, config, filters};
 pub use reducer::Reducer;
 pub use util::{create_remote_store_client, create_remote_store_client_with_ops};
 pub use worker_pool::WorkerPool;

--- a/crates/iota-data-ingestion-core/src/reader/config.rs
+++ b/crates/iota-data-ingestion-core/src/reader/config.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use crate::{
-    IngestionLimit, ReaderOptions,
+    ReaderOptions,
     filters::fullnode::TransactionFilter,
     reader::v2::{CheckpointReaderConfig, RemoteUrl},
 };
@@ -21,8 +21,6 @@ pub struct IngestionConfig {
     pub(crate) ingestion_path: Option<PathBuf>,
     /// Remote source for checkpoint data stream.
     pub(crate) remote_store_url: Option<RemoteUrl>,
-    /// Determines when the ingestion process should stop.
-    pub(crate) ingestion_limit: Option<IngestionLimit>,
     /// Filter applied to transactions within a checkpoint.
     pub(crate) fullnode_transaction_filter: Option<TransactionFilter>,
 }
@@ -58,13 +56,6 @@ impl IngestionConfig {
     /// Sets the remote store URL for checkpoint to be downloaded from.
     pub fn with_remote_store_url(mut self, url: RemoteUrl) -> Self {
         self.remote_store_url = Some(url);
-        self
-    }
-
-    /// Adds an upper‑limit policy that determines when the ingestion
-    /// process should stop.
-    pub fn with_ingestion_limit(mut self, limit: IngestionLimit) -> Self {
-        self.ingestion_limit = Some(limit);
         self
     }
 

--- a/crates/iota-data-ingestion-core/src/reader/config.rs
+++ b/crates/iota-data-ingestion-core/src/reader/config.rs
@@ -1,45 +1,96 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Configuration options for the ingestion framework.
+//! Configuration types for the checkpoint reader.
+//!
+//! The two main types are:
+//!
+//! - [`CheckpointReaderConfig`]: the base configuration for the checkpoint
+//!   reader. Suited for most default use cases.
+//! - [`CheckpointReaderConfigExt`]: extends [`CheckpointReaderConfig`] with
+//!   opt-in configuration toggles beyond the base, such as server-side
+//!   transaction filters for fullnode connections.
+//!
+//! [`CheckpointReaderConfigExt`] wraps [`CheckpointReaderConfig`] and exposes
+//! a builder for the extra toggles. A `From<CheckpointReaderConfig>` impl is
+//! provided so existing [`CheckpointReaderConfig`] values can be converted
+//! to [`CheckpointReaderConfigExt`].
 
 use std::path::PathBuf;
 
-use crate::{
+use crate::filters::fullnode::TransactionFilter;
+pub use crate::{
     ReaderOptions,
-    filters::fullnode::TransactionFilter,
     reader::v2::{CheckpointReaderConfig, RemoteUrl},
 };
 
-/// Configuration options for the ingestion framework.
+/// Extends [`CheckpointReaderConfig`] with opt-in configuration toggles.
+///
+/// Use this type when you need framework features beyond what the base
+/// [`CheckpointReaderConfig`] exposes (e.g. server-side transaction filtering
+/// for fullnode connections).
+///
+/// # Example
+///
+/// ```rust
+/// use iota_data_ingestion_core::{
+///     ReaderOptions,
+///     filters::fullnode::{ExecutionStatusFilter, TransactionFilter},
+///     reader::config::{CheckpointReaderConfig, CheckpointReaderConfigExt, RemoteUrl},
+/// };
+///
+/// let filter = TransactionFilter::default()
+///     .with_execution_status(ExecutionStatusFilter::default().with_success(true));
+///
+/// let config = CheckpointReaderConfigExt::new(ReaderOptions::default())
+///     .with_remote_store_url(RemoteUrl::Fullnode("http://127.0.0.1:50051".into()))
+///     .with_fullnode_transaction_filter(filter);
+/// ```
+/// # Example with an existing [`CheckpointReaderConfig`]
+///
+/// ```rust
+/// use iota_data_ingestion_core::{
+///     ReaderOptions,
+///     filters::fullnode::{ExecutionStatusFilter, TransactionFilter},
+///     reader::config::{CheckpointReaderConfig, CheckpointReaderConfigExt, RemoteUrl},
+/// };
+///
+/// let base_config = CheckpointReaderConfig {
+///     reader_options: ReaderOptions::default(),
+///     remote_store_url: Some(RemoteUrl::Fullnode("http://127.0.0.1:50051".into())),
+///     ..Default::default()
+/// };
+///
+/// let filter = TransactionFilter::default()
+///     .with_execution_status(ExecutionStatusFilter::default().with_success(true));
+/// let config =
+///     CheckpointReaderConfigExt::from(base_config).with_fullnode_transaction_filter(filter);
+/// ```
 #[derive(Clone, Default)]
-pub struct IngestionConfig {
-    /// Config the checkpoint reader behavior for downloading new checkpoints.
-    pub(crate) reader_options: ReaderOptions,
-    /// Local path for checkpoint ingestion. If not provided, checkpoints will
-    /// be ingested from a temporary directory.
-    pub(crate) ingestion_path: Option<PathBuf>,
-    /// Remote source for checkpoint data stream.
-    pub(crate) remote_store_url: Option<RemoteUrl>,
+pub struct CheckpointReaderConfigExt {
+    /// The base configuration for the checkpoint reader.
+    pub(crate) base: CheckpointReaderConfig,
     /// Filter applied to transactions within a checkpoint.
     pub(crate) fullnode_transaction_filter: Option<TransactionFilter>,
 }
 
-impl From<CheckpointReaderConfig> for IngestionConfig {
+impl From<CheckpointReaderConfig> for CheckpointReaderConfigExt {
     fn from(config: CheckpointReaderConfig) -> Self {
         Self {
-            reader_options: config.reader_options,
-            ingestion_path: config.ingestion_path,
-            remote_store_url: config.remote_store_url,
+            base: config,
             ..Default::default()
         }
     }
 }
 
-impl IngestionConfig {
+impl CheckpointReaderConfigExt {
+    /// Constructs a new configuration with the given [`ReaderOptions`].
     pub fn new(reader_options: ReaderOptions) -> Self {
         Self {
-            reader_options,
+            base: CheckpointReaderConfig {
+                reader_options,
+                ..Default::default()
+            },
             ..Default::default()
         }
     }
@@ -49,13 +100,13 @@ impl IngestionConfig {
     /// If not provided, checkpoints will be ingested from a temporary
     /// directory.
     pub fn with_ingestion_path(mut self, path: impl Into<PathBuf>) -> Self {
-        self.ingestion_path = Some(path.into());
+        self.base.ingestion_path = Some(path.into());
         self
     }
 
-    /// Sets the remote store URL for checkpoint to be downloaded from.
+    /// Sets the remote source from which checkpoints are downloaded.
     pub fn with_remote_store_url(mut self, url: RemoteUrl) -> Self {
-        self.remote_store_url = Some(url);
+        self.base.remote_store_url = Some(url);
         self
     }
 
@@ -64,8 +115,10 @@ impl IngestionConfig {
     /// When set, the remote source will only return checkpoints containing
     /// transactions that match the provided [`TransactionFilter`].
     ///
-    /// ### Connection Requirements
-    /// This is only supported for [`RemoteUrl::Fullnode`] connections.
+    /// # Errors
+    ///
+    /// Using this filter with any source other than [`RemoteUrl::Fullnode`]
+    /// will cause the executor to return an error when started.
     pub fn with_fullnode_transaction_filter(mut self, filter: TransactionFilter) -> Self {
         self.fullnode_transaction_filter = Some(filter);
         self

--- a/crates/iota-data-ingestion-core/src/reader/filters/fullnode.rs
+++ b/crates/iota-data-ingestion-core/src/reader/filters/fullnode.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Server-side filtering logic for Fullnode gRPC connections.
+//!
+//! These filters operate at the content level (transactions and events)
+//! within each checkpoint.
+pub use iota_grpc_types::v1::{
+    filter::{
+        AddressFilter, AllEventFilter, AllTransactionFilter, AnyEventFilter, AnyTransactionFilter,
+        CommandFilter, EventFilter, ExecutionStatusFilter, MakeMoveVecCommandFilter,
+        MergeCoinsCommandFilter, MoveCallCommandFilter, MoveEventTypeFilter,
+        MovePackageAndModuleFilter, NotEventFilter, NotTransactionFilter, ObjectIdFilter,
+        PublishCommandFilter, SplitCoinsCommandFilter, TransactionFilter, TransactionKind,
+        TransactionKindsFilter, TransferObjectsCommandFilter, UpgradeCommandFilter, command_filter,
+        event_filter, transaction_filter,
+    },
+    types::{Address, ObjectId, ObjectReference},
+};

--- a/crates/iota-data-ingestion-core/src/reader/filters/mod.rs
+++ b/crates/iota-data-ingestion-core/src/reader/filters/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types and utilities for checkpoint filtering.
+//!
+//! These filters allow consumers to reduce network load by requesting only
+//! specific data from remote sources.
+
+pub mod fullnode;

--- a/crates/iota-data-ingestion-core/src/reader/mod.rs
+++ b/crates/iota-data-ingestion-core/src/reader/mod.rs
@@ -4,10 +4,9 @@
 //! Types and utilities for fetching checkpoints from local and remote sources.
 
 pub(crate) mod common;
-pub(crate) mod config;
+pub mod config;
 pub(crate) mod fetch;
 pub mod filters;
 pub mod v2;
 
 pub use common::ReaderOptions;
-pub use config::IngestionConfig;

--- a/crates/iota-data-ingestion-core/src/reader/mod.rs
+++ b/crates/iota-data-ingestion-core/src/reader/mod.rs
@@ -4,8 +4,10 @@
 //! Types and utilities for fetching checkpoints from local and remote sources.
 
 pub(crate) mod common;
+pub(crate) mod config;
 pub(crate) mod fetch;
 pub mod filters;
 pub mod v2;
 
 pub use common::ReaderOptions;
+pub use config::IngestionConfig;

--- a/crates/iota-data-ingestion-core/src/reader/mod.rs
+++ b/crates/iota-data-ingestion-core/src/reader/mod.rs
@@ -1,8 +1,11 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! Types and utilities for fetching checkpoints from local and remote sources.
+
 pub(crate) mod common;
 pub(crate) mod fetch;
+pub mod filters;
 pub mod v2;
 
 pub use common::ReaderOptions;

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -41,6 +41,7 @@ use crate::{
         fetch::{
             GRPC_MAX_DECODING_MESSAGE_SIZE_BYTES, LocalRead, ReadSource, fetch_from_object_store,
         },
+        filters::fullnode::TransactionFilter,
     },
 };
 
@@ -196,6 +197,8 @@ struct CheckpointReaderActor {
     reader_options: ReaderOptions,
     /// Limit the amount of downloaded checkpoints held in memory to avoid OOM.
     data_limiter: DataLimiter,
+    /// Filter applied to transactions within a checkpoint.
+    fullnode_transaction_filter: Option<TransactionFilter>,
 }
 
 impl LocalRead for CheckpointReaderActor {
@@ -324,7 +327,7 @@ impl CheckpointReaderActor {
                 Some(self.current_checkpoint_number),
                 None,
                 Some(iota_grpc_client::CHECKPOINT_RESPONSE_CHECKPOINT_DATA),
-                None,
+                self.fullnode_transaction_filter.clone(),
                 None,
             )
             .await
@@ -551,7 +554,16 @@ impl CheckpointReader {
     pub(crate) async fn new(
         starting_checkpoint_number: CheckpointSequenceNumber,
         config: CheckpointReaderConfig,
+        fullnode_transaction_filter: Option<TransactionFilter>,
     ) -> IngestionResult<Self> {
+        if fullnode_transaction_filter.is_some()
+            && !matches!(config.remote_store_url, Some(RemoteUrl::Fullnode(_)))
+        {
+            return Err(IngestionError::Unsupported(
+                "filter is only supported on `RemoteUrl::Fullnode` connections".into(),
+            ));
+        }
+
         let (checkpoint_tx, checkpoint_rx) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (gc_signal_tx, gc_signal_rx) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
 
@@ -583,6 +595,7 @@ impl CheckpointReader {
             token: token.clone(),
             data_limiter: DataLimiter::new(config.reader_options.data_limit),
             reader_options: config.reader_options,
+            fullnode_transaction_filter,
         };
 
         let handle = spawn_monitored_task!(reader.run());

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -33,7 +33,8 @@ use tracing::{debug, error, info};
 #[cfg(not(target_os = "macos"))]
 use crate::reader::fetch::init_watcher;
 use crate::{
-    IngestionConfig, IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS,
+    IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS,
+    config::CheckpointReaderConfigExt,
     create_remote_store_client,
     history::reader::HistoricalReader,
     reader::{
@@ -554,10 +555,10 @@ pub(crate) struct CheckpointReader {
 impl CheckpointReader {
     pub(crate) async fn new(
         starting_checkpoint_number: CheckpointSequenceNumber,
-        config: IngestionConfig,
+        config: CheckpointReaderConfigExt,
     ) -> IngestionResult<Self> {
         if config.fullnode_transaction_filter.is_some()
-            && !matches!(config.remote_store_url, Some(RemoteUrl::Fullnode(_)))
+            && !matches!(config.base.remote_store_url, Some(RemoteUrl::Fullnode(_)))
         {
             return Err(IngestionError::Unsupported(
                 "filter is only supported on `RemoteUrl::Fullnode` connections".into(),
@@ -567,12 +568,12 @@ impl CheckpointReader {
         let (checkpoint_tx, checkpoint_rx) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (gc_signal_tx, gc_signal_rx) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
 
-        let remote_store = if let Some(url) = config.remote_store_url {
+        let remote_store = if let Some(url) = config.base.remote_store_url {
             Some(Arc::new(
                 RemoteStore::new(
                     url,
-                    config.reader_options.batch_size,
-                    config.reader_options.timeout_secs,
+                    config.base.reader_options.batch_size,
+                    config.base.reader_options.timeout_secs,
                 )
                 .await?,
             ))
@@ -580,7 +581,7 @@ impl CheckpointReader {
             None
         };
 
-        let path = match config.ingestion_path {
+        let path = match config.base.ingestion_path {
             Some(p) => p,
             None => tempfile::tempdir()?.keep(),
         };
@@ -593,8 +594,8 @@ impl CheckpointReader {
             gc_signal_rx,
             remote_store,
             token: token.clone(),
-            data_limiter: DataLimiter::new(config.reader_options.data_limit),
-            reader_options: config.reader_options,
+            data_limiter: DataLimiter::new(config.base.reader_options.data_limit),
+            reader_options: config.base.reader_options,
             fullnode_transaction_filter: config.fullnode_transaction_filter,
         };
 

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -33,7 +33,8 @@ use tracing::{debug, error, info};
 #[cfg(not(target_os = "macos"))]
 use crate::reader::fetch::init_watcher;
 use crate::{
-    IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, create_remote_store_client,
+    IngestionConfig, IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS,
+    create_remote_store_client,
     history::reader::HistoricalReader,
     reader::{
         ReaderOptions,
@@ -553,10 +554,9 @@ pub(crate) struct CheckpointReader {
 impl CheckpointReader {
     pub(crate) async fn new(
         starting_checkpoint_number: CheckpointSequenceNumber,
-        config: CheckpointReaderConfig,
-        fullnode_transaction_filter: Option<TransactionFilter>,
+        config: IngestionConfig,
     ) -> IngestionResult<Self> {
-        if fullnode_transaction_filter.is_some()
+        if config.fullnode_transaction_filter.is_some()
             && !matches!(config.remote_store_url, Some(RemoteUrl::Fullnode(_)))
         {
             return Err(IngestionError::Unsupported(
@@ -595,7 +595,7 @@ impl CheckpointReader {
             token: token.clone(),
             data_limiter: DataLimiter::new(config.reader_options.data_limit),
             reader_options: config.reader_options,
-            fullnode_transaction_filter,
+            fullnode_transaction_filter: config.fullnode_transaction_filter,
         };
 
         let handle = spawn_monitored_task!(reader.run());


### PR DESCRIPTION
# Description of change

This PR adds an optional `TransactionFilter` parameter to the `IndexerExecutor`, forwarded to the fullnode's `stream_checkpoints` gRPC call when checkpoints are streamed from a `RemoteUrl::Fullnode` source.

Filters are only supported for `RemoteUrl::Fullnode`. Configuring a filter together with `RemoteUrl::HybridHistoricalStore` is rejected at startup with `IngestionError::Unsupported`.

Introduced a `config` module in the `reader`, it contains two main types `CheckpointReaderConfig` (re-exported from `reader::v2`) and `CheckpointReaderConfigExt`, the latter supports the new filter configuration option needed for the checkpoint reader and could be extended without any breaking change in the future is configuration would require new config options.

### Behavior when a transaction filter is provided:

- **Filtering happens server-side** on the fullnode. The ingestion framework performs no client-side filtering.
- **Every checkpoint still delivered** to the executor. Sequence contiguity is preserved so the framework's watermarks, ordering and gap detection continue to work unchanged.
- **Within each checkpoint, the `transactions` vector contains only transactions matching the filter.** If no transaction in the checkpoint matches, the vector is empty.
- **`checkpoint_summary` and `checkpoint_contents` are always populated** regardless of whether any transaction matched.

### Known limitation / follow-up

- Checkpoints whose contents fully fail to match the filter still travel over the wire as empty transaction vector. A follow-up issue will explore fixing this limitation while still preserving the contiguity guarantee the executor relies on. (#11419 )
- The public API currently leans on the proto `TransactionFilter` type. From a user perspective, building a filter is verbose, non-intuitive, and leaks proto types into the consumer's code. A follow-up issue will introduce a dedicated wrapper API (#11435).

## Links to any relevant issues

fixes #11325 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the normal operations of the indexer, thus no further tests were conducted.
