### PR TITLE
feat(ci): add bump version workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -21,13 +21,6 @@ jobs:
   bump-version:
     runs-on: ubuntu-latest
     steps:
-      - name: Validate version
-        run: |
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
-            echo "Error: '${{ inputs.version }}' is not a valid version (expected MAJOR.MINOR.PATCH[-prerelease])" >&2
-            exit 1
-          fi
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.base_branch }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,46 @@
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (MAJOR.MINOR.PATCH[-prerelease], e.g. 1.24.0-alpha)"
+        type: string
+        required: true
+      base_branch:
+        description: "Branch to open the PR against"
+        type: string
+        required: true
+        default: develop
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "Error: '${{ inputs.version }}' is not a valid version (expected MAJOR.MINOR.PATCH[-prerelease])" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.base_branch }}
+
+      - name: Run bump_version.sh
+        run: scripts/bump_version.sh "${{ inputs.version }}"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          base: ${{ inputs.base_branch }}
+          branch: release/bump-version-${{ inputs.version }}
+          title: "release: bump version to `${{ inputs.version }}`"
+          commit-message: "release: bump version to `${{ inputs.version }}`"
+          body: Automated version bump to `${{ inputs.version }}`.
+          delete-branch: true

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -3,10 +3,24 @@ name: Bump version
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "New version (MAJOR.MINOR.PATCH[-prerelease], e.g. 1.24.0-alpha)"
-        type: string
+      bump:
+        description: "Which segment of the base version to bump"
+        type: choice
         required: true
+        default: none
+        options:
+          - none
+          - minor
+          - patch
+      prerelease:
+        description: "Pre-release suffix to set (release = no suffix)"
+        type: choice
+        required: true
+        options:
+          - alpha
+          - beta
+          - rc
+          - release
       base_branch:
         description: "Branch to open the PR against"
         type: string
@@ -26,14 +40,14 @@ jobs:
           ref: ${{ inputs.base_branch }}
 
       - name: Run bump_version.sh
-        run: scripts/bump_version.sh "${{ inputs.version }}"
+        run: scripts/bump_version.sh "${{ inputs.bump }}" "${{ inputs.prerelease }}"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: ${{ inputs.base_branch }}
-          branch: release/bump-version-${{ inputs.version }}
-          title: "release: bump version to `${{ inputs.version }}`"
-          commit-message: "release: bump version to `${{ inputs.version }}`"
-          body: Automated version bump to `${{ inputs.version }}`.
+          branch: release/bump-version-${{ env.IOTA_VERSION }}
+          title: "release: bump version to `${{ env.IOTA_VERSION }}`"
+          commit-message: "release: bump version to `${{ env.IOTA_VERSION }}`"
+          body: Automated version bump to `${{ env.IOTA_VERSION }}`.
           delete-branch: true

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -25,6 +25,7 @@ jobs:
             chore
             upstream
             backport
+            release
           requireScope: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,29 +1,45 @@
 #!/usr/bin/env bash
 # Bump the workspace version and propagate it to dependent files.
 #
-# Usage: scripts/bump_version.sh <new-version>
-# Example: scripts/bump_version.sh 1.24.0-alpha
+# Usage: scripts/bump_version.sh <minor|patch|none> <alpha|beta|rc|release>
+#
+# The first argument controls which segment of MAJOR.MINOR.PATCH gets
+# incremented; "none" keeps the base version unchanged (useful for promoting
+# a pre-release in place, e.g. alpha -> beta).
+#
+# The second argument sets the pre-release suffix; "release" means no suffix.
+#
+# Examples:
+#   scripts/bump_version.sh minor alpha    # 1.24.0       -> 1.25.0-alpha
+#   scripts/bump_version.sh none  beta     # 1.24.0-alpha -> 1.24.0-beta
+#   scripts/bump_version.sh none  release  # 1.24.0-rc    -> 1.24.0
+#   scripts/bump_version.sh patch release  # 1.24.0       -> 1.24.1
 
 set -euo pipefail
 
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <new-version>" >&2
-    echo "Example: $0 1.24.0-alpha" >&2
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <minor|patch|none> <alpha|beta|rc|release>" >&2
     exit 1
 fi
 
-new_version="$1"
+bump="$1"
+prerelease="$2"
 
-if [[ ! "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
-    echo "Error: '$new_version' is not a valid version (expected MAJOR.MINOR.PATCH[-prerelease])" >&2
-    exit 1
-fi
+case "$bump" in
+    minor|patch|none) ;;
+    *)
+        echo "Error: first argument must be one of: minor, patch, none (got '$bump')" >&2
+        exit 1
+        ;;
+esac
 
-# Forms used across the touched files:
-#   new_base  = MAJOR.MINOR.PATCH (no prerelease) e.g. 1.24.0
-#   new_short = MAJOR.MINOR                       e.g. 1.24
-new_base="${new_version%%-*}"
-new_short="${new_base%.*}"
+case "$prerelease" in
+    alpha|beta|rc|release) ;;
+    *)
+        echo "Error: second argument must be one of: alpha, beta, rc, release (got '$prerelease')" >&2
+        exit 1
+        ;;
+esac
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -42,6 +58,43 @@ old_version="$(awk '
 if [ -z "$old_version" ]; then
     echo "Error: failed to read current version from Cargo.toml" >&2
     exit 1
+fi
+
+if [[ ! "$old_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-[A-Za-z0-9.]+)?$ ]]; then
+    echo "Error: current version '$old_version' is not a valid MAJOR.MINOR.PATCH[-prerelease]" >&2
+    exit 1
+fi
+
+major="${BASH_REMATCH[1]}"
+minor="${BASH_REMATCH[2]}"
+patch="${BASH_REMATCH[3]}"
+
+case "$bump" in
+    minor)
+        minor=$((minor + 1))
+        patch=0
+        ;;
+    patch)
+        patch=$((patch + 1))
+        ;;
+    none) ;;
+esac
+
+# Forms used across the touched files:
+#   new_base  = MAJOR.MINOR.PATCH (no prerelease) e.g. 1.24.0
+#   new_short = MAJOR.MINOR                       e.g. 1.24
+new_base="$major.$minor.$patch"
+new_short="$major.$minor"
+
+if [ "$prerelease" = "release" ]; then
+    new_version="$new_base"
+else
+    new_version="$new_base-$prerelease"
+fi
+
+# Expose the resolved version to GitHub Actions if running there.
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "IOTA_VERSION=$new_version" >> "$GITHUB_ENV"
 fi
 
 if [ "$old_version" = "$new_version" ]; then


### PR DESCRIPTION
# Description of change

Adds a manually-triggered `Bump version` GitHub Actions workflow plus a refactored `scripts/bump_version.sh`, so version bumps no longer need to be done by hand.

The workflow takes two structured inputs instead of a free-form version string:

- `bump` — `none`, `minor`, or `patch`. Controls which segment of `MAJOR.MINOR.PATCH` is incremented. `none` keeps the base version unchanged, which is what's used to promote a pre-release in place (e.g. `alpha → beta → rc → release`).
- `prerelease` — `alpha`, `beta`, `rc`, or `release`. Sets the pre-release suffix; `release` means no suffix.
- `base_branch` — branch the resulting PR is opened against (defaults to `develop`).

`scripts/bump_version.sh` reads the current workspace version from `Cargo.toml`, computes the new version from the two inputs, and propagates it to:

- `Cargo.toml` (only `[workspace.package].version`)
- `crates/iota-open-rpc/spec/openrpc.json`
- `crates/iota-graphql-e2e-tests/tests/call/simple.snap` (both the `*-testing-no-sha` form and the `MAJOR.MINOR` `availableVersions` entry)
- `Cargo.lock` (via `cargo update --workspace`)

The script also writes `IOTA_VERSION=<new-version>` to `$GITHUB_ENV` when running under Actions, so the workflow's PR-creation step can reuse the resolved version directly without re-parsing `Cargo.toml`.

Finally, `release` is added to the allowed PR title prefixes in `.github/workflows/pr_lint.yml`, so the auto-generated `release: bump version to ...` PR passes title linting.

Common invocations:

| Current        | Goal               | Inputs            | Result          |
| -------------- | ------------------ | ----------------- | --------------- |
| `1.24.0`       | start next cycle   | `minor` / `alpha` | `1.25.0-alpha`  |
| `1.24.0-alpha` | promote to beta    | `none`  / `beta`  | `1.24.0-beta`   |
| `1.24.0-rc`    | release            | `none`  / `release` | `1.24.0`      |
| `1.24.0`       | patch release      | `patch` / `release` | `1.24.1`      |

## Links to any relevant issues

N/A.

## How the change has been tested

- [x] Local dry-run of `scripts/bump_version.sh` against a stub workspace covering `minor alpha`, `none beta`, `patch release`, and `none release`, plus the no-op path (same args twice) and the input-validation paths (bad first arg, bad second arg, wrong arg count).
- [x] Verified the `[workspace.package]`-scoped sed leaves sibling tables with their own `version =` keys untouched.
- [x] Verified the script appends `IOTA_VERSION=<new>` to `$GITHUB_ENV` when that variable is set.
- [ ] Trigger the workflow manually against `develop` with `bump=minor`, `prerelease=alpha` and confirm a PR is opened on `release/bump-version-<new-version>` with the expected title and file changes.
- [ ] Confirm the resulting PR passes `pr_lint` with the `release:` prefix.

