### PR TITLE
feat(setups): add disabled `MALLOC_CONF` to fullnode docker compose for easier debugging

### DIFF
--- a/setups/fullnode/docker/docker-compose.yaml
+++ b/setups/fullnode/docker/docker-compose.yaml
@@ -7,6 +7,13 @@ services:
       - "9184:9184/tcp" # Metrics port
     volumes:
       - ./data:/opt/iota/:rw
+    #environment:
+    #  # activate jemalloc's heap profiler with the following settings:
+    #  #  - "prof_prefix:/opt/iota/profiles/memory/node" - writes heap profiles with the prefix "node"
+    #  #  - "prof_final:true" - writes a final heap profile on exit
+    #  #  - "lg_prof_interval:30" - to write a heap profile every 2^30 bytes (1GB) of allocated memory
+    #  #  - "prof_sample:19" - samples 1 out of 2^19 allocations for the heap profile, which is a good balance between overhead and detail.
+    #  - MALLOC_CONF=prof:true,prof_active:true,prof_prefix:/opt/iota/profiles/memory/node,prof_final:true,lg_prof_interval:30,lg_prof_sample:19
     command: [
       "/usr/local/bin/iota-node",
       "--config-path",

--- a/setups/fullnode/docker/prepare_devnet.sh
+++ b/setups/fullnode/docker/prepare_devnet.sh
@@ -16,3 +16,6 @@ docker compose pull
 curl -fLJ https://dbfiles.devnet.iota.cafe/genesis.blob -o "$CONFIG_DIR/genesis.blob"
 # download the migration file
 curl -fLJ https://dbfiles.devnet.iota.cafe/migration.blob -o "$CONFIG_DIR/migration.blob"
+
+# create the memory profiles directory for jemalloc
+mkdir -p "$DATA_DIR/profiles/memory"

--- a/setups/fullnode/docker/prepare_mainnet.sh
+++ b/setups/fullnode/docker/prepare_mainnet.sh
@@ -16,3 +16,6 @@ docker compose pull
 curl -fLJ https://dbfiles.mainnet.iota.cafe/genesis.blob -o "$CONFIG_DIR/genesis.blob"
 # download the migration file
 curl -fLJ https://dbfiles.mainnet.iota.cafe/migration.blob -o "$CONFIG_DIR/migration.blob"
+
+# create the memory profiles directory for jemalloc
+mkdir -p "$DATA_DIR/profiles/memory"

--- a/setups/fullnode/docker/prepare_testnet.sh
+++ b/setups/fullnode/docker/prepare_testnet.sh
@@ -14,3 +14,6 @@ docker compose pull
 
 # download the genesis file
 curl -fLJ https://dbfiles.testnet.iota.cafe/genesis.blob -o $CONFIG_DIR/genesis.blob
+
+# create the memory profiles directory for jemalloc
+mkdir -p "$DATA_DIR/profiles/memory"


### PR DESCRIPTION
# Description of change

This PR adds a preconfigured setting for jemalloc, which can be used for debugging memory leaks in the fullnode docker setup.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes