### PR TITLE
feat(docs): add gRPC endpoints for mainnet, testnet, and devnet

### DIFF
--- a/docs/site/src/components/NetworkInfo/index.tsx
+++ b/docs/site/src/components/NetworkInfo/index.tsx
@@ -91,6 +91,14 @@ function L1(props: NetworkProps) {
             <CodeBlock>{props.rpc.graphql}</CodeBlock>
           </td>
         </tr>
+        {props.rpc.grpc && (
+          <tr>
+            <th>gRPC URL</th>
+            <td>
+              <CodeBlock>{props.rpc.grpc}</CodeBlock>
+            </td>
+          </tr>
+        )}
         {props.faucet && (
           <tr>
             <th>Faucet</th>

--- a/docs/site/src/components/constant.tsx
+++ b/docs/site/src/components/constant.tsx
@@ -21,6 +21,7 @@ export const Networks: Record<string, NetworkProps> = {
         ],
       },
       graphql: 'https://graphql.mainnet.iota.cafe',
+      grpc: 'grpc.mainnet.iota.cafe:443',
     },
     explorer: 'https://explorer.iota.org/',
     evm: {
@@ -67,6 +68,7 @@ export const Networks: Record<string, NetworkProps> = {
         ],
       },
       graphql: 'https://graphql.testnet.iota.cafe',
+      grpc: 'grpc.testnet.iota.cafe:443',
     },
     faucet: 'https://faucet.testnet.iota.cafe',
     explorer: {
@@ -111,6 +113,7 @@ export const Networks: Record<string, NetworkProps> = {
         },
       },
       graphql: 'https://graphql.devnet.iota.cafe',
+      grpc: 'grpc.devnet.iota.cafe:443',
     },
     faucet: 'https://faucet.devnet.iota.cafe',
     explorer: {
@@ -182,6 +185,7 @@ export interface Rpc {
     thirdParty?: JsonRpcEndpoints[];
   };
   graphql: string;
+  grpc?: string;
 };
 
 export interface JsonRpcEndpoints {


### PR DESCRIPTION
## Summary

Adds the gRPC endpoints to the [Network Overview](https://docs.iota.org/developer/network-overview) docs page, following the `grpc.<network>.iota.cafe:443` format.

- Added `grpc` field to the `Rpc` type in `docs/site/src/components/constant.tsx`
- Populated the endpoint for IOTA Mainnet, Testnet, and Devnet
- Rendered a new **gRPC URL** row in the `NetworkInfo.L1` component (conditionally shown when `grpc` is set, so Localnet is unaffected)

## Test plan

Checked in the preview: https://iota-docs-r4t7swgr9-iota1.vercel.app/developer/network-overview