### PR TITLE
upstream(core): Enable DOS protection by default (dryRun)

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -215,7 +215,10 @@ pub struct NodeConfig {
     pub run_with_range: Option<RunWithRange>,
 
     // For killswitch use None
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default = "default_traffic_controller_policy_config"
+    )]
     pub policy_config: Option<PolicyConfig>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1280,6 +1283,10 @@ impl Default for AuthorityOverloadConfig {
 
 fn default_authority_overload_config() -> AuthorityOverloadConfig {
     AuthorityOverloadConfig::default()
+}
+
+fn default_traffic_controller_policy_config() -> Option<PolicyConfig> {
+    Some(PolicyConfig::default_dos_protection_policy())
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -41,8 +41,9 @@ use iota_types::{
 };
 use nonempty::{NonEmpty, nonempty};
 use prometheus::{
-    Histogram, IntCounter, IntCounterVec, Registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    Gauge, Histogram, IntCounter, IntCounterVec, Registry, register_gauge_with_registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry,
 };
 use tap::TapFallible;
 use tonic::{
@@ -191,6 +192,7 @@ pub struct ValidatorServiceMetrics {
     forwarded_header_invalid: IntCounter,
     forwarded_header_not_included: IntCounter,
     client_id_source_config_mismatch: IntCounter,
+    x_forwarded_for_num_hops: Gauge,
 }
 
 impl ValidatorServiceMetrics {
@@ -340,6 +342,12 @@ impl ValidatorServiceMetrics {
             client_id_source_config_mismatch: register_int_counter_with_registry!(
                 "validator_service_client_id_source_config_mismatch",
                 "Number of times detected that client id source config doesn't agree with x-forwarded-for header",
+                registry,
+            )
+            .unwrap(),
+            x_forwarded_for_num_hops: register_gauge_with_registry!(
+                "validator_service_x_forwarded_for_num_hops",
+                "Number of hops in x-forwarded-for header",
                 registry,
             )
             .unwrap(),
@@ -1020,6 +1028,17 @@ impl ValidatorService {
         request: &tonic::Request<T>,
         source: &ClientIdSource,
     ) -> Option<IpAddr> {
+        let forwarded_header = request.metadata().get_all("x-forwarded-for").iter().next();
+
+        if let Some(header) = forwarded_header {
+            let num_hops = header
+                .to_str()
+                .map(|h| h.split(',').count().saturating_sub(1))
+                .unwrap_or(0);
+
+            self.metrics.x_forwarded_for_num_hops.set(num_hops as f64);
+        }
+
         match source {
             ClientIdSource::SocketAddr => {
                 let socket_addr: Option<SocketAddr> = request.remote_addr();

--- a/crates/iota-types/src/traffic_control.rs
+++ b/crates/iota-types/src/traffic_control.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Deserializer};
 use serde_with::serde_as;
 
 // These values set to loosely attempt to limit
@@ -104,6 +104,15 @@ impl Weight {
         let sample = rand::distributions::Uniform::new(0.0, 1.0).sample(&mut rng);
         sample <= self.value()
     }
+}
+
+fn validate_sample_rate<'de, D>(deserializer: D) -> Result<Weight, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = f32::deserialize(deserializer)?;
+    Weight::new(value)
+        .map_err(|_| serde::de::Error::custom("spam-sample-rate must be between 0.0 and 1.0"))
 }
 
 impl PartialEq for Weight {
@@ -217,6 +226,7 @@ pub enum PolicyType {
     /// Blocks connection_ip after reaching a tally frequency (tallies per
     /// second) of `threshold`, as calculated over an average window of
     /// `window_size_secs` with granularity of `update_interval_secs`
+    #[serde(rename = "freq-threshold", alias = "FreqThreshold")]
     FreqThreshold(FreqThresholdConfig),
 
     // Below this point are test policies, and thus should not be used in production
@@ -246,7 +256,10 @@ pub struct PolicyConfig {
     pub error_policy_type: PolicyType,
     #[serde(default = "default_channel_capacity")]
     pub channel_capacity: usize,
-    #[serde(default = "default_spam_sample_rate")]
+    #[serde(
+        default = "default_spam_sample_rate",
+        deserialize_with = "validate_sample_rate"
+    )]
     /// Note that this sample policy is applied on top of the
     /// endpoint-specific sample policy (not configurable) which
     /// weighs endpoints by the relative effort required to serve
@@ -274,6 +287,30 @@ impl Default for PolicyConfig {
             spam_sample_rate: default_spam_sample_rate(),
             dry_run: default_dry_run(),
             allow_list: None,
+        }
+    }
+}
+
+impl PolicyConfig {
+    pub fn default_dos_protection_policy() -> PolicyConfig {
+        PolicyConfig {
+            client_id_source: ClientIdSource::SocketAddr,
+            spam_policy_type: PolicyType::FreqThreshold(FreqThresholdConfig {
+                client_threshold: 500,
+                window_size_secs: 5,
+                update_interval_secs: 1,
+                ..FreqThresholdConfig::default()
+            }),
+            error_policy_type: PolicyType::FreqThreshold(FreqThresholdConfig {
+                client_threshold: 50,
+                window_size_secs: 5,
+                update_interval_secs: 1,
+                ..FreqThresholdConfig::default()
+            }),
+            channel_capacity: 6000,
+            spam_sample_rate: Weight::new(1.0).unwrap(),
+            dry_run: true,
+            ..PolicyConfig::default()
         }
     }
 }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.49.2, v1.50.1)
- Port commit:
  - [MystenLabs/sui@9006185](https://github.com/MystenLabs/sui/commit/9006185009afa2fe239fec771a7d067437814a42)
- Description:

In order for the traffic controller to be enabled in any form, validators must add a `policy-config:` block to their nodes, copying the examples from:
https://gist.github.com/williampsmith/4de166d8be9bb9e183594d631452fb19

Turning the traffic controller on in dry-run mode by default matches what operators are already being asked to do in the above guide. The configs used in `default_dos_protection_policy()` are taken directly from that gist.

## Links to any relevant issues

Part of #11322

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Release notes

- [x] Nodes (Validators and Full nodes): DoS protection is enabled in dryRun mode by default for validators