### PR TITLE
fix(transaction-builder): [cherry-pick]avoid double-serializing Move view pure args (#11510)

### DIFF
--- a/crates/iota-indexer/tests/data/wat_counter/sources/wat_counter.move
+++ b/crates/iota-indexer/tests/data/wat_counter/sources/wat_counter.move
@@ -27,4 +27,8 @@ module wat_counter::wat_counter {
     public fun get_wat_object(wat_obj: &Wat): &Wat{
         wat_obj
     }
+
+    public fun has_address_arg(wat_obj: &Wat, flag: bool, addr: address): bool {
+        wat_obj.counter == 10 && flag && addr == @0x1
+    }
 }

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1456,6 +1456,30 @@ fn move_view_function_call() {
         };
         assert_eq!(type_.name().to_string(), "Wat");
         assert!(fields.contains_key(&"counter".to_string()));
+
+        // Test mixed object, bool and address arguments.
+        let fn_name = format!("{}::wat_counter::has_address_arg", object_ref.object_id);
+        let address = IotaAddress::from_str(
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .unwrap();
+        let view_results = client
+            .view_function_call(
+                fn_name,
+                None,
+                vec![
+                    call_arg!(review_id).unwrap(),
+                    call_arg!("true").unwrap(),
+                    call_arg!(address).unwrap(),
+                ],
+            )
+            .await
+            .unwrap();
+        assert!(view_results.error().is_none(), "{view_results:?}");
+        assert_eq!(
+            view_results.into_return_values(),
+            vec![IotaMoveValue::Bool(true)]
+        );
     });
 }
 

--- a/crates/iota-transaction-builder/src/utils.rs
+++ b/crates/iota-transaction-builder/src/utils.rs
@@ -314,7 +314,8 @@ impl TransactionBuilder {
         for (arg, expected_type) in json_args_and_tokens {
             args.push(match arg {
                 // Move View Functions can accept pure arguments.
-                ResolvedCallArg::Pure(p) => builder.pure(p),
+                // `p` is already BCS-encoded for the expected Move type.
+                ResolvedCallArg::Pure(p) => Ok(builder.pure_bytes(p, false)),
                 // Move View Functions can accept only immutable object references.
                 ResolvedCallArg::Object(id) => {
                     fp_ensure!(


### PR DESCRIPTION
# Description of change

Fixes a regression in `iota_view` where pure Move view arguments were BCS-serialized twice after the `CallArg` replacement. This caused arguments such as `address` to reach the VM with the wrong byte layout and fail with `FAILED_TO_DESERIALIZE_ARGUMENT`.

Adding a regression test covering a view call with object, bool, and address arguments.

## Links to any relevant issues

fixes #11504

## How the change has been tested

- [x ] Basic tests (linting, compilation, formatting, unit/integration tests)

---------


(cherry picked from commit e845fa31ad01b519fffd6a1eaef0987684149f74)

Please go to the `Preview` tab and select the appropriate sub-template:

- [Default PR Template for External Contributors](?expand=1&template=default_external_contributors.md)
- [Default PR Template for Internal Contributors](?expand=1&template=default_internal_contributors.md)
- [Infrastructure Team](?expand=1&template=infra.md)
- [Tooling Team](?expand=1&template=tooling.md)
