### PR TITLE
chore(ci): sign commits of bump version PRs

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -59,3 +59,4 @@ jobs:
           commit-message: "release: bump version to `${{ env.IOTA_VERSION }}`"
           body: Automated version bump to `${{ env.IOTA_VERSION }}`.
           delete-branch: true
+          sign-commits: true


### PR DESCRIPTION
# Description of change

According to https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signature-verification-for-bots, this will sign the commits of `github-actions[bot]`.
