### PR TITLE
chore: warn `uninlined_format_args` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(msim)', 'cfg(fail_points)'
 
 [workspace.lints.clippy]
 redundant_clone = "warn"
+uninlined_format_args = "warn"
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]

--- a/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
@@ -234,7 +234,6 @@ async fn test_starfish_consensus_handler_handles_older_commits() {
     let highest_handled = commit_consumer_monitor.highest_handled_commit();
     assert_eq!(
         highest_handled, 10,
-        "Expected highest handled commit to be 10, got {}",
-        highest_handled
+        "Expected highest handled commit to be 10, got {highest_handled}"
     );
 }

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -335,8 +335,7 @@ async fn test_receive_object_in_main_tx_succeeds() -> Result<(), anyhow::Error> 
     let error_string = format!("{:#?}", tx_result.status());
     assert!(
         error_string.contains("abort"),
-        "Expected MoveAbort error, got: {}",
-        error_string
+        "Expected MoveAbort error, got: {error_string}"
     );
 
     Ok(())

--- a/crates/iota-e2e-tests/tests/grpc/utils.rs
+++ b/crates/iota-e2e-tests/tests/grpc/utils.rs
@@ -542,8 +542,7 @@ pub(crate) fn assert_field_presence(
     for expected_top_level_field in &expected_top_level_fields {
         assert!(
             actual_top_level_fields.contains(expected_top_level_field),
-            "Invalid field '{}' in '{scenario}': field does not exist on this type",
-            expected_top_level_field
+            "Invalid field '{expected_top_level_field}' in '{scenario}': field does not exist on this type"
         );
     }
 
@@ -573,7 +572,7 @@ pub(crate) fn assert_field_presence(
                 "Contradictory field paths in '{scenario}': '{non_nested_field}' specified both as non-nested (implying no nested fields) and with nested fields ({})",
                 expected_nested_field_paths[non_nested_field]
                     .iter()
-                    .map(|s| format!("{}.{}", non_nested_field, s))
+                    .map(|s| format!("{non_nested_field}.{s}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             );

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
@@ -32,7 +32,7 @@ fn first_executed_transaction(response: &ExecuteTransactionsResponse) -> &Execut
     match &result.result {
         Some(execute_transaction_result::Result::ExecutedTransaction(tx)) => tx,
         Some(execute_transaction_result::Result::Error(e)) => {
-            panic!("expected executed transaction, got error: {:?}", e)
+            panic!("expected executed transaction, got error: {e:?}")
         }
         _ => panic!("expected executed transaction, got None"),
     }

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/address_derivation.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/address_derivation.rs
@@ -33,10 +33,7 @@ pub fn derive_address(
     internal: bool,
 ) -> anyhow::Result<Ed25519Address> {
     let change = if internal { 1 } else { 0 };
-    let path = format!(
-        "m/44'/{}'/{}'/{}'/{}'",
-        coin_type, account_index, change, address_index
-    );
+    let path = format!("m/44'/{coin_type}'/{account_index}'/{change}'/{address_index}'");
 
     let private_key = Ed25519PrivateKey::from_mnemonic_with_path(mnemonic, path, None)?;
     let public_key = private_key.public_key();

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -31,7 +31,7 @@ impl RpcError {
     /// Add context to an existing error
     pub fn with_context<T: std::fmt::Display>(mut self, context: T) -> Self {
         self.message = Some(match self.message {
-            Some(existing) => format!("{}: {}", context, existing),
+            Some(existing) => format!("{context}: {existing}"),
             None => context.to_string(),
         });
         self

--- a/crates/iota-grpc-server/src/event_filter.rs
+++ b/crates/iota-grpc-server/src/event_filter.rs
@@ -88,19 +88,18 @@ impl TryFrom<iota_grpc_types::v1::filter::EventFilter> for EventFilter {
                     .ok_or("sender address is missing")?
                     .address;
                 let iota_address = IotaAddress::from_bytes(&address)
-                    .map_err(|e| format!("invalid sender address: {}", e))?;
+                    .map_err(|e| format!("invalid sender address: {e}"))?;
                 Ok(EventFilter::Sender(iota_address))
             }
             ProtoFilter::MovePackageAndModule(filter) => {
                 // TODO: add a function to parse the package and the module name
                 let package_bytes = filter.package_id.ok_or("package_id is missing")?.object_id;
                 let package = ObjectID::from_bytes(&package_bytes)
-                    .map_err(|e| format!("invalid package_id: {}", e))?;
+                    .map_err(|e| format!("invalid package_id: {e}"))?;
                 let module = filter
                     .module
                     .map(|m| {
-                        Identifier::new(m.as_str())
-                            .map_err(|e| format!("invalid module name: {}", e))
+                        Identifier::new(m.as_str()).map_err(|e| format!("invalid module name: {e}"))
                     })
                     .transpose()?;
                 Ok(EventFilter::MovePackageAndModule { package, module })
@@ -109,12 +108,11 @@ impl TryFrom<iota_grpc_types::v1::filter::EventFilter> for EventFilter {
                 // TODO: add a function to parse the package and the module name
                 let package_bytes = filter.package_id.ok_or("package_id is missing")?.object_id;
                 let package = ObjectID::from_bytes(&package_bytes)
-                    .map_err(|e| format!("invalid package_id: {}", e))?;
+                    .map_err(|e| format!("invalid package_id: {e}"))?;
                 let module = filter
                     .module
                     .map(|m| {
-                        Identifier::new(m.as_str())
-                            .map_err(|e| format!("invalid module name: {}", e))
+                        Identifier::new(m.as_str()).map_err(|e| format!("invalid module name: {e}"))
                     })
                     .transpose()?;
                 Ok(EventFilter::MoveEventPackageAndModule { package, module })
@@ -123,7 +121,7 @@ impl TryFrom<iota_grpc_types::v1::filter::EventFilter> for EventFilter {
                 let tag: StructTag = filter
                     .struct_tag
                     .parse()
-                    .map_err(|e| format!("invalid struct tag: {}", e))?;
+                    .map_err(|e| format!("invalid struct tag: {e}"))?;
                 Ok(EventFilter::MoveEventType(tag))
             }
             _ => Err("Unsupported event filter type".to_string()),
@@ -170,8 +168,7 @@ impl EventFilter {
     pub(crate) fn validate_depth_recursive(&self, current_depth: usize) -> Result<(), String> {
         if current_depth > MAX_FILTER_DEPTH {
             return Err(format!(
-                "Event filter depth exceeds maximum allowed depth of {}",
-                MAX_FILTER_DEPTH
+                "Event filter depth exceeds maximum allowed depth of {MAX_FILTER_DEPTH}"
             ));
         }
 
@@ -229,8 +226,7 @@ impl EventFilter {
         let node_count = self.count_nodes();
         if node_count > MAX_FILTER_NODES {
             return Err(format!(
-                "Event filter complexity exceeds maximum allowed nodes: {} > {}",
-                node_count, MAX_FILTER_NODES
+                "Event filter complexity exceeds maximum allowed nodes: {node_count} > {MAX_FILTER_NODES}"
             ));
         }
 

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -378,8 +378,7 @@ pub(crate) fn stream_checkpoints(
             })?;
         if start < lowest_available {
             return Err(Status::not_found(format!(
-                "Requested checkpoint {} is below the lowest available checkpoint {}",
-                start, lowest_available
+                "Requested checkpoint {start} is below the lowest available checkpoint {lowest_available}"
             ))
             .into());
         }

--- a/crates/iota-grpc-server/src/ledger_service/get_health.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_health.rs
@@ -30,10 +30,7 @@ pub fn get_health(
     if now_ms.saturating_sub(checkpoint_ts) > threshold_ms {
         return Err(RpcError::new(
             Code::Unavailable,
-            format!(
-                "Latest checkpoint timestamp is beyond the threshold of {}ms",
-                threshold_ms
-            ),
+            format!("Latest checkpoint timestamp is beyond the threshold of {threshold_ms}ms"),
         ));
     }
 

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -104,10 +104,7 @@ fn validate_batch_size(items_len: usize, max_batch: usize) -> Result<(), RpcErro
     if items_len > max_batch {
         return Err(RpcError::new(
             tonic::Code::InvalidArgument,
-            format!(
-                "batch size {} exceeds maximum allowed ({})",
-                items_len, max_batch
-            ),
+            format!("batch size {items_len} exceeds maximum allowed ({max_batch})"),
         ));
     }
     Ok(())

--- a/crates/iota-grpc-server/src/transaction_filter.rs
+++ b/crates/iota-grpc-server/src/transaction_filter.rs
@@ -144,7 +144,7 @@ impl TryFrom<proto_filter::CommandFilter> for CommandFilter {
                     .ok_or("package_id is missing")?
                     .object_id;
                 let package = ObjectID::from_bytes(&package_bytes)
-                    .map_err(|e| format!("invalid package_id: {}", e))?;
+                    .map_err(|e| format!("invalid package_id: {e}"))?;
                 Ok(CommandFilter::MoveCall {
                     package,
                     module: call_filter.module,
@@ -161,7 +161,7 @@ impl TryFrom<proto_filter::CommandFilter> for CommandFilter {
                     .package_id
                     .map(|addr| {
                         ObjectID::from_bytes(&addr.object_id)
-                            .map_err(|e| format!("invalid package_id: {}", e))
+                            .map_err(|e| format!("invalid package_id: {e}"))
                     })
                     .transpose()?;
                 Ok(CommandFilter::Upgrade { package })
@@ -281,7 +281,7 @@ impl TryFrom<proto_filter::TransactionFilter> for TransactionFilter {
                     .ok_or("sender address is missing")?
                     .address;
                 let iota_address = IotaAddress::from_bytes(&address)
-                    .map_err(|e| format!("invalid sender address: {}", e))?;
+                    .map_err(|e| format!("invalid sender address: {e}"))?;
                 Ok(TransactionFilter::Sender(iota_address))
             }
             ProtoFilter::Receiver(addr_filter) => {
@@ -290,7 +290,7 @@ impl TryFrom<proto_filter::TransactionFilter> for TransactionFilter {
                     .ok_or("receiver address is missing")?
                     .address;
                 let iota_address = IotaAddress::from_bytes(&address)
-                    .map_err(|e| format!("invalid receiver address: {}", e))?;
+                    .map_err(|e| format!("invalid receiver address: {e}"))?;
                 Ok(TransactionFilter::Receiver(iota_address))
             }
             ProtoFilter::AffectedObject(obj_filter) => {
@@ -300,7 +300,7 @@ impl TryFrom<proto_filter::TransactionFilter> for TransactionFilter {
                     .as_ref()
                     .ok_or("object_id is missing")?
                     .object_id()
-                    .map_err(|e| format!("invalid object_id: {}", e))?;
+                    .map_err(|e| format!("invalid object_id: {e}"))?;
                 Ok(TransactionFilter::AffectedObject(object_id))
             }
             ProtoFilter::Command(command_filter) => {
@@ -393,8 +393,7 @@ impl TransactionFilter {
     fn validate_depth_recursive(&self, current_depth: usize) -> Result<(), String> {
         if current_depth > MAX_FILTER_DEPTH {
             return Err(format!(
-                "Filter depth exceeds maximum allowed depth of {}",
-                MAX_FILTER_DEPTH
+                "Filter depth exceeds maximum allowed depth of {MAX_FILTER_DEPTH}"
             ));
         }
 
@@ -459,8 +458,7 @@ impl TransactionFilter {
         let node_count = self.count_nodes();
         if node_count > MAX_FILTER_NODES {
             return Err(format!(
-                "Filter complexity exceeds maximum allowed nodes: {} > {}",
-                node_count, MAX_FILTER_NODES
+                "Filter complexity exceeds maximum allowed nodes: {node_count} > {MAX_FILTER_NODES}"
             ));
         }
 

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -1182,8 +1182,7 @@ impl GrpcReader {
                                 crate::error::RpcError::new(
                                     tonic::Code::Internal,
                                     format!(
-                                        "Checkpoint summary {} not found for transaction {}",
-                                        checkpoint_seq, digest
+                                        "Checkpoint summary {checkpoint_seq} not found for transaction {digest}"
                                     ),
                                 )
                             })?;

--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -218,7 +218,7 @@ impl From<reqwest::Error> for IndexerError {
 
 impl From<url::ParseError> for IndexerError {
     fn from(err: url::ParseError) -> Self {
-        IndexerError::Generic(format!("URL parse error: {}", err))
+        IndexerError::Generic(format!("URL parse error: {err}"))
     }
 }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1100,7 +1100,7 @@ impl IndexerReader {
         // NULL  — not ready yet (missing, older version, or not finalized)
         let query = format!(
             "WITH \
-               input_objects(id, version) AS (VALUES {}), \
+               input_objects(id, version) AS (VALUES {values_clause}), \
                max_chk AS (SELECT COALESCE(MAX(sequence_number), -1) AS max_sn FROM checkpoints), \
                matches AS ( \
                  SELECT \
@@ -1117,8 +1117,7 @@ impl IndexerReader {
                WHEN COUNT(*) FILTER (WHERE finalized_in_cp IS NOT NULL \
                  AND finalized_in_cp > (SELECT max_sn FROM max_chk)) > 0 THEN NULL \
                ELSE TRUE \
-             END AS result FROM matches",
-            values_clause
+             END AS result FROM matches"
         );
 
         #[derive(QueryableByName)]

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -101,8 +101,7 @@ async fn get_counter_value(counter_obj_id: ObjectID, client: &HttpClient) -> u64
         counter_value_str.parse().unwrap()
     } else {
         panic!(
-            "Counter value field is not a string (expected u64 serialized as string), got: {:?}",
-            value_field
+            "Counter value field is not a string (expected u64 serialized as string), got: {value_field:?}"
         );
     }
 }
@@ -744,8 +743,7 @@ fn test_parallel_shared_object_updates() {
                 let counter_value = get_counter_value(counter_obj, client).await;
                 assert_eq!(
                     counter_value, expected_count,
-                    "Counter value should be {} but was {} at iteration {}",
-                    expected_count, counter_value, i
+                    "Counter value should be {expected_count} but was {counter_value} at iteration {i}"
                 );
             }
 

--- a/crates/iota-json-rpc-types/src/object_changes.rs
+++ b/crates/iota-json-rpc-types/src/object_changes.rs
@@ -257,8 +257,7 @@ impl Display for ObjectChange {
             } => {
                 write!(
                     f,
-                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Recipient: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
-                    object_id, sender, recipient, object_type, version, digest
+                    " ┌──\n │ ObjectID: {object_id}\n │ Sender: {sender} \n │ Recipient: {recipient}\n │ ObjectType: {object_type} \n │ Version: {version}\n │ Digest: {digest}\n └──"
                 )
             }
             ObjectChange::Mutated {
@@ -272,8 +271,7 @@ impl Display for ObjectChange {
             } => {
                 write!(
                     f,
-                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Owner: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
-                    object_id, sender, owner, object_type, version, digest
+                    " ┌──\n │ ObjectID: {object_id}\n │ Sender: {sender} \n │ Owner: {owner}\n │ ObjectType: {object_type} \n │ Version: {version}\n │ Digest: {digest}\n └──"
                 )
             }
             ObjectChange::Deleted {
@@ -284,8 +282,7 @@ impl Display for ObjectChange {
             } => {
                 write!(
                     f,
-                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ ObjectType: {} \n │ Version: {}\n └──",
-                    object_id, sender, object_type, version
+                    " ┌──\n │ ObjectID: {object_id}\n │ Sender: {sender} \n │ ObjectType: {object_type} \n │ Version: {version}\n └──"
                 )
             }
             ObjectChange::Wrapped {
@@ -296,8 +293,7 @@ impl Display for ObjectChange {
             } => {
                 write!(
                     f,
-                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ ObjectType: {} \n │ Version: {}\n └──",
-                    object_id, sender, object_type, version
+                    " ┌──\n │ ObjectID: {object_id}\n │ Sender: {sender} \n │ ObjectType: {object_type} \n │ Version: {version}\n └──"
                 )
             }
             ObjectChange::Unwrapped {
@@ -329,8 +325,7 @@ impl Display for ObjectChange {
             } => {
                 write!(
                     f,
-                    " ┌──\n │ ObjectID: {}\n │ Sender: {} \n │ Owner: {}\n │ ObjectType: {} \n │ Version: {}\n │ Digest: {}\n └──",
-                    object_id, sender, owner, object_type, version, digest
+                    " ┌──\n │ ObjectID: {object_id}\n │ Sender: {sender} \n │ Owner: {owner}\n │ ObjectType: {object_type} \n │ Version: {version}\n │ Digest: {digest}\n └──"
                 )
             }
         }

--- a/crates/iota-metrics-push-client/Cargo.toml
+++ b/crates/iota-metrics-push-client/Cargo.toml
@@ -21,3 +21,6 @@ tracing.workspace = true
 iota-metrics.workspace = true
 iota-tls.workspace = true
 iota-types.workspace = true
+
+[lints]
+workspace = true

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -393,8 +393,7 @@ mod checked {
                     Owner::Address(_) => {
                         debug_assert!(
                             false,
-                            "Receiving object {:?} is invalid but we expect it should be valid. {:?}",
-                            object_ref, object
+                            "Receiving object {object_ref:?} is invalid but we expect it should be valid. {object:?}"
                         );
                         error!(
                             "Receiving object {:?} is invalid but we expect it should be valid. {:?}",

--- a/crates/simulacrum-server/src/faucet.rs
+++ b/crates/simulacrum-server/src/faucet.rs
@@ -76,7 +76,7 @@ async fn request_gas_internal(
         }
         Err(err) => {
             warn!("Failed to request gas: {:?}", err);
-            Err(format!("Failed to request gas: {}", err))
+            Err(format!("Failed to request gas: {err}"))
         }
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2915,8 +2915,8 @@ mod tests {
         for i in 0..expected_number {
             match tokio::time::timeout(Duration::from_secs(5), stream.next()).await {
                 Ok(Some(bundle)) => received_bundles.push(bundle),
-                Ok(None) => panic!("Stream ended at bundle {} of {}", i, expected_number),
-                Err(_) => panic!("Timeout at bundle {} of {}", i, expected_number),
+                Ok(None) => panic!("Stream ended at bundle {i} of {expected_number}"),
+                Err(_) => panic!("Timeout at bundle {i} of {expected_number}"),
             }
         }
 
@@ -2999,7 +2999,7 @@ mod tests {
             sleep(Duration::from_millis(50)).await;
             match tokio::time::timeout(Duration::from_secs(5), stream.next()).await {
                 Ok(Some(bundle)) => received_bundles.push(bundle),
-                Ok(None) => panic!("Stream ended at round {}", round),
+                Ok(None) => panic!("Stream ended at round {round}"),
                 Err(_) => panic!(
                     "Timeout at round {}, got {} bundles",
                     round,

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -998,7 +998,7 @@ mod tests {
         let transactions_added_count = has_transactions_results.iter().filter(|&&x| x).count();
 
         // Print diagnostic information
-        println!("Suspended full blocks count: {}", suspended_count);
+        println!("Suspended full blocks count: {suspended_count}");
         println!(
             "Transactions added to DagState: {}/{}",
             transactions_added_count,
@@ -1008,8 +1008,7 @@ mod tests {
         // Assert the bug: suspended_blocks should be empty but it's not
         assert_eq!(
             suspended_count, 0,
-            "BUG CONFIRMED: {} full blocks are stuck in suspended_blocks! They should have been processed or dropped.",
-            suspended_count
+            "BUG CONFIRMED: {suspended_count} full blocks are stuck in suspended_blocks! They should have been processed or dropped."
         );
 
         // Assert that transactions should have been added

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -1091,13 +1091,11 @@ mod tests {
         // this happens at commit 4 or later depending on how blocks are ordered.
         assert!(
             first_missing_index > 1,
-            "Expected first missing at index > 1, got {}",
-            first_missing_index
+            "Expected first missing at index > 1, got {first_missing_index}"
         );
         assert!(
             first_missing_index <= num_rounds as CommitIndex,
-            "Expected first missing within num_rounds, got {}",
-            first_missing_index
+            "Expected first missing within num_rounds, got {first_missing_index}"
         );
 
         // Re-create commit observer starting from index 0 to simulate full recovery.
@@ -1155,16 +1153,14 @@ mod tests {
         for missing_ref in &expected_missing_refs {
             assert!(
                 missing.contains_key(missing_ref),
-                "Missing ref {:?} not tracked",
-                missing_ref
+                "Missing ref {missing_ref:?} not tracked"
             );
             // Each missing transaction should have acknowledgers recorded since
             // all commits are within the recovery window (gc_depth * 2).
             let acknowledgers = missing.get(missing_ref).unwrap();
             assert!(
                 !acknowledgers.is_empty(),
-                "No acknowledgers tracked for {:?}",
-                missing_ref
+                "No acknowledgers tracked for {missing_ref:?}"
             );
         }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1175,25 +1175,18 @@ mod tests {
 
         assert!(
             a_final > last_processed_a,
-            "Validator A should have progressed: before_restart={}, final={}",
-            last_processed_a,
-            a_final
+            "Validator A should have progressed: before_restart={last_processed_a}, final={a_final}"
         );
         assert!(
             b_final > last_processed_b,
-            "Validator B should have progressed: before_restart={}, final={}",
-            last_processed_b,
-            b_final
+            "Validator B should have progressed: before_restart={last_processed_b}, final={b_final}"
         );
 
         // Both should be within reasonable range of each other
         let diff = (a_final as i64 - b_final as i64).unsigned_abs() as u32;
         assert!(
             diff < 30,
-            "Validators A and B should have similar commit indices: A={}, B={}, diff={}",
-            a_final,
-            b_final,
-            diff
+            "Validators A and B should have similar commit indices: A={a_final}, B={b_final}, diff={diff}"
         );
 
         // Collect voting block headers metrics to verify voting storage was used.
@@ -1229,8 +1222,7 @@ mod tests {
         // so we should get voting hits.
         assert!(
             total_hits > 0,
-            "Expected voting block headers hits > 0, got {}",
-            total_hits
+            "Expected voting block headers hits > 0, got {total_hits}"
         );
 
         let commit_sync_fetch_commits_handler_uncertified_skipped: u64 = authorities
@@ -1247,8 +1239,7 @@ mod tests {
 
         assert!(
             commit_sync_fetch_commits_handler_uncertified_skipped > 0,
-            "Expected uncertified commits skipped > 0 for fast sync, got {}",
-            commit_sync_fetch_commits_handler_uncertified_skipped
+            "Expected uncertified commits skipped > 0 for fast sync, got {commit_sync_fetch_commits_handler_uncertified_skipped}"
         );
 
         // Stop all authorities
@@ -1454,10 +1445,9 @@ mod tests {
         let has_gap = last_commit > last_solid.unwrap_or(0);
         assert!(
             has_gap,
-            "Expected pending subdags gap: last_commit={}, last_solid={:?}. \
-             DAG round={}, new_commits={}. \
-             Validator 1's new blocks should have missing transactions.",
-            last_commit, last_solid, dag_round, new_commits
+            "Expected pending subdags gap: last_commit={last_commit}, last_solid={last_solid:?}. \
+             DAG round={dag_round}, new_commits={new_commits}. \
+             Validator 1's new blocks should have missing transactions."
         );
 
         // Record where the validator is now (with pending subdags)
@@ -1497,9 +1487,7 @@ mod tests {
         let gap = max_other.saturating_sub(last_processed_with_pending);
         assert!(
             gap > COMMIT_GAP_THRESHOLD,
-            "Gap {} should be greater than threshold {}",
-            gap,
-            COMMIT_GAP_THRESHOLD
+            "Gap {gap} should be greater than threshold {COMMIT_GAP_THRESHOLD}"
         );
 
         // Phase 6: Restart test validator with full connectivity and fast commit
@@ -1562,8 +1550,7 @@ mod tests {
 
         assert!(
             caught_up,
-            "Validator {} should have caught up via fast sync",
-            test_validator_index
+            "Validator {test_validator_index} should have caught up via fast sync"
         );
 
         // Verify the validator progressed significantly after restart with pending
@@ -1571,9 +1558,7 @@ mod tests {
         let final_index = consumer_monitors[test_validator_index].highest_handled_commit();
         assert!(
             final_index > last_processed_with_pending,
-            "Validator should have progressed after restart: with_pending_subdags={}, final={}",
-            last_processed_with_pending,
-            final_index
+            "Validator should have progressed after restart: with_pending_subdags={last_processed_with_pending}, final={final_index}"
         );
 
         // Verify that fast sync was actually used by checking the fetched commits
@@ -1592,8 +1577,7 @@ mod tests {
 
         assert!(
             commit_sync_fetched_commits > 0,
-            "Expected commits fetched via fast sync > 0, got {}",
-            commit_sync_fetched_commits
+            "Expected commits fetched via fast sync > 0, got {commit_sync_fetched_commits}"
         );
 
         // Stop all authorities

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3383,9 +3383,8 @@ mod test {
                     }
                 }
                 _ = tokio::time::sleep(timeout_duration) => {
-                    panic!("Test timed out after {:?}. Received {}/{} notifications. \
-                           This suggests notifications are not being sent properly.",
-                           timeout_duration, received_notifications, expected_notifications);
+                    panic!("Test timed out after {timeout_duration:?}. Received {received_notifications}/{expected_notifications} notifications. \
+                           This suggests notifications are not being sent properly.");
                 }
             }
         }
@@ -3393,8 +3392,7 @@ mod test {
         // Verify we got all expected notifications
         assert_eq!(
             received_notifications, expected_notifications,
-            "Expected {} notifications but only received {}",
-            expected_notifications, received_notifications
+            "Expected {expected_notifications} notifications but only received {received_notifications}"
         );
     }
 }

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -149,8 +149,8 @@ impl GenericTransactionRef {
 impl fmt::Display for GenericTransactionRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            GenericTransactionRef::BlockRef(b) => write!(f, "{}", b),
-            GenericTransactionRef::TransactionRef(t) => write!(f, "{}", t),
+            GenericTransactionRef::BlockRef(b) => write!(f, "{b}"),
+            GenericTransactionRef::TransactionRef(t) => write!(f, "{t}"),
         }
     }
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -45,8 +45,8 @@ pub(crate) enum ColumnFamily {
 impl std::fmt::Debug for ColumnFamily {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ColumnFamily::Rocks(name) => write!(f, "RocksDB cf: {}", name),
-            ColumnFamily::InMemory(name) => write!(f, "InMemory cf: {}", name),
+            ColumnFamily::Rocks(name) => write!(f, "RocksDB cf: {name}"),
+            ColumnFamily::InMemory(name) => write!(f, "InMemory cf: {name}"),
         }
     }
 }
@@ -82,8 +82,8 @@ pub(crate) enum Storage {
 impl std::fmt::Debug for Storage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Storage::Rocks(db) => write!(f, "RocksDB Storage {:?}", db),
-            Storage::InMemory(db) => write!(f, "InMemoryDB Storage {:?}", db),
+            Storage::Rocks(db) => write!(f, "RocksDB Storage {db:?}"),
+            Storage::InMemory(db) => write!(f, "InMemoryDB Storage {db:?}"),
         }
     }
 }


### PR DESCRIPTION
# Description of change

Promote clippy's [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) to `warn` at the workspace level and fix all existing call sites it flagged. New format-args are captured inline (`format!("{x}")`) instead of passed positionally (`format!("{}", x)`), which is shorter and easier to read.

While auditing, I also noticed `crates/iota-metrics-push-client` was the only workspace member without `[lints] workspace = true`, so the lint wouldn't have applied to it — added the inheritance stanza so it's now covered like every other crate.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)