### PR TITLE
chore: seal all SDK extension traits

### DIFF
--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -152,7 +152,12 @@ pub struct UpgradeReceipt {
     pub package: ID,
 }
 
-pub trait MovePackageExt {
+mod move_package_ext {
+    pub trait Sealed {}
+    impl Sealed for super::MovePackage {}
+}
+
+pub trait MovePackageExt: Sized + move_package_ext::Sealed {
     fn new_initial<'p>(
         modules: &[CompiledModule],
         protocol_config: &ProtocolConfig,

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -46,12 +46,12 @@ pub const OBJECT_START_VERSION: SequenceNumber = SequenceNumber::from_u64(1);
 /// Index marking the end of the object's ID + the beginning of its version
 pub const ID_END_INDEX: usize = ObjectID::LENGTH;
 
-mod move_object_ext_private {
+mod move_object_ext {
     pub trait Sealed {}
-    impl Sealed for iota_sdk_types::MoveStruct {}
+    impl Sealed for super::MoveObject {}
 }
 
-pub trait MoveObjectExt: Sized + move_object_ext_private::Sealed {
+pub trait MoveObjectExt: Sized + move_object_ext::Sealed {
     fn new_from_execution(
         tag: StructTag,
         version: SequenceNumber,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -261,8 +261,13 @@ impl EndOfEpochTransactionKindExt for EndOfEpochTransactionKind {
     }
 }
 
+mod call_arg_ext {
+    pub trait Sealed {}
+    impl Sealed for super::CallArg {}
+}
+
 /// Extension trait for [`CallArg`] providing helper methods.
-pub trait CallArgExt {
+pub trait CallArgExt: Sized + call_arg_ext::Sealed {
     /// Returns the input object kind for this argument, excluding receiving
     /// objects.
     fn input_object_kind(&self) -> Option<InputObjectKind>;
@@ -334,7 +339,12 @@ fn add_type_tag_packages(packages: &mut BTreeSet<ObjectID>, type_argument: &Type
     }
 }
 
-pub trait MoveCallExt {
+mod move_call_ext {
+    pub trait Sealed {}
+    impl Sealed for super::ProgrammableMoveCall {}
+}
+
+pub trait MoveCallExt: Sized + move_call_ext::Sealed {
     fn input_objects(&self) -> Vec<InputObjectKind>;
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult;
     fn is_input_arg_used(&self, arg: u16) -> bool;
@@ -394,7 +404,12 @@ impl MoveCallExt for ProgrammableMoveCall {
     }
 }
 
-pub trait CommandExt {
+mod command_ext {
+    pub trait Sealed {}
+    impl Sealed for super::Command {}
+}
+
+pub trait CommandExt: Sized + command_ext::Sealed {
     fn input_objects(&self) -> Vec<InputObjectKind>;
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult;
     fn non_system_packages_to_be_published(&self) -> Option<&Vec<Vec<u8>>>;
@@ -551,7 +566,12 @@ impl CommandExt for Command {
     }
 }
 
-pub trait ProgrammableTransactionExt {
+mod programmable_transaction_ext {
+    pub trait Sealed {}
+    impl Sealed for super::ProgrammableTransaction {}
+}
+
+pub trait ProgrammableTransactionExt: Sized + programmable_transaction_ext::Sealed {
     fn input_objects(&self) -> UserInputResult<Vec<InputObjectKind>>;
     fn receiving_objects(&self) -> Vec<ObjectRef>;
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult;
@@ -699,7 +719,12 @@ fn left_union_shared_input_objects(
     Ok(())
 }
 
-pub trait TransactionKindExt {
+mod transaction_kind_ext {
+    pub trait Sealed {}
+    impl Sealed for super::TransactionKind {}
+}
+
+pub trait TransactionKindExt: Sized + transaction_kind_ext::Sealed {
     /// If this is an advance epoch transaction, returns (total gas charged,
     /// total gas rebated). TODO: We should use `GasCostSummary` directly in
     /// `ChangeEpoch` struct, and return that directly.

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -344,13 +344,13 @@ mod programmable_move_call_ext {
     impl Sealed for super::ProgrammableMoveCall {}
 }
 
-pub trait MoveCallExt: Sized + programmable_move_call_ext::Sealed {
+pub trait ProgrammableMoveCallExt: Sized + programmable_move_call_ext::Sealed {
     fn input_objects(&self) -> Vec<InputObjectKind>;
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult;
     fn is_input_arg_used(&self, arg: u16) -> bool;
 }
 
-impl MoveCallExt for ProgrammableMoveCall {
+impl ProgrammableMoveCallExt for ProgrammableMoveCall {
     fn input_objects(&self) -> Vec<InputObjectKind> {
         let mut packages = BTreeSet::from([self.package]);
         for type_argument in &self.type_arguments {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -339,12 +339,12 @@ fn add_type_tag_packages(packages: &mut BTreeSet<ObjectID>, type_argument: &Type
     }
 }
 
-mod move_call_ext {
+mod programmable_move_call_ext {
     pub trait Sealed {}
     impl Sealed for super::ProgrammableMoveCall {}
 }
 
-pub trait MoveCallExt: Sized + move_call_ext::Sealed {
+pub trait MoveCallExt: Sized + programmable_move_call_ext::Sealed {
     fn input_objects(&self) -> Vec<InputObjectKind>;
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult;
     fn is_input_arg_used(&self, arg: u16) -> bool;


### PR DESCRIPTION
# Description of change

- Seal all SDK extension traits in `iota-types` (`MovePackageExt`, `MoveObjectExt`, `CallArgExt`, `MoveCallExt`, `CommandExt`, `ProgrammableTransactionExt`, `TransactionKindExt`, `EndOfEpochTransactionKindExt`) so that downstream crates cannot add their own implementations.
- Each extension trait now requires `Sized` and a private `Sealed` supertrait defined in a sibling module, following the standard sealed-trait pattern.
- Renames `move_object_ext_private` → `move_object_ext` and reseats its `Sealed` impl on the local `MoveObject` (rather than `iota_sdk_types::MoveStruct`) for consistency with the other extension traits.

## Links to any relevant issues

Closes https://github.com/iotaledger/iota/issues/11434

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

