### PR TITLE
refactor(indexer,graphql): optimize transaction execution flow

### DIFF
--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -2,69 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 use async_graphql::*;
-use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::Base64;
-use iota_indexer::{
-    models::transactions::{OptimisticTransaction, StoredTransaction},
-    schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
-};
-use iota_json_rpc_api::WriteApiServer;
-use iota_json_rpc_types::IotaTransactionBlockResponseOptions;
 
 use crate::{
-    data::{Db, DbConnection, QueryExecutor},
     error::Error,
     server::builder::get_write_api,
     types::{
-        execution_result::ExecutionResult, transaction_block::TransactionBlock,
-        transaction_block_effects::TransactionBlockEffects,
+        execution_result::ExecutionResult, transaction_block_effects::TransactionBlockEffects,
     },
 };
 pub struct Mutation;
-
-/// Query checkpointed transaction by digest from the database
-async fn query_checkpointed_transaction_by_digest(
-    db: &Db,
-    digest_bytes: Vec<u8>,
-) -> Result<StoredTransaction, Error> {
-    db.execute_repeatable(move |conn| {
-        conn.first(move || {
-            transactions::table
-                .inner_join(
-                    tx_digests::table
-                        .on(transactions::tx_sequence_number.eq(tx_digests::tx_sequence_number)),
-                )
-                .filter(tx_digests::tx_digest.eq(digest_bytes.clone()))
-                .select(StoredTransaction::as_select())
-        })
-    })
-    .await
-    .map_err(|e| Error::Internal(format!("Unable to query checkpointed transaction: {e}")))
-}
-
-/// Query optimistic transaction by digest from the database
-async fn query_optimistic_transaction_by_digest(
-    db: &Db,
-    digest_bytes: Vec<u8>,
-) -> Result<OptimisticTransaction, Error> {
-    db.execute_repeatable(move |conn| {
-        conn.first(move || {
-            optimistic_transactions::table
-                .inner_join(
-                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
-                        .eq(tx_global_order::global_sequence_number)
-                        .and(
-                            optimistic_transactions::optimistic_sequence_number
-                                .eq(tx_global_order::optimistic_sequence_number),
-                        )),
-                )
-                .filter(tx_global_order::tx_digest.eq(digest_bytes.clone()))
-                .select(OptimisticTransaction::as_select())
-        })
-    })
-    .await
-    .map_err(|e| Error::Internal(format!("Unable to query optimistic transaction: {e}")))
-}
 
 /// Mutations are used to write to the IOTA network.
 #[Object]
@@ -115,47 +62,18 @@ impl Mutation {
                     .extend()?,
             );
         }
-        let options = IotaTransactionBlockResponseOptions::new()
-            .with_events()
-            .with_raw_input()
-            .with_raw_effects();
-
-        let result = write_api
-            .execute_transaction_block(tx_data, sigs, Some(options), None)
+        let ingestion_path = write_api
+            .executor()
+            .execute_and_index_transaction(tx_data, sigs)
             .await
             .map_err(|e| Error::Internal(format!("Unable to execute transaction: {e}")))
             .extend()?;
 
-        let tx_digest = result.digest;
-        let digest_bytes = tx_digest.inner().to_vec();
-
-        let db: &Db = ctx.data_unchecked();
-        let query_optimistic_tx = query_optimistic_transaction_by_digest(db, digest_bytes.clone());
-        let query_checkpointed_tx = query_checkpointed_transaction_by_digest(db, digest_bytes);
-        tokio::pin!(query_optimistic_tx, query_checkpointed_tx);
-
-        let effects: Result<TransactionBlockEffects, _> = tokio::select! {
-                checkpointed_tx = &mut query_checkpointed_tx => match checkpointed_tx {
-                    Ok(checkpointed_tx) => TransactionBlock::try_from(checkpointed_tx)?.try_into(),
-                    _ => query_optimistic_tx.await?.try_into()
-                },
-                optimistic_tx = &mut query_optimistic_tx => {
-                    match optimistic_tx {
-                        Ok(optimistic_tx) => optimistic_tx.try_into(),
-                        _ => TransactionBlock::try_from(query_checkpointed_tx.await?)?.try_into(),
-                    }
-                }
-        };
+        let effects = TransactionBlockEffects::try_from(ingestion_path).extend()?;
 
         Ok(ExecutionResult {
-            errors: if result.errors.is_empty() {
-                None
-            } else {
-                Some(result.errors)
-            },
-            effects: effects
-                .map_err(|_| Error::Internal("Transaction not indexed after execution".into()))
-                .extend()?,
+            errors: effects.errors(ctx).await?.map(|e| vec![e]),
+            effects,
         })
     }
 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -6,7 +6,10 @@ use async_graphql::{
     connection::{Connection, ConnectionNameType, CursorType, Edge, EdgeNameType, EmptyFields},
     *,
 };
-use iota_indexer::models::transactions::{OptimisticTransaction, StoredTransaction};
+use iota_indexer::{
+    models::transactions::{OptimisticTransaction, StoredTransaction},
+    optimistic_indexing::IngestionPath,
+};
 use iota_json_rpc_types::IotaExecutionStatus;
 use iota_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
@@ -124,7 +127,7 @@ impl TransactionBlockEffects {
     /// human-readable form if possible, otherwise it will fall back to
     /// displaying the abort code and location.
     #[graphql(complexity = 0)]
-    async fn errors(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+    pub(crate) async fn errors(&self, ctx: &Context<'_>) -> Result<Option<String>> {
         let resolver: &PackageResolver = ctx.data_unchecked();
 
         let status = IotaExecutionStatus::from_native_with_clever_error(
@@ -564,5 +567,18 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffects {
             kind: block.try_into()?,
             checkpoint_viewed_at,
         })
+    }
+}
+
+impl TryFrom<IngestionPath> for TransactionBlockEffects {
+    type Error = Error;
+
+    fn try_from(ingestion_path: IngestionPath) -> std::result::Result<Self, Self::Error> {
+        match ingestion_path {
+            IngestionPath::Optimistic(optimistic_tx) => optimistic_tx.try_into(),
+            IngestionPath::Checkpoint(checkpointed_tx) => {
+                TransactionBlock::try_from(checkpointed_tx)?.try_into()
+            }
+        }
     }
 }

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -238,7 +238,7 @@ impl WriteApi {
             kind,
             sender: sender_address,
             gas_data: GasData {
-                payment,
+                objects: payment,
                 owner,
                 price,
                 budget,

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -43,11 +43,11 @@ use crate::{
     apis::error::Error as ApiError,
     errors::{IndexerError, IndexerResult},
     ingestion::primary::prepare::InMemObjectCache,
-    models::transactions::tx_events_to_iota_tx_events,
-    optimistic_indexing::OptimisticTransactionExecutor,
+    models::transactions::{StoredTransaction, tx_events_to_iota_tx_events},
+    optimistic_indexing::{IngestionPath, OptimisticTransactionExecutor},
     read::IndexerReader,
     store::package_resolver::IndexerStorePackageResolver,
-    types::{IndexedObjectChange, IotaTransactionBlockResponseWithOptions, grpc_conversion},
+    types::{IndexedObjectChange, grpc_conversion},
 };
 
 // As an optimization, we're trying to request only the fields we actually need.
@@ -238,7 +238,7 @@ impl WriteApi {
             kind,
             sender: sender_address,
             gas_data: GasData {
-                objects: payment,
+                payment,
                 owner,
                 price,
                 budget,
@@ -349,6 +349,18 @@ impl OptimisticWriteApi {
             optimistic_tx_executor,
         }
     }
+
+    async fn build_response(
+        &self,
+        ingestion_path: IngestionPath,
+        options: IotaTransactionBlockResponseOptions,
+    ) -> Result<IotaTransactionBlockResponse, IndexerError> {
+        let package_resolver = self.write_api.package_resolver.clone();
+        let stored_transaction = StoredTransaction::from(ingestion_path);
+        stored_transaction
+            .try_into_iota_transaction_block_response(options, &package_resolver)
+            .await
+    }
 }
 
 #[async_trait]
@@ -441,9 +453,12 @@ impl WriteApiServer for OptimisticWriteApi {
         options: Option<IotaTransactionBlockResponseOptions>,
         _request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<IotaTransactionBlockResponse> {
-        Ok(self
+        let ingestion_path = self
             .optimistic_tx_executor
-            .execute_and_index_transaction(tx_bytes, signatures, options.clone())
+            .execute_and_index_transaction(tx_bytes, signatures)
+            .await?;
+        Ok(self
+            .build_response(ingestion_path, options.unwrap_or_default())
             .await?)
     }
 

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -361,6 +361,10 @@ impl OptimisticWriteApi {
             .try_into_iota_transaction_block_response(options, &package_resolver)
             .await
     }
+
+    pub fn executor(&self) -> &OptimisticTransactionExecutor {
+        &self.optimistic_tx_executor
+    }
 }
 
 #[async_trait]

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -441,15 +441,10 @@ impl WriteApiServer for OptimisticWriteApi {
         options: Option<IotaTransactionBlockResponseOptions>,
         _request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<IotaTransactionBlockResponse> {
-        let iota_transaction_response = self
+        Ok(self
             .optimistic_tx_executor
             .execute_and_index_transaction(tx_bytes, signatures, options.clone())
-            .await?;
-        Ok(IotaTransactionBlockResponseWithOptions {
-            response: iota_transaction_response,
-            options: options.unwrap_or_default(),
-        }
-        .into())
+            .await?)
     }
 
     async fn dev_inspect_transaction_block(

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -13,7 +13,7 @@ use iota_grpc_types::{
 use iota_json_rpc_types::{IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions};
 use iota_types::{
     base_types::{ObjectID, SequenceNumber, TransactionDigest},
-    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
+    effects::{TransactionEffectsAPI, TransactionEvents},
     full_checkpoint_content::CheckpointTransaction,
     signature::GenericSignature,
     transaction::{Transaction, TransactionData},
@@ -39,10 +39,7 @@ use crate::{
     read::{IndexerReader, InputObjectsStatus},
     store::{IndexerStore, PgIndexerStore},
     transactional_blocking_with_retry_with_conditional_abort,
-    types::{
-        IndexedDeletedObject, IndexedObject, IndexerResult,
-        IotaTransactionBlockResponseWithOptions, grpc_conversion,
-    },
+    types::{IndexedDeletedObject, IndexedObject, IndexerResult, grpc_conversion},
 };
 
 const WAIT_FOR_DEPS_MAX_ELAPSED_TIME: Duration = Duration::from_secs(3);
@@ -258,85 +255,51 @@ impl OptimisticTransactionExecutor {
             .collect::<Result<Vec<_>, FastCryptoError>>()?;
 
         let transaction = Transaction::from_generic_sig_data(tx_data, sigs);
+        let tx_digest = *transaction.digest();
 
         let executed_transaction = self.execute_transaction(transaction.clone()).await?;
-
-        let tx_digest = *TransactionEffects::try_from(executed_transaction.effects()?.effects()?)?
-            .transaction_digest();
 
         let optimistic_tx = self
             .maybe_index_executed_transaction(transaction, executed_transaction)
             .await?;
 
+        let indexed_transaction = match optimistic_tx {
+            Some(optimistic_tx) => optimistic_tx.into(),
+            None => self.resolve_checkpointed_transaction(tx_digest).await?,
+        };
+        let package_resolver = self.read.package_resolver.clone();
+        indexed_transaction
+            .try_into_iota_transaction_block_response(
+                options.unwrap_or_default(),
+                &package_resolver,
+            )
+            .await
+    }
+
+    async fn resolve_checkpointed_transaction(
+        &self,
+        tx_digest: TransactionDigest,
+    ) -> Result<StoredTransaction, IndexerError> {
         let db_read_timer = self
             .metrics
             .optimistic_tx_db_wait_and_read_time
             .start_timer();
-        self.wait_for_read_write_consistency(&optimistic_tx, tx_digest)
-            .await?;
-        let tx_block_response = self
-            .get_transaction_block_response(optimistic_tx, tx_digest, options.clone())
-            .await?;
+        // When checkpoint indexing wins over optimistic indexing, the transaction row
+        // may be persisted before objects and other related tables. We wait until all
+        // such updates are completed.
+        self.wait_for_local_indexing(tx_digest).await?;
+        let stored_transaction = self
+            .read
+            .multi_get_transactions(&[tx_digest])
+            .await?
+            .pop()
+            .ok_or_else(|| {
+                IndexerError::PersistentStorageDataCorruption(format!(
+                    "transaction {tx_digest} not found in the DB after being marked as indexed."
+                ))
+            })?;
         db_read_timer.stop_and_record();
-
-        Ok(IotaTransactionBlockResponseWithOptions {
-            response: tx_block_response,
-            options: options.unwrap_or_default(),
-        }
-        .into())
-    }
-
-    /// Waits until it is guaranteed that objects and display table are
-    /// persisted for given tx.
-    ///
-    /// This effectively waits only if we fell back to checkpoint path, as
-    /// optimistic path persists all this data at once.
-    async fn wait_for_read_write_consistency(
-        &self,
-        optimistic_tx: &Option<OptimisticTransaction>,
-        tx_digest: TransactionDigest,
-    ) -> Result<(), IndexerError> {
-        if optimistic_tx.is_none() {
-            // When checkpoint indexing wins over optimistic indexing, the transaction row
-            // may be persisted before objects and other related tables. We wait until all
-            // such updates are completed.
-            self.wait_for_local_indexing(tx_digest).await?;
-        }
-        Ok(())
-    }
-
-    /// Returns the transaction block response, either by converting the
-    /// optimistic transaction directly (if optimistic indexing succeeded) or by
-    /// fetching checkpointed transaction from DB.
-    ///
-    /// It is a requirement that transaction passed to this function is
-    /// completely indexed either on checkpoint path or optimistic path.
-    async fn get_transaction_block_response(
-        &self,
-        optimistic_tx: Option<OptimisticTransaction>,
-        tx_digest: TransactionDigest,
-        options: Option<IotaTransactionBlockResponseOptions>,
-    ) -> Result<IotaTransactionBlockResponse, IndexerError> {
-        if let Some(optimistic_tx) = optimistic_tx {
-            self.optimistic_transaction_to_block_response(
-                optimistic_tx,
-                options.unwrap_or_default(),
-            )
-            .await
-        } else {
-            self.read
-                .multi_get_transaction_block_response_in_blocking_task(
-                    vec![tx_digest],
-                    options.unwrap_or_default(),
-                )
-                .await?
-                .pop()
-                .ok_or_else(|| {
-                    IndexerError::PersistentStorageDataCorruption(format!(
-                        "transaction {tx_digest} not found in the DB after being marked as indexed."
-                    ))
-                })
-        }
+        Ok(stored_transaction)
     }
 
     /// Waits until the transaction is fully indexed (via either the optimistic

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -142,7 +142,7 @@ impl OptimisticTransactionExecutor {
     /// Returns `Some` with the indexed transaction on success, or `None` if
     /// optimistic indexing was skipped — the checkpoint indexing path
     /// should be relied upon in that case.
-    pub(crate) async fn maybe_index_executed_transaction(
+    pub async fn maybe_index_executed_transaction(
         &self,
         transaction: Transaction,
         executed_transaction: ExecutedTransaction,
@@ -205,6 +205,41 @@ impl OptimisticTransactionExecutor {
         Ok(optimistic_tx)
     }
 
+    pub async fn execute_transaction(
+        &self,
+        signed_transaction: Transaction,
+    ) -> Result<ExecutedTransaction, IndexerError> {
+        let node_timer = self
+            .metrics
+            .optimistic_tx_node_response_wait_time
+            .start_timer();
+
+        let readmask = FieldMask::from_paths(EXECUTE_TRANSACTION_READ_MASK)
+            .display()
+            .to_string();
+
+        let response = self
+            .rpc_client
+            .execute_transaction(
+                signed_transaction.try_into()?,
+                Some(readmask.as_str()),
+                None,
+            )
+            .await;
+
+        match response {
+            Ok(response) => {
+                node_timer.stop_and_record();
+                Ok(response.into_inner())
+            }
+            Err(e) => {
+                node_timer.stop_and_discard();
+                self.metrics.optimistic_tx_failed_node_requests_count.inc();
+                return Err(IndexerError::from(e));
+            }
+        }
+    }
+
     pub async fn execute_and_index_transaction(
         &self,
         tx_bytes: Base64,
@@ -224,35 +259,7 @@ impl OptimisticTransactionExecutor {
 
         let transaction = Transaction::from_generic_sig_data(tx_data, sigs);
 
-        let node_timer = self
-            .metrics
-            .optimistic_tx_node_response_wait_time
-            .start_timer();
-
-        let readmask = FieldMask::from_paths(EXECUTE_TRANSACTION_READ_MASK)
-            .display()
-            .to_string();
-
-        let response = self
-            .rpc_client
-            .execute_transaction(
-                transaction.clone().try_into()?,
-                Some(readmask.as_str()),
-                None,
-            )
-            .await;
-
-        let executed_transaction = match response {
-            Ok(response) => {
-                node_timer.stop_and_record();
-                response.into_inner()
-            }
-            Err(e) => {
-                node_timer.stop_and_discard();
-                self.metrics.optimistic_tx_failed_node_requests_count.inc();
-                return Err(IndexerError::from(e));
-            }
-        };
+        let executed_transaction = self.execute_transaction(transaction.clone()).await?;
 
         let tx_digest = *TransactionEffects::try_from(executed_transaction.effects()?.effects()?)?
             .transaction_digest();

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -10,7 +10,6 @@ use iota_grpc_types::{
     field::{FieldMask, FieldMaskUtil},
     v1::transaction::ExecutedTransaction,
 };
-use iota_json_rpc_types::{IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions};
 use iota_types::{
     base_types::{ObjectID, SequenceNumber, TransactionDigest},
     effects::{TransactionEffectsAPI, TransactionEvents},
@@ -57,6 +56,30 @@ type TransactionDataToCommit = (
     BTreeMap<String, StoredDisplay>,
     TransactionObjectChangesToCommit,
 );
+
+/// Represents the ingestion path taken after execution.
+///
+/// The executor tries to ingest the transaction effects after the fullnode
+/// sends back the execution response. This is referred to as the optimistic
+/// path.
+///
+/// Under certain conditions, however, the transaction might be indexed by the
+/// parallel ingestion pipeline that processes transactions included in
+/// checkpoints. This is referred to as the checkpoint path.
+#[derive(Clone, Debug)]
+pub enum IngestionPath {
+    Optimistic(OptimisticTransaction),
+    Checkpoint(StoredTransaction),
+}
+
+impl From<IngestionPath> for StoredTransaction {
+    fn from(path: IngestionPath) -> Self {
+        match path {
+            IngestionPath::Optimistic(optimistic_tx) => optimistic_tx.into(),
+            IngestionPath::Checkpoint(stored_tx) => stored_tx,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct OptimisticTransactionExecutor {
@@ -139,7 +162,7 @@ impl OptimisticTransactionExecutor {
     /// Returns `Some` with the indexed transaction on success, or `None` if
     /// optimistic indexing was skipped — the checkpoint indexing path
     /// should be relied upon in that case.
-    pub async fn maybe_index_executed_transaction(
+    async fn maybe_index_executed_transaction(
         &self,
         transaction: Transaction,
         executed_transaction: ExecutedTransaction,
@@ -202,6 +225,7 @@ impl OptimisticTransactionExecutor {
         Ok(optimistic_tx)
     }
 
+    /// Execute the signed transaction on the fullnode through gRPC.
     pub async fn execute_transaction(
         &self,
         signed_transaction: Transaction,
@@ -232,7 +256,7 @@ impl OptimisticTransactionExecutor {
             Err(e) => {
                 node_timer.stop_and_discard();
                 self.metrics.optimistic_tx_failed_node_requests_count.inc();
-                return Err(IndexerError::from(e));
+                Err(IndexerError::from(e))
             }
         }
     }
@@ -241,8 +265,7 @@ impl OptimisticTransactionExecutor {
         &self,
         tx_bytes: Base64,
         signatures: Vec<Base64>,
-        options: Option<IotaTransactionBlockResponseOptions>,
-    ) -> Result<IotaTransactionBlockResponse, IndexerError> {
+    ) -> Result<IngestionPath, IndexerError> {
         let _total_execution_time = self
             .metrics
             .optimistic_tx_total_execution_and_indexing_time
@@ -263,17 +286,12 @@ impl OptimisticTransactionExecutor {
             .maybe_index_executed_transaction(transaction, executed_transaction)
             .await?;
 
-        let indexed_transaction = match optimistic_tx {
-            Some(optimistic_tx) => optimistic_tx.into(),
-            None => self.resolve_checkpointed_transaction(tx_digest).await?,
-        };
-        let package_resolver = self.read.package_resolver.clone();
-        indexed_transaction
-            .try_into_iota_transaction_block_response(
-                options.unwrap_or_default(),
-                &package_resolver,
-            )
-            .await
+        Ok(match optimistic_tx {
+            Some(optimistic_tx) => IngestionPath::Optimistic(optimistic_tx),
+            None => {
+                IngestionPath::Checkpoint(self.resolve_checkpointed_transaction(tx_digest).await?)
+            }
+        })
     }
 
     async fn resolve_checkpointed_transaction(
@@ -336,27 +354,6 @@ impl OptimisticTransactionExecutor {
                 "timeout waiting for transaction to be fully indexed".to_string(),
             )
         })
-    }
-
-    /// Converts an [`OptimisticTransaction`] (already persisted atomically)
-    /// directly into an [`IotaTransactionBlockResponse`] without unnecessary DB
-    /// round-trips.
-    async fn optimistic_transaction_to_block_response(
-        &self,
-        optimistic_tx: OptimisticTransaction,
-        options: IotaTransactionBlockResponseOptions,
-    ) -> IndexerResult<IotaTransactionBlockResponse> {
-        self.read
-            .stored_transaction_to_transaction_block(
-                vec![StoredTransaction::from(optimistic_tx)],
-                options,
-            )
-            .await?
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                IndexerError::Generic("expected a transaction block response".to_string())
-            })
     }
 
     async fn index_transaction_in_blocking_task(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -116,7 +116,7 @@ pub enum InputObjectsStatus {
 #[derive(Clone)]
 pub struct IndexerReader {
     pool: ConnectionPool,
-    package_resolver: PackageResolver,
+    pub(crate) package_resolver: PackageResolver,
     obj_type_cache: Arc<Mutex<SizedCache<String, Option<ObjectID>>>>,
     fallback: Option<HistoricalFallbackReader>,
     watermark_cache: WatermarkCache,
@@ -779,7 +779,7 @@ impl IndexerReader {
     ///  Retrieval order:
     /// 1. Checkpointed data (finalized transactions)
     /// 2. Optimistic data (pending transactions not yet checkpointed)
-    async fn multi_get_transactions(
+    pub(crate) async fn multi_get_transactions(
         &self,
         digests: &[TransactionDigest],
     ) -> IndexerResult<Vec<StoredTransaction>> {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -116,7 +116,7 @@ pub enum InputObjectsStatus {
 #[derive(Clone)]
 pub struct IndexerReader {
     pool: ConnectionPool,
-    pub(crate) package_resolver: PackageResolver,
+    package_resolver: PackageResolver,
     obj_type_cache: Arc<Mutex<SizedCache<String, Option<ObjectID>>>>,
     fallback: Option<HistoricalFallbackReader>,
     watermark_cache: WatermarkCache,


### PR DESCRIPTION
# Description of change

This patch refactors the optimistic transaction execution flow in `iota-indexer`. The main motivation is to avoid the redundant database queries in the `Mutation.executeTransactionBlock` as identified in #8775.

The changes implemented have been dictated by the observation that GraphQL only requires the transaction ingested after execution, let it be either optimistic or checkpointed.

We therefore decouple execution and ingestion from constructing the JSON-RPC response in `iota_indexer::optimistic_indexing`. This leads to a series of simplifications both in `iota-indexer` and particularly in `iota-graphql-rpc`. 

In summary:

* We introduce a new `IngestionPath` enum that represents the dual possibility of ingestion in this context: `Optimistic` or `Checkpoint`. This is the returned by `OptimisticExecutor::execute_and_index_transaction`. 
* Building the JSON-RPC response is delegated directly in `OptimisticWriteApi` where it fits the scope more.
* GraphQL uses `IngestionPath` to construct the `TransactionBlockEffects` required for the associated response, and the errors are generated by the available methods of the latter.

## Links to any relevant issues

Fixes #8775 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Release Notes

- [x] GraphQL: Optimize `Mutation.executeTransactionBlock`.
