### PR TITLE
chore(iota-json-rpc-types): simplify `IotaTransactionBlockKind::try_from_with_package_resolver`

### DIFF
--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -617,37 +617,16 @@ impl IotaTransactionBlockKind {
         package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
-        Ok(match tx {
-            TransactionKind::Genesis(g) => Self::Genesis(IotaGenesisTransaction {
-                objects: g.objects.iter().map(GenesisObject::id).collect(),
-                events: g
-                    .events
-                    .into_iter()
-                    .enumerate()
-                    .map(|(seq, _event)| EventID::from((tx_digest, seq as u64)))
-                    .collect(),
-            }),
-            TransactionKind::ConsensusCommitPrologueV1(p) => {
-                Self::ConsensusCommitPrologueV1(IotaConsensusCommitPrologueV1 {
-                    epoch: p.epoch,
-                    round: p.round,
-                    sub_dag_index: p.sub_dag_index,
-                    commit_timestamp_ms: p.commit_timestamp_ms,
-                    consensus_commit_digest: p.consensus_commit_digest,
-                    consensus_determined_version_assignments: p
-                        .consensus_determined_version_assignments
-                        .into(),
-                })
-            }
-            TransactionKind::Programmable(p) => Self::ProgrammableTransaction(
+        match tx {
+            TransactionKind::Programmable(p) => Ok(Self::ProgrammableTransaction(
                 IotaProgrammableTransactionBlock::try_from_with_package_resolver(
                     p,
                     package_resolver,
                 )
                 .await?,
-            ),
-            tx => Self::try_from_inner(tx, tx_digest)?,
-        })
+            )),
+            tx => Self::try_from_inner(tx, tx_digest),
+        }
     }
 
     pub fn transaction_count(&self) -> usize {


### PR DESCRIPTION
# Description of change

Simplify `IotaTransactionBlockKind::try_from_with_package_resolver` by deduplicating the `Genesis` and `ConsensusCommitPrologueV1` arms, which were copy-pasted from `try_from_inner`. The function now matches the shape of its sibling `try_from_with_module_cache`: only the `Programmable` variant needs special handling (since it's the only one that requires the resolver), and everything else delegates to `try_from_inner`.

No behavior change — the removed arms produced identical output to the `try_from_inner` fallback they shadowed.

## Links to any relevant issues

N/A

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage) — pure refactor, covered by existing tests
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
