### PR TITLE
feat(node): reduce log spamming

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -161,6 +161,7 @@ use crate::{
         epoch_start_configuration::{EpochStartConfigTrait, EpochStartConfiguration},
     },
     authority_client::NetworkAuthorityClient,
+    checkpoint_progress_tracker::CheckpointProgressTracker,
     checkpoints::CheckpointStore,
     congestion_tracker::CongestionTracker,
     consensus_adapter::ConsensusAdapter,
@@ -809,6 +810,7 @@ pub struct AuthorityState {
     pub metrics: Arc<AuthorityMetrics>,
     _pruner: AuthorityStorePruner,
     _authority_per_epoch_pruner: AuthorityPerEpochStorePruner,
+    checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
 
     /// Take db checkpoints of different dbs
     db_checkpoint_config: DBCheckpointConfig,
@@ -3035,6 +3037,7 @@ impl AuthorityState {
         validator_tx_finalizer: Option<Arc<ValidatorTxFinalizer<NetworkAuthorityClient>>>,
         chain_identifier: ChainIdentifier,
         pruner_db: Option<Arc<AuthorityPrunerTables>>,
+        checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
     ) -> Arc<Self> {
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
 
@@ -3066,6 +3069,7 @@ impl AuthorityState {
             prometheus_registry,
             archive_readers,
             pruner_db,
+            checkpoint_progress_tracker.clone(),
         );
         let input_loader =
             TransactionInputLoader::new(execution_cache_trait_pointers.object_cache_reader.clone());
@@ -3088,6 +3092,7 @@ impl AuthorityState {
             metrics,
             _pruner,
             _authority_per_epoch_pruner,
+            checkpoint_progress_tracker,
             db_checkpoint_config: db_checkpoint_config.clone(),
             config,
             overload_info: AuthorityOverloadInfo::default(),
@@ -3180,6 +3185,7 @@ impl AuthorityState {
             metrics,
             archive_readers,
             EPOCH_DURATION_MS_FOR_TESTING,
+            self.checkpoint_progress_tracker.as_ref(),
         )
         .await
     }

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -1684,6 +1684,7 @@ impl AuthorityStore {
             pruning_config,
             AuthorityStorePruningMetrics::new_for_test(),
             EPOCH_DURATION_MS_FOR_TESTING,
+            None,
         )
         .await;
         let _ = AuthorityStorePruner::compact(&self.perpetual_tables);

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -476,7 +476,6 @@ impl AuthorityStorePruner {
         let mut effects_to_prune = vec![];
 
         let mut pruning_start = Instant::now();
-        let mut total_checkpoints_pruned: u64 = 0;
 
         loop {
             let Some(ckpt) = checkpoint_store
@@ -519,8 +518,6 @@ impl AuthorityStorePruner {
             if effects_to_prune.len() >= config.max_transactions_in_batch
                 || checkpoints_to_prune.len() >= config.max_checkpoints_in_batch
             {
-                total_checkpoints_pruned += checkpoints_to_prune.len() as u64;
-
                 match mode {
                     PruningMode::Objects => {
                         Self::prune_objects(
@@ -565,8 +562,6 @@ impl AuthorityStorePruner {
         }
 
         if !checkpoints_to_prune.is_empty() {
-            total_checkpoints_pruned += checkpoints_to_prune.len() as u64;
-
             match mode {
                 PruningMode::Objects => {
                     Self::prune_objects(
@@ -589,9 +584,10 @@ impl AuthorityStorePruner {
                     metrics.clone(),
                 )?,
             };
-        }
 
-        if total_checkpoints_pruned > 0 {
+            // Report pruning time for this batch so the progress logger
+            // shows time alongside the checkpoint deltas it reads from the
+            // DB (which are already updated at this point).
             if let Some(tracker) = progress_tracker {
                 let elapsed = pruning_start.elapsed();
                 match mode {
@@ -600,6 +596,7 @@ impl AuthorityStorePruner {
                 }
             }
         }
+
         Ok(())
     }
 

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -40,6 +40,7 @@ use typed_store::{
 use super::authority_store_tables::{AuthorityPerpetualTables, AuthorityPrunerTables};
 use crate::{
     authority::authority_store_types::{StoreObject, StoreObjectWrapper},
+    checkpoint_progress_tracker::CheckpointProgressTracker,
     checkpoints::{CheckpointStore, CheckpointWatermark},
     grpc_indexes::GrpcIndexesStore,
     jsonrpc_index::IndexStore,
@@ -340,6 +341,7 @@ impl AuthorityStorePruner {
         config: AuthorityStorePruningConfig,
         metrics: Arc<AuthorityStorePruningMetrics>,
         epoch_duration_ms: u64,
+        progress_tracker: Option<&Arc<CheckpointProgressTracker>>,
     ) -> anyhow::Result<()> {
         let _scope = monitored_scope("PruneObjectsForEligibleEpochs");
         let (mut max_eligible_checkpoint_number, epoch_id) = checkpoint_store
@@ -370,6 +372,7 @@ impl AuthorityStorePruner {
             max_eligible_checkpoint_number,
             config,
             metrics.clone(),
+            progress_tracker,
         )
         .await
     }
@@ -391,6 +394,7 @@ impl AuthorityStorePruner {
         metrics: Arc<AuthorityStorePruningMetrics>,
         archive_readers: ArchiveReaderBalancer,
         epoch_duration_ms: u64,
+        progress_tracker: Option<&Arc<CheckpointProgressTracker>>,
     ) -> anyhow::Result<()> {
         let _scope = monitored_scope("PruneCheckpointsForEligibleEpochs");
         let pruned_checkpoint_number = checkpoint_store
@@ -439,6 +443,7 @@ impl AuthorityStorePruner {
             max_eligible_checkpoint,
             config,
             metrics.clone(),
+            progress_tracker,
         )
         .await
     }
@@ -456,6 +461,7 @@ impl AuthorityStorePruner {
         max_eligible_checkpoint: CheckpointSequenceNumber,
         config: AuthorityStorePruningConfig,
         metrics: Arc<AuthorityStorePruningMetrics>,
+        progress_tracker: Option<&Arc<CheckpointProgressTracker>>,
     ) -> anyhow::Result<()> {
         let _scope = monitored_scope("PruneForEligibleEpochs");
 
@@ -468,6 +474,9 @@ impl AuthorityStorePruner {
         let mut checkpoints_to_prune = vec![];
         let mut checkpoint_content_to_prune = vec![];
         let mut effects_to_prune = vec![];
+
+        let mut pruning_start = Instant::now();
+        let mut total_checkpoints_pruned: u64 = 0;
 
         loop {
             let Some(ckpt) = checkpoint_store
@@ -502,7 +511,7 @@ impl AuthorityStorePruner {
                 .effects
                 .multi_get(content.iter().map(|tx| tx.effects))?;
 
-            info!("scheduling pruning for checkpoint {:?}", checkpoint_number);
+            debug!("scheduling pruning for checkpoint {:?}", checkpoint_number);
             checkpoints_to_prune.push(*checkpoint.digest());
             checkpoint_content_to_prune.push(content);
             effects_to_prune.extend(effects.into_iter().flatten());
@@ -510,6 +519,8 @@ impl AuthorityStorePruner {
             if effects_to_prune.len() >= config.max_transactions_in_batch
                 || checkpoints_to_prune.len() >= config.max_checkpoints_in_batch
             {
+                total_checkpoints_pruned += checkpoints_to_prune.len() as u64;
+
                 match mode {
                     PruningMode::Objects => {
                         Self::prune_objects(
@@ -532,6 +543,19 @@ impl AuthorityStorePruner {
                         metrics.clone(),
                     )?,
                 };
+
+                // Report pruning time for this batch so the progress logger
+                // shows time alongside the checkpoint deltas it reads from the
+                // DB (which are already updated at this point).
+                if let Some(tracker) = progress_tracker {
+                    let elapsed = pruning_start.elapsed();
+                    match mode {
+                        PruningMode::Objects => tracker.add_object_pruning_time(elapsed),
+                        PruningMode::Checkpoints => tracker.add_checkpoint_pruning_time(elapsed),
+                    }
+                    pruning_start = Instant::now();
+                }
+
                 checkpoints_to_prune = vec![];
                 checkpoint_content_to_prune = vec![];
                 effects_to_prune = vec![];
@@ -541,6 +565,8 @@ impl AuthorityStorePruner {
         }
 
         if !checkpoints_to_prune.is_empty() {
+            total_checkpoints_pruned += checkpoints_to_prune.len() as u64;
+
             match mode {
                 PruningMode::Objects => {
                     Self::prune_objects(
@@ -563,6 +589,16 @@ impl AuthorityStorePruner {
                     metrics.clone(),
                 )?,
             };
+        }
+
+        if total_checkpoints_pruned > 0 {
+            if let Some(tracker) = progress_tracker {
+                let elapsed = pruning_start.elapsed();
+                match mode {
+                    PruningMode::Objects => tracker.add_object_pruning_time(elapsed),
+                    PruningMode::Checkpoints => tracker.add_checkpoint_pruning_time(elapsed),
+                }
+            }
         }
         Ok(())
     }
@@ -694,6 +730,7 @@ impl AuthorityStorePruner {
         pruner_db: Option<Arc<AuthorityPrunerTables>>,
         metrics: Arc<AuthorityStorePruningMetrics>,
         archive_readers: ArchiveReaderBalancer,
+        progress_tracker: Option<Arc<CheckpointProgressTracker>>,
     ) -> Sender<()> {
         let (sender, mut recv) = tokio::sync::oneshot::channel();
         debug!(
@@ -753,12 +790,12 @@ impl AuthorityStorePruner {
             loop {
                 tokio::select! {
                     _ = objects_prune_interval.tick(), if config.num_epochs_to_retain != u64::MAX => {
-                        if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, grpc_indexes_store.as_deref(), pruner_db.as_ref(), config.clone(), metrics.clone(), epoch_duration_ms).await {
+                        if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, grpc_indexes_store.as_deref(), pruner_db.as_ref(), config.clone(), metrics.clone(), epoch_duration_ms, progress_tracker.as_ref()).await {
                             error!("Failed to prune objects: {:?}", err);
                         }
                     },
                     _ = checkpoints_prune_interval.tick(), if !matches!(config.num_epochs_to_retain_for_checkpoints(), None | Some(u64::MAX) | Some(0)) => {
-                        if let Err(err) = Self::prune_checkpoints_for_eligible_epochs(&perpetual_db, &checkpoint_store, grpc_indexes_store.as_deref(), pruner_db.as_ref(), config.clone(), metrics.clone(), archive_readers.clone(), epoch_duration_ms).await {
+                        if let Err(err) = Self::prune_checkpoints_for_eligible_epochs(&perpetual_db, &checkpoint_store, grpc_indexes_store.as_deref(), pruner_db.as_ref(), config.clone(), metrics.clone(), archive_readers.clone(), epoch_duration_ms, progress_tracker.as_ref()).await {
                             error!("Failed to prune checkpoints: {:?}", err);
                         }
                     },
@@ -787,6 +824,7 @@ impl AuthorityStorePruner {
         registry: &Registry,
         archive_readers: ArchiveReaderBalancer,
         pruner_db: Option<Arc<AuthorityPrunerTables>>,
+        progress_tracker: Option<Arc<CheckpointProgressTracker>>,
     ) -> Self {
         if pruning_config.num_epochs_to_retain > 0 && pruning_config.num_epochs_to_retain < u64::MAX
         {
@@ -812,6 +850,7 @@ impl AuthorityStorePruner {
                 pruner_db,
                 AuthorityStorePruningMetrics::new(registry),
                 archive_readers,
+                progress_tracker,
             ),
         }
     }

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -378,6 +378,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             None,
             chain_identifier,
             pruner_db,
+            None,
         )
         .await;
 

--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -20,15 +20,14 @@ use crate::{
 ///
 /// Passed as `Option<Arc<CheckpointProgressTracker>>` — callers that don't need
 /// progress reporting (CLI tools, tests) simply pass `None`.
+///
+/// All values are accumulated and reset on each logging tick.
 pub struct CheckpointProgressTracker {
-    /// Accumulated checkpoint execution time in nanoseconds (monotonically
-    /// increasing).
+    /// Accumulated checkpoint execution time in nanoseconds.
     execution_time_ns: AtomicU64,
-    /// Accumulated object pruning time in nanoseconds (monotonically
-    /// increasing).
+    /// Accumulated object pruning time in nanoseconds.
     object_pruning_time_ns: AtomicU64,
-    /// Accumulated checkpoint/effects pruning time in nanoseconds
-    /// (monotonically increasing).
+    /// Accumulated checkpoint/effects pruning time in nanoseconds.
     checkpoint_pruning_time_ns: AtomicU64,
 }
 
@@ -70,9 +69,6 @@ impl CheckpointProgressTracker {
             let mut prev_total_tx: u64 = 0;
             let mut prev_obj_pruned: u64 = 0;
             let mut prev_ckpt_pruned: u64 = 0;
-            let mut prev_exec_time_ns: u64 = 0;
-            let mut prev_obj_prune_time_ns: u64 = 0;
-            let mut prev_ckpt_prune_time_ns: u64 = 0;
 
             loop {
                 interval.tick().await;
@@ -109,52 +105,41 @@ impl CheckpointProgressTracker {
                     .flatten()
                     .unwrap_or(0);
 
-                let exec_time_ns = tracker.execution_time_ns.load(Ordering::Relaxed);
-                let object_prune_time_ns = tracker.object_pruning_time_ns.load(Ordering::Relaxed);
-                let checkpoint_prune_time_ns =
-                    tracker.checkpoint_pruning_time_ns.load(Ordering::Relaxed);
-
                 let exec_delta = highest_executed_seq_number.saturating_sub(prev_executed);
                 let tx_delta = total_tx.saturating_sub(prev_total_tx);
                 let object_prune_delta = object_pruned_seq_number.saturating_sub(prev_obj_pruned);
                 let checkpoint_prune_delta =
                     checkpoint_pruned_seq_number.saturating_sub(prev_ckpt_pruned);
 
-                if exec_delta > 0 || object_prune_delta > 0 || checkpoint_prune_delta > 0 {
-                    let exec_time_delta =
-                        Duration::from_nanos(exec_time_ns.saturating_sub(prev_exec_time_ns));
-                    let object_prune_time_delta = Duration::from_nanos(
-                        object_prune_time_ns.saturating_sub(prev_obj_prune_time_ns),
-                    );
-                    let checkpoint_prune_time_delta = Duration::from_nanos(
-                        checkpoint_prune_time_ns.saturating_sub(prev_ckpt_prune_time_ns),
-                    );
-                    info!(
-                        "checkpoint progress [epoch {}]: executed {}/{} (+{}, {} tx/s, {:.2?}), \
-                         objects pruned {} (+{}, {:.2?}), \
-                         checkpoints pruned {} (+{}, {:.2?})",
-                        epoch,
-                        highest_executed_seq_number,
-                        synced_seq_number,
-                        exec_delta,
-                        tx_delta,
-                        exec_time_delta,
-                        object_pruned_seq_number,
-                        object_prune_delta,
-                        object_prune_time_delta,
-                        checkpoint_pruned_seq_number,
-                        checkpoint_prune_delta,
-                        checkpoint_prune_time_delta,
-                    );
-                }
+                if exec_delta > 0
+                    || tx_delta > 0
+                    || object_prune_delta > 0
+                    || checkpoint_prune_delta > 0
+                {
+                    let exec_time_delta_ns = tracker.execution_time_ns.swap(0, Ordering::Relaxed);
+                    let exec_time_delta = Duration::from_nanos(exec_time_delta_ns);
 
-                prev_executed = highest_executed_seq_number;
-                prev_total_tx = total_tx;
-                prev_obj_pruned = object_pruned_seq_number;
-                prev_ckpt_pruned = checkpoint_pruned_seq_number;
-                prev_exec_time_ns = exec_time_ns;
-                prev_obj_prune_time_ns = object_prune_time_ns;
-                prev_ckpt_prune_time_ns = checkpoint_prune_time_ns;
+                    let object_prune_time_delta_ns =
+                        tracker.object_pruning_time_ns.swap(0, Ordering::Relaxed);
+                    let object_prune_time_delta = Duration::from_nanos(object_prune_time_delta_ns);
+
+                    let checkpoint_prune_time_delta_ns = tracker
+                        .checkpoint_pruning_time_ns
+                        .swap(0, Ordering::Relaxed);
+                    let checkpoint_prune_time_delta =
+                        Duration::from_nanos(checkpoint_prune_time_delta_ns);
+
+                    info!(
+                        "checkpoint progress [epoch {epoch}]: executed {highest_executed_seq_number}/{synced_seq_number} (+{exec_delta}, {tx_delta} tx/s, {exec_time_delta:.2?}), \
+                         objects pruned {object_pruned_seq_number} (+{object_prune_delta}, {object_prune_time_delta:.2?}), \
+                         checkpoints pruned {checkpoint_pruned_seq_number} (+{checkpoint_prune_delta}, {checkpoint_prune_time_delta:.2?})",
+                    );
+
+                    prev_executed = highest_executed_seq_number;
+                    prev_total_tx = total_tx;
+                    prev_obj_pruned = object_pruned_seq_number;
+                    prev_ckpt_pruned = checkpoint_pruned_seq_number;
+                }
             }
         });
     }

--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use tracing::info;
+
+use crate::{
+    authority::authority_store_tables::AuthorityPerpetualTables, checkpoints::CheckpointStore,
+};
+
+/// Shared progress tracker for checkpoint operations. Updated by the
+/// checkpoint executor and pruner, periodically logs a one-line summary.
+///
+/// Passed as `Option<Arc<CheckpointProgressTracker>>` — callers that don't need
+/// progress reporting (CLI tools, tests) simply pass `None`.
+pub struct CheckpointProgressTracker {
+    /// Accumulated checkpoint execution time in nanoseconds (monotonically
+    /// increasing).
+    execution_time_ns: AtomicU64,
+    /// Accumulated object pruning time in nanoseconds (monotonically
+    /// increasing).
+    object_pruning_time_ns: AtomicU64,
+    /// Accumulated checkpoint/effects pruning time in nanoseconds
+    /// (monotonically increasing).
+    checkpoint_pruning_time_ns: AtomicU64,
+}
+
+impl CheckpointProgressTracker {
+    pub fn new() -> Self {
+        Self {
+            execution_time_ns: AtomicU64::new(0),
+            object_pruning_time_ns: AtomicU64::new(0),
+            checkpoint_pruning_time_ns: AtomicU64::new(0),
+        }
+    }
+
+    pub fn add_execution_time(&self, duration: Duration) {
+        self.execution_time_ns
+            .fetch_add(duration.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    pub fn add_object_pruning_time(&self, duration: Duration) {
+        self.object_pruning_time_ns
+            .fetch_add(duration.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    pub fn add_checkpoint_pruning_time(&self, duration: Duration) {
+        self.checkpoint_pruning_time_ns
+            .fetch_add(duration.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    /// Spawns a periodic logging task that prints a one-line checkpoint
+    /// progress summary every second (only when there is actual progress).
+    pub fn spawn_logging_task(
+        self: &Arc<Self>,
+        checkpoint_store: Arc<CheckpointStore>,
+        perpetual_db: Arc<AuthorityPerpetualTables>,
+    ) {
+        let tracker = self.clone();
+        tokio::task::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(1));
+            let mut prev_executed: u64 = 0;
+            let mut prev_total_tx: u64 = 0;
+            let mut prev_obj_pruned: u64 = 0;
+            let mut prev_ckpt_pruned: u64 = 0;
+            let mut prev_exec_time_ns: u64 = 0;
+            let mut prev_obj_prune_time_ns: u64 = 0;
+            let mut prev_ckpt_prune_time_ns: u64 = 0;
+
+            loop {
+                interval.tick().await;
+
+                let highest_executed_checkpoint = checkpoint_store
+                    .get_highest_executed_checkpoint()
+                    .ok()
+                    .flatten();
+                let epoch = highest_executed_checkpoint
+                    .as_ref()
+                    .map(|c| c.epoch())
+                    .unwrap_or(0);
+                let highest_executed_seq_number = highest_executed_checkpoint
+                    .as_ref()
+                    .map(|c| *c.sequence_number())
+                    .unwrap_or(0);
+                let total_tx = highest_executed_checkpoint
+                    .as_ref()
+                    .map(|c| c.network_total_transactions)
+                    .unwrap_or(0);
+                let synced_seq_number = checkpoint_store
+                    .get_highest_synced_checkpoint_seq_number()
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0);
+                let object_pruned_seq_number = perpetual_db
+                    .get_highest_pruned_checkpoint()
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0);
+                let checkpoint_pruned_seq_number = checkpoint_store
+                    .get_highest_pruned_checkpoint_seq_number()
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0);
+
+                let exec_time_ns = tracker.execution_time_ns.load(Ordering::Relaxed);
+                let object_prune_time_ns = tracker.object_pruning_time_ns.load(Ordering::Relaxed);
+                let checkpoint_prune_time_ns =
+                    tracker.checkpoint_pruning_time_ns.load(Ordering::Relaxed);
+
+                let exec_delta = highest_executed_seq_number.saturating_sub(prev_executed);
+                let tx_delta = total_tx.saturating_sub(prev_total_tx);
+                let object_prune_delta = object_pruned_seq_number.saturating_sub(prev_obj_pruned);
+                let checkpoint_prune_delta =
+                    checkpoint_pruned_seq_number.saturating_sub(prev_ckpt_pruned);
+
+                if exec_delta > 0 || object_prune_delta > 0 || checkpoint_prune_delta > 0 {
+                    let exec_time_delta =
+                        Duration::from_nanos(exec_time_ns.saturating_sub(prev_exec_time_ns));
+                    let object_prune_time_delta = Duration::from_nanos(
+                        object_prune_time_ns.saturating_sub(prev_obj_prune_time_ns),
+                    );
+                    let checkpoint_prune_time_delta = Duration::from_nanos(
+                        checkpoint_prune_time_ns.saturating_sub(prev_ckpt_prune_time_ns),
+                    );
+                    info!(
+                        "checkpoint progress [epoch {}]: executed {}/{} (+{}, {} tx/s, {:.2?}), \
+                         objects pruned {} (+{}, {:.2?}), \
+                         checkpoints pruned {} (+{}, {:.2?})",
+                        epoch,
+                        highest_executed_seq_number,
+                        synced_seq_number,
+                        exec_delta,
+                        tx_delta,
+                        exec_time_delta,
+                        object_pruned_seq_number,
+                        object_prune_delta,
+                        object_prune_time_delta,
+                        checkpoint_pruned_seq_number,
+                        checkpoint_prune_delta,
+                        checkpoint_prune_time_delta,
+                    );
+                }
+
+                prev_executed = highest_executed_seq_number;
+                prev_total_tx = total_tx;
+                prev_obj_pruned = object_pruned_seq_number;
+                prev_ckpt_pruned = checkpoint_pruned_seq_number;
+                prev_exec_time_ns = exec_time_ns;
+                prev_obj_prune_time_ns = object_prune_time_ns;
+                prev_ckpt_prune_time_ns = checkpoint_prune_time_ns;
+            }
+        });
+    }
+}
+
+impl Default for CheckpointProgressTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -47,6 +47,7 @@ use crate::{
         AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore,
         backpressure::BackpressureManager,
     },
+    checkpoint_progress_tracker::CheckpointProgressTracker,
     checkpoints::CheckpointStore,
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
     global_state_hasher::GlobalStateHasher,
@@ -65,8 +66,6 @@ use metrics::CheckpointExecutorMetrics;
 use utils::*;
 
 type CheckpointDataSender = Box<dyn Fn(&CheckpointData) + Send + Sync>;
-
-const CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL: u64 = 5000;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum StopReason {
@@ -132,6 +131,7 @@ pub struct CheckpointExecutor {
     config: CheckpointExecutorConfig,
     metrics: Arc<CheckpointExecutorMetrics>,
     tps_estimator: Mutex<TPSEstimator>,
+    checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
     data_sender: Option<CheckpointDataSender>,
 }
 
@@ -145,6 +145,7 @@ impl CheckpointExecutor {
         config: CheckpointExecutorConfig,
         metrics: Arc<CheckpointExecutorMetrics>,
         data_sender: Option<CheckpointDataSender>,
+        checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
     ) -> Self {
         Self {
             epoch_store,
@@ -158,6 +159,7 @@ impl CheckpointExecutor {
             config,
             metrics,
             tps_estimator: Mutex::new(TPSEstimator::default()),
+            checkpoint_progress_tracker,
             data_sender,
         }
     }
@@ -177,6 +179,7 @@ impl CheckpointExecutor {
             Default::default(),
             CheckpointExecutorMetrics::new_for_tests(),
             None, // No callback for data
+            None, // No progress tracker for tests
         )
     }
 
@@ -287,13 +290,13 @@ impl CheckpointExecutor {
 impl CheckpointExecutor {
     /// Load all data for a checkpoint, ensure all transactions are executed,
     /// and check for forks.
-    #[instrument(level = "info", skip_all, fields(seq = ?checkpoint.sequence_number()))]
+    #[instrument(level = "debug", skip_all, fields(seq = ?checkpoint.sequence_number()))]
     async fn execute_checkpoint(
         self: Arc<Self>,
         checkpoint: VerifiedCheckpoint,
         mut pipeline_handle: PipelineHandle,
     ) -> bool /* is final checkpoint */ {
-        info!("executing checkpoint");
+        debug!("executing checkpoint");
         let sequence_number = checkpoint.sequence_number;
 
         checkpoint.report_checkpoint_age(&self.metrics.checkpoint_contents_age);
@@ -317,6 +320,7 @@ impl CheckpointExecutor {
 
         // Note: only `execute_transactions_from_synced_checkpoint` has end-of-epoch
         // logic.
+        let exec_start = Instant::now();
         let ckpt_state = if self.state.is_fullnode(&self.epoch_store)
             || checkpoint.is_last_checkpoint_of_epoch()
         {
@@ -448,6 +452,10 @@ impl CheckpointExecutor {
         self.broadcast_checkpoint(&ckpt_state.data, ckpt_state.full_data.as_ref());
 
         finish_stage!(pipeline_handle, BumpHighestExecutedCheckpoint);
+
+        if let Some(tracker) = &self.checkpoint_progress_tracker {
+            tracker.add_execution_time(exec_start.elapsed());
+        }
 
         // Important: code after the last pipeline stage is finished can run out of
         // checkpoint order.
@@ -908,10 +916,6 @@ impl CheckpointExecutor {
         } else {
             assert_eq!(seq, 0);
         }
-        if seq.is_multiple_of(CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL) {
-            info!("Finished syncing and executing checkpoint {}", seq);
-        }
-
         fail_point!("highest-executed-checkpoint");
 
         // We store a fixed number of additional FullCheckpointContents after execution

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/utils.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/utils.rs
@@ -16,7 +16,7 @@ use iota_types::{
 };
 use strum::VariantNames;
 use tokio::sync::watch;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, instrument, warn};
 
 use super::metrics::CheckpointExecutorMetrics;
 use crate::{checkpoints::CheckpointStore, execution_cache::TransactionCacheRead};
@@ -60,7 +60,7 @@ pub(super) fn stream_synced_checkpoints(
                     state.panic_timeout,
                 )
                 .await;
-                info!(
+                debug!(
                     "received synced checkpoint: {:?}",
                     checkpoint.sequence_number
                 );

--- a/crates/iota-core/src/db_checkpoint_handler.rs
+++ b/crates/iota-core/src/db_checkpoint_handler.rs
@@ -26,6 +26,7 @@ use crate::{
         },
         authority_store_tables::AuthorityPerpetualTables,
     },
+    checkpoint_progress_tracker::CheckpointProgressTracker,
     checkpoints::CheckpointStore,
     grpc_indexes::{GRPC_INDEXES_DIR, GrpcIndexesStore},
 };
@@ -80,6 +81,7 @@ pub struct DBCheckpointHandler {
     /// Pruning objects
     pruning_config: AuthorityStorePruningConfig,
     metrics: Arc<DBCheckpointMetrics>,
+    checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
 }
 
 impl DBCheckpointHandler {
@@ -91,6 +93,7 @@ impl DBCheckpointHandler {
         pruning_config: AuthorityStorePruningConfig,
         registry: &Registry,
         state_snapshot_enabled: bool,
+        checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
     ) -> Result<Arc<Self>> {
         let input_store_config = ObjectStoreConfig {
             object_store: Some(ObjectStoreType::File),
@@ -112,6 +115,7 @@ impl DBCheckpointHandler {
             state_snapshot_enabled,
             pruning_config,
             metrics: DBCheckpointMetrics::new(registry),
+            checkpoint_progress_tracker,
         }))
     }
     pub fn new_for_test(
@@ -136,6 +140,7 @@ impl DBCheckpointHandler {
             state_snapshot_enabled,
             pruning_config: AuthorityStorePruningConfig::default(),
             metrics: DBCheckpointMetrics::new(&Registry::default()),
+            checkpoint_progress_tracker: None,
         }))
     }
 
@@ -290,6 +295,7 @@ impl DBCheckpointHandler {
             self.pruning_config.clone(),
             metrics,
             epoch_duration_ms,
+            self.checkpoint_progress_tracker.as_ref(),
         )
         .await?;
         info!(

--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod authority;
 pub mod authority_aggregator;
 pub mod authority_client;
 pub mod authority_server;
+pub mod checkpoint_progress_tracker;
 pub mod checkpoints;
 pub mod congestion_tracker;
 pub mod connection_monitor;

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -143,6 +143,10 @@ impl Handle {
     }
 }
 
+/// Minimum interval between batched log messages for pruned checkpoint sync
+/// failures, to avoid flooding the log when many tasks fail simultaneously.
+const PRUNED_SYNC_LOG_INTERVAL: Duration = Duration::from_secs(30);
+
 struct PeerHeights {
     /// Table used to track the highest checkpoint for each of our peers.
     peers: HashMap<PeerId, PeerStateSyncInfo>,
@@ -378,6 +382,28 @@ enum StateSyncMessage {
     // it was able to successfully sync a checkpoint's contents. If multiple checkpoints were
     // synced at the same time, only the highest checkpoint is sent.
     SyncedCheckpoint(Box<VerifiedCheckpoint>),
+}
+
+/// Reason a checkpoint content sync failed.
+enum ContentSyncError {
+    /// The checkpoint is below all peers' pruning watermark.
+    /// No peer will ever serve this content; it must come from archive.
+    PrunedOnAllPeers {
+        checkpoint: VerifiedCheckpoint,
+        lowest_peer_watermark: CheckpointSequenceNumber,
+        connected_peers: usize,
+        known_peers: usize,
+    },
+    /// A transient failure: network error, timeout, or no peers currently
+    /// connected. Retrying may succeed.
+    Transient {
+        checkpoint: VerifiedCheckpoint,
+        /// Lowest pruning watermark across connected peers, if any are
+        /// connected.
+        lowest_peer_watermark: Option<CheckpointSequenceNumber>,
+        connected_peers: usize,
+        known_peers: usize,
+    },
 }
 
 struct StateSyncEventLoop<S> {
@@ -1298,6 +1324,13 @@ async fn sync_checkpoint_contents<S>(
 
     let mut tx_concurrency_remaining = checkpoint_content_download_tx_concurrency;
 
+    // Batched logging state for pruned checkpoint failures.
+    // (lowest_failed_seq, highest_failed_seq) range of checkpoint sequence
+    // numbers that failed due to pruning since the last log flush.
+    let mut pruned_failure_range: Option<(CheckpointSequenceNumber, CheckpointSequenceNumber)> =
+        None;
+    let mut last_pruned_log_time = tokio::time::Instant::now();
+
     loop {
         tokio::select! {
             result = target_sequence_channel.changed() => {
@@ -1325,25 +1358,84 @@ async fn sync_checkpoint_contents<S>(
                         highest_synced = checkpoint;
 
                     }
-                    Err(checkpoint) => {
-                        let _: &VerifiedCheckpoint = &checkpoint;  // type hint
-                        if let Some(lowest_peer_checkpoint) =
-                            peer_heights.read().ok().and_then(|x| x.peers.values().map(|state_sync_info| state_sync_info.lowest).min()) {
-                            if checkpoint.sequence_number() >= &lowest_peer_checkpoint {
-                                info!("unable to sync contents of checkpoint through state sync {} with lowest peer checkpoint: {}", checkpoint.sequence_number(), lowest_peer_checkpoint);
-                            }
-                        } else {
-                            info!("unable to sync contents of checkpoint through state sync {}", checkpoint.sequence_number());
+                    Err(error) => {
+                        match error {
+                            ContentSyncError::PrunedOnAllPeers {
+                                checkpoint,
+                                lowest_peer_watermark,
+                                connected_peers,
+                                known_peers,
+                            } => {
+                                // Accumulate for batched logging.
+                                let seq = *checkpoint.sequence_number();
+                                // Expand the (min_seq, max_seq) range of failed
+                                // checkpoint sequence numbers seen since the last
+                                // log flush, or initialize it with this sequence.
+                                pruned_failure_range = Some(match pruned_failure_range {
+                                    Some((lo, hi)) => (lo.min(seq), hi.max(seq)),
+                                    None => (seq, seq),
+                                });
 
+                                // Log at most once every 30 seconds.
+                                if last_pruned_log_time.elapsed() >= PRUNED_SYNC_LOG_INTERVAL {
+                                    if let Some((lo, hi)) = pruned_failure_range {
+                                        warn!(
+                                            "Unable to sync checkpoint contents ({lo}..={hi}) via peers: \
+                                             all connected peers ({connected_peers}/{known_peers}) \
+                                             have pruned below watermark {lowest_peer_watermark}. \
+                                             Waiting for archive sync to advance highest_synced.",
+                                        );
+                                    }
+                                    pruned_failure_range = None;
+                                    last_pruned_log_time = tokio::time::Instant::now();
+                                }
+
+                                // Push to back (not front) — don't block progress.
+                                // On the next cycle the early-exit check picks up
+                                // any archive progress.
+                                checkpoint_contents_tasks.push_back(
+                                    sync_one_checkpoint_contents(
+                                        network.clone(),
+                                        &store,
+                                        peer_heights.clone(),
+                                        timeout,
+                                        checkpoint,
+                                    ),
+                                );
+                            }
+                            ContentSyncError::Transient {
+                                checkpoint,
+                                lowest_peer_watermark,
+                                connected_peers,
+                                known_peers,
+                            } => {
+                                if let Some(watermark) = lowest_peer_watermark {
+                                    info!(
+                                        "unable to sync contents of checkpoint {} via peers \
+                                         (transient failure, {connected_peers}/{known_peers} peers connected, \
+                                         lowest peer watermark: {watermark})",
+                                        checkpoint.sequence_number(),
+                                    );
+                                } else {
+                                    info!(
+                                        "unable to sync contents of checkpoint {} via peers \
+                                         (transient failure, {connected_peers}/{known_peers} peers connected)",
+                                        checkpoint.sequence_number(),
+                                    );
+                                }
+                                // Retry at front — transient errors may succeed
+                                // on the next attempt.
+                                checkpoint_contents_tasks.push_front(
+                                    sync_one_checkpoint_contents(
+                                        network.clone(),
+                                        &store,
+                                        peer_heights.clone(),
+                                        timeout,
+                                        checkpoint,
+                                    ),
+                                );
+                            }
                         }
-                        // Retry contents sync on failure.
-                        checkpoint_contents_tasks.push_front(sync_one_checkpoint_contents(
-                            network.clone(),
-                            &store,
-                            peer_heights.clone(),
-                            timeout,
-                            checkpoint,
-                        ));
                     }
                 }
             },
@@ -1402,14 +1494,15 @@ async fn sync_one_checkpoint_contents<S>(
     peer_heights: Arc<RwLock<PeerHeights>>,
     timeout: Duration,
     checkpoint: VerifiedCheckpoint,
-) -> Result<VerifiedCheckpoint, VerifiedCheckpoint>
+) -> Result<VerifiedCheckpoint, ContentSyncError>
 where
     S: WriteStore + Clone,
 {
     debug!("syncing checkpoint contents");
 
-    // Check if we already have produced this checkpoint locally. If so, we don't
-    // need to get it from peers anymore.
+    // Check if we already have produced this checkpoint locally (e.g. via
+    // consensus output or archive sync). If so, we don't need to get it from
+    // peers anymore.
     if store
         .try_get_highest_synced_checkpoint()
         .expect("store operation should not fail")
@@ -1418,6 +1511,42 @@ where
     {
         debug!("checkpoint was already created via consensus output");
         return Ok(checkpoint);
+    }
+
+    // Gather peer state: count known/connected peers and check pruning watermark.
+    let (known_peers, connected_peers, lowest_peer_watermark, is_pruned) = {
+        let guard = peer_heights.read().unwrap();
+        let known = guard.peers_on_same_chain().count();
+        let connected_peers_lowest: Vec<CheckpointSequenceNumber> = guard
+            .peers_on_same_chain()
+            .filter(|(peer_id, _)| network.peer(**peer_id).is_some())
+            .map(|(_, info)| info.lowest)
+            .collect();
+        let connected = connected_peers_lowest.len();
+        let lowest = connected_peers_lowest.into_iter().min();
+        // If the checkpoint we need is below the lowest watermark of all
+        // connected peers, no peer can serve it — only archive can.
+        let pruned = lowest.is_some_and(|l| *checkpoint.sequence_number() < l);
+        (known, connected, lowest, pruned)
+    };
+
+    if is_pruned {
+        // Sleep to avoid hammer the network with retries, but don't log — the outer
+        // loop batches these.
+        let duration = peer_heights
+            .read()
+            .unwrap()
+            .wait_interval_when_no_peer_to_sync_content();
+        tokio::time::sleep(duration).await;
+
+        return Err(ContentSyncError::PrunedOnAllPeers {
+            checkpoint,
+            // Safe to unwrap: is_pruned is only true when lowest_peer_watermark
+            // is Some.
+            lowest_peer_watermark: lowest_peer_watermark.unwrap(),
+            connected_peers,
+            known_peers,
+        });
     }
 
     // Request checkpoint contents from peers.
@@ -1438,10 +1567,15 @@ where
             .wait_interval_when_no_peer_to_sync_content();
         if now.elapsed() < duration {
             let duration = duration - now.elapsed();
-            info!("retrying checkpoint sync after {:?}", duration);
+            debug!("retrying checkpoint sync after {:?}", duration);
             tokio::time::sleep(duration).await;
         }
-        return Err(checkpoint);
+        return Err(ContentSyncError::Transient {
+            checkpoint,
+            lowest_peer_watermark,
+            connected_peers,
+            known_peers,
+        });
     };
     debug!("completed checkpoint contents sync");
     Ok(checkpoint)

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -46,6 +46,7 @@ use iota_core::{
     },
     authority_client::NetworkAuthorityClient,
     authority_server::{ValidatorService, ValidatorServiceMetrics},
+    checkpoint_progress_tracker::CheckpointProgressTracker,
     checkpoints::{
         CheckpointMetrics, CheckpointService, CheckpointStore, SendCheckpointToStateSync,
         SubmitCheckpointToConsensus,
@@ -233,6 +234,8 @@ pub struct IotaNode {
 
     backpressure_manager: Arc<BackpressureManager>,
 
+    checkpoint_progress_tracker: Arc<CheckpointProgressTracker>,
+
     _db_checkpoint_handle: Option<tokio::sync::broadcast::Sender<()>>,
 
     #[cfg(msim)]
@@ -385,6 +388,7 @@ impl IotaNode {
         let backpressure_manager =
             BackpressureManager::new_from_checkpoint_store(&checkpoint_store);
 
+        let perpetual_tables_for_progress = perpetual_tables.clone();
         let store = AuthorityStore::open(
             perpetual_tables,
             &genesis,
@@ -570,12 +574,15 @@ impl IotaNode {
         let state_snapshot_handle =
             Self::start_state_snapshot(&config, &prometheus_registry, checkpoint_store.clone())?;
 
+        let checkpoint_progress_tracker = Arc::new(CheckpointProgressTracker::new());
+
         // Start uploading db checkpoints to remote store
         info!("start db checkpoint");
         let (db_checkpoint_config, db_checkpoint_handle) = Self::start_db_checkpoint(
             &config,
             &prometheus_registry,
             state_snapshot_handle.is_some(),
+            Some(checkpoint_progress_tracker.clone()),
         )?;
 
         let mut genesis_objects = genesis.objects().to_vec();
@@ -613,6 +620,7 @@ impl IotaNode {
             validator_tx_finalizer,
             chain_identifier,
             pruner_db,
+            Some(checkpoint_progress_tracker.clone()),
         )
         .await;
 
@@ -789,6 +797,7 @@ impl IotaNode {
             connection_monitor_status,
             trusted_peer_change_tx,
             backpressure_manager,
+            checkpoint_progress_tracker: checkpoint_progress_tracker.clone(),
 
             _db_checkpoint_handle: db_checkpoint_handle,
 
@@ -813,6 +822,9 @@ impl IotaNode {
                 warn!("Reconfiguration finished with error {:?}", error);
             }
         });
+
+        node.checkpoint_progress_tracker
+            .spawn_logging_task(node.checkpoint_store.clone(), perpetual_tables_for_progress);
 
         Ok(node)
     }
@@ -920,6 +932,7 @@ impl IotaNode {
         config: &NodeConfig,
         prometheus_registry: &Registry,
         state_snapshot_enabled: bool,
+        checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
     ) -> Result<(
         DBCheckpointConfig,
         Option<tokio::sync::broadcast::Sender<()>>,
@@ -967,6 +980,7 @@ impl IotaNode {
                     config.authority_store_pruning_config.clone(),
                     prometheus_registry,
                     state_snapshot_enabled,
+                    checkpoint_progress_tracker,
                 )?;
                 Ok((
                     db_checkpoint_config,
@@ -1626,6 +1640,7 @@ impl IotaNode {
                 self.config.checkpoint_executor_config.clone(),
                 checkpoint_executor_metrics.clone(),
                 data_sender,
+                Some(self.checkpoint_progress_tracker.clone()),
             );
 
             let run_with_range = self.config.run_with_range;

--- a/crates/iota-tool/src/db_tool/db_dump.rs
+++ b/crates/iota-tool/src/db_tool/db_dump.rs
@@ -231,6 +231,7 @@ pub async fn prune_objects(db_path: PathBuf) -> anyhow::Result<()> {
         pruning_config,
         metrics,
         EPOCH_DURATION_MS_FOR_TESTING,
+        None,
     )
     .await?;
     Ok(())
@@ -257,6 +258,7 @@ pub async fn prune_checkpoints(db_path: PathBuf) -> anyhow::Result<()> {
         metrics,
         archive_readers,
         EPOCH_DURATION_MS_FOR_TESTING,
+        None,
     )
     .await?;
     Ok(())


### PR DESCRIPTION
# Description of change

This PR massively reduces the log spamming in the `iota-node` on `"info"` level.
It introduces a periodic status message that is printed every second, that reports about progress of synced and pruned checkpoints, instead of prints per every single received, executed and pruned checkpoint.

It also removes the log spam if peers don't have the range of checkpoints we want to sync, which was repeatedly 400 lines every 10s.

The `lowest` available checkpoint is now calculated based on the information from the connected peers on the same chain. Before it was based on all connected peers, which was wrong.

We reduced the log level from `info` to `debug` for `"scheduling pruning for checkpoint"`, `"executing checkpoint"` and `"received synced checkpoint"`. The Log message `"Finished syncing and executing checkpoint"` was removed and replace by the `CheckpointProgressTracker` message.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Added periodic checkpoint progress status message and reduced log spam
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
