### PR TITLE
feat(graphql): clean up remaining objects_snapshot usages

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/available_range/available_range.move
+++ b/crates/iota-graphql-e2e-tests/tests/available_range/available_range.move
@@ -2,7 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-// Test that available range is correctly updated per objects_snapshot catching up
+// Test that `availableRange` reports the backward-diff retention window:
+// `first = max(backward-history watermark, latest - lookback)`, `last = latest`.
+// In this test the watermark sits at 0 (migration ran before any checkpoint
+// committed; no pruner advances it) and `latest` never reaches the lookback
+// threshold, so the range is always `(0, latest)`.
 
 //# init --protocol-version 4 --simulator --objects-snapshot-min-checkpoint-lag 2
 

--- a/crates/iota-graphql-e2e-tests/tests/available_range/available_range.snap
+++ b/crates/iota-graphql-e2e-tests/tests/available_range/available_range.snap
@@ -1,9 +1,10 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
 ---
 processed 17 tasks
 
-task 1, lines 9-31:
+task 1, lines 13-35:
 //# run-graphql
 Response: {
   "data": {
@@ -28,11 +29,11 @@ Response: {
   }
 }
 
-task 3, line 35:
+task 3, line 39:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 37-47:
+task 4, lines 41-51:
 //# run-graphql
 Response: {
   "data": {
@@ -47,11 +48,11 @@ Response: {
   }
 }
 
-task 6, line 51:
+task 6, line 55:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 7, lines 53-63:
+task 7, lines 57-67:
 //# run-graphql
 Response: {
   "data": {
@@ -66,17 +67,17 @@ Response: {
   }
 }
 
-task 9, line 67:
+task 9, line 71:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 10, lines 69-79:
+task 10, lines 73-83:
 //# run-graphql
 Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 1
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 3
@@ -85,17 +86,17 @@ Response: {
   }
 }
 
-task 12, line 83:
+task 12, line 87:
 //# create-checkpoint
 Checkpoint created: 4
 
-task 13, lines 85-95:
+task 13, lines 89-99:
 //# run-graphql
 Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 2
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 4
@@ -104,17 +105,17 @@ Response: {
   }
 }
 
-task 15, line 99:
+task 15, line 103:
 //# create-checkpoint
 Checkpoint created: 5
 
-task 16, lines 101-121:
+task 16, lines 105-125:
 //# run-graphql
 Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 3
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 5

--- a/crates/iota-graphql-e2e-tests/tests/consistency/balances.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/balances.move
@@ -227,7 +227,10 @@ module P0::fake {
 //# create-checkpoint
 
 //# run-graphql --cursors {"c":2,"t":1,"i":false}
-# Outside available range
+# Backward-diff retention covers cp 2 even after the forward-diff snapshot
+# watermark has advanced past it; balance still serves historical data (700).
+# `availableRange.first` reflects the backward-history watermark and so
+# matches what balance can serve.
 {
   availableRange {
     first {
@@ -320,7 +323,8 @@ module P0::fake {
 //# create-checkpoint
 
 //# run-graphql --cursors {"c":2,"t":1,"i":false}
-# Outside available range
+# Same as the cp 2 view above, several checkpoints later — still in
+# backward-diff range, balance keeps serving historical data.
 {
   availableRange {
     first {
@@ -351,7 +355,7 @@ module P0::fake {
 }
 
 //# run-graphql --cursors {"c":3,"t":1,"i":false}
-# Outside available range
+# cp 3 view: in backward-diff range, returns the historical balance.
 {
   availableRange {
     first {
@@ -382,7 +386,7 @@ module P0::fake {
 }
 
 //# run-graphql --cursors {"c":4,"t":1,"i":false}
-# Outside available range
+# cp 4 view: in backward-diff range, returns the historical balance.
 {
   availableRange {
     first {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/balances.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/balances.snap
@@ -1,5 +1,6 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
 ---
 processed 42 tasks
 
@@ -289,13 +290,13 @@ task 27, line 227:
 //# create-checkpoint
 Checkpoint created: 10
 
-task 28, lines 229-258:
+task 28, lines 229-261:
 //# run-graphql --cursors {"c":2,"t":1,"i":false}
 Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 3
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 10
@@ -305,36 +306,35 @@ Response: {
       "nodes": [
         {
           "sender": {
-            "fakeCoinBalance": null
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinObjectCount": 1,
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA"
+                  },
+                  "totalBalance": "299999982382000"
+                },
+                {
+                  "coinObjectCount": 3,
+                  "coinType": {
+                    "repr": "0x97a73654d6f792c4f911e41da7099fa0ba3c9fd820112a3772c282cca96e98ab::fake::FAKE"
+                  },
+                  "totalBalance": "700"
+                }
+              ]
+            },
+            "fakeCoinBalance": {
+              "totalBalance": "700"
+            }
           }
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 17,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        0,
-        "sender",
-        "allBalances"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
+  }
 }
 
-task 29, lines 260-281:
+task 29, lines 263-284:
 //# run-graphql --cursors {"c":3,"t":1,"i":false}
 Response: {
   "data": {
@@ -370,7 +370,7 @@ Response: {
   }
 }
 
-task 30, lines 283-304:
+task 30, lines 286-307:
 //# run-graphql --cursors {"c":4,"t":1,"i":false}
 Response: {
   "data": {
@@ -406,29 +406,29 @@ Response: {
   }
 }
 
-task 32, line 308:
+task 32, line 311:
 //# create-checkpoint
 Checkpoint created: 11
 
-task 34, line 312:
+task 34, line 315:
 //# create-checkpoint
 Checkpoint created: 12
 
-task 36, line 316:
+task 36, line 319:
 //# create-checkpoint
 Checkpoint created: 13
 
-task 38, line 320:
+task 38, line 323:
 //# create-checkpoint
 Checkpoint created: 14
 
-task 39, lines 322-351:
+task 39, lines 325-355:
 //# run-graphql --cursors {"c":2,"t":1,"i":false}
 Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 7
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 14
@@ -438,42 +438,41 @@ Response: {
       "nodes": [
         {
           "sender": {
-            "fakeCoinBalance": null
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinObjectCount": 1,
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA"
+                  },
+                  "totalBalance": "299999982382000"
+                },
+                {
+                  "coinObjectCount": 3,
+                  "coinType": {
+                    "repr": "0x97a73654d6f792c4f911e41da7099fa0ba3c9fd820112a3772c282cca96e98ab::fake::FAKE"
+                  },
+                  "totalBalance": "700"
+                }
+              ]
+            },
+            "fakeCoinBalance": {
+              "totalBalance": "700"
+            }
           }
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 17,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        0,
-        "sender",
-        "allBalances"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
+  }
 }
 
-task 40, lines 353-382:
+task 40, lines 357-386:
 //# run-graphql --cursors {"c":3,"t":1,"i":false}
 Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 7
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 14
@@ -483,42 +482,41 @@ Response: {
       "nodes": [
         {
           "sender": {
-            "fakeCoinBalance": null
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinObjectCount": 1,
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA"
+                  },
+                  "totalBalance": "299999981382000"
+                },
+                {
+                  "coinObjectCount": 2,
+                  "coinType": {
+                    "repr": "0x97a73654d6f792c4f911e41da7099fa0ba3c9fd820112a3772c282cca96e98ab::fake::FAKE"
+                  },
+                  "totalBalance": "600"
+                }
+              ]
+            },
+            "fakeCoinBalance": {
+              "totalBalance": "600"
+            }
           }
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 17,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        0,
-        "sender",
-        "allBalances"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
+  }
 }
 
-task 41, lines 384-413:
+task 41, lines 388-417:
 //# run-graphql --cursors {"c":4,"t":1,"i":false}
 Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 7
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 14
@@ -528,31 +526,30 @@ Response: {
       "nodes": [
         {
           "sender": {
-            "fakeCoinBalance": null
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinObjectCount": 1,
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA"
+                  },
+                  "totalBalance": "299999980382000"
+                },
+                {
+                  "coinObjectCount": 1,
+                  "coinType": {
+                    "repr": "0x97a73654d6f792c4f911e41da7099fa0ba3c9fd820112a3772c282cca96e98ab::fake::FAKE"
+                  },
+                  "totalBalance": "400"
+                }
+              ]
+            },
+            "fakeCoinBalance": {
+              "totalBalance": "400"
+            }
           }
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 17,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        0,
-        "sender",
-        "allBalances"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
+  }
 }

--- a/crates/iota-graphql-e2e-tests/tests/consistency/coins.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/coins.snap
@@ -1,5 +1,6 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
 ---
 processed 15 tasks
 
@@ -103,7 +104,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 1
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 2
@@ -183,7 +184,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 2
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 3
@@ -247,7 +248,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 2
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 3
@@ -298,7 +299,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 2
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 3
@@ -349,7 +350,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 2
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 3

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.snap
@@ -804,7 +804,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 4
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 8

--- a/crates/iota-graphql-e2e-tests/tests/consistency/object_at_version.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/object_at_version.snap
@@ -1,5 +1,6 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
 ---
 processed 33 tasks
 
@@ -260,7 +261,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 7
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 12
@@ -304,7 +305,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 7
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 12

--- a/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination.snap
@@ -1,5 +1,6 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
 ---
 processed 26 tasks
 
@@ -523,7 +524,7 @@ Response: {
   "data": {
     "availableRange": {
       "first": {
-        "sequenceNumber": 3
+        "sequenceNumber": 0
       },
       "last": {
         "sequenceNumber": 7

--- a/crates/iota-graphql-e2e-tests/tests/tests.rs
+++ b/crates/iota-graphql-e2e-tests/tests/tests.rs
@@ -32,12 +32,6 @@ pub struct OffchainReaderForAdapter {
 
 #[async_trait]
 impl OffchainStateReader for OffchainReaderForAdapter {
-    async fn wait_for_objects_snapshot_catchup(&self, base_timeout: Duration) {
-        self.cluster
-            .wait_for_objects_snapshot_catchup(base_timeout)
-            .await
-    }
-
     async fn wait_for_checkpoint_catchup(&self, checkpoint: u64, base_timeout: Duration) {
         self.cluster
             .wait_for_checkpoint_catchup(checkpoint, base_timeout)

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -9,7 +9,7 @@ pub use iota_indexer::config::SnapshotLagConfig;
 use iota_indexer::{
     config::PruningOptions,
     errors::IndexerError,
-    store::{PgIndexerStore, indexer_store::IndexerStore},
+    store::PgIndexerStore,
     test_utils::{IndexerTypeConfig, force_delete_database, start_test_indexer_impl},
 };
 use iota_node_storage::GrpcStateReader;
@@ -380,36 +380,6 @@ impl ExecutorCluster {
     /// Waits for the indexer to prune a given checkpoint.
     pub async fn wait_for_checkpoint_pruned(&self, checkpoint: u64, base_timeout: Duration) {
         wait_for_graphql_checkpoint_pruned(&self.graphql_client, checkpoint, base_timeout).await
-    }
-
-    /// The ObjectsSnapshotProcessor is a long-running task that periodically
-    /// takes a snapshot of the objects table. This leads to flakiness in
-    /// tests, so we wait until the objects_snapshot has reached the
-    /// expected state.
-    pub async fn wait_for_objects_snapshot_catchup(&self, base_timeout: Duration) {
-        let mut latest_snapshot_cp = 0;
-
-        let latest_cp = self
-            .indexer_store
-            .get_latest_checkpoint_sequence_number()
-            .await
-            .unwrap()
-            .unwrap();
-
-        tokio::time::timeout(base_timeout, async {
-            while latest_cp > latest_snapshot_cp + self.snapshot_config.snapshot_min_lag as u64 {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-                latest_snapshot_cp = self
-                    .indexer_store
-                    .get_latest_object_snapshot_watermark()
-                    .await
-                    .unwrap()
-                    .map(|watermark| watermark.max_committed_cp)
-                    .unwrap_or_default();
-            }
-        })
-        .await
-        .unwrap_or_else(|_| panic!("timeout waiting for indexer to update objects snapshot - latest_cp: {latest_cp}, latest_snapshot_cp: {latest_snapshot_cp}"));
     }
 
     /// Sends a cancellation signal to the graphql and indexer services, waits

--- a/crates/iota-graphql-rpc/src/types/available_range.rs
+++ b/crates/iota-graphql-rpc/src/types/available_range.rs
@@ -58,11 +58,12 @@ impl AvailableRange {
     /// traverse).
     const BACKWARD_HISTORY_MAX_LOOKBACK: u64 = 900;
 
-    /// Computes the backward-diff retention window and returns it iff
-    /// `checkpoint_viewed_at` falls inside it. The lower bound is the greater
-    /// of the backward history watermark (`min_available_cp`) and
-    /// `latest_checkpoint - BACKWARD_HISTORY_MAX_LOOKBACK`; the upper bound
-    /// is `checkpoint_viewed_at` itself, so the returned range never extends
+    /// Computes the backward-diff retention window. Returns `Some(range)`
+    /// when `checkpoint_viewed_at` falls inside it, `None` otherwise. The
+    /// lower bound is the greater of the backward history watermark
+    /// (`min_available_cp`) and `latest_checkpoint -
+    /// BACKWARD_HISTORY_MAX_LOOKBACK`; the upper bound is
+    /// `checkpoint_viewed_at` itself, so the returned range never extends
     /// past the request's captured watermark.
     pub(crate) fn result(conn: &mut Conn, checkpoint_viewed_at: u64) -> QueryResult<Option<Self>> {
         use checkpoints::dsl as cp;

--- a/crates/iota-graphql-rpc/src/types/available_range.rs
+++ b/crates/iota-graphql-rpc/src/types/available_range.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use diesel::{CombineDsl, ExpressionMethods, QueryDsl, QueryResult};
-use iota_indexer::schema::{checkpoints, objects_snapshot, watermarks};
+use diesel::{ExpressionMethods, QueryDsl, QueryResult};
+use iota_indexer::schema::{checkpoints, watermarks};
 
 use crate::{
     data::{Conn, Db, DbConnection, QueryExecutor},
@@ -52,64 +52,19 @@ impl AvailableRange {
         Ok(range)
     }
 
-    /// Look up the available range when viewing the data consistently at
-    /// `checkpoint_viewed_at`. Made available on the `Conn` type to make it
-    /// easier to call as part of other queries.
-    ///
-    /// Returns an error if there was an issue querying the database, Ok(None)
-    /// if the checkpoint being viewed is not in the database's available
-    /// range, or Ok(Some(AvailableRange)) otherwise.
-    pub(crate) fn result(conn: &mut Conn, checkpoint_viewed_at: u64) -> QueryResult<Option<Self>> {
-        use checkpoints::dsl as checkpoints;
-        use objects_snapshot::dsl as snapshots;
-
-        let checkpoint_range: Vec<i64> = conn.results(move || {
-            let rhs = checkpoints::checkpoints
-                .select(checkpoints::sequence_number)
-                .order(checkpoints::sequence_number.desc())
-                .limit(1);
-
-            let lhs = snapshots::objects_snapshot
-                .select(snapshots::checkpoint_sequence_number)
-                .order(snapshots::checkpoint_sequence_number.desc())
-                .limit(1);
-            // We need to use `union_all` in case `lhs` and `rhs` have the same value.
-            lhs.union_all(rhs)
-        })?;
-
-        let (first, mut last) = match checkpoint_range.as_slice() {
-            [] => (0, 0),
-            [single_value] => (0, *single_value as u64),
-            values => {
-                let min_value = *values.iter().min().unwrap();
-                let max_value = *values.iter().max().unwrap();
-                (min_value as u64, max_value as u64)
-            }
-        };
-
-        if checkpoint_viewed_at < first || last < checkpoint_viewed_at {
-            return Ok(None);
-        }
-
-        last = checkpoint_viewed_at;
-        Ok(Some(Self { first, last }))
-    }
-
     /// Maximum number of checkpoints to look back for backward diff queries.
     /// Limits how far back a consistent view can be requested, for performance
     /// reasons (the further back, the more backward history entries to
     /// traverse).
     const BACKWARD_HISTORY_MAX_LOOKBACK: u64 = 900;
 
-    /// Returns whether `checkpoint_viewed_at` is within the range served by
-    /// backward diff queries. The lower bound is the greater of the backward
-    /// history watermark (`min_available_cp`) and `latest_checkpoint -
-    /// BACKWARD_HISTORY_MAX_LOOKBACK`. The upper bound is the latest
-    /// checkpoint.
-    pub(crate) fn is_checkpoint_in_backward_history_range(
-        conn: &mut Conn,
-        checkpoint_viewed_at: u64,
-    ) -> QueryResult<bool> {
+    /// Computes the backward-diff retention window and returns it iff
+    /// `checkpoint_viewed_at` falls inside it. The lower bound is the greater
+    /// of the backward history watermark (`min_available_cp`) and
+    /// `latest_checkpoint - BACKWARD_HISTORY_MAX_LOOKBACK`; the upper bound
+    /// is `checkpoint_viewed_at` itself, so the returned range never extends
+    /// past the request's captured watermark.
+    pub(crate) fn result(conn: &mut Conn, checkpoint_viewed_at: u64) -> QueryResult<Option<Self>> {
         use checkpoints::dsl as cp;
         use watermarks::dsl as wm;
 
@@ -140,6 +95,21 @@ impl AvailableRange {
         let lag_first = last.saturating_sub(Self::BACKWARD_HISTORY_MAX_LOOKBACK);
         let first = watermark_first.max(lag_first);
 
-        Ok(checkpoint_viewed_at >= first && checkpoint_viewed_at <= last)
+        if checkpoint_viewed_at < first || checkpoint_viewed_at > last {
+            return Ok(None);
+        }
+        // Cap `last` to `checkpoint_viewed_at` so a single request never
+        // reports a range extending past its captured watermark.
+        Ok(Some(Self {
+            first,
+            last: checkpoint_viewed_at,
+        }))
+    }
+
+    pub(crate) fn is_checkpoint_in_backward_history_range(
+        conn: &mut Conn,
+        checkpoint_viewed_at: u64,
+    ) -> QueryResult<bool> {
+        Ok(Self::result(conn, checkpoint_viewed_at)?.is_some())
     }
 }

--- a/crates/iota-graphql-rpc/src/types/balance.rs
+++ b/crates/iota-graphql-rpc/src/types/balance.rs
@@ -83,12 +83,16 @@ impl Balance {
     ) -> Result<Option<Balance>, Error> {
         let stored: Option<StoredBalance> = db
             .execute_repeatable(move |conn| {
-                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
+                if !AvailableRange::is_checkpoint_in_backward_history_range(
+                    conn,
+                    checkpoint_viewed_at,
+                )? {
                     return Ok::<_, diesel::result::Error>(None);
-                };
+                }
 
                 conn.result(move || {
-                    balance_query(address, Some(coin_type.clone()), range).into_boxed()
+                    balance_query(address, Some(coin_type.clone()), checkpoint_viewed_at)
+                        .into_boxed()
                 })
                 .optional()
             })
@@ -115,14 +119,17 @@ impl Balance {
 
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
-                let Some(range) = AvailableRange::result(conn, checkpoint_viewed_at)? else {
+                if !AvailableRange::is_checkpoint_in_backward_history_range(
+                    conn,
+                    checkpoint_viewed_at,
+                )? {
                     return Ok::<_, diesel::result::Error>(None);
-                };
+                }
 
                 let result = page.paginate_raw_query::<StoredBalance>(
                     conn,
                     checkpoint_viewed_at,
-                    balance_query(address, None, range),
+                    balance_query(address, None, checkpoint_viewed_at),
                 )?;
 
                 Ok(Some(result))
@@ -207,69 +214,92 @@ impl TryFrom<StoredBalance> for Balance {
     }
 }
 
-/// Query the database for a `page` of coin balances. Each balance represents
-/// the total balance for a particular coin type, owned by `address`. This
-/// function is meant to be called within a thunk and returns a RawQuery that
-/// can be converted into a BoxedSqlQuery with `.into_boxed()`.
+/// Builds the aggregating SQL that totals each coin type's balance for
+/// `address` at `checkpoint_viewed_at`, using the backward-diff tables.
+///
+/// The consistent set of objects at `checkpoint_viewed_at` is the union of two
+/// disjoint sources:
+///
+/// * Source A — `checkpointed_objects` rows for objects that have not changed
+///   since `checkpoint_viewed_at` (no `objects_backward_history` entry with
+///   `superseded_at_checkpoint > checkpoint_viewed_at`).
+/// * Source B — `objects_backward_history` rows for the version of each object
+///   current at `checkpoint_viewed_at`: the earliest version whose
+///   `superseded_at_checkpoint > checkpoint_viewed_at`. Synthetic rows
+///   (`NotYetCreated`, `WrappedOrDeleted`) drop out automatically — they carry
+///   NULL `owner_id`/`coin_type`, so the owner+coin filter excludes them.
+///
+/// Each object can match at most one source: A only returns objects that
+/// did not change after `checkpoint_viewed_at`, while B only returns objects
+/// that did. So `UNION ALL` already gives one row per `object_id` — no
+/// dedup needed before aggregation.
 fn balance_query(
     address: IotaAddress,
     coin_type: Option<TypeTag>,
-    range: AvailableRange,
+    checkpoint_viewed_at: u64,
 ) -> RawQuery {
-    // Construct the filtered inner query - apply the same filtering criteria to
-    // both objects_snapshot and objects_history tables.
-    let mut snapshot_objs = query!("SELECT * FROM objects_snapshot");
-    snapshot_objs = filter(snapshot_objs, address, coin_type.clone());
+    let checkpoint_viewed_at = checkpoint_viewed_at as i64;
 
-    // Additionally filter objects_history table for results between the available
-    // range, or checkpoint_viewed_at, if provided.
-    let mut history_objs = query!("SELECT * FROM objects_history");
-    history_objs = filter(history_objs, address, coin_type);
-    history_objs = filter!(
-        history_objs,
-        format!(
-            r#"checkpoint_sequence_number BETWEEN {} AND {}"#,
-            range.first, range.last
-        )
+    let checkpointed = filter(
+        query!("SELECT object_id, coin_balance, coin_type FROM checkpointed_objects"),
+        address,
+        coin_type.clone(),
+    );
+    let changed = query!(format!(
+        "SELECT DISTINCT object_id FROM objects_backward_history \
+         WHERE superseded_at_checkpoint > {checkpoint_viewed_at}"
+    ));
+    let source_a = filter!(
+        query!(
+            r#"SELECT candidates.object_id, candidates.coin_balance, candidates.coin_type
+               FROM ({}) candidates
+               LEFT JOIN ({}) changed ON candidates.object_id = changed.object_id"#,
+            checkpointed,
+            changed
+        ),
+        "changed.object_id IS NULL"
     );
 
-    // Combine the two queries, and select the most recent version of each object.
-    let candidates = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ALL ({})) o"#,
-        snapshot_objs,
-        history_objs
-    )
-    .order_by("object_id")
-    .order_by("object_version DESC");
-
-    // Objects that fulfill the filtering criteria may not be the most recent
-    // version available. Left join the candidates table on newer to filter out
-    // any objects that have a newer version.
-    let mut newer = query!("SELECT object_id, object_version FROM objects_history");
-    newer = filter!(
-        newer,
-        format!(
-            r#"checkpoint_sequence_number BETWEEN {} AND {}"#,
-            range.first, range.last
-        )
+    let mut history = filter(
+        query!(
+            "SELECT object_id, object_version, coin_balance, coin_type \
+             FROM objects_backward_history"
+        ),
+        address,
+        coin_type,
     );
-    let final_ = query!(
+    // NotYetCreated and WrappedOrDeleted rows are already excluded above by
+    // `filter`'s `coin_type IS NOT NULL` / `owner_id = ...` clauses, since
+    // `from_empty` leaves those columns NULL.
+    history = filter!(
+        history,
+        format!("superseded_at_checkpoint > {checkpoint_viewed_at}")
+    );
+    let oldest = query!(format!(
+        "SELECT object_id, MIN(object_version) AS min_version \
+         FROM objects_backward_history \
+         WHERE superseded_at_checkpoint > {checkpoint_viewed_at} \
+         GROUP BY object_id"
+    ));
+    let source_b = query!(
+        r#"SELECT candidates.object_id, candidates.coin_balance, candidates.coin_type
+           FROM ({}) candidates
+           JOIN ({}) oldest ON candidates.object_id = oldest.object_id
+               AND candidates.object_version = oldest.min_version"#,
+        history,
+        oldest
+    );
+
+    query!(
         r#"SELECT
             CAST(SUM(coin_balance) AS TEXT) as balance,
             COUNT(*) as count,
             coin_type
-        FROM ({}) candidates
-        LEFT JOIN ({}) newer
-        ON (
-            candidates.object_id = newer.object_id
-            AND candidates.object_version < newer.object_version
-        )"#,
-        candidates,
-        newer
-    );
-
-    // Additionally for balance's query, group coins by coin_type.
-    filter!(final_, "newer.object_version IS NULL").group_by("coin_type")
+        FROM (({}) UNION ALL ({})) candidates"#,
+        source_a,
+        source_b
+    )
+    .group_by("coin_type")
 }
 
 /// Applies the filtering criteria for balances to the input `RawQuery` and

--- a/crates/iota-transactional-test-runner/src/offchain_state.rs
+++ b/crates/iota-transactional-test-runner/src/offchain_state.rs
@@ -17,9 +17,6 @@ pub struct TestResponse {
 /// stabilize the off-chain indexed state.
 #[async_trait]
 pub trait OffchainStateReader: Send + Sync + 'static {
-    /// Polls the objects snapshot table until it is within the allowed lag from
-    /// the latest checkpoint.
-    async fn wait_for_objects_snapshot_catchup(&self, base_timeout: Duration);
     /// Polls the checkpoint table until the given checkpoint is committed.
     async fn wait_for_checkpoint_catchup(&self, checkpoint: u64, base_timeout: Duration);
     /// Polls the checkpoint table until the given checkpoint is pruned.

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -663,10 +663,6 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                     .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(60))
                     .await;
 
-                offchain_reader
-                    .wait_for_objects_snapshot_catchup(Duration::from_secs(180))
-                    .await;
-
                 if let Some(checkpoint_to_prune) = wait_for_checkpoint_pruned {
                     offchain_reader
                         .wait_for_pruned_checkpoint(checkpoint_to_prune, Duration::from_secs(60))


### PR DESCRIPTION
# Description of change

Migrate the two remaining consumers off `objects_snapshot` onto the backward-diff tables:

- `balance_query` rewritten in place to merge `checkpointed_objects` with `objects_backward_history` (Source A / Source B partition, `MIN(object_version)`), then aggregate by `coin_type`.
- `AvailableRange::result` reuses the watermark+lookback logic already in `is_checkpoint_in_backward_history_range`, so the GraphQL `availableRange` field reports the backward-diff retention window.
- Drops `wait_for_objects_snapshot_catchup` end-to-end (call site, trait, impl, helper). With graphql off `objects_snapshot` and the backward-diff tables committed atomically with `checkpoints`, `wait_for_checkpoint_catchup` is sufficient.

Snapshots re-recorded: previously-out-of-range historical views now return reconstructed balances, and `availableRange.first` reflects the backward-history retention floor.

## Links to any relevant issues

fixes #11310

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.


