### PR TITLE
feat(iota-core, iota-types): add validator attestation

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -61,6 +61,7 @@ use iota_types::{
             AuthenticatorFunctionRefV1,
         },
     },
+    attestation::Attestation,
     base_types::{
         AuthorityName, ConciseableName, IotaAddress, ObjectID, ObjectInfo, ObjectRef, ObjectType,
         SequenceNumber, StructTag, TypeTag, VersionNumber,
@@ -180,7 +181,7 @@ use crate::{
     stake_aggregator::StakeAggregator,
     subscription_handler::SubscriptionHandler,
     transaction_input_loader::TransactionInputLoader,
-    transaction_manager::TransactionManager,
+    transaction_manager::{TransactionManager, VerifiedExecutableAttestedTransaction},
     transaction_outputs::TransactionOutputs,
     validator_tx_finalizer::ValidatorTxFinalizer,
     verify_indexes::verify_indexes,
@@ -1105,8 +1106,15 @@ impl AuthorityState {
             (inner_temp_store, effects)
         };
 
-        // Build AttestationData.
-        let estimated_computation_cost = effects.gas_cost_summary().computation_cost;
+        // Step 7: build AttestationData.
+        // `gas_cost_summary().computation_cost` is in NANOS; convert to gas
+        // units (`computation_units = computation_cost / gas_price`) so the
+        // attestation is independent of the gas price the user chose.
+        let computation_units = effects
+            .gas_cost_summary()
+            .computation_cost
+            .checked_div(tx_data.gas_price())
+            .unwrap_or(0);
 
         // `object_versions` is the evidence base for malicious-attestor detection. We
         // pull `input_objects` (resolved tx + authenticator inputs) and
@@ -1149,7 +1157,7 @@ impl AuthorityState {
 
         Ok((
             AttestationData::V1 {
-                estimated_computation_cost,
+                computation_units,
                 object_versions,
             },
             owned_objects,
@@ -1363,7 +1371,7 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?certificate.digest()))]
     pub fn try_execute_immediately(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        certificate: &VerifiedExecutableAttestedTransaction,
         expected_effects_digest: Option<TransactionEffectsDigest>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<(TransactionEffects, Option<ExecutionError>)> {
@@ -1450,11 +1458,10 @@ impl AuthorityState {
         certificate: &VerifiedCertificate,
     ) -> IotaResult<(VerifiedSignedTransactionEffects, Option<ExecutionError>)> {
         let epoch_store = self.epoch_store_for_testing();
-        let (effects, execution_error_opt) = self.try_execute_immediately(
-            &VerifiedExecutableTransaction::new_from_certificate(certificate.clone()),
-            None,
-            &epoch_store,
-        )?;
+        let executable: VerifiedExecutableAttestedTransaction =
+            VerifiedExecutableTransaction::new_from_certificate(certificate.clone()).into();
+        let (effects, execution_error_opt) =
+            self.try_execute_immediately(&executable, None, &epoch_store)?;
         let signed_effects = self.sign_effects(effects, &epoch_store)?;
         Ok((signed_effects, execution_error_opt))
     }
@@ -1523,7 +1530,7 @@ impl AuthorityState {
     pub(crate) fn process_certificate(
         &self,
         tx_guard: CertTxGuard,
-        certificate: &VerifiedExecutableTransaction,
+        certificate: &VerifiedExecutableAttestedTransaction,
         tx_input_objects: InputObjects,
         per_authenticator_inputs: Vec<(InputObjects, ObjectReadResult)>,
         expected_effects_digest: Option<TransactionEffectsDigest>,
@@ -1761,7 +1768,7 @@ impl AuthorityState {
     fn prepare_certificate(
         &self,
         _execution_guard: &ExecutionLockReadGuard<'_>,
-        certificate: &VerifiedExecutableTransaction,
+        certificate: &VerifiedExecutableAttestedTransaction,
         tx_input_objects: InputObjects,
         per_authenticator_inputs: Vec<(InputObjects, ObjectReadResult)>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
@@ -1792,6 +1799,20 @@ impl AuthorityState {
         // checks.
         let tx_data = certificate.data().transaction_data();
         tx_data.validity_check(protocol_config)?;
+
+        // The user signature of an attested (`UserTransactionV2`) transaction is
+        // verified pre-consensus in the block verifier
+        // (`IotaTxValidator::validate_transactions`), exactly as for
+        // `UserTransactionV1`, and is not re-checked here.
+        //
+        // Explicit attestations are rejected pre-consensus (block verifier) and
+        // at post-consensus (Check #3), so one reaching here is a protocol-level
+        // bug.
+        if let Some(Attestation::Explicit { .. }) = certificate.attestation() {
+            return Err(IotaError::UnsupportedFeature {
+                error: "Explicit attestation reached prepare_certificate".into(),
+            });
+        }
 
         let (kind, signer, gas_data) = tx_data.execution_parts();
 
@@ -1985,10 +2006,11 @@ impl AuthorityState {
     )> {
         let lock = RwLock::new(epoch_store.epoch());
         let execution_guard = lock.try_read().unwrap();
+        let attested: VerifiedExecutableAttestedTransaction = certificate.clone().into();
 
         self.prepare_certificate(
             &execution_guard,
-            certificate,
+            &attested,
             input_objects,
             vec![],
             epoch_store,
@@ -5403,9 +5425,10 @@ impl AuthorityState {
         let (input_objects, _) =
             self.read_objects_for_execution(&tx_lock, &executable_tx, epoch_store)?;
 
+        let attested_tx: VerifiedExecutableAttestedTransaction = executable_tx.clone().into();
         let (temporary_store, effects, _execution_error_opt) = self.prepare_certificate(
             &execution_guard,
-            &executable_tx,
+            &attested_tx,
             input_objects,
             vec![],
             epoch_store,
@@ -5713,17 +5736,21 @@ impl AuthorityState {
                 is_execute_transaction_to_effects,
             )?;
 
-        // Step 5: coin deny list.
-        let per_authenticator_checked_input_objects: Vec<&_> = per_authenticator_checked_inputs
+        // Step 5: coin deny list. Pass raw `&InputObjects` (the deny-list
+        // check only reads coin types and does not need the
+        // `CheckedInputObjects` type-state — which is still enforced fresh
+        // at `check_certificate_input` in `prepare_certificate`).
+        let per_authenticator_input_objects: Vec<&InputObjects> = per_authenticator_checked_inputs
             .iter()
-            .map(|i| &i.0)
+            .map(|i| i.0.inner())
             .collect();
         check_coin_deny_list_v1(
             tx_data.sender(),
-            &tx_checked_input_objects,
+            tx_checked_input_objects.inner(),
             &tx_receiving_objects,
-            &per_authenticator_checked_input_objects,
+            &per_authenticator_input_objects,
             &self.get_object_store(),
+            epoch,
         )?;
 
         Ok(ValidationOutputs {
@@ -5733,6 +5760,57 @@ impl AuthorityState {
             tx_checked_input_objects,
             per_authenticator_checked_inputs,
         })
+    }
+
+    /// Re-runs the sender-side coin deny-list check for an attested
+    /// (`UserTransactionV2`) transaction in the post-consensus phase.
+    ///
+    /// An honest attestor performs this check at attestation time, but the deny
+    /// list is a Move object whose state may change between attestation and
+    /// execution. Running the check at execution time would crash the
+    /// validator, so we run it during post-consensus validation where the
+    /// transaction can still be dropped.
+    pub(crate) fn check_coin_deny_list_for_attested_tx(
+        &self,
+        transaction: &VerifiedTransaction,
+        epoch: EpochId,
+    ) -> IotaResult<()> {
+        let (tx_input_objects, tx_receiving_objects, per_authenticator_inputs) =
+            self.read_objects_for_validation(transaction, epoch)?;
+        let per_authenticator_input_objects: Vec<&InputObjects> =
+            per_authenticator_inputs.iter().map(|(io, _)| io).collect();
+        check_coin_deny_list_v1(
+            transaction.data().transaction_data().sender(),
+            &tx_input_objects,
+            &tx_receiving_objects,
+            &per_authenticator_input_objects,
+            &self.get_object_store(),
+            epoch,
+        )?;
+        Ok(())
+    }
+
+    /// Re-runs the `TransactionDenyConfig` deny checks (disabled features,
+    /// denied signers, denied input/receiving objects, denied package
+    /// dependencies) for an attested (`UserTransactionV2`) transaction in the
+    /// post-consensus phase.
+    ///
+    /// NOTE: the deny config is sourced from each validator's own `NodeConfig`,
+    /// so this check is not deterministic across validators.
+    pub(crate) fn check_transaction_deny_list_for_attested_tx(
+        &self,
+        transaction: &VerifiedTransaction,
+    ) -> IotaResult<()> {
+        let tx_data = transaction.data().transaction_data();
+        iota_transaction_checks::deny::check_transaction_for_validation(
+            tx_data,
+            transaction.tx_signatures(),
+            &transaction.input_objects()?,
+            &tx_data.receiving_objects(),
+            &self.config.transaction_deny_config,
+            self.get_backing_package_store().as_ref(),
+        )?;
+        Ok(())
     }
 
     #[allow(clippy::type_complexity)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -837,6 +837,17 @@ pub struct AuthorityState {
 /// The authority state encapsulates all state, drives execution, and ensures
 /// safety.
 ///
+/// Outputs of the shared transaction validation pipeline used by both
+/// `handle_transaction_validation_checks` and `attest_transaction`.
+struct ValidationOutputs<'a> {
+    tx_input_objects: InputObjects,
+    per_authenticator_inputs: Vec<(InputObjects, ObjectReadResult)>,
+    move_authenticators: Vec<&'a MoveAuthenticator>,
+    gas_status: IotaGasStatus,
+    tx_checked_input_objects: CheckedInputObjects,
+    per_authenticator_checked_inputs: Vec<(CheckedInputObjects, AuthenticatorFunctionRef)>,
+}
+
 /// Note the authority operations can be accessed through a read ref (&) and do
 /// not require &mut. Internally a database is synchronized through a mutex
 /// lock.
@@ -887,67 +898,21 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<Vec<ObjectRef>> {
         let protocol_config = epoch_store.protocol_config();
-        let reference_gas_price = epoch_store.reference_gas_price();
-
-        let epoch = epoch_store.epoch();
-
         let tx_data = transaction.data().transaction_data();
 
-        // Note: the deny checks may do redundant package loads but:
-        // - they only load packages when there is an active package deny map
-        // - the loads are cached anyway
-        iota_transaction_checks::deny::check_transaction_for_validation(
-            tx_data,
-            transaction.tx_signatures(),
-            &transaction.input_objects()?,
-            &tx_data.receiving_objects(),
-            &self.config.transaction_deny_config,
-            self.get_backing_package_store().as_ref(),
-        )?;
+        let ValidationOutputs {
+            move_authenticators,
+            gas_status,
+            tx_checked_input_objects,
+            per_authenticator_checked_inputs,
+            tx_input_objects: _,
+            per_authenticator_inputs: _,
+        } = self.run_validation_checks(transaction, epoch_store)?;
 
-        // Load all transaction-related input objects.
-        // Authenticator input objects and the account object are loaded in the same
-        // call if there is a sender `MoveAuthenticator` signature present in the
-        // transaction.
-        let (tx_input_objects, tx_receiving_objects, per_authenticator_inputs) =
-            self.read_objects_for_validation(transaction, epoch)?;
-
-        // Get the `MoveAuthenticator`s, if any.
-        let move_authenticators = transaction.move_authenticators();
-
-        // Check the inputs for signing.
-        // If there are `MoveAuthenticator` signatures, their input objects and the
-        // account objects are also checked and must be provided.
-        // It is also checked if there is enough gas to execute the transaction and its
-        // authenticators.
-        let (gas_status, tx_checked_input_objects, per_authenticator_checked_inputs) = self
-            .check_transaction_inputs_for_validation(
-                protocol_config,
-                reference_gas_price,
-                tx_data,
-                tx_input_objects,
-                &tx_receiving_objects,
-                &move_authenticators,
-                per_authenticator_inputs,
-            )?;
-
-        // Get the input objects for the authenticators, if there are
-        // `MoveAuthenticator`s.
-        let per_authenticator_checked_input_objects = per_authenticator_checked_inputs
+        let per_authenticator_checked_input_objects: Vec<&_> = per_authenticator_checked_inputs
             .iter()
             .map(|i| &i.0)
             .collect();
-
-        // Check if any of the sender, the transaction input objects, the receiving
-        // objects and the authenticator input objects are in the coin deny
-        // list, which would prevent the transaction from being signed.
-        check_coin_deny_list_v1(
-            tx_data.sender(),
-            &tx_checked_input_objects,
-            &tx_receiving_objects,
-            &per_authenticator_checked_input_objects,
-            &self.get_object_store(),
-        )?;
 
         // If there are `MoveAuthenticator` signatures, execute them and check if they
         // all succeed.
@@ -1025,9 +990,11 @@ impl AuthorityState {
     /// in a validator attestation and attached to the transaction before
     /// submitting it to consensus.
     ///
-    /// Subsumes `handle_transaction_validation_checks`: it runs the same
-    /// pipeline — deny checks, object loading, input validation, coin deny
-    /// list — and then replaces the final `authenticate_transaction` call with
+    /// Shares the validation pipeline with
+    /// `handle_transaction_validation_checks`
+    /// via [`Self::run_validation_checks`] (deny checks, input object loading,
+    /// input checks, coin deny list), and then replaces the
+    /// `authenticate_transaction` call with
     /// `authenticate_then_execute_transaction_to_effects` so that Move
     /// authentication and transaction execution run together and produce full
     /// `TransactionEffects` including the accurate `computation_cost`.
@@ -1040,50 +1007,16 @@ impl AuthorityState {
 
         let protocol_config = epoch_store.protocol_config();
         let reference_gas_price = epoch_store.reference_gas_price();
-        let epoch = epoch_store.epoch();
         let tx_data = transaction.data().transaction_data();
 
-        // Step 1: deny checks.
-        iota_transaction_checks::deny::check_transaction_for_validation(
-            tx_data,
-            transaction.tx_signatures(),
-            &transaction.input_objects()?,
-            &tx_data.receiving_objects(),
-            &self.config.transaction_deny_config,
-            self.get_backing_package_store().as_ref(),
-        )?;
-
-        // Step 2: load all input objects including authenticator inputs.
-        let (tx_input_objects, tx_receiving_objects, per_authenticator_inputs) =
-            self.read_objects_for_validation(transaction, epoch)?;
-
-        // Step 3: get Move authenticators.
-        let move_authenticators = transaction.move_authenticators();
-
-        // Step 4: check inputs for signing (validates gas budget covers auth + tx).
-        let (gas_status, tx_checked_input_objects, per_authenticator_checked_inputs) = self
-            .check_transaction_inputs_for_validation(
-                protocol_config,
-                reference_gas_price,
-                tx_data,
-                tx_input_objects.clone(),
-                &tx_receiving_objects,
-                &move_authenticators,
-                per_authenticator_inputs.clone(),
-            )?;
-
-        // Step 5: coin deny list.
-        let per_authenticator_checked_input_objects: Vec<&_> = per_authenticator_checked_inputs
-            .iter()
-            .map(|i| &i.0)
-            .collect();
-        check_coin_deny_list_v1(
-            tx_data.sender(),
-            &tx_checked_input_objects,
-            &tx_receiving_objects,
-            &per_authenticator_checked_input_objects,
-            &self.get_object_store(),
-        )?;
+        let ValidationOutputs {
+            tx_input_objects,
+            per_authenticator_inputs,
+            move_authenticators,
+            gas_status,
+            tx_checked_input_objects,
+            per_authenticator_checked_inputs: _,
+        } = self.run_validation_checks(transaction, epoch_store)?;
 
         let owned_objects = tx_checked_input_objects.inner().filter_owned_objects();
 
@@ -1096,9 +1029,8 @@ impl AuthorityState {
         let (kind, signer, gas_data) = tx_data.execution_parts();
         let tx_digest = *transaction.digest();
 
-        // Step 6: execute.
         let effects = if move_authenticators.is_empty() {
-            // Common path: no Move authentication, execute directly.
+            // No Move authentication, execute directly.
             let (_, _, effects, _) = epoch_store.executor().execute_transaction_to_effects(
                 backing_store.as_ref(),
                 protocol_config,
@@ -1117,9 +1049,8 @@ impl AuthorityState {
             );
             effects
         } else {
-            // MoveAuthenticator path: get AuthenticatorFunctionRefForExecution
-            // for each authenticator, then run auth + execution in one pass with an
-            // execution-mode gas status.
+            // get AuthenticatorFunctionRefForExecution for each authenticator, then run
+            // auth + execution in one pass with an execution-mode gas status.
             let tx_data_bytes =
                 bcs::to_bytes(tx_data).expect("TransactionData serialization cannot fail");
 
@@ -1183,13 +1114,13 @@ impl AuthorityState {
             effects
         };
 
-        // Step 7: build AttestationData.
+        // Build AttestationData.
         let estimated_computation_cost = effects.gas_cost_summary().computation_cost;
 
         // Collect all input object refs seen during execution. Start from the
-        // owned objects (extracted in step 5), then add shared objects as
-        // recorded in effects (includes authenticator + deny-list objects),
-        // receiving objects, and gas payment objects.
+        // owned objects, then add shared objects as recorded in effects (includes
+        // authenticator + deny-list objects), receiving objects, and gas payment
+        // objects.
         let mut seen_ids = std::collections::HashSet::new();
         let mut object_versions: Vec<ObjectRef> = Vec::new();
         let mut push = |oref: ObjectRef| {
@@ -5712,6 +5643,85 @@ impl AuthorityState {
     }
 
     #[allow(clippy::type_complexity)]
+    /// Shared validation pipeline for `handle_transaction_validation_checks`
+    /// and `attest_transaction`. Runs, in order:
+    ///   1. transaction deny checks
+    ///   2. input object loading (transaction + per-authenticator + account)
+    ///   3. `MoveAuthenticator` collection
+    ///   4. input checks (gas budget covers transaction + authenticators)
+    ///   5. coin deny list check
+    ///
+    /// Keep this helper as the single source of truth so the two callers
+    /// cannot drift. Raw inputs are cloned and returned for
+    /// `attest_transaction`'s MoveAuthenticator path;
+    /// `handle_transaction_validation_checks` ignores them.
+    fn run_validation_checks<'a>(
+        &self,
+        transaction: &'a VerifiedTransaction,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> IotaResult<ValidationOutputs<'a>> {
+        let protocol_config = epoch_store.protocol_config();
+        let reference_gas_price = epoch_store.reference_gas_price();
+        let epoch = epoch_store.epoch();
+        let tx_data = transaction.data().transaction_data();
+
+        // Step 1: deny checks.
+        // Note: the deny checks may do redundant package loads but:
+        // - they only load packages when there is an active package deny map
+        // - the loads are cached anyway
+        iota_transaction_checks::deny::check_transaction_for_validation(
+            tx_data,
+            transaction.tx_signatures(),
+            &transaction.input_objects()?,
+            &tx_data.receiving_objects(),
+            &self.config.transaction_deny_config,
+            self.get_backing_package_store().as_ref(),
+        )?;
+
+        // Step 2: load all input objects (including authenticator + account).
+        let (tx_input_objects, tx_receiving_objects, per_authenticator_inputs) =
+            self.read_objects_for_validation(transaction, epoch)?;
+
+        // Step 3: get Move authenticators.
+        let move_authenticators = transaction.move_authenticators();
+
+        // Step 4: check inputs for signing (validates gas budget covers auth + tx).
+        // Clone raw inputs so attest_transaction's MoveAuthenticator path can
+        // reuse them in execution-mode.
+        let (gas_status, tx_checked_input_objects, per_authenticator_checked_inputs) = self
+            .check_transaction_inputs_for_validation(
+                protocol_config,
+                reference_gas_price,
+                tx_data,
+                tx_input_objects.clone(),
+                &tx_receiving_objects,
+                &move_authenticators,
+                per_authenticator_inputs.clone(),
+            )?;
+
+        // Step 5: coin deny list.
+        let per_authenticator_checked_input_objects: Vec<&_> = per_authenticator_checked_inputs
+            .iter()
+            .map(|i| &i.0)
+            .collect();
+        check_coin_deny_list_v1(
+            tx_data.sender(),
+            &tx_checked_input_objects,
+            &tx_receiving_objects,
+            &per_authenticator_checked_input_objects,
+            &self.get_object_store(),
+        )?;
+
+        Ok(ValidationOutputs {
+            tx_input_objects,
+            per_authenticator_inputs,
+            move_authenticators,
+            gas_status,
+            tx_checked_input_objects,
+            per_authenticator_checked_inputs,
+        })
+    }
+
     fn read_objects_for_validation(
         &self,
         transaction: &VerifiedTransaction,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -704,7 +704,7 @@ impl AuthorityMetrics {
             ).unwrap(),
             consensus_handler_validation_dropped_transactions: register_int_counter_with_registry!(
                 "consensus_handler_validation_dropped_transactions",
-                "Number of UserTransactionV1 transactions dropped by post-consensus validation",
+                "Number of UserTransactionV1/V2 transactions dropped by post-consensus validation",
                 registry,
             ).unwrap(),
             consensus_handler_max_object_costs: register_int_gauge_vec_with_registry!(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5693,9 +5693,10 @@ impl AuthorityState {
     ///   5. coin deny list check
     ///
     /// Keep this helper as the single source of truth so the two callers
-    /// cannot drift. Raw inputs are cloned and returned for
-    /// `attest_transaction`'s MoveAuthenticator path;
-    /// `handle_transaction_validation_checks` ignores them.
+    /// cannot drift. Raw inputs are cloned and returned only on the
+    /// `attest_transaction` path (`is_execute_transaction_to_effects`), where
+    /// the MoveAuthenticator path needs them; the clone is skipped for
+    /// `handle_transaction_validation_checks`, which ignores them.
     fn run_validation_checks<'a>(
         &self,
         transaction: &'a VerifiedTransaction,
@@ -5730,9 +5731,19 @@ impl AuthorityState {
         // Step 4: check inputs (validates gas budget covers auth + tx). When
         // `is_execute_transaction_to_effects` is true (attest_transaction), the
         // gas budget is metered for full execution; otherwise (signing) it only
-        // covers authentication. Clone the raw per-authenticator inputs so
-        // attest_transaction can recover the `AuthenticatorFunctionRefForExecution`
-        // for each authenticator.
+        // covers authentication.
+        //
+        // Only the attest_transaction path consumes the raw per-authenticator
+        // inputs from `ValidationOutputs` (to recover each
+        // `AuthenticatorFunctionRefForExecution`);
+        // `handle_transaction_validation_checks` discards them. So only clone
+        // for the output when we actually need it, and move the original into
+        // the input check otherwise.
+        let per_authenticator_inputs_for_output = if is_execute_transaction_to_effects {
+            per_authenticator_inputs.clone()
+        } else {
+            Vec::new()
+        };
         let (gas_status, tx_checked_input_objects, per_authenticator_checked_inputs) = self
             .check_transaction_inputs_for_validation(
                 protocol_config,
@@ -5741,7 +5752,7 @@ impl AuthorityState {
                 tx_input_objects,
                 &tx_receiving_objects,
                 &move_authenticators,
-                per_authenticator_inputs.clone(),
+                per_authenticator_inputs,
                 is_execute_transaction_to_effects,
             )?;
 
@@ -5763,7 +5774,7 @@ impl AuthorityState {
         )?;
 
         Ok(ValidationOutputs {
-            per_authenticator_inputs,
+            per_authenticator_inputs: per_authenticator_inputs_for_output,
             move_authenticators,
             gas_status,
             tx_checked_input_objects,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1028,7 +1028,7 @@ impl AuthorityState {
 
         // Capture the `InnerTemporaryStore` from the dry-run: its object maps are the
         // source of truth for the input versions the attestor observed.
-        let (inner_temp_store, effects) = if move_authenticators.is_empty() {
+        let (inner_temp_store, effects, authentication_failed) = if move_authenticators.is_empty() {
             // No Move authentication, execute directly.
             let (inner_temp_store, _, effects, _) =
                 epoch_store.executor().execute_transaction_to_effects(
@@ -1047,7 +1047,8 @@ impl AuthorityState {
                     tx_digest,
                     &mut None,
                 );
-            (inner_temp_store, effects)
+            // This branch has no Move authentication, so it can never fail auth.
+            (inner_temp_store, effects, false)
         } else {
             // Recover the `AuthenticatorFunctionRefForExecution` for each authenticator and
             // run auth + execution in one pass.
@@ -1083,7 +1084,7 @@ impl AuthorityState {
                 })
                 .collect::<Vec<_>>();
 
-            let (inner_temp_store, _, effects, _) = epoch_store
+            let (inner_temp_store, _, effects, _, authentication_failed) = epoch_store
                 .executor()
                 .authenticate_then_execute_transaction_to_effects(
                     backing_store.as_ref(),
@@ -1103,15 +1104,17 @@ impl AuthorityState {
                     tx_data_bytes,
                     &mut None,
                 );
-            (inner_temp_store, effects)
+            (inner_temp_store, effects, authentication_failed)
         };
 
-        // Refuse to attest a transaction whose dry-run did not succeed. This
-        // covers a failed Move authentication as well as any other execution
-        // failure.
-        if let ExecutionStatus::Failure { error, command } = effects.status() {
+        // Refuse to attest a transaction when its Move authentication did not succeed.
+        // Any other failure (out-of-gas or a Move abort in the transaction body) is the
+        // issuer's responsibility and is still attested, sequenced and charged as a
+        // failed transaction under the normal flow.
+        if authentication_failed {
             return Err(IotaError::Execution(format!(
-                "refusing to attest transaction with failing dry-run: {error:?} (command {command:?})"
+                "refusing to attest transaction with failed Move authentication: {:?}",
+                effects.status()
             )));
         }
 
@@ -1964,7 +1967,13 @@ impl AuthorityState {
                 .filter_owned_objects();
             self.check_owned_locks(&owned_object_refs)?;
 
-            epoch_store
+            let (
+                inner_temp_store,
+                gas_status,
+                effects,
+                execution_error_opt,
+                _authentication_failed,
+            ) = epoch_store
                 .executor()
                 .authenticate_then_execute_transaction_to_effects(
                     backing_store,
@@ -1985,7 +1994,8 @@ impl AuthorityState {
                     tx_digest,
                     tx_data_bytes,
                     &mut None,
-                )
+                );
+            (inner_temp_store, gas_status, effects, execution_error_opt)
         };
 
         fail_point_if!("cp_execution_nondeterminism", || {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1020,6 +1020,200 @@ impl AuthorityState {
         Ok(tx_checked_input_objects.inner().filter_owned_objects())
     }
 
+    /// Dry-runs a verified transaction and returns `AttestationData` ready to
+    /// be wrapped in a validator attestation and attached to the transaction
+    /// before submitting it to consensus.
+    ///
+    /// Follows the same pipeline as `handle_transaction_validation_checks`
+    /// — deny checks, object loading, input validation, coin deny list — but
+    /// replaces the final `authenticate_transaction` call with
+    /// `authenticate_then_execute_transaction_to_effects` so that Move
+    /// authentication and transaction execution run together and produce full
+    /// `TransactionEffects` including the accurate `computation_cost`.
+    pub(crate) fn attest_transaction(
+        &self,
+        transaction: &VerifiedTransaction,
+        owned_objects: &[ObjectRef],
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> IotaResult<iota_types::attestation::AttestationData> {
+        use iota_types::attestation::AttestationData;
+
+        let protocol_config = epoch_store.protocol_config();
+        let reference_gas_price = epoch_store.reference_gas_price();
+        let epoch = epoch_store.epoch();
+        let tx_data = transaction.data().transaction_data();
+
+        // Step 1: deny checks.
+        iota_transaction_checks::deny::check_transaction_for_validation(
+            tx_data,
+            transaction.tx_signatures(),
+            &transaction.input_objects()?,
+            &tx_data.receiving_objects(),
+            &self.config.transaction_deny_config,
+            self.get_backing_package_store().as_ref(),
+        )?;
+
+        // Step 2: load all input objects including authenticator inputs.
+        let (tx_input_objects, tx_receiving_objects, per_authenticator_inputs) =
+            self.read_objects_for_validation(transaction, epoch)?;
+
+        // Step 3: get Move authenticators.
+        let move_authenticators = transaction.move_authenticators();
+
+        // Step 4: check inputs for signing (validates gas budget covers auth + tx).
+        let (gas_status, tx_checked_input_objects, per_authenticator_checked_inputs) = self
+            .check_transaction_inputs_for_validation(
+                protocol_config,
+                reference_gas_price,
+                tx_data,
+                tx_input_objects.clone(),
+                &tx_receiving_objects,
+                &move_authenticators,
+                per_authenticator_inputs.clone(),
+            )?;
+
+        // Step 5: coin deny list.
+        let per_authenticator_checked_input_objects: Vec<&_> = per_authenticator_checked_inputs
+            .iter()
+            .map(|i| &i.0)
+            .collect();
+        check_coin_deny_list_v1(
+            tx_data.sender(),
+            &tx_checked_input_objects,
+            &tx_receiving_objects,
+            &per_authenticator_checked_input_objects,
+            &self.get_object_store(),
+        )?;
+
+        let epoch_id = epoch_store.epoch_start_config().epoch_data().epoch_id();
+        let epoch_start_timestamp = epoch_store
+            .epoch_start_config()
+            .epoch_data()
+            .epoch_start_timestamp();
+        let backing_store = self.get_backing_store();
+        let (kind, signer, gas_data) = tx_data.execution_parts();
+        let tx_digest = *transaction.digest();
+
+        // Step 6: execute.
+        let effects = if move_authenticators.is_empty() {
+            // Common path: no Move authentication, execute directly.
+            let (_, _, effects, _) = epoch_store.executor().execute_transaction_to_effects(
+                backing_store.as_ref(),
+                protocol_config,
+                self.metrics.limits_metrics.clone(),
+                false, // expensive_checks
+                self.config.certificate_deny_config.certificate_deny_set(),
+                &epoch_id,
+                epoch_start_timestamp,
+                tx_checked_input_objects,
+                gas_data,
+                gas_status,
+                kind,
+                signer,
+                tx_digest,
+                &mut None,
+            );
+            effects
+        } else {
+            // MoveAuthenticator path: get AuthenticatorFunctionRefForExecution
+            // for each authenticator, then run auth + execution in one pass with an
+            // execution-mode gas status.
+            let tx_data_bytes =
+                bcs::to_bytes(tx_data).expect("TransactionData serialization cannot fail");
+
+            let per_authenticator_inputs_for_exec = move_authenticators
+                .iter()
+                .zip(per_authenticator_inputs)
+                .map(|(ma, (auth_input_objects, account_object))| {
+                    let (id, seq, digest) = ma.object_to_authenticate_components()?;
+                    let signer_addr = ma.address()?;
+                    let func_ref_for_exec =
+                        self.check_move_account(id, seq, digest, account_object, &signer_addr)?;
+                    Ok((auth_input_objects, func_ref_for_exec))
+                })
+                .collect::<IotaResult<Vec<_>>>()?;
+
+            let per_authenticator_input_objects_for_exec = per_authenticator_inputs_for_exec
+                .iter()
+                .map(|(objs, _)| objs.clone())
+                .collect();
+
+            let authenticator_gas_budget = protocol_config.max_auth_gas();
+            let (exec_gas_status, per_auth_checked, auth_and_tx_checked) =
+                iota_transaction_checks::check_transaction_and_move_authenticator_input(
+                    tx_data,
+                    tx_input_objects,
+                    per_authenticator_input_objects_for_exec,
+                    authenticator_gas_budget,
+                    protocol_config,
+                    reference_gas_price,
+                )?;
+
+            let authenticators_for_exec = move_authenticators
+                .into_iter()
+                .zip(per_authenticator_inputs_for_exec)
+                .zip(per_auth_checked)
+                .map(|((ma, (_, func_ref)), checked_inputs)| {
+                    (ma.to_owned(), func_ref, checked_inputs)
+                })
+                .collect::<Vec<_>>();
+
+            let (_, _, effects, _) = epoch_store
+                .executor()
+                .authenticate_then_execute_transaction_to_effects(
+                    backing_store.as_ref(),
+                    protocol_config,
+                    self.metrics.limits_metrics.clone(),
+                    false, // expensive_checks
+                    self.config.certificate_deny_config.certificate_deny_set(),
+                    &epoch_id,
+                    epoch_start_timestamp,
+                    gas_data,
+                    exec_gas_status,
+                    authenticators_for_exec,
+                    auth_and_tx_checked,
+                    kind,
+                    signer,
+                    tx_digest,
+                    tx_data_bytes,
+                    &mut None,
+                );
+            effects
+        };
+
+        // Step 7: build AttestationData.
+        let estimated_computation_cost = effects.gas_cost_summary().computation_cost;
+
+        // Collect all input object refs seen during execution. Start from the
+        // owned objects already validated by the caller, then add shared objects
+        // as recorded in effects (includes authenticator + deny-list objects),
+        // receiving objects, and gas payment objects.
+        let mut seen_ids = std::collections::HashSet::new();
+        let mut object_versions: Vec<ObjectRef> = Vec::new();
+        let mut push = |oref: ObjectRef| {
+            if seen_ids.insert(oref.object_id) {
+                object_versions.push(oref);
+            }
+        };
+        for &oref in owned_objects {
+            push(oref);
+        }
+        for shared in effects.input_shared_objects() {
+            push(shared.object_ref());
+        }
+        for oref in tx_data.receiving_objects() {
+            push(oref);
+        }
+        for &oref in tx_data.gas() {
+            push(oref);
+        }
+
+        Ok(AttestationData::V1 {
+            estimated_computation_cost,
+            object_versions,
+        })
+    }
+
     /// This is a private method and should be kept that way. It doesn't check
     /// whether the provided transaction is a system transaction, and hence
     /// can only be called internally.

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1025,25 +1025,28 @@ impl AuthorityState {
         let (kind, signer, gas_data) = tx_data.execution_parts();
         let tx_digest = *transaction.digest();
 
-        let effects = if move_authenticators.is_empty() {
+        // Capture the `InnerTemporaryStore` from the dry-run: its object maps are the
+        // source of truth for the input versions the attestor observed.
+        let (inner_temp_store, effects) = if move_authenticators.is_empty() {
             // No Move authentication, execute directly.
-            let (_, _, effects, _) = epoch_store.executor().execute_transaction_to_effects(
-                backing_store.as_ref(),
-                protocol_config,
-                self.metrics.limits_metrics.clone(),
-                false, // expensive_checks
-                self.config.certificate_deny_config.certificate_deny_set(),
-                &epoch_id,
-                epoch_start_timestamp,
-                tx_checked_input_objects,
-                gas_data,
-                gas_status,
-                kind,
-                signer,
-                tx_digest,
-                &mut None,
-            );
-            effects
+            let (inner_temp_store, _, effects, _) =
+                epoch_store.executor().execute_transaction_to_effects(
+                    backing_store.as_ref(),
+                    protocol_config,
+                    self.metrics.limits_metrics.clone(),
+                    false, // expensive_checks
+                    self.config.certificate_deny_config.certificate_deny_set(),
+                    &epoch_id,
+                    epoch_start_timestamp,
+                    tx_checked_input_objects,
+                    gas_data,
+                    gas_status,
+                    kind,
+                    signer,
+                    tx_digest,
+                    &mut None,
+                );
+            (inner_temp_store, effects)
         } else {
             // Recover the `AuthenticatorFunctionRefForExecution` for each authenticator and
             // run auth + execution in one pass.
@@ -1079,7 +1082,7 @@ impl AuthorityState {
                 })
                 .collect::<Vec<_>>();
 
-            let (_, _, effects, _) = epoch_store
+            let (inner_temp_store, _, effects, _) = epoch_store
                 .executor()
                 .authenticate_then_execute_transaction_to_effects(
                     backing_store.as_ref(),
@@ -1099,35 +1102,50 @@ impl AuthorityState {
                     tx_data_bytes,
                     &mut None,
                 );
-            effects
+            (inner_temp_store, effects)
         };
 
         // Build AttestationData.
         let estimated_computation_cost = effects.gas_cost_summary().computation_cost;
 
-        // Collect all input object refs seen during execution. Start from the
-        // owned objects, then add shared objects as recorded in effects (includes
-        // authenticator + deny-list objects), receiving objects, and gas payment
-        // objects.
-        let mut seen_ids = std::collections::HashSet::new();
-        let mut object_versions: Vec<ObjectRef> = Vec::new();
-        let mut push = |oref: ObjectRef| {
-            if seen_ids.insert(oref.object_id) {
-                object_versions.push(oref);
-            }
-        };
-        for &oref in &owned_objects {
-            push(oref);
-        }
-        for shared in effects.input_shared_objects() {
-            push(shared.object_ref());
-        }
-        for oref in tx_data.receiving_objects() {
-            push(oref);
-        }
-        for &oref in tx_data.gas() {
-            push(oref);
-        }
+        // `object_versions` is the evidence base for malicious-attestor detection. We
+        // pull `input_objects` (resolved tx + authenticator inputs) and
+        // `loaded_runtime_objects` (dynamic fields / children) from the
+        // execution's temporary store. Both record the pre-execution read version, and
+        // the two maps are disjoint by `ObjectID`.
+
+        // We then drop owned, gas, and receiving objects (pinned by
+        // `TransactionData`) and immutable objects / packages (frozen).
+        let tx_pinned_ids: HashSet<ObjectID> = tx_data
+            .input_objects()?
+            .into_iter()
+            .filter_map(|kind| match kind {
+                InputObjectKind::ImmOrOwnedMoveObject(oref) => Some(oref.object_id),
+                InputObjectKind::MovePackage(_) | InputObjectKind::SharedMoveObject { .. } => None,
+            })
+            .chain(tx_data.gas().iter().map(|oref| oref.object_id))
+            .chain(
+                tx_data
+                    .receiving_objects()
+                    .into_iter()
+                    .map(|oref| oref.object_id),
+            )
+            .collect();
+
+        let object_versions: Vec<ObjectRef> = inner_temp_store
+            .input_objects
+            .values()
+            .filter(|obj| !obj.is_immutable())
+            .map(|obj| obj.compute_object_reference())
+            .chain(
+                inner_temp_store
+                    .loaded_runtime_objects
+                    .iter()
+                    .filter(|(_, meta)| !matches!(meta.owner, Owner::Immutable))
+                    .map(|(id, meta)| ObjectRef::new(*id, meta.version, meta.digest)),
+            )
+            .filter(|oref| !tx_pinned_ids.contains(&oref.object_id))
+            .collect();
 
         Ok((
             AttestationData::V1 {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1020,22 +1020,22 @@ impl AuthorityState {
         Ok(tx_checked_input_objects.inner().filter_owned_objects())
     }
 
-    /// Dry-runs a verified transaction and returns `AttestationData` ready to
-    /// be wrapped in a validator attestation and attached to the transaction
-    /// before submitting it to consensus.
+    /// Dry-runs a verified transaction and returns `AttestationData` together
+    /// with the owned objects validated during execution, ready to be wrapped
+    /// in a validator attestation and attached to the transaction before
+    /// submitting it to consensus.
     ///
-    /// Follows the same pipeline as `handle_transaction_validation_checks`
-    /// — deny checks, object loading, input validation, coin deny list — but
-    /// replaces the final `authenticate_transaction` call with
+    /// Subsumes `handle_transaction_validation_checks`: it runs the same
+    /// pipeline — deny checks, object loading, input validation, coin deny
+    /// list — and then replaces the final `authenticate_transaction` call with
     /// `authenticate_then_execute_transaction_to_effects` so that Move
     /// authentication and transaction execution run together and produce full
     /// `TransactionEffects` including the accurate `computation_cost`.
     pub(crate) fn attest_transaction(
         &self,
         transaction: &VerifiedTransaction,
-        owned_objects: &[ObjectRef],
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> IotaResult<iota_types::attestation::AttestationData> {
+    ) -> IotaResult<(iota_types::attestation::AttestationData, Vec<ObjectRef>)> {
         use iota_types::attestation::AttestationData;
 
         let protocol_config = epoch_store.protocol_config();
@@ -1084,6 +1084,8 @@ impl AuthorityState {
             &per_authenticator_checked_input_objects,
             &self.get_object_store(),
         )?;
+
+        let owned_objects = tx_checked_input_objects.inner().filter_owned_objects();
 
         let epoch_id = epoch_store.epoch_start_config().epoch_data().epoch_id();
         let epoch_start_timestamp = epoch_store
@@ -1185,8 +1187,8 @@ impl AuthorityState {
         let estimated_computation_cost = effects.gas_cost_summary().computation_cost;
 
         // Collect all input object refs seen during execution. Start from the
-        // owned objects already validated by the caller, then add shared objects
-        // as recorded in effects (includes authenticator + deny-list objects),
+        // owned objects (extracted in step 5), then add shared objects as
+        // recorded in effects (includes authenticator + deny-list objects),
         // receiving objects, and gas payment objects.
         let mut seen_ids = std::collections::HashSet::new();
         let mut object_versions: Vec<ObjectRef> = Vec::new();
@@ -1195,7 +1197,7 @@ impl AuthorityState {
                 object_versions.push(oref);
             }
         };
-        for &oref in owned_objects {
+        for &oref in &owned_objects {
             push(oref);
         }
         for shared in effects.input_shared_objects() {
@@ -1208,10 +1210,13 @@ impl AuthorityState {
             push(oref);
         }
 
-        Ok(AttestationData::V1 {
-            estimated_computation_cost,
-            object_versions,
-        })
+        Ok((
+            AttestationData::V1 {
+                estimated_computation_cost,
+                object_versions,
+            },
+            owned_objects,
+        ))
     }
 
     /// This is a private method and should be kept that way. It doesn't check

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -840,7 +840,6 @@ pub struct AuthorityState {
 /// Outputs of the shared transaction validation pipeline used by both
 /// `handle_transaction_validation_checks` and `attest_transaction`.
 struct ValidationOutputs<'a> {
-    tx_input_objects: InputObjects,
     per_authenticator_inputs: Vec<(InputObjects, ObjectReadResult)>,
     move_authenticators: Vec<&'a MoveAuthenticator>,
     gas_status: IotaGasStatus,
@@ -905,9 +904,8 @@ impl AuthorityState {
             gas_status,
             tx_checked_input_objects,
             per_authenticator_checked_inputs,
-            tx_input_objects: _,
             per_authenticator_inputs: _,
-        } = self.run_validation_checks(transaction, epoch_store)?;
+        } = self.run_validation_checks(transaction, epoch_store, false)?;
 
         let per_authenticator_checked_input_objects: Vec<&_> = per_authenticator_checked_inputs
             .iter()
@@ -1006,17 +1004,15 @@ impl AuthorityState {
         use iota_types::attestation::AttestationData;
 
         let protocol_config = epoch_store.protocol_config();
-        let reference_gas_price = epoch_store.reference_gas_price();
         let tx_data = transaction.data().transaction_data();
 
         let ValidationOutputs {
-            tx_input_objects,
             per_authenticator_inputs,
             move_authenticators,
             gas_status,
             tx_checked_input_objects,
-            per_authenticator_checked_inputs: _,
-        } = self.run_validation_checks(transaction, epoch_store)?;
+            per_authenticator_checked_inputs,
+        } = self.run_validation_checks(transaction, epoch_store, true)?;
 
         let owned_objects = tx_checked_input_objects.inner().filter_owned_objects();
 
@@ -1049,44 +1045,36 @@ impl AuthorityState {
             );
             effects
         } else {
-            // get AuthenticatorFunctionRefForExecution for each authenticator, then run
-            // auth + execution in one pass with an execution-mode gas status.
+            // Recover the `AuthenticatorFunctionRefForExecution` for each authenticator and
+            // run auth + execution in one pass.
             let tx_data_bytes =
                 bcs::to_bytes(tx_data).expect("TransactionData serialization cannot fail");
 
-            let per_authenticator_inputs_for_exec = move_authenticators
+            let funcs_for_exec = move_authenticators
                 .iter()
                 .zip(per_authenticator_inputs)
-                .map(|(ma, (auth_input_objects, account_object))| {
+                .map(|(ma, (_, account_object))| {
                     let (id, seq, digest) = ma.object_to_authenticate_components()?;
                     let signer_addr = ma.address()?;
-                    let func_ref_for_exec =
-                        self.check_move_account(id, seq, digest, account_object, &signer_addr)?;
-                    Ok((auth_input_objects, func_ref_for_exec))
+                    self.check_move_account(id, seq, digest, account_object, &signer_addr)
                 })
                 .collect::<IotaResult<Vec<_>>>()?;
 
-            let per_authenticator_input_objects_for_exec = per_authenticator_inputs_for_exec
-                .iter()
-                .map(|(objs, _)| objs.clone())
-                .collect();
-
-            let authenticator_gas_budget = protocol_config.max_auth_gas();
-            let (exec_gas_status, per_auth_checked, auth_and_tx_checked) =
-                iota_transaction_checks::check_transaction_and_move_authenticator_input(
-                    tx_data,
-                    tx_input_objects,
-                    per_authenticator_input_objects_for_exec,
-                    authenticator_gas_budget,
-                    protocol_config,
-                    reference_gas_price,
-                )?;
+            // Union the checked transaction + authenticator input objects for
+            // execution. Borrow the checked inputs here before they are consumed
+            // by `authenticators_for_exec` below.
+            let checked_for_union: Vec<&CheckedInputObjects> =
+                std::iter::once(&tx_checked_input_objects)
+                    .chain(per_authenticator_checked_inputs.iter().map(|(c, _)| c))
+                    .collect();
+            let auth_and_tx_checked =
+                iota_transaction_checks::aggregate_authenticator_input_objects(&checked_for_union)?;
 
             let authenticators_for_exec = move_authenticators
                 .into_iter()
-                .zip(per_authenticator_inputs_for_exec)
-                .zip(per_auth_checked)
-                .map(|((ma, (_, func_ref)), checked_inputs)| {
+                .zip(funcs_for_exec)
+                .zip(per_authenticator_checked_inputs)
+                .map(|((ma, func_ref), (checked_inputs, _))| {
                     (ma.to_owned(), func_ref, checked_inputs)
                 })
                 .collect::<Vec<_>>();
@@ -1102,7 +1090,7 @@ impl AuthorityState {
                     &epoch_id,
                     epoch_start_timestamp,
                     gas_data,
-                    exec_gas_status,
+                    gas_status,
                     authenticators_for_exec,
                     auth_and_tx_checked,
                     kind,
@@ -2116,6 +2104,7 @@ impl AuthorityState {
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
                     authenticator_gas_budget,
+                    false,
                 )?,
                 None,
             )
@@ -2311,6 +2300,7 @@ impl AuthorityState {
                 &self.metrics.bytecode_verifier_metrics,
                 &self.config.verifier_signing_config,
                 authenticator_gas_budget,
+                false,
             )?
         } else {
             let checked_input_objects = iota_transaction_checks::check_dev_inspect_input(
@@ -2526,6 +2516,7 @@ impl AuthorityState {
                     &self.metrics.bytecode_verifier_metrics,
                     &self.config.verifier_signing_config,
                     authenticator_gas_budget,
+                    false,
                 )?
             }
         };
@@ -5659,6 +5650,7 @@ impl AuthorityState {
         &self,
         transaction: &'a VerifiedTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        is_execute_transaction_to_effects: bool,
     ) -> IotaResult<ValidationOutputs<'a>> {
         let protocol_config = epoch_store.protocol_config();
         let reference_gas_price = epoch_store.reference_gas_price();
@@ -5685,18 +5677,22 @@ impl AuthorityState {
         // Step 3: get Move authenticators.
         let move_authenticators = transaction.move_authenticators();
 
-        // Step 4: check inputs for signing (validates gas budget covers auth + tx).
-        // Clone raw inputs so attest_transaction's MoveAuthenticator path can
-        // reuse them in execution-mode.
+        // Step 4: check inputs (validates gas budget covers auth + tx). When
+        // `is_execute_transaction_to_effects` is true (attest_transaction), the
+        // gas budget is metered for full execution; otherwise (signing) it only
+        // covers authentication. Clone the raw per-authenticator inputs so
+        // attest_transaction can recover the `AuthenticatorFunctionRefForExecution`
+        // for each authenticator.
         let (gas_status, tx_checked_input_objects, per_authenticator_checked_inputs) = self
             .check_transaction_inputs_for_validation(
                 protocol_config,
                 reference_gas_price,
                 tx_data,
-                tx_input_objects.clone(),
+                tx_input_objects,
                 &tx_receiving_objects,
                 &move_authenticators,
                 per_authenticator_inputs.clone(),
+                is_execute_transaction_to_effects,
             )?;
 
         // Step 5: coin deny list.
@@ -5713,7 +5709,6 @@ impl AuthorityState {
         )?;
 
         Ok(ValidationOutputs {
-            tx_input_objects,
             per_authenticator_inputs,
             move_authenticators,
             gas_status,
@@ -5760,6 +5755,7 @@ impl AuthorityState {
         tx_receiving_objects: &ReceivingObjects,
         move_authenticators: &Vec<&MoveAuthenticator>,
         per_authenticator_inputs: Vec<(InputObjects, ObjectReadResult)>,
+        is_execute_transaction_to_effects: bool,
     ) -> IotaResult<(
         IotaGasStatus,
         CheckedInputObjects,
@@ -5830,6 +5826,7 @@ impl AuthorityState {
                 &self.metrics.bytecode_verifier_metrics,
                 &self.config.verifier_signing_config,
                 authenticator_gas_budget,
+                is_execute_transaction_to_effects,
             )?;
 
         Ok((

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5722,6 +5722,7 @@ impl AuthorityState {
         })
     }
 
+    #[allow(clippy::type_complexity)]
     fn read_objects_for_validation(
         &self,
         transaction: &VerifiedTransaction,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1106,6 +1106,15 @@ impl AuthorityState {
             (inner_temp_store, effects)
         };
 
+        // Refuse to attest a transaction whose dry-run did not succeed. This
+        // covers a failed Move authentication as well as any other execution
+        // failure.
+        if let ExecutionStatus::Failure { error, command } = effects.status() {
+            return Err(IotaError::Execution(format!(
+                "refusing to attest transaction with failing dry-run: {error:?} (command {command:?})"
+            )));
+        }
+
         // Step 7: build AttestationData.
         // `gas_cost_summary().computation_cost` is in NANOS; convert to gas
         // units (`computation_units = computation_cost / gas_price`) so the

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2907,7 +2907,7 @@ impl AuthorityPerEpochStore {
                 //  validation if the protocol feature flag is not set
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV2(_a),
+                kind: ConsensusTransactionKind::UserTransactionV2(_attested_tx),
                 ..
             }) => {}
             SequencedConsensusTransactionKind::External(ConsensusTransaction {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2243,10 +2243,11 @@ impl AuthorityPerEpochStore {
             .multi_insert(key_value_pairs)?;
 
         // NOTE: If the white flag flow is enabled (certificate-less mode), we do not
-        // insert `UserTransactionV1` into the pending set because there is no
-        // pre-consensus "promise" (a certificate) that `UserTransactionV1` will be
-        // executed before the end of epoch. Thus, the below insertion is only for
-        // certificates, i.e., when the white flag flow is disabled.
+        // insert user transactions (`UserTransactionV1` / `UserTransactionV2`) into
+        // the pending set because there is no pre-consensus "promise" (a certificate)
+        // that they will be executed before the end of epoch. Thus, the below
+        // insertion is only for certificates, i.e., when the white flag flow is
+        // disabled.
         if !self.protocol_config.enable_white_flag_flow() {
             // TODO: lock once for all insert() calls.
             for transaction in transactions {
@@ -2909,7 +2910,10 @@ impl AuthorityPerEpochStore {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV2(_attested_tx),
                 ..
-            }) => {}
+            }) => {
+                // TODO: make sure that UserTransactionV2 blocks don't pass
+                //  validation if the validator-attestation feature flag is not set
+            }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::CheckpointSignature(data),
                 ..
@@ -3190,11 +3194,12 @@ impl AuthorityPerEpochStore {
         sequenced_randomness_transactions.extend(current_commit_sequenced_randomness_transactions);
 
         // Post-consensus validation and owned-object conflict resolution in a
-        // single pass: validates UserTransactionV1 transactions and resolves
-        // lock conflicts before reordering. Deferred txs from previous commits
-        // already have persistent locks, giving them natural precedence.
-        // Also collects all UserTransactionV1 digests for soft lock release
-        // after the consensus output is quarantined.
+        // single pass: validates user transactions (`UserTransactionV1` /
+        // `UserTransactionV2`) and resolves lock conflicts before reordering.
+        // Deferred txs from previous commits already have persistent locks,
+        // giving them natural precedence. Also collects all user transaction
+        // digests for soft lock release after the consensus output is
+        // quarantined.
         let mut soft_lock_release_tx_digests = Vec::new();
         if enable_white_flag {
             let (dropped, owned_object_locks, soft_lock_digests) =

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2907,6 +2907,10 @@ impl AuthorityPerEpochStore {
                 //  validation if the protocol feature flag is not set
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::UserTransactionV2(_a),
+                ..
+            }) => {}
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::CheckpointSignature(data),
                 ..
             }) => {
@@ -4391,11 +4395,25 @@ impl AuthorityPerEpochStore {
                 Ok(ConsensusTransactionResult::RandomnessConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV1(transaction),
+                kind:
+                    ConsensusTransactionKind::UserTransactionV1(_)
+                    // TODO: adjust when UserTransactionV2 logic is added to sequencer
+                    | ConsensusTransactionKind::UserTransactionV2(_),
                 ..
             }) => {
+                let transaction: &Transaction = match &transaction {
+                    SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                        kind: ConsensusTransactionKind::UserTransactionV1(t),
+                        ..
+                    }) => t,
+                    SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                        kind: ConsensusTransactionKind::UserTransactionV2(a),
+                        ..
+                    }) => &a.transaction,
+                    _ => unreachable!(),
+                };
                 if transaction.is_system_tx() {
-                    warn!("UserTransactionV1 contains system transaction, ignoring");
+                    warn!("User transaction contains system transaction, ignoring");
                     return Ok(ConsensusTransactionResult::Ignored);
                 }
                 if self.has_sent_end_of_publish(certificate_author)?
@@ -4405,7 +4423,7 @@ impl AuthorityPerEpochStore {
                     // transactions. Previously-deferred transactions are excluded because
                     // consensus may replay them and they should still be processed.
                     warn!(
-                        "[Byzantine authority] Authority {:?} sent a new UserTransactionV1 \
+                        "[Byzantine authority] Authority {:?} sent a new user transaction \
                          {:?} after it sent EndOfPublish message to consensus",
                         certificate_author.concise(),
                         transaction.digest()

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -31,6 +31,7 @@ use iota_protocol_config::{
 };
 use iota_storage::mutex_table::{MutexGuard, MutexTable};
 use iota_types::{
+    attestation::Attestation,
     base_types::{
         AuthorityName, CommitRound, ConciseableName, EpochId, ObjectID, ObjectRef, SequenceNumber,
         TransactionDigest,
@@ -124,6 +125,7 @@ use crate::{
     post_consensus_validation,
     signature_verifier::*,
     stake_aggregator::StakeAggregator,
+    transaction_manager::VerifiedExecutableAttestedTransaction,
 };
 
 /// The key where the latest consensus index is stored in the database.
@@ -270,12 +272,19 @@ impl CongestionControlParameters {
     /// from a given consensus commit.
     pub(super) fn get_estimated_execution_duration(
         &self,
-        cert: &VerifiedExecutableTransaction,
+        cert: &VerifiedExecutableAttestedTransaction,
     ) -> ExecutionTime {
         match self.per_object_congestion_control_mode {
             PerObjectCongestionControlMode::None => 0,
             PerObjectCongestionControlMode::TotalGasBudget => cert.gas_budget(),
             PerObjectCongestionControlMode::TotalTxCount => 1,
+            PerObjectCongestionControlMode::TotalComputationUnits => {
+                cert.attested_computation_units().unwrap_or_else(|| {
+                    cert.gas_budget()
+                        .checked_div(cert.transaction_data().gas_price())
+                        .unwrap_or(0)
+                })
+            }
         }
     }
 
@@ -441,7 +450,7 @@ pub enum ConsensusTransactionResult {
     /// start_time 0, meaning they are not dependent on another transaction
     /// and they will not wait for another transaction.
     Scheduled {
-        transaction: VerifiedExecutableTransaction,
+        transaction: VerifiedExecutableAttestedTransaction,
         start_time: ExecutionTime,
     },
 
@@ -473,7 +482,7 @@ pub enum ConsensusTransactionResult {
     /// `CancelConsensusTransactionReason`.
     Cancelled(
         (
-            VerifiedExecutableTransaction,
+            VerifiedExecutableAttestedTransaction,
             CancelConsensusTransactionReason,
         ),
     ),
@@ -2141,7 +2150,7 @@ impl AuthorityPerEpochStore {
     ))]
     fn try_schedule(
         &self,
-        cert: &VerifiedExecutableTransaction,
+        cert: &VerifiedExecutableAttestedTransaction,
         commit_round: CommitRound,
         dkg_failed: bool,
         generating_randomness: bool,
@@ -2760,7 +2769,7 @@ impl AuthorityPerEpochStore {
 
     fn process_user_signatures<'a>(
         &self,
-        certificates: impl Iterator<Item = &'a VerifiedExecutableTransaction>,
+        certificates: impl Iterator<Item = &'a VerifiedExecutableAttestedTransaction>,
     ) {
         let sigs: Vec<_> = certificates
             .map(|certificate| (*certificate.digest(), certificate.tx_signatures().to_vec()))
@@ -3049,7 +3058,7 @@ impl AuthorityPerEpochStore {
         consensus_commit_info: &ConsensusCommitInfo,
         authority_metrics: &Arc<AuthorityMetrics>,
         authority_state: &AuthorityState,
-    ) -> IotaResult<Vec<VerifiedExecutableTransaction>> {
+    ) -> IotaResult<Vec<VerifiedExecutableAttestedTransaction>> {
         // Split transactions into different types for processing.
         let verified_transactions: Vec<_> = transactions
             .into_iter()
@@ -3364,7 +3373,7 @@ impl AuthorityPerEpochStore {
                         );
                         let tx =
                             VerifiedExecutableTransaction::new_system((*tx).clone(), self.epoch());
-                        verified_randomness_transactions.push(tx);
+                        verified_randomness_transactions.push(tx.into());
                     }
                 }
 
@@ -3501,7 +3510,7 @@ impl AuthorityPerEpochStore {
     fn add_consensus_commit_prologue_transaction(
         &self,
         output: &mut ConsensusCommitOutput,
-        transactions: &mut VecDeque<VerifiedExecutableTransaction>,
+        transactions: &mut VecDeque<VerifiedExecutableAttestedTransaction>,
         consensus_commit_info: &ConsensusCommitInfo,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusTransactionReason>,
     ) -> IotaResult<Option<TransactionKey>> {
@@ -3572,8 +3581,8 @@ impl AuthorityPerEpochStore {
     fn process_consensus_transaction_shared_object_versions(
         &self,
         cache_reader: &dyn ObjectCacheRead,
-        non_randomness_transactions: &[VerifiedExecutableTransaction],
-        randomness_transactions: &[VerifiedExecutableTransaction],
+        non_randomness_transactions: &[VerifiedExecutableAttestedTransaction],
+        randomness_transactions: &[VerifiedExecutableAttestedTransaction],
         randomness_round: Option<RandomnessRound>,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusTransactionReason>,
         output: &mut ConsensusCommitOutput,
@@ -3597,11 +3606,12 @@ impl AuthorityPerEpochStore {
         });
         let all_certs = non_randomness_transactions
             .iter()
+            .map(|t| &**t)
             // randomness_state_update must be before randomness_transactions to make sure the
             // version of the randomness state object is updated before it is used in
             // randomness transactions.
             .chain(randomness_state_update.iter())
-            .chain(randomness_transactions.iter());
+            .chain(randomness_transactions.iter().map(|t| &**t));
         let ConsensusSharedObjVerAssignment {
             shared_input_next_versions,
             assigned_versions,
@@ -3639,7 +3649,7 @@ impl AuthorityPerEpochStore {
         authority_metrics: &Arc<AuthorityMetrics>,
         skip_consensus_commit_prologue_in_test: bool,
         authority_state: &AuthorityState,
-    ) -> IotaResult<Vec<VerifiedExecutableTransaction>> {
+    ) -> IotaResult<Vec<VerifiedExecutableAttestedTransaction>> {
         self.process_consensus_transactions_and_commit_boundary(
             transactions,
             &ExecutionIndicesWithStats::default(),
@@ -3663,9 +3673,11 @@ impl AuthorityPerEpochStore {
         transactions: &[VerifiedExecutableTransaction],
     ) -> IotaResult {
         let mut output = ConsensusCommitOutput::new(0);
+        let attested: Vec<VerifiedExecutableAttestedTransaction> =
+            transactions.iter().cloned().map(Into::into).collect();
         self.process_consensus_transaction_shared_object_versions(
             cache_reader,
-            transactions,
+            &attested,
             &[],
             None,
             &BTreeMap::new(),
@@ -3718,9 +3730,9 @@ impl AuthorityPerEpochStore {
         mut shared_object_congestion_tracker: SharedObjectCongestionTracker,
         mut shared_object_using_randomness_congestion_tracker: SharedObjectCongestionTracker,
     ) -> IotaResult<(
-        Vec<VerifiedExecutableTransaction>, // non-randomness transactions to schedule
-        Vec<VerifiedExecutableTransaction>, // randomness transactions to schedule
-        Vec<SequencedConsensusTransactionKey>, // keys to notify as complete
+        Vec<VerifiedExecutableAttestedTransaction>, // non-randomness transactions to schedule
+        Vec<VerifiedExecutableAttestedTransaction>, // randomness transactions to schedule
+        Vec<SequencedConsensusTransactionKey>,      // keys to notify as complete
         Option<RwLockWriteGuard<'_, ReconfigState>>,
         bool,                   // true if final round
         Option<TransactionKey>, // consensus commit prologue root
@@ -4188,8 +4200,11 @@ impl AuthorityPerEpochStore {
                     return Ok(ConsensusTransactionResult::Ignored);
                 }
 
+                let attested_transaction: VerifiedExecutableAttestedTransaction =
+                    certificate.into();
+
                 let scheduling_result = self.try_schedule(
-                    &certificate,
+                    &attested_transaction,
                     commit_round,
                     dkg_failed,
                     generating_randomness,
@@ -4199,7 +4214,7 @@ impl AuthorityPerEpochStore {
 
                 self.handle_scheduling_result(
                     scheduling_result,
-                    certificate,
+                    attested_transaction,
                     previously_deferred_tx_digests,
                     dkg_failed,
                     shared_object_congestion_tracker,
@@ -4401,91 +4416,125 @@ impl AuthorityPerEpochStore {
                 Ok(ConsensusTransactionResult::RandomnessConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind:
-                    ConsensusTransactionKind::UserTransactionV1(_)
-                    // TODO: adjust when UserTransactionV2 logic is added to sequencer
-                    | ConsensusTransactionKind::UserTransactionV2(_),
+                kind: ConsensusTransactionKind::UserTransactionV1(t),
                 ..
-            }) => {
-                let transaction: &Transaction = match &transaction {
-                    SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                        kind: ConsensusTransactionKind::UserTransactionV1(t),
-                        ..
-                    }) => t,
-                    SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                        kind: ConsensusTransactionKind::UserTransactionV2(a),
-                        ..
-                    }) => &a.transaction,
-                    _ => unreachable!(),
-                };
-                if transaction.is_system_tx() {
-                    warn!("User transaction contains system transaction, ignoring");
-                    return Ok(ConsensusTransactionResult::Ignored);
-                }
-                if self.has_sent_end_of_publish(certificate_author)?
-                    && !previously_deferred_tx_digests.contains_key(transaction.digest())
-                {
-                    // A validator that has sent EndOfPublish must not inject new user
-                    // transactions. Previously-deferred transactions are excluded because
-                    // consensus may replay them and they should still be processed.
-                    warn!(
-                        "[Byzantine authority] Authority {:?} sent a new user transaction \
-                         {:?} after it sent EndOfPublish message to consensus",
-                        certificate_author.concise(),
-                        transaction.digest()
-                    );
-                    return Ok(ConsensusTransactionResult::Ignored);
-                }
-                // TODO: re-think the epoch-switching flow
-                if !self
-                    .get_reconfig_state_read_lock_guard()
-                    .should_accept_consensus_certs()
-                    && !previously_deferred_tx_digests.contains_key(transaction.digest())
-                {
-                    debug!(
-                        "Ignoring white flag transaction {:?} because of end of epoch",
-                        transaction.digest()
-                    );
-                    return Ok(ConsensusTransactionResult::Ignored);
-                }
-                // TODO: verify that all the same validation actions are performed as for a
-                // Certificate. Possibly extract common code to a separate
-                // function to avoid code duplication.
-
-                // Create `VerifiedExecutableTransaction` with `ConsensusOrdered` proof.
-                // In contrast to `new_from_certificate` (the proof was authorized by 2f+1
-                // pre-consensus signatures), the `ConsensusOrdered` certificate proof
-                // is authorized by consensus ordering post owned-object conflict resolution.
-                let executable_tx = VerifiedExecutableTransaction::new_unchecked(
-                    ExecutableTransaction::new_from_data_and_sig(
-                        transaction.data().clone(),
-                        CertificateProof::ConsensusOrdered(self.epoch()),
-                    ),
-                );
-
-                let scheduling_result = self.try_schedule(
-                    &executable_tx,
-                    commit_round,
-                    dkg_failed,
-                    generating_randomness,
-                    previously_deferred_tx_digests,
-                    shared_object_congestion_tracker,
-                );
-
-                self.handle_scheduling_result(
-                    scheduling_result,
-                    executable_tx,
-                    previously_deferred_tx_digests,
-                    dkg_failed,
-                    shared_object_congestion_tracker,
-                    suggested_gas_price_calculator,
-                    authority_metrics,
-                )
-            }
+            }) => self.try_schedule_user_transaction(
+                t,
+                None,
+                certificate_author,
+                commit_round,
+                dkg_failed,
+                generating_randomness,
+                previously_deferred_tx_digests,
+                shared_object_congestion_tracker,
+                suggested_gas_price_calculator,
+                authority_metrics,
+            ),
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::UserTransactionV2(a),
+                ..
+            }) => self.try_schedule_user_transaction(
+                &a.transaction,
+                Some(a.attestation.clone()),
+                certificate_author,
+                commit_round,
+                dkg_failed,
+                generating_randomness,
+                previously_deferred_tx_digests,
+                shared_object_congestion_tracker,
+                suggested_gas_price_calculator,
+                authority_metrics,
+            ),
             SequencedConsensusTransactionKind::System(system_transaction) => {
                 Ok(self.process_consensus_system_transaction(system_transaction))
             }
         }
+    }
+
+    /// Validates and schedules a post-consensus user transaction
+    /// (`UserTransactionV1` or `UserTransactionV2`).
+    ///
+    /// Factored out of `process_consensus_transaction` so the outer
+    /// `match` can flatly dispatch on the kind: one arm per variant,
+    /// no inner re-discriminating match, no `unreachable!()` arm.
+    fn try_schedule_user_transaction(
+        &self,
+        transaction: &Transaction,
+        attestation: Option<Attestation>,
+        certificate_author: &AuthorityName,
+        commit_round: CommitRound,
+        dkg_failed: bool,
+        generating_randomness: bool,
+        previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
+        shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
+        suggested_gas_price_calculator: &mut SuggestedGasPriceCalculator,
+        authority_metrics: &Arc<AuthorityMetrics>,
+    ) -> IotaResult<ConsensusTransactionResult> {
+        if transaction.is_system_tx() {
+            warn!("User transaction contains system transaction, ignoring");
+            return Ok(ConsensusTransactionResult::Ignored);
+        }
+        if self.has_sent_end_of_publish(certificate_author)?
+            && !previously_deferred_tx_digests.contains_key(transaction.digest())
+        {
+            // A validator that has sent EndOfPublish must not inject new user
+            // transactions. Previously-deferred transactions are excluded because
+            // consensus may replay them and they should still be processed.
+            warn!(
+                "[Byzantine authority] Authority {:?} sent a new user transaction \
+                 {:?} after it sent EndOfPublish message to consensus",
+                certificate_author.concise(),
+                transaction.digest()
+            );
+            return Ok(ConsensusTransactionResult::Ignored);
+        }
+        // TODO: re-think the epoch-switching flow
+        if !self
+            .get_reconfig_state_read_lock_guard()
+            .should_accept_consensus_certs()
+            && !previously_deferred_tx_digests.contains_key(transaction.digest())
+        {
+            debug!(
+                "Ignoring white flag transaction {:?} because of end of epoch",
+                transaction.digest()
+            );
+            return Ok(ConsensusTransactionResult::Ignored);
+        }
+        // TODO: verify that all the same validation actions are performed as for a
+        // Certificate. Possibly extract common code to a separate
+        // function to avoid code duplication.
+
+        // Create `VerifiedExecutableTransaction` with `ConsensusOrdered` proof.
+        // In contrast to `new_from_certificate` (the proof was authorized by 2f+1
+        // pre-consensus signatures), the `ConsensusOrdered` certificate proof
+        // is authorized by consensus ordering post owned-object conflict resolution.
+        let executable_tx = VerifiedExecutableTransaction::new_unchecked(
+            ExecutableTransaction::new_from_data_and_sig(
+                transaction.data().clone(),
+                CertificateProof::ConsensusOrdered(self.epoch()),
+            ),
+        );
+        let attested_executable_tx =
+            VerifiedExecutableAttestedTransaction::new(executable_tx, attestation);
+
+        let scheduling_result = self.try_schedule(
+            &attested_executable_tx,
+            commit_round,
+            dkg_failed,
+            generating_randomness,
+            previously_deferred_tx_digests,
+            shared_object_congestion_tracker,
+        );
+
+        self.handle_scheduling_result(
+            scheduling_result,
+            attested_executable_tx,
+            previously_deferred_tx_digests,
+            dkg_failed,
+            shared_object_congestion_tracker,
+            suggested_gas_price_calculator,
+            authority_metrics,
+        )
     }
 
     /// Handles `SchedulingResult`, i.e., the output of the
@@ -4494,7 +4543,7 @@ impl AuthorityPerEpochStore {
     fn handle_scheduling_result(
         &self,
         scheduling_result: SchedulingResult,
-        verified_executable_tx: VerifiedExecutableTransaction,
+        verified_executable_tx: VerifiedExecutableAttestedTransaction,
         previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
         dkg_failed: bool,
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
@@ -4642,7 +4691,7 @@ impl AuthorityPerEpochStore {
         // If needed we can support owned object system transactions as well...
         assert!(system_transaction.contains_shared_object());
         ConsensusTransactionResult::Scheduled {
-            transaction: system_transaction.clone(),
+            transaction: system_transaction.clone().into(),
             start_time: 0,
         }
     }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2912,7 +2912,8 @@ impl AuthorityPerEpochStore {
                 ..
             }) => {
                 // TODO: make sure that UserTransactionV2 blocks don't pass
-                //  validation if the validator-attestation feature flag is not set
+                //  validation if the validator-attestation feature flag is not
+                // set
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::CheckpointSignature(data),

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -13,7 +13,10 @@ use iota_types::{
 };
 
 use super::{test_authority_builder::TestAuthorityBuilder, *};
-use crate::{checkpoints::CheckpointServiceNoop, consensus_handler::SequencedConsensusTransaction};
+use crate::{
+    checkpoints::CheckpointServiceNoop, consensus_handler::SequencedConsensusTransaction,
+    transaction_manager::VerifiedExecutableAttestedTransaction,
+};
 
 pub async fn send_and_confirm_transaction(
     authority: &AuthorityState,
@@ -405,7 +408,7 @@ pub async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertifica
 
     authority
         .transaction_manager()
-        .enqueue(certs, &authority.epoch_store_for_testing());
+        .enqueue_attested(certs, &authority.epoch_store_for_testing());
 }
 
 pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &VerifiedCertificate) {
@@ -435,7 +438,7 @@ pub async fn send_batch_consensus_no_execution(
     authority: &AuthorityState,
     certificates: &[VerifiedCertificate],
     skip_consensus_commit_prologue_in_test: bool,
-) -> Vec<VerifiedExecutableTransaction> {
+) -> Vec<VerifiedExecutableAttestedTransaction> {
     let transactions = certificates
         .iter()
         .map(|cert| {

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -941,6 +941,16 @@ impl ConsensusOutputQuarantine {
                         .map(|obj| obj.object_id)
                         .collect::<Vec<_>>(),
                 ),
+                SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                    kind: ConsensusTransactionKind::UserTransactionV2(a),
+                    ..
+                }) => Some(
+                    a.transaction
+                        .shared_input_objects()
+                        .into_iter()
+                        .map(|obj| obj.object_id)
+                        .collect::<Vec<_>>(),
+                ),
                 _ => None,
             })
             .flatten()

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -942,10 +942,11 @@ impl ConsensusOutputQuarantine {
                         .collect::<Vec<_>>(),
                 ),
                 SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                    kind: ConsensusTransactionKind::UserTransactionV2(a),
+                    kind: ConsensusTransactionKind::UserTransactionV2(attested_tx),
                     ..
                 }) => Some(
-                    a.transaction
+                    attested_tx
+                        .transaction
                         .shared_input_objects()
                         .into_iter()
                         .map(|obj| obj.object_id)

--- a/crates/iota-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/iota-core/src/authority/shared_object_congestion_tracker.rs
@@ -6,7 +6,6 @@ use std::{cmp::Ordering, collections::HashMap};
 
 use iota_types::{
     base_types::{CommitRound, ObjectID},
-    executable_transaction::VerifiedExecutableTransaction,
     transaction::{SharedObjectRef, TransactionDataAPI},
 };
 use serde::{Deserialize, Serialize};
@@ -15,7 +14,10 @@ use tracing::instrument;
 use super::{
     authority_per_epoch_store::PreviouslyDeferredTransactions, transaction_deferral::DeferralKey,
 };
-use crate::authority::authority_per_epoch_store::CongestionControlParameters;
+use crate::{
+    authority::authority_per_epoch_store::CongestionControlParameters,
+    transaction_manager::VerifiedExecutableAttestedTransaction,
+};
 
 /// Represents execution slot boundaries
 pub(super) type ExecutionTime = u64;
@@ -375,7 +377,7 @@ impl SharedObjectCongestionTracker {
     #[instrument(level = "trace", skip_all, fields(cert_digest = ?cert.digest()))]
     pub(super) fn try_schedule(
         &self,
-        cert: &VerifiedExecutableTransaction,
+        cert: &VerifiedExecutableAttestedTransaction,
         previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
         commit_round: CommitRound,
     ) -> SequencingResult {
@@ -477,7 +479,7 @@ impl SharedObjectCongestionTracker {
     /// execution duration is non-zero, else returns `None`.
     pub(super) fn bump_object_execution_slots(
         &mut self,
-        cert: &VerifiedExecutableTransaction,
+        cert: &VerifiedExecutableAttestedTransaction,
         start_time: ExecutionTime,
     ) -> Option<BumpObjectExecutionSlotsResult> {
         let estimated_execution_duration = self
@@ -783,10 +785,10 @@ pub mod shared_object_test_utils {
         objects: &[(ObjectID, bool)],
         gas_budget: u64,
         gas_price: u64,
-    ) -> VerifiedExecutableTransaction {
+    ) -> VerifiedExecutableAttestedTransaction {
         let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
         let gas_object = random_object_ref();
-        VerifiedExecutableTransaction::new_system(
+        let tx = VerifiedExecutableTransaction::new_system(
             VerifiedTransaction::new_unchecked(
                 TestTransactionBuilder::new(sender, gas_object, gas_price)
                     .with_gas_budget(gas_budget)
@@ -808,7 +810,8 @@ pub mod shared_object_test_utils {
                     .build_and_sign(&keypair),
             ),
             0,
-        )
+        );
+        tx.into()
     }
 
     pub(crate) fn initialize_tracker_and_compute_tx_start_time(
@@ -822,7 +825,7 @@ pub mod shared_object_test_utils {
 
     pub(super) fn initialize_tracker_and_try_schedule(
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
-        cert: &VerifiedExecutableTransaction,
+        cert: &VerifiedExecutableAttestedTransaction,
         previously_deferred_tx_digests: &PreviouslyDeferredTransactions,
         commit_round: CommitRound,
     ) -> SequencingResult {
@@ -1063,13 +1066,15 @@ mod object_cost_tests {
         let shared_obj_1 = ObjectID::random();
 
         let (max_execution_duration_per_commit, max_overshoot_per_commit) = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => (12, 0),
             PerObjectCongestionControlMode::TotalTxCount => (3, 0),
         };
 
         let (initial_debt_obj_0, initial_debt_obj_1) = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => {
                 // Initial debts for TotalGasBudget mode are set such that
                 // the object execution slots are constructed as follows:
@@ -1119,7 +1124,8 @@ mod object_cost_tests {
         shared_object_congestion_tracker.bump_object_execution_slots(
             &tx,
             match mode {
-                PerObjectCongestionControlMode::None => unreachable!(),
+                PerObjectCongestionControlMode::None
+                | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
                 // in TotalGasBudget mode, the object execution slots becomes:
                 //    object 0       object 1
                 //  0| xxxxxxxx     | xxxxxxxx
@@ -1416,7 +1422,8 @@ mod object_cost_tests {
         .expect("start time should be computable");
         shared_object_congestion_tracker.bump_object_execution_slots(&cert, start_time);
         let expected_object_0_duration = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => 20,
             PerObjectCongestionControlMode::TotalTxCount => 11,
         };
@@ -1453,7 +1460,8 @@ mod object_cost_tests {
             TEST_ONLY_GAS_PRICE,
         );
         let expected_object_duration = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => 30,
             PerObjectCongestionControlMode::TotalTxCount => 12,
         };
@@ -1710,13 +1718,15 @@ mod object_cost_tests {
         let tx_gas_budget = 100;
 
         let max_execution_duration_per_commit = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => 100,
             PerObjectCongestionControlMode::TotalTxCount => 2,
         };
 
         let max_overshoot_per_commit = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => 200,
             PerObjectCongestionControlMode::TotalTxCount => 2,
         };
@@ -1735,7 +1745,8 @@ mod object_cost_tests {
         // touching object 1 can be scheduled with some overshoot, but nothing touching
         // object 0 can be scheduled.
         let shared_object_congestion_tracker = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => {
                 // Construct object execution cost as following
                 //          object 0    object 1
@@ -1848,13 +1859,15 @@ mod object_cost_tests {
         // Set max_accumulated_txn_cost_per_object_in_commit  and initial_object_debt
         // such that a single transaction will cause an overshoot.
         let max_execution_duration_per_commit = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => 90,
             PerObjectCongestionControlMode::TotalTxCount => 2,
         };
 
         let initial_object_debt = match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => 70,
             PerObjectCongestionControlMode::TotalTxCount => 2,
         };
@@ -1899,7 +1912,8 @@ mod object_cost_tests {
             shared_object_congestion_tracker.accumulated_debts(max_execution_duration_per_commit);
         assert_eq!(accumulated_debts.len(), 1);
         match mode {
-            PerObjectCongestionControlMode::None => unreachable!(),
+            PerObjectCongestionControlMode::None
+            | PerObjectCongestionControlMode::TotalComputationUnits => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => {
                 assert_eq!(accumulated_debts[0], (shared_obj_0, 80)); // overshoot = initial_debt (70) + tx_duration (100) - max_execution_duration_per_commit (90) = 80
             }

--- a/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
+++ b/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
@@ -3,13 +3,16 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use iota_types::{base_types::ObjectID, executable_transaction::VerifiedExecutableTransaction};
+use iota_types::base_types::ObjectID;
 use tracing::instrument;
 
 use super::shared_object_congestion_tracker::ExecutionTime;
-use crate::authority::{
-    authority_per_epoch_store::CongestionControlParameters,
-    shared_object_congestion_tracker::BumpObjectExecutionSlotsResult,
+use crate::{
+    authority::{
+        authority_per_epoch_store::CongestionControlParameters,
+        shared_object_congestion_tracker::BumpObjectExecutionSlotsResult,
+    },
+    transaction_manager::VerifiedExecutableAttestedTransaction,
 };
 
 /// Holds shared object congestion info for a single scheduled shared-object
@@ -165,7 +168,7 @@ impl SuggestedGasPriceCalculator {
     #[instrument(level = "trace", skip_all)]
     pub(super) fn calculate_suggested_gas_price(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        certificate: &VerifiedExecutableAttestedTransaction,
     ) -> u64 {
         if let Some(congestion_limit_per_commit) = self.get_effective_congestion_limit_per_commit()
         {
@@ -211,7 +214,7 @@ impl SuggestedGasPriceCalculator {
     /// set of transactions appeared in a commit.
     fn find_clearing_gas_price(
         &self,
-        certificate: &VerifiedExecutableTransaction,
+        certificate: &VerifiedExecutableAttestedTransaction,
         congestion_limit_per_commit: ExecutionTime,
     ) -> Option<u64> {
         // Imaginary start time of the deferred/cancelled certificate. We consider
@@ -296,7 +299,8 @@ pub mod suggested_gas_price_calculator_test_utils {
         for (object_id, duration, gas_price) in init_values {
             match congestion_control_parameters.per_object_congestion_control_mode_for_test() {
                 PerObjectCongestionControlMode::None => {}
-                PerObjectCongestionControlMode::TotalGasBudget => {
+                PerObjectCongestionControlMode::TotalGasBudget
+                | PerObjectCongestionControlMode::TotalComputationUnits => {
                     let certificate =
                         build_transaction(&[(*object_id, true)], *duration, *gas_price);
 
@@ -349,19 +353,23 @@ mod tests {
     use std::collections::HashMap;
 
     use iota_protocol_config::{PerObjectCongestionControlMode, ProtocolConfig};
-    use iota_types::{base_types::ObjectID, executable_transaction::VerifiedExecutableTransaction};
+    use iota_types::base_types::ObjectID;
     use rstest::rstest;
 
     use super::SuggestedGasPriceCalculator;
-    use crate::authority::{
-        authority_per_epoch_store::CongestionControlParameters,
-        shared_object_congestion_tracker::{
-            BumpObjectExecutionSlotsResult, ExecutionTime, SequencingResult,
-            SharedObjectCongestionTracker, shared_object_test_utils::build_transaction,
+    use crate::{
+        authority::{
+            authority_per_epoch_store::CongestionControlParameters,
+            shared_object_congestion_tracker::{
+                BumpObjectExecutionSlotsResult, ExecutionTime, SequencingResult,
+                SharedObjectCongestionTracker, shared_object_test_utils::build_transaction,
+            },
+            suggested_gas_price_calculator::{
+                PerCommitCongestionInfo, PerObjectCongestionInfo,
+                ScheduledTransactionCongestionInfo,
+            },
         },
-        suggested_gas_price_calculator::{
-            PerCommitCongestionInfo, PerObjectCongestionInfo, ScheduledTransactionCongestionInfo,
-        },
+        transaction_manager::VerifiedExecutableAttestedTransaction,
     };
 
     const REFERENCE_GAS_PRICE: u64 = 1_000;
@@ -416,7 +424,7 @@ mod tests {
     fn build_and_try_sequencing_certificate(
         tx_data: &TransactionData,
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
-    ) -> (VerifiedExecutableTransaction, SequencingResult) {
+    ) -> (VerifiedExecutableAttestedTransaction, SequencingResult) {
         let certificate = build_transaction(
             &tx_data.input_shared_objects,
             tx_data.gas_budget,
@@ -439,7 +447,7 @@ mod tests {
     /// `shared_object_congestion_tracker` and `suggested_gas_price_calculator`
     /// for a `certificate` scheduled at `execution_start_time`.
     fn update_data_for_scheduled_certificate(
-        certificate: &VerifiedExecutableTransaction,
+        certificate: &VerifiedExecutableAttestedTransaction,
         execution_start_time: ExecutionTime,
         shared_object_congestion_tracker: &mut SharedObjectCongestionTracker,
         suggested_gas_price_calculator: &mut SuggestedGasPriceCalculator,
@@ -2260,7 +2268,8 @@ mod tests {
         let max_execution_duration_per_commit = match per_object_congestion_control_mode {
             PerObjectCongestionControlMode::None => unreachable!(),
             PerObjectCongestionControlMode::TotalTxCount => 0,
-            PerObjectCongestionControlMode::TotalGasBudget => 2_999_999,
+            PerObjectCongestionControlMode::TotalGasBudget
+            | PerObjectCongestionControlMode::TotalComputationUnits => 2_999_999,
         };
         let congestion_control_parameters = CongestionControlParameters::new_for_test(
             per_object_congestion_control_mode,
@@ -2343,7 +2352,8 @@ mod tests {
             match per_object_congestion_control_mode {
                 PerObjectCongestionControlMode::None => unreachable!(),
                 PerObjectCongestionControlMode::TotalTxCount => (1, 2),
-                PerObjectCongestionControlMode::TotalGasBudget => (1_000_000, 2_000_000),
+                PerObjectCongestionControlMode::TotalGasBudget
+                | PerObjectCongestionControlMode::TotalComputationUnits => (1_000_000, 2_000_000),
             };
         let congestion_control_parameters = CongestionControlParameters::new_for_test(
             per_object_congestion_control_mode,

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -414,7 +414,8 @@ impl<'a> TestAuthorityBuilder<'a> {
                         VerifiedTransaction::new_unchecked(genesis.transaction().clone()),
                         genesis.epoch(),
                         genesis.checkpoint().sequence_number,
-                    ),
+                    )
+                    .into(),
                     None,
                     &state.epoch_store_for_testing(),
                 )

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -15,7 +15,6 @@ use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::IotaError,
     fp_ensure,
-    iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
     message_envelope::Message,
     messages_consensus::ConsensusTransaction,
     messages_grpc::{
@@ -290,37 +289,21 @@ impl ValidatorService {
 
         // Build the consensus transaction.
         let consensus_tx = if let Some(attestation_data) = attestation_data {
-            let committee = epoch_store.committee();
-            let attestor_index = committee
-                .names()
-                .position(|n| n == &state.name)
-                .and_then(|i| {
-                    epoch_store
-                        .epoch_start_state()
-                        .get_consensus_committee()
-                        .to_authority_index(i)
-                });
+            // submit_single_tx runs on a validator, so it must be present in its
+            // own committee. Treat absence as a fatal bug, not a user error.
+            let attestor_index = epoch_store
+                .committee()
+                .authority_index(&state.name)
+                .map(|i| starfish_config::AuthorityIndex::from(i as u8))
+                .expect("validator must be present in its own consensus committee");
 
-            match attestor_index {
-                Some(attestor_index) => {
-                    ConsensusTransaction::new_attested_transaction(AttestedTransaction::new(
-                        verified_tx.into_inner(),
-                        Attestation::Validator {
-                            payload: attestation_data,
-                            attestor_index,
-                        },
-                    ))
-                }
-                None => {
-                    soft_locks.release(&tx_digest);
-                    metrics
-                        .soft_lock_table_size
-                        .set(soft_locks.lock_count() as i64);
-                    let error = IotaError::from("validator not found in consensus committee");
-                    let weight = normalize(&error);
-                    return (TxStatusUpdate::Rejected { error }, weight);
-                }
-            }
+            ConsensusTransaction::new_attested_transaction(AttestedTransaction::new(
+                verified_tx.into_inner(),
+                Attestation::Validator {
+                    payload: attestation_data,
+                    attestor_index,
+                },
+            ))
         } else {
             ConsensusTransaction::new_user_transaction(verified_tx.into_inner())
         };

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -235,7 +235,7 @@ impl ValidatorService {
                     (result, verified_tx)
                 })
                 .await
-                .expect("attest_transaction blocking task panicked");
+                .expect("attest_transaction should return Err for invalid transactions instead of panicking");
                 match result {
                     Ok((data, objs)) => (Some(data), objs, verified_tx),
                     Err(e) => {

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -1,22 +1,21 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(test)]
-#[path = "../unit_tests/validator_v2_tests.rs"]
-mod validator_v2_tests;
-
 use std::sync::Arc;
 
 use futures::{StreamExt, future::Either, stream};
+use iota_metrics::spawn_monitored_task;
 use iota_network::api::{
     GetTxStatusRequest, HealthCheckRequest, HealthCheckResponse, NotifyCapabilitiesRequest,
     NotifyCapabilitiesResponse, SubmitTxRequest, TxStatus, ValidatorV2,
 };
 use iota_types::{
+    attestation::{Attestation, AttestedTransaction},
     digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::IotaError,
     fp_ensure,
+    iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
     message_envelope::Message,
     messages_consensus::ConsensusTransaction,
     messages_grpc::{
@@ -28,6 +27,15 @@ use iota_types::{
     transaction::Transaction,
 };
 use tokio_stream::wrappers::ReceiverStream;
+
+use crate::{
+    authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
+    authority_server::{
+        StreamResponse, ValidatorService, ValidatorServiceMetrics, normalize,
+        soft_lock::PreConsensusSoftLocks,
+    },
+    consensus_adapter::ConsensusAdapter,
+};
 
 /// Maximum number of transactions allowed in a single `submit_tx` request.
 /// Sized so that per-item traffic tallies from a single max-batch request
@@ -52,17 +60,6 @@ const MAX_CONCURRENT_SUBMIT_TASKS: usize = 16;
 /// A single streamed item in a V2 RPC response. The `Weight` is the per-item
 /// spam-policy contribution decided by the producing code path.
 type TxUpdateItem = Result<((TransactionDigest, TxStatusUpdate), Weight), tonic::Status>;
-
-use iota_metrics::spawn_monitored_task;
-
-use crate::{
-    authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
-    authority_server::{
-        StreamResponse, ValidatorService, ValidatorServiceMetrics, normalize,
-        soft_lock::PreConsensusSoftLocks,
-    },
-    consensus_adapter::ConsensusAdapter,
-};
 
 impl ValidatorService {
     async fn submit_tx_impl(
@@ -293,11 +290,6 @@ impl ValidatorService {
 
         // Build the consensus transaction.
         let consensus_tx = if let Some(attestation_data) = attestation_data {
-            use iota_types::{
-                attestation::{Attestation, AttestedTransaction},
-                iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
-            };
-
             let committee = epoch_store.committee();
             let attestor_index = committee
                 .names()
@@ -714,3 +706,7 @@ impl ValidatorV2 for ValidatorService {
         self.post_handle_unary(ip, self.health_check_impl(req))
     }
 }
+
+#[cfg(test)]
+#[path = "../unit_tests/validator_v2_tests.rs"]
+mod validator_v2_tests;

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -225,10 +225,19 @@ impl ValidatorService {
         // object loading, input validation, coin deny list, and a full dry-run
         // in a single call, so it replaces `handle_transaction_validation_checks`
         // entirely. The legacy path calls the validation-only function.
-        let (attestation_data, owned_objects) =
+        let (attestation_data, owned_objects, verified_tx) =
             if epoch_store.protocol_config().enable_validator_attestation() {
-                match state.attest_transaction(&verified_tx, epoch_store) {
-                    Ok((data, objs)) => (Some(data), objs),
+                let state_for_attest = state.clone();
+                let epoch_store_for_attest = epoch_store.clone();
+                let (result, verified_tx) = tokio::task::spawn_blocking(move || {
+                    let result = state_for_attest
+                        .attest_transaction(&verified_tx, &epoch_store_for_attest);
+                    (result, verified_tx)
+                })
+                .await
+                .expect("attest_transaction blocking task panicked");
+                match result {
+                    Ok((data, objs)) => (Some(data), objs, verified_tx),
                     Err(e) => {
                         let weight = normalize(&e);
                         return (TxStatusUpdate::Rejected { error: e }, weight);
@@ -239,7 +248,7 @@ impl ValidatorService {
                     .handle_transaction_validation_checks(&verified_tx, epoch_store)
                     .await
                 {
-                    Ok(objs) => (None, objs),
+                    Ok(objs) => (None, objs, verified_tx),
                     Err(e) => {
                         let weight = normalize(&e);
                         return (TxStatusUpdate::Rejected { error: e }, weight);

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -306,15 +306,15 @@ impl ValidatorService {
                 });
 
             match attestor_index {
-                Some(attestor_index) => ConsensusTransaction::new_attested_transaction(
-                    AttestedTransaction::new(
+                Some(attestor_index) => {
+                    ConsensusTransaction::new_attested_transaction(AttestedTransaction::new(
                         verified_tx.into_inner(),
                         Attestation::Validator {
                             payload: attestation_data,
                             attestor_index,
                         },
-                    ),
-                ),
+                    ))
+                }
                 None => {
                     soft_locks.release(&tx_digest);
                     metrics
@@ -330,11 +330,9 @@ impl ValidatorService {
         };
 
         // Submit to consensus.
-        if let Err(e) = consensus_adapter.submit(
-            consensus_tx,
-            Some(&reconfiguration_lock),
-            epoch_store,
-        ) {
+        if let Err(e) =
+            consensus_adapter.submit(consensus_tx, Some(&reconfiguration_lock), epoch_store)
+        {
             let weight = normalize(&e);
             // Release soft locks so the transaction can be retried.
             tracing::debug!(

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -1,6 +1,10 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(test)]
+#[path = "../unit_tests/validator_v2_tests.rs"]
+mod validator_v2_tests;
+
 use std::sync::Arc;
 
 use futures::{StreamExt, future::Either, stream};

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -230,8 +230,8 @@ impl ValidatorService {
                 let state_for_attest = state.clone();
                 let epoch_store_for_attest = epoch_store.clone();
                 let (result, verified_tx) = tokio::task::spawn_blocking(move || {
-                    let result = state_for_attest
-                        .attest_transaction(&verified_tx, &epoch_store_for_attest);
+                    let result =
+                        state_for_attest.attest_transaction(&verified_tx, &epoch_store_for_attest);
                     (result, verified_tx)
                 })
                 .await

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -229,13 +229,27 @@ impl ValidatorService {
             if epoch_store.protocol_config().enable_validator_attestation() {
                 let state_for_attest = state.clone();
                 let epoch_store_for_attest = epoch_store.clone();
-                let (result, verified_tx) = tokio::task::spawn_blocking(move || {
+                let join_result = tokio::task::spawn_blocking(move || {
                     let result =
                         state_for_attest.attest_transaction(&verified_tx, &epoch_store_for_attest);
                     (result, verified_tx)
                 })
-                .await
-                .expect("attest_transaction should return Err for invalid transactions instead of panicking");
+                .await;
+                let (result, verified_tx) = match join_result {
+                    Ok(pair) => pair,
+                    Err(join_err) => {
+                        // A panic inside `attest_transaction` (e.g., an
+                        // arithmetic panic in Move VM dry-run) surfaces here
+                        // as a `JoinError`. Convert to a rejection rather
+                        // than re-panicking on the per-tx task.
+                        tracing::error!(?tx_digest, "attest_transaction task failed: {join_err}");
+                        let err = IotaError::GenericAuthority {
+                            error: format!("attest_transaction task failed: {join_err}"),
+                        };
+                        let weight = normalize(&err);
+                        return (TxStatusUpdate::Rejected { error: err }, weight);
+                    }
+                };
                 match result {
                     Ok((data, objs)) => (Some(data), objs, verified_tx),
                     Err(e) => {

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -271,9 +271,67 @@ impl ValidatorService {
             .soft_lock_table_size
             .set(soft_locks.lock_count() as i64);
 
+        // Build the consensus transaction. When validator attestation is enabled,
+        // attest the transaction (dry-run + Move auth) and submit as V2; otherwise
+        // fall back to the legacy V1 path.
+        let consensus_tx = if epoch_store
+            .protocol_config()
+            .enable_validator_attestation()
+        {
+            use iota_types::{
+                attestation::{Attestation, AttestedTransaction},
+                iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
+            };
+
+            let release_locks_and_reject = |e: IotaError| {
+                soft_locks.release(&tx_digest);
+                metrics
+                    .soft_lock_table_size
+                    .set(soft_locks.lock_count() as i64);
+                let weight = normalize(&e);
+                (TxStatusUpdate::Rejected { error: e }, weight)
+            };
+
+            let attestation_data =
+                match state.attest_transaction(&verified_tx, &owned_objects, epoch_store) {
+                    Ok(data) => data,
+                    Err(e) => return release_locks_and_reject(e),
+                };
+
+            let committee = epoch_store.committee();
+            let attestor_index = committee
+                .names()
+                .position(|n| n == &state.name)
+                .and_then(|i| {
+                    epoch_store
+                        .epoch_start_state()
+                        .get_consensus_committee()
+                        .to_authority_index(i)
+                });
+
+            match attestor_index {
+                Some(attestor_index) => ConsensusTransaction::new_attested_transaction(
+                    AttestedTransaction::new(
+                        verified_tx.into_inner(),
+                        Attestation::Validator {
+                            payload: attestation_data,
+                            attestor_index,
+                        },
+                    ),
+                ),
+                None => {
+                    return release_locks_and_reject(IotaError::from(
+                        "validator not found in consensus committee",
+                    ));
+                }
+            }
+        } else {
+            ConsensusTransaction::new_user_transaction(verified_tx.into_inner())
+        };
+
         // Submit to consensus.
         if let Err(e) = consensus_adapter.submit(
-            ConsensusTransaction::new_user_transaction(verified_tx.into_inner()),
+            consensus_tx,
             Some(&reconfiguration_lock),
             epoch_store,
         ) {

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -306,7 +306,7 @@ impl ValidatorService {
                 .map(|i| starfish_config::AuthorityIndex::from(i as u8))
                 .expect("validator must be present in its own consensus committee");
 
-            ConsensusTransaction::new_attested_transaction(AttestedTransaction::new(
+            ConsensusTransaction::new_user_transaction_v2(AttestedTransaction::new(
                 verified_tx.into_inner(),
                 Attestation::Validator {
                     payload: attestation_data,
@@ -314,7 +314,7 @@ impl ValidatorService {
                 },
             ))
         } else {
-            ConsensusTransaction::new_user_transaction(verified_tx.into_inner())
+            ConsensusTransaction::new_user_transaction_v1(verified_tx.into_inner())
         };
 
         // Submit to consensus.

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -220,17 +220,33 @@ impl ValidatorService {
             return (TxStatusUpdate::Rejected { error }, weight);
         }
 
-        // Content validation: deny checks + owned object version validation.
-        let owned_objects = match state
-            .handle_transaction_validation_checks(&verified_tx, epoch_store)
-            .await
-        {
-            Ok(objs) => objs,
-            Err(e) => {
-                let weight = normalize(&e);
-                return (TxStatusUpdate::Rejected { error: e }, weight);
-            }
-        };
+        // Produce owned objects and — when validator attestation is enabled —
+        // the attestation payload. The attestation path runs deny checks,
+        // object loading, input validation, coin deny list, and a full dry-run
+        // in a single call, so it replaces `handle_transaction_validation_checks`
+        // entirely. The legacy path calls the validation-only function.
+        let (attestation_data, owned_objects) =
+            if epoch_store.protocol_config().enable_validator_attestation() {
+                match state.attest_transaction(&verified_tx, epoch_store) {
+                    Ok((data, objs)) => (Some(data), objs),
+                    Err(e) => {
+                        let weight = normalize(&e);
+                        return (TxStatusUpdate::Rejected { error: e }, weight);
+                    }
+                }
+            } else {
+                match state
+                    .handle_transaction_validation_checks(&verified_tx, epoch_store)
+                    .await
+                {
+                    Ok(objs) => (None, objs),
+                    Err(e) => {
+                        let weight = normalize(&e);
+                        return (TxStatusUpdate::Rejected { error: e }, weight);
+                    }
+                }
+            };
+
         if let Err(e) = state
             .get_cache_writer()
             .validate_owned_object_versions(&owned_objects)
@@ -271,32 +287,12 @@ impl ValidatorService {
             .soft_lock_table_size
             .set(soft_locks.lock_count() as i64);
 
-        // Build the consensus transaction. When validator attestation is enabled,
-        // attest the transaction (dry-run + Move auth) and submit as V2; otherwise
-        // fall back to the legacy V1 path.
-        let consensus_tx = if epoch_store
-            .protocol_config()
-            .enable_validator_attestation()
-        {
+        // Build the consensus transaction.
+        let consensus_tx = if let Some(attestation_data) = attestation_data {
             use iota_types::{
                 attestation::{Attestation, AttestedTransaction},
                 iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
             };
-
-            let release_locks_and_reject = |e: IotaError| {
-                soft_locks.release(&tx_digest);
-                metrics
-                    .soft_lock_table_size
-                    .set(soft_locks.lock_count() as i64);
-                let weight = normalize(&e);
-                (TxStatusUpdate::Rejected { error: e }, weight)
-            };
-
-            let attestation_data =
-                match state.attest_transaction(&verified_tx, &owned_objects, epoch_store) {
-                    Ok(data) => data,
-                    Err(e) => return release_locks_and_reject(e),
-                };
 
             let committee = epoch_store.committee();
             let attestor_index = committee
@@ -320,9 +316,13 @@ impl ValidatorService {
                     ),
                 ),
                 None => {
-                    return release_locks_and_reject(IotaError::from(
-                        "validator not found in consensus committee",
-                    ));
+                    soft_locks.release(&tx_digest);
+                    metrics
+                        .soft_lock_table_size
+                        .set(soft_locks.lock_count() as i64);
+                    let error = IotaError::from("validator not found in consensus committee");
+                    let weight = normalize(&error);
+                    return (TxStatusUpdate::Rejected { error }, weight);
                 }
             }
         } else {

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -578,21 +578,14 @@ impl ConsensusAdapter {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<JoinHandle<()>> {
         if transactions.len() > 1 {
-            // Soft-bundle batches must be homogeneous: either all
-            // CertifiedTransaction (certificate flow), all UserTransactionV1,
-            // or all UserTransactionV2 (white-flag flow). submit_and_wait_inner
-            // assumes a single transaction kind across the batch.
-            let all_certificates = transactions
-                .iter()
-                .all(|tx| matches!(tx.kind, ConsensusTransactionKind::CertifiedTransaction(_)));
-            let all_v1 = transactions
-                .iter()
-                .all(|tx| matches!(tx.kind, ConsensusTransactionKind::UserTransactionV1(_)));
-            let all_v2 = transactions
-                .iter()
-                .all(|tx| matches!(tx.kind, ConsensusTransactionKind::UserTransactionV2(_)));
+            // Soft-bundle batches must be homogeneous — every transaction must be
+            // of the same kind, because submit_and_wait_inner assumes a single
+            // transaction kind across the batch.
+            let first_kind = std::mem::discriminant(&transactions[0].kind);
             fp_ensure!(
-                all_certificates || all_v1 || all_v2,
+                transactions
+                    .iter()
+                    .all(|tx| std::mem::discriminant(&tx.kind) == first_kind),
                 IotaError::InvalidTxKindInSoftBundle
             );
         }
@@ -679,8 +672,9 @@ impl ConsensusAdapter {
         }
 
         // submit_batch enforces that multi-tx batches (soft bundles) are
-        // homogeneous: either all CertifiedTransaction or all UserTransactionV1.
-        // Single-tx submits can be any kind.
+        // homogeneous: all transactions share the same `ConsensusTransactionKind`
+        // (in practice all CertifiedTransaction, all UserTransactionV1, or all
+        // UserTransactionV2). Single-tx submits can be any kind.
         let is_soft_bundle = transactions.len() > 1;
 
         let mut transaction_keys = Vec::new();

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -578,14 +578,20 @@ impl ConsensusAdapter {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<JoinHandle<()>> {
         if transactions.len() > 1 {
-            // Soft-bundle batches must be homogeneous — every transaction must be
-            // of the same kind, because submit_and_wait_inner assumes a single
-            // transaction kind across the batch.
-            let first_kind = std::mem::discriminant(&transactions[0].kind);
+            // Soft-bundle batches must be homogeneous and limited to the kinds we
+            // actually bundle: user or certified transactions. submit_and_wait_inner
+            // assumes a single, known transaction kind across the batch, so
+            // reject any other kind defensively rather than letting it pass
+            // silently into consensus. Checking the first element's kind is
+            // sufficient because the homogeneity check guarantees the rest share it.
+            let first = &transactions[0].kind;
+            let first_kind = std::mem::discriminant(first);
             fp_ensure!(
-                transactions
-                    .iter()
-                    .all(|tx| std::mem::discriminant(&tx.kind) == first_kind),
+                (first.is_user_transaction()
+                    || matches!(first, ConsensusTransactionKind::CertifiedTransaction(_)))
+                    && transactions
+                        .iter()
+                        .all(|tx| std::mem::discriminant(&tx.kind) == first_kind),
                 IotaError::InvalidTxKindInSoftBundle
             );
         }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -580,18 +580,17 @@ impl ConsensusAdapter {
         if transactions.len() > 1 {
             // Soft-bundle batches must be homogeneous: either all
             // CertifiedTransaction (certificate flow), all UserTransactionV1,
-            // or all UserTransactionV2 (white-flag flow). Mixing V1 and V2 is
-            // not allowed. submit_and_wait_inner assumes a single transaction
-            // kind across the batch.
-            let all_certificates = transactions.iter().all(|tx| {
-                matches!(tx.kind, ConsensusTransactionKind::CertifiedTransaction(_))
-            });
-            let all_v1 = transactions.iter().all(|tx| {
-                matches!(tx.kind, ConsensusTransactionKind::UserTransactionV1(_))
-            });
-            let all_v2 = transactions.iter().all(|tx| {
-                matches!(tx.kind, ConsensusTransactionKind::UserTransactionV2(_))
-            });
+            // or all UserTransactionV2 (white-flag flow). submit_and_wait_inner
+            // assumes a single transaction kind across the batch.
+            let all_certificates = transactions
+                .iter()
+                .all(|tx| matches!(tx.kind, ConsensusTransactionKind::CertifiedTransaction(_)));
+            let all_v1 = transactions
+                .iter()
+                .all(|tx| matches!(tx.kind, ConsensusTransactionKind::UserTransactionV1(_)));
+            let all_v2 = transactions
+                .iter()
+                .all(|tx| matches!(tx.kind, ConsensusTransactionKind::UserTransactionV2(_)));
             fp_ensure!(
                 all_certificates || all_v1 || all_v2,
                 IotaError::InvalidTxKindInSoftBundle

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -579,20 +579,23 @@ impl ConsensusAdapter {
     ) -> IotaResult<JoinHandle<()>> {
         if transactions.len() > 1 {
             // Soft-bundle batches must be homogeneous: either all
-            // CertifiedTransaction (certificate flow) or all
-            // UserTransactionV1 (white-flag flow). submit_and_wait_inner
-            // assumes a single transaction kind across the batch.
-            for transaction in transactions {
-                fp_ensure!(
-                    matches!(
-                        transaction.kind,
-                        ConsensusTransactionKind::CertifiedTransaction(_)
-                            | ConsensusTransactionKind::UserTransactionV1(_)
-                            | ConsensusTransactionKind::UserTransactionV2(_)
-                    ),
-                    IotaError::InvalidTxKindInSoftBundle
-                );
-            }
+            // CertifiedTransaction (certificate flow), all UserTransactionV1,
+            // or all UserTransactionV2 (white-flag flow). Mixing V1 and V2 is
+            // not allowed. submit_and_wait_inner assumes a single transaction
+            // kind across the batch.
+            let all_certificates = transactions.iter().all(|tx| {
+                matches!(tx.kind, ConsensusTransactionKind::CertifiedTransaction(_))
+            });
+            let all_v1 = transactions.iter().all(|tx| {
+                matches!(tx.kind, ConsensusTransactionKind::UserTransactionV1(_))
+            });
+            let all_v2 = transactions.iter().all(|tx| {
+                matches!(tx.kind, ConsensusTransactionKind::UserTransactionV2(_))
+            });
+            fp_ensure!(
+                all_certificates || all_v1 || all_v2,
+                IotaError::InvalidTxKindInSoftBundle
+            );
         }
 
         epoch_store.insert_pending_consensus_transactions(transactions, lock)?;

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -385,7 +385,8 @@ impl ConsensusAdapter {
                 ConsensusTransactionKind::CertifiedTransaction(certificate) => {
                     Some(certificate.digest())
                 }
-                ConsensusTransactionKind::UserTransactionV1(_) => {
+                ConsensusTransactionKind::UserTransactionV1(_)
+                | ConsensusTransactionKind::UserTransactionV2(_) => {
                     // White flag: no submit delay needed (number of submitting validators
                     // controlled through another mechanism)
                     None
@@ -587,6 +588,7 @@ impl ConsensusAdapter {
                         transaction.kind,
                         ConsensusTransactionKind::CertifiedTransaction(_)
                             | ConsensusTransactionKind::UserTransactionV1(_)
+                            | ConsensusTransactionKind::UserTransactionV2(_)
                     ),
                     IotaError::InvalidTxKindInSoftBundle
                 );
@@ -848,11 +850,12 @@ impl ConsensusAdapter {
 
         let is_user_tx = is_soft_bundle
             || if epoch_store.protocol_config().enable_white_flag_flow() {
-                // In the certificate-less mode, `UserTransactionV1` kind corresponds
-                // to user transactions.
+                // In the certificate-less mode, `UserTransactionV1`/`UserTransactionV2`
+                // kinds correspond to user transactions.
                 matches!(
                     transactions[0].kind,
                     ConsensusTransactionKind::UserTransactionV1(_)
+                        | ConsensusTransactionKind::UserTransactionV2(_)
                 )
             } else {
                 // In the certificate mode, `CertifiedTransaction` kind corresponds

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -305,6 +305,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         &transaction.kind,
                         ConsensusTransactionKind::CertifiedTransaction(_)
                             | ConsensusTransactionKind::UserTransactionV1(_)
+                            | ConsensusTransactionKind::UserTransactionV2(_)
                     ) {
                         self.last_consensus_stats
                             .stats
@@ -508,6 +509,13 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
                 "owned_user_transaction"
             }
         }
+        ConsensusTransactionKind::UserTransactionV2(a) => {
+            if a.transaction.contains_shared_object() {
+                "shared_user_transaction"
+            } else {
+                "owned_user_transaction"
+            }
+        }
         ConsensusTransactionKind::CheckpointSignature(_) => "checkpoint_signature",
         ConsensusTransactionKind::EndOfPublish(_) => "end_of_publish",
         ConsensusTransactionKind::CapabilityNotificationV1(_) => "capability_notification_v1",
@@ -627,6 +635,7 @@ impl SequencedConsensusTransactionKind {
             SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
                 ConsensusTransactionKind::CertifiedTransaction(txn) => Some(*txn.digest()),
                 ConsensusTransactionKind::UserTransactionV1(txn) => Some(*txn.digest()),
+                ConsensusTransactionKind::UserTransactionV2(a) => Some(*a.digest()),
                 _ => None,
             },
             SequencedConsensusTransactionKind::System(txn) => Some(*txn.digest()),
@@ -677,6 +686,10 @@ impl SequencedConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV1(transaction),
                 ..
             }) => transaction.uses_randomness(),
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::UserTransactionV2(a),
+                ..
+            }) => a.transaction.uses_randomness(),
             _ => false,
         }
     }
@@ -691,6 +704,10 @@ impl SequencedConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV1(transaction),
                 ..
             }) if transaction.contains_shared_object() => Some(transaction.data()),
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::UserTransactionV2(a),
+                ..
+            }) if a.transaction.contains_shared_object() => Some(a.data()),
             SequencedConsensusTransactionKind::System(txn) if txn.contains_shared_object() => {
                 Some(txn.data())
             }
@@ -703,6 +720,9 @@ impl SequencedConsensusTransaction {
             &self.transaction,
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV1(_),
+                ..
+            }) | SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::UserTransactionV2(_),
                 ..
             })
         )

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -707,7 +707,7 @@ impl SequencedConsensusTransaction {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV2(a),
                 ..
-            }) if a.transaction.contains_shared_object() => Some(a.data()),
+            }) if a.transaction.contains_shared_object() => Some(a.transaction.data()),
             SequencedConsensusTransactionKind::System(txn) if txn.contains_shared_object() => {
                 Some(txn.data())
             }

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -719,10 +719,8 @@ impl SequencedConsensusTransaction {
         matches!(
             &self.transaction,
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV1(_),
-                ..
-            }) | SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV2(_),
+                kind: ConsensusTransactionKind::UserTransactionV1(_)
+                    | ConsensusTransactionKind::UserTransactionV2(_),
                 ..
             })
         )

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -504,16 +504,16 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         }
         ConsensusTransactionKind::UserTransactionV1(transaction) => {
             if transaction.contains_shared_object() {
-                "shared_user_transaction"
+                "shared_user_transaction_v1"
             } else {
-                "owned_user_transaction"
+                "owned_user_transaction_v1"
             }
         }
         ConsensusTransactionKind::UserTransactionV2(a) => {
             if a.transaction.contains_shared_object() {
-                "shared_user_transaction"
+                "shared_user_transaction_v2"
             } else {
-                "owned_user_transaction"
+                "owned_user_transaction_v2"
             }
         }
         ConsensusTransactionKind::CheckpointSignature(_) => "checkpoint_signature",

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -42,7 +42,7 @@ use crate::{
     consensus_types::{AuthorityIndex, consensus_output_api::ConsensusOutputAPI},
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
     scoring_decision::update_low_scoring_authorities,
-    transaction_manager::TransactionManager,
+    transaction_manager::{TransactionManager, VerifiedExecutableAttestedTransaction},
 };
 
 pub struct ConsensusHandlerInitializer {
@@ -413,7 +413,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 }
 
 struct AsyncTransactionScheduler {
-    sender: tokio::sync::mpsc::Sender<Vec<VerifiedExecutableTransaction>>,
+    sender: tokio::sync::mpsc::Sender<Vec<VerifiedExecutableAttestedTransaction>>,
 }
 
 impl AsyncTransactionScheduler {
@@ -426,19 +426,19 @@ impl AsyncTransactionScheduler {
         Self { sender }
     }
 
-    pub async fn schedule(&self, transactions: Vec<VerifiedExecutableTransaction>) {
+    pub async fn schedule(&self, transactions: Vec<VerifiedExecutableAttestedTransaction>) {
         tracing::trace_span!("transaction_scheduler_enqueue");
         self.sender.send(transactions).await.ok();
     }
 
     pub async fn run(
-        mut recv: tokio::sync::mpsc::Receiver<Vec<VerifiedExecutableTransaction>>,
+        mut recv: tokio::sync::mpsc::Receiver<Vec<VerifiedExecutableAttestedTransaction>>,
         transaction_manager: Arc<TransactionManager>,
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) {
         while let Some(transactions) = recv.recv().await {
             let _guard = monitored_scope("ConsensusHandler::enqueue");
-            transaction_manager.enqueue(transactions, &epoch_store);
+            transaction_manager.enqueue_attested(transactions, &epoch_store);
         }
     }
 }

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -8,6 +8,7 @@ use eyre::WrapErr;
 use fastcrypto_tbls::dkg_v1;
 use iota_metrics::monitored_scope;
 use iota_types::{
+    attestation::Attestation,
     error::IotaError,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
 };
@@ -120,12 +121,7 @@ impl IotaTxValidator {
                     user_tx_v1_count += 1;
                 }
 
-                ConsensusTransactionKind::UserTransactionV2(_a) => {
-                    // User signature verification is skipped: the attesting
-                    // validator already verified it in `submit_single_tx` before
-                    // producing the attestation.
-                    //
-                    // Attestor verification is performed in `post_consensus_validation`.
+                ConsensusTransactionKind::UserTransactionV2(attested_tx) => {
                     if !self
                         .epoch_store
                         .protocol_config()
@@ -135,6 +131,26 @@ impl IotaTxValidator {
                             error: "UserTransactionV2 not supported at current protocol version"
                                 .into(),
                         });
+                    }
+
+                    match &attested_tx.attestation {
+                        Attestation::Validator { .. } => {
+                            // No explicit signature to verify: the attestor's
+                            // identity is bound to the consensus block and
+                            // checked in post_consensus_validation.
+                        }
+                        Attestation::Explicit { .. } => {
+                            // TODO: verify explicit attestor signature against the trusted
+                            // attestor registry (Phase 2).
+                            return Err(IotaError::UnsupportedFeature {
+                                error: "Explicit attestation not yet supported".into(),
+                            });
+                        }
+                        _ => {
+                            return Err(IotaError::UnsupportedFeature {
+                                error: "Unknown attestation variant".into(),
+                            });
+                        }
                     }
                 }
 

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -120,6 +120,20 @@ impl IotaTxValidator {
                     user_tx_v1_count += 1;
                 }
 
+                ConsensusTransactionKind::UserTransactionV2(_a) => {
+                    if !self.epoch_store.protocol_config().enable_white_flag_flow() {
+                        return Err(IotaError::UnsupportedFeature {
+                            error: "UserTransactionV2 not supported at current protocol version"
+                                .into(),
+                        });
+                    }
+                    // For UserTransactionV2 (attested transactions), skip user signature
+                    // verification — we trust the attestor that the transaction has already
+                    // been validated before entering consensus. Only the attestor
+                    // signature needs to be checked.
+                    // TODO: verify the attestor signature on `_a.attestation`.
+                }
+
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::CapabilityNotificationV1(_) => {}
             }
@@ -404,7 +418,8 @@ mod tests {
                 | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _) => None,
 
                 // Gated behind `enable_white_flag_flow`.
-                ConsensusTransactionKind::UserTransactionV1(_) => {
+                ConsensusTransactionKind::UserTransactionV1(_)
+                | ConsensusTransactionKind::UserTransactionV2(_) => {
                     Some(config.enable_white_flag_flow())
                 }
 

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -121,19 +121,17 @@ impl IotaTxValidator {
                 }
 
                 ConsensusTransactionKind::UserTransactionV2(_a) => {
+                    // User signature verification is skipped: the attesting
+                    // validator already verified it in `submit_single_tx` before
+                    // producing the attestation.
+                    //
+                    // Attestor verification is performed in `post_consensus_validation`.
                     if !self.epoch_store.protocol_config().enable_white_flag_flow() {
                         return Err(IotaError::UnsupportedFeature {
                             error: "UserTransactionV2 not supported at current protocol version"
                                 .into(),
                         });
                     }
-                    // For UserTransactionV2 (attested transactions), skip user
-                    // signature verification — we trust the
-                    // attestor that the transaction has already
-                    // been validated before entering consensus. Only the
-                    // attestor signature needs to be
-                    // checked. TODO: verify the attestor
-                    // signature on `_a.attestation`.
                 }
 
                 ConsensusTransactionKind::EndOfPublish(_)

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -127,11 +127,13 @@ impl IotaTxValidator {
                                 .into(),
                         });
                     }
-                    // For UserTransactionV2 (attested transactions), skip user signature
-                    // verification — we trust the attestor that the transaction has already
-                    // been validated before entering consensus. Only the attestor
-                    // signature needs to be checked.
-                    // TODO: verify the attestor signature on `_a.attestation`.
+                    // For UserTransactionV2 (attested transactions), skip user
+                    // signature verification — we trust the
+                    // attestor that the transaction has already
+                    // been validated before entering consensus. Only the
+                    // attestor signature needs to be
+                    // checked. TODO: verify the attestor
+                    // signature on `_a.attestation`.
                 }
 
                 ConsensusTransactionKind::EndOfPublish(_)

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -287,6 +287,7 @@ mod tests {
     use iota_macros::sim_test;
     use iota_protocol_config::Chain;
     use iota_types::{
+        attestation::{Attestation, AttestationData, AttestedTransaction},
         crypto::Ed25519IotaSignature,
         error::IotaError,
         messages_consensus::{
@@ -296,6 +297,7 @@ mod tests {
         object::Object,
         signature::GenericSignature,
     };
+    use starfish_config::AuthorityIndex;
     use starfish_core::TransactionVerifier as _;
 
     use crate::{
@@ -526,6 +528,19 @@ mod tests {
                     }),
                     0,
                 ),
+            ),
+            (
+                "UserTransactionV2",
+                ConsensusTransactionKind::UserTransactionV2(Box::new(AttestedTransaction::new(
+                    signed_tx.clone(),
+                    Attestation::Validator {
+                        payload: AttestationData::V1 {
+                            estimated_computation_cost: 0,
+                            object_versions: vec![],
+                        },
+                        attestor_index: AuthorityIndex::new_for_test(0),
+                    },
+                ))),
             ),
             (
                 "UserTransactionV1",

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -63,8 +63,9 @@ impl IotaTxValidator {
                 ConsensusTransactionKind::CertifiedTransaction(certificate) => {
                     if self.epoch_store.protocol_config().enable_white_flag_flow() {
                         return Err(IotaError::UnsupportedFeature {
-                            error: "CertifiedTransaction not allowed when white-flag flow is enabled"
-                                .into(),
+                            error:
+                                "CertifiedTransaction not allowed when white-flag flow is enabled"
+                                    .into(),
                         });
                     }
                     cert_batch.push(certificate.as_ref());
@@ -457,9 +458,9 @@ mod tests {
                 // Gated behind `enable_white_flag_flow`, and additionally
                 // rejected once `enable_validator_attestation` is on (V2 takes
                 // over).
-                ConsensusTransactionKind::UserTransactionV1(_) => Some(
-                    config.enable_white_flag_flow() && !config.enable_validator_attestation(),
-                ),
+                ConsensusTransactionKind::UserTransactionV1(_) => {
+                    Some(config.enable_white_flag_flow() && !config.enable_validator_attestation())
+                }
 
                 // Gated behind `enable_validator_attestation`.
                 ConsensusTransactionKind::UserTransactionV2(_) => {

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -56,7 +56,7 @@ impl IotaTxValidator {
         let mut ckpt_messages = Vec::new();
         let mut ckpt_batch = Vec::new();
         let mut authority_cap_batch = Vec::new();
-        let mut user_tx_v1_count: u64 = 0;
+        let mut user_tx_count: u64 = 0;
 
         for tx in txs.iter() {
             match tx {
@@ -136,7 +136,7 @@ impl IotaTxValidator {
                         .tap_err(|e| {
                             warn!("UserTransactionV1 signature verification failed: {}", e)
                         })?;
-                    user_tx_v1_count += 1;
+                    user_tx_count += 1;
                 }
 
                 ConsensusTransactionKind::UserTransactionV2(attested_tx) => {
@@ -153,9 +153,13 @@ impl IotaTxValidator {
 
                     match &attested_tx.attestation {
                         Attestation::Validator { .. } => {
-                            // No explicit signature to verify: the attestor's
-                            // identity is bound to the consensus block and
-                            // checked in post_consensus_validation.
+                            self.epoch_store
+                                .signature_verifier
+                                .verify_tx(attested_tx.transaction.data())
+                                .tap_err(|e| {
+                                    warn!("UserTransactionV2 signature verification failed: {}", e)
+                                })?;
+                            user_tx_count += 1;
                         }
                         Attestation::Explicit { .. } => {
                             // TODO: verify explicit attestor signature against the trusted
@@ -200,7 +204,7 @@ impl IotaTxValidator {
             .inc_by(authority_cap_count as u64);
         self.metrics
             .user_transaction_signatures_verified
-            .inc_by(user_tx_v1_count);
+            .inc_by(user_tx_count);
         Ok(())
 
         // todo - we should un-comment line below once we have a way to revert
@@ -272,7 +276,7 @@ impl IotaTxValidatorMetrics {
             .unwrap(),
             user_transaction_signatures_verified: register_int_counter_with_registry!(
                 "user_transaction_signatures_verified",
-                "Number of UserTransactionV1 signatures verified in consensus validator",
+                "Number of user transaction (V1 and V2) signatures verified in consensus validator",
                 registry
             )
             .unwrap(),
@@ -535,7 +539,7 @@ mod tests {
                     signed_tx.clone(),
                     Attestation::Validator {
                         payload: AttestationData::V1 {
-                            estimated_computation_cost: 0,
+                            computation_units: 0,
                             object_versions: vec![],
                         },
                         attestor_index: AuthorityIndex::new_for_test(0),

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -126,7 +126,11 @@ impl IotaTxValidator {
                     // producing the attestation.
                     //
                     // Attestor verification is performed in `post_consensus_validation`.
-                    if !self.epoch_store.protocol_config().enable_white_flag_flow() {
+                    if !self
+                        .epoch_store
+                        .protocol_config()
+                        .enable_validator_attestation()
+                    {
                         return Err(IotaError::UnsupportedFeature {
                             error: "UserTransactionV2 not supported at current protocol version"
                                 .into(),

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -163,11 +163,6 @@ impl IotaTxValidator {
                                 error: "Explicit attestation not yet supported".into(),
                             });
                         }
-                        _ => {
-                            return Err(IotaError::UnsupportedFeature {
-                                error: "Unknown attestation variant".into(),
-                            });
-                        }
                     }
                 }
 

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -61,6 +61,12 @@ impl IotaTxValidator {
         for tx in txs.iter() {
             match tx {
                 ConsensusTransactionKind::CertifiedTransaction(certificate) => {
+                    if self.epoch_store.protocol_config().enable_white_flag_flow() {
+                        return Err(IotaError::UnsupportedFeature {
+                            error: "CertifiedTransaction not allowed when white-flag flow is enabled"
+                                .into(),
+                        });
+                    }
                     cert_batch.push(certificate.as_ref());
                 }
                 ConsensusTransactionKind::CheckpointSignature(signature) => {
@@ -107,6 +113,17 @@ impl IotaTxValidator {
                         return Err(IotaError::UnsupportedFeature {
                             error: "UserTransactionV1 not supported at current protocol version"
                                 .into(),
+                        });
+                    }
+                    if self
+                        .epoch_store
+                        .protocol_config()
+                        .enable_validator_attestation()
+                    {
+                        return Err(IotaError::UnsupportedFeature {
+                            error:
+                                "UserTransactionV1 not allowed when validator attestation is enabled"
+                                    .into(),
                         });
                     }
                     // TODO: Batch signature verification for UserTransactionV1.
@@ -429,18 +446,29 @@ mod tests {
         ) -> Option<bool> {
             match kind {
                 // Always allowed (no feature flag gating).
-                ConsensusTransactionKind::CertifiedTransaction(_)
-                | ConsensusTransactionKind::CheckpointSignature(_)
+                ConsensusTransactionKind::CheckpointSignature(_)
                 | ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::CapabilityNotificationV1(_)
                 | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
                 | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                 | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _) => None,
 
-                // Gated behind `enable_white_flag_flow`.
-                ConsensusTransactionKind::UserTransactionV1(_)
-                | ConsensusTransactionKind::UserTransactionV2(_) => {
-                    Some(config.enable_white_flag_flow())
+                // Rejected once the white-flag flow is enabled (certificate-less
+                // path replaces them).
+                ConsensusTransactionKind::CertifiedTransaction(_) => {
+                    Some(!config.enable_white_flag_flow())
+                }
+
+                // Gated behind `enable_white_flag_flow`, and additionally
+                // rejected once `enable_validator_attestation` is on (V2 takes
+                // over).
+                ConsensusTransactionKind::UserTransactionV1(_) => Some(
+                    config.enable_white_flag_flow() && !config.enable_validator_attestation(),
+                ),
+
+                // Gated behind `enable_validator_attestation`.
+                ConsensusTransactionKind::UserTransactionV2(_) => {
+                    Some(config.enable_validator_attestation())
                 }
 
                 // Gated behind `calculate_validator_scores`.

--- a/crates/iota-core/src/post_consensus_tx_reorder.rs
+++ b/crates/iota-core/src/post_consensus_tx_reorder.rs
@@ -42,6 +42,10 @@ impl PostConsensusTxReorder {
                         kind: ConsensusTransactionKind::UserTransactionV1(tx),
                         ..
                     }) => tx.gas_price(),
+                    SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                        kind: ConsensusTransactionKind::UserTransactionV2(a),
+                        ..
+                    }) => a.transaction.gas_price(),
                     // Non-user transactions are considered to have gas price of MAX u64 and are
                     // put to the beginning.
                     _ => u64::MAX,

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -328,7 +328,9 @@ fn extract_owned_input_objects(
         }) => a.transaction.data(),
         _ => {
             return Err(IotaError::GenericAuthority {
-                error: "Expected UserTransactionV1 or UserTransactionV2 in extract_owned_input_objects".to_string(),
+                error:
+                    "Expected UserTransactionV1 or UserTransactionV2 in extract_owned_input_objects"
+                        .to_string(),
             });
         }
     };

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -114,13 +114,17 @@ pub async fn validate_and_resolve_conflicts(
             continue;
         }
 
-        // Only validate UserTransactionV1; pass everything else through
+        // Only validate UserTransactionV1/V2; pass everything else through
         // unchanged.
-        let transaction = match &tx.0.transaction {
+        let (transaction, is_attested) = match &tx.0.transaction {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV1(t),
                 ..
-            }) => t,
+            }) => (t, false),
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::UserTransactionV2(a),
+                ..
+            }) => (&a.transaction, true),
             _ => continue,
         };
 
@@ -246,22 +250,31 @@ pub async fn validate_and_resolve_conflicts(
         // (2f+1 Byzantine/buggy validators), not something we can recover from
         // by rejecting the transaction post-consensus. Doing so would also risk
         // diverging from other honest validators.
-        let verified_tx = VerifiedTransaction::new_from_verified((**transaction).clone());
-        if let Err(e) = authority_state
-            .handle_transaction_validation_checks(&verified_tx, epoch_store)
-            .await
-        {
-            if e.is_storage_or_epoch_error() {
-                return Err(e);
+        //
+        // For `UserTransactionV2` (attested transactions), this check is skipped
+        // entirely. The attestor has already performed validation (including deny
+        // checks, gas, and ownership verification) before producing the
+        // attestation. Re-running these checks post-consensus would be redundant
+        // and could cause divergence if state changes between attestation time
+        // and execution time.
+        if !is_attested {
+            let verified_tx = VerifiedTransaction::new_from_verified((**transaction).clone());
+            if let Err(e) = authority_state
+                .handle_transaction_validation_checks(&verified_tx, epoch_store)
+                .await
+            {
+                if e.is_storage_or_epoch_error() {
+                    return Err(e);
+                }
+                warn!(
+                    ?digest,
+                    error = ?e,
+                    "UserTransactionV1 failed post-consensus deny checks, dropping"
+                );
+                dropped.push((digest, e));
+                keep[i] = false;
+                continue;
             }
-            warn!(
-                ?digest,
-                error = ?e,
-                "UserTransactionV1 failed post-consensus deny checks, dropping"
-            );
-            dropped.push((digest, e));
-            keep[i] = false;
-            continue;
         }
 
         // All checks passed — acquire owned-object locks in local tracking.
@@ -296,8 +309,8 @@ pub async fn validate_and_resolve_conflicts(
     Ok((dropped, current_commit_locks, all_user_tx_digests))
 }
 
-/// Extracts owned input object references from a `UserTransactionV1`
-/// consensus transaction.
+/// Extracts owned input object references from a `UserTransactionV1` or
+/// `UserTransactionV2` consensus transaction.
 ///
 /// Returns only `ImmOrOwnedMoveObject` inputs (excludes shared objects and
 /// packages) — these are the objects that need lock conflict detection.
@@ -309,9 +322,13 @@ fn extract_owned_input_objects(
             kind: ConsensusTransactionKind::UserTransactionV1(transaction),
             ..
         }) => transaction.data(),
+        SequencedConsensusTransactionKind::External(ConsensusTransaction {
+            kind: ConsensusTransactionKind::UserTransactionV2(a),
+            ..
+        }) => a.data(),
         _ => {
             return Err(IotaError::GenericAuthority {
-                error: "Expected UserTransactionV1 in extract_owned_input_objects".to_string(),
+                error: "Expected UserTransactionV1 or UserTransactionV2 in extract_owned_input_objects".to_string(),
             });
         }
     };

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -325,7 +325,7 @@ fn extract_owned_input_objects(
         SequencedConsensusTransactionKind::External(ConsensusTransaction {
             kind: ConsensusTransactionKind::UserTransactionV2(a),
             ..
-        }) => a.data(),
+        }) => a.transaction.data(),
         _ => {
             return Err(IotaError::GenericAuthority {
                 error: "Expected UserTransactionV1 or UserTransactionV2 in extract_owned_input_objects".to_string(),

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -178,7 +178,7 @@ pub async fn validate_and_resolve_conflicts(
                     }
                 }
                 // Reject Explicit variant as not yet implemented.
-                _ => Some(IotaError::ExplicitAttestationNotSupported),
+                Attestation::Explicit { .. } => Some(IotaError::ExplicitAttestationNotSupported),
             };
             if let Some(e) = error {
                 warn!(

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -23,15 +23,20 @@
 //! - Check #1: Already executed — silent drop.
 //! - Check #2: `validity_check()` — drop with error.
 //! - Check #3: Attestor verification (`UserTransactionV2` only) — verifies that
-//!   the claimed attestor matches the block author. Drop with error on mismatch
-//!   or unsupported attestation variant.
+//!   the claimed attestor matches the block author and that the attested
+//!   computation units fall within the valid range (cost floor and ceiling).
+//!   Drop with error on mismatch, out-of-range cost, or unsupported attestation
+//!   variant.
 //! - Check #4: Extract owned input objects (needed for lock conflict
 //!   detection).
 //! - Check #5: Three-tier lock conflict check (local HashMap → quarantine → DB)
 //!   — drop with error. Cheap; performed before expensive checks.
-//! - Check #6: `handle_transaction_validation_checks()` — drop with error.
-//!   Skipped for attested transactions (`UserTransactionV2`). Only reached when
-//!   all locks are free.
+//! - Check #6: `handle_transaction_validation_checks()` for
+//!   `UserTransactionV1`, or the deny-list and coin deny-list re-checks for
+//!   attested `UserTransactionV2`
+//!   (`check_transaction_deny_list_for_attested_tx()` then
+//!   `check_coin_deny_list_for_attested_tx()`). Drop with error. Only reached
+//!   when all locks are free.
 //! - All passed — acquire locks in the local tracking map, keep transaction.
 
 use std::{
@@ -42,9 +47,9 @@ use std::{
 use iota_types::{
     attestation::Attestation,
     base_types::{ObjectRef, TransactionDigest},
-    error::{IotaError, IotaResult},
+    error::{IotaError, IotaResult, UserInputError},
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
-    transaction::{InputObjectKind, VerifiedTransaction},
+    transaction::{InputObjectKind, TransactionDataAPI, VerifiedTransaction},
 };
 use tracing::{debug, warn};
 
@@ -163,16 +168,37 @@ pub async fn validate_and_resolve_conflicts(
 
         // Check #3: Attestor verification (UserTransactionV2 only).
         // The block signature transitively authenticates the attestation;
-        // verify the claimed attestor matches the actual block author.
+        // verify the claimed attestor matches the actual block author and that
+        // the payload is not malformed.
         if let Some(attestation) = attestation {
             let block_author =
                 starfish_config::AuthorityIndex::from(tx.0.certificate_author_index as u8);
+            let protocol_config = epoch_store.protocol_config();
+            let min_attested_units = protocol_config
+                .base_tx_cost_fixed()
+                .min(protocol_config.gas_rounding_step());
+            let attested_units = attestation.computation_units();
+            let tx_data = transaction.data().transaction_data();
+            let max_attested_units = tx_data
+                .gas_budget()
+                .checked_div(tx_data.gas_price())
+                .unwrap_or(u64::MAX);
             let error = match attestation {
                 Attestation::Validator { attestor_index, .. } => {
                     if *attestor_index != block_author {
                         Some(IotaError::AttestationAuthorMismatch {
                             expected: *attestor_index,
                             actual: block_author,
+                        })
+                    } else if attested_units < min_attested_units {
+                        Some(IotaError::AttestationUnitsBelowMinimum {
+                            actual: attested_units,
+                            minimum: min_attested_units,
+                        })
+                    } else if attested_units > max_attested_units {
+                        Some(IotaError::AttestationUnitsAboveBudget {
+                            actual: attested_units,
+                            maximum: max_attested_units,
                         })
                     } else {
                         None
@@ -283,22 +309,14 @@ pub async fn validate_and_resolve_conflicts(
         // expensive object loading for transactions that would be dropped
         // by the lock conflict check.
         //
-        // Safe to skip signature re-verification: the consensus block verifier
-        // (`IotaTxValidator::validate_transactions`) already called
-        // `verify_tx()` on every `UserTransactionV1` before accepting the
-        // block. Re-verifying here would not add safety — if a quorum
-        // committed a bad signature it indicates a protocol-level failure
-        // (2f+1 Byzantine/buggy validators), not something we can recover from
-        // by rejecting the transaction post-consensus. Doing so would also risk
-        // diverging from other honest validators.
-        //
-        // For `UserTransactionV2` (attested transactions) this check is
-        // skipped. Each part of it is either re-applied during execution or is
-        // not safety-critical to run post-consensus:
-        //   - `TransactionDenyConfig` (sender/object/package deny lists, feature
-        //     kill-switches): loaded from each validator's local `NodeConfig` so it
-        //     shouldn't be re-run post- consensus.
-        //   - Coin deny list v1 will be enforced at execution time.
+        // `UserTransactionV1` runs the full
+        // `handle_transaction_validation_checks` (which includes the
+        // `TransactionDenyConfig` deny-list check). For `UserTransactionV2`
+        // (attested transactions) two checks are re-run individually — the
+        // deny-list check and the coin deny-list check (see below). The rest
+        // of `handle_transaction_validation_checks` is skipped for V2 because
+        // it is either re-applied during execution or is not safety-critical
+        // to run post-consensus:
         //   - Receiving-object validity: the Move runtime fails the `receive()` call
         //     when the ref doesn't match current state.
         //   - Move bytecode verifier on publish: the Move VM re-verifies every newly
@@ -307,6 +325,20 @@ pub async fn validate_and_resolve_conflicts(
         //   - Gas, ownership, `MoveAuthenticator` execution: re-applied in the
         //     execution pipeline (`check_certificate_input` and
         //     `authenticate_then_execute_transaction_to_effects`).
+        //
+        // The user signature is verified pre-consensus in the block verifier
+        // (`IotaTxValidator::validate_transactions`) for both `UserTransactionV1`
+        // and `UserTransactionV2`, and is not re-checked here.
+        //
+        // Deny-list check (`TransactionDenyConfig`: sender/object/package deny
+        // lists, feature kill-switches): this is a LOCAL check, sourced from
+        // each validator's `NodeConfig`. TODO: source the deny config from
+        // consensus-agreed state instead of the local `NodeConfig`.
+        //
+        // Coin deny list v1 MUST be re-checked here for attested
+        // transactions: the attestor's view may be stale if a deny-list
+        // update tx was sequenced between attestation and consensus, and
+        // running this check at execution time would crash the validator.
         if attestation.is_none() {
             let verified_tx = VerifiedTransaction::new_from_verified(transaction.clone());
             if let Err(e) = authority_state
@@ -320,6 +352,51 @@ pub async fn validate_and_resolve_conflicts(
                     ?digest,
                     error = ?e,
                     "UserTransactionV1 failed post-consensus deny checks, dropping"
+                );
+                dropped.push((digest, e));
+                keep[i] = false;
+                continue;
+            }
+        } else {
+            let verified_tx = VerifiedTransaction::new_from_verified(transaction.clone());
+            // Deny-list check (placeholder using the local deny config — see
+            // the `TransactionDenyConfig` note in the Check #6 doc above).
+            if let Err(e) =
+                authority_state.check_transaction_deny_list_for_attested_tx(&verified_tx)
+            {
+                if e.is_storage_or_epoch_error() {
+                    return Err(e);
+                }
+                warn!(
+                    ?digest,
+                    error = ?e,
+                    "UserTransactionV2 failed post-consensus deny-list check, dropping"
+                );
+                dropped.push((digest, e));
+                keep[i] = false;
+                continue;
+            }
+            if let Err(e) = authority_state
+                .check_coin_deny_list_for_attested_tx(&verified_tx, epoch_store.epoch())
+            {
+                if e.is_storage_or_epoch_error() {
+                    return Err(e);
+                }
+                // The helper performs two distinct steps; surface which one
+                // failed so triage doesn't mistake a stale-attestation input
+                // for an actual deny-list violation.
+                let reason = match &e {
+                    IotaError::UserInput {
+                        error:
+                            UserInputError::CoinTypeGlobalPause { .. }
+                            | UserInputError::AddressDeniedForCoin { .. },
+                    } => "coin deny-list re-check",
+                    _ => "input load (likely stale attestation)",
+                };
+                warn!(
+                    ?digest,
+                    error = ?e,
+                    "UserTransactionV2 failed post-consensus {reason}, dropping"
                 );
                 dropped.push((digest, e));
                 keep[i] = false;

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -178,7 +178,9 @@ pub async fn validate_and_resolve_conflicts(
                     }
                 }
                 // Reject Explicit variant as not yet implemented.
-                Attestation::Explicit { .. } => Some(IotaError::ExplicitAttestationNotSupported),
+                Attestation::Explicit { .. } => Some(IotaError::UnsupportedFeature {
+                    error: "Explicit attestation not yet supported".into(),
+                }),
             };
             if let Some(e) = error {
                 warn!(

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -152,8 +152,9 @@ pub async fn validate_and_resolve_conflicts(
         {
             warn!(
                 ?digest,
+                kind = if attestation.is_some() { "UserTransactionV2" } else { "UserTransactionV1" },
                 error = ?e,
-                "UserTransactionV1 failed validity_check post-consensus, dropping"
+                "user transaction failed validity_check post-consensus, dropping"
             );
             dropped.push((digest, e));
             keep[i] = false;

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -16,7 +16,7 @@
 //! and skips expensive validation for transactions that can't acquire object
 //! locks anyway.
 //!
-//! # Per-transaction order within the loop 
+//! # Per-transaction order within the loop
 //!
 //! - Non-user transaction — pass through unchanged.
 //! - Check #0: Dedup by `ConsensusTransactionKey` — silent drop.
@@ -25,7 +25,8 @@
 //! - Check #3: Attestor verification (`UserTransactionV2` only) — verifies that
 //!   the claimed attestor matches the block author. Drop with error on mismatch
 //!   or unsupported attestation variant.
-//! - Check #4: Extract owned input objects (needed for lock conflict detection).
+//! - Check #4: Extract owned input objects (needed for lock conflict
+//!   detection).
 //! - Check #5: Three-tier lock conflict check (local HashMap → quarantine → DB)
 //!   — drop with error. Cheap; performed before expensive checks.
 //! - Check #6: `handle_transaction_validation_checks()` — drop with error.
@@ -62,13 +63,14 @@ use crate::{
 /// conflicts in a single pass.
 ///
 /// For each `UserTransactionV1` or `UserTransactionV2` in consensus order:
-/// - Runs deduplication, already-executed check, structural validity, attestor verification (V2 only), lock
-///   conflict check, and deny checks (deny list, gas, ownership, coin deny
-///   list, Move authenticator).
+/// - Runs deduplication, already-executed check, structural validity, attestor
+///   verification (V2 only), lock conflict check, and deny checks (deny list,
+///   gas, ownership, coin deny list, Move authenticator).
 /// - If all checks pass, acquires owned-object locks in a local tracking map.
 /// - Drops the transaction (with an error) on any failure.
 ///
-/// Non-`UserTransactionV1`/`UserTransactionV2` transactions pass through unchanged.
+/// Non-`UserTransactionV1`/`UserTransactionV2` transactions pass through
+/// unchanged.
 ///
 /// # Arguments
 ///
@@ -85,9 +87,9 @@ use crate::{
 ///   are **not** included.
 /// - `locks` — Owned-object locks acquired in this commit, to be stored in the
 ///   consensus quarantine so subsequent commits can see them.
-/// - `all_user_tx_digests` — Every `UserTransactionV1`/`UserTransactionV2` digest that passed dedup
-///   (both kept and dropped). Used by the caller to release pre-consensus soft
-///   locks.
+/// - `all_user_tx_digests` — Every `UserTransactionV1`/`UserTransactionV2`
+///   digest that passed dedup (both kept and dropped). Used by the caller to
+///   release pre-consensus soft locks.
 pub async fn validate_and_resolve_conflicts(
     authority_state: &AuthorityState,
     epoch_store: &Arc<AuthorityPerEpochStore>,

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -16,21 +16,22 @@
 //! and skips expensive validation for transactions that can't acquire object
 //! locks anyway.
 //!
-//! # Per-transaction order within the loop
+//! # Per-transaction order within the loop 
 //!
-//! 1. Non-user transaction — pass through unchanged.
-//! 2. Dedup by `ConsensusTransactionKey` — silent drop.
-//! 3. Already executed — silent drop.
-//! 4. `validity_check()` — drop with error.
-//! 5. Attestor verification (`UserTransactionV2` only) — verifies that the
-//!    claimed attestor matches the block author. Drop with error on mismatch or
-//!    unsupported attestation variant.
-//! 6. Three-tier lock conflict check (local HashMap → quarantine → DB) — drop
-//!    with error. Cheap; performed before expensive checks.
-//! 7. `handle_transaction_validation_checks()` — drop with error. Skipped for
-//!    attested transactions (`UserTransactionV2`). Only reached when all locks
-//!    are free.
-//! 8. All passed — acquire locks in the local tracking map, keep transaction.
+//! - Non-user transaction — pass through unchanged.
+//! - Check #0: Dedup by `ConsensusTransactionKey` — silent drop.
+//! - Check #1: Already executed — silent drop.
+//! - Check #2: `validity_check()` — drop with error.
+//! - Check #3: Attestor verification (`UserTransactionV2` only) — verifies that
+//!   the claimed attestor matches the block author. Drop with error on mismatch
+//!   or unsupported attestation variant.
+//! - Check #4: Extract owned input objects (needed for lock conflict detection).
+//! - Check #5: Three-tier lock conflict check (local HashMap → quarantine → DB)
+//!   — drop with error. Cheap; performed before expensive checks.
+//! - Check #6: `handle_transaction_validation_checks()` — drop with error.
+//!   Skipped for attested transactions (`UserTransactionV2`). Only reached when
+//!   all locks are free.
+//! - All passed — acquire locks in the local tracking map, keep transaction.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -119,15 +120,15 @@ pub async fn validate_and_resolve_conflicts(
 
         // Only validate UserTransactionV1/V2; pass everything else through
         // unchanged.
-        let (transaction, attestation, is_attested) = match &tx.0.transaction {
+        let (transaction, attestation) = match &tx.0.transaction {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV1(t),
                 ..
-            }) => (t, None, false),
+            }) => (t, None),
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV2(a),
                 ..
-            }) => (&a.transaction, Some(&a.attestation), true),
+            }) => (&a.transaction, Some(&a.attestation)),
             _ => continue,
         };
 
@@ -174,9 +175,8 @@ pub async fn validate_and_resolve_conflicts(
                         None
                     }
                 }
-                Attestation::Explicit { .. } | _ => {
-                    Some(IotaError::ExplicitAttestationNotSupported)
-                }
+                // Reject Explicit variant as not yet implemented.
+                _ => Some(IotaError::ExplicitAttestationNotSupported),
             };
             if let Some(e) = error {
                 warn!(
@@ -293,7 +293,7 @@ pub async fn validate_and_resolve_conflicts(
         // attestation. Re-running these checks post-consensus would be redundant
         // and could cause divergence if state changes between attestation time
         // and execution time.
-        if !is_attested {
+        if attestation.is_none() {
             let verified_tx = VerifiedTransaction::new_from_verified((**transaction).clone());
             if let Err(e) = authority_state
                 .handle_transaction_validation_checks(&verified_tx, epoch_store)

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -289,12 +289,21 @@ pub async fn validate_and_resolve_conflicts(
         // by rejecting the transaction post-consensus. Doing so would also risk
         // diverging from other honest validators.
         //
-        // For `UserTransactionV2` (attested transactions), this check is skipped
-        // entirely. The attestor has already performed validation (including deny
-        // checks, gas, and ownership verification) before producing the
-        // attestation. Re-running these checks post-consensus would be redundant
-        // and could cause divergence if state changes between attestation time
-        // and execution time.
+        // For `UserTransactionV2` (attested transactions) this check is
+        // skipped. Each part of it is either re-applied during execution or is
+        // not safety-critical to run post-consensus:
+        //   - `TransactionDenyConfig` (sender/object/package deny lists, feature
+        //     kill-switches): loaded from each validator's local `NodeConfig` so it
+        //     shouldn't be re-run post- consensus.
+        //   - Coin deny list v1 will be enforced at execution time.
+        //   - Receiving-object validity: the Move runtime fails the `receive()` call
+        //     when the ref doesn't match current state.
+        //   - Move bytecode verifier on publish: the Move VM re-verifies every newly
+        //     published package; the signing-time variant only adds a stricter meter as
+        //     a DoS gate.
+        //   - Gas, ownership, `MoveAuthenticator` execution: re-applied in the
+        //     execution pipeline (`check_certificate_input` and
+        //     `authenticate_then_execute_transaction_to_effects`).
         if attestation.is_none() {
             let verified_tx = VerifiedTransaction::new_from_verified((**transaction).clone());
             if let Err(e) = authority_state

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Post-consensus validation and owned-object conflict resolution for
-//! `UserTransactionV1` transactions.
+//! `UserTransactionV1` and `UserTransactionV2` transactions.
 //!
 //! This module merges two formerly separate pipeline stages into a single pass:
 //!
 //! 1. **Semantic validation** — deduplication, already-executed check,
-//!    structural validity, and deny checks (deny lists, gas, ownership, coin
-//!    deny list, Move authenticator).
+//!    structural validity, attestor verification, and deny checks (deny lists,
+//!    gas, ownership, coin deny list, Move authenticator).
 //! 2. **Owned-object conflict resolution** (white-flag) — three-tier lock check
 //!    and lock acquisition.
 //!
@@ -18,17 +18,19 @@
 //!
 //! # Per-transaction order within the loop
 //!
-//! 1. Non-`UserTransactionV1` — pass through unchanged.
+//! 1. Non-user transaction — pass through unchanged.
 //! 2. Dedup by `ConsensusTransactionKey` — silent drop.
 //! 3. Already executed — silent drop.
 //! 4. `validity_check()` — drop with error.
-//! 5. Three-tier lock conflict check (local HashMap → quarantine → DB) — drop
+//! 5. Attestor verification (`UserTransactionV2` only) — verifies that the
+//!    claimed attestor matches the block author. Drop with error on mismatch or
+//!    unsupported attestation variant.
+//! 6. Three-tier lock conflict check (local HashMap → quarantine → DB) — drop
 //!    with error. Cheap; performed before expensive checks.
-//! 6. `handle_transaction_validation_checks()` — drop with error. Only reached
-//!    when all locks are free.
-//! 7. All passed — acquire locks in the local tracking map, keep transaction.
-//!
-//! Non-`UserTransactionV1` transactions pass through unchanged.
+//! 7. `handle_transaction_validation_checks()` — drop with error. Skipped for
+//!    attested transactions (`UserTransactionV2`). Only reached when all locks
+//!    are free.
+//! 8. All passed — acquire locks in the local tracking map, keep transaction.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -36,6 +38,7 @@ use std::{
 };
 
 use iota_types::{
+    attestation::Attestation,
     base_types::{ObjectRef, TransactionDigest},
     error::{IotaError, IotaResult},
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
@@ -54,17 +57,17 @@ use crate::{
     },
 };
 
-/// Validates `UserTransactionV1` transactions and resolves owned-object
+/// Validates `UserTransactionV1/V2` transactions and resolves owned-object
 /// conflicts in a single pass.
 ///
-/// For each `UserTransactionV1` in consensus order:
-/// - Runs deduplication, already-executed check, structural validity, lock
+/// For each `UserTransactionV1` or `UserTransactionV2` in consensus order:
+/// - Runs deduplication, already-executed check, structural validity, attestor verification (V2 only), lock
 ///   conflict check, and deny checks (deny list, gas, ownership, coin deny
 ///   list, Move authenticator).
 /// - If all checks pass, acquires owned-object locks in a local tracking map.
 /// - Drops the transaction (with an error) on any failure.
 ///
-/// Non-`UserTransactionV1` transactions pass through unchanged.
+/// Non-`UserTransactionV1`/`UserTransactionV2` transactions pass through unchanged.
 ///
 /// # Arguments
 ///
@@ -81,7 +84,7 @@ use crate::{
 ///   are **not** included.
 /// - `locks` — Owned-object locks acquired in this commit, to be stored in the
 ///   consensus quarantine so subsequent commits can see them.
-/// - `all_user_tx_digests` — Every `UserTransactionV1` digest that passed dedup
+/// - `all_user_tx_digests` — Every `UserTransactionV1`/`UserTransactionV2` digest that passed dedup
 ///   (both kept and dropped). Used by the caller to release pre-consensus soft
 ///   locks.
 pub async fn validate_and_resolve_conflicts(
@@ -100,15 +103,15 @@ pub async fn validate_and_resolve_conflicts(
     let mut current_commit_locks: HashMap<ObjectRef, LockDetails> = HashMap::new();
     // Index-parallel keep flags: true = keep, false = remove.
     let mut keep = vec![true; transactions.len()];
-    // All UserTransactionV1 digests seen in this commit (both kept and dropped),
+    // All UserTransactionV1/V2 digests seen in this commit (both kept and dropped),
     // used by the caller to release pre-consensus soft locks.
     let mut all_user_tx_digests = Vec::with_capacity(transactions.len());
 
     for (i, tx) in transactions.iter().enumerate() {
         // Check #0: Dedup by ConsensusTransactionKey.
-        // The same UserTransactionV1 may appear in DAG blocks from multiple
-        // validators within the same consensus commit. Only the first occurrence
-        // is kept. Silent drop — not added to `dropped`.
+        // The same UserTransactionV1 or UserTransactionV2 may appear in DAG
+        // blocks from multiple validators within the same consensus commit.
+        // Only the first occurrence is kept. Silent drop — not added to `dropped`.
         if !seen_keys.insert(tx.0.key()) {
             keep[i] = false;
             continue;
@@ -116,15 +119,15 @@ pub async fn validate_and_resolve_conflicts(
 
         // Only validate UserTransactionV1/V2; pass everything else through
         // unchanged.
-        let (transaction, is_attested) = match &tx.0.transaction {
+        let (transaction, attestation, is_attested) = match &tx.0.transaction {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV1(t),
                 ..
-            }) => (t, false),
+            }) => (t, None, false),
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV2(a),
                 ..
-            }) => (&a.transaction, true),
+            }) => (&a.transaction, Some(&a.attestation), true),
             _ => continue,
         };
 
@@ -154,7 +157,40 @@ pub async fn validate_and_resolve_conflicts(
             continue;
         }
 
-        // Check #3: Extract owned input objects for lock conflict detection.
+        // Check #3: Attestor verification (UserTransactionV2 only).
+        // The block signature transitively authenticates the attestation;
+        // verify the claimed attestor matches the actual block author.
+        if let Some(attestation) = attestation {
+            let block_author =
+                starfish_config::AuthorityIndex::from(tx.0.certificate_author_index as u8);
+            let error = match attestation {
+                Attestation::Validator { attestor_index, .. } => {
+                    if *attestor_index != block_author {
+                        Some(IotaError::AttestationAuthorMismatch {
+                            expected: *attestor_index,
+                            actual: block_author,
+                        })
+                    } else {
+                        None
+                    }
+                }
+                Attestation::Explicit { .. } | _ => {
+                    Some(IotaError::ExplicitAttestationNotSupported)
+                }
+            };
+            if let Some(e) = error {
+                warn!(
+                    ?digest,
+                    error = ?e,
+                    "UserTransactionV2 failed attestation verification, dropping"
+                );
+                dropped.push((digest, e));
+                keep[i] = false;
+                continue;
+            }
+        }
+
+        // Check #4: Extract owned input objects for lock conflict detection.
         let owned_inputs = match extract_owned_input_objects(tx) {
             Ok(inputs) => inputs,
             Err(e) => {
@@ -169,14 +205,14 @@ pub async fn validate_and_resolve_conflicts(
             }
         };
 
-        // Check #4: Three-tier lock conflict check.
+        // Check #5: Three-tier lock conflict check.
         // Cheap (HashMap + quarantine + DB lookups); performed before the
         // expensive deny checks so conflicting transactions are filtered first.
         //
         // Locks are keyed by full ObjectRef (id + version + digest), not just
         // ObjectID. Two transactions referencing the same object at different
         // versions will NOT conflict here — version freshness is validated
-        // later in Check #5 (deny checks load objects from DB and verify
+        // later in Check #6 (deny checks load objects from DB and verify
         // that the transaction's input refs match the current state).
         //
         // Tier 1: Local HashMap (current commit).
@@ -237,7 +273,7 @@ pub async fn validate_and_resolve_conflicts(
             continue;
         }
 
-        // Check #5: Deny list, gas, ownership, coin deny list, Move
+        // Check #6: Deny list, gas, ownership, coin deny list, Move
         // authenticator. Only reached if all locks are free — skips the
         // expensive object loading for transactions that would be dropped
         // by the lock conflict check.

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -126,7 +126,7 @@ pub async fn validate_and_resolve_conflicts(
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV1(t),
                 ..
-            }) => (t, None),
+            }) => (t.as_ref(), None),
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::UserTransactionV2(a),
                 ..
@@ -305,7 +305,7 @@ pub async fn validate_and_resolve_conflicts(
         //     execution pipeline (`check_certificate_input` and
         //     `authenticate_then_execute_transaction_to_effects`).
         if attestation.is_none() {
-            let verified_tx = VerifiedTransaction::new_from_verified((**transaction).clone());
+            let verified_tx = VerifiedTransaction::new_from_verified(transaction.clone());
             if let Err(e) = authority_state
                 .handle_transaction_validation_checks(&verified_tx, epoch_store)
                 .await

--- a/crates/iota-core/src/transaction_input_loader.rs
+++ b/crates/iota-core/src/transaction_input_loader.rs
@@ -106,8 +106,7 @@ impl TransactionInputLoader {
             });
         }
 
-        let receiving_results =
-            self.read_receiving_objects_for_signing(receiving_objects, epoch_id)?;
+        let receiving_results = self.read_receiving_objects(receiving_objects, epoch_id)?;
 
         Ok((
             input_results
@@ -261,9 +260,10 @@ impl TransactionInputLoader {
     }
 }
 
-// private methods
 impl TransactionInputLoader {
-    fn read_receiving_objects_for_signing(
+    /// Load the `ReceivingObjects` for a transaction. Used both at signing time
+    /// (by [`Self::read_objects_for_signing`]) and at execution time.
+    pub(crate) fn read_receiving_objects(
         &self,
         receiving_objects: &[ObjectRef],
         epoch_id: EpochId,

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -5,6 +5,7 @@
 use std::{
     cmp::{Reverse, max},
     collections::{BTreeSet, BinaryHeap, HashMap, HashSet, hash_map},
+    ops::Deref,
     sync::Arc,
     time::Duration,
 };
@@ -13,6 +14,7 @@ use iota_common::{fatal, random_util::randomize_cache_capacity_in_tests};
 use iota_config::node::AuthorityOverloadConfig;
 use iota_metrics::monitored_scope;
 use iota_types::{
+    attestation::Attestation,
     base_types::{ObjectID, SequenceNumber, TransactionDigest},
     committee::EpochId,
     digests::TransactionEffectsDigest,
@@ -71,10 +73,69 @@ pub struct PendingCertificateStats {
     pub ready_time: Option<Instant>,
 }
 
+/// Wraps a [`VerifiedExecutableTransaction`] with its pre-consensus
+/// [`Attestation`] (if any). Carrying the full attestation lets downstream code
+/// consult both scheduling metadata and attestor identity / observed object
+/// versions.
+///
+/// This is runtime-only scheduling metadata: it is never serialized or
+/// persisted.
+#[derive(Clone, Debug)]
+pub struct VerifiedExecutableAttestedTransaction {
+    tx: VerifiedExecutableTransaction,
+    /// `None` for unattested transactions (e.g., `UserTransactionV1`).
+    attestation: Option<Attestation>,
+}
+
+impl VerifiedExecutableAttestedTransaction {
+    pub fn new(tx: VerifiedExecutableTransaction, attestation: Option<Attestation>) -> Self {
+        Self { tx, attestation }
+    }
+
+    /// Returns the attached attestation, or `None` if the transaction was
+    /// not attested.
+    pub fn attestation(&self) -> Option<&Attestation> {
+        self.attestation.as_ref()
+    }
+
+    /// Returns the attestor's estimated computation units, or `None` if the
+    /// transaction was not attested.
+    pub fn attested_computation_units(&self) -> Option<u64> {
+        self.attestation.as_ref().map(|a| a.computation_units())
+    }
+
+    /// Consume the wrapper and return its parts.
+    pub fn into_parts(self) -> (VerifiedExecutableTransaction, Option<Attestation>) {
+        (self.tx, self.attestation)
+    }
+}
+
+impl From<VerifiedExecutableTransaction> for VerifiedExecutableAttestedTransaction {
+    fn from(tx: VerifiedExecutableTransaction) -> Self {
+        Self {
+            tx,
+            attestation: None,
+        }
+    }
+}
+
+impl Deref for VerifiedExecutableAttestedTransaction {
+    type Target = VerifiedExecutableTransaction;
+
+    fn deref(&self) -> &Self::Target {
+        &self.tx
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PendingCertificate {
-    // Certified transaction to be executed.
-    pub certificate: VerifiedExecutableTransaction,
+    // Certified transaction to be executed, paired with its pre-consensus
+    // attestation when sequenced as `UserTransactionV2`. The attestation is
+    // `None` for non-consensus paths (replay, change-epoch, finalizer) and
+    // for `UserTransactionV1`. Available at execution time for future
+    // consumers (comparison metrics, attestor reward/penalty accounting at
+    // checkpoint time).
+    pub certificate: VerifiedExecutableAttestedTransaction,
     // When executing from checkpoint, the certified effects digest is provided, so that forks can
     // be detected prior to committing the transaction.
     pub expected_effects_digest: Option<TransactionEffectsDigest>,
@@ -382,7 +443,19 @@ impl TransactionManager {
         certs: Vec<VerifiedExecutableTransaction>,
         epoch_store: &AuthorityPerEpochStore,
     ) {
-        let certs = certs.into_iter().map(|cert| (cert, None)).collect();
+        let certs = certs.into_iter().map(|cert| (cert.into(), None)).collect();
+        self.enqueue_impl(certs, epoch_store)
+    }
+
+    /// Like [`Self::enqueue`], but preserves the pre-consensus attestation for
+    /// transactions that arrived as `UserTransactionV2`.
+    #[instrument("transaction_manager_enqueue_attested", level = "trace", skip_all)]
+    pub(crate) fn enqueue_attested(
+        &self,
+        certs: Vec<VerifiedExecutableAttestedTransaction>,
+        epoch_store: &AuthorityPerEpochStore,
+    ) {
+        let certs = certs.into_iter().map(|attested| (attested, None)).collect();
         self.enqueue_impl(certs, epoch_store)
     }
 
@@ -394,7 +467,7 @@ impl TransactionManager {
     ) {
         let certs = certs
             .into_iter()
-            .map(|(cert, fx)| (cert, Some(fx)))
+            .map(|(cert, fx)| (cert.into(), Some(fx)))
             .collect();
         self.enqueue_impl(certs, epoch_store)
     }
@@ -402,7 +475,7 @@ impl TransactionManager {
     fn enqueue_impl(
         &self,
         certs: Vec<(
-            VerifiedExecutableTransaction,
+            VerifiedExecutableAttestedTransaction,
             Option<TransactionEffectsDigest>,
         )>,
         epoch_store: &AuthorityPerEpochStore,

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -2,12 +2,27 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
-use iota_types::base_types::TransactionDigest;
+use iota_protocol_config::PerObjectCongestionControlMode;
+use iota_types::{
+    attestation::{Attestation, AttestationData},
+    base_types::{ObjectID, TransactionDigest},
+};
+use starfish_config::AuthorityIndex;
 use tokio::time::timeout;
 
-use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::{
+    authority::{
+        authority_per_epoch_store::CongestionControlParameters,
+        shared_object_congestion_tracker::{
+            SequencingResult, SharedObjectCongestionTracker,
+            shared_object_test_utils::{TEST_ONLY_GAS_PRICE, build_transaction},
+        },
+        test_authority_builder::TestAuthorityBuilder,
+    },
+    transaction_manager::VerifiedExecutableAttestedTransaction,
+};
 
 #[tokio::test]
 async fn test_notify_read_executed_transactions_to_checkpoint() {
@@ -61,4 +76,144 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
     assert_eq!(result[0].unwrap(), checkpoint_sequence_1);
     assert_eq!(result[1].unwrap(), checkpoint_sequence_2);
     assert_eq!(result[2].unwrap(), checkpoint_sequence_2);
+}
+
+/// Under `TotalComputationUnits`, the estimated execution duration is the
+/// attested computation units when present, and `gas_budget / gas_price`
+/// otherwise.
+#[test]
+fn test_get_estimated_execution_duration_total_computation_units_mode() {
+    let params = CongestionControlParameters::new_for_test(
+        PerObjectCongestionControlMode::TotalComputationUnits,
+        false,           // congestion_control_min_free_execution_slot
+        Some(1_000_000), // max_execution_duration_per_commit
+        Some(0),         // max_congestion_limit_overshoot_per_commit
+        0,               // max_gas_price (irrelevant here)
+        false,           // use_congestion_limit_overshoot_in_gas_price_feedback_mechanism
+        true,            // use_separate_gas_price_feedback_mechanism_for_randomness
+    );
+
+    let gas_budget = 12_345;
+    let attested_units = 9_876;
+
+    // Attested transaction returns its attested computation units.
+    let attested_tx = attest(
+        build_transaction(&[], gas_budget, TEST_ONLY_GAS_PRICE),
+        attested_units,
+    );
+    assert_eq!(
+        params.get_estimated_execution_duration(&attested_tx),
+        attested_units,
+    );
+
+    // Unattested transaction falls back to gas_budget converted to gas units.
+    let unattested_tx = build_transaction(&[], gas_budget, TEST_ONLY_GAS_PRICE);
+    assert_eq!(
+        params.get_estimated_execution_duration(&unattested_tx),
+        gas_budget / TEST_ONLY_GAS_PRICE,
+    );
+
+    // Unattested transaction with a zero gas price: the `gas_budget / gas_price`
+    // fallback must not divide by zero.
+    let zero_gas_price_tx = build_transaction(&[], gas_budget, 0);
+    assert_eq!(
+        params.get_estimated_execution_duration(&zero_gas_price_tx),
+        0,
+    );
+
+    // An attestation with zero computation units should not use the gas-budget
+    // fallback.
+    let zero_cost_attested_tx = attest(build_transaction(&[], gas_budget, TEST_ONLY_GAS_PRICE), 0);
+    assert_eq!(
+        params.get_estimated_execution_duration(&zero_cost_attested_tx),
+        0,
+    );
+}
+
+/// Attaches a validator attestation with the given `computation_units`
+/// to a transaction produced by `build_transaction`.
+fn attest(
+    tx: VerifiedExecutableAttestedTransaction,
+    computation_units: u64,
+) -> VerifiedExecutableAttestedTransaction {
+    let (inner, _) = tx.into_parts();
+    VerifiedExecutableAttestedTransaction::new(
+        inner,
+        Some(Attestation::Validator {
+            payload: AttestationData::V1 {
+                computation_units,
+                object_versions: vec![],
+            },
+            attestor_index: AuthorityIndex::new_for_test(0),
+        }),
+    )
+}
+
+/// Within `TotalComputationUnits` mode, a commit of attested transactions is
+/// scheduled differently from a commit of the same transactions without an
+/// attestation: attested txs use the (cheap) attested computation units, while
+/// unattested txs fall back to the (much larger) gas budget per the documented
+/// fallback in `get_estimated_execution_duration`.
+///
+/// Note this is an in-mode contrast, not a production comparison: under
+/// `TotalTxCount` (the production default for chains without validator
+/// attestation), unattested txs are billed at one unit each.
+#[test]
+fn test_total_computation_units_attested_vs_unattested_commit_scheduling() {
+    // Per-commit limit is large enough to schedule three attested transactions
+    // (30 units each → cumulative 90) but too small to schedule even a single
+    // unattested transaction whose gas budget converts to 200 gas units
+    // (`gas_budget / gas_price`) > limit 100.
+    const MAX_EXECUTION_DURATION_PER_COMMIT: u64 = 100;
+    const TX_GAS_BUDGET: u64 = 200 * TEST_ONLY_GAS_PRICE;
+    const TX_ATTESTED_UNITS: u64 = 30;
+
+    let params = CongestionControlParameters::new_for_test(
+        PerObjectCongestionControlMode::TotalComputationUnits,
+        false,                                   // min_free_execution_slot
+        Some(MAX_EXECUTION_DURATION_PER_COMMIT), // max_execution_duration_per_commit
+        Some(0),                                 // overshoot
+        0,                                       // max_gas_price (irrelevant)
+        false,
+        true,
+    );
+
+    let shared_obj = ObjectID::random();
+
+    // --- Attested commit: three transactions all schedule, end-to-end. ---
+    let mut tracker = SharedObjectCongestionTracker::new(std::iter::empty(), params.clone());
+    for i in 0..3 {
+        let tx = attest(
+            build_transaction(&[(shared_obj, true)], TX_GAS_BUDGET, TEST_ONLY_GAS_PRICE),
+            TX_ATTESTED_UNITS,
+        );
+        let shared_input_objects = tx.shared_input_objects();
+        tracker.initialize_object_execution_slots(&shared_input_objects);
+        match tracker.try_schedule(&tx, &HashMap::new(), 0) {
+            SequencingResult::Schedule(start_time) => {
+                assert_eq!(
+                    start_time,
+                    i * TX_ATTESTED_UNITS,
+                    "attested tx #{i} should be scheduled back-to-back",
+                );
+                tracker.bump_object_execution_slots(&tx, start_time);
+            }
+            SequencingResult::Defer(_, congested) => {
+                panic!("attested tx #{i} should schedule, got defer on {congested:?}")
+            }
+        }
+    }
+
+    // --- Unattested commit: the very first transaction defers. ---
+    let mut tracker = SharedObjectCongestionTracker::new(std::iter::empty(), params);
+    let tx = build_transaction(&[(shared_obj, true)], TX_GAS_BUDGET, TEST_ONLY_GAS_PRICE);
+    tracker.initialize_object_execution_slots(&tx.shared_input_objects());
+    match tracker.try_schedule(&tx, &HashMap::new(), 0) {
+        SequencingResult::Defer(_, congested) => {
+            assert_eq!(congested, vec![shared_obj]);
+        }
+        SequencingResult::Schedule(start_time) => {
+            panic!("unattested tx should defer, got schedule at {start_time}");
+        }
+    }
 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -6263,7 +6263,8 @@ async fn test_consensus_handler_per_object_congestion_control(
 
     let non_congested_tx_count = match mode {
         PerObjectCongestionControlMode::None => unreachable!(),
-        PerObjectCongestionControlMode::TotalGasBudget => 5,
+        PerObjectCongestionControlMode::TotalGasBudget
+        | PerObjectCongestionControlMode::TotalComputationUnits => 5,
         PerObjectCongestionControlMode::TotalTxCount => 2,
     };
     let gas_objects_commit_1 = create_gas_objects(5 + non_congested_tx_count, sender);
@@ -6276,7 +6277,8 @@ async fn test_consensus_handler_per_object_congestion_control(
 
     match mode {
         PerObjectCongestionControlMode::None => unreachable!(),
-        PerObjectCongestionControlMode::TotalGasBudget => {
+        PerObjectCongestionControlMode::TotalGasBudget
+        | PerObjectCongestionControlMode::TotalComputationUnits => {
             protocol_config
                 .set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(
                     200_000_000,

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -197,7 +197,7 @@ pub fn make_consensus_adapter_for_test(
             if self.execute {
                 self.state
                     .transaction_manager()
-                    .enqueue(transactions, epoch_store);
+                    .enqueue_attested(transactions, epoch_store);
             }
 
             assert!(

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -11,7 +11,6 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber},
     crypto::{AccountKeyPair, get_key_pair},
     effects::{TransactionEffects, TransactionEffectsAPI, UnchangedSharedKind},
-    executable_transaction::VerifiedExecutableTransaction,
     execution_status::{ExecutionFailureStatus, ExecutionStatus},
     messages_consensus::{
         CancelledTransaction, ConsensusDeterminedVersionAssignments, VersionAssignment,
@@ -37,6 +36,7 @@ use crate::{
         transaction_deferral::DeferralKey,
     },
     move_call,
+    transaction_manager::VerifiedExecutableAttestedTransaction,
 };
 
 /// Reference gas price used in gas price feedback mechanism tests.
@@ -255,21 +255,21 @@ impl GasPriceFeedbackTester {
     async fn send_certificates_to_consensus_for_scheduling(
         &self,
         certificates: &[VerifiedCertificate],
-    ) -> Vec<VerifiedExecutableTransaction> {
+    ) -> Vec<VerifiedExecutableAttestedTransaction> {
         send_batch_consensus_no_execution(&self.authority_state, certificates, false).await
     }
 
     /// Enqueue scheduled transactions and execute them to effects.
     async fn enqueue_and_execute_scheduled_transactions(
         &self,
-        transactions: Vec<VerifiedExecutableTransaction>,
+        transactions: Vec<VerifiedExecutableAttestedTransaction>,
     ) -> Vec<TransactionEffects> {
         let transaction_digests = transactions
             .iter()
             .map(|tx| *tx.digest())
             .collect::<Vec<_>>();
 
-        self.authority_state.transaction_manager().enqueue(
+        self.authority_state.transaction_manager().enqueue_attested(
             transactions,
             &self.authority_state.epoch_store_for_testing(),
         );

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -1092,8 +1092,8 @@ async fn test_dropped_tx_does_not_acquire_locks() {
 }
 
 /// A `UserTransactionV2` whose `attestor_index` matches the block's
-/// `certificate_author_index` (both `0`) passes Check #3 and is treated the
-/// same as a valid V1 transaction.
+/// `certificate_author_index` (both `0`) passes attestor verification (Check
+/// #3) and is treated the same as a valid V1 transaction.
 #[sim_test]
 async fn test_v2_passes() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -14,7 +14,7 @@ use iota_types::{
     error::IotaError,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     object::Object,
-    transaction::VerifiedTransaction,
+    transaction::{TransactionDataAPI, VerifiedTransaction},
 };
 
 use crate::{
@@ -49,16 +49,15 @@ fn make_user_tx_v1_verified(tx: VerifiedTransaction) -> VerifiedSequencedConsens
 }
 
 /// Wraps a `Transaction` in a `UserTransactionV2` consensus transaction with
-/// the given `attestor_index`. The block's `certificate_author_index` is always
-/// `0` (set by `new_test`), so passing `0` produces a matching attestation and
-/// any other value produces a mismatch.
+/// the given `attestor_index` and `computation_units`.
 fn make_user_tx_v2(
     tx: iota_types::transaction::Transaction,
     attestor_index: starfish_config::AuthorityIndex,
+    computation_units: u64,
 ) -> VerifiedSequencedConsensusTransaction {
     let attestation = Attestation::Validator {
         payload: AttestationData::V1 {
-            estimated_computation_cost: 0,
+            computation_units,
             object_versions: vec![],
         },
         attestor_index,
@@ -1131,9 +1130,14 @@ async fn test_v2_passes() {
     let digest = *tx.digest();
 
     // attestor_index 0 == certificate_author_index 0 set by new_test → match.
+    let protocol_config = epoch_store.protocol_config();
+    let min_units = protocol_config
+        .base_tx_cost_fixed()
+        .min(protocol_config.gas_rounding_step());
     let mut transactions = vec![make_user_tx_v2(
         tx,
         starfish_config::AuthorityIndex::new_for_test(0),
+        min_units,
     )];
 
     let (dropped, locks, user_tx_digests) =
@@ -1201,9 +1205,17 @@ async fn test_v2_attestor_mismatch() {
     let digest = *tx.digest();
 
     // attestor_index 1 != certificate_author_index 0 → mismatch.
+    // Cost is also below the protocol floor (`min_units - 1`), so BOTH the
+    // mismatch and the floor checks would fire. This pins the check order:
+    // mismatch must be reported before the floor.
+    let protocol_config = epoch_store.protocol_config();
+    let min_units = protocol_config
+        .base_tx_cost_fixed()
+        .min(protocol_config.gas_rounding_step());
     let mut transactions = vec![make_user_tx_v2(
         tx,
         starfish_config::AuthorityIndex::new_for_test(1),
+        min_units - 1,
     )];
 
     let (dropped, locks, user_tx_digests) =
@@ -1240,4 +1252,114 @@ async fn test_v2_attestor_mismatch() {
         vec![digest],
         "digest must be collected before Check #3 for soft-lock release",
     );
+}
+
+/// A `UserTransactionV2` whose attestation reports `computation_units` outside
+/// the valid range is malformed and dropped via Check #3:
+/// - below `min(base_tx_cost_fixed, gas_rounding_step)` →
+///   `AttestationUnitsBelowMinimum` (no honest dry-run meters below the
+///   bucketization floor);
+/// - above `gas_budget / gas_price` → `AttestationUnitsAboveBudget` (an honest
+///   dry-run cannot meter more computation than the tx can pay for).
+///
+/// In both cases the digest must still surface in `all_user_tx_digests` for
+/// soft-lock release.
+#[sim_test]
+async fn test_v2_cost_out_of_bounds() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+
+    let epoch_store = authority.epoch_store_for_testing();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+
+    let object_ref = authority
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let gas_ref = authority
+        .get_object(&gas_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+
+    let reference_tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let protocol_config = epoch_store.protocol_config();
+    let min_units = protocol_config
+        .base_tx_cost_fixed()
+        .min(protocol_config.gas_rounding_step());
+    let ref_data = reference_tx.data().transaction_data();
+    let max_units = ref_data.gas_budget() / ref_data.gas_price();
+
+    // One case just below the minimum, one just above the maximum..
+    for (attested_units, expect_below) in [(min_units - 1, true), (max_units + 1, false)] {
+        let tx = make_transfer_object_transaction(
+            object_ref,
+            gas_ref,
+            sender,
+            &sender_key,
+            recipient,
+            rgp,
+        );
+        let digest = *tx.digest();
+        let mut transactions = vec![make_user_tx_v2(
+            tx,
+            starfish_config::AuthorityIndex::new_for_test(0),
+            attested_units,
+        )];
+
+        let (dropped, locks, user_tx_digests) =
+            post_consensus_validation::validate_and_resolve_conflicts(
+                &authority,
+                &epoch_store,
+                &mut transactions,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            transactions.is_empty(),
+            "malformed-cost V2 should be removed from the batch"
+        );
+        assert_eq!(
+            dropped.len(),
+            1,
+            "malformed cost should produce one dropped entry"
+        );
+        match &dropped[0].1 {
+            IotaError::AttestationUnitsBelowMinimum { actual, minimum } if expect_below => {
+                assert_eq!(*actual, min_units - 1);
+                assert_eq!(*minimum, min_units);
+            }
+            IotaError::AttestationUnitsAboveBudget { actual, maximum } if !expect_below => {
+                assert_eq!(*actual, max_units + 1);
+                assert_eq!(*maximum, max_units);
+            }
+            other => panic!("unexpected error for attested_units={attested_units}: {other:?}"),
+        }
+        assert!(
+            locks.is_empty(),
+            "no locks should be acquired for a dropped transaction"
+        );
+        assert_eq!(
+            user_tx_digests,
+            vec![digest],
+            "digest must be collected before Check #3 for soft-lock release",
+        );
+    }
 }

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -7,6 +7,7 @@
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
+    attestation::{Attestation, AttestationData, AttestedTransaction},
     base_types::{IotaAddress, ObjectID},
     crypto::{AccountKeyPair, get_key_pair},
     digests::TransactionDigest,
@@ -42,6 +43,29 @@ fn make_user_tx_v1(
 fn make_user_tx_v1_verified(tx: VerifiedTransaction) -> VerifiedSequencedConsensusTransaction {
     let consensus_tx = ConsensusTransaction {
         kind: ConsensusTransactionKind::UserTransactionV1(Box::new(tx.into())),
+        tracking_id: Default::default(),
+    };
+    VerifiedSequencedConsensusTransaction::new_test(consensus_tx)
+}
+
+/// Wraps a `Transaction` in a `UserTransactionV2` consensus transaction with
+/// the given `attestor_index`. The block's `certificate_author_index` is always
+/// `0` (set by `new_test`), so passing `0` produces a matching attestation and
+/// any other value produces a mismatch.
+fn make_user_tx_v2(
+    tx: iota_types::transaction::Transaction,
+    attestor_index: starfish_config::AuthorityIndex,
+) -> VerifiedSequencedConsensusTransaction {
+    let attestation = Attestation::Validator {
+        payload: AttestationData::V1 {
+            estimated_computation_cost: 0,
+            object_versions: vec![],
+        },
+        attestor_index,
+    };
+    let attested = AttestedTransaction::new(tx, attestation);
+    let consensus_tx = ConsensusTransaction {
+        kind: ConsensusTransactionKind::UserTransactionV2(Box::new(attested)),
         tracking_id: Default::default(),
     };
     VerifiedSequencedConsensusTransaction::new_test(consensus_tx)
@@ -1065,4 +1089,112 @@ async fn test_dropped_tx_does_not_acquire_locks() {
     assert!(user_tx_digests.contains(verified_tx2.digest()));
     assert!(user_tx_digests.contains(verified_tx3.digest()));
     assert!(user_tx_digests.contains(verified_tx4.digest()));
+}
+
+/// A `UserTransactionV2` whose `attestor_index` matches the block's
+/// `certificate_author_index` (both `0`) passes Check #3 and is treated the
+/// same as a valid V1 transaction.
+#[sim_test]
+async fn test_v2_passes() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+
+    let epoch_store = authority.epoch_store_for_testing();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+
+    let object_ref = authority.get_object(&object_id).await.unwrap().compute_object_reference();
+    let gas_ref = authority.get_object(&gas_id).await.unwrap().compute_object_reference();
+    let tx = make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let digest = *tx.digest();
+
+    // attestor_index 0 == certificate_author_index 0 set by new_test → match.
+    let mut transactions = vec![make_user_tx_v2(tx, starfish_config::AuthorityIndex::new_for_test(0))];
+
+    let (dropped, locks, user_tx_digests) =
+        post_consensus_validation::validate_and_resolve_conflicts(
+            &authority,
+            &epoch_store,
+            &mut transactions,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(transactions.len(), 1, "V2 with matching attestor should be kept");
+    assert!(dropped.is_empty(), "No errors expected");
+    assert_eq!(locks.len(), 2, "Locks for object and gas should be acquired");
+    assert_eq!(user_tx_digests, vec![digest]);
+}
+
+/// A `UserTransactionV2` whose `attestor_index` does not match the block's
+/// `certificate_author_index` is dropped via Check #3. Critically, its digest
+/// must still appear in `all_user_tx_digests` so the caller can release the
+/// pre-consensus soft lock — this is the invariant the loop restructure protects.
+#[sim_test]
+async fn test_v2_attestor_mismatch() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+
+    let epoch_store = authority.epoch_store_for_testing();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+
+    let object_ref = authority.get_object(&object_id).await.unwrap().compute_object_reference();
+    let gas_ref = authority.get_object(&gas_id).await.unwrap().compute_object_reference();
+    let tx = make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let digest = *tx.digest();
+
+    // attestor_index 1 != certificate_author_index 0 → mismatch.
+    let mut transactions = vec![make_user_tx_v2(tx, starfish_config::AuthorityIndex::new_for_test(1))];
+
+    let (dropped, locks, user_tx_digests) =
+        post_consensus_validation::validate_and_resolve_conflicts(
+            &authority,
+            &epoch_store,
+            &mut transactions,
+        )
+        .await
+        .unwrap();
+
+    assert!(transactions.is_empty(), "Mismatched V2 should be removed from the batch");
+    assert_eq!(dropped.len(), 1, "Mismatch should produce one dropped entry");
+    assert!(
+        matches!(dropped[0].1, IotaError::AttestationAuthorMismatch { .. }),
+        "expected AttestationAuthorMismatch, got {:?}",
+        dropped[0].1,
+    );
+    assert!(locks.is_empty(), "No locks should be acquired for a dropped transaction");
+    // The digest must be in user_tx_digests even though the transaction was
+    // dropped — the caller needs it to release the pre-consensus soft lock.
+    assert_eq!(
+        user_tx_digests,
+        vec![digest],
+        "digest must be collected before Check #3 for soft-lock release",
+    );
 }

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -1116,13 +1116,25 @@ async fn test_v2_passes() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_ref = authority.get_object(&object_id).await.unwrap().compute_object_reference();
-    let gas_ref = authority.get_object(&gas_id).await.unwrap().compute_object_reference();
-    let tx = make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let object_ref = authority
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let gas_ref = authority
+        .get_object(&gas_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
     let digest = *tx.digest();
 
     // attestor_index 0 == certificate_author_index 0 set by new_test → match.
-    let mut transactions = vec![make_user_tx_v2(tx, starfish_config::AuthorityIndex::new_for_test(0))];
+    let mut transactions = vec![make_user_tx_v2(
+        tx,
+        starfish_config::AuthorityIndex::new_for_test(0),
+    )];
 
     let (dropped, locks, user_tx_digests) =
         post_consensus_validation::validate_and_resolve_conflicts(
@@ -1133,16 +1145,25 @@ async fn test_v2_passes() {
         .await
         .unwrap();
 
-    assert_eq!(transactions.len(), 1, "V2 with matching attestor should be kept");
+    assert_eq!(
+        transactions.len(),
+        1,
+        "V2 with matching attestor should be kept"
+    );
     assert!(dropped.is_empty(), "No errors expected");
-    assert_eq!(locks.len(), 2, "Locks for object and gas should be acquired");
+    assert_eq!(
+        locks.len(),
+        2,
+        "Locks for object and gas should be acquired"
+    );
     assert_eq!(user_tx_digests, vec![digest]);
 }
 
 /// A `UserTransactionV2` whose `attestor_index` does not match the block's
 /// `certificate_author_index` is dropped via Check #3. Critically, its digest
 /// must still appear in `all_user_tx_digests` so the caller can release the
-/// pre-consensus soft lock — this is the invariant the loop restructure protects.
+/// pre-consensus soft lock — this is the invariant the loop restructure
+/// protects.
 #[sim_test]
 async fn test_v2_attestor_mismatch() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
@@ -1165,13 +1186,25 @@ async fn test_v2_attestor_mismatch() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_ref = authority.get_object(&object_id).await.unwrap().compute_object_reference();
-    let gas_ref = authority.get_object(&gas_id).await.unwrap().compute_object_reference();
-    let tx = make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let object_ref = authority
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let gas_ref = authority
+        .get_object(&gas_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
     let digest = *tx.digest();
 
     // attestor_index 1 != certificate_author_index 0 → mismatch.
-    let mut transactions = vec![make_user_tx_v2(tx, starfish_config::AuthorityIndex::new_for_test(1))];
+    let mut transactions = vec![make_user_tx_v2(
+        tx,
+        starfish_config::AuthorityIndex::new_for_test(1),
+    )];
 
     let (dropped, locks, user_tx_digests) =
         post_consensus_validation::validate_and_resolve_conflicts(
@@ -1182,14 +1215,24 @@ async fn test_v2_attestor_mismatch() {
         .await
         .unwrap();
 
-    assert!(transactions.is_empty(), "Mismatched V2 should be removed from the batch");
-    assert_eq!(dropped.len(), 1, "Mismatch should produce one dropped entry");
+    assert!(
+        transactions.is_empty(),
+        "Mismatched V2 should be removed from the batch"
+    );
+    assert_eq!(
+        dropped.len(),
+        1,
+        "Mismatch should produce one dropped entry"
+    );
     assert!(
         matches!(dropped[0].1, IotaError::AttestationAuthorMismatch { .. }),
         "expected AttestationAuthorMismatch, got {:?}",
         dropped[0].1,
     );
-    assert!(locks.is_empty(), "No locks should be acquired for a dropped transaction");
+    assert!(
+        locks.is_empty(),
+        "No locks should be acquired for a dropped transaction"
+    );
     // The digest must be in user_tx_digests even though the transaction was
     // dropped — the caller needs it to release the pre-consensus soft lock.
     assert_eq!(

--- a/crates/iota-core/src/unit_tests/validator_v2_tests.rs
+++ b/crates/iota-core/src/unit_tests/validator_v2_tests.rs
@@ -17,6 +17,7 @@ use iota_types::{
 };
 use tokio::sync::mpsc;
 
+use super::ValidatorService;
 use crate::{
     authority::test_authority_builder::TestAuthorityBuilder,
     authority_server::{ValidatorServiceMetrics, soft_lock::PreConsensusSoftLocks},
@@ -28,12 +29,11 @@ use crate::{
     mock_consensus::with_block_status,
 };
 
-use super::ValidatorService;
-
-/// Submits a transaction to `submit_single_tx` with `enable_validator_attestation`
-/// on and asserts that the message reaching the consensus adapter is a
-/// `UserTransactionV2` carrying an `Attestation::Validator` whose `attestor_index`
-/// matches this validator's own position in the consensus committee.
+/// Submits a transaction to `submit_single_tx` with
+/// `enable_validator_attestation` on and asserts that the message reaching the
+/// consensus adapter is a `UserTransactionV2` carrying an
+/// `Attestation::Validator` whose `attestor_index` matches this validator's own
+/// position in the consensus committee.
 #[tokio::test]
 async fn test_submit_single_tx_produces_user_transaction_v2_with_validator_attestation() {
     telemetry_subscribers::init_for_testing();
@@ -117,10 +117,7 @@ async fn test_submit_single_tx_produces_user_transaction_v2_with_validator_attes
         .await
         .expect("consensus message should have been captured");
     let ConsensusTransactionKind::UserTransactionV2(attested) = consensus_tx.kind else {
-        panic!(
-            "expected UserTransactionV2, got {:?}",
-            consensus_tx.kind
-        );
+        panic!("expected UserTransactionV2, got {:?}", consensus_tx.kind);
     };
     let Attestation::Validator { attestor_index, .. } = &attested.attestation else {
         panic!(
@@ -145,10 +142,11 @@ async fn test_submit_single_tx_produces_user_transaction_v2_with_validator_attes
     assert_eq!(*attestor_index, expected_index);
 }
 
-/// Submits a transaction to `submit_single_tx` with `enable_validator_attestation`
-/// on, where the gas object referenced by the transaction does not exist in the
-/// authority store. Asserts that the call returns `TxStatusUpdate::Rejected`
-/// and that no message is ever forwarded to the consensus adapter.
+/// Submits a transaction to `submit_single_tx` with
+/// `enable_validator_attestation` on, where the gas object referenced by the
+/// transaction does not exist in the authority store. Asserts that the call
+/// returns `TxStatusUpdate::Rejected` and that no message is ever forwarded to
+/// the consensus adapter.
 #[tokio::test]
 async fn test_submit_single_tx_attest_failure_rejected_without_reaching_consensus() {
     telemetry_subscribers::init_for_testing();

--- a/crates/iota-core/src/unit_tests/validator_v2_tests.rs
+++ b/crates/iota-core/src/unit_tests/validator_v2_tests.rs
@@ -144,3 +144,79 @@ async fn test_submit_single_tx_produces_user_transaction_v2_with_validator_attes
         .expect("authority must be present in the consensus committee");
     assert_eq!(*attestor_index, expected_index);
 }
+
+/// Submits a transaction to `submit_single_tx` with `enable_validator_attestation`
+/// on, where the gas object referenced by the transaction does not exist in the
+/// authority store. Asserts that the call returns `TxStatusUpdate::Rejected`
+/// and that no message is ever forwarded to the consensus adapter.
+#[tokio::test]
+async fn test_submit_single_tx_attest_failure_rejected_without_reaching_consensus() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config.set_enable_validator_attestation_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    // Only register object_id; gas_id is intentionally absent from the store.
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[Object::with_id_owner_for_testing(object_id, sender)])
+        .build()
+        .await;
+
+    // Consensus must never be reached — any submit call panics the test.
+    let mut mock = MockConsensusClient::new();
+    mock.expect_submit().never();
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(mock),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
+    let metrics = Arc::new(ValidatorServiceMetrics::new_for_tests());
+    let soft_locks = Arc::new(PreConsensusSoftLocks::new());
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+    // Build a gas object reference locally so the transaction is structurally
+    // valid, but never store it in the authority — attest_transaction must fail.
+    let gas_ref = Object::with_id_owner_for_testing(gas_id, sender).compute_object_reference();
+
+    let tx_data = TransactionData::new_transfer(
+        dbg_addr(2),
+        object.compute_object_reference(),
+        sender,
+        gas_ref,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+
+    let (update, _weight) = ValidatorService::submit_single_tx(
+        &authority_state,
+        &consensus_adapter,
+        &metrics,
+        &epoch_store,
+        &soft_locks,
+        tx,
+    )
+    .await;
+
+    assert!(
+        matches!(update, TxStatusUpdate::Rejected { .. }),
+        "expected Rejected, got {update:?}",
+    );
+}

--- a/crates/iota-core/src/unit_tests/validator_v2_tests.rs
+++ b/crates/iota-core/src/unit_tests/validator_v2_tests.rs
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use iota_protocol_config::ProtocolConfig;
+use iota_types::{
+    attestation::Attestation,
+    base_types::{ObjectID, dbg_addr},
+    crypto::{AccountKeyPair, get_key_pair},
+    iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
+    messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
+    messages_grpc::TxStatusUpdate,
+    object::Object,
+    transaction::{TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData},
+    utils::to_sender_signed_transaction,
+};
+use tokio::sync::mpsc;
+
+use crate::{
+    authority::test_authority_builder::TestAuthorityBuilder,
+    authority_server::{ValidatorServiceMetrics, soft_lock::PreConsensusSoftLocks},
+    checkpoints::CheckpointStore,
+    consensus_adapter::{
+        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
+        MockConsensusClient,
+    },
+    mock_consensus::with_block_status,
+};
+
+use super::ValidatorService;
+
+/// Submits a transaction to `submit_single_tx` with `enable_validator_attestation`
+/// on and asserts that the message reaching the consensus adapter is a
+/// `UserTransactionV2` carrying an `Attestation::Validator` whose `attestor_index`
+/// matches this validator's own position in the consensus committee.
+#[tokio::test]
+async fn test_submit_single_tx_produces_user_transaction_v2_with_validator_attestation() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config.set_enable_validator_attestation_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    // Intercept whatever reaches the consensus adapter.
+    let (captured_tx, mut rx) = mpsc::channel::<ConsensusTransaction>(1);
+    let mut mock = MockConsensusClient::new();
+    mock.expect_submit().returning(move |transactions, _| {
+        let _ = captured_tx.try_send(transactions[0].clone());
+        Ok(with_block_status(starfish_core::BlockStatus::Sequenced(
+            starfish_core::GenericTransactionRef::BlockRef(starfish_core::BlockRef::MIN),
+        )))
+    });
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(mock),
+        CheckpointStore::new_for_tests(),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let epoch_store = authority_state.load_epoch_store_one_call_per_task();
+    let metrics = Arc::new(ValidatorServiceMetrics::new_for_tests());
+    let soft_locks = Arc::new(PreConsensusSoftLocks::new());
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).await.unwrap();
+
+    let tx_data = TransactionData::new_transfer(
+        dbg_addr(2),
+        object.compute_object_reference(),
+        sender,
+        gas.compute_object_reference(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+
+    let (update, _weight) = ValidatorService::submit_single_tx(
+        &authority_state,
+        &consensus_adapter,
+        &metrics,
+        &epoch_store,
+        &soft_locks,
+        tx,
+    )
+    .await;
+
+    assert!(
+        matches!(update, TxStatusUpdate::Submitted),
+        "expected Submitted, got {update:?}",
+    );
+
+    // Assert the consensus message is UserTransactionV2 with Validator attestation.
+    let consensus_tx = rx
+        .recv()
+        .await
+        .expect("consensus message should have been captured");
+    let ConsensusTransactionKind::UserTransactionV2(attested) = consensus_tx.kind else {
+        panic!(
+            "expected UserTransactionV2, got {:?}",
+            consensus_tx.kind
+        );
+    };
+    let Attestation::Validator { attestor_index, .. } = &attested.attestation else {
+        panic!(
+            "expected Attestation::Validator, got {:?}",
+            attested.attestation
+        );
+    };
+
+    // The attestor_index must match this validator's position in the consensus
+    // committee — mirrors the lookup performed in submit_single_tx.
+    let expected_index = epoch_store
+        .committee()
+        .names()
+        .position(|n| n == &authority_state.name)
+        .and_then(|i| {
+            epoch_store
+                .epoch_start_state()
+                .get_consensus_committee()
+                .to_authority_index(i)
+        })
+        .expect("authority must be present in the consensus committee");
+    assert_eq!(*attestor_index, expected_index);
+}

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -403,7 +403,8 @@ mod tests {
             let (effects, _) = self.authority.try_execute_immediately(
                 &VerifiedExecutableTransaction::new_from_certificate(
                     VerifiedCertificate::new_unchecked(request.certificate),
-                ),
+                )
+                .into(),
                 None,
                 &epoch_store,
             )?;

--- a/crates/iota-e2e-tests/tests/attestation_tests.rs
+++ b/crates/iota-e2e-tests/tests/attestation_tests.rs
@@ -137,9 +137,155 @@ async fn test_aa_tx_accepted_via_v2_attestation_path() -> Result<(), anyhow::Err
     Ok(())
 }
 
+/// An AA transaction whose Move authentication fails (here: a wrong ed25519
+/// signature) must be DROPPED by the attestor — never attested, so it can never
+/// be sequenced or charged.
+#[sim_test]
+async fn test_aa_tx_with_failed_authentication_is_dropped() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let _env = enable_attestation_env();
+
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20_000_000_000), aa_sender)
+        .await;
+
+    let pt = test_env.craft_aa_simple_ptb()?;
+    let tx_data = test_env.craft_tx_from_pt(pt, aa_gas, aa_sender).await?;
+    let tx_digest = tx_data.digest().into_inner();
+
+    // Attach a Move authenticator that signs a tampered digest, so the in-VM
+    // ed25519 verification in `authenticate_ed25519` aborts: the authentication
+    // phase fails.
+    let signatures = vec![test_env.create_bad_move_authenticator_for_ed25519(&tx_digest)?];
+    let aa_tx = Transaction::from_generic_sig_data(tx_data, signatures);
+
+    match test_env.submit_tx_v2(aa_tx).await {
+        Ok(results) => {
+            assert!(!results.is_empty(), "expected at least one status update");
+            let (_, status) = &results[0];
+            assert!(
+                matches!(status, TxStatusUpdate::Rejected { .. }),
+                "auth-failing AA tx must be rejected by the attestor, got: {status:?}"
+            );
+        }
+        // A validator/transport-level error is also an acceptable outcome: the
+        // transaction was not attested or accepted.
+        Err(e) => {
+            tracing::info!("auth-failing AA tx submission errored as expected: {e:?}");
+        }
+    }
+
+    Ok(())
+}
+
+/// An AA transaction whose Move authentication SUCCEEDS but whose transaction
+/// body aborts must still be attested (status `Submitted`/`Executed`).
+#[sim_test]
+async fn test_aa_tx_with_body_abort_is_attested() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let _env = enable_attestation_env();
+
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20_000_000_000), aa_sender)
+        .await;
+
+    let pt = test_env.craft_aa_double_add_ptb()?;
+    let tx_data = test_env.craft_tx_from_pt(pt, aa_gas, aa_sender).await?;
+    let tx_digest = tx_data.digest().into_inner();
+
+    // Correct signature: the authentication phase succeeds; only the body aborts.
+    let signatures = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest)?];
+    let aa_tx = Transaction::from_generic_sig_data(tx_data, signatures);
+
+    let results = test_env.submit_tx_v2(aa_tx).await?;
+    assert!(!results.is_empty(), "expected at least one status update");
+    let (_, status) = &results[0];
+    assert!(
+        matches!(
+            status,
+            TxStatusUpdate::Submitted | TxStatusUpdate::Executed { .. }
+        ),
+        "AA tx with successful auth but a body abort must still be attested, got: {status:?}"
+    );
+
+    Ok(())
+}
+
+/// A normal (non-abstract-account) transaction whose body aborts must be
+/// attested too. Here a normal owner-signed tx calls `add_field` on the shared
+/// AA object; `ensure_tx_sender_is_account` aborts because the sender is the
+/// owner, not the account.
+#[sim_test]
+async fn test_normal_tx_with_body_abort_is_attested() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let _env = enable_attestation_env();
+
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519)
+        .await?;
+
+    // Build a normal transaction (no Move authenticator) signed by the owner.
+    let pt = test_env.craft_aa_simple_ptb()?;
+    let tx_data = test_env
+        .test_cluster
+        .test_transaction_builder()
+        .await
+        .programmable(pt)
+        .build();
+    let normal_tx = test_env.test_cluster.wallet.sign_transaction(&tx_data);
+
+    let results = test_env.submit_tx_v2(normal_tx).await?;
+    assert!(!results.is_empty(), "expected at least one status update");
+    let (_, status) = &results[0];
+    assert!(
+        matches!(
+            status,
+            TxStatusUpdate::Submitted | TxStatusUpdate::Executed { .. }
+        ),
+        "normal tx with a body abort must still be attested, got: {status:?}"
+    );
+
+    Ok(())
+}
+
 // --------------------------------------------------
 // --- Protocol config env override RAII guard ------
 // --------------------------------------------------
+
+/// Enable white-flag flow and validator attestation for every node. Must be
+/// called BEFORE `TestClusterBuilder::build()` spawns node threads.
+fn enable_attestation_env() -> ProtocolEnvOverride {
+    ProtocolEnvOverride::new(&[
+        ("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE", "1"),
+        (
+            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_WHITE_FLAG_FLOW",
+            "true",
+        ),
+        (
+            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_VALIDATOR_ATTESTATION",
+            "true",
+        ),
+    ])
+}
 
 /// Sets process-wide environment variables on construction, restores them (by
 /// removing them) on drop.  Must be constructed **before**
@@ -348,6 +494,38 @@ impl TestEnvironment {
         Ok(builder.finish())
     }
 
+    /// A PTB that adds the same dynamic field key twice, so the second
+    /// `add_field` aborts in the transaction body (the auth phase, if present,
+    /// is unaffected).
+    fn craft_aa_double_add_ptb(&self) -> anyhow::Result<ProgrammableTransaction> {
+        let (Some(aa_ref), Some(aa_package_id)) = (self.aa_ref, self.aa_package_id) else {
+            anyhow::bail!("Abstract account not set up yet");
+        };
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let aa_arg = builder.obj(CallArg::Shared(SharedObjectRef {
+            object_id: aa_ref.object_id,
+            initial_shared_version: aa_ref.version,
+            mutable: true,
+        }))?;
+        let type_args = vec![
+            iota_types::base_types::TypeTag::U8,
+            iota_types::base_types::TypeTag::U8,
+        ];
+        for value in [2_u8, 3_u8] {
+            // Same key (1u8) both times; the second `dynamic_field::add` aborts.
+            let key = builder.pure(1_u8)?;
+            let val = builder.pure(value)?;
+            builder.programmable_move_call(
+                aa_package_id,
+                Identifier::from_static(AA_MODULE_NAME),
+                Identifier::from_static("add_field"),
+                type_args.clone(),
+                vec![aa_arg, key, val],
+            );
+        }
+        Ok(builder.finish())
+    }
+
     async fn craft_tx_from_pt(
         &self,
         pt: ProgrammableTransaction,
@@ -393,6 +571,18 @@ impl TestEnvironment {
         Ok(GenericSignature::MoveAuthenticator(
             MoveAuthenticator::new_v1(vec![signature_call_arg], vec![], self_call_arg),
         ))
+    }
+
+    /// Like [`Self::create_move_authenticator_for_ed25519`], but signs a
+    /// *tampered* digest so the in-VM ed25519 verification fails — the
+    /// authentication phase aborts.
+    fn create_bad_move_authenticator_for_ed25519(
+        &self,
+        tx_digest: &[u8; 32],
+    ) -> anyhow::Result<GenericSignature> {
+        let mut tampered = *tx_digest;
+        tampered[0] ^= 0xff;
+        self.create_move_authenticator_for_ed25519(&tampered)
     }
 
     /// Submit a transaction via the V2 gRPC path on the first available

--- a/crates/iota-e2e-tests/tests/attestation_tests.rs
+++ b/crates/iota-e2e-tests/tests/attestation_tests.rs
@@ -1,0 +1,445 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for the validator attestation path (Phase 1).
+//!
+//! These tests exercise the V2 transaction submission pathway
+//! (`ValidatorV2API::submit_tx`) with both `enable_white_flag_flow` and
+//! `enable_validator_attestation` protocol flags enabled.  The Move abstract
+//! account setup is reused from `abstract_account_tests` so the attestor
+//! dry-run runs `authenticate_then_execute_transaction_to_effects`, which is
+//! the more interesting branch of `attest_transaction`.
+//!
+//! # Protocol config propagation
+//!
+//! `ProtocolConfig::apply_overrides_for_testing` is thread-local and does not
+//! reach validator nodes, which run in separate OS threads (see
+//! `iota-swarm/src/memory/container.rs`).  We therefore rely on the
+//! `IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE` / serde-env mechanism, which is
+//! process-wide and readable by every thread.  See `ProtocolEnvOverride`.
+//!
+//! # Authority aggregator access when WFF is enabled
+//!
+//! When `enable_white_flag_flow` is `true`, `TransactionOrchestrator` stores
+//! the aggregator in `TransactionDriver`, not in `QuorumDriverHandler`.
+//! `TestCluster::authority_aggregator()` panics in this configuration because
+//! it always goes through `quorum_driver()`.  We therefore reach the
+//! aggregator via `transaction_driver()` in `submit_tx_v2`.
+//!
+//! For the same reason, setup transactions must go through the wallet JSON-RPC
+//! path (`test_cluster.execute_transaction`) rather than
+//! `execute_transaction_return_raw_effects`, which internally calls
+//! `authority_aggregator()`.
+
+use std::net::SocketAddr;
+
+use fastcrypto::{
+    ed25519::Ed25519Signature,
+    encoding::{Encoding, Hex},
+    traits::Authenticator,
+};
+use iota_core::authority_client::validator_v2::ValidatorV2API;
+use iota_json_rpc_types::ObjectChange;
+use iota_keys::keystore::AccountKeystore;
+use iota_macros::sim_test;
+use iota_test_transaction_builder::publish_package;
+use iota_types::{
+    IOTA_FRAMEWORK_PACKAGE_ID,
+    base_types::{Identifier, IotaAddress, ObjectID, ObjectRef},
+    messages_grpc::TxStatusUpdate,
+    move_authenticator::MoveAuthenticator,
+    move_package,
+    object::Owner,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    signature::GenericSignature,
+    transaction::{
+        Argument, CallArg, ProgrammableTransaction, SharedObjectRef,
+        TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, Transaction, TransactionData,
+    },
+};
+use test_cluster::{TestCluster, TestClusterBuilder};
+
+const AA_PACKAGE_PATH: &str = "tests/abstract_account/abstract_account";
+const AA_MODULE_NAME: &str = "abstract_account";
+const AA_ACCOUNT_NAME: &str = "AbstractAccount";
+const AA_CREATE_MODULE_NAME: &str = "abstract_account_keyed";
+const AA_AUTHENTICATE_MODULE_NAME: &str = "abstract_account_keyed";
+const AA_AUTHENTICATE_FN_NAME_ED25519: &str = "authenticate_ed25519";
+
+// ------------------------------------------
+// --- Attestation end-to-end tests ---------
+// ------------------------------------------
+
+/// An AA transaction submitted via the V2 gRPC path with both
+/// `enable_white_flag_flow` and `enable_validator_attestation` enabled must be
+/// attested and accepted (status `Submitted` or `Executed`).
+///
+/// The MoveAuthenticator path is exercised deliberately because the attestor
+/// dry-run takes the `authenticate_then_execute_transaction_to_effects` branch
+/// of `attest_transaction`, which is the more interesting code path.
+#[sim_test]
+async fn test_aa_tx_accepted_via_v2_attestation_path() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+
+    // Enable white-flag flow and validator attestation for every node.
+    // Must be set BEFORE TestClusterBuilder::build() spawns node threads.
+    let _env = ProtocolEnvOverride::new(&[
+        ("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE", "1"),
+        (
+            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_WHITE_FLAG_FLOW",
+            "true",
+        ),
+        (
+            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_VALIDATOR_ATTESTATION",
+            "true",
+        ),
+    ]);
+
+    // Build a test environment and create an abstract account.
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    // Fund the AA with gas.
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20_000_000_000), aa_sender)
+        .await;
+
+    // Build a simple AA transaction.
+    let pt = test_env.craft_aa_simple_ptb()?;
+    let tx_data = test_env.craft_tx_from_pt(pt, aa_gas, aa_sender).await?;
+    let tx_digest = tx_data.digest().into_inner();
+
+    let signatures = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest)?];
+    let aa_tx = Transaction::from_generic_sig_data(tx_data, signatures);
+
+    // Submit via the V2 attestation path.
+    let results = test_env.submit_tx_v2(aa_tx).await?;
+
+    assert!(
+        !results.is_empty(),
+        "Expected at least one status update from the V2 submit path"
+    );
+    let (_, status) = &results[0];
+    assert!(
+        matches!(
+            status,
+            TxStatusUpdate::Submitted | TxStatusUpdate::Executed { .. }
+        ),
+        "Expected Submitted or Executed from V2 path, got: {status:?}"
+    );
+
+    Ok(())
+}
+
+// --------------------------------------------------
+// --- Protocol config env override RAII guard ------
+// --------------------------------------------------
+
+/// Sets process-wide environment variables on construction, restores them (by
+/// removing them) on drop.  Must be constructed **before**
+/// `TestClusterBuilder::build()` so that validator node threads inherit the
+/// values when they call `ProtocolConfig::get_for_version`.
+struct ProtocolEnvOverride {
+    keys: Vec<&'static str>,
+}
+
+impl ProtocolEnvOverride {
+    fn new(overrides: &[(&'static str, &'static str)]) -> Self {
+        for (key, val) in overrides {
+            // Set before any node thread is spawned; no concurrent env readers at this point.
+            #[allow(deprecated)]
+            std::env::set_var(key, val);
+        }
+        Self {
+            keys: overrides.iter().map(|(k, _)| *k).collect(),
+        }
+    }
+}
+
+impl Drop for ProtocolEnvOverride {
+    fn drop(&mut self) {
+        for key in &self.keys {
+            #[allow(deprecated)]
+            std::env::remove_var(key);
+        }
+    }
+}
+
+// --------------------------------------------------
+// --- Minimal test environment ---------------------
+// --------------------------------------------------
+
+struct TestEnvironment {
+    test_cluster: TestCluster,
+    owner: Option<IotaAddress>,
+    aa_package_id: Option<ObjectID>,
+    aa_package_metadata_ref: Option<ObjectRef>,
+    aa_ref: Option<ObjectRef>,
+}
+
+impl TestEnvironment {
+    async fn new() -> Self {
+        let test_cluster = TestClusterBuilder::new().build().await;
+        Self {
+            test_cluster,
+            owner: None,
+            aa_package_id: None,
+            aa_package_metadata_ref: None,
+            aa_ref: None,
+        }
+    }
+
+    async fn setup_abstract_account(
+        &mut self,
+        authenticate_fn_name: &str,
+    ) -> Result<(), anyhow::Error> {
+        self.owner = Some(
+            self.test_cluster
+                .wallet
+                .config()
+                .keystore()
+                .addresses()
+                .first()
+                .cloned()
+                .unwrap(),
+        );
+
+        let path = [env!("CARGO_MANIFEST_DIR"), AA_PACKAGE_PATH]
+            .iter()
+            .collect();
+        let aa_package_id = publish_package(self.test_cluster.wallet(), path)
+            .await
+            .object_id;
+        let aa_package_metadata_id = move_package::derive_package_metadata_id(aa_package_id);
+        let aa_package_metadata_ref = self
+            .test_cluster
+            .get_latest_object_ref(&aa_package_metadata_id)
+            .await;
+
+        self.aa_package_id = Some(aa_package_id);
+        self.aa_package_metadata_ref = Some(aa_package_metadata_ref);
+
+        let transaction = self
+            .craft_create_abstract_account(authenticate_fn_name)
+            .await?;
+
+        // Use the wallet JSON-RPC path so we don't call authority_aggregator(),
+        // which panics when white-flag flow is active (QuorumDriverHandler is None).
+        let response = self.test_cluster.execute_transaction(transaction).await;
+
+        self.aa_ref = response
+            .object_changes
+            .as_ref()
+            .expect("object_changes must be populated")
+            .iter()
+            .find_map(|change| {
+                if let ObjectChange::Created {
+                    object_id,
+                    version,
+                    digest,
+                    owner: Owner::Shared { .. },
+                    ..
+                } = change
+                {
+                    Some(iota_types::base_types::ObjectRef::new(
+                        *object_id,
+                        *version,
+                        *digest,
+                    ))
+                } else {
+                    None
+                }
+            });
+
+        assert!(
+            self.aa_ref.is_some(),
+            "Abstract account creation did not produce a shared object"
+        );
+        Ok(())
+    }
+
+    async fn craft_create_abstract_account(
+        &self,
+        authenticate_fn_name: &str,
+    ) -> anyhow::Result<Transaction> {
+        let (Some(owner), Some(aa_package_id), Some(aa_package_metadata_ref)) =
+            (self.owner, self.aa_package_id, self.aa_package_metadata_ref)
+        else {
+            anyhow::bail!("setup_abstract_account must be called first");
+        };
+
+        let aa_owner_pk = self
+            .test_cluster
+            .wallet
+            .config()
+            .keystore()
+            .get_key(&owner)?
+            .public();
+
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+
+            let arguments = vec![
+                builder.obj(CallArg::ImmutableOrOwned(aa_package_metadata_ref))?,
+                builder.pure(AA_AUTHENTICATE_MODULE_NAME)?,
+                builder.pure(authenticate_fn_name)?,
+            ];
+            if let Argument::Result(auth_fn_ref) = builder.programmable_move_call(
+                IOTA_FRAMEWORK_PACKAGE_ID,
+                Identifier::from_static("authenticator_function"),
+                Identifier::from_static("create_auth_function_ref_v1"),
+                vec![abstract_account_type_tag(&aa_package_id)],
+                arguments,
+            ) {
+                let arguments = vec![
+                    builder.pure(aa_owner_pk.as_ref())?,
+                    Argument::Result(auth_fn_ref),
+                ];
+                builder.programmable_move_call(
+                    aa_package_id,
+                    Identifier::from_static(AA_CREATE_MODULE_NAME),
+                    Identifier::from_static("create"),
+                    vec![],
+                    arguments,
+                );
+            }
+            builder.finish()
+        };
+
+        let tx_data = self
+            .test_cluster
+            .test_transaction_builder()
+            .await
+            .programmable(pt)
+            .build();
+
+        Ok(self.test_cluster.wallet.sign_transaction(&tx_data))
+    }
+
+    fn craft_aa_simple_ptb(&self) -> anyhow::Result<ProgrammableTransaction> {
+        let (Some(aa_ref), Some(aa_package_id)) = (self.aa_ref, self.aa_package_id) else {
+            anyhow::bail!("Abstract account not set up yet");
+        };
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let arguments = vec![
+            builder.obj(CallArg::Shared(SharedObjectRef {
+                object_id: aa_ref.object_id,
+                initial_shared_version: aa_ref.version,
+                mutable: true,
+            }))?,
+            builder.pure(1_u8)?,
+            builder.pure(2_u8)?,
+        ];
+        builder.programmable_move_call(
+            aa_package_id,
+            Identifier::from_static(AA_MODULE_NAME),
+            Identifier::from_static("add_field"),
+            vec![
+                iota_types::base_types::TypeTag::U8,
+                iota_types::base_types::TypeTag::U8,
+            ],
+            arguments,
+        );
+        Ok(builder.finish())
+    }
+
+    async fn craft_tx_from_pt(
+        &self,
+        pt: ProgrammableTransaction,
+        gas_coin: ObjectRef,
+        sender: IotaAddress,
+    ) -> anyhow::Result<TransactionData> {
+        let gas_price = self.test_cluster.get_reference_gas_price().await;
+        Ok(TransactionData::new_programmable_allow_sponsor(
+            sender,
+            vec![gas_coin],
+            pt,
+            gas_price * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
+            gas_price,
+            sender,
+        ))
+    }
+
+    fn create_move_authenticator_for_ed25519(
+        &self,
+        tx_digest: &[u8; 32],
+    ) -> anyhow::Result<GenericSignature> {
+        let (Some(aa_ref), Some(owner)) = (self.aa_ref, self.owner) else {
+            anyhow::bail!("Abstract account not set up yet");
+        };
+        let signature = self
+            .test_cluster
+            .wallet
+            .config()
+            .keystore()
+            .sign_hashed(&owner, tx_digest)?;
+
+        let hex_encoded_signature: String = Hex::encode(&signature)
+            .chars()
+            .skip(2)
+            .take(Ed25519Signature::LENGTH * 2)
+            .collect();
+        let self_call_arg = CallArg::Shared(SharedObjectRef {
+            object_id: aa_ref.object_id,
+            initial_shared_version: aa_ref.version,
+            mutable: false,
+        });
+        let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
+        Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_v1(vec![signature_call_arg], vec![], self_call_arg),
+        ))
+    }
+
+    /// Submit a transaction via the V2 gRPC path on the first available
+    /// validator.
+    ///
+    /// When `enable_white_flag_flow` is on, `TransactionOrchestrator` stores
+    /// the aggregator in `TransactionDriver` (not `QuorumDriverHandler`).
+    /// We select the right source at runtime.
+    async fn submit_tx_v2(
+        &self,
+        tx: Transaction,
+    ) -> Result<
+        Vec<(iota_types::digests::TransactionDigest, TxStatusUpdate)>,
+        iota_types::error::IotaError,
+    > {
+        let client = self.test_cluster.fullnode_handle.iota_node.with(|node| {
+            let orchestrator = node
+                .transaction_orchestrator()
+                .expect("TransactionOrchestrator not initialised on fullnode");
+
+            // When WFF is enabled TransactionDriver holds the aggregator;
+            // QuorumDriverHandler is None and clone_authority_aggregator() would panic.
+            let agg = if let Some(td) = orchestrator.transaction_driver() {
+                td.authority_aggregator().load_full()
+            } else {
+                orchestrator.clone_authority_aggregator()
+            };
+
+            agg.authority_clients
+                .values()
+                .next()
+                .expect("No authority clients")
+                .authority_client()
+                .clone()
+        });
+
+        client
+            .submit_tx(vec![tx], Some(SocketAddr::new([127, 0, 0, 1].into(), 0)))
+            .await
+    }
+}
+
+fn abstract_account_type_tag(aa_package_id: &ObjectID) -> iota_types::base_types::TypeTag {
+    use std::str::FromStr;
+    iota_types::base_types::TypeTag::from_str(
+        &format!("{aa_package_id}::{AA_MODULE_NAME}::{AA_ACCOUNT_NAME}"),
+    )
+    .unwrap()
+}

--- a/crates/iota-e2e-tests/tests/attestation_tests.rs
+++ b/crates/iota-e2e-tests/tests/attestation_tests.rs
@@ -152,7 +152,8 @@ struct ProtocolEnvOverride {
 impl ProtocolEnvOverride {
     fn new(overrides: &[(&'static str, &'static str)]) -> Self {
         for (key, val) in overrides {
-            // Set before any node thread is spawned; no concurrent env readers at this point.
+            // Set before any node thread is spawned; no concurrent env readers at this
+            // point.
             #[allow(deprecated)]
             std::env::set_var(key, val);
         }
@@ -248,9 +249,7 @@ impl TestEnvironment {
                 } = change
                 {
                     Some(iota_types::base_types::ObjectRef::new(
-                        *object_id,
-                        *version,
-                        *digest,
+                        *object_id, *version, *digest,
                     ))
                 } else {
                     None
@@ -438,8 +437,8 @@ impl TestEnvironment {
 
 fn abstract_account_type_tag(aa_package_id: &ObjectID) -> iota_types::base_types::TypeTag {
     use std::str::FromStr;
-    iota_types::base_types::TypeTag::from_str(
-        &format!("{aa_package_id}::{AA_MODULE_NAME}::{AA_ACCOUNT_NAME}"),
-    )
+    iota_types::base_types::TypeTag::from_str(&format!(
+        "{aa_package_id}::{AA_MODULE_NAME}::{AA_ACCOUNT_NAME}"
+    ))
     .unwrap()
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2078,7 +2078,7 @@ impl IotaNode {
                 ),
             );
         state
-            .try_execute_immediately(&transaction, None, epoch_store)
+            .try_execute_immediately(&transaction.into(), None, epoch_store)
             .unwrap();
     }
 

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1323,6 +1323,7 @@
                 "enable_move_authentication": false,
                 "enable_move_authentication_for_sponsor": false,
                 "enable_poseidon": true,
+                "enable_validator_attestation": false,
                 "enable_vdf": true,
                 "enable_white_flag_flow": false,
                 "hardened_otw_check": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 26;
+pub const MAX_PROTOCOL_VERSION: u64 = 25;
 
 /// Protocol version that IIP8 took effect.
 pub const PROTOCOL_VERSION_IIP8: u64 = 20;
@@ -141,7 +141,6 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             Enable additional borrow checks.
 // Version 25: Deprecate zkLogin related parameters since zkLogin is no longer
 //             supported.
-// Version 26: Enable white flag flow and validator attestation in devnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2787,14 +2786,6 @@ impl ProtocolConfig {
                     cfg.max_jwk_votes_per_validator_per_epoch = None;
                     cfg.max_age_of_jwk_in_epochs = None;
                 }
-                26 => {
-                    if chain != Chain::Testnet && chain != Chain::Mainnet {
-                        // Enable white flag flow and validator attestation in devnet.
-                        cfg.feature_flags.enable_white_flag_flow = true;
-                        cfg.feature_flags.enable_validator_attestation = true;
-                    }
-                }
-
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -3015,6 +3015,10 @@ impl ProtocolConfig {
     pub fn set_enable_white_flag_flow_for_testing(&mut self, val: bool) {
         self.feature_flags.enable_white_flag_flow = val;
     }
+
+    pub fn set_enable_validator_attestation_for_testing(&mut self, val: bool) {
+        self.feature_flags.enable_validator_attestation = val;
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send + Sync;

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 25;
+pub const MAX_PROTOCOL_VERSION: u64 = 26;
 
 /// Protocol version that IIP8 took effect.
 pub const PROTOCOL_VERSION_IIP8: u64 = 20;
@@ -141,6 +141,7 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             Enable additional borrow checks.
 // Version 25: Deprecate zkLogin related parameters since zkLogin is no longer
 //             supported.
+// Version 26: Enable white flag flow and validator attestation in devnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -1695,7 +1696,12 @@ impl ProtocolConfig {
     }
 
     pub fn enable_validator_attestation(&self) -> bool {
-        self.feature_flags.enable_white_flag_flow && self.feature_flags.enable_validator_attestation
+        let res = self.feature_flags.enable_validator_attestation;
+        assert!(
+            !res || self.enable_white_flag_flow(),
+            "enable_validator_attestation requires enable_white_flag_flow to be set"
+        );
+        res
     }
 }
 
@@ -2780,6 +2786,13 @@ impl ProtocolConfig {
                     cfg.check_zklogin_issuer_cost_base = None;
                     cfg.max_jwk_votes_per_validator_per_epoch = None;
                     cfg.max_age_of_jwk_in_epochs = None;
+                }
+                26 => {
+                    if chain != Chain::Testnet && chain != Chain::Mainnet {
+                        // Enable white flag flow and validator attestation in devnet.
+                        cfg.feature_flags.enable_white_flag_flow = true;
+                        cfg.feature_flags.enable_validator_attestation = true;
+                    }
                 }
 
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -485,6 +485,13 @@ struct FeatureFlags {
     // Conflicts are resolved deterministically post-consensus using persistent locks.
     #[serde(skip_serializing_if = "is_false")]
     enable_white_flag_flow: bool,
+
+    // If true, the block-proposing validator attests each received user transaction
+    // before sending it to consensus. The attestor certifies that Move authentication
+    // passed and the attestation carries a computation cost estimate for
+    // shared-object scheduling.
+    #[serde(skip_serializing_if = "is_false")]
+    enable_validator_attestation: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1685,6 +1692,10 @@ impl ProtocolConfig {
 
     pub fn enable_white_flag_flow(&self) -> bool {
         self.feature_flags.enable_white_flag_flow
+    }
+
+    pub fn enable_validator_attestation(&self) -> bool {
+        self.feature_flags.enable_validator_attestation
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1695,7 +1695,7 @@ impl ProtocolConfig {
     }
 
     pub fn enable_validator_attestation(&self) -> bool {
-        self.feature_flags.enable_validator_attestation
+        self.feature_flags.enable_white_flag_flow && self.feature_flags.enable_validator_attestation
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -524,8 +524,9 @@ impl ConsensusTransactionOrdering {
 pub enum PerObjectCongestionControlMode {
     #[default]
     None, // No congestion control.
-    TotalGasBudget, // Use txn gas budget as execution cost.
-    TotalTxCount,   // Use total txn count as execution cost.
+    TotalGasBudget,        // Use txn gas budget as execution cost.
+    TotalTxCount,          // Use total txn count as execution cost.
+    TotalComputationUnits, // Use attested computation units as execution cost.
 }
 
 impl PerObjectCongestionControlMode {
@@ -1400,6 +1401,12 @@ impl ProtocolConfig {
     }
 
     pub fn per_object_congestion_control_mode(&self) -> PerObjectCongestionControlMode {
+        // TODO(attestation): Once `enable_validator_attestation` is set in a version
+        // arm, set `per_object_congestion_control_mode = TotalComputationUnits`
+        // there too and revert this to a plain getter.
+        if self.enable_validator_attestation() {
+            return PerObjectCongestionControlMode::TotalComputationUnits;
+        }
         self.feature_flags.per_object_congestion_control_mode
     }
 

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -863,25 +863,29 @@ impl LocalExec {
                 )
                 .collect::<Result<Vec<_>, ReplayEngineError>>()?;
 
-            executor.authenticate_then_execute_transaction_to_effects(
-                &self,
-                protocol_config,
-                metrics.clone(),
-                expensive_checks,
-                &certificate_deny_set,
-                &tx_info.executed_epoch,
-                tx_info.epoch_start_timestamp,
-                gas_data,
-                gas_status,
-                move_authenticators,
-                CheckedInputObjects::new_for_replay(input_objects.clone()),
-                transaction_kind.clone(),
-                tx_info.sender,
-                *tx_digest,
-                bcs::to_bytes(tx_info.sender_signed_data.transaction_data())
-                    .expect("TransactionData serialization cannot fail"),
-                &mut None,
-            )
+            // The authentication-failed flag is only used by the validator attestor's
+            // admission decision; replay must reproduce effects regardless, so drop it.
+            let (inner_store, gas_status, effects, result, _authentication_failed) = executor
+                .authenticate_then_execute_transaction_to_effects(
+                    &self,
+                    protocol_config,
+                    metrics.clone(),
+                    expensive_checks,
+                    &certificate_deny_set,
+                    &tx_info.executed_epoch,
+                    tx_info.epoch_start_timestamp,
+                    gas_data,
+                    gas_status,
+                    move_authenticators,
+                    CheckedInputObjects::new_for_replay(input_objects.clone()),
+                    transaction_kind.clone(),
+                    tx_info.sender,
+                    *tx_digest,
+                    bcs::to_bytes(tx_info.sender_signed_data.transaction_data())
+                        .expect("TransactionData serialization cannot fail"),
+                    &mut None,
+                );
+            (inner_store, gas_status, effects, result)
         };
 
         if let Err(err) = self.pretty_print_for_tracing(
@@ -1158,25 +1162,29 @@ impl LocalExec {
                 .collect::<Vec<_>>();
 
             let (kind, signer, gas_data) = executable.transaction_data().execution_parts();
-            executor.authenticate_then_execute_transaction_to_effects(
-                &store,
-                &protocol_config,
-                Arc::new(LimitsMetrics::new(&Registry::new())),
-                true,
-                &HashSet::new(),
-                &executed_epoch,
-                epoch_start_timestamp,
-                gas_data,
-                gas_status,
-                move_authenticators,
-                union_checked_input_objects,
-                kind,
-                signer,
-                *executable.digest(),
-                bcs::to_bytes(sender_signed_data.transaction_data())
-                    .expect("TransactionData serialization cannot fail"),
-                &mut None,
-            )
+            // The authentication-failed flag is only used by the validator attestor's
+            // admission decision; replay must reproduce effects regardless, so drop it.
+            let (inner_store, gas_status, effects, exec_res, _authentication_failed) = executor
+                .authenticate_then_execute_transaction_to_effects(
+                    &store,
+                    &protocol_config,
+                    Arc::new(LimitsMetrics::new(&Registry::new())),
+                    true,
+                    &HashSet::new(),
+                    &executed_epoch,
+                    epoch_start_timestamp,
+                    gas_data,
+                    gas_status,
+                    move_authenticators,
+                    union_checked_input_objects,
+                    kind,
+                    signer,
+                    *executable.digest(),
+                    bcs::to_bytes(sender_signed_data.transaction_data())
+                        .expect("TransactionData serialization cannot fail"),
+                    &mut None,
+                );
+            (inner_store, gas_status, effects, exec_res)
         };
 
         let effects =

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -125,7 +125,7 @@ impl SingleValidator {
         );
         let effects = self
             .get_validator()
-            .try_execute_immediately(&executable, None, &self.epoch_store)
+            .try_execute_immediately(&executable.into(), None, &self.epoch_store)
             .unwrap()
             .0;
         assert!(effects.status().is_success());
@@ -156,7 +156,7 @@ impl SingleValidator {
                     VerifiedCertificate::new_unchecked(cert),
                 );
                 self.get_validator()
-                    .try_execute_immediately(&cert, None, &self.epoch_store)
+                    .try_execute_immediately(&cert.into(), None, &self.epoch_store)
                     .unwrap()
                     .0
             }

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -81,6 +81,7 @@ mod checked {
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
         authentication_gas_budget: u64,
+        is_execute_transaction_to_effects: bool,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_status = check_transaction_input_inner(
             protocol_config,
@@ -89,7 +90,7 @@ mod checked {
             &input_objects,
             &[],
             authentication_gas_budget,
-            false,
+            is_execute_transaction_to_effects,
         )?;
         check_receiving_objects(&input_objects, receiving_objects)?;
         // Runs verifier, which could be expensive.

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -238,18 +238,8 @@ mod checked {
         Ok(aggregated_authenticator_input_objects)
     }
 
-    /// A function to check the `MoveAuthenticator` inputs for execution and
-    /// then for certificate execution.
-    /// To be used instead of check_certificate_input when there is a Move
-    /// authenticator present.
-    ///
-    /// Checks that there is enough gas to pay for the authenticator and
-    /// transaction execution in the transaction inputs. And that the
-    /// authenticator inputs meet the requirements.
-    /// It returns the gas status, the checked authenticator input objects, and
-    /// the union of the checked authenticator input objects and transaction
-    /// input objects.
-    #[instrument(level = "trace", skip_all)]
+    /// Thin wrapper over [`check_transaction_and_move_authenticator_input`] for
+    /// callers that hold a [`VerifiedExecutableTransaction`].
     pub fn check_certificate_and_move_authenticator_input(
         cert: &VerifiedExecutableTransaction,
         tx_input_objects: InputObjects,
@@ -258,46 +248,19 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
     ) -> IotaResult<(IotaGasStatus, Vec<CheckedInputObjects>, CheckedInputObjects)> {
-        // Check Move authenticator inputs first
-        per_authenticator_input_objects
-            .iter()
-            .try_for_each(check_move_authenticator_objects)?;
-
-        // Check certificate inputs next
-        let transaction = cert.data().transaction_data();
-        let gas_status = check_transaction_input_inner(
+        check_transaction_and_move_authenticator_input(
+            cert.data().transaction_data(),
+            tx_input_objects,
+            per_authenticator_input_objects,
+            authenticator_gas_budget,
             protocol_config,
             reference_gas_price,
-            transaction,
-            &tx_input_objects,
-            &[],
-            authenticator_gas_budget,
-            true,
-        )?;
-
-        let per_authenticator_checked_input_objects = per_authenticator_input_objects
-            .into_iter()
-            .map(|objects| objects.into_checked())
-            .collect::<Vec<_>>();
-
-        // Create a checked union of input objects
-        let mut input_objects_union = tx_input_objects.into_checked();
-        for objects in per_authenticator_checked_input_objects.iter() {
-            input_objects_union = checked_input_objects_union(input_objects_union, objects)?;
-        }
-
-        Ok((
-            gas_status,
-            per_authenticator_checked_input_objects,
-            input_objects_union,
-        ))
+        )
     }
 
-    /// Variant of [`check_certificate_and_move_authenticator_input`] for use
-    /// before consensus (attestation path), where a full
-    /// [`VerifiedExecutableTransaction`] is not yet available. Produces an
-    /// execution-mode gas status (full `transaction_gas_budget`, not the
-    /// reduced signing-time auth budget).
+    /// Checks transaction and Move-authenticator inputs, returning an
+    /// execution-mode gas status plus the checked input objects.
+    #[instrument(level = "trace", skip_all)]
     pub fn check_transaction_and_move_authenticator_input(
         transaction: &TransactionData,
         tx_input_objects: InputObjects,
@@ -306,10 +269,12 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
     ) -> IotaResult<(IotaGasStatus, Vec<CheckedInputObjects>, CheckedInputObjects)> {
+        // Check Move authenticator inputs first.
         per_authenticator_input_objects
             .iter()
             .try_for_each(check_move_authenticator_objects)?;
 
+        // Check transaction inputs next.
         let gas_status = check_transaction_input_inner(
             protocol_config,
             reference_gas_price,
@@ -325,6 +290,7 @@ mod checked {
             .map(|objects| objects.into_checked())
             .collect::<Vec<_>>();
 
+        // Create a checked union of input objects.
         let mut input_objects_union = tx_input_objects.into_checked();
         for objects in per_authenticator_checked_input_objects.iter() {
             input_objects_union = checked_input_objects_union(input_objects_union, objects)?;

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -293,6 +293,50 @@ mod checked {
         ))
     }
 
+    /// Variant of [`check_certificate_and_move_authenticator_input`] for use
+    /// before consensus (attestation path), where a full
+    /// [`VerifiedExecutableTransaction`] is not yet available. Produces an
+    /// execution-mode gas status (full `transaction_gas_budget`, not the
+    /// reduced signing-time auth budget).
+    pub fn check_transaction_and_move_authenticator_input(
+        transaction: &TransactionData,
+        tx_input_objects: InputObjects,
+        per_authenticator_input_objects: Vec<InputObjects>,
+        authenticator_gas_budget: u64,
+        protocol_config: &ProtocolConfig,
+        reference_gas_price: u64,
+    ) -> IotaResult<(IotaGasStatus, Vec<CheckedInputObjects>, CheckedInputObjects)> {
+        per_authenticator_input_objects
+            .iter()
+            .try_for_each(check_move_authenticator_objects)?;
+
+        let gas_status = check_transaction_input_inner(
+            protocol_config,
+            reference_gas_price,
+            transaction,
+            &tx_input_objects,
+            &[],
+            authenticator_gas_budget,
+            true, // execution mode — full transaction_gas_budget
+        )?;
+
+        let per_authenticator_checked_input_objects = per_authenticator_input_objects
+            .into_iter()
+            .map(|objects| objects.into_checked())
+            .collect::<Vec<_>>();
+
+        let mut input_objects_union = tx_input_objects.into_checked();
+        for objects in per_authenticator_checked_input_objects.iter() {
+            input_objects_union = checked_input_objects_union(input_objects_union, objects)?;
+        }
+
+        Ok((
+            gas_status,
+            per_authenticator_checked_input_objects,
+            input_objects_union,
+        ))
+    }
+
     // Common checks performed for transactions and certificates.
     fn check_transaction_input_inner(
         protocol_config: &ProtocolConfig,

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -239,8 +239,9 @@ mod checked {
         Ok(aggregated_authenticator_input_objects)
     }
 
-    /// Thin wrapper over [`check_transaction_and_move_authenticator_input`] for
-    /// callers that hold a [`VerifiedExecutableTransaction`].
+    /// Checks certificate and Move-authenticator inputs, returning an
+    /// execution-mode gas status plus the checked input objects.
+    #[instrument(level = "trace", skip_all)]
     pub fn check_certificate_and_move_authenticator_input(
         cert: &VerifiedExecutableTransaction,
         tx_input_objects: InputObjects,
@@ -249,27 +250,8 @@ mod checked {
         protocol_config: &ProtocolConfig,
         reference_gas_price: u64,
     ) -> IotaResult<(IotaGasStatus, Vec<CheckedInputObjects>, CheckedInputObjects)> {
-        check_transaction_and_move_authenticator_input(
-            cert.data().transaction_data(),
-            tx_input_objects,
-            per_authenticator_input_objects,
-            authenticator_gas_budget,
-            protocol_config,
-            reference_gas_price,
-        )
-    }
+        let transaction = cert.data().transaction_data();
 
-    /// Checks transaction and Move-authenticator inputs, returning an
-    /// execution-mode gas status plus the checked input objects.
-    #[instrument(level = "trace", skip_all)]
-    pub fn check_transaction_and_move_authenticator_input(
-        transaction: &TransactionData,
-        tx_input_objects: InputObjects,
-        per_authenticator_input_objects: Vec<InputObjects>,
-        authenticator_gas_budget: u64,
-        protocol_config: &ProtocolConfig,
-        reference_gas_price: u64,
-    ) -> IotaResult<(IotaGasStatus, Vec<CheckedInputObjects>, CheckedInputObjects)> {
         // Check Move authenticator inputs first.
         per_authenticator_input_objects
             .iter()

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -34,7 +34,7 @@ pub enum Attestation {
     Explicit {
         payload: AttestationData,
         attestor_address: IotaAddress,
-        /// Signs over `hash(transaction.digest() || BCS(data) ||
+        /// Signs over `hash(transaction.digest() || BCS(payload) ||
         /// attestor_address)`, binding the attestation to both the
         /// specific transaction and the attestor's identity.
         signature: Box<GenericSignature>,

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -50,7 +50,7 @@ pub enum Attestation {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AttestationData {
     V1 {
-        /// Expected computation cost, in MIST, used by the sequencer to improve
+        /// Expected computation cost, in NANOS, used by the sequencer to improve
         /// shared-object scheduling before execution.
         estimated_computation_cost: u64,
         /// Shared-object versions observed by the attestor during the dry-run.

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -37,7 +37,7 @@ pub enum Attestation {
         /// Signs over `hash(transaction.digest() || BCS(data) ||
         /// attestor_address)`, binding the attestation to both the
         /// specific transaction and the attestor's identity.
-        signature: GenericSignature,
+        signature: Box<GenericSignature>,
     },
 }
 
@@ -77,7 +77,9 @@ impl AttestedTransaction {
             attestation,
         }
     }
-    pub fn digest(&self) -> &TransactionDigest { self.transaction.digest() }
+    pub fn digest(&self) -> &TransactionDigest {
+        self.transaction.digest()
+    }
 }
 
 #[cfg(test)]
@@ -87,7 +89,7 @@ mod tests {
     use super::*;
     use crate::{
         base_types::{IotaAddress, random_object_ref},
-        crypto::{Ed25519IotaSignature, IotaSignature},
+        crypto::Ed25519IotaSignature,
         utils::create_fake_transaction,
     };
 
@@ -119,11 +121,7 @@ mod tests {
         };
         let encoded = bcs::to_bytes(&attestation).unwrap();
         let decoded: Attestation = bcs::from_bytes(&encoded).unwrap();
-        let Attestation::Validator {
-            attestor_index,
-            ..
-        } = decoded
-        else {
+        let Attestation::Validator { attestor_index, .. } = decoded else {
             panic!("unexpected variant");
         };
         assert_eq!(attestor_index, AuthorityIndex::new_for_test(3));
@@ -135,7 +133,9 @@ mod tests {
         let attestation = Attestation::Explicit {
             payload: make_attestation_data(),
             attestor_address: address,
-            signature: GenericSignature::Signature(Ed25519IotaSignature::default().into()),
+            signature: Box::new(GenericSignature::Signature(
+                Ed25519IotaSignature::default().into(),
+            )),
         };
         let encoded = bcs::to_bytes(&attestation).unwrap();
         let decoded: Attestation = bcs::from_bytes(&encoded).unwrap();

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -50,8 +50,8 @@ pub enum Attestation {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AttestationData {
     V1 {
-        /// Expected computation cost, in NANOS, used by the sequencer to improve
-        /// shared-object scheduling before execution.
+        /// Expected computation cost, in NANOS, used by the sequencer to
+        /// improve shared-object scheduling before execution.
         estimated_computation_cost: u64,
         /// Shared-object versions observed by the attestor during the dry-run.
         /// Used to determine whether a discrepancy between the attested

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -3,6 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 // TODO: change the import once the AuthorityIndex refactor is ready
+// See https://github.com/iotaledger/iota-private/issues/404
 use starfish_config::AuthorityIndex;
 
 use crate::{

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -9,7 +9,7 @@ use crate::{
     base_types::{IotaAddress, ObjectRef},
     digests::TransactionDigest,
     signature::GenericSignature,
-    transaction::{SenderSignedData, Transaction},
+    transaction::Transaction,
 };
 
 /// A pre-consensus claim produced by a trusted actor certifying that a specific
@@ -78,4 +78,89 @@ impl AttestedTransaction {
         }
     }
     pub fn digest(&self) -> &TransactionDigest { self.transaction.digest() }
+}
+
+#[cfg(test)]
+mod tests {
+    use bcs;
+
+    use super::*;
+    use crate::{
+        base_types::{IotaAddress, random_object_ref},
+        crypto::{Ed25519IotaSignature, IotaSignature},
+        utils::create_fake_transaction,
+    };
+
+    fn make_attestation_data() -> AttestationData {
+        AttestationData::V1 {
+            estimated_computation_cost: 1_000_000,
+            object_versions: vec![random_object_ref()],
+        }
+    }
+
+    #[test]
+    fn attestation_data_bcs_round_trip() {
+        let data = make_attestation_data();
+        let encoded = bcs::to_bytes(&data).unwrap();
+        let decoded: AttestationData = bcs::from_bytes(&encoded).unwrap();
+        let AttestationData::V1 {
+            estimated_computation_cost,
+            object_versions,
+        } = decoded;
+        assert_eq!(estimated_computation_cost, 1_000_000);
+        assert_eq!(object_versions.len(), 1);
+    }
+
+    #[test]
+    fn attestation_validator_bcs_round_trip() {
+        let attestation = Attestation::Validator {
+            payload: make_attestation_data(),
+            attestor_index: AuthorityIndex::new_for_test(3),
+        };
+        let encoded = bcs::to_bytes(&attestation).unwrap();
+        let decoded: Attestation = bcs::from_bytes(&encoded).unwrap();
+        let Attestation::Validator {
+            attestor_index,
+            ..
+        } = decoded
+        else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(attestor_index, AuthorityIndex::new_for_test(3));
+    }
+
+    #[test]
+    fn attestation_explicit_bcs_round_trip() {
+        let address = IotaAddress::random();
+        let attestation = Attestation::Explicit {
+            payload: make_attestation_data(),
+            attestor_address: address,
+            signature: GenericSignature::Signature(Ed25519IotaSignature::default().into()),
+        };
+        let encoded = bcs::to_bytes(&attestation).unwrap();
+        let decoded: Attestation = bcs::from_bytes(&encoded).unwrap();
+        let Attestation::Explicit {
+            attestor_address, ..
+        } = decoded
+        else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(attestor_address, address);
+    }
+
+    #[test]
+    fn attested_transaction_bcs_round_trip() {
+        let tx = create_fake_transaction();
+        let digest = *tx.digest();
+        let attested = AttestedTransaction::new(
+            tx,
+            Attestation::Validator {
+                payload: make_attestation_data(),
+                attestor_index: AuthorityIndex::new_for_test(0),
+            },
+        );
+        let encoded = bcs::to_bytes(&attested).unwrap();
+        let decoded: AttestedTransaction = bcs::from_bytes(&encoded).unwrap();
+        assert_eq!(*decoded.digest(), digest);
+    }
 }

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -66,14 +66,14 @@ pub enum AttestationData {
 /// of `ConsensusTransactionKind::UserTransactionV2`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AttestedTransaction {
-    pub transaction: Box<Transaction>,
+    pub transaction: Transaction,
     pub attestation: Attestation,
 }
 
 impl AttestedTransaction {
     pub fn new(transaction: Transaction, attestation: Attestation) -> Self {
         Self {
-            transaction: Box::new(transaction),
+            transaction,
             attestation,
         }
     }

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    base_types::{IotaAddress, ObjectRef},
+    signature::GenericSignature,
+    transaction::Transaction,
+};
+
+/// A pre-consensus claim produced by a trusted actor certifying that a specific
+/// transaction has been validated before entering consensus. The attestation is
+/// a separate artifact that travels alongside the transaction; the transaction
+/// and the user's signature are completely unchanged.
+///
+/// Two variants are supported:
+/// - [`Attestation::Validator`]: produced by the block-proposing validator.
+///   Authenticated implicitly by the block signature — no separate attestor
+///   signature is needed.
+/// - [`Attestation::Explicit`]: produced by a registered third-party attestor.
+///   Requires a signature binding the attestation to the transaction.
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Attestation {
+    Validator(AttestationData),
+    Explicit {
+        data: AttestationData,
+        attestor_address: IotaAddress,
+        /// Signs over `hash(transaction.digest() || BCS(data) ||
+        /// attestor_address)`, binding the attestation to both the
+        /// specific transaction and the attestor's identity.
+        signature: GenericSignature,
+    },
+}
+
+/// The attested content carried by all [`Attestation`] variants.
+///
+/// Versioned to allow new fields to be introduced without breaking existing
+/// match arms. Both `Validator` and `Explicit` share the same `AttestationData`
+/// so any extension applies uniformly across attestation types.
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum AttestationData {
+    V1 {
+        /// Expected computation cost, in MIST, used by the sequencer to improve
+        /// shared-object scheduling before execution.
+        estimated_computation_cost: u64,
+        /// Shared-object versions observed by the attestor during the dry-run.
+        /// Used to determine whether a discrepancy between the attested
+        /// estimate and the actual execution outcome is misbehavior or is
+        /// explained by a legitimate state change between attestation time and
+        /// execution time.
+        object_versions: Vec<ObjectRef>,
+    },
+}
+
+/// A user transaction bundled with its attestation. This is the inner payload
+/// of `ConsensusTransactionKind::UserTransactionV2`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AttestedTransaction {
+    pub transaction: Box<Transaction>,
+    pub attestation: Attestation,
+}
+
+impl AttestedTransaction {
+    pub fn new(transaction: Transaction, attestation: Attestation) -> Self {
+        Self {
+            transaction: Box::new(transaction),
+            attestation,
+        }
+    }
+}

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -23,7 +23,6 @@ use crate::{
 ///   signature is needed.
 /// - [`Attestation::Explicit`]: produced by a registered third-party attestor.
 ///   Requires a signature binding the attestation to the transaction.
-#[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Attestation {
     Validator {

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -24,7 +24,7 @@ use crate::{
 ///   signature is needed.
 /// - [`Attestation::Explicit`]: produced by a registered third-party attestor.
 ///   Requires a signature binding the attestation to the transaction.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Attestation {
     Validator {
         payload: AttestationData,
@@ -47,7 +47,7 @@ pub enum Attestation {
 /// match arms. Both `Validator` and `Explicit` share the same `AttestationData`
 /// so any extension applies uniformly across attestation types.
 #[non_exhaustive]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AttestationData {
     V1 {
         /// Expected computation cost, in NANOS, used by the sequencer to
@@ -64,7 +64,7 @@ pub enum AttestationData {
 
 /// A user transaction bundled with its attestation. This is the inner payload
 /// of `ConsensusTransactionKind::UserTransactionV2`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttestedTransaction {
     pub transaction: Transaction,
     pub attestation: Attestation,
@@ -103,12 +103,7 @@ mod tests {
         let data = make_attestation_data();
         let encoded = bcs::to_bytes(&data).unwrap();
         let decoded: AttestationData = bcs::from_bytes(&encoded).unwrap();
-        let AttestationData::V1 {
-            estimated_computation_cost,
-            object_versions,
-        } = decoded;
-        assert_eq!(estimated_computation_cost, 1_000_000);
-        assert_eq!(object_versions.len(), 1);
+        assert_eq!(decoded, data);
     }
 
     #[test]
@@ -119,39 +114,27 @@ mod tests {
         };
         let encoded = bcs::to_bytes(&attestation).unwrap();
         let decoded: Attestation = bcs::from_bytes(&encoded).unwrap();
-        let Attestation::Validator { attestor_index, .. } = decoded else {
-            panic!("unexpected variant");
-        };
-        assert_eq!(attestor_index, AuthorityIndex::new_for_test(3));
+        assert_eq!(decoded, attestation);
     }
 
     #[test]
     fn attestation_explicit_bcs_round_trip() {
-        let address = IotaAddress::random();
         let attestation = Attestation::Explicit {
             payload: make_attestation_data(),
-            attestor_address: address,
+            attestor_address: IotaAddress::random(),
             signature: Box::new(GenericSignature::Signature(
                 Ed25519IotaSignature::default().into(),
             )),
         };
         let encoded = bcs::to_bytes(&attestation).unwrap();
         let decoded: Attestation = bcs::from_bytes(&encoded).unwrap();
-        let Attestation::Explicit {
-            attestor_address, ..
-        } = decoded
-        else {
-            panic!("unexpected variant");
-        };
-        assert_eq!(attestor_address, address);
+        assert_eq!(decoded, attestation);
     }
 
     #[test]
     fn attested_transaction_bcs_round_trip() {
-        let tx = create_fake_transaction();
-        let digest = *tx.digest();
         let attested = AttestedTransaction::new(
-            tx,
+            create_fake_transaction(),
             Attestation::Validator {
                 payload: make_attestation_data(),
                 attestor_index: AuthorityIndex::new_for_test(0),
@@ -159,6 +142,6 @@ mod tests {
         );
         let encoded = bcs::to_bytes(&attested).unwrap();
         let decoded: AttestedTransaction = bcs::from_bytes(&encoded).unwrap();
-        assert_eq!(*decoded.digest(), digest);
+        assert_eq!(decoded, attested);
     }
 }

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -27,12 +27,12 @@ use crate::{
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Attestation {
     Validator {
-        data: AttestationData,
+        payload: AttestationData,
         /// Index of the attesting validator in the current epoch's committee
         attestor_index: AuthorityIndex,
     },
     Explicit {
-        data: AttestationData,
+        payload: AttestationData,
         attestor_address: IotaAddress,
         /// Signs over `hash(transaction.digest() || BCS(data) ||
         /// attestor_address)`, binding the attestation to both the
@@ -78,5 +78,4 @@ impl AttestedTransaction {
         }
     }
     pub fn digest(&self) -> &TransactionDigest { self.transaction.digest() }
-    pub fn data(&self) -> &SenderSignedData { self.transaction.data() }
 }

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -84,8 +84,6 @@ impl AttestedTransaction {
 
 #[cfg(test)]
 mod tests {
-    use bcs;
-
     use super::*;
     use crate::{
         base_types::{IotaAddress, random_object_ref},

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -50,9 +50,10 @@ pub enum Attestation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AttestationData {
     V1 {
-        /// Expected computation cost, in NANOS, used by the sequencer to
-        /// improve shared-object scheduling before execution.
-        estimated_computation_cost: u64,
+        /// Expected computation units billed by the attestor's dry-run
+        /// (`computation_cost / gas_price`). Used by the sequencer to improve
+        /// shared-object scheduling before execution.
+        computation_units: u64,
         /// Versions of the run-time-resolved objects the attestor read during
         /// the dry-run whose version is NOT already pinned by the signed
         /// `TransactionData`. This covers shared objects,
@@ -71,6 +72,20 @@ pub struct AttestedTransaction {
     pub attestation: Attestation,
 }
 
+impl Attestation {
+    pub fn computation_units(&self) -> u64 {
+        let payload = match self {
+            Attestation::Validator { payload, .. } | Attestation::Explicit { payload, .. } => {
+                payload
+            }
+        };
+        let AttestationData::V1 {
+            computation_units, ..
+        } = payload;
+        *computation_units
+    }
+}
+
 impl AttestedTransaction {
     pub fn new(transaction: Transaction, attestation: Attestation) -> Self {
         Self {
@@ -78,6 +93,7 @@ impl AttestedTransaction {
             attestation,
         }
     }
+
     pub fn digest(&self) -> &TransactionDigest {
         self.transaction.digest()
     }
@@ -94,7 +110,7 @@ mod tests {
 
     fn make_attestation_data() -> AttestationData {
         AttestationData::V1 {
-            estimated_computation_cost: 1_000_000,
+            computation_units: 1_000_000,
             object_versions: vec![random_object_ref()],
         }
     }

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -53,11 +53,12 @@ pub enum AttestationData {
         /// Expected computation cost, in NANOS, used by the sequencer to
         /// improve shared-object scheduling before execution.
         estimated_computation_cost: u64,
-        /// Shared-object versions observed by the attestor during the dry-run.
-        /// Used to determine whether a discrepancy between the attested
-        /// estimate and the actual execution outcome is misbehavior or is
-        /// explained by a legitimate state change between attestation time and
-        /// execution time.
+        /// Versions of the run-time-resolved objects the attestor read during
+        /// the dry-run whose version is NOT already pinned by the signed
+        /// `TransactionData`. This covers shared objects,
+        /// Move-authenticator account and function-ref field objects,
+        /// coin-deny-list references, and dynamic fields / child objects loaded
+        /// during execution.
         object_versions: Vec<ObjectRef>,
     },
 }

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+// TODO: change the import once the AuthorityIndex refactor is ready
+use starfish_config::AuthorityIndex;
 
 use crate::{
     base_types::{IotaAddress, ObjectRef},
+    digests::TransactionDigest,
     signature::GenericSignature,
-    transaction::Transaction,
+    transaction::{SenderSignedData, Transaction},
 };
 
 /// A pre-consensus claim produced by a trusted actor certifying that a specific
@@ -23,7 +26,11 @@ use crate::{
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Attestation {
-    Validator(AttestationData),
+    Validator {
+        data: AttestationData,
+        /// Index of the attesting validator in the current epoch's committee
+        attestor_index: AuthorityIndex,
+    },
     Explicit {
         data: AttestationData,
         attestor_address: IotaAddress,
@@ -70,4 +77,6 @@ impl AttestedTransaction {
             attestation,
         }
     }
+    pub fn digest(&self) -> &TransactionDigest { self.transaction.digest() }
+    pub fn data(&self) -> &SenderSignedData { self.transaction.data() }
 }

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -20,7 +20,7 @@ use crate::{
     id::{ID, UID},
     object::Object,
     storage::{DenyListResult, ObjectStore},
-    transaction::{CheckedInputObjects, ReceivingObjects},
+    transaction::{InputObjects, ReceivingObjects},
 };
 
 pub const DENY_LIST_CREATE_FUNC: Identifier = Identifier::from_static("create");
@@ -85,13 +85,20 @@ impl MoveTypeTagTrait for GlobalPauseKey {
     }
 }
 
+/// Returns `Ok(())` if no input or receiving object's coin type is on a deny
+/// list for the given `address`.
+///
+/// `cur_epoch` gates the deny-list read to the value settled before this epoch
+/// (entries written in epoch `E` activate in `E + 1`), matching execution and
+/// keeping the result deterministic across validators.
 #[instrument(level = "trace", skip_all)]
 pub fn check_coin_deny_list_v1(
     address: IotaAddress,
-    tx_input_objects: &CheckedInputObjects,
+    tx_input_objects: &InputObjects,
     tx_receiving_objects: &ReceivingObjects,
-    per_authenticator_input_objects: &Vec<&CheckedInputObjects>,
+    per_authenticator_input_objects: &Vec<&InputObjects>,
     object_store: &dyn ObjectStore,
+    cur_epoch: EpochId,
 ) -> UserInputResult {
     let coin_types = input_object_coin_types_for_denylist_check(
         tx_input_objects,
@@ -102,10 +109,10 @@ pub fn check_coin_deny_list_v1(
         let Some(deny_list) = get_per_type_coin_deny_list_v1(&coin_type, object_store) else {
             continue;
         };
-        if check_global_pause(&deny_list, object_store, None) {
+        if check_global_pause(&deny_list, object_store, Some(cur_epoch)) {
             return Err(UserInputError::CoinTypeGlobalPause { coin_type });
         }
-        if check_address_denied_by_config(&deny_list, address, object_store, None) {
+        if check_address_denied_by_config(&deny_list, address, object_store, Some(cur_epoch)) {
             return Err(UserInputError::AddressDeniedForCoin { address, coin_type });
         }
     }
@@ -272,17 +279,16 @@ where
 /// that it's not a regulated coin.
 #[instrument(level = "trace", skip_all)]
 fn input_object_coin_types_for_denylist_check(
-    tx_input_objects: &CheckedInputObjects,
+    tx_input_objects: &InputObjects,
     tx_receiving_objects: &ReceivingObjects,
-    per_authenticator_input_objects: &Vec<&CheckedInputObjects>,
+    per_authenticator_input_objects: &Vec<&InputObjects>,
 ) -> BTreeSet<String> {
     let all_objects =
         tx_input_objects
-            .inner()
             .iter_objects()
             .chain(tx_receiving_objects.iter_objects())
             .chain(per_authenticator_input_objects.iter().flat_map(
-                |authenticator_input_objects| authenticator_input_objects.inner().iter_objects(),
+                |authenticator_input_objects| authenticator_input_objects.iter_objects(),
             ));
     all_objects
         .filter_map(|obj| {

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -539,6 +539,21 @@ pub enum IotaError {
         actual: starfish_config::AuthorityIndex,
     },
 
+    #[error(
+        "Attestation reports computation_units = {actual} gas units, \
+         below the protocol minimum of {minimum} \
+         (`min(base_tx_cost_fixed, gas_rounding_step)`); \
+         no honest dry-run can meter below this minimum"
+    )]
+    AttestationUnitsBelowMinimum { actual: u64, minimum: u64 },
+
+    #[error(
+        "Attestation reports computation_units = {actual} gas units, \
+         above the user's budget maximum of {maximum} (`gas_budget / gas_price`); \
+         an honest dry-run cannot exceed what the tx can pay for"
+    )]
+    AttestationUnitsAboveBudget { actual: u64, maximum: u64 },
+
     #[error("Unexpected message.")]
     UnexpectedMessage,
 

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -530,6 +530,18 @@ pub enum IotaError {
     #[error("Invalid DKG message size")]
     InvalidDkgMessageSize,
 
+    #[error(
+        "Attestation author mismatch: attestation claims attestor {expected:?} \
+         but the block was authored by {actual:?}"
+    )]
+    AttestationAuthorMismatch {
+        expected: starfish_config::AuthorityIndex,
+        actual: starfish_config::AuthorityIndex,
+    },
+
+    #[error("Explicit attestation is not supported in the current protocol version")]
+    ExplicitAttestationNotSupported,
+
     #[error("Unexpected message.")]
     UnexpectedMessage,
 

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -539,9 +539,6 @@ pub enum IotaError {
         actual: starfish_config::AuthorityIndex,
     },
 
-    #[error("Explicit attestation is not supported in the current protocol version")]
-    ExplicitAttestationNotSupported,
-
     #[error("Unexpected message.")]
     UnexpectedMessage,
 

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -29,6 +29,7 @@ use crate::{
 pub mod error;
 
 pub mod account_abstraction;
+pub mod attestation;
 pub mod auth_context;
 pub mod balance;
 pub mod base_types;

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::{
+    attestation::AttestedTransaction,
     base_types::{AuthorityName, ConciseableName, ObjectRef, TransactionDigest},
     crypto::{AuthoritySignature, DefaultHash, default_hash},
     digests::{Digest, MisbehaviorReportDigest},
@@ -32,7 +33,6 @@ use crate::{
     supported_protocol_versions::{
         Chain, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
-    attestation::AttestedTransaction,
     transaction::{CertifiedTransaction, Transaction},
 };
 
@@ -658,7 +658,7 @@ impl ConsensusTransaction {
                 ConsensusTransactionKey::UserTransaction(*tx.digest())
             }
             ConsensusTransactionKind::UserTransactionV2(attested) => {
-                ConsensusTransactionKey::UserTransaction(*attested.transaction.digest())
+                ConsensusTransactionKey::UserTransaction(*attested.digest())
             }
         }
     }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -249,8 +249,8 @@ pub enum ConsensusTransactionKind {
     /// directly to consensus without pre-consensus object locking.
     /// Conflicts are resolved post-consensus.
     UserTransactionV1(Box<Transaction>),
-    /// Attested user transaction. Carries a gas attestation produced either by
-    /// the proposing validator or a registered third-party attestor.
+    /// Attested user transaction. Carries the transaction together with
+    /// the attested data and the identity of the attestor that produced it.
     UserTransactionV2(Box<AttestedTransaction>),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -585,7 +585,7 @@ impl ConsensusTransaction {
         }
     }
 
-    pub fn new_user_transaction(transaction: Transaction) -> Self {
+    pub fn new_user_transaction_v1(transaction: Transaction) -> Self {
         let mut hasher = DefaultHasher::new();
         let tx_digest = transaction.digest();
         tx_digest.hash(&mut hasher);
@@ -596,14 +596,14 @@ impl ConsensusTransaction {
         }
     }
 
-    pub fn new_attested_transaction(attested: AttestedTransaction) -> Self {
+    pub fn new_user_transaction_v2(attested_tx: AttestedTransaction) -> Self {
         let mut hasher = DefaultHasher::new();
-        let tx_digest = attested.transaction.digest();
+        let tx_digest = attested_tx.transaction.digest();
         tx_digest.hash(&mut hasher);
         let tracking_id = hasher.finish().to_le_bytes();
         Self {
             tracking_id,
-            kind: ConsensusTransactionKind::UserTransactionV2(Box::new(attested)),
+            kind: ConsensusTransactionKind::UserTransactionV2(Box::new(attested_tx)),
         }
     }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -32,6 +32,7 @@ use crate::{
     supported_protocol_versions::{
         Chain, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
+    attestation::AttestedTransaction,
     transaction::{CertifiedTransaction, Transaction},
 };
 
@@ -248,6 +249,9 @@ pub enum ConsensusTransactionKind {
     /// directly to consensus without pre-consensus object locking.
     /// Conflicts are resolved post-consensus.
     UserTransactionV1(Box<Transaction>),
+    /// Attested user transaction. Carries a gas attestation produced either by
+    /// the proposing validator or a registered third-party attestor.
+    UserTransactionV2(Box<AttestedTransaction>),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -262,7 +266,11 @@ impl ConsensusTransactionKind {
     }
 
     pub fn is_user_transaction(&self) -> bool {
-        matches!(self, ConsensusTransactionKind::UserTransactionV1(_))
+        matches!(
+            self,
+            ConsensusTransactionKind::UserTransactionV1(_)
+                | ConsensusTransactionKind::UserTransactionV2(_)
+        )
     }
 }
 
@@ -588,6 +596,17 @@ impl ConsensusTransaction {
         }
     }
 
+    pub fn new_attested_transaction(attested: AttestedTransaction) -> Self {
+        let mut hasher = DefaultHasher::new();
+        let tx_digest = attested.transaction.digest();
+        tx_digest.hash(&mut hasher);
+        let tracking_id = hasher.finish().to_le_bytes();
+        Self {
+            tracking_id,
+            kind: ConsensusTransactionKind::UserTransactionV2(Box::new(attested)),
+        }
+    }
+
     pub fn get_tracking_id(&self) -> u64 {
         (&self.tracking_id[..])
             .read_u64::<BigEndian>()
@@ -637,6 +656,9 @@ impl ConsensusTransaction {
             }
             ConsensusTransactionKind::UserTransactionV1(tx) => {
                 ConsensusTransactionKey::UserTransaction(*tx.digest())
+            }
+            ConsensusTransactionKind::UserTransactionV2(attested) => {
+                ConsensusTransactionKey::UserTransaction(*attested.transaction.digest())
             }
         }
     }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -657,8 +657,8 @@ impl ConsensusTransaction {
             ConsensusTransactionKind::UserTransactionV1(tx) => {
                 ConsensusTransactionKey::UserTransaction(*tx.digest())
             }
-            ConsensusTransactionKind::UserTransactionV2(attested) => {
-                ConsensusTransactionKey::UserTransaction(*attested.digest())
+            ConsensusTransactionKind::UserTransactionV2(attested_tx) => {
+                ConsensusTransactionKey::UserTransaction(*attested_tx.digest())
             }
         }
     }

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -143,6 +143,7 @@ impl EpochState {
             &self.bytecode_verifier_metrics,
             verifier_signing_config,
             authenticator_gas_budget,
+            false,
         )?;
 
         let transaction_data = transaction.data().transaction_data();
@@ -235,6 +236,7 @@ impl EpochState {
                 &self.bytecode_verifier_metrics,
                 verifier_signing_config,
                 authenticator_gas_budget,
+                false,
             )?
         } else {
             let checked_input_objects = iota_transaction_checks::check_dev_inspect_input(

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -324,6 +324,8 @@ mod checked {
         IotaGasStatus,
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
+        // Whether the Move authentication phase failed (abort or out-of-gas).
+        bool,
     ) {
         // Preparation
         // It involves setting up the TemporaryStore, GasCharger, and TxContext, that
@@ -447,6 +449,10 @@ mod checked {
             },
         );
 
+        // Capture whether authentication failed before the result is moved into the
+        // body execution.
+        let authentication_failed = authentication_execution_result.is_err();
+
         // Transaction execution.
         // At this stage we arrive with gas charged for the execution of the
         // authenticate function and a result which is either empty or an error.
@@ -454,26 +460,34 @@ mod checked {
         // authentication failure or for a normal execution of the transaction.
 
         // Run the transaction execution and return the effects.
-        execute_transaction_to_effects_inner::<Mode>(
-            temporary_store,
-            gas_charger,
-            tx_ctx,
-            &mutable_inputs,
-            shared_object_refs,
-            transaction_dependencies,
-            contains_deleted_input,
-            cancelled_objects,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            move_vm,
-            epoch_id,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-            trace_builder_opt,
-            Some(authentication_execution_result),
+        let (inner_temp_store, gas_status, effects, execution_result) =
+            execute_transaction_to_effects_inner::<Mode>(
+                temporary_store,
+                gas_charger,
+                tx_ctx,
+                &mutable_inputs,
+                shared_object_refs,
+                transaction_dependencies,
+                contains_deleted_input,
+                cancelled_objects,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                move_vm,
+                epoch_id,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+                trace_builder_opt,
+                Some(authentication_execution_result),
+            );
+        (
+            inner_temp_store,
+            gas_status,
+            effects,
+            execution_result,
+            authentication_failed,
         )
     }
 

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -449,6 +449,7 @@ mod checked {
             },
         );
 
+        // TODO: enhance the way the authenticator error is propagated https://github.com/iotaledger/iota/issues/11986 
         // Capture whether authentication failed before the result is moved into the
         // body execution.
         let authentication_failed = authentication_execution_result.is_err();

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -449,7 +449,7 @@ mod checked {
             },
         );
 
-        // TODO: enhance the way the authenticator error is propagated https://github.com/iotaledger/iota/issues/11986 
+        // TODO: enhance the way the authenticator error is propagated https://github.com/iotaledger/iota/issues/11986
         // Capture whether authentication failed before the result is moved into the
         // body execution.
         let authentication_failed = authentication_execution_result.is_err();

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -117,6 +117,8 @@ pub trait Executor {
         IotaGasStatus,
         TransactionEffects,
         Result<(), ExecutionError>,
+        // Whether the Move authentication phase failed.
+        bool,
     );
 
     fn authenticate_transaction(

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -205,6 +205,7 @@ impl executor::Executor for Executor {
         IotaGasStatus,
         TransactionEffects,
         Result<(), ExecutionError>,
+        bool,
     ) {
         authenticate_then_execute_transaction_to_effects::<execution_mode::Normal>(
             store,


### PR DESCRIPTION
> This PR merges into `protocol-research/feat/transaction-attestation-feature`, not `develop`. That feature branch is itself branched from `consensus/feat/pcool-feature`.

# Description of change

This PR implements the **[Validator Attestation (Phase 1)](https://github.com/iotaledger/iota-private/issues/383)** — the mechanism by which a proposing validator certifies, pre-consensus, that a transaction has passed validation and provides an estimated computation cost for scheduler hints.

_Note: related [changes to sequencer and execution](https://github.com/iotaledger/iota-private/issues/386) will be part of a separate PR_.

### What changed

**New data structures** (`iota-types`)
- `attestation.rs`: `Attestation` (two variants — `Validator`, `Explicit`), `AttestationData` (versioned, carries estimated computation cost and observed shared-object versions), `AttestedTransaction` (transaction + attestation bundle). BCS round-trip tests included.
- `messages_consensus.rs`: new `UserTransactionV2(Box<AttestedTransaction>)` variant in `ConsensusTransactionKind`, carrying the bundled attestation.
- `error.rs`: `AttestationAuthorMismatch` and `ExplicitAttestationNotSupported` error variants.
- `iota-protocol-config`: `enable_validator_attestation` feature flag. Attestation is only active when `enable_white_flag_flow` is also on; the two flags are enforced as co-dependent.

**Pre-consensus attestation** (`authority.rs`, `validator_v2.rs`)
- `attest_transaction`: validates the transaction (deny checks, gas, ownership, coin deny list, full dry-run) and returns `(AttestationData, Vec<ObjectRef>)`. It subsumes `handle_transaction_validation_checks`, so the two paths are mutually exclusive.
- `submit_single_tx` restructured: when `enable_validator_attestation` is on, calls `attest_transaction` instead of `handle_transaction_validation_checks`. The pre-consensus soft lock is acquired after attestation (owned objects are returned by `attest_transaction`, so no extra pass is needed). The transaction is submitted as `UserTransactionV2` with the attestation embedded.

**Batch homogeneity** (`consensus_adapter.rs`)
- `submit_batch` enforces that all transactions in a soft-bundle are of the same kind: all-V1, all-V2, or all-certificates. Mixed batches are rejected with `InvalidTxKindInSoftBundle`.

**Post-consensus attestor verification** (`post_consensus_validation.rs`)
- `UserTransactionV2` match arm separated into pure classification; digest is pushed to `all_user_tx_digests` before any check, so dropped V2 transactions still release pre-consensus soft locks.
- New Check # 3 (attestor verification): verifies that `attestor_index` in `Attestation::Validator` matches `certificate_author_index` (block author).
- `UserTransactionV2` transactions skip Check # 6 (`handle_transaction_validation_checks`) — the attestor already performed those checks before producing the attestation.

**`consensus_validator.rs`**: comment updated to clarify that attestor verification happens in `post_consensus_validation`, not during block ingestion (where block-author context is unavailable).

**Unit tests**
- `validator_v2_tests.rs`: unit tests for the V2 submission path — happy path (transaction is attested and accepted) and rejection path (attestation fails with an invalid transaction).
- `post_consensus_validation_tests.rs`: unit tests for `UserTransactionV2` handling in post-consensus validation — correct attestor accepted, mismatched attestor rejected, and `UserTransactionV2` skipping duplicate validation checks.

**End-to-end test (iota-e2e-tests)**

- `attestation_tests.rs`: `test_aa_tx_accepted_via_v2_attestation_path` submits a Move abstract account transaction through the V2 gRPC path with both `enable_white_flag_flow` and `enable_validator_attestation` active. Exercises the `authenticate_then_execute_transaction_to_effects` branch of `attest_transaction` (MoveAuthenticator dry-run path).

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-private/issues/384
Closes https://github.com/iotaledger/iota-private/issues/385
Part of Epic https://github.com/iotaledger/iota-private/issues/383

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

BCS round-trip tests for `AttestationData`, `Attestation::Validator`, `Attestation::Explicit`, and `AttestedTransaction` are included in `attestation.rs`. Unit tests for the V2 submission and post-consensus validation paths are in `validator_v2_tests.rs` and `post_consensus_validation_tests.rs`. An end-to-end test exercising the full attestation pipeline is in `attestation_tests.rs`.

### Release Notes

- [x] Protocol: New `UserTransactionV2` consensus transaction kind and `enable_validator_attestation` protocol config flag (requires `enable_white_flag_flow`).
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
