### PR TITLE
fix(network): fix node state sync and add comments about invariant

### DIFF
--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -700,6 +700,10 @@ where
             self.store
                 .try_update_highest_verified_checkpoint(&checkpoint)
                 .expect("store operation should not fail");
+
+            // INVARIANT: checkpoint contents must exist in the store for
+            // every checkpoint up to the synced watermark. The checkpoint
+            // executor will panic if it encounters missing contents.
             self.store
                 .try_update_highest_synced_checkpoint(&checkpoint)
                 .expect("store operation should not fail");
@@ -1482,6 +1486,10 @@ async fn sync_checkpoint_contents<S>(
                     Ok(checkpoint) => {
                         let _: &VerifiedCheckpoint = &checkpoint;  // type hint
 
+                        // INVARIANT: checkpoint contents must exist in the store
+                        // for every checkpoint up to the synced watermark. The
+                        // checkpoint executor will panic if it encounters missing
+                        // contents.
                         store
                             .try_update_highest_synced_checkpoint(&checkpoint)
                             .expect("store operation should not fail");
@@ -1523,10 +1531,13 @@ async fn sync_checkpoint_contents<S>(
                                     last_pruned_log_time = tokio::time::Instant::now();
                                 }
 
-                                // Push to back (not front) — don't block progress.
-                                // On the next cycle the early-exit check picks up
-                                // any archive progress.
-                                checkpoint_contents_tasks.push_back(
+                                // Retry at front to block the synced watermark
+                                // from advancing past this checkpoint.
+                                // INVARIANT: checkpoint contents must exist in the
+                                // store for every checkpoint up to the synced
+                                // watermark. The checkpoint executor will panic if
+                                // it encounters missing contents.
+                                checkpoint_contents_tasks.push_front(
                                     sync_one_checkpoint_contents(
                                         network.clone(),
                                         &store,
@@ -1636,6 +1647,12 @@ where
     // Check if we already have produced this checkpoint locally (e.g. via
     // consensus output or archive sync). If so, we don't need to get it from
     // peers anymore.
+    //
+    // INVARIANT: checkpoint contents must exist in the store for every
+    // checkpoint up to the synced watermark. The checkpoint executor will
+    // panic if it encounters missing contents. This is maintained by
+    // retrying failed content syncs at the front of the queue, blocking
+    // the watermark from advancing past them.
     if store
         .try_get_highest_synced_checkpoint()
         .expect("store operation should not fail")

--- a/crates/iota-tool/src/db_tool/mod.rs
+++ b/crates/iota-tool/src/db_tool/mod.rs
@@ -476,6 +476,18 @@ pub fn set_checkpoint_watermark(
         else {
             bail!("Checkpoint {highest_synced} not found");
         };
+        // Verify that checkpoint contents exist, since the checkpoint executor
+        // will panic if it tries to execute a checkpoint whose contents are
+        // missing from the store.
+        if checkpoint_db
+            .get_checkpoint_contents(&checkpoint.content_digest)?
+            .is_none()
+        {
+            bail!(
+                "Checkpoint contents not found for checkpoint {highest_synced}. \
+                 Setting highest_synced without contents would cause the executor to panic."
+            );
+        }
         checkpoint_db.update_highest_synced_checkpoint(&checkpoint)?;
     }
     Ok(())

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -769,6 +769,9 @@ fn start_summary_sync(
             verify_progress_bar.finish_with_message("Checkpoint summary verification is complete");
         }
 
+        // SAFETY: All four watermarks must be set together so the executor
+        // starts from `highest_executed + 1` and never tries to access
+        // checkpoint contents in the restored (summary-only) range.
         checkpoint_store.update_highest_verified_checkpoint(&checkpoint)?;
         checkpoint_store.update_highest_synced_checkpoint(&checkpoint)?;
         checkpoint_store.update_highest_executed_checkpoint(&checkpoint)?;


### PR DESCRIPTION
# Description of change

This PR fixes a regression that was introduced in #11450.

The change to `push_back` caused that checkpoint syncing continued with following checkpoints if no peers had the requested checkpoint, and the archive syncing didn't fill the gap in time. The checkpoint executor relies on the fact that the watermark for the synced checkpoint is only set, if all checkpoints and their data are available.

```bash
fullnode-1  | 2026-05-09T00:47:03.149901Z  INFO iota_core::checkpoint_progress_tracker: checkpoint progress [epoch 101]: executed 38909003/38914406 (+1606, 8153 tx/s, 3.96s), objects pruned 38902849 (+0, 0.00ns), checkpoints pruned 6631843 (+0, 0.00ns)
fullnode-1  | 2026-05-09T00:47:04.149573Z  INFO iota_core::checkpoint_progress_tracker: checkpoint progress [epoch 101]: executed 38910594/38915491 (+1591, 8141 tx/s, 3.95s), objects pruned 38902849 (+0, 0.00ns), checkpoints pruned 6631843 (+0, 0.00ns)
fullnode-1  | 2026-05-09T00:47:05.149621Z  INFO iota_core::checkpoint_progress_tracker: checkpoint progress [epoch 101]: executed 38912231/38916605 (+1637, 8330 tx/s, 3.96s), objects pruned 38902849 (+0, 0.00ns), checkpoints pruned 6631843 (+0, 0.00ns)
fullnode-1  | 2026-05-09T00:47:06.149586Z  INFO iota_core::checkpoint_progress_tracker: checkpoint progress [epoch 101]: executed 38913831/38917684 (+1600, 8155 tx/s, 3.94s), objects pruned 38903359 (+510, 22.74ms), checkpoints pruned 6631843 (+0, 0.00ns)
fullnode-1  | 2026-05-09T00:47:07.093063Z  INFO iota_core::checkpoints::checkpoint_executor: Reached end of epoch checkpoint, waiting for all previous checkpoints to be executed
fullnode-1  | 2026-05-09T00:47:07.094818Z  INFO execute_transactions_from_synced_checkpoint:execute_change_epoch_tx: iota_core::checkpoints::checkpoint_executor: scheduling change epoch txn with digest: Digest("Barwwq22THCsGV3Bbm7eqvj5ujcRCg5UG3KN5U8n8cHC"), expected effects digest: Digest("76SuR4nKGoAWf22rVxvCJZFiEExqav5mBMs5zHBHoqHo")
fullnode-1  | 2026-05-09T00:47:07.094887Z  INFO executing_pending_cert{tx_digest=Digest("Barwwq22THCsGV3Bbm7eqvj5ujcRCg5UG3KN5U8n8cHC")}: iota_adapter_latest::execution_engine::checked: Call arguments to advance_epoch transaction: AdvanceEpochParams { epoch: 102, next_protocol_version: ProtocolVersion(3), validator_subsidy: 767000000000000, storage_charge: 578276035200, computation_charge: 208617000000, computation_charge_burned: 208617000000, storage_rebate: 574555234800, non_refundable_storage_fee: 0, reward_slashing_rate: 10000, epoch_start_timestamp_ms: 1740683963989, max_committee_members_count: 0, eligible_active_validators: [], scores: [], adjust_rewards_by_score: false }
fullnode-1  | 2026-05-09T00:47:07.150048Z  INFO iota_core::checkpoint_progress_tracker: checkpoint progress [epoch 101]: executed 38915372/38918780 (+1541, 7310 tx/s, 3.78s), objects pruned 38913794 (+10435, 375.71ms), checkpoints pruned 6633913 (+2070, 622.80ms)
fullnode-1  | 2026-05-09T00:47:07.188670Z  INFO iota_node: Finished executing all checkpoints in epoch. About to reconfigure the system. next_epoch=102
fullnode-1  | 2026-05-09T00:47:07.188744Z  INFO reconfigure: iota_core::authority: current protocol version is now ProtocolVersion(3)
fullnode-1  | 2026-05-09T00:47:07.188748Z  INFO reconfigure: iota_core::authority: supported versions are: SupportedProtocolVersions { min: ProtocolVersion(1), max: ProtocolVersion(26) }
fullnode-1  | 2026-05-09T00:47:07.188780Z  INFO reconfigure:revert_uncommitted_epoch_transactions: iota_core::authority: Reverting 0 locally executed transactions that was not included in the epoch: {}
fullnode-1  | 2026-05-09T00:47:07.188783Z  INFO reconfigure:revert_uncommitted_epoch_transactions: iota_core::authority: All uncommitted local transactions reverted
fullnode-1  | 2026-05-09T00:47:07.188786Z  INFO reconfigure: iota_core::execution_cache::writeback_cache: clearing state at end of epoch
fullnode-1  | 2026-05-09T00:47:07.188888Z  INFO reconfigure: iota_core::execution_cache::writeback_cache: clearing old transaction locks
fullnode-1  | 2026-05-09T00:47:07.188891Z  INFO reconfigure: iota_core::execution_cache::object_locks: clearing old transaction locks
fullnode-1  | 2026-05-09T00:47:07.188894Z  INFO reconfigure:check_system_consistency: iota_core::authority: Performing iota conservation consistency check for epoch 101
fullnode-1  | 2026-05-09T00:47:07.189056Z  INFO reconfigure: iota_core::execution_cache::proxy_cache: switching to cache impl WritebackCache
fullnode-1  | 2026-05-09T00:47:07.189060Z  INFO reconfigure:reopen_epoch_db: iota_core::authority: re-opening AuthorityEpochTables for new epoch new_epoch=102
fullnode-1  | 2026-05-09T00:47:07.203313Z  INFO reconfigure:reopen_epoch_db:AuthorityPerEpochStore::new{epoch=102}: iota_core::authority::authority_per_epoch_store: epoch flags: [WritebackCacheEnabled]
fullnode-1  | 2026-05-09T00:47:07.203322Z  INFO reconfigure:reopen_epoch_db:AuthorityPerEpochStore::new{epoch=102}: iota_core::authority::authority_per_epoch_store: initializing epoch store from chain id Testnet to chain id Testnet
fullnode-1  | 2026-05-09T00:47:07.203840Z  INFO iota_node: Node State has been reconfigured next_epoch=102
fullnode-1  | 2026-05-09T00:47:07.206910Z  INFO iota_core::authority::authority_per_epoch_store_pruner: Dropping epoch directory "/opt/iota/db/live/store/epoch_101"
fullnode-1  | 2026-05-09T00:47:07.235282Z  INFO iota_core::quorum_driver::reconfig_observer: Got reconfig message. New committee: Committee (epoch=102, voting_rights=[k#802246b0..: 86, k#807be453..: 145, k#814e6e59..: 178, k#826b4176..: 87, k#83496906..: 117, k#8406bbc1..: 115, k#854a8e27..: 129, k#85f1264a..: 87, k#86c2dcb2..: 122, k#87ec193f..: 1000, k#8e1af168..: 94, k#8e826b08..: 87, k#8f892414..: 88, k#8fe62b19..: 86, k#9079b073..: 115, k#92554292..: 87, k#92711a6d..: 128, k#92c29c0e..: 87, k#9312bc7c..: 87, k#94020329..: 90, k#95970c57..: 140, k#968e0564..: 153, k#97b660a3..: 119, k#99ae3858..: 125, k#99ae9e6d..: 89, k#a1050b12..: 86, k#a31b4d8a..: 93, k#a42a1410..: 183, k#a4c1754c..: 1000, k#a4deaef7..: 1000, k#a5873882..: 93, k#a58bf2bb..: 85, k#a6777f59..: 90, k#a8aa78fe..: 140, k#a959d8e5..: 1000, k#a975a968..: 119, k#ab251caf..: 146, k#ab98c5e9..: 121, k#abed0314..: 116, k#abfb077a..: 126, k#ac957543..: 116, k#ad5470a4..: 94, k#aebe1d2a..: 93, k#af459b55..: 98, k#b01c1082..: 87, k#b037dac9..: 180, k#b0395039..: 91, k#b05e9172..: 116, k#b0e20ab9..: 137, k#b3e30367..: 93, k#b554ab55..: 120, k#b5ca9d81..: 145, k#b6165d47..: 135, k#b6fa583a..: 125, k#b97ff919..: 116, k#b98fc9d7..: 122, k#b9b08763..: 93, ])
fullnode-1  | 2026-05-09T00:47:07.237135Z  INFO iota_core::quorum_driver: Quorum Driver updating AuthorityAggregator with committee Committee (epoch=102, voting_rights=[k#802246b0..: 86, k#807be453..: 145, k#814e6e59..: 178, k#826b4176..: 87, k#83496906..: 117, k#8406bbc1..: 115, k#854a8e27..: 129, k#85f1264a..: 87, k#86c2dcb2..: 122, k#87ec193f..: 1000, k#8e1af168..: 94, k#8e826b08..: 87, k#8f892414..: 88, k#8fe62b19..: 86, k#9079b073..: 115, k#92554292..: 87, k#92711a6d..: 128, k#92c29c0e..: 87, k#9312bc7c..: 87, k#94020329..: 90, k#95970c57..: 140, k#968e0564..: 153, k#97b660a3..: 119, k#99ae3858..: 125, k#99ae9e6d..: 89, k#a1050b12..: 86, k#a31b4d8a..: 93, k#a42a1410..: 183, k#a4c1754c..: 1000, k#a4deaef7..: 1000, k#a5873882..: 93, k#a58bf2bb..: 85, k#a6777f59..: 90, k#a8aa78fe..: 140, k#a959d8e5..: 1000, k#a975a968..: 119, k#ab251caf..: 146, k#ab98c5e9..: 121, k#abed0314..: 116, k#abfb077a..: 126, k#ac957543..: 116, k#ad5470a4..: 94, k#aebe1d2a..: 93, k#af459b55..: 98, k#b01c1082..: 87, k#b037dac9..: 180, k#b0395039..: 91, k#b05e9172..: 116, k#b0e20ab9..: 137, k#b3e30367..: 93, k#b554ab55..: 120, k#b5ca9d81..: 145, k#b6165d47..: 135, k#b6fa583a..: 125, k#b97ff919..: 116, k#b98fc9d7..: 122, k#b9b08763..: 93, ])
fullnode-1  | 2026-05-09T00:47:07.293720Z  INFO iota_core::authority::authority_per_epoch_store_pruner: Pruned 1 old epoch databases
fullnode-1  | 2026-05-09T00:47:07.328810Z  INFO iota_node: Reconfiguration finished
fullnode-1  | 2026-05-09T00:47:07.328819Z  INFO iota_node: Creating checkpoint executor for epoch 102
fullnode-1  | 2026-05-09T00:47:07.328835Z  INFO run_epoch{epoch=102}: iota_core::checkpoints::checkpoint_executor: CheckpointExecutor::run_epoch run_with_range=None
fullnode-1  | 2026-05-09T00:47:07.617961Z  INFO iota_storage::mutex_table: Stopping mutex table cleanup!
fullnode-1  | 2026-05-09T00:47:07.910491Z  INFO iota_storage::mutex_table: Stopping mutex table cleanup!
fullnode-1  | 2026-05-09T00:47:08.149657Z  INFO iota_core::checkpoint_progress_tracker: checkpoint progress [epoch 102]: executed 38916770/38919882 (+1398, 6510 tx/s, 3.23s), objects pruned 38913794 (+0, 0.00ns), checkpoints pruned 6635488 (+1575, 472.43ms)
fullnode-1  | 
fullnode-1  | thread 'iota-node-runtime' (27) panicked at crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs:690:14:
fullnode-1  | checkpoint contents not found
fullnode-1  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fullnode-1  | 2026-05-09T00:47:08.880421Z ERROR execute_transactions_from_synced_checkpoint:load_checkpoint_transactions: telemetry_subscribers: panicked at crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs:690:14:
fullnode-1  | checkpoint contents not found panic.file="crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs" panic.line=690 panic.column=14
```

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes