### PR TITLE
chore(consensus): test coverage for StarfishSpeed

### DIFF
--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1644,6 +1644,7 @@ mod tests {
     use std::sync::Arc;
 
     use fastcrypto::error::FastCryptoError;
+    use rstest::rstest;
 
     use crate::{
         BlockHeaderAPI,
@@ -1786,5 +1787,57 @@ mod tests {
         for ack in acknowledgments.iter() {
             assert!(compressed_acknowledgments.contains(ack));
         }
+    }
+
+    #[rstest]
+    #[test]
+    fn test_verify_references_indices(#[values(false, true)] use_v2: bool) {
+        use crate::block_header::{BlockHeader, BlockHeaderV1, BlockHeaderV2, BlockRef};
+        let rng = &mut rand::thread_rng();
+        let refs = vec![
+            BlockRef::new(1, 0.into(), BlockHeaderDigest::random(&mut *rng)),
+            BlockRef::new(1, 1.into(), BlockHeaderDigest::random(&mut *rng)),
+            BlockRef::new(1, 2.into(), BlockHeaderDigest::random(&mut *rng)),
+        ];
+        let build = |overlap_start: u8, overlap_end: u8| -> BlockHeader {
+            if use_v2 {
+                BlockHeader::V2(BlockHeaderV2 {
+                    references: refs.clone(),
+                    overlap_start_index: overlap_start,
+                    overlap_end_index: overlap_end,
+                    ..Default::default()
+                })
+            } else {
+                BlockHeader::V1(BlockHeaderV1 {
+                    references: refs.clone(),
+                    overlap_start_index: overlap_start,
+                    overlap_end_index: overlap_end,
+                    ..Default::default()
+                })
+            }
+        };
+
+        // Valid indices: 0 <= start <= end <= references.len().
+        build(1, 2).verify_references_indices().unwrap(); // overlap region
+        build(2, 2).verify_references_indices().unwrap(); // no overlap, interior split
+        build(3, 3).verify_references_indices().unwrap(); // no overlap, boundary at len
+
+        // overlap_end > references.len().
+        assert!(matches!(
+            build(0, 4).verify_references_indices(),
+            Err(ConsensusError::InvalidOverlapIndices { .. })
+        ));
+
+        // overlap_start > references.len().
+        assert!(matches!(
+            build(4, 4).verify_references_indices(),
+            Err(ConsensusError::InvalidOverlapIndices { .. })
+        ));
+
+        // overlap_start > overlap_end.
+        assert!(matches!(
+            build(2, 1).verify_references_indices(),
+            Err(ConsensusError::InvalidOverlapIndices { .. })
+        ));
     }
 }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1484,6 +1484,7 @@ pub struct TestBlockHeader {
     ancestors: Vec<BlockRef>,
     acknowledgments: Vec<BlockRef>,
     block_header: BlockHeaderV1,
+    strong_vote: Option<StrongVote>,
 }
 
 impl TestBlockHeader {
@@ -1500,6 +1501,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1527,6 +1529,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1558,6 +1561,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1601,7 +1605,27 @@ impl TestBlockHeader {
         self
     }
 
+    /// Sets the V2-only `strong_vote` payload. When `Some`, `build()` emits a
+    /// `BlockHeader::V2`; otherwise a V1.
+    pub fn set_strong_vote(mut self, strong_vote: Option<StrongVote>) -> Self {
+        self.strong_vote = strong_vote;
+        self
+    }
+
     pub fn build(mut self) -> BlockHeader {
+        if let Some(strong_vote) = self.strong_vote {
+            return BlockHeader::V2(BlockHeaderV2::new(
+                self.block_header.epoch,
+                self.block_header.round,
+                self.block_header.author,
+                self.block_header.timestamp_ms,
+                self.ancestors,
+                self.acknowledgments,
+                self.block_header.commit_votes,
+                self.block_header.transactions_commitment,
+                Some(strong_vote),
+            ));
+        }
         let (references, overlap_start_index, overlap_end_index) =
             BlockHeader::compress_references(self.ancestors, self.acknowledgments);
         self.block_header.references = references;

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1830,7 +1830,7 @@ mod tests {
 
         // overlap_start > references.len().
         assert!(matches!(
-            build(4, 4).verify_references_indices(),
+            build(4, 3).verify_references_indices(),
             Err(ConsensusError::InvalidOverlapIndices { .. })
         ));
 

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -207,11 +207,9 @@ impl BlockVerifier for SignedBlockVerifier {
             });
         }
 
-        // Validate strong_vote field.
+        // Validate strong_vote field. Reachable only on V2 headers, which the
+        // version-flag check above already gated on `consensus_starfish_speed`.
         if let Some(strong_vote) = block.strong_vote() {
-            if !self.context.protocol_config.consensus_starfish_speed() {
-                return Err(ConsensusError::UnexpectedStrongVote);
-            }
             if !committee.is_valid_index(strong_vote.leader_authority) {
                 return Err(ConsensusError::InvalidStrongVoteAuthority {
                     index: strong_vote.leader_authority,
@@ -577,17 +575,14 @@ pub(crate) mod test {
 
     #[tokio::test]
     async fn test_verify_block_strong_vote() {
-        let (context_off, keypairs) = Context::new_for_test(4);
-        let (mut context_on, _) = Context::new_for_test(4);
+        let (mut context_on, keypairs) = Context::new_for_test(4);
         context_on
             .protocol_config
             .set_consensus_starfish_speed_for_testing(true);
-        let context_off = Arc::new(context_off);
         let context_on = Arc::new(context_on);
 
         let keypair = &keypairs[2].1;
         let leader_authority = AuthorityIndex::new_for_test(0);
-        let verifier_off = SignedBlockVerifier::new(context_off, Arc::new(TxnSizeVerifier {}));
         let verifier_on = SignedBlockVerifier::new(context_on, Arc::new(TxnSizeVerifier {}));
 
         let base = TestBlockHeader::new(10, 2).set_ancestors(vec![
@@ -600,16 +595,6 @@ pub(crate) mod test {
             leader_authority,
             missing: AuthoritySet::new(),
         };
-
-        // Flag off + Some(strong_vote) -> UnexpectedStrongVote.
-        {
-            let block = base.clone().set_strong_vote(Some(well_formed)).build();
-            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
-            assert!(matches!(
-                verifier_off.verify(&signed_block),
-                Err(ConsensusError::UnexpectedStrongVote)
-            ));
-        }
 
         // Flag on + missing contains an index >= committee.size() ->
         // InvalidStrongVoteAuthority.

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -630,6 +630,43 @@ pub(crate) mod test {
             ));
         }
 
+        // Flag on + leader_authority >= committee.size() ->
+        // InvalidStrongVoteAuthority. Trips the leader_authority bound check
+        // before the leader-in-ancestors check below.
+        {
+            let block = base
+                .clone()
+                .set_strong_vote(Some(StrongVote {
+                    leader_authority: AuthorityIndex::new_for_test(99),
+                    missing: AuthoritySet::new(),
+                }))
+                .build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            assert!(matches!(
+                verifier_on.verify(&signed_block),
+                Err(ConsensusError::InvalidStrongVoteAuthority { .. })
+            ));
+        }
+
+        // Flag on + valid leader_authority but pinned leader not in ancestors
+        // at round-1 -> StrongVoteLeaderNotInAncestors. Authority 3 is in the
+        // base block's ancestors only at round 7, not at round 9
+        // (= leader_round).
+        {
+            let block = base
+                .clone()
+                .set_strong_vote(Some(StrongVote {
+                    leader_authority: AuthorityIndex::new_for_test(3),
+                    missing: AuthoritySet::new(),
+                }))
+                .build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            assert!(matches!(
+                verifier_on.verify(&signed_block),
+                Err(ConsensusError::StrongVoteLeaderNotInAncestors { .. })
+            ));
+        }
+
         // Flag on + well-formed strong_vote (empty missing, leader at R-1 in
         // ancestors) -> Ok.
         {

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -275,7 +275,8 @@ pub(crate) mod test {
 
     use super::*;
     use crate::{
-        block_header::{BlockHeaderDigest, BlockRef, TestBlockHeader},
+        authority_set::AuthoritySet,
+        block_header::{BlockHeaderDigest, BlockRef, StrongVote, TestBlockHeader},
         context::Context,
         transaction::{TransactionVerifier, ValidationError},
     };
@@ -571,6 +572,70 @@ pub(crate) mod test {
                     starfish_speed: false,
                 })
             ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_block_strong_vote() {
+        let (context_off, keypairs) = Context::new_for_test(4);
+        let (mut context_on, _) = Context::new_for_test(4);
+        context_on
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(true);
+        let context_off = Arc::new(context_off);
+        let context_on = Arc::new(context_on);
+
+        let keypair = &keypairs[2].1;
+        let leader_authority = AuthorityIndex::new_for_test(0);
+        let verifier_off = SignedBlockVerifier::new(context_off, Arc::new(TxnSizeVerifier {}));
+        let verifier_on = SignedBlockVerifier::new(context_on, Arc::new(TxnSizeVerifier {}));
+
+        let base = TestBlockHeader::new(10, 2).set_ancestors(vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+            BlockRef::new(9, leader_authority, BlockHeaderDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+            BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+        ]);
+        let well_formed = StrongVote {
+            leader_authority,
+            missing: AuthoritySet::new(),
+        };
+
+        // Flag off + Some(strong_vote) -> UnexpectedStrongVote.
+        {
+            let block = base.clone().set_strong_vote(Some(well_formed)).build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            assert!(matches!(
+                verifier_off.verify(&signed_block),
+                Err(ConsensusError::UnexpectedStrongVote)
+            ));
+        }
+
+        // Flag on + missing contains an index >= committee.size() ->
+        // InvalidStrongVoteAuthority.
+        {
+            let mut missing = AuthoritySet::new();
+            missing.insert(AuthorityIndex::new_for_test(99));
+            let block = base
+                .clone()
+                .set_strong_vote(Some(StrongVote {
+                    leader_authority,
+                    missing,
+                }))
+                .build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            assert!(matches!(
+                verifier_on.verify(&signed_block),
+                Err(ConsensusError::InvalidStrongVoteAuthority { .. })
+            ));
+        }
+
+        // Flag on + well-formed strong_vote (empty missing, leader at R-1 in
+        // ancestors) -> Ok.
+        {
+            let block = base.set_strong_vote(Some(well_formed)).build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            verifier_on.verify(&signed_block).unwrap();
         }
     }
 }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3569,4 +3569,69 @@ mod test {
             "Expected {expected_notifications} notifications but only received {received_notifications}"
         );
     }
+
+    #[tokio::test]
+    async fn test_compute_strong_vote() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(true);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context, store)));
+
+        // Round-1 ack targets at authorities 2 and 3.
+        let r1_a2 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build());
+        let r1_a3 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 3).build());
+
+        // Leader at round=2, author=1, acknowledging the two round-1 blocks.
+        let leader = VerifiedBlock::new_for_test(
+            TestBlockHeader::new(2, 1)
+                .set_acknowledgments(vec![r1_a2.reference(), r1_a3.reference()])
+                .build(),
+        );
+
+        let add_data_for = |block: &VerifiedBlock| {
+            let mut s = dag_state.write();
+            s.accept_block_header(block.verified_block_header.clone(), DataSource::Test);
+            s.add_transactions(block.verified_transactions.clone(), DataSource::Test);
+        };
+
+        let a1 = AuthorityIndex::new_for_test(1);
+        let a2 = AuthorityIndex::new_for_test(2);
+        let a3 = AuthorityIndex::new_for_test(3);
+
+        // Empty DagState: leader and both acks are missing.
+        {
+            let sv = Core::compute_strong_vote(&dag_state.read(), &leader.verified_block_header);
+            assert_eq!(sv.leader_authority, a1);
+            assert!(sv.missing.contains(a1));
+            assert!(sv.missing.contains(a2));
+            assert!(sv.missing.contains(a3));
+            assert_eq!(sv.missing.len(), 3);
+            assert!(!sv.is_strong_vote());
+        }
+
+        // Leader and ack at author 2 present; ack at author 3 still missing.
+        add_data_for(&leader);
+        add_data_for(&r1_a2);
+        {
+            let sv = Core::compute_strong_vote(&dag_state.read(), &leader.verified_block_header);
+            assert_eq!(sv.leader_authority, a1);
+            assert!(!sv.missing.contains(a1));
+            assert!(!sv.missing.contains(a2));
+            assert!(sv.missing.contains(a3));
+            assert_eq!(sv.missing.len(), 1);
+            assert!(!sv.is_strong_vote());
+        }
+
+        // All data present: empty missing, strong vote.
+        add_data_for(&r1_a3);
+        {
+            let sv = Core::compute_strong_vote(&dag_state.read(), &leader.verified_block_header);
+            assert_eq!(sv.leader_authority, a1);
+            assert!(sv.missing.is_empty());
+            assert!(sv.is_strong_vote());
+        }
+    }
 }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3634,4 +3634,69 @@ mod test {
             assert!(sv.is_strong_vote());
         }
     }
+
+    #[tokio::test]
+    async fn test_has_strong_vote_quorum() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(true);
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(true);
+        let fixture = CoreTextFixture::new(
+            context,
+            vec![1; 4],
+            AuthorityIndex::new_for_test(0),
+            false,
+            false,
+        );
+
+        let leader = AuthorityIndex::new_for_test(1);
+        let strong_vote = StrongVote {
+            leader_authority: leader,
+            missing: AuthoritySet::new(),
+        };
+        let mut blame_missing = AuthoritySet::new();
+        blame_missing.insert(AuthorityIndex::new_for_test(3));
+        let strong_blame = StrongVote {
+            leader_authority: leader,
+            missing: blame_missing,
+        };
+
+        let add_block = |round: Round, author: u8, sv: StrongVote| {
+            let header = VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(round, author)
+                    .set_strong_vote(Some(sv))
+                    .build(),
+            );
+            fixture
+                .core
+                .dag_state
+                .write()
+                .accept_block_header(header, DataSource::Test);
+        };
+
+        // Empty DagState at round 5 -> no quorum.
+        assert!(!fixture.core.has_strong_vote_quorum(5, leader));
+
+        // 3 strong votes for `leader` at round 5 -> quorum.
+        for author in [0u8, 1, 2] {
+            add_block(5, author, strong_vote);
+        }
+        assert!(fixture.core.has_strong_vote_quorum(5, leader));
+
+        // 2 strong votes for `leader` at round 6 -> below quorum.
+        for author in [0u8, 1] {
+            add_block(6, author, strong_vote);
+        }
+        assert!(!fixture.core.has_strong_vote_quorum(6, leader));
+
+        // 2 strong votes + 1 strong blame for `leader` at round 7 -> below
+        // quorum (blame does not count as vote).
+        add_block(7, 0, strong_vote);
+        add_block(7, 1, strong_vote);
+        add_block(7, 2, strong_blame);
+        assert!(!fixture.core.has_strong_vote_quorum(7, leader));
+    }
 }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3698,5 +3698,17 @@ mod test {
         add_block(7, 1, strong_vote);
         add_block(7, 2, strong_blame);
         assert!(!fixture.core.has_strong_vote_quorum(7, leader));
+
+        // 3 strong votes at round 8 pinned to a different leader -> the
+        // pinning filter rejects them and the quorum check returns false.
+        let other = AuthorityIndex::new_for_test(2);
+        let strong_vote_other = StrongVote {
+            leader_authority: other,
+            missing: AuthoritySet::new(),
+        };
+        for author in [0u8, 1, 2] {
+            add_block(8, author, strong_vote_other);
+        }
+        assert!(!fixture.core.has_strong_vote_quorum(8, leader));
     }
 }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3836,6 +3836,42 @@ mod test {
         assert_eq!(result, expected);
     }
 
+    #[rstest]
+    #[tokio::test]
+    async fn test_is_data_available(#[values(true, false)] consensus_fast_commit_sync: bool) {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let mut dag_state = DagState::new(context, store);
+
+        let block = VerifiedBlock::new_for_test(TestBlockHeader::new(5, 1).build());
+        let block_ref = block.reference();
+
+        // Empty DagState.
+        assert!(!dag_state.is_data_available(&block_ref));
+
+        // Header without transactions.
+        dag_state.accept_block_header(block.verified_block_header.clone(), DataSource::Test);
+        assert!(!dag_state.is_data_available(&block_ref));
+
+        // Header and transactions both present.
+        dag_state.add_transactions(block.verified_transactions, DataSource::Test);
+        assert!(dag_state.is_data_available(&block_ref));
+
+        // Transactions without a header: flag-off ignores the header check;
+        // flag-on requires it.
+        let other = VerifiedBlock::new_for_test(TestBlockHeader::new(6, 2).build());
+        let other_ref = other.reference();
+        dag_state.add_transactions(other.verified_transactions, DataSource::Test);
+        assert_eq!(
+            dag_state.is_data_available(&other_ref),
+            !consensus_fast_commit_sync,
+        );
+    }
+
     #[tokio::test]
     async fn test_no_panic_on_future_timestamp() {
         // GIVEN

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -335,9 +335,6 @@ pub(crate) enum ConsensusError {
         starfish_speed: bool,
     },
 
-    #[error("Block has strong_vote field but consensus_starfish_speed is disabled")]
-    UnexpectedStrongVote,
-
     #[error("Block strong_vote contains invalid authority index {index}, committee size is {max}")]
     InvalidStrongVoteAuthority { index: AuthorityIndex, max: usize },
 


### PR DESCRIPTION
# Description of change

Adds unit-test coverage for new functions and behavior introduced on the
StarfishSpeed feature branch. Five new tests across `block_verifier.rs`,
`block_header.rs`, `dag_state.rs`, and `core.rs`, with two of them later
extended for the leader-authority pinning surface:

- `test_verify_block_strong_vote` — block-verifier strong-vote rejection
  paths (flag-off, invalid index, valid-accepted; later extended with
  out-of-bounds `leader_authority` and `StrongVoteLeaderNotInAncestors`).
- `test_is_data_available` — parametrized over `consensus_fast_commit_sync`,
  covering the four scenarios including the flag-on/flag-off divergence.
- `test_verify_references_indices` — parametrized over `BlockHeader` V1/V2,
  covering valid and three rejection cases for `InvalidOverlapIndices`.
- `test_compute_strong_vote` — build-up scenarios mapping DagState data
  availability to `(leader_authority, missing)`.
- `test_has_strong_vote_quorum` — quorum aggregation over a
  `CoreTextFixture` (empty / quorum / below-quorum / blame-doesn't-count;
  later extended with the wrong-leader-pin case).

Also adds `TestBlockHeader::set_strong_vote` so the builder can emit V2
blocks for the verifier tests.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
