### PR TITLE
fix(iota-benchmark): align remaining simtest epoch durations

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -222,7 +222,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_restarts() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 5_000, 1).await;
+        let test_cluster = build_test_cluster(4, 10_000, 1).await;
         let node_restarter = test_cluster
             .random_node_restarter()
             .with_kill_interval_secs(5, 15)
@@ -234,7 +234,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_small_committee_reconfig() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(1, 5_000, 0).await;
+        let test_cluster = build_test_cluster(1, 10_000, 0).await;
         test_simulated_load(test_cluster, 120).await;
     }
 
@@ -561,7 +561,7 @@ mod test {
             config
         });
 
-        let test_cluster = build_test_cluster(4, 5000, 2).await;
+        let test_cluster = build_test_cluster(4, 30_000, 2).await;
         let mut simulated_load_config = SimulatedLoadConfig::default();
         {
             let mut rng = thread_rng();
@@ -689,7 +689,7 @@ mod test {
     // designed to test performance.
     #[sim_test(config = "test_config_low_latency()")]
     async fn test_simulated_load_large_consensus_commit_prologue_size() {
-        let test_cluster = build_test_cluster(4, 5_000, 1).await;
+        let test_cluster = build_test_cluster(4, 10_000, 1).await;
 
         let mut additional_cancelled_txns = Vec::new();
         let num_txns = thread_rng().gen_range(500..2000);


### PR DESCRIPTION
# Description of change

Four simtests missed in #11452 still used 5s epochs, causing `ValidatorHaltedAtEpochEnd` failures when the surfer cannot get a transaction window during the long epoch-transition period.

Aligned epoch durations:
- `test_simulated_load_reconfig_restarts`: 5_000 → 10_000
- `test_simulated_load_small_committee_reconfig`: 5_000 → 10_000
- `test_simulated_load_shared_object_congestion_control`: 5_000 → 30_000
- `test_simulated_load_large_consensus_commit_prologue_size`: 5_000 → 10_000

The congestion control test gets 30s because it needs additional time for deferral-round mechanics to play out.

## Links to any relevant issues

Follow-up to #11452

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)