### PR TITLE
fix(iota-core): quorum falsely lost after bad-sig eviction in StakeAggregator

### DIFF
--- a/crates/iota-core/src/stake_aggregator.rs
+++ b/crates/iota-core/src/stake_aggregator.rs
@@ -187,9 +187,21 @@ impl<const STRENGTH: bool> StakeAggregator<AuthoritySignInfo, STRENGTH> {
                                         bad_authorities.push(*name);
                                     }
                                 }
-                                InsertResult::NotEnoughVotes {
-                                    bad_votes,
-                                    bad_authorities,
+                                // After evicting invalid sigs, the remaining valid sigs may
+                                // still constitute a quorum on their own.
+                                if self.total_votes >= self.committee.threshold::<STRENGTH>() {
+                                    match AuthorityQuorumSignInfo::<STRENGTH>::new_from_auth_sign_infos(
+                                        self.data.values().cloned().collect(),
+                                        self.committee(),
+                                    ) {
+                                        Ok(aggregated) => InsertResult::QuorumReached(aggregated),
+                                        Err(error) => InsertResult::Failed { error },
+                                    }
+                                } else {
+                                    InsertResult::NotEnoughVotes {
+                                        bad_votes,
+                                        bad_authorities,
+                                    }
                                 }
                             }
                         }
@@ -323,5 +335,102 @@ where
     /// value
     pub fn quorum_unreachable(&self) -> bool {
         self.uncommitted_stake() + self.plurality_stake() < self.committee.threshold::<STRENGTH>()
+    }
+}
+
+#[cfg(test)]
+mod stake_aggregator_insert_tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use fastcrypto::{
+        hash::{HashFunction, Sha3_256},
+        traits::KeyPair,
+    };
+    use iota_sdk_types::crypto::IntentScope;
+    use iota_types::{
+        base_types::AuthorityName,
+        committee::Committee,
+        crypto::{AuthoritySignInfo, random_committee_key_pairs_of_size},
+        message_envelope::{Envelope, Message},
+    };
+    use serde::Serialize;
+
+    use super::*;
+
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq, Hash)]
+    struct TestMessage {
+        value: String,
+    }
+
+    impl Message for TestMessage {
+        type DigestType = [u8; 32];
+        const SCOPE: IntentScope = IntentScope::SenderSignedTransaction;
+
+        fn digest(&self) -> Self::DigestType {
+            let mut hasher = Sha3_256::default();
+            hasher.update(self.value.as_bytes());
+            hasher.finalize().digest
+        }
+    }
+
+    /// Regression test: `StakeAggregator::insert` must not return
+    /// `NotEnoughVotes` when the remaining valid sigs (after bad-sig
+    /// eviction) still form a quorum.
+    #[test]
+    fn test_quorum_not_lost_after_bad_sig_eviction() {
+        // Two-validator committee: first sorted authority has ~7000 weight
+        // (> QUORUM_THRESHOLD ~6667), second has ~3000 weight.
+        let key_pairs = random_committee_key_pairs_of_size(2);
+        let mut names: Vec<AuthorityName> = key_pairs
+            .iter()
+            .map(|kp| AuthorityName::from(kp.public()))
+            .collect();
+        names.sort();
+
+        let voting_rights: BTreeMap<AuthorityName, u64> = names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (*name, if i == 0 { 7 } else { 3 }))
+            .collect();
+        let committee = Arc::new(Committee::new_for_testing_with_normalized_voting_power(
+            0,
+            voting_rights,
+        ));
+
+        let find_kp = |name: &AuthorityName| {
+            key_pairs
+                .iter()
+                .find(|kp| &AuthorityName::from(kp.public()) == name)
+                .unwrap()
+        };
+        let (auth0, key0) = (names[0], find_kp(&names[0]));
+        let (auth1, key1) = (names[1], find_kp(&names[1]));
+
+        let mut agg: StakeAggregator<AuthoritySignInfo, true> = StakeAggregator::new(committee);
+
+        let msg = TestMessage {
+            value: "real".to_string(),
+        };
+        let msg_bad = TestMessage {
+            value: "wrong".to_string(),
+        };
+
+        // auth1 signs the wrong message — weight (~3000) < threshold, no quorum yet.
+        let envelope_bad = Envelope::<TestMessage, AuthoritySignInfo>::new(0, msg_bad, key1, auth1);
+        assert!(matches!(
+            agg.insert(envelope_bad),
+            InsertResult::NotEnoughVotes { .. }
+        ));
+
+        // auth0 signs the real message — total weight crosses threshold, triggering
+        // batch verify. Batch fails (auth1's sig is for the wrong message);
+        // individual verify evicts auth1. auth0's weight alone (~7000) still
+        // exceeds the threshold, so the result must be QuorumReached, not
+        // NotEnoughVotes.
+        let envelope_good = Envelope::<TestMessage, AuthoritySignInfo>::new(0, msg, key0, auth0);
+        assert!(
+            agg.insert(envelope_good).is_quorum_reached(),
+            "valid sig with weight > quorum threshold must yield QuorumReached after bad sig eviction"
+        );
     }
 }


### PR DESCRIPTION
# Description of change

Porting upstream change: https://github.com/MystenLabs/sui/pull/26553
After the individual-verification eviction loop in `StakeAggregator::insert()` removes invalid sigs, the code unconditionally returned `NotEnoughVotes` — even when the remaining valid sigs still met the quorum threshold.

This fix re-checks `total_votes` against the threshold after eviction. If quorum is still met, it aggregates the remaining valid sigs and returns `QuorumReached`.

Includes a regression test covering the two-validator scenario from the bug report.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes