### PR TITLE
refactor(types,json-rpc)!: consolidate the IotaObjectResponseError types

### DIFF
--- a/crates/iota-cluster-test/src/helper.rs
+++ b/crates/iota-cluster-test/src/helper.rs
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::bail;
-use iota_json_rpc_types::{BalanceChange, IotaData, IotaObjectData, IotaObjectDataOptions};
+use iota_json_rpc_types::{
+    BalanceChange, IotaData, IotaObjectData, IotaObjectDataOptions, IotaObjectResponseError,
+};
 use iota_sdk::IotaClient;
 use iota_types::{
     base_types::{ObjectID, TypeTag},
-    error::IotaObjectResponseError,
     gas_coin::GasCoin,
     object::Owner,
     parse_iota_type_tag,

--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -9,7 +9,7 @@ use iota_json_rpc::IotaRpcModule;
 use iota_json_rpc_api::{IndexerApiServer, cap_page_limit, error_object_from_rpc, internal_error};
 use iota_json_rpc_types::{
     DynamicFieldPage, EventFilter, EventPage, IotaNameRecord, IotaObjectData, IotaObjectDataFilter,
-    IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseQuery,
+    IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseError, IotaObjectResponseQuery,
     IotaTransactionBlockResponseQuery, IotaTransactionBlockResponseQueryV2, ObjectsPage, Page,
     TransactionBlocksPage, TransactionFilter,
 };
@@ -22,7 +22,6 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID, TypeTag},
     digests::TransactionDigest,
     dynamic_field::{DynamicFieldName, Field},
-    error::IotaObjectResponseError,
     event::EventID,
     object::ObjectRead,
 };

--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -10,7 +10,7 @@ use iota_json_rpc::{IotaRpcModule, error::IotaRpcInputError};
 use iota_json_rpc_api::{QUERY_MAX_RESULT_LIMIT, ReadApiServer, internal_error};
 use iota_json_rpc_types::{
     Checkpoint, CheckpointId, CheckpointPage, IotaEvent, IotaGetPastObjectRequest, IotaObjectData,
-    IotaObjectDataOptions, IotaObjectResponse, IotaPastObjectResponse,
+    IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseError, IotaPastObjectResponse,
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ProtocolConfigResponse,
 };
 use iota_open_rpc::Module;
@@ -18,7 +18,6 @@ use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
     digests::{ChainIdentifier, TransactionDigest},
-    error::IotaObjectResponseError,
     iota_serde::BigInt,
     object::{ObjectRead, PastObjectRead},
 };

--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -5,10 +5,11 @@
 use fastcrypto::error::FastCryptoError;
 use iota_data_ingestion_core::IngestionError;
 use iota_json_rpc_api::{error_object_from_rpc, internal_error};
+use iota_json_rpc_types::IotaObjectResponseError;
 use iota_names::error::IotaNamesError;
 use iota_types::{
     base_types::{ObjectID, ObjectIDParseError, SequenceNumber},
-    error::{IotaError, IotaObjectResponseError, UserInputError},
+    error::{IotaError, UserInputError},
     iota_sdk_types_conversions::SdkTypeConversionError,
 };
 use jsonrpsee::{core::ClientError as RpcError, types::ErrorObjectOwned};

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -14,9 +14,10 @@ use iota_json::{IotaJsonValue, call_args, type_args};
 use iota_json_rpc_api::{IndexerApiClient, ReadApiClient, TransactionBuilderClient};
 use iota_json_rpc_types::{
     CheckpointId, IotaGetPastObjectRequest, IotaObjectDataOptions, IotaObjectResponse,
-    IotaObjectResponseQuery, IotaPastObjectResponse, IotaTransactionBlockEffectsAPI,
-    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
-    IotaTransactionBlockResponseQueryV2, ObjectChange, TransactionFilterV2,
+    IotaObjectResponseError, IotaObjectResponseQuery, IotaPastObjectResponse,
+    IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
+    IotaTransactionBlockResponseOptions, IotaTransactionBlockResponseQueryV2, ObjectChange,
+    TransactionFilterV2,
 };
 use iota_package_resolver::Resolver;
 use iota_protocol_config::ProtocolVersion;
@@ -28,7 +29,6 @@ use iota_types::{
     base_types::{Identifier, ObjectID, ObjectRef, SequenceNumber},
     crypto::{AccountKeyPair, IotaKeyPair, get_key_pair},
     digests::{ChainIdentifier, ObjectDigest, TransactionDigest},
-    error::IotaObjectResponseError,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::CallArg,
     utils::to_sender_signed_transaction,

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -10,8 +10,8 @@ use iota_json_rpc_api::{
 };
 use iota_json_rpc_types::{
     CheckpointId, IotaGetPastObjectRequest, IotaObjectDataOptions, IotaObjectResponse,
-    IotaObjectResponseQuery, IotaPastObjectResponse, IotaTransactionBlockDataAPI,
-    IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
+    IotaObjectResponseError, IotaObjectResponseQuery, IotaPastObjectResponse,
+    IotaTransactionBlockDataAPI, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
     IotaTransactionBlockResponseOptions, ObjectChange, ProtocolConfigResponse,
     TransactionBlockBytes,
 };
@@ -20,7 +20,6 @@ use iota_move_build::BuildConfig;
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber},
     digests::TransactionDigest,
-    error::IotaObjectResponseError,
     messages_checkpoint::CheckpointSequenceNumber,
     quorum_driver_types::ExecuteTransactionRequestType,
     transaction::CallArg,

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -18,10 +18,7 @@ use iota_types::{
         Identifier, IotaAddress, ObjectDigest, ObjectID, ObjectInfo, ObjectRef, ObjectType,
         SequenceNumber, StructTag, TransactionDigest,
     },
-    error::{
-        ExecutionError, IotaError, IotaObjectResponseError, IotaResult, UserInputError,
-        UserInputResult,
-    },
+    error::{ExecutionError, IotaError, IotaResult, UserInputError, UserInputResult},
     gas_coin::GasCoin,
     messages_checkpoint::CheckpointSequenceNumber,
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
@@ -35,7 +32,7 @@ use serde_json::Value;
 use serde_with::{DeserializeAs, DisplayFromStr, SerializeAs, serde_as};
 
 use crate::{
-    IotaMoveStruct, IotaMoveValue, IotaObjectResponseError as IotaObjectResponseErrorSchema, Page,
+    IotaMoveStruct, IotaMoveValue, IotaObjectResponseError, Page,
     iota_owner::OwnerSchema,
     iota_primitives::{
         Base58 as Base58Schema, Base64 as Base64Schema, Identifier as IdentifierSchema,
@@ -45,14 +42,11 @@ use crate::{
     },
 };
 
-#[serde_as]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, Eq)]
 pub struct IotaObjectResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<IotaObjectData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "Option<IotaObjectResponseErrorSchema>")]
-    #[serde_as(as = "Option<IotaObjectResponseErrorSchema>")]
     pub error: Option<IotaObjectResponseError>,
 }
 
@@ -197,7 +191,6 @@ impl TryFrom<IotaObjectResponse> for ObjectInfo {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq)]
 pub struct DisplayFieldsResponse {
     pub data: Option<BTreeMap<String, String>>,
-    #[schemars(with = "Option<IotaObjectResponseErrorSchema>")]
     pub error: Option<IotaObjectResponseError>,
 }
 

--- a/crates/iota-json-rpc-types/src/iota_object_response_error.rs
+++ b/crates/iota-json-rpc-types/src/iota_object_response_error.rs
@@ -41,10 +41,7 @@ pub enum IotaObjectResponseError {
         parent_object_id: ObjectID,
     },
     #[error(
-        "Object has been deleted object_id: {:?} at version: {:?} in digest {:?}",
-        object_id,
-        version,
-        digest
+        "Object has been deleted object_id: {object_id:?} at version: {version:?} in digest {digest:?}"
     )]
     Deleted {
         #[schemars(with = "ObjectIDSchema")]

--- a/crates/iota-json-rpc-types/src/iota_object_response_error.rs
+++ b/crates/iota-json-rpc-types/src/iota_object_response_error.rs
@@ -4,29 +4,48 @@
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
     digests::ObjectDigest,
-    error::IotaObjectResponseError as NativeObjectResponseError,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_with::{DeserializeAs, SerializeAs, serde_as};
+use strum::{AsRefStr, IntoStaticStr};
+use thiserror::Error;
 
 use crate::iota_primitives::{
     Base58 as Base58Schema, ObjectID as ObjectIDSchema,
     SequenceNumberU64 as SequenceNumberU64Schema,
 };
 
-#[serde_as]
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Eq,
+    PartialEq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Hash,
+    AsRefStr,
+    IntoStaticStr,
+    Error,
+)]
 #[serde(tag = "code", rename = "ObjectResponseError", rename_all = "camelCase")]
 pub enum IotaObjectResponseError {
+    #[error("Object {:?} does not exist", object_id)]
     NotExists {
         #[schemars(with = "ObjectIDSchema")]
         object_id: ObjectID,
     },
+    #[error("Cannot find dynamic field for parent object {:?}", parent_object_id)]
     DynamicFieldNotFound {
         #[schemars(with = "ObjectIDSchema")]
         parent_object_id: ObjectID,
     },
+    #[error(
+        "Object has been deleted object_id: {:?} at version: {:?} in digest {:?}",
+        object_id,
+        version,
+        digest
+    )]
     Deleted {
         #[schemars(with = "ObjectIDSchema")]
         object_id: ObjectID,
@@ -37,71 +56,8 @@ pub enum IotaObjectResponseError {
         #[schemars(with = "Base58Schema")]
         digest: ObjectDigest,
     },
+    #[error("Unknown Error")]
     Unknown,
-    Display {
-        error: String,
-    },
-}
-
-impl SerializeAs<NativeObjectResponseError> for IotaObjectResponseError {
-    fn serialize_as<S>(source: &NativeObjectResponseError, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        IotaObjectResponseError::from(source.clone()).serialize(serializer)
-    }
-}
-
-impl<'de> DeserializeAs<'de, NativeObjectResponseError> for IotaObjectResponseError {
-    fn deserialize_as<D>(deserializer: D) -> Result<NativeObjectResponseError, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let schema = IotaObjectResponseError::deserialize(deserializer)?;
-        Ok(NativeObjectResponseError::from(schema))
-    }
-}
-
-impl From<NativeObjectResponseError> for IotaObjectResponseError {
-    fn from(error: NativeObjectResponseError) -> Self {
-        match error {
-            NativeObjectResponseError::NotExists { object_id } => Self::NotExists { object_id },
-            NativeObjectResponseError::DynamicFieldNotFound { parent_object_id } => {
-                Self::DynamicFieldNotFound { parent_object_id }
-            }
-            NativeObjectResponseError::Deleted {
-                object_id,
-                version,
-                digest,
-            } => Self::Deleted {
-                object_id,
-                version,
-                digest,
-            },
-            NativeObjectResponseError::Unknown => Self::Unknown,
-            NativeObjectResponseError::Display { error } => Self::Display { error },
-        }
-    }
-}
-
-impl From<IotaObjectResponseError> for NativeObjectResponseError {
-    fn from(error: IotaObjectResponseError) -> Self {
-        match error {
-            IotaObjectResponseError::NotExists { object_id } => Self::NotExists { object_id },
-            IotaObjectResponseError::DynamicFieldNotFound { parent_object_id } => {
-                Self::DynamicFieldNotFound { parent_object_id }
-            }
-            IotaObjectResponseError::Deleted {
-                object_id,
-                version,
-                digest,
-            } => Self::Deleted {
-                object_id,
-                version,
-                digest,
-            },
-            IotaObjectResponseError::Unknown => Self::Unknown,
-            IotaObjectResponseError::Display { error } => Self::Display { error },
-        }
-    }
+    #[error("Display Error: {:?}", error)]
+    Display { error: String },
 }

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -9,9 +9,10 @@ use hyper::header::InvalidHeaderValue;
 use iota_json_rpc_api::{
     TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSIENT_ERROR_CODE, error_object_from_rpc,
 };
+use iota_json_rpc_types::IotaObjectResponseError;
 use iota_names::error::IotaNamesError;
 use iota_types::{
-    error::{IotaError, IotaObjectResponseError, UserInputError},
+    error::{IotaError, UserInputError},
     quorum_driver_types::QuorumDriverError,
 };
 use jsonrpsee::{
@@ -86,7 +87,6 @@ impl From<IotaError> for Error {
     fn from(e: IotaError) -> Self {
         match e {
             IotaError::UserInput { error } => Self::UserInput(error),
-            IotaError::IotaObjectResponse { error } => Self::IotaObjectResponse(error),
             IotaError::UnsupportedFeature { error } => Self::UnsupportedFeature(error),
             IotaError::IndexStoreNotAvailable => Self::UnsupportedFeature(
                 "Required indexes are not available on this node".to_string(),

--- a/crates/iota-json-rpc/src/indexer_api.rs
+++ b/crates/iota-json-rpc/src/indexer_api.rs
@@ -15,7 +15,7 @@ use iota_json_rpc_api::{
 };
 use iota_json_rpc_types::{
     DynamicFieldPage, EventFilter, EventPage, IotaNameRecord, IotaObjectDataFilter,
-    IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseQuery,
+    IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseError, IotaObjectResponseQuery,
     IotaTransactionBlockResponse, IotaTransactionBlockResponseQuery,
     IotaTransactionBlockResponseQueryV2, ObjectsPage, Page, TransactionBlocksPage,
     TransactionFilter,
@@ -31,7 +31,7 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID, TypeTag},
     digests::TransactionDigest,
     dynamic_field::{DynamicFieldName, Field},
-    error::{IotaObjectResponseError, UserInputError},
+    error::UserInputError,
     event::EventID,
     iota_sdk_types_conversions::type_tag_sdk_to_core,
 };

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -17,10 +17,10 @@ use iota_json_rpc_api::{
 use iota_json_rpc_types::{
     BalanceChange, Checkpoint, CheckpointId, CheckpointPage, DisplayFieldsResponse, EventFilter,
     IotaEvent, IotaGetPastObjectRequest, IotaMoveStruct, IotaMoveValue, IotaMoveVariant,
-    IotaObjectData, IotaObjectDataOptions, IotaObjectResponse, IotaPastObjectResponse,
-    IotaTransactionBlock, IotaTransactionBlockEffects, IotaTransactionBlockEvents,
-    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
-    ProtocolConfigResponse,
+    IotaObjectData, IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseError,
+    IotaPastObjectResponse, IotaTransactionBlock, IotaTransactionBlockEffects,
+    IotaTransactionBlockEvents, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
+    ObjectChange, ProtocolConfigResponse,
 };
 use iota_metrics::{add_server_timing, spawn_monitored_task};
 use iota_open_rpc::Module;
@@ -35,7 +35,7 @@ use iota_types::{
     crypto::AggregateAuthoritySignature,
     display::DisplayVersionUpdatedEvent,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
-    error::{IotaError, IotaObjectResponseError},
+    error::IotaError,
     iota_serde::BigInt,
     messages_checkpoint::{
         CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, CheckpointTimestamp,

--- a/crates/iota-replay/src/types.rs
+++ b/crates/iota-replay/src/types.rs
@@ -4,13 +4,13 @@
 
 use std::fmt::Debug;
 
-use iota_json_rpc_types::{IotaEvent, IotaTransactionBlockEffects};
+use iota_json_rpc_types::{IotaEvent, IotaObjectResponseError, IotaTransactionBlockEffects};
 use iota_protocol_config::{Chain, ProtocolVersion};
 use iota_sdk::error::Error as IotaRpcError;
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber, VersionNumber},
     digests::{ObjectDigest, TransactionDigest},
-    error::{IotaError, IotaObjectResponseError, IotaResult, UserInputError},
+    error::{IotaError, IotaResult, UserInputError},
     object::Object,
     transaction::{InputObjectKind, SenderSignedData, TransactionKind},
 };

--- a/crates/iota-source-validation/src/error.rs
+++ b/crates/iota-source-validation/src/error.rs
@@ -4,13 +4,10 @@
 
 use std::fmt;
 
-use iota_json_rpc_types::IotaRawMoveObject;
+use iota_json_rpc_types::{IotaObjectResponseError, IotaRawMoveObject};
 use iota_package_management::PublishedAtError;
 use iota_sdk::error::Error as SdkError;
-use iota_types::{
-    base_types::{IotaAddress, ObjectID},
-    error::IotaObjectResponseError,
-};
+use iota_types::base_types::{IotaAddress, ObjectID};
 use move_symbol_pool::Symbol;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -380,35 +380,6 @@ pub enum UserInputError {
     MutableSharedIsInMoveAuthenticatorInput { object_id: ObjectID },
 }
 
-#[derive(
-    Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, AsRefStr, IntoStaticStr, Error,
-)]
-#[serde(tag = "code", rename = "ObjectResponseError", rename_all = "camelCase")]
-pub enum IotaObjectResponseError {
-    #[error("Object {:?} does not exist", object_id)]
-    NotExists { object_id: ObjectID },
-    #[error("Cannot find dynamic field for parent object {:?}", parent_object_id)]
-    DynamicFieldNotFound { parent_object_id: ObjectID },
-    #[error(
-        "Object has been deleted object_id: {:?} at version: {:?} in digest {:?}",
-        object_id,
-        version,
-        digest
-    )]
-    Deleted {
-        object_id: ObjectID,
-        /// Object version.
-        version: SequenceNumber,
-        /// Base64 string representing the object digest
-        digest: ObjectDigest,
-    },
-    #[error("Unknown Error")]
-    Unknown,
-    #[error("Display Error: {:?}", error)]
-    Display { error: String },
-    // TODO: also integrate IotaPastObjectResponse (VersionNotFound,  VersionTooHigh)
-}
-
 /// Custom error type for Iota.
 #[derive(
     Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, AsRefStr, IntoStaticStr,
@@ -416,9 +387,6 @@ pub enum IotaObjectResponseError {
 pub enum IotaError {
     #[error("Error checking transaction input objects: {error}")]
     UserInput { error: UserInputError },
-
-    #[error("Error checking transaction object: {error}")]
-    IotaObjectResponse { error: IotaObjectResponseError },
 
     #[error("There are already {queue_len} transactions pending, above threshold of {threshold}")]
     TooManyTransactionsPendingExecution { queue_len: usize, threshold: usize },
@@ -858,12 +826,6 @@ impl TryFrom<IotaError> for UserInputError {
 impl From<UserInputError> for IotaError {
     fn from(error: UserInputError) -> Self {
         IotaError::UserInput { error }
-    }
-}
-
-impl From<IotaObjectResponseError> for IotaError {
-    fn from(error: IotaObjectResponseError) -> Self {
-        IotaError::IotaObjectResponse { error }
     }
 }
 

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -14,7 +14,7 @@ use clap::Parser;
 use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
     IotaData, IotaObjectDataFilter, IotaObjectDataOptions, IotaObjectResponse,
-    IotaObjectResponseQuery, IotaTransactionBlockResponse,
+    IotaObjectResponseError, IotaObjectResponseQuery, IotaTransactionBlockResponse,
 };
 use iota_names::{
     IotaNamesNft, NameRegistration, SubnameRegistration,
@@ -29,7 +29,6 @@ use iota_types::{
     collection_types::{Entry, VecMap},
     digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::Field,
-    error::IotaObjectResponseError,
     iota_sdk_types_conversions::struct_tag_sdk_to_core,
 };
 use move_core_types::{

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -33,9 +33,9 @@ use iota_config::IOTA_CLIENT_CONFIG;
 use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
     IotaExecutionStatus, IotaObjectData, IotaObjectDataFilter, IotaObjectDataOptions,
-    IotaObjectResponse, IotaObjectResponseQuery, IotaRawData, IotaTransactionBlockDataAPI,
-    IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, ObjectChange, OwnedObjectRef,
-    get_new_package_obj_from_response,
+    IotaObjectResponse, IotaObjectResponseError, IotaObjectResponseQuery, IotaRawData,
+    IotaTransactionBlockDataAPI, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
+    ObjectChange, OwnedObjectRef, get_new_package_obj_from_response,
 };
 use iota_keys::keystore::AccountKeystore;
 use iota_macros::sim_test;
@@ -50,7 +50,6 @@ use iota_types::{
         AccountKeyPair, Ed25519IotaSignature, IotaKeyPair, IotaSignatureInner,
         Secp256k1IotaSignature, SignatureScheme, get_key_pair,
     },
-    error::IotaObjectResponseError,
     gas_coin::GasCoin,
     move_package::{MovePackage, UpgradeInfo},
     object::Owner,


### PR DESCRIPTION
# Description of change

This patch follows #11380 and is based on the observation that we can consolidate the two `IotaObjectResponseError` variants living in `iota-types` and `iota-json-rpc-types` into the latter library. 

This is plausible because `IotaObjectResponseError` only lives in the context of JSON-RPC. Every call site that constructs, pattern-matches, or transports it sits in crates dependent on `iota-json-rpc-types`: `iota-json-rpc`, `iota-indexer`, `iota-cluster-test`, `iota-replay`,  `iota-source-validation`, the `iota` RPC client paths. `iota-types` doesn't actually need it for internal node logic.

The JSON-RPC wire format an the OpenRPC schema representation remain the same.

## Links to any relevant issues

Closes #11385

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Verification of API backward compatibility.

