### PR TITLE
fix(dev-tools): update pg-services-local local-network gRPC healthcheck to v1

### DIFF
--- a/dev-tools/pg-services-local/docker-compose.yaml
+++ b/dev-tools/pg-services-local/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       - "127.0.0.1:9123:9123"
       - "127.0.0.1:50051:50051"
     healthcheck:
-      test: "grpcurl -plaintext -import-path /iota/proto -proto iota/grpc/v0/ledger_service.proto localhost:50051 iota.grpc.v0.ledger_service.LedgerService/GetHealth"
+      test: "grpcurl -plaintext -import-path /iota/proto -proto iota/grpc/v1/ledger_service.proto localhost:50051 iota.grpc.v1.ledger_service.LedgerService/GetHealth"
       interval: 1s
       start_period: 5s
       timeout: 2s


### PR DESCRIPTION
# Description of change

The healthcheck still referenced `iota/grpc/v0/ledger_service.proto` and `iota.grpc.v0.ledger_service.LedgerService`, but the proto package has since moved to `v1`. As a result the healthcheck always failed and `local-network` was reported as unhealthy on startup, blocking any dependent service that waits on `condition: service_healthy`.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11512

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage) - `docker compose up`

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
