### PR TITLE
upstream(core): Add default TLS to iota-tool with optional --no-tls flag

### DIFF
--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -59,6 +59,9 @@ pub enum ToolCommand {
         /// RPC address to provide the up-to-date committee info
         #[arg(long)]
         fullnode_rpc_url: String,
+        /// If true, uses plain HTTP to connect to validator interface
+        #[arg(long)]
+        no_tls: bool,
         /// Should attempt to rescue the object if it's locked but not fully
         /// locked
         #[arg(long)]
@@ -83,6 +86,10 @@ pub enum ToolCommand {
         #[arg(long)]
         fullnode_rpc_url: String,
 
+        /// If true, uses plain HTTP to connect to validator interface
+        #[arg(long)]
+        no_tls: bool,
+
         /// Concise mode groups responses by results.
         /// prints tabular output suitable for processing with unix tools. For
         /// instance, to quickly check that all validators agree on the history
@@ -103,6 +110,10 @@ pub enum ToolCommand {
         // RPC address to provide the up-to-date committee info
         #[arg(long)]
         fullnode_rpc_url: String,
+
+        /// If true, uses plain HTTP to connect to validator interface
+        #[arg(long)]
+        no_tls: bool,
 
         #[arg(long, help = "The transaction ID to fetch")]
         digest: TransactionDigest,
@@ -215,6 +226,10 @@ pub enum ToolCommand {
         // RPC address to provide the up-to-date committee info
         #[arg(long)]
         fullnode_rpc_url: String,
+
+        /// If true, uses plain HTTP to connect to validator interface
+        #[arg(long)]
+        no_tls: bool,
 
         #[arg(long, help = "Fetch checkpoint at a specific sequence number")]
         sequence_number: Option<CheckpointSequenceNumber>,
@@ -409,8 +424,9 @@ async fn check_locked_object(
     committee: Arc<BTreeMap<AuthorityPublicKeyBytes, u64>>,
     id: ObjectID,
     rescue: bool,
+    use_tls: bool,
 ) -> anyhow::Result<()> {
-    let clients = Arc::new(make_clients(iota_client).await?);
+    let clients = Arc::new(make_clients(iota_client, use_tls).await?);
     let output = get_object(id, None, None, clients.clone()).await?;
     let output = GroupedObjectOutput::new(output, committee);
     if output.fully_locked {
@@ -471,6 +487,7 @@ impl ToolCommand {
             ToolCommand::LockedObject {
                 id,
                 fullnode_rpc_url,
+                no_tls,
                 rescue,
                 address,
             } => {
@@ -505,6 +522,7 @@ impl ToolCommand {
                             committee.clone(),
                             *id,
                             rescue,
+                            !no_tls,
                         ))
                     }
                     join_all(tasks)
@@ -518,12 +536,13 @@ impl ToolCommand {
                 validator,
                 version,
                 fullnode_rpc_url,
+                no_tls,
                 verbosity,
                 concise_no_header,
             } => {
                 let iota_client =
                     Arc::new(IotaClientBuilder::default().build(fullnode_rpc_url).await?);
-                let clients = Arc::new(make_clients(&iota_client).await?);
+                let clients = Arc::new(make_clients(&iota_client, !no_tls).await?);
                 let output = get_object(id, version, validator, clients).await?;
 
                 match verbosity {
@@ -554,10 +573,11 @@ impl ToolCommand {
                 digest,
                 show_input_tx,
                 fullnode_rpc_url,
+                no_tls,
             } => {
                 print!(
                     "{}",
-                    get_transaction_block(digest, show_input_tx, fullnode_rpc_url).await?
+                    get_transaction_block(digest, show_input_tx, fullnode_rpc_url, !no_tls).await?
                 );
             }
             ToolCommand::DbTool { db_path, cmd } => {
@@ -606,10 +626,11 @@ impl ToolCommand {
             ToolCommand::FetchCheckpoint {
                 sequence_number,
                 fullnode_rpc_url,
+                no_tls,
             } => {
                 let iota_client =
                     Arc::new(IotaClientBuilder::default().build(fullnode_rpc_url).await?);
-                let clients = make_clients(&iota_client).await?;
+                let clients = make_clients(&iota_client, !no_tls).await?;
 
                 for (name, (_, client)) in clients {
                     let resp = client

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -104,6 +104,7 @@ pub enum SnapshotVerifyMode {
 // from the current committee members.
 async fn make_clients(
     iota_client: &Arc<IotaClient>,
+    use_tls: bool,
 ) -> Result<BTreeMap<AuthorityName, (Multiaddr, NetworkAuthorityClient)>> {
     let mut net_config = default_iota_network_config();
     net_config.connect_timeout = Some(Duration::from_secs(5));
@@ -115,9 +116,7 @@ async fn make_clients(
         .await?;
 
     for committee_member in state.iter_committee_members() {
-        let net_addr = Multiaddr::try_from(committee_member.net_address.clone())
-            .unwrap()
-            .rewrite_http_to_https();
+        let mut net_addr = Multiaddr::try_from(committee_member.net_address.clone()).unwrap();
         let tls_config = iota_tls::create_rustls_client_config(
             iota_types::crypto::NetworkPublicKey::from_bytes(
                 &committee_member.network_pubkey_bytes,
@@ -125,8 +124,11 @@ async fn make_clients(
             iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
             None,
         );
+        if use_tls {
+            net_addr = net_addr.rewrite_http_to_https();
+        }
         let channel = net_config
-            .connect_lazy(&net_addr, Some(tls_config))
+            .connect_lazy(&net_addr, use_tls.then_some(tls_config))
             .map_err(|err| anyhow!(err.to_string()))?;
         let client = NetworkAuthorityClient::new(channel);
         let public_key_bytes =
@@ -386,9 +388,10 @@ pub async fn get_transaction_block(
     tx_digest: TransactionDigest,
     show_input_tx: bool,
     fullnode_rpc: String,
+    use_tls: bool,
 ) -> Result<String> {
     let iota_client = Arc::new(IotaClientBuilder::default().build(fullnode_rpc).await?);
-    let clients = make_clients(&iota_client).await?;
+    let clients = make_clients(&iota_client, use_tls).await?;
     let timer = Instant::now();
     let responses = join_all(clients.iter().map(|(name, (address, client))| async {
         let result = client


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.49.2, v1.50.1)
- Port commit:
  - [MystenLabs/sui@e204edf](https://github.com/MystenLabs/sui/commit/e204edf75d5359c745b4e72ca7409a19e878c6ca)
- Description:

Adds an optional `--no-tls` flag to four `iota-tool` subcommands (`locked-object`, `fetch-object`, `fetch-transaction`, `fetch-checkpoint`) and threads a `use_tls` parameter through `make_clients` / `get_transaction_block` / `check_locked_object`, so callers can opt out of TLS when connecting to the validator interface.

Note: this fork already enabled TLS by default in `make_clients` (no upstream `TODO: Enable TLS` block). 

## Links to any relevant issues

Part of #11322

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): `iota-tool` now connects to the validator interface over TLS by default; pass `--no-tls` to fall back to plain HTTP on `locked-object`, `fetch-object`, `fetch-transaction`, and `fetch-checkpoint`.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC: