### PR TITLE
feat(network): improve state sync peer registration and tracking

### DIFF
--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -223,6 +223,15 @@ fn build_anemo_services(out_dir: &Path) {
                 .codec_path(codec_path)
                 .build(),
         )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("push_state_sync_handshake")
+                .route_name("PushStateSyncHandshake")
+                .request_type("crate::state_sync::StateSyncHandshake")
+                .response_type("()")
+                .codec_path(codec_path)
+                .build(),
+        )
         .build();
 
     let randomness = anemo_build::manual::Service::builder()

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -225,10 +225,10 @@ fn build_anemo_services(out_dir: &Path) {
         )
         .method(
             anemo_build::manual::Method::builder()
-                .name("push_state_sync_handshake")
-                .route_name("PushStateSyncHandshake")
+                .name("exchange_state_sync_handshake")
+                .route_name("ExchangeStateSyncHandshake")
                 .request_type("crate::state_sync::StateSyncHandshake")
-                .response_type("()")
+                .response_type("crate::state_sync::StateSyncHandshake")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/crates/iota-network/src/state_sync/builder.rs
+++ b/crates/iota-network/src/state_sync/builder.rs
@@ -151,10 +151,17 @@ where
         .pipe(RwLock::new)
         .pipe(Arc::new);
 
+        let genesis_checkpoint = Arc::new(
+            store
+                .get_checkpoint_by_sequence_number(0)
+                .expect("store should contain genesis checkpoint before building state sync"),
+        );
+
         let server = Server {
             store: store.clone(),
             peer_heights: peer_heights.clone(),
             sender: weak_sender,
+            genesis_checkpoint: genesis_checkpoint.clone(),
         };
 
         (
@@ -168,6 +175,7 @@ where
                 checkpoint_event_sender,
                 metrics,
                 archive_readers,
+                genesis_checkpoint,
             },
             server,
         )
@@ -184,6 +192,8 @@ pub struct UnstartedStateSync<S> {
     pub(super) checkpoint_event_sender: broadcast::Sender<VerifiedCheckpoint>,
     pub(super) metrics: Metrics,
     pub(super) archive_readers: ArchiveReaderBalancer,
+    /// Cached genesis checkpoint, shared with the RPC server.
+    pub(super) genesis_checkpoint: Arc<VerifiedCheckpoint>,
 }
 
 impl<S> UnstartedStateSync<S>
@@ -201,6 +211,7 @@ where
             checkpoint_event_sender,
             metrics,
             archive_readers,
+            genesis_checkpoint,
         } = self;
 
         (
@@ -219,6 +230,7 @@ where
                 metrics,
                 archive_readers,
                 sync_checkpoint_from_archive_task: None,
+                genesis_checkpoint,
             },
             handle,
         )

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -892,74 +892,106 @@ async fn get_latest_from_peer(
     let peer_id = peer.peer_id();
     let mut client = StateSyncClient::new(peer);
 
-    let info = {
-        let maybe_info = peer_heights.read().unwrap().peers.get(&peer_id).copied();
+    // If we already know this peer, just refresh its latest info.
+    let existing_info = peer_heights.read().unwrap().peers.get(&peer_id).copied();
+    if let Some(existing_info) = existing_info {
+        if !existing_info.on_same_chain_as_us {
+            // We already know this peer is not on the same chain as us, no need to query
+            // further.
+            return;
+        }
 
-        if let Some(info) = maybe_info {
-            info
-        } else {
-            // TODO do we want to create a new API just for querying a node's chainid?
-            //
-            // We need to query this node's genesis checkpoint to see if they're on the same
-            // chain as us
-            let request = Request::new(GetCheckpointSummaryRequest::BySequenceNumber(0))
-                .with_timeout(timeout);
-            let response = client
-                .get_checkpoint_summary(request)
-                .await
-                .map(Response::into_inner);
+        // Refresh height and lowest watermark.
+        if let Some((highest_checkpoint, low_watermark)) =
+            query_peer_for_latest_info(&mut client, timeout).await
+        {
+            peer_heights.write().unwrap().update_peer_info(
+                peer_id,
+                highest_checkpoint,
+                Some(low_watermark),
+            );
+        };
 
-            let info = match response {
-                Ok(Some(checkpoint)) => {
-                    let digest = *checkpoint.digest();
-                    PeerStateSyncInfo {
-                        genesis_checkpoint_digest: digest,
-                        on_same_chain_as_us: our_genesis_checkpoint_digest == digest,
-                        height: *checkpoint.sequence_number(),
-                        lowest: CheckpointSequenceNumber::default(),
-                    }
-                }
-                Ok(None) => PeerStateSyncInfo {
+        return;
+    }
+
+    // New peer — query genesis checkpoint to determine chain identity.
+    let response = client
+        .get_checkpoint_summary(
+            Request::new(GetCheckpointSummaryRequest::BySequenceNumber(0)).with_timeout(timeout),
+        )
+        .await
+        .map(Response::into_inner);
+
+    let peer_genesis_checkpoint_digest = match response {
+        Ok(Some(checkpoint)) => *checkpoint.digest(),
+        Ok(None) => {
+            // Peer doesn't have checkpoint 0 (likely pruned). We can't
+            // determine chain identity — insert as not-on-same-chain so
+            // we don't re-query genesis on every connection event.
+            peer_heights.write().unwrap().insert_peer_info(
+                peer_id,
+                PeerStateSyncInfo {
                     genesis_checkpoint_digest: CheckpointDigest::default(),
                     on_same_chain_as_us: false,
                     height: CheckpointSequenceNumber::default(),
                     lowest: CheckpointSequenceNumber::default(),
                 },
-                Err(status) => {
-                    trace!("get_latest_checkpoint_summary request failed: {status:?}");
-                    return;
-                }
-            };
-            peer_heights
-                .write()
-                .unwrap()
-                .insert_peer_info(peer_id, info);
-            info
+            );
+            trace!("peer {peer_id} returned None for genesis checkpoint, marking as unknown chain");
+            return;
+        }
+        Err(status) => {
+            trace!(
+                "peer {peer_id} get_latest_checkpoint_summary request for genesis checkpoint failed: {status:?}"
+            );
+            return;
         }
     };
 
-    // Bail early if this node isn't on the same chain as us
-    if !info.on_same_chain_as_us {
-        trace!(?info, "Peer {peer_id} not on same chain as us");
+    if our_genesis_checkpoint_digest != peer_genesis_checkpoint_digest {
+        // Not on our chain — insert as not-on-same-chain so we don't re-query genesis
+        // on every connection event.
+        peer_heights.write().unwrap().insert_peer_info(
+            peer_id,
+            PeerStateSyncInfo {
+                genesis_checkpoint_digest: peer_genesis_checkpoint_digest,
+                on_same_chain_as_us: false,
+                height: CheckpointSequenceNumber::default(),
+                lowest: CheckpointSequenceNumber::default(),
+            },
+        );
         return;
     }
-    let Some((highest_checkpoint, low_watermark)) =
+
+    // Peer is on our chain. Query availability to get the correct lowest
+    // watermark, then insert with complete info in a single step.
+    // Note: there is an inherent race here — a push_checkpoint_summary from
+    // this peer may arrive before we finish this query and register the peer.
+    // The 5-second event loop tick recovers from any missed pushes. A proper
+    // fix would be a handshake protocol where both sides exchange chain_id,
+    // lowest, and highest on connect.
+    if let Some((highest_checkpoint, low_watermark)) =
         query_peer_for_latest_info(&mut client, timeout).await
-    else {
-        return;
-    };
-    peer_heights
-        .write()
-        .unwrap()
-        .update_peer_info(peer_id, highest_checkpoint, low_watermark);
+    {
+        peer_heights.write().unwrap().insert_peer_info(
+            peer_id,
+            PeerStateSyncInfo {
+                genesis_checkpoint_digest: peer_genesis_checkpoint_digest,
+                on_same_chain_as_us: true,
+                height: *highest_checkpoint.sequence_number(),
+                lowest: low_watermark,
+            },
+        );
+    }
 }
 
-/// Queries a peer for their highest_synced_checkpoint and low checkpoint
-/// watermark
+/// Queries a peer for their highest_synced_checkpoint and lowest available
+/// checkpoint watermark.
 async fn query_peer_for_latest_info(
     client: &mut StateSyncClient<anemo::Peer>,
     timeout: Duration,
-) -> Option<(Checkpoint, Option<CheckpointSequenceNumber>)> {
+) -> Option<(Checkpoint, CheckpointSequenceNumber)> {
     let request = Request::new(()).with_timeout(timeout);
     let response = client
         .get_checkpoint_availability(request)
@@ -969,30 +1001,9 @@ async fn query_peer_for_latest_info(
         Ok(GetCheckpointAvailabilityResponse {
             highest_synced_checkpoint,
             lowest_available_checkpoint,
-        }) => {
-            return Some((highest_synced_checkpoint, Some(lowest_available_checkpoint)));
-        }
+        }) => Some((highest_synced_checkpoint, lowest_available_checkpoint)),
         Err(status) => {
-            // If peer hasn't upgraded they would return 404 NotFound error
-            if status.status() != anemo::types::response::StatusCode::NotFound {
-                trace!("get_checkpoint_availability request failed: {status:?}");
-                return None;
-            }
-        }
-    };
-
-    // Then we try the old query
-    // TODO: Remove this once the new feature stabilizes
-    let request = Request::new(GetCheckpointSummaryRequest::Latest).with_timeout(timeout);
-    let response = client
-        .get_checkpoint_summary(request)
-        .await
-        .map(Response::into_inner);
-    match response {
-        Ok(Some(checkpoint)) => Some((checkpoint, None)),
-        Ok(None) => None,
-        Err(status) => {
-            trace!("get_checkpoint_summary (latest) request failed: {status:?}");
+            trace!("get_checkpoint_availability request failed: {status:?}");
             None
         }
     }
@@ -1026,7 +1037,7 @@ async fn query_peers_for_their_latest_checkpoint(
                     Some((highest_checkpoint, low_watermark)) => peer_heights
                         .write()
                         .unwrap()
-                        .update_peer_info(peer_id, highest_checkpoint.clone(), low_watermark)
+                        .update_peer_info(peer_id, highest_checkpoint.clone(), Some(low_watermark))
                         .then_some(highest_checkpoint),
                     None => None,
                 }

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -104,7 +104,9 @@ pub use generated::{
 };
 use iota_archival::reader::ArchiveReaderBalancer;
 use iota_storage::verify_checkpoint;
-pub use server::{GetCheckpointAvailabilityResponse, GetCheckpointSummaryRequest};
+pub use server::{
+    GetCheckpointAvailabilityResponse, GetCheckpointSummaryRequest, StateSyncHandshake,
+};
 
 use self::{metrics::Metrics, server::CheckpointContentsDownloadLimitLayer};
 
@@ -232,6 +234,7 @@ impl PeerHeights {
                 let entry = entry.get_mut();
                 if entry.genesis_checkpoint_digest == info.genesis_checkpoint_digest {
                     entry.height = std::cmp::max(entry.height, info.height);
+                    entry.lowest = info.lowest;
                 } else {
                     *entry = info;
                 }
@@ -394,6 +397,10 @@ enum StateSyncMessage {
     // it was able to successfully sync a checkpoint's contents. If multiple checkpoints were
     // synced at the same time, only the highest checkpoint is sent.
     SyncedCheckpoint(Box<VerifiedCheckpoint>),
+    // A new same-chain peer was registered (e.g. via handshake). The event
+    // loop should push our latest checkpoint to this peer in case we are
+    // ahead, and start syncing from them if they are ahead of us.
+    NewSameChainPeerRegistered(PeerId),
 }
 
 /// Reason a checkpoint content sync failed.
@@ -439,6 +446,8 @@ struct StateSyncEventLoop<S> {
 
     archive_readers: ArchiveReaderBalancer,
     sync_checkpoint_from_archive_task: Option<AbortHandle>,
+    /// Cached genesis checkpoint, shared with the RPC server.
+    genesis_checkpoint: Arc<VerifiedCheckpoint>,
 }
 
 impl<S> StateSyncEventLoop<S>
@@ -459,6 +468,9 @@ where
         let mut peer_events = {
             let (subscriber, peers) = self.network.subscribe().unwrap();
             for peer_id in peers {
+                self.send_handshake_to_peer(peer_id);
+                // TODO: remove get_latest_from_peer once all nodes support
+                // handshake — it's kept as a fallback for old peers.
                 self.spawn_get_latest_from_peer(peer_id);
             }
             subscriber
@@ -582,6 +594,17 @@ where
             // After we've successfully synced a checkpoint we can notify our peers
             StateSyncMessage::SyncedCheckpoint(checkpoint) => {
                 self.spawn_notify_peers_of_checkpoint(*checkpoint)
+            }
+            // A new same-chain peer registered — push our latest checkpoint
+            // in case we are ahead of them (they may have missed an earlier
+            // push that arrived before they were registered).
+            StateSyncMessage::NewSameChainPeerRegistered(peer_id) => {
+                let checkpoint = self
+                    .store
+                    .try_get_highest_synced_checkpoint()
+                    .expect("store operation should not fail");
+                self.spawn_push_checkpoint_to_peer(peer_id, checkpoint);
+                self.maybe_start_checkpoint_summary_sync_task();
             }
         }
     }
@@ -708,6 +731,9 @@ where
 
         match peer_event {
             Ok(PeerEvent::NewPeer(peer_id)) => {
+                self.send_handshake_to_peer(peer_id);
+                // TODO: remove get_latest_from_peer once all nodes support
+                // handshake — it's kept as a fallback for old peers.
                 self.spawn_get_latest_from_peer(peer_id);
             }
             Ok(PeerEvent::LostPeer(peer_id, _)) => {
@@ -726,11 +752,7 @@ where
 
     fn spawn_get_latest_from_peer(&mut self, peer_id: PeerId) {
         if let Some(peer) = self.network.peer(peer_id) {
-            let genesis_checkpoint_digest = *self
-                .store
-                .get_checkpoint_by_sequence_number(0)
-                .expect("store should contain genesis checkpoint")
-                .digest();
+            let genesis_checkpoint_digest = *self.genesis_checkpoint.digest();
             let task = get_latest_from_peer(
                 genesis_checkpoint_digest,
                 peer,
@@ -738,6 +760,54 @@ where
                 self.config.timeout(),
             );
             self.tasks.spawn(task);
+        }
+    }
+
+    /// Sends our state sync handshake to a newly connected peer. This
+    /// registers us in the peer's `peer_heights` immediately — no round-trip
+    /// queries needed.
+    fn send_handshake_to_peer(&mut self, peer_id: PeerId) {
+        if let Some(peer) = self.network.peer(peer_id) {
+            let genesis_checkpoint = self.genesis_checkpoint.as_ref().clone().into_inner();
+            let highest_synced_checkpoint = self
+                .store
+                .try_get_highest_synced_checkpoint()
+                .expect("store operation should not fail")
+                .into_inner();
+            let lowest_available_checkpoint = self
+                .store
+                .try_get_lowest_available_checkpoint()
+                .expect("store operation should not fail");
+
+            let handshake = server::StateSyncHandshake {
+                genesis_checkpoint,
+                highest_synced_checkpoint,
+                lowest_available_checkpoint,
+            };
+            let timeout = self.config.timeout();
+            self.tasks.spawn(async move {
+                let mut client = StateSyncClient::new(peer);
+                // Retry with exponential backoff (100ms, 200ms, 400ms, 800ms,
+                // 1.6s) until the peer acknowledges. The peer may not be
+                // fully ready yet or may not support the handshake RPC.
+                const MAX_RETRIES: u32 = 5;
+                for attempt in 0..MAX_RETRIES {
+                    let request = Request::new(handshake.clone()).with_timeout(timeout);
+                    match client.push_state_sync_handshake(request).await {
+                        Ok(_) => return,
+                        Err(e) => {
+                            // NotFound means the peer doesn't support
+                            // handshake (old version) — no point retrying.
+                            if e.status() == anemo::types::response::StatusCode::NotFound {
+                                return;
+                            }
+                            debug!(attempt, "handshake push failed, retrying: {e:?}");
+                            tokio::time::sleep(Duration::from_millis(100 * 2u64.pow(attempt)))
+                                .await;
+                        }
+                    }
+                }
+            });
         }
     }
 
@@ -850,6 +920,20 @@ where
             self.config.timeout(),
         );
         self.tasks.spawn(task);
+    }
+
+    /// Pushes our latest checkpoint to a single peer. Used when a new
+    /// same-chain peer registers via handshake — they may have missed an
+    /// earlier push that arrived before they were registered.
+    fn spawn_push_checkpoint_to_peer(&mut self, peer_id: PeerId, checkpoint: VerifiedCheckpoint) {
+        if let Some(peer) = self.network.peer(peer_id) {
+            let timeout = self.config.timeout();
+            self.tasks.spawn(async move {
+                let mut client = StateSyncClient::new(peer);
+                let request = Request::new(checkpoint.into_inner()).with_timeout(timeout);
+                let _ = client.push_checkpoint_summary(request).await;
+            });
+        }
     }
 }
 

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -401,10 +401,6 @@ enum StateSyncMessage {
     // it was able to successfully sync a checkpoint's contents. If multiple checkpoints were
     // synced at the same time, only the highest checkpoint is sent.
     SyncedCheckpoint(Box<VerifiedCheckpoint>),
-    // A new same-chain peer was registered (e.g. via handshake). The event
-    // loop should push our latest checkpoint to this peer in case we are
-    // ahead, and start syncing from them if they are ahead of us.
-    NewSameChainPeerRegistered(PeerId),
 }
 
 /// Reason a checkpoint content sync failed.
@@ -472,7 +468,7 @@ where
         let mut peer_events = {
             let (subscriber, peers) = self.network.subscribe().unwrap();
             for peer_id in peers {
-                self.send_handshake_to_peer(peer_id);
+                self.exchange_handshake_with_peer(peer_id);
                 // TODO: remove get_latest_from_peer once all nodes support
                 // handshake — it's kept as a fallback for old peers.
                 self.spawn_get_latest_from_peer(peer_id);
@@ -599,17 +595,6 @@ where
             StateSyncMessage::SyncedCheckpoint(checkpoint) => {
                 self.spawn_notify_peers_of_checkpoint(*checkpoint)
             }
-            // A new same-chain peer registered — push our latest checkpoint
-            // in case we are ahead of them (they may have missed an earlier
-            // push that arrived before they were registered).
-            StateSyncMessage::NewSameChainPeerRegistered(peer_id) => {
-                let checkpoint = self
-                    .store
-                    .try_get_highest_synced_checkpoint()
-                    .expect("store operation should not fail");
-                self.spawn_push_checkpoint_to_peer(peer_id, checkpoint);
-                self.maybe_start_checkpoint_summary_sync_task();
-            }
         }
     }
 
@@ -735,7 +720,7 @@ where
 
         match peer_event {
             Ok(PeerEvent::NewPeer(peer_id)) => {
-                self.send_handshake_to_peer(peer_id);
+                self.exchange_handshake_with_peer(peer_id);
                 // TODO: remove get_latest_from_peer once all nodes support
                 // handshake — it's kept as a fallback for old peers.
                 self.spawn_get_latest_from_peer(peer_id);
@@ -769,9 +754,11 @@ where
 
     /// Sends our state sync handshake to a newly connected peer. This
     /// registers us in the peer's `peer_heights` immediately — no round-trip
-    /// queries needed.
-    fn send_handshake_to_peer(&mut self, peer_id: PeerId) {
+    /// queries needed. The peer returns its own state in the response so we
+    /// can register it before any pushed checkpoints arrive.
+    fn exchange_handshake_with_peer(&mut self, peer_id: PeerId) {
         if let Some(peer) = self.network.peer(peer_id) {
+            let our_genesis_digest = *self.genesis_checkpoint.digest();
             let genesis_checkpoint = self.genesis_checkpoint.as_ref().clone().into_inner();
             let highest_synced_checkpoint = self
                 .store
@@ -789,6 +776,8 @@ where
                 lowest_available_checkpoint,
             };
             let timeout = self.config.timeout();
+            let peer_heights = self.peer_heights.clone();
+            let weak_sender = self.weak_sender.clone();
             self.tasks.spawn(async move {
                 let mut client = StateSyncClient::new(peer);
                 // Retry with exponential backoff (100ms, 200ms, 400ms, 800ms,
@@ -797,15 +786,48 @@ where
                 const MAX_RETRIES: u32 = 5;
                 for attempt in 0..MAX_RETRIES {
                     let request = Request::new(handshake.clone()).with_timeout(timeout);
-                    match client.push_state_sync_handshake(request).await {
-                        Ok(_) => return,
+                    match client.exchange_state_sync_handshake(request).await {
+                        Ok(response) => {
+                            // Register the remote peer from the response so
+                            // that subsequent checkpoint pushes from them are
+                            // accepted immediately.
+                            let their = response.into_inner();
+                            let on_same_chain =
+                                *their.genesis_checkpoint.digest() == our_genesis_digest;
+                            {
+                                let mut guard = peer_heights.write().unwrap();
+                                guard.insert_peer_info(
+                                    peer_id,
+                                    PeerStateSyncInfo {
+                                        genesis_checkpoint_digest: *their
+                                            .genesis_checkpoint
+                                            .digest(),
+                                        on_same_chain_as_us: on_same_chain,
+                                        height: *their.highest_synced_checkpoint.sequence_number(),
+                                        lowest: their.lowest_available_checkpoint,
+                                    },
+                                );
+                                if on_same_chain {
+                                    guard.insert_checkpoint(their.highest_synced_checkpoint);
+                                }
+                            }
+                            // Kick the event loop so it can start syncing.
+                            if on_same_chain {
+                                if let Some(sender) = weak_sender.upgrade() {
+                                    let _ = sender.send(StateSyncMessage::StartSyncJob).await;
+                                }
+                            }
+                            return;
+                        }
                         Err(e) => {
                             // NotFound means the peer doesn't support
                             // handshake (old version) — no point retrying.
                             if e.status() == anemo::types::response::StatusCode::NotFound {
                                 return;
                             }
-                            debug!(attempt, "handshake push failed, retrying: {e:?}");
+                            debug!(attempt, "handshake exchange failed, retrying: {e:?}");
+
+                            // Wait before retrying with exponential backoff.
                             tokio::time::sleep(Duration::from_millis(100 * 2u64.pow(attempt)))
                                 .await;
                         }
@@ -925,20 +947,6 @@ where
         );
         self.tasks.spawn(task);
     }
-
-    /// Pushes our latest checkpoint to a single peer. Used when a new
-    /// same-chain peer registers via handshake — they may have missed an
-    /// earlier push that arrived before they were registered.
-    fn spawn_push_checkpoint_to_peer(&mut self, peer_id: PeerId, checkpoint: VerifiedCheckpoint) {
-        if let Some(peer) = self.network.peer(peer_id) {
-            let timeout = self.config.timeout();
-            self.tasks.spawn(async move {
-                let mut client = StateSyncClient::new(peer);
-                let request = Request::new(checkpoint.into_inner()).with_timeout(timeout);
-                let _ = client.push_checkpoint_summary(request).await;
-            });
-        }
-    }
 }
 
 /// Sends a notification of the new checkpoint to all connected peers that are
@@ -1054,11 +1062,8 @@ async fn get_latest_from_peer(
 
     // Peer is on our chain. Query availability to get the correct lowest
     // watermark, then insert with complete info in a single step.
-    // Note: there is an inherent race here — a push_checkpoint_summary from
-    // this peer may arrive before we finish this query and register the peer.
-    // The 5-second event loop tick recovers from any missed pushes. A proper
-    // fix would be a handshake protocol where both sides exchange chain_id,
-    // lowest, and highest on connect.
+    // The handshake protocol (bidirectional) normally registers peers faster;
+    // this path is kept as a fallback for peers that don't support handshake.
     if let Some((highest_checkpoint, low_watermark)) =
         query_peer_for_latest_info(&mut client, timeout).await
     {

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -112,6 +112,10 @@ use self::{metrics::Metrics, server::CheckpointContentsDownloadLimitLayer};
 
 const PEER_BALANCER_SELECTION_WINDOW: usize = 10;
 
+// Periodically prune `peer_heights` so the temp maps don't accumulate the
+// entire sync range.
+const PEER_HEIGHTS_CLEANUP_CHECKPOINT_INTERVAL: u64 = 10_000;
+
 /// A handle to the StateSync subsystem.
 ///
 /// This handle can be cloned and shared. Once all copies of a StateSync
@@ -1261,6 +1265,7 @@ where
         .pipe(futures::stream::iter)
         .buffered(checkpoint_header_download_concurrency);
 
+    let mut last_cleaned = *current.sequence_number();
     while let Some((maybe_checkpoint, next, maybe_peer_id)) = request_stream.next().await {
         assert_eq!(
             current
@@ -1327,6 +1332,12 @@ where
         store
             .try_insert_checkpoint(&checkpoint)
             .expect("store operation should not fail");
+
+        let seq = *checkpoint.sequence_number();
+        if seq.saturating_sub(last_cleaned) >= PEER_HEIGHTS_CLEANUP_CHECKPOINT_INTERVAL {
+            peer_heights.write().unwrap().cleanup_old_checkpoints(seq);
+            last_cleaned = seq;
+        }
     }
 
     peer_heights

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -108,6 +108,8 @@ pub use server::{GetCheckpointAvailabilityResponse, GetCheckpointSummaryRequest}
 
 use self::{metrics::Metrics, server::CheckpointContentsDownloadLimitLayer};
 
+const PEER_BALANCER_SELECTION_WINDOW: usize = 10;
+
 /// A handle to the StateSync subsystem.
 ///
 /// This handle can be cloned and shared. Once all copies of a StateSync
@@ -297,6 +299,7 @@ impl PeerHeights {
 // randomness.
 #[derive(Clone)]
 struct PeerBalancer {
+    network: anemo::Network,
     peers: VecDeque<(anemo::Peer, PeerStateSyncInfo)>,
     requested_checkpoint: Option<CheckpointSequenceNumber>,
     request_type: PeerCheckpointRequestType,
@@ -327,6 +330,7 @@ impl PeerBalancer {
             .collect();
         peers.sort_by(|(rtt_a, _, _), (rtt_b, _, _)| rtt_a.cmp(rtt_b));
         Self {
+            network: network.clone(),
             peers: peers
                 .into_iter()
                 .map(|(_, peer, info)| (peer, info))
@@ -347,11 +351,19 @@ impl Iterator for PeerBalancer {
 
     fn next(&mut self) -> Option<Self::Item> {
         while !self.peers.is_empty() {
-            const SELECTION_WINDOW: usize = 2;
-            let idx =
-                rand::thread_rng().gen_range(0..std::cmp::min(SELECTION_WINDOW, self.peers.len()));
+            let idx = rand::thread_rng()
+                .gen_range(0..std::cmp::min(PEER_BALANCER_SELECTION_WINDOW, self.peers.len()));
+
+            // Remove the selected peer
             let (peer, info) = self.peers.remove(idx).unwrap();
             let requested_checkpoint = self.requested_checkpoint.unwrap_or(0);
+
+            // Skip peers that have disconnected since the balancer was
+            // constructed.
+            if self.network.peer(peer.peer_id()).is_none() {
+                continue;
+            }
+
             match &self.request_type {
                 // Summary will never be pruned
                 PeerCheckpointRequestType::Summary if info.height >= requested_checkpoint => {
@@ -784,7 +796,7 @@ where
             .map(|result| match result {
                 Ok(()) => {}
                 Err(e) => {
-                    debug!("error syncing checkpoint {e}");
+                    info!("error syncing checkpoint summary: {e}");
                 }
             });
             let task_handle = self.tasks.spawn(task);
@@ -1165,8 +1177,18 @@ where
 
         // Verify the checkpoint
         let checkpoint = 'cp: {
-            let checkpoint = maybe_checkpoint
-                .ok_or_else(|| anyhow!("no peers were able to help sync checkpoint {next}"))?;
+            let checkpoint = maybe_checkpoint.ok_or_else(|| {
+                let guard = peer_heights.read().unwrap();
+                let known = guard.peers_on_same_chain().count();
+                let connected = guard
+                    .peers_on_same_chain()
+                    .filter(|(peer_id, _)| network.peer(**peer_id).is_some())
+                    .count();
+                anyhow!(
+                    "no peers were able to help sync checkpoint summary {next} \
+                     ({connected}/{known} peers connected)"
+                )
+            })?;
             // Skip verification for manually pinned checkpoints.
             if pinned_checkpoints
                 .binary_search_by_key(checkpoint.sequence_number(), |(seq_num, _digest)| *seq_num)

--- a/crates/iota-network/src/state_sync/server.rs
+++ b/crates/iota-network/src/state_sync/server.rs
@@ -21,7 +21,7 @@ use iota_types::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 
-use super::{PeerHeights, StateSync, StateSyncMessage};
+use super::{PeerHeights, PeerStateSyncInfo, StateSync, StateSyncMessage};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum GetCheckpointSummaryRequest {
@@ -36,10 +36,25 @@ pub struct GetCheckpointAvailabilityResponse {
     pub(crate) lowest_available_checkpoint: CheckpointSequenceNumber,
 }
 
+/// Handshake message exchanged by both sides immediately on connect.
+/// Contains everything needed to register a peer: chain identity (verified
+/// genesis checkpoint), pruning watermark, and sync height.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StateSyncHandshake {
+    /// The verified genesis checkpoint for chain identity verification.
+    pub genesis_checkpoint: Checkpoint,
+    /// The highest synced checkpoint of the sending node.
+    pub highest_synced_checkpoint: Checkpoint,
+    /// The lowest available checkpoint (pruning watermark).
+    pub lowest_available_checkpoint: CheckpointSequenceNumber,
+}
+
 pub(super) struct Server<S> {
     pub(super) store: S,
     pub(super) peer_heights: Arc<RwLock<PeerHeights>>,
     pub(super) sender: mpsc::WeakSender<StateSyncMessage>,
+    /// Cached genesis checkpoint, shared with the event loop.
+    pub(super) genesis_checkpoint: Arc<VerifiedCheckpoint>,
 }
 
 #[anemo::async_trait]
@@ -141,6 +156,54 @@ where
             .try_get_full_checkpoint_contents(request.inner())
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(contents))
+    }
+
+    /// Handles a handshake from a newly connected peer. Registers the peer
+    /// with correct chain identity, sync height, and pruning watermark in a
+    /// single step — no additional queries needed.
+    async fn push_state_sync_handshake(
+        &self,
+        request: Request<StateSyncHandshake>,
+    ) -> Result<Response<()>, Status> {
+        let peer_id = request
+            .peer_id()
+            .copied()
+            .ok_or_else(|| Status::internal("unable to query sender's PeerId"))?;
+
+        let handshake = request.into_inner();
+
+        let our_genesis_digest = *self.genesis_checkpoint.digest();
+
+        let on_same_chain = *handshake.genesis_checkpoint.digest() == our_genesis_digest;
+
+        {
+            let mut guard = self.peer_heights.write().unwrap();
+            guard.insert_peer_info(
+                peer_id,
+                PeerStateSyncInfo {
+                    genesis_checkpoint_digest: *handshake.genesis_checkpoint.digest(),
+                    on_same_chain_as_us: on_same_chain,
+                    height: *handshake.highest_synced_checkpoint.sequence_number(),
+                    lowest: handshake.lowest_available_checkpoint,
+                },
+            );
+            if on_same_chain {
+                guard.insert_checkpoint(handshake.highest_synced_checkpoint.clone());
+            }
+        }
+
+        if on_same_chain {
+            if let Some(sender) = self.sender.upgrade() {
+                // Notify the event loop that a new same-chain peer was
+                // registered so it can push our latest checkpoint to them
+                // and start syncing from them if they are ahead.
+                let _ = sender
+                    .send(StateSyncMessage::NewSameChainPeerRegistered(peer_id))
+                    .await;
+            }
+        }
+
+        Ok(Response::new(()))
     }
 }
 

--- a/crates/iota-network/src/state_sync/server.rs
+++ b/crates/iota-network/src/state_sync/server.rs
@@ -161,10 +161,14 @@ where
     /// Handles a handshake from a newly connected peer. Registers the peer
     /// with correct chain identity, sync height, and pruning watermark in a
     /// single step — no additional queries needed.
-    async fn push_state_sync_handshake(
+    ///
+    /// Returns our own state so the caller can register us in a single
+    /// round-trip, eliminating the race where a pushed checkpoint arrives
+    /// before the reverse handshake completes.
+    async fn exchange_state_sync_handshake(
         &self,
         request: Request<StateSyncHandshake>,
-    ) -> Result<Response<()>, Status> {
+    ) -> Result<Response<StateSyncHandshake>, Status> {
         let peer_id = request
             .peer_id()
             .copied()
@@ -194,16 +198,30 @@ where
 
         if on_same_chain {
             if let Some(sender) = self.sender.upgrade() {
-                // Notify the event loop that a new same-chain peer was
-                // registered so it can push our latest checkpoint to them
-                // and start syncing from them if they are ahead.
-                let _ = sender
-                    .send(StateSyncMessage::NewSameChainPeerRegistered(peer_id))
-                    .await;
+                // Kick the event loop so it can start syncing from the new
+                // peer if they are ahead of us.  No separate push needed —
+                // both sides already exchanged full checkpoint objects in
+                // the handshake request/response.
+                let _ = sender.send(StateSyncMessage::StartSyncJob).await;
             }
         }
 
-        Ok(Response::new(()))
+        // Return our own state so the caller can register us immediately.
+        let our_highest = self
+            .store
+            .try_get_highest_synced_checkpoint()
+            .map_err(|e| Status::internal(e.to_string()))?;
+        let our_lowest = self
+            .store
+            .try_get_lowest_available_checkpoint()
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let response = StateSyncHandshake {
+            genesis_checkpoint: self.genesis_checkpoint.as_ref().clone().into_inner(),
+            highest_synced_checkpoint: our_highest.into_inner(),
+            lowest_available_checkpoint: our_lowest,
+        };
+        Ok(Response::new(response))
     }
 }
 

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -12,9 +12,12 @@ use iota_config::{
     object_storage_config::{ObjectStoreConfig, ObjectStoreType},
 };
 use iota_storage::{FileCompression, StorageFormat};
-use iota_swarm_config::test_utils::{CommitteeFixture, empty_contents};
+use iota_swarm_config::test_utils::{
+    CommitteeFixture, MakeCheckpointResults, empty_contents, random_contents,
+};
 use iota_types::{
-    messages_checkpoint::CheckpointDigest,
+    committee::{Committee, EpochId},
+    messages_checkpoint::{CheckpointDigest, VerifiedCheckpoint, VerifiedCheckpointContents},
     storage::{ReadStore, SharedInMemoryStore, WriteStore},
 };
 use prometheus::Registry;
@@ -28,15 +31,41 @@ use crate::{
     utils::build_network,
 };
 
+fn make_committee_and_checkpoints<F: Fn() -> VerifiedCheckpointContents>(
+    epoch: EpochId,
+    committee_size: usize,
+    number_of_checkpoints: usize,
+    previous_checkpoint: Option<VerifiedCheckpoint>,
+    content_generator: F,
+) -> (CommitteeFixture, MakeCheckpointResults) {
+    let committee = CommitteeFixture::generate(rand::rngs::OsRng, epoch, committee_size);
+    let results = committee.make_checkpoints(
+        number_of_checkpoints,
+        previous_checkpoint,
+        content_generator,
+    );
+    (committee, results)
+}
+
+fn store_with_genesis_state(
+    genesis_checkpoint: VerifiedCheckpoint,
+    genesis_contents: VerifiedCheckpointContents,
+    committee: Committee,
+) -> SharedInMemoryStore {
+    let store = SharedInMemoryStore::default();
+    store
+        .inner_mut()
+        .insert_genesis_state(genesis_checkpoint, genesis_contents, committee);
+    store
+}
+
 #[tokio::test]
 // Test that the server stores the pushed checkpoint summary and triggers the
 // sync job.
 async fn server_push_checkpoint() {
-    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
-    let (ordered_checkpoints, _, _sequence_number_to_digest, _checkpoints) =
-        committee.make_empty_checkpoints(2, None);
-    let store = SharedInMemoryStore::default();
-    store.inner_mut().insert_genesis_state(
+    let (committee, (ordered_checkpoints, _, _, _)) =
+        make_committee_and_checkpoints(0, 4, 2, None, empty_contents);
+    let store = store_with_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
         committee.committee().to_owned(),
@@ -103,19 +132,15 @@ async fn server_push_checkpoint() {
 
 #[tokio::test]
 async fn server_get_checkpoint() {
-    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
-    let (ordered_checkpoints, _, _sequence_number_to_digest, _checkpoints) =
-        committee.make_empty_checkpoints(3, None);
+    let (committee, (ordered_checkpoints, _, _, _)) =
+        make_committee_and_checkpoints(0, 4, 3, None, empty_contents);
 
-    let (builder, server) = Builder::new()
-        .store(SharedInMemoryStore::default())
-        .build_internal();
-
-    builder.store.inner_mut().insert_genesis_state(
+    let store = store_with_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
         committee.committee().to_owned(),
     );
+    let (builder, server) = Builder::new().store(store).build_internal();
 
     // Requests for the Latest checkpoint should return the genesis checkpoint
     let response = server
@@ -186,31 +211,29 @@ async fn server_get_checkpoint() {
 
 #[tokio::test]
 async fn isolated_sync_job() {
-    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
     // Build mock data
-    let (ordered_checkpoints, _, sequence_number_to_digest, checkpoints) =
-        committee.make_empty_checkpoints(100, None);
+    let (committee, (ordered_checkpoints, _, sequence_number_to_digest, checkpoints)) =
+        make_committee_and_checkpoints(0, 4, 100, None, empty_contents);
 
-    // Build and connect two nodes
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    // Build and connect two nodes — genesis is initialized in each store before
+    // it is passed to the builder.
+    let store_1 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        empty_contents(),
+        committee.committee().to_owned(),
+    );
+    let store_2 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        empty_contents(),
+        committee.committee().to_owned(),
+    );
+    let (builder, server) = Builder::new().store(store_1).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (mut event_loop_1, _handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new().store(store_2).build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, _handle_2) = builder.build(network_2.clone());
     network_1.connect(network_2.local_addr()).await.unwrap();
-
-    // Init the root committee in both nodes
-    event_loop_1.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        empty_contents(),
-        committee.committee().to_owned(),
-    );
-    event_loop_2.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        empty_contents(),
-        committee.committee().to_owned(),
-    );
 
     // Node 2 will have all the data
     {
@@ -271,10 +294,9 @@ async fn isolated_sync_job() {
 
 #[tokio::test]
 async fn test_state_sync_using_archive() -> anyhow::Result<()> {
-    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
     // Build mock data
-    let (ordered_checkpoints, _, sequence_number_to_digest, checkpoints) =
-        committee.make_empty_checkpoints(100, None);
+    let (committee, (ordered_checkpoints, _, sequence_number_to_digest, checkpoints)) =
+        make_committee_and_checkpoints(0, 4, 100, None, empty_contents);
     // Initialize archive store with all checkpoints
     let tmp_dir = iota_common::tempdir();
     let local_path = tmp_dir.path().join("local_dir");
@@ -294,13 +316,12 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
         remote_store_config.clone(),
         FileCompression::Zstd,
         StorageFormat::Blob,
-        Duration::from_secs(10),
+        Duration::from_secs(1),
         20,
         &Registry::default(),
     )
     .await?;
-    let test_store = SharedInMemoryStore::default();
-    test_store.inner_mut().insert_genesis_state(
+    let test_store = store_with_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
         empty_contents(),
         committee.committee().to_owned(),
@@ -337,29 +358,28 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
     }
     // Build and connect two nodes where Node 1 will be given access to an archive
     // store Node 2 will prune older checkpoints, so Node 1 is forced to
-    // backfill from the archive
+    // backfill from the archive. Genesis is initialized in each store before it
+    // is passed to the builder.
+    let store_1 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        empty_contents(),
+        committee.committee().to_owned(),
+    );
+    let store_2 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        empty_contents(),
+        committee.committee().to_owned(),
+    );
     let (builder, server) = Builder::new()
-        .store(SharedInMemoryStore::default())
+        .store(store_1)
         .archive_readers(archive_readers)
         .build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, _handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new().store(store_2).build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, _handle_2) = builder.build(network_2.clone());
     network_1.connect(network_2.local_addr()).await.unwrap();
-
-    // Init the root committee in both nodes
-    event_loop_1.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        empty_contents(),
-        committee.committee().to_owned(),
-    );
-    event_loop_2.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        empty_contents(),
-        committee.committee().to_owned(),
-    );
 
     // Node 2 will have all the data at first
     {
@@ -455,31 +475,28 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
 #[tokio::test]
 async fn sync_with_checkpoints_being_inserted() {
     telemetry_subscribers::init_for_testing();
-    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
     // Build mock data
-    let (ordered_checkpoints, _contents, sequence_number_to_digest, checkpoints) =
-        committee.make_empty_checkpoints(4, None);
+    let (committee, (ordered_checkpoints, _contents, sequence_number_to_digest, checkpoints)) =
+        make_committee_and_checkpoints(0, 4, 4, None, empty_contents);
 
-    // Build and connect two nodes
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    // Build two nodes — genesis must be in the store before passing to the
+    // builder so the cached genesis checkpoint is available.
+    let store_1 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        empty_contents(),
+        committee.committee().to_owned(),
+    );
+    let store_2 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        empty_contents(),
+        committee.committee().to_owned(),
+    );
+    let (builder, server) = Builder::new().store(store_1).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new().store(store_2).build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, handle_2) = builder.build(network_2.clone());
-    network_1.connect(network_2.local_addr()).await.unwrap();
-
-    // Init the root committee in both nodes
-    event_loop_1.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        empty_contents(),
-        committee.committee().to_owned(),
-    );
-    event_loop_2.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        empty_contents(),
-        committee.committee().to_owned(),
-    );
 
     // Get handles to each node's stores
     let store_1 = event_loop_1.store.clone();
@@ -498,6 +515,8 @@ async fn sync_with_checkpoints_being_inserted() {
     tokio::spawn(event_loop_1.start());
     tokio::spawn(event_loop_2.start());
 
+    network_1.connect(network_2.local_addr()).await.unwrap();
+
     let mut subscriber_1 = handle_1.subscribe_to_synced_checkpoints();
     let mut subscriber_2 = handle_2.subscribe_to_synced_checkpoints();
 
@@ -510,11 +529,7 @@ async fn sync_with_checkpoints_being_inserted() {
     store_1.insert_certified_checkpoint(&checkpoint);
     handle_1.send_checkpoint(checkpoint).await;
 
-    // Timeout is 10s because peer registration completes only after the
-    // availability query, so a pushed checkpoint may be missed and recovery
-    // depends on the 5-second event loop tick.
-    // TODO: reduce after adding a handshake message on connect.
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(1), async {
         assert_eq!(
             subscriber_1.recv().await.unwrap().data(),
             ordered_checkpoints[1].data(),
@@ -533,11 +548,7 @@ async fn sync_with_checkpoints_being_inserted() {
         handle_1.send_checkpoint(checkpoint).await;
     }
 
-    // Timeout is 10s because peer registration completes only after the
-    // availability query, so a pushed checkpoint may be missed and recovery
-    // depends on the 5-second event loop tick.
-    // TODO: reduce after adding a handshake message on connect.
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(1), async {
         for checkpoint in &ordered_checkpoints[2..] {
             assert_eq!(subscriber_1.recv().await.unwrap().data(), checkpoint.data());
             assert_eq!(subscriber_2.recv().await.unwrap().data(), checkpoint.data());
@@ -593,35 +604,33 @@ async fn sync_with_checkpoints_being_inserted() {
 #[tokio::test]
 async fn sync_with_checkpoints_watermark() {
     telemetry_subscribers::init_for_testing();
-    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
     // Build mock data
-    let (ordered_checkpoints, contents, _sequence_number_to_digest, _checkpoints) =
-        committee.make_random_checkpoints(4, None);
+    let (committee, (ordered_checkpoints, contents, _, _)) =
+        make_committee_and_checkpoints(0, 4, 4, None, random_contents);
     let last_checkpoint_seq = *ordered_checkpoints
         .last()
         .cloned()
         .unwrap()
         .sequence_number();
-    // Build and connect two nodes
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    // Build and connect two nodes — genesis is initialized in each store before
+    // it is passed to the builder.
+    let genesis_checkpoint_content = contents.first().cloned().unwrap();
+    let store_1 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        genesis_checkpoint_content.clone(),
+        committee.committee().to_owned(),
+    );
+    let store_2 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        genesis_checkpoint_content.clone(),
+        committee.committee().to_owned(),
+    );
+    let (builder, server) = Builder::new().store(store_1).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new().store(store_2).build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, handle_2) = builder.build(network_2.clone());
-
-    // Init the root committee in both nodes
-    let genesis_checkpoint_content = contents.first().cloned().unwrap();
-    event_loop_1.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        genesis_checkpoint_content.clone(),
-        committee.committee().to_owned(),
-    );
-    event_loop_2.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        genesis_checkpoint_content.clone(),
-        committee.committee().to_owned(),
-    );
 
     // Get handles to each node's stores
     let store_1 = event_loop_1.store.clone();
@@ -660,11 +669,7 @@ async fn sync_with_checkpoints_watermark() {
     store_1.insert_certified_checkpoint(&checkpoint_1);
     handle_1.send_checkpoint(checkpoint_1.clone()).await;
 
-    // Timeout is 10s because peer registration completes only after the
-    // availability query, so a pushed checkpoint may be missed and recovery
-    // depends on the 5-second event loop tick.
-    // TODO: reduce after adding a handshake message on connect.
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(3), async {
         assert_eq!(
             subscriber_1.recv().await.unwrap().data(),
             ordered_checkpoints[1].data(),
@@ -729,11 +734,7 @@ async fn sync_with_checkpoints_watermark() {
     }
 
     // Peer 1 has all the checkpoint contents, but not Peer 2
-    // Timeout is 10s because peer registration completes only after the
-    // availability query, so a pushed checkpoint may be missed and recovery
-    // depends on the 5-second event loop tick.
-    // TODO: reduce after adding a handshake message on connect.
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(1), async {
         for (checkpoint, contents) in ordered_checkpoints[2..]
             .iter()
             .zip(contents.clone().into_iter().skip(2))
@@ -773,33 +774,30 @@ async fn sync_with_checkpoints_watermark() {
         &last_checkpoint_seq
     );
 
-    // Add Peer 3
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    // Add Peer 3 — genesis is initialized in the store before it is passed to
+    // the builder so the store is ready for handshake.
+    let store_3 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        genesis_checkpoint_content.clone(),
+        committee.committee().to_owned(),
+    );
+    let (builder, server) = Builder::new().store(store_3).build();
     let network_3 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_3, handle_3) = builder.build(network_3.clone());
 
     let mut subscriber_3 = handle_3.subscribe_to_synced_checkpoints();
-    network_3.connect(network_1.local_addr()).await.unwrap();
-    network_3.connect(network_2.local_addr()).await.unwrap();
     let store_3 = event_loop_3.store.clone();
     let peer_heights_3 = event_loop_3.peer_heights.clone();
     peer_heights_3
         .write()
         .unwrap()
         .set_wait_interval_when_no_peer_to_sync_content(Duration::from_secs(1));
-    event_loop_3.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        genesis_checkpoint_content.clone(),
-        committee.committee().to_owned(),
-    );
     tokio::spawn(event_loop_3.start());
+    network_3.connect(network_1.local_addr()).await.unwrap();
+    network_3.connect(network_2.local_addr()).await.unwrap();
 
     // Peer 3 is able to sync checkpoint 1 with the help from Peer 2
-    // Timeout is 10s because peer registration completes only after the
-    // availability query, so a pushed checkpoint may be missed and recovery
-    // depends on the 5-second event loop tick.
-    // TODO: reduce after adding a handshake message on connect.
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(3), async {
         assert_eq!(
             subscriber_3.recv().await.unwrap().data(),
             ordered_checkpoints[1].data()
@@ -835,11 +833,7 @@ async fn sync_with_checkpoints_watermark() {
     // Peer 2 and Peer 3 will know about this change by
     // `get_checkpoint_availability` Soon we expect them to have all
     // checkpoints's content.
-    // Timeout is 10s because peer registration completes only after the
-    // availability query, so a pushed checkpoint may be missed and recovery
-    // depends on the 5-second event loop tick.
-    // TODO: reduce after adding a handshake message on connect.
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(6), async {
         for (checkpoint, contents) in ordered_checkpoints[2..]
             .iter()
             .zip(contents.clone().into_iter().skip(2))
@@ -895,8 +889,14 @@ async fn sync_with_checkpoints_watermark() {
         .inner_mut()
         .set_lowest_available_checkpoint(a_very_high_checkpoint_seq);
 
-    // Start Peer 4
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    // Start Peer 4 — genesis is initialized in the store before it is passed
+    // to the builder.
+    let store_4 = store_with_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        genesis_checkpoint_content,
+        committee.committee().to_owned(),
+    );
+    let (builder, server) = Builder::new().store(store_4).build();
     let network_4 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_4, handle_4) = builder.build(network_4.clone());
 
@@ -907,11 +907,6 @@ async fn sync_with_checkpoints_watermark() {
         .write()
         .unwrap()
         .set_wait_interval_when_no_peer_to_sync_content(Duration::from_secs(1));
-    event_loop_4.store.inner_mut().insert_genesis_state(
-        ordered_checkpoints.first().cloned().unwrap(),
-        genesis_checkpoint_content,
-        committee.committee().to_owned(),
-    );
     tokio::spawn(event_loop_4.start());
     // Need to connect 4 to 1, 2, 3 manually, as it does not have discovery enabled
     network_4.connect(network_1.local_addr()).await.unwrap();
@@ -919,11 +914,7 @@ async fn sync_with_checkpoints_watermark() {
     network_4.connect(network_3.local_addr()).await.unwrap();
 
     // Peer 4 syncs everything with Peer 3
-    // Timeout is 10s because peer registration completes only after the
-    // availability query, so a pushed checkpoint may be missed and recovery
-    // depends on the 5-second event loop tick.
-    // TODO: reduce after adding a handshake message on connect.
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(3), async {
         for (checkpoint, contents) in ordered_checkpoints[1..]
             .iter()
             .zip(contents.clone().into_iter().skip(1))

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -510,7 +510,11 @@ async fn sync_with_checkpoints_being_inserted() {
     store_1.insert_certified_checkpoint(&checkpoint);
     handle_1.send_checkpoint(checkpoint).await;
 
-    timeout(Duration::from_secs(1), async {
+    // Timeout is 10s because peer registration completes only after the
+    // availability query, so a pushed checkpoint may be missed and recovery
+    // depends on the 5-second event loop tick.
+    // TODO: reduce after adding a handshake message on connect.
+    timeout(Duration::from_secs(10), async {
         assert_eq!(
             subscriber_1.recv().await.unwrap().data(),
             ordered_checkpoints[1].data(),
@@ -529,7 +533,11 @@ async fn sync_with_checkpoints_being_inserted() {
         handle_1.send_checkpoint(checkpoint).await;
     }
 
-    timeout(Duration::from_secs(1), async {
+    // Timeout is 10s because peer registration completes only after the
+    // availability query, so a pushed checkpoint may be missed and recovery
+    // depends on the 5-second event loop tick.
+    // TODO: reduce after adding a handshake message on connect.
+    timeout(Duration::from_secs(10), async {
         for checkpoint in &ordered_checkpoints[2..] {
             assert_eq!(subscriber_1.recv().await.unwrap().data(), checkpoint.data());
             assert_eq!(subscriber_2.recv().await.unwrap().data(), checkpoint.data());
@@ -652,7 +660,11 @@ async fn sync_with_checkpoints_watermark() {
     store_1.insert_certified_checkpoint(&checkpoint_1);
     handle_1.send_checkpoint(checkpoint_1.clone()).await;
 
-    timeout(Duration::from_secs(3), async {
+    // Timeout is 10s because peer registration completes only after the
+    // availability query, so a pushed checkpoint may be missed and recovery
+    // depends on the 5-second event loop tick.
+    // TODO: reduce after adding a handshake message on connect.
+    timeout(Duration::from_secs(10), async {
         assert_eq!(
             subscriber_1.recv().await.unwrap().data(),
             ordered_checkpoints[1].data(),
@@ -717,7 +729,11 @@ async fn sync_with_checkpoints_watermark() {
     }
 
     // Peer 1 has all the checkpoint contents, but not Peer 2
-    timeout(Duration::from_secs(1), async {
+    // Timeout is 10s because peer registration completes only after the
+    // availability query, so a pushed checkpoint may be missed and recovery
+    // depends on the 5-second event loop tick.
+    // TODO: reduce after adding a handshake message on connect.
+    timeout(Duration::from_secs(10), async {
         for (checkpoint, contents) in ordered_checkpoints[2..]
             .iter()
             .zip(contents.clone().into_iter().skip(2))
@@ -779,7 +795,11 @@ async fn sync_with_checkpoints_watermark() {
     tokio::spawn(event_loop_3.start());
 
     // Peer 3 is able to sync checkpoint 1 with the help from Peer 2
-    timeout(Duration::from_secs(1), async {
+    // Timeout is 10s because peer registration completes only after the
+    // availability query, so a pushed checkpoint may be missed and recovery
+    // depends on the 5-second event loop tick.
+    // TODO: reduce after adding a handshake message on connect.
+    timeout(Duration::from_secs(10), async {
         assert_eq!(
             subscriber_3.recv().await.unwrap().data(),
             ordered_checkpoints[1].data()
@@ -815,7 +835,11 @@ async fn sync_with_checkpoints_watermark() {
     // Peer 2 and Peer 3 will know about this change by
     // `get_checkpoint_availability` Soon we expect them to have all
     // checkpoints's content.
-    timeout(Duration::from_secs(6), async {
+    // Timeout is 10s because peer registration completes only after the
+    // availability query, so a pushed checkpoint may be missed and recovery
+    // depends on the 5-second event loop tick.
+    // TODO: reduce after adding a handshake message on connect.
+    timeout(Duration::from_secs(10), async {
         for (checkpoint, contents) in ordered_checkpoints[2..]
             .iter()
             .zip(contents.clone().into_iter().skip(2))
@@ -895,7 +919,11 @@ async fn sync_with_checkpoints_watermark() {
     network_4.connect(network_3.local_addr()).await.unwrap();
 
     // Peer 4 syncs everything with Peer 3
-    timeout(Duration::from_secs(3), async {
+    // Timeout is 10s because peer registration completes only after the
+    // availability query, so a pushed checkpoint may be missed and recovery
+    // depends on the 5-second event loop tick.
+    // TODO: reduce after adding a handshake message on connect.
+    timeout(Duration::from_secs(10), async {
         for (checkpoint, contents) in ordered_checkpoints[1..]
             .iter()
             .zip(contents.clone().into_iter().skip(1))

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1048,7 +1048,7 @@ impl IotaNode {
                 .layer(
                     TraceLayer::new_for_client_and_server_errors()
                         .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO))
-                        .on_failure(DefaultOnFailure::new().level(tracing::Level::WARN)),
+                        .on_failure(DefaultOnFailure::new().level(tracing::Level::DEBUG)),
                 )
                 .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                     Arc::new(outbound_network_metrics),

--- a/crates/iota-swarm-config/src/test_utils.rs
+++ b/crates/iota-swarm-config/src/test_utils.rs
@@ -29,7 +29,7 @@ pub struct CommitteeFixture {
     genesis: Option<Arc<Genesis>>,
 }
 
-type MakeCheckpointResults = (
+pub type MakeCheckpointResults = (
     Vec<VerifiedCheckpoint>,
     Vec<VerifiedCheckpointContents>,
     HashMap<CheckpointSequenceNumber, CheckpointDigest>,
@@ -177,7 +177,7 @@ impl CommitteeFixture {
         self.make_checkpoints(number_of_checkpoints, previous_checkpoint, empty_contents)
     }
 
-    fn make_checkpoints<F: Fn() -> VerifiedCheckpointContents>(
+    pub fn make_checkpoints<F: Fn() -> VerifiedCheckpointContents>(
         &self,
         number_of_checkpoints: usize,
         previous_checkpoint: Option<VerifiedCheckpoint>,


### PR DESCRIPTION
# Description of change

  - Adds a StateSyncHandshake protocol — on connect, both sides immediately exchange chain identity (genesis checkpoint), sync height, and pruning watermark. This eliminates a race condition where push_checkpoint_summary could arrive before the peer was registered (the old flow required multiple sequential queries).
  - Fixes PeerHeights insertion — new peers are now registered with complete info (chain identity + height + lowest watermark) in a single step, and the lowest field is correctly updated on reconnect.
  - Filters disconnected peers in PeerBalancer — peers that disappeared between balancer construction and iteration are skipped, avoiding wasted requests. The RTT selection window is also widened (2 → 10).
  - Periodic PeerHeights cleanup during sync — temp maps are pruned every 10k checkpoints to prevent unbounded memory growth during long syncs.
  - Removes the legacy get_checkpoint_summary(Latest) fallback in query_peer_for_latest_info.                                                                                                                       
  - Improves error context — failed checkpoint sync now reports connected/known peer counts.        

## Links to any relevant issues

fixes #11440 
fixes #11441 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Hardened state sync peer tracking:
  - added a handshake protocol to eliminate race conditions during peer registration
  - fixed stale peer handling
  - added periodic cleanup to prevent memory growth during long syncs
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
