### PR TITLE
feat(iota-sdk): impl ClientMethods for IotaClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,9 +2034,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecount"
@@ -2548,6 +2548,27 @@ name = "const-str"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -5125,7 +5146,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.6.12",
+ "parity-scale-codec 3.7.5",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
+dependencies = [
+ "parity-scale-codec 3.7.5",
 ]
 
 [[package]]
@@ -5147,14 +5177,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.2"
+name = "impl-serde"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7314,6 +7353,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
+ "iota-sdk-transaction-builder",
  "iota-sdk-types",
  "iota-transaction-builder",
  "iota-types",
@@ -7335,12 +7375,14 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=fcbc436a1da0e9f46ea22a072627feaf6c518eaf#fcbc436a1da0e9f46ea22a072627feaf6c518eaf"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4feb5ee8387eda1f586e514502331bf39e81e357#4feb5ee8387eda1f586e514502331bf39e81e357"
 dependencies = [
  "bip32",
  "bip39",
  "ed25519-dalek",
  "iota-sdk-types",
+ "k256",
+ "p256",
  "rand_core 0.6.4",
  "signature 2.2.0",
  "slip10_ed25519",
@@ -7348,9 +7390,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-sdk-graphql-client"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4feb5ee8387eda1f586e514502331bf39e81e357#4feb5ee8387eda1f586e514502331bf39e81e357"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "chrono",
+ "cynic",
+ "derive_more 2.1.1",
+ "futures",
+ "getrandom 0.2.15",
+ "iota-sdk-graphql-client-build",
+ "iota-sdk-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "variadics_please",
+]
+
+[[package]]
+name = "iota-sdk-graphql-client-build"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4feb5ee8387eda1f586e514502331bf39e81e357#4feb5ee8387eda1f586e514502331bf39e81e357"
+dependencies = [
+ "cynic-codegen",
+]
+
+[[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=fcbc436a1da0e9f46ea22a072627feaf6c518eaf#fcbc436a1da0e9f46ea22a072627feaf6c518eaf"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4feb5ee8387eda1f586e514502331bf39e81e357#4feb5ee8387eda1f586e514502331bf39e81e357"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7367,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=fcbc436a1da0e9f46ea22a072627feaf6c518eaf#fcbc436a1da0e9f46ea22a072627feaf6c518eaf"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4feb5ee8387eda1f586e514502331bf39e81e357#4feb5ee8387eda1f586e514502331bf39e81e357"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7381,9 +7456,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-sdk-transaction-builder"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4feb5ee8387eda1f586e514502331bf39e81e357#4feb5ee8387eda1f586e514502331bf39e81e357"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "derive_more 2.1.1",
+ "iota-sdk-crypto",
+ "iota-sdk-graphql-client",
+ "iota-sdk-types",
+ "primitive-types 0.14.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "variadics_please",
+]
+
+[[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=fcbc436a1da0e9f46ea22a072627feaf6c518eaf#fcbc436a1da0e9f46ea22a072627feaf6c518eaf"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4feb5ee8387eda1f586e514502331bf39e81e357#4feb5ee8387eda1f586e514502331bf39e81e357"
 dependencies = [
  "base64ct",
  "bcs",
@@ -8344,6 +8439,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9164,7 +9274,7 @@ dependencies = [
  "serde_bytes",
  "serde_with",
  "thiserror 1.0.64",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -9985,7 +10095,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10355,15 +10465,17 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
  "bitvec 1.0.1",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.6.12",
+ "parity-scale-codec-derive 3.7.5",
+ "rustversion",
  "serde",
 ]
 
@@ -10381,14 +10493,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10941,7 +11053,7 @@ checksum = "1f1799f398371ad6957951ec446d3ff322d35c46d9db2e217b67e828b311c249"
 dependencies = [
  "hex",
  "primitive-types 0.12.2",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -10982,7 +11094,7 @@ dependencies = [
  "fixed-hash 0.7.0",
  "impl-codec 0.5.1",
  "impl-serde 0.3.2",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -10994,7 +11106,19 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-codec 0.6.0",
  "impl-serde 0.4.0",
- "uint",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
+dependencies = [
+ "fixed-hash 0.8.0",
+ "impl-codec 0.7.1",
+ "impl-serde 0.5.0",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -14478,7 +14602,7 @@ dependencies = [
  "tracing",
  "typed-store-derive",
  "typed-store-error",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -14543,6 +14667,18 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -14728,6 +14864,17 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "variadics_please"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "variant_count"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,9 +395,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "fcbc436a1da0e9f46ea22a072627feaf6c518eaf" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "4feb5ee8387eda1f586e514502331bf39e81e357" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "fcbc436a1da0e9f46ea22a072627feaf6c518eaf" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "4feb5ee8387eda1f586e514502331bf39e81e357" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -436,7 +436,7 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "fcbc436a1da0e9f46ea22a072627feaf6c518eaf", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "4feb5ee8387eda1f586e514502331bf39e81e357", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -77,7 +77,7 @@ test-outputs = ["dep:iota-sdk-crypto"]
 
 [target.'cfg(not(msim))'.dependencies]
 # iota-sdk-crypto is only used when compiling test-outputs feature
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "fcbc436a1da0e9f46ea22a072627feaf6c518eaf", optional = true, features = ["ed25519", "mnemonic"] }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "4feb5ee8387eda1f586e514502331bf39e81e357", optional = true, features = ["ed25519", "mnemonic"] }
 
 [[example]]
 name = "snapshot_add_test_outputs"

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -34,6 +34,7 @@ iota-json.workspace = true
 iota-json-rpc-api.workspace = true
 iota-json-rpc-types.workspace = true
 iota-keys.workspace = true
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "4feb5ee8387eda1f586e514502331bf39e81e357" }
 iota-sdk-types.workspace = true
 iota-transaction-builder.workspace = true
 iota-types.workspace = true

--- a/crates/iota-sdk/examples/transaction_builder/pay_iota.rs
+++ b/crates/iota-sdk/examples/transaction_builder/pay_iota.rs
@@ -14,42 +14,26 @@ use iota_sdk::{
     rpc_types::IotaTransactionBlockResponseOptions,
     types::{quorum_driver_types::ExecuteTransactionRequestType, transaction::Transaction},
 };
+use iota_sdk_transaction_builder::TransactionBuilder;
 use iota_sdk_types::crypto::Intent;
-use utils::setup_for_write;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // 1) Get the IOTA client, the sender and recipient that we will use
     // for the transaction
-    let (client, sender, recipient) = setup_for_write().await?;
+    let (client, sender, recipient) = utils::setup_for_write().await?;
 
-    // 2) Get the coin we will use as gas and for the payment
-    let coins = client
-        .coin_read_api()
-        .get_coins(sender, None, None, None)
-        .await?;
-    let gas_coin = coins.data.into_iter().next().unwrap();
-
-    let gas_budget = 5_000_000;
-
-    // 3) Build the transaction data, to transfer 1_000 NANOS from the gas coin to
+    // 2) Build the transaction data, to transfer 1_000 NANOS from the gas coin to
     //    the recipient address
-    let tx_data = client
-        .transaction_builder()
-        .pay_iota(
-            sender,
-            vec![gas_coin.coin_object_id],
-            vec![recipient],
-            vec![1_000],
-            gas_budget,
-        )
-        .await?;
+    let mut builder = TransactionBuilder::new(sender).with_client(&client);
+    builder.send_iota(recipient, 1_000u64);
+    let tx_data = builder.finish().await?;
 
-    // 4) Sign transaction
+    // 3) Sign transaction
     let keystore = FileBasedKeystore::new(&iota_config_dir()?.join(IOTA_KEYSTORE_FILENAME))?;
     let signature = keystore.sign_secure(&sender, &tx_data, Intent::iota_transaction())?;
 
-    // 5) Execute the transaction
+    // 4) Execute the transaction
     println!("Executing the transaction...");
     let transaction_response = client
         .quorum_driver_api()

--- a/crates/iota-sdk/src/client_methods.rs
+++ b/crates/iota-sdk/src/client_methods.rs
@@ -1,0 +1,451 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements [`ClientMethods`] for the JSON-RPC [`IotaClient`], exposing it
+//! as a backend for the external `iota-sdk-transaction-builder` to build,
+//! dry-run, and submit transactions through.
+
+use std::{str::FromStr, time::Duration};
+
+use iota_json_rpc_types::{
+    DevInspectArgs, IotaArgument, IotaExecutionResult, IotaExecutionStatus, IotaObjectData,
+    IotaObjectDataFilter, IotaObjectDataOptions, IotaObjectResponseQuery, IotaPastObjectResponse,
+    IotaRawData, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
+    IotaTransactionBlockResponseOptions, IotaTypeTag,
+};
+use iota_sdk_transaction_builder::{
+    ClientMethods, DryRunEffect, DryRunMutation, DryRunResult, DryRunReturn, TransactionArgument,
+    WaitForTx,
+};
+use iota_sdk_types::{
+    Address, Digest, Object, ObjectId, SignedTransaction, Transaction, TransactionEffects, TypeTag,
+    UserSignature, Version,
+    effects::TransactionEffectsV1,
+    execution_status::{ExecutionError, ExecutionStatus},
+    gas::GasCostSummary as SdkGasCostSummary,
+};
+use iota_types::{
+    base_types::SequenceNumber,
+    coin::Coin,
+    iota_serde::BigInt,
+    object::Object as CoreObject,
+    transaction::{SenderSignedData, Transaction as CoreTransaction, TransactionDataAPI},
+};
+
+use crate::{IotaClient, error::Error};
+
+/// Default dry-run gas budget when none is supplied: 50 IOTA in nanos.
+const DEFAULT_DRY_RUN_BUDGET_NANOS: u64 = 50_000_000_000;
+
+/// Network-enforced minimum gas budget multiplier: `base_tx_cost_fixed`.
+const MIN_GAS_BUDGET_MULTIPLIER: u64 = 1000;
+
+impl ClientMethods for IotaClient {
+    type Error = crate::error::Error;
+    type DryRunResult = DryRunResult;
+
+    async fn object(
+        &self,
+        object_id: ObjectId,
+        version: impl Into<Option<Version>>,
+    ) -> Result<Option<Object>, Self::Error> {
+        let data = if let Some(v) = version.into() {
+            match self
+                .read_api()
+                .try_get_parsed_past_object(
+                    object_id,
+                    SequenceNumber::from_u64(v.as_u64()),
+                    IotaObjectDataOptions::bcs_lossless(),
+                )
+                .await?
+            {
+                IotaPastObjectResponse::VersionFound(d) => Some(d),
+                _ => None,
+            }
+        } else {
+            self.read_api()
+                .get_object_with_options(object_id, IotaObjectDataOptions::bcs_lossless())
+                .await?
+                .data
+        };
+
+        data.map(data_to_sdk_object).transpose()
+    }
+
+    async fn objects(
+        &self,
+        type_tag: Option<TypeTag>,
+        owner: Option<Address>,
+        object_ids: Option<Vec<ObjectId>>,
+        _ascending: bool,
+        _cursor: Option<String>,
+        limit: Option<usize>,
+    ) -> Result<Vec<Object>, Self::Error> {
+        if let Some(ids) = object_ids {
+            let responses = self
+                .read_api()
+                .multi_get_object_with_options(ids, IotaObjectDataOptions::bcs_lossless())
+                .await?;
+            responses
+                .into_iter()
+                .filter_map(|r| r.data)
+                .map(data_to_sdk_object)
+                .collect()
+        } else if let Some(owner) = owner {
+            // Only struct types can be used as a filter on this endpoint.
+            let filter = type_tag.and_then(|tt| match tt {
+                TypeTag::Struct(s) => Some(IotaObjectDataFilter::StructType(*s)),
+                _ => None,
+            });
+            let query = Some(IotaObjectResponseQuery {
+                filter,
+                options: Some(IotaObjectDataOptions::bcs_lossless()),
+            });
+            let page = self
+                .read_api()
+                .get_owned_objects(owner, query, None, limit)
+                .await?;
+            page.data
+                .into_iter()
+                .filter_map(|r| r.data)
+                .map(data_to_sdk_object)
+                .collect()
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    async fn transaction(&self, digest: Digest) -> Result<Option<SignedTransaction>, Self::Error> {
+        let options = IotaTransactionBlockResponseOptions {
+            show_raw_input: true,
+            ..Default::default()
+        };
+        let response = self
+            .read_api()
+            .get_transaction_with_options(digest, options)
+            .await?;
+
+        if response.raw_transaction.is_empty() {
+            return Ok(None);
+        }
+
+        let sender_signed: SenderSignedData = bcs::from_bytes(&response.raw_transaction)
+            .map_err(|e| Error::Data(format!("failed to deserialize transaction: {e}")))?;
+
+        sender_signed
+            .try_into()
+            .map(Some)
+            .map_err(|e| Error::Data(format!("failed to convert transaction: {e:?}")))
+    }
+
+    async fn transaction_effects(
+        &self,
+        digest: Digest,
+    ) -> Result<Option<TransactionEffects>, Self::Error> {
+        let options = IotaTransactionBlockResponseOptions {
+            show_raw_effects: true,
+            ..Default::default()
+        };
+        let response = self
+            .read_api()
+            .get_transaction_with_options(digest, options)
+            .await?;
+
+        if response.raw_effects.is_empty() {
+            return Ok(None);
+        }
+
+        bcs::from_bytes(&response.raw_effects)
+            .map(Some)
+            .map_err(|e| Error::Data(format!("failed to deserialize effects: {e}")))
+    }
+
+    async fn reference_gas_price(
+        &self,
+        _epoch: impl Into<Option<u64>>,
+    ) -> Result<Option<u64>, Self::Error> {
+        // `iota_getReferenceGasPrice` only returns the current epoch's value.
+        // Per-epoch RGP lives in `iotax_getEpochs`, which requires an indexer,
+        // so the epoch parameter is ignored here.
+        Ok(Some(self.read_api().get_reference_gas_price().await?))
+    }
+
+    async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
+        let res = self.dry_run_tx(tx, true).await?;
+        Ok(res.effects.map(|e| e.gas_summary().gas_used()))
+    }
+
+    async fn dry_run_tx(
+        &self,
+        tx: &Transaction,
+        skip_checks: bool,
+    ) -> Result<DryRunResult, Self::Error> {
+        let mut tx_for_estimation = tx.clone();
+        let Transaction::V1(v1) = &mut tx_for_estimation else {
+            unimplemented!("a new Transaction enum variant was added and needs to be handled")
+        };
+
+        // Set a temporary gas budget so the dry run doesn't fail for lack of
+        // funds: if gas coins are listed, cap at their total balance; otherwise
+        // use the default.
+        if !v1.gas_payment.objects.is_empty() {
+            let mut total_balance = 0u64;
+            for coin_ref in &v1.gas_payment.objects {
+                let obj = self
+                    .read_api()
+                    .get_object_with_options(
+                        coin_ref.object_id,
+                        IotaObjectDataOptions::new().with_bcs(),
+                    )
+                    .await?;
+                if let Some(IotaObjectData {
+                    bcs: Some(IotaRawData::MoveObject(raw)),
+                    ..
+                }) = obj.data
+                {
+                    let coin: Coin = bcs::from_bytes(&raw.bcs_bytes)?;
+                    total_balance += coin.balance.value();
+                }
+            }
+            // Reject up front when the supplied gas coins can't cover the
+            // network's minimum budget; otherwise the dry run would just
+            // surface the same condition as an opaque OutOfGas effect.
+            let min_budget = v1
+                .gas_payment
+                .price
+                .saturating_mul(MIN_GAS_BUDGET_MULTIPLIER);
+            if total_balance < min_budget {
+                return Err(Error::InsufficientFunds {
+                    address: v1.gas_payment.owner,
+                    amount: min_budget as u128,
+                });
+            }
+            v1.gas_payment.budget = total_balance.min(DEFAULT_DRY_RUN_BUDGET_NANOS);
+        } else if v1.gas_payment.budget == 0 {
+            v1.gas_payment.budget = DEFAULT_DRY_RUN_BUDGET_NANOS;
+        }
+
+        let gas_objects =
+            (!v1.gas_payment.objects.is_empty()).then(|| v1.gas_payment.objects.clone());
+        let gas_sponsor = v1.gas_payment.owner;
+        let gas_budget = v1.gas_payment.budget;
+        let gas_price = v1.gas_payment.price;
+
+        if skip_checks {
+            let sender = tx_for_estimation.sender();
+
+            let dev_inspect_args = DevInspectArgs {
+                gas_sponsor: Some(gas_sponsor),
+                gas_budget: Some(gas_budget),
+                gas_objects,
+                skip_checks: Some(true),
+                show_raw_txn_data_and_effects: Some(false),
+            };
+
+            let dev_inspect = self
+                .read_api()
+                .dev_inspect_transaction_block(
+                    sender,
+                    tx_for_estimation.into_kind(),
+                    Some(BigInt::from(gas_price)),
+                    None,
+                    Some(dev_inspect_args),
+                )
+                .await?;
+
+            let results = dev_inspect
+                .results
+                .unwrap_or_default()
+                .into_iter()
+                .map(convert_effect)
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(DryRunResult {
+                error: dev_inspect.error,
+                results,
+                transaction: None,
+                effects: Some(rpc_effects_to_sdk(&dev_inspect.effects)),
+            })
+        } else {
+            let response = self
+                .read_api()
+                .dry_run_transaction_block(tx_for_estimation)
+                .await?;
+
+            Ok(DryRunResult {
+                error: response.execution_error_source,
+                results: vec![],
+                transaction: None,
+                effects: Some(rpc_effects_to_sdk(&response.effects)),
+            })
+        }
+    }
+
+    async fn execute_tx(
+        &self,
+        signatures: &[UserSignature],
+        tx: &Transaction,
+        wait_for: impl Into<Option<WaitForTx>>,
+    ) -> Result<TransactionEffects, Self::Error> {
+        let signed_tx = SignedTransaction {
+            transaction: tx.clone(),
+            signatures: signatures.to_vec(),
+        };
+
+        let core_tx: CoreTransaction = signed_tx
+            .try_into()
+            .map_err(|e| Error::Data(format!("failed to convert signed transaction: {e:?}")))?;
+
+        let options = IotaTransactionBlockResponseOptions {
+            show_effects: true,
+            show_raw_effects: true,
+            ..Default::default()
+        };
+        let response = self
+            .quorum_driver_api()
+            .execute_transaction_block(core_tx, options, None)
+            .await?;
+
+        if let Some(wait) = wait_for.into() {
+            self.wait_for_tx(response.digest, wait).await?;
+        }
+
+        if response.raw_effects.is_empty() {
+            return Err(Error::Data(
+                "no effects returned from execution".to_string(),
+            ));
+        }
+
+        bcs::from_bytes(&response.raw_effects)
+            .map_err(|e| Error::Data(format!("failed to deserialize effects: {e}")))
+    }
+
+    async fn wait_for_tx(&self, digest: Digest, wait_for: WaitForTx) -> Result<(), Self::Error> {
+        let timeout = Duration::from_secs(60);
+        let poll_interval = Duration::from_millis(100);
+
+        tokio::time::timeout(timeout, async {
+            let mut interval = tokio::time::interval(poll_interval);
+            loop {
+                interval.tick().await;
+
+                let options = IotaTransactionBlockResponseOptions {
+                    show_effects: true,
+                    ..Default::default()
+                };
+                let resp = self
+                    .read_api()
+                    .get_transaction_with_options(digest, options)
+                    .await?;
+
+                let is_ready = match wait_for {
+                    // Checkpoint inclusion indicates finalization.
+                    WaitForTx::Finalized => resp.checkpoint.is_some(),
+                    // Otherwise wait until effects are queryable.
+                    _ => resp.effects.is_some(),
+                };
+
+                if is_ready {
+                    break Ok(());
+                }
+            }
+        })
+        .await
+        .map_err(|_| Error::Data("timeout waiting for transaction".to_string()))?
+    }
+}
+
+fn data_to_sdk_object(data: IotaObjectData) -> Result<Object, Error> {
+    let core: CoreObject = data
+        .try_into()
+        .map_err(|e| Error::Data(format!("object conversion failed: {e}")))?;
+    core.try_into()
+        .map_err(|e| Error::Data(format!("object sdk conversion failed: {e}")))
+}
+
+fn rpc_effects_to_sdk(effects: &IotaTransactionBlockEffects) -> TransactionEffects {
+    let rpc_gas = effects.gas_cost_summary();
+    let gas_used = SdkGasCostSummary::new(
+        rpc_gas.computation_cost,
+        rpc_gas.computation_cost_burned,
+        rpc_gas.storage_cost,
+        rpc_gas.storage_rebate,
+        rpc_gas.non_refundable_storage_fee,
+    );
+
+    let status = match effects.status() {
+        IotaExecutionStatus::Success => ExecutionStatus::Success,
+        // The RPC response carries the error as a string only; the structured
+        // ExecutionError variant isn't reconstructible from it.
+        IotaExecutionStatus::Failure { .. } => ExecutionStatus::Failure {
+            error: ExecutionError::InvariantViolation,
+            command: None,
+        },
+    };
+
+    TransactionEffects::V1(Box::new(TransactionEffectsV1 {
+        status,
+        epoch: effects.executed_epoch(),
+        gas_used,
+        transaction_digest: *effects.transaction_digest(),
+        gas_object_index: None,
+        events_digest: effects.events_digest().copied(),
+        dependencies: effects.dependencies().to_vec(),
+        lamport_version: Version::from_u64(0),
+        changed_objects: vec![],
+        unchanged_shared_objects: vec![],
+        auxiliary_data_digest: None,
+    }))
+}
+
+fn convert_argument(arg: IotaArgument) -> TransactionArgument {
+    match arg {
+        IotaArgument::GasCoin => TransactionArgument::GasCoin,
+        IotaArgument::Input(ix) => TransactionArgument::Input { index: ix as u32 },
+        IotaArgument::Result(cmd) => TransactionArgument::Result {
+            cmd: cmd as u32,
+            index: None,
+        },
+        IotaArgument::NestedResult(cmd, ix) => TransactionArgument::Result {
+            cmd: cmd as u32,
+            index: Some(ix as u32),
+        },
+    }
+}
+
+fn convert_type_tag(type_tag: IotaTypeTag) -> Result<TypeTag, Error> {
+    TypeTag::from_str(type_tag.as_ref())
+        .map_err(|e| Error::Data(format!("failed to parse type tag: {e:?}")))
+}
+
+fn convert_mutation(
+    (arg, bcs, type_tag): (IotaArgument, Vec<u8>, IotaTypeTag),
+) -> Result<DryRunMutation, Error> {
+    Ok(DryRunMutation {
+        input: convert_argument(arg),
+        type_tag: convert_type_tag(type_tag)?,
+        bcs,
+    })
+}
+
+fn convert_return((bcs, type_tag): (Vec<u8>, IotaTypeTag)) -> Result<DryRunReturn, Error> {
+    Ok(DryRunReturn {
+        type_tag: convert_type_tag(type_tag)?,
+        bcs,
+    })
+}
+
+fn convert_effect(exec: IotaExecutionResult) -> Result<DryRunEffect, Error> {
+    Ok(DryRunEffect {
+        mutated_references: exec
+            .mutable_reference_outputs
+            .into_iter()
+            .map(convert_mutation)
+            .collect::<Result<_, _>>()?,
+        return_values: exec
+            .return_values
+            .into_iter()
+            .map(convert_return)
+            .collect::<Result<_, _>>()?,
+    })
+}

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -79,6 +79,7 @@
 //! in the [repository](https://github.com/iotaledger/iota/tree/main/crates/iota-sdk/examples).
 
 pub mod apis;
+pub mod client_methods;
 pub mod error;
 pub mod iota_client_config;
 pub mod json_rpc_error;

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "fcbc436a1da0e9f46ea22a072627feaf6c518eaf" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "4feb5ee8387eda1f586e514502331bf39e81e357" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -17,5 +17,5 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "fcbc436a1da0e9f46ea22a072627feaf6c518eaf" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "4feb5ee8387eda1f586e514502331bf39e81e357" }
 iota-types = { path = "../../../crates/iota-types" }


### PR DESCRIPTION
# Description of change

`impl ClientMethods for IotaClient` so the new tx builder can be used
I updated only one example in this PR with the new tx builder to show that it works, other places will be done in a second PR.

## Links to any relevant issues

First part for https://github.com/iotaledger/iota-rust-sdk/issues/431

## How the change has been tested

Running the example and tests (not included in this PR)

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: `impl ClientMethods for IotaClient` so the tx builder from the external SDK can be used
- [ ] gRPC:
