### PR TITLE
fix(consensus): version-flag check for ShardWithProof

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -26,7 +26,7 @@ use crate::{
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, ShardWithProof,
         ShardWithProofAPI, ShardWithProofV1, SignedBlockHeader, TransactionsCommitment,
-        VerifiedBlock, VerifiedOwnShard, VerifiedTransactions,
+        VerifiedBlock, VerifiedOwnShard, VerifiedTransactions, check_shard_version_matches_flags,
     },
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
@@ -346,6 +346,18 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 } else {
                     bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?
                 };
+
+            if let Err(e) = check_shard_version_matches_flags(&shard, &self.context.protocol_config)
+            {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .bundles_with_invalid_parts
+                    .with_label_values(&[peer_hostname, "shard", e.name()])
+                    .inc();
+                info!("Invalid shard from {}: {}", peer, e);
+                return Err(e);
+            }
 
             if shard.round() >= block_round {
                 let e = ConsensusError::TooBigShardRoundInABundle {
@@ -4007,5 +4019,43 @@ mod tests {
                 verified_block_header.reference()
             );
         }
+    }
+
+    #[test]
+    fn check_shard_version_matches_flags_when_fast_commit_sync_enabled() {
+        use crate::{
+            block_header::{ShardWithProof, check_shard_version_matches_flags},
+            error::ConsensusError,
+        };
+        let mut config = iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE();
+        config.set_consensus_fast_commit_sync_for_testing(true);
+
+        // V1 reaching a flag-ON receiver — the case the wire-format dispatch
+        // does not catch on its own.
+        let shard_v1 = ShardWithProof::new(
+            vec![],
+            vec![],
+            BlockRef::default(),
+            TransactionsCommitment::default(),
+            false,
+        );
+        let result = check_shard_version_matches_flags(&shard_v1, &config);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::WrongShardVersionForFlags {
+                actual: "V1",
+                fast_commit_sync: true,
+            })
+        ));
+
+        // V2 with flag ON — accepted (positive control).
+        let shard_v2 = ShardWithProof::new(
+            vec![],
+            vec![],
+            BlockRef::default(),
+            TransactionsCommitment::default(),
+            true,
+        );
+        check_shard_version_matches_flags(&shard_v2, &config).unwrap();
     }
 }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -533,6 +533,34 @@ impl ShardWithProof {
     }
 }
 
+/// Rejects a deserialized `ShardWithProof` whose variant does not match the
+/// local protocol-flag configuration. The flag is uniform across the network
+/// within an epoch, so any mismatch implies either a malicious peer or a
+/// misconfigured upgrade path. In the flag-OFF (raw V1 wire form) branch the
+/// check is a tautology — the deserializer always produces V1 — but it is
+/// called there for symmetry.
+pub(crate) fn check_shard_version_matches_flags(
+    shard: &ShardWithProof,
+    protocol_config: &iota_protocol_config::ProtocolConfig,
+) -> ConsensusResult<()> {
+    let fast_commit_sync = protocol_config.consensus_fast_commit_sync();
+    let variant_matches_flags = matches!(
+        (shard, fast_commit_sync),
+        (ShardWithProof::V1(_), false) | (ShardWithProof::V2(_), true)
+    );
+    if !variant_matches_flags {
+        let actual = match shard {
+            ShardWithProof::V1(_) => "V1",
+            ShardWithProof::V2(_) => "V2",
+        };
+        return Err(ConsensusError::WrongShardVersionForFlags {
+            actual,
+            fast_commit_sync,
+        });
+    }
+    Ok(())
+}
+
 impl ShardWithProofAPI for ShardWithProofV1 {
     fn shard(&self) -> &Shard {
         &self.shard

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -319,6 +319,14 @@ pub(crate) enum ConsensusError {
     FastCommitSyncNotEnabled,
 
     #[error(
+        "ShardWithProof variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync})"
+    )]
+    WrongShardVersionForFlags {
+        actual: &'static str,
+        fast_commit_sync: bool,
+    },
+
+    #[error(
         "Commit variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync})"
     )]
     WrongCommitVersionForFlags {


### PR DESCRIPTION
# Description of change

A peer can send a `ShardWithProof` whose tagged-enum variant does not
match the local `consensus_fast_commit_sync` flag — specifically a V1
wrapped in the tagged form sent to a flag-on receiver. The bytes parse
cleanly today and no version check rejects them; the flag-off branch is
already protected by the wire-format switch from #10591.

Add `check_shard_version_matches_flags` next to `ShardWithProof` and
call it in `extract_shards_from_bundle` after the flag-aware
deserialization. Rejections are recorded via the existing
`bundles_with_invalid_parts{authority, invalid_part, error}` metric.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
