### PR TITLE
feat(node): prune `AuthorityPerEpochStorePruner` during epoch transitions

### DIFF
--- a/crates/iota-config/data/fullnode-template-with-path.yaml
+++ b/crates/iota-config/data/fullnode-template-with-path.yaml
@@ -19,7 +19,6 @@ migration-tx-data-path: "migration.blob"
 
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 1
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000

--- a/crates/iota-config/data/fullnode-template.yaml
+++ b/crates/iota-config/data/fullnode-template.yaml
@@ -19,7 +19,6 @@ migration-tx-data-path: "/opt/iota/config/migration.blob"
 
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 1
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1000,10 +1000,6 @@ pub struct AuthorityStorePruningConfig {
     /// number of the latest epoch dbs to retain
     #[serde(default = "default_num_latest_epoch_dbs_to_retain")]
     pub num_latest_epoch_dbs_to_retain: usize,
-    /// time interval used by the pruner to determine whether there are any
-    /// epoch DBs to remove
-    #[serde(default = "default_epoch_db_pruning_period_secs")]
-    pub epoch_db_pruning_period_secs: u64,
     /// number of epochs to keep the latest version of objects for.
     /// Note that a zero value corresponds to an aggressive pruner.
     /// This mode is experimental and needs to be used with caution.
@@ -1050,10 +1046,6 @@ fn default_num_latest_epoch_dbs_to_retain() -> usize {
     3
 }
 
-fn default_epoch_db_pruning_period_secs() -> u64 {
-    3600
-}
-
 fn default_max_transactions_in_batch() -> usize {
     1000
 }
@@ -1074,7 +1066,6 @@ impl Default for AuthorityStorePruningConfig {
     fn default() -> Self {
         Self {
             num_latest_epoch_dbs_to_retain: default_num_latest_epoch_dbs_to_retain(),
-            epoch_db_pruning_period_secs: default_epoch_db_pruning_period_secs(),
             num_epochs_to_retain: 0,
             pruning_run_delay_seconds: if cfg!(msim) { Some(2) } else { None },
             max_checkpoints_in_batch: default_max_checkpoints_in_batch(),

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -809,7 +809,7 @@ pub struct AuthorityState {
 
     pub metrics: Arc<AuthorityMetrics>,
     _pruner: AuthorityStorePruner,
-    _authority_per_epoch_pruner: AuthorityPerEpochStorePruner,
+    authority_per_epoch_pruner: AuthorityPerEpochStorePruner,
     checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
 
     /// Take db checkpoints of different dbs
@@ -3054,10 +3054,13 @@ impl AuthorityState {
         ));
         let (tx_execution_shutdown, rx_execution_shutdown) = oneshot::channel();
 
-        let _authority_per_epoch_pruner = AuthorityPerEpochStorePruner::new(
+        let authority_per_epoch_pruner = AuthorityPerEpochStorePruner::new(
             epoch_store.get_parent_path(),
-            &config.authority_store_pruning_config,
-        );
+            config
+                .authority_store_pruning_config
+                .num_latest_epoch_dbs_to_retain,
+        )
+        .await;
         let _pruner = AuthorityStorePruner::new(
             store.perpetual_tables.clone(),
             checkpoint_store.clone(),
@@ -3091,7 +3094,7 @@ impl AuthorityState {
             tx_execution_shutdown: Mutex::new(Some(tx_execution_shutdown)),
             metrics,
             _pruner,
-            _authority_per_epoch_pruner,
+            authority_per_epoch_pruner,
             checkpoint_progress_tracker,
             db_checkpoint_config: db_checkpoint_config.clone(),
             config,
@@ -3116,6 +3119,10 @@ impl AuthorityState {
             .expect("Error indexing genesis objects.");
 
         state
+    }
+
+    pub fn epoch_db_pruner(&self) -> &AuthorityPerEpochStorePruner {
+        &self.authority_per_epoch_pruner
     }
 
     // TODO: Consolidate our traits to reduce the number of methods here.

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1122,9 +1122,30 @@ impl AuthorityPerEpochStore {
     // epoch significantly right now, so we need to manually release the tables to
     // release its memory usage.
     pub fn release_db_handles(&self) {
-        // When the logic to release DB handles becomes obsolete, it may still be useful
-        // to make sure AuthorityEpochTables is not used after the next epoch starts.
-        self.tables.store(None);
+        let epoch = self.epoch();
+        // Swap out the tables Arc so no new references can be obtained via tables().
+        if let Some(tables) = self.tables.swap(None) {
+            // strong_count() == 1 means we hold the only reference and the
+            // RocksDB handles will be freed when this Arc is dropped below.
+            // A higher count means some code path still holds a reference,
+            // which delays freeing the underlying RocksDB memory.
+            let strong_count = Arc::strong_count(&tables);
+            if strong_count > 1 {
+                warn!(
+                    epoch,
+                    strong_count,
+                    "Epoch tables Arc has lingering references after release_db_handles(). \
+                     RocksDB memory for epoch {} will not be freed until all {} references \
+                     are dropped.",
+                    epoch,
+                    strong_count
+                );
+            } else {
+                debug!(epoch, "Epoch tables released cleanly for epoch {}", epoch);
+            }
+            // tables Arc is dropped here, freeing the RocksDB handles if
+            // strong_count == 1
+        }
     }
 
     pub fn randomness_reporter(&self) -> Option<RandomnessReporter> {

--- a/crates/iota-core/src/authority/authority_per_epoch_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store_pruner.rs
@@ -4,51 +4,52 @@
 
 use std::{fs, path::PathBuf, time::Duration};
 
-use iota_config::node::AuthorityStorePruningConfig;
 use itertools::Itertools;
-use tokio::sync::oneshot;
 use tracing::{info, warn};
 use typed_store::rocks::safe_drop_db;
 
 use crate::authority::authority_per_epoch_store::EPOCH_DB_PREFIX;
 
 /// The `AuthorityPerEpochStorePruner` manages the pruning process for Authority
-/// Store databases on a per-epoch basis. It contains a cancellation handle that
-/// can be used to stop the pruning task.
+/// Store databases on a per-epoch basis. It retains only the N most recent (by
+/// epoch number). Pruning is triggered at node startup and after each epoch
+/// transition.
 pub struct AuthorityPerEpochStorePruner {
-    _cancel_handle: oneshot::Sender<()>,
+    parent_path: PathBuf,
+    num_latest_epoch_dbs_to_retain: usize,
 }
 
 impl AuthorityPerEpochStorePruner {
-    /// Creates a new pruning task for the `AuthorityStore` with the specified
-    /// configuration. The task runs periodically based on the
-    /// `epoch_db_pruning_period_secs` value from the config, pruning old
-    /// epoch databases unless all versions are to be retained. The function
-    /// returns a struct containing a cancellation handle for the pruning task.
-    pub fn new(parent_path: PathBuf, config: &AuthorityStorePruningConfig) -> Self {
-        let (_cancel_handle, mut recv) = tokio::sync::oneshot::channel();
-        let num_latest_epoch_dbs_to_retain = config.num_latest_epoch_dbs_to_retain;
-        if num_latest_epoch_dbs_to_retain == 0 || num_latest_epoch_dbs_to_retain == usize::MAX {
-            info!("Skipping pruning of epoch tables as we want to retain all versions");
-            return Self { _cancel_handle };
+    /// Creates a new epoch DB pruner and immediately prunes any stale epoch
+    /// databases left over from a previous run (e.g. after a crash).
+    pub async fn new(parent_path: PathBuf, num_latest_epoch_dbs_to_retain: usize) -> Self {
+        let pruner = Self {
+            parent_path,
+            num_latest_epoch_dbs_to_retain,
+        };
+        // Prune on startup to clean up stale epoch DBs from prior runs.
+        pruner.prune_old_epoch_dbs().await;
+        pruner
+    }
+
+    /// Prunes old epoch databases, retaining only the configured number of
+    /// most recent ones. Should be called after each epoch transition.
+    pub async fn prune_old_epoch_dbs(&self) {
+        if self.num_latest_epoch_dbs_to_retain == 0
+            || self.num_latest_epoch_dbs_to_retain == usize::MAX
+        {
+            return;
         }
-        let mut prune_interval =
-            tokio::time::interval(Duration::from_secs(config.epoch_db_pruning_period_secs));
-        tokio::task::spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = prune_interval.tick() => {
-                        info!("Starting pruning of epoch tables");
-                        match Self::prune_old_directories(&parent_path, num_latest_epoch_dbs_to_retain).await {
-                            Ok(pruned_count) => info!("Finished pruning old epoch databases. Pruned {} dbs", pruned_count),
-                            Err(err) => warn!("Error while removing old epoch databases {:?}", err),
-                        }
-                    }
-                    _ = &mut recv => break,
+        match Self::prune_old_directories(&self.parent_path, self.num_latest_epoch_dbs_to_retain)
+            .await
+        {
+            Ok(pruned_count) => {
+                if pruned_count > 0 {
+                    info!("Pruned {} old epoch databases", pruned_count);
                 }
             }
-        });
-        Self { _cancel_handle }
+            Err(err) => warn!("Error while removing old epoch databases: {:?}", err),
+        }
     }
 
     /// Prunes old epoch directories from the specified parent path, retaining

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1914,6 +1914,11 @@ impl IotaNode {
             // Arc<AuthorityPerEpochStore> may linger.
             cur_epoch_store.release_db_handles();
 
+            // Prune old epoch databases after each epoch transition to prevent
+            // accumulation of RocksDB instances during fast catch-up sync
+            // (e.g. syncing from genesis).
+            self.state.epoch_db_pruner().prune_old_epoch_dbs().await;
+
             if cfg!(msim)
                 && !matches!(
                     self.config

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1914,6 +1914,11 @@ impl IotaNode {
             // Arc<AuthorityPerEpochStore> may linger.
             cur_epoch_store.release_db_handles();
 
+            // Drop the old epoch store to free its in-memory structures
+            // (ConsensusOutputCache, ConsensusQuarantine, DashMaps, etc.).
+            // The DB tables were already released above.
+            drop(cur_epoch_store);
+
             // Prune old epoch databases after each epoch transition to prevent
             // accumulation of RocksDB instances during fast catch-up sync
             // (e.g. syncing from genesis).

--- a/crates/iota-proxy/README.md
+++ b/crates/iota-proxy/README.md
@@ -166,7 +166,6 @@ migration-tx-data-path: /opt/iota/config/migration.blob
 # Pruning configuration
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   num-epochs-to-retain: 0

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -36,7 +36,6 @@ validator_configs:
     migration-tx-data-path: "[fake migration path]"
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
-      epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
@@ -136,7 +135,6 @@ validator_configs:
     migration-tx-data-path: "[fake migration path]"
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
-      epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
@@ -236,7 +234,6 @@ validator_configs:
     migration-tx-data-path: "[fake migration path]"
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
-      epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
@@ -336,7 +333,6 @@ validator_configs:
     migration-tx-data-path: "[fake migration path]"
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
-      epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
@@ -436,7 +432,6 @@ validator_configs:
     migration-tx-data-path: "[fake migration path]"
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
-      epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
@@ -536,7 +531,6 @@ validator_configs:
     migration-tx-data-path: "[fake migration path]"
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
-      epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
@@ -636,7 +630,6 @@ validator_configs:
     migration-tx-data-path: "[fake migration path]"
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
-      epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 0
       max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000

--- a/crates/iota-tool/src/db_tool/mod.rs
+++ b/crates/iota-tool/src/db_tool/mod.rs
@@ -356,7 +356,6 @@ pub async fn reset_db_to_genesis(path: &Path) -> anyhow::Result<()> {
     //   genesis-file-location:  <path to genesis blob for the network>
     // authority-store-pruning-config:
     //   num-latest-epoch-dbs-to-retain: 3
-    //   epoch-db-pruning-period-secs: 3600
     //   num-epochs-to-retain: 18446744073709551615
     //   max-checkpoints-in-batch: 10
     //   max-transactions-in-batch: 1000

--- a/dev-tools/iota-network/genesis/static/fullnode.yaml
+++ b/dev-tools/iota-network/genesis/static/fullnode.yaml
@@ -12,7 +12,6 @@ genesis:
   genesis-file-location: /opt/iota/config/genesis.blob
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 18446744073709551615
   max-checkpoints-in-batch: 5
   max-transactions-in-batch: 1000

--- a/dev-tools/iota-private-network/configs/fullnodes/backup.yaml
+++ b/dev-tools/iota-private-network/configs/fullnodes/backup.yaml
@@ -12,7 +12,6 @@ genesis:
   genesis-file-location: /opt/iota/config/genesis.blob
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 18446744073709551615
   max-checkpoints-in-batch: 5
   max-transactions-in-batch: 1000

--- a/dev-tools/iota-private-network/configs/fullnodes/fullnode.yaml
+++ b/dev-tools/iota-private-network/configs/fullnodes/fullnode.yaml
@@ -12,7 +12,6 @@ genesis:
   genesis-file-location: /opt/iota/config/genesis.blob
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 18446744073709551615
   max-checkpoints-in-batch: 5
   max-transactions-in-batch: 1000

--- a/docs/content/operator/common/pruning.mdx
+++ b/docs/content/operator/common/pruning.mdx
@@ -30,7 +30,6 @@ enable-index-processing: false
 authority-store-pruning-config:
   # default values
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   # end of default values
@@ -57,7 +56,6 @@ This setup manages secondary indexing in addition to the latest state, but aggre
 authority-store-pruning-config:
   # default values
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   # end of default values
@@ -83,7 +81,6 @@ In addition to the regular (pruned) snapshots, the IOTA Foundation also maintain
 authority-store-pruning-config:
   # default values
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   # end of default values
@@ -111,9 +108,6 @@ authority-store-pruning-config:
   # Number of epoch dbs to keep
   # Not relevant for object pruning
   num-latest-epoch-dbs-to-retain: 3
-  # The amount of time, in seconds, between running the object pruning task.
-  # Not relevant for object pruning
-  epoch-db-pruning-period-secs: 3600
   # Number of epochs to wait before performing object pruning.
   # When set to 0, IOTA prunes old object versions as soon
   # as possible. This is also called *aggressive pruning*, and results in the most effective
@@ -149,7 +143,6 @@ to the `authority-store-pruning-config` config for the node:
 ```yaml
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 0
   max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000


### PR DESCRIPTION
# Description of change

This PR removes the time-based pruning parameter `epoch-db-pruning-period-secs` for the AuthorityPerEpochStore and triggers pruning during every epoch transition instead. The reasoning is twofold: First, during fast-syncing processes, epochs may sync faster than the configured pruning interval, causing pruning to fail or behave unexpectedly. Second, since pruning configuration is purely epoch-based, it is more logical to trigger it immediately after a new epoch is created.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes):  Removed the `epoch-db-pruning-period-secs` node config parameter. Pruning is now automatically triggered during every epoch transition. This fixes a potential memory leak and ensures consistent pruning behavior during node synchronization.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
