### PR TITLE
fix(iota-node,iota-benchmark): fix capability chain mismatch and align simtest epoch durations

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -111,7 +111,6 @@ mod test {
         test_simulated_load(test_cluster, 60).await;
     }
 
-    #[ignore("https://github.com/iotaledger/iota/issues/11438")]
     #[sim_test(config = "test_config()")]
     async fn test_mainnet_config() {
         chain_config_smoke_test(Chain::Mainnet).await;
@@ -124,7 +123,8 @@ mod test {
 
     async fn chain_config_smoke_test(chain: Chain) {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = init_test_cluster_builder(2, 3000)
+        // 2 validators, 10 seconds per epoch.
+        let test_cluster = init_test_cluster_builder(2, 10_000)
             .with_authority_overload_config(AuthorityOverloadConfig {
                 // Disable system overload checks for the test - during tests with crashes,
                 // it is possible for overload protection to trigger due to validators
@@ -148,7 +148,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_with_accumulator_v2_partial_upgrade() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = init_test_cluster_builder(4, 1000)
+        let test_cluster = init_test_cluster_builder(4, 10_000)
             .with_authority_overload_config(AuthorityOverloadConfig {
                 // Disable system overload checks for the test - during tests with crashes,
                 // it is possible for overload protection to trigger due to validators
@@ -356,7 +356,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_with_prune_and_compact() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 1000, 0).await;
+        let test_cluster = build_test_cluster(4, 10_000, 0).await;
 
         let node_state = test_cluster.fullnode_handle.iota_node.clone().state();
         register_fail_point_async("prune-and-compact", move || {
@@ -376,7 +376,7 @@ mod test {
         register_fail_point_if("select-random-cache", || true);
 
         let test_cluster = Arc::new(
-            init_test_cluster_builder(4, 1000)
+            init_test_cluster_builder(4, 10_000)
                 .with_num_unpruned_validators(4)
                 .build()
                 .await,
@@ -657,7 +657,7 @@ mod test {
     async fn test_data_ingestion_pipeline() {
         let path = nondeterministic!(TempDir::new().unwrap()).keep();
         let test_cluster = Arc::new(
-            init_test_cluster_builder(4, 5000)
+            init_test_cluster_builder(4, 10_000)
                 .with_data_ingestion_dir(path.clone())
                 .build()
                 .await,

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1647,7 +1647,7 @@ impl IotaNode {
                 let transaction = ConsensusTransaction::new_capability_notification_v1(
                     AuthorityCapabilitiesV1::new(
                         self.state.name,
-                        cur_epoch_store.get_chain_identifier().chain(),
+                        cur_epoch_store.get_chain(),
                         self.config
                             .supported_protocol_versions
                             .expect("Supported versions should be populated")
@@ -2047,7 +2047,7 @@ impl IotaNode {
         // Create the capability notification
         let capabilities = AuthorityCapabilitiesV1::new(
             self.state.name,
-            epoch_store.get_chain_identifier().chain(),
+            epoch_store.get_chain(),
             self.config
                 .supported_protocol_versions
                 .expect("Supported versions should be populated")


### PR DESCRIPTION
# Description of change

Fix protocol config digest mismatch in capability notifications when using `with_chain_override` in tests, and align simtest epoch durations with upstream.

**Chain mismatch bug:** When creating `AuthorityCapabilitiesV1`, the code used `epoch_store.get_chain_identifier().chain()` to determine the chain. In test clusters using `with_chain_override(Chain::Mainnet)`, the `ChainIdentifier` is derived from the genesis checkpoint digest, which doesn't match known chain digests — so `.chain()` returns `Chain::Unknown`. Meanwhile, the epoch store's protocol config is computed with the correct `Chain::Mainnet` from the override. This caused `get_validators_supporting_protocol_version` to always find 0 matching validators (different chain → different protocol config → different digest), triggering the "Eligible validators weight 0" fallback on every epoch change.

**Fix:** Use `epoch_store.get_chain()` which returns the authoritative chain value the epoch store was configured with. In production, this is identical to `get_chain_identifier().chain()` since the genesis digest matches the known chain. In tests with chain override, it correctly returns the override chain.

**Epoch duration alignment:** Several simtests had shorter epoch durations (1-5s) than upstream (10s). With short epochs and ~15s epoch transitions, the network spends most of its time in transition, leaving the surfer too few transaction windows. This caused flaky failures where all surfer transactions hit epoch boundaries.

## Links to any relevant issues

Closes #11438

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] Reproduced failure with `MSIM_TEST_SEED=1778094833170` on Linux x86_64
- [x] Verified fix eliminates "Eligible validators weight 0" errors
- [x] Verified previously-failing seed `1778097890094` now passes
- [x] Seed search with 200 seeds on Linux x86_64