### PR TITLE
feat(starfish-core,iota-core): emit misbehavior counts to iota-core

### DIFF
--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -883,6 +883,7 @@ mod tests {
             leader_header.timestamp_ms(),
             CommitRef::new(10, CommitDigest::MIN),
             vec![],
+            vec![],
         );
 
         // Test that the consensus handler respects backpressure.

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -135,4 +135,24 @@ impl ConsensusOutputAPI for starfish_core::CommittedSubDag {
             });
         num_of_committed_headers.into_iter().collect()
     }
+
+    fn misbehavior_counts(&self) -> ConsensusOutputMisbehaviorCounts {
+        let n = self.misbehavior_counts.len();
+        let mut faulty_blocks_provable = Vec::with_capacity(n);
+        let mut faulty_blocks_unprovable = Vec::with_capacity(n);
+        let mut missing_proposals = Vec::with_capacity(n);
+        let mut equivocations = Vec::with_capacity(n);
+        for c in &self.misbehavior_counts {
+            faulty_blocks_provable.push(c.faulty_blocks_provable);
+            faulty_blocks_unprovable.push(c.faulty_blocks_unprovable);
+            missing_proposals.push(c.missing_proposals);
+            equivocations.push(c.equivocations);
+        }
+        ConsensusOutputMisbehaviorCounts {
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+        }
+    }
 }

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -156,3 +156,70 @@ impl ConsensusOutputAPI for starfish_core::CommittedSubDag {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use starfish_core::{
+        BlockRef, CommitDigest, CommitRef, CommittedSubDag, MisbehaviorCountsV1,
+        VerifiedBlockHeader,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_misbehavior_counts_transposes_per_authority_to_per_field_vecs() {
+        let counts = vec![
+            MisbehaviorCountsV1 {
+                faulty_blocks_provable: 1,
+                faulty_blocks_unprovable: 2,
+                missing_proposals: 3,
+                equivocations: 4,
+            },
+            MisbehaviorCountsV1 {
+                faulty_blocks_provable: 10,
+                faulty_blocks_unprovable: 20,
+                missing_proposals: 30,
+                equivocations: 40,
+            },
+            MisbehaviorCountsV1::default(),
+        ];
+
+        let mut subdag = CommittedSubDag::new(
+            BlockRef::MIN,
+            Vec::<VerifiedBlockHeader>::new(),
+            vec![],
+            vec![],
+            0,
+            CommitRef::new(1, CommitDigest::MIN),
+            vec![],
+            counts,
+        );
+        // Sanity: keep the snapshot reachable via the trait even after construction.
+        subdag.misbehavior_counts.shrink_to_fit();
+
+        let out = subdag.misbehavior_counts();
+        assert_eq!(out.faulty_blocks_provable, vec![1, 10, 0]);
+        assert_eq!(out.faulty_blocks_unprovable, vec![2, 20, 0]);
+        assert_eq!(out.missing_proposals, vec![3, 30, 0]);
+        assert_eq!(out.equivocations, vec![4, 40, 0]);
+    }
+
+    #[test]
+    fn test_misbehavior_counts_empty_snapshot_produces_empty_vecs() {
+        let subdag = CommittedSubDag::new(
+            BlockRef::MIN,
+            Vec::<VerifiedBlockHeader>::new(),
+            vec![],
+            vec![],
+            0,
+            CommitRef::new(1, CommitDigest::MIN),
+            vec![],
+            vec![],
+        );
+        let out = subdag.misbehavior_counts();
+        assert!(out.faulty_blocks_provable.is_empty());
+        assert!(out.faulty_blocks_unprovable.is_empty());
+        assert!(out.missing_proposals.is_empty());
+        assert!(out.equivocations.is_empty());
+    }
+}

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -137,16 +137,22 @@ impl ConsensusOutputAPI for starfish_core::CommittedSubDag {
     }
 
     fn misbehavior_counts(&self) -> ConsensusOutputMisbehaviorCounts {
-        let n = self.misbehavior_counts.len();
-        let mut faulty_blocks_provable = Vec::with_capacity(n);
-        let mut faulty_blocks_unprovable = Vec::with_capacity(n);
-        let mut missing_proposals = Vec::with_capacity(n);
-        let mut equivocations = Vec::with_capacity(n);
-        for c in &self.misbehavior_counts {
-            faulty_blocks_provable.push(c.faulty_blocks_provable);
-            faulty_blocks_unprovable.push(c.faulty_blocks_unprovable);
-            missing_proposals.push(c.missing_proposals);
-            equivocations.push(c.equivocations);
+        let authority_count = self.misbehavior_counts.len();
+        let mut faulty_blocks_provable = Vec::with_capacity(authority_count);
+        let mut faulty_blocks_unprovable = Vec::with_capacity(authority_count);
+        let mut missing_proposals = Vec::with_capacity(authority_count);
+        let mut equivocations = Vec::with_capacity(authority_count);
+        // Exhaustive `match` on the versioned envelope: adding a new variant in
+        // starfish-core will fail to compile here until this consumer is updated.
+        for counts in &self.misbehavior_counts {
+            match counts {
+                starfish_core::MisbehaviorCounts::V1(v1) => {
+                    faulty_blocks_provable.push(v1.faulty_blocks_provable);
+                    faulty_blocks_unprovable.push(v1.faulty_blocks_unprovable);
+                    missing_proposals.push(v1.missing_proposals);
+                    equivocations.push(v1.equivocations);
+                }
+            }
         }
         ConsensusOutputMisbehaviorCounts {
             faulty_blocks_provable,
@@ -160,7 +166,7 @@ impl ConsensusOutputAPI for starfish_core::CommittedSubDag {
 #[cfg(test)]
 mod tests {
     use starfish_core::{
-        BlockRef, CommitDigest, CommitRef, CommittedSubDag, MisbehaviorCountsV1,
+        BlockRef, CommitDigest, CommitRef, CommittedSubDag, MisbehaviorCounts, MisbehaviorCountsV1,
         VerifiedBlockHeader,
     };
 
@@ -169,22 +175,22 @@ mod tests {
     #[test]
     fn test_misbehavior_counts_transposes_per_authority_to_per_field_vecs() {
         let counts = vec![
-            MisbehaviorCountsV1 {
+            MisbehaviorCounts::V1(MisbehaviorCountsV1 {
                 faulty_blocks_provable: 1,
                 faulty_blocks_unprovable: 2,
                 missing_proposals: 3,
                 equivocations: 4,
-            },
-            MisbehaviorCountsV1 {
+            }),
+            MisbehaviorCounts::V1(MisbehaviorCountsV1 {
                 faulty_blocks_provable: 10,
                 faulty_blocks_unprovable: 20,
                 missing_proposals: 30,
                 equivocations: 40,
-            },
-            MisbehaviorCountsV1::default(),
+            }),
+            MisbehaviorCounts::default(),
         ];
 
-        let mut subdag = CommittedSubDag::new(
+        let subdag = CommittedSubDag::new(
             BlockRef::MIN,
             Vec::<VerifiedBlockHeader>::new(),
             vec![],
@@ -194,8 +200,6 @@ mod tests {
             vec![],
             counts,
         );
-        // Sanity: keep the snapshot reachable via the trait even after construction.
-        subdag.misbehavior_counts.shrink_to_fit();
 
         let out = subdag.misbehavior_counts();
         assert_eq!(out.faulty_blocks_provable, vec![1, 10, 0]);

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -5,6 +5,7 @@
 use std::{collections::BTreeMap, fmt::Display};
 
 use iota_types::{digests::ConsensusCommitDigest, messages_consensus::ConsensusTransaction};
+use itertools::Itertools as _;
 
 use crate::consensus_types::AuthorityIndex;
 /// A list of tuples of:
@@ -137,23 +138,18 @@ impl ConsensusOutputAPI for starfish_core::CommittedSubDag {
     }
 
     fn misbehavior_counts(&self) -> ConsensusOutputMisbehaviorCounts {
-        let authority_count = self.misbehavior_counts.len();
-        let mut faulty_blocks_provable = Vec::with_capacity(authority_count);
-        let mut faulty_blocks_unprovable = Vec::with_capacity(authority_count);
-        let mut missing_proposals = Vec::with_capacity(authority_count);
-        let mut equivocations = Vec::with_capacity(authority_count);
-        // Exhaustive `match` on the versioned envelope: adding a new variant in
-        // starfish-core will fail to compile here until this consumer is updated.
-        for counts in &self.misbehavior_counts {
-            match counts {
-                starfish_core::MisbehaviorCounts::V1(v1) => {
-                    faulty_blocks_provable.push(v1.faulty_blocks_provable);
-                    faulty_blocks_unprovable.push(v1.faulty_blocks_unprovable);
-                    missing_proposals.push(v1.missing_proposals);
-                    equivocations.push(v1.equivocations);
-                }
-            }
-        }
+        let (faulty_blocks_provable, faulty_blocks_unprovable, missing_proposals, equivocations) =
+            self.misbehavior_counts
+                .iter()
+                .map(|counts| match counts {
+                    starfish_core::MisbehaviorCounts::V1(v1) => (
+                        v1.faulty_blocks_provable,
+                        v1.faulty_blocks_unprovable,
+                        v1.missing_proposals,
+                        v1.equivocations,
+                    ),
+                })
+                .multiunzip();
         ConsensusOutputMisbehaviorCounts {
             faulty_blocks_provable,
             faulty_blocks_unprovable,

--- a/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
@@ -201,6 +201,7 @@ async fn test_starfish_consensus_handler_handles_older_commits() {
                 1000 + commit_idx * 1000,
                 StarfishCommitRef::new(commit_idx as u32, StarfishCommitDigest::MIN),
                 vec![],
+                vec![],
             )
         })
         .collect();

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -580,11 +580,8 @@ pub struct CommittedSubDag {
     /// All the committed blocks that are part of this sub-dag
     pub transactions: Vec<VerifiedTransactions>,
     /// Absolute per-authority misbehavior counts (`persisted + in_memory`)
-    /// snapshotted from `MisbehaviorStore` at the moment this subdag was
-    /// emitted. Indexed by `AuthorityIndex` (`vec[i]` = authority `i`).
-    /// Consumers in iota-core diff against their own last-seen state if they
-    /// need deltas. Versioned envelope: consumers must `match` exhaustively
-    /// on the enum so adding a new variant is a compile error downstream.
+    /// snapshotted from `MisbehaviorStore` at emission. Indexed by
+    /// `AuthorityIndex`; consumers diff for deltas.
     pub misbehavior_counts: Vec<MisbehaviorCounts>,
 }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -25,6 +25,7 @@ use crate::{
     },
     context::Context,
     leader_scoring::ReputationScores,
+    misbehavior_store::MisbehaviorCountsV1,
     storage::Store,
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _, TransactionRef},
 };
@@ -578,6 +579,12 @@ pub struct CommittedSubDag {
     pub base: SubDagBase,
     /// All the committed blocks that are part of this sub-dag
     pub transactions: Vec<VerifiedTransactions>,
+    /// Absolute per-authority misbehavior counts (`persisted + in_memory`)
+    /// snapshotted from `MisbehaviorStore` at the moment this subdag was
+    /// emitted. Indexed by `AuthorityIndex` (`vec[i]` = authority `i`).
+    /// Consumers in iota-core diff against their own last-seen state if they
+    /// need deltas.
+    pub misbehavior_counts: Vec<MisbehaviorCountsV1>,
 }
 
 impl CommittedSubDag {
@@ -590,6 +597,7 @@ impl CommittedSubDag {
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
+        misbehavior_counts: Vec<MisbehaviorCountsV1>,
     ) -> Self {
         Self {
             base: SubDagBase {
@@ -601,6 +609,7 @@ impl CommittedSubDag {
                 reputation_scores_desc,
             },
             transactions,
+            misbehavior_counts,
         }
     }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     context::Context,
     leader_scoring::ReputationScores,
-    misbehavior_store::MisbehaviorCountsV1,
+    misbehavior_store::MisbehaviorCounts,
     storage::Store,
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _, TransactionRef},
 };
@@ -583,8 +583,9 @@ pub struct CommittedSubDag {
     /// snapshotted from `MisbehaviorStore` at the moment this subdag was
     /// emitted. Indexed by `AuthorityIndex` (`vec[i]` = authority `i`).
     /// Consumers in iota-core diff against their own last-seen state if they
-    /// need deltas.
-    pub misbehavior_counts: Vec<MisbehaviorCountsV1>,
+    /// need deltas. Versioned envelope: consumers must `match` exhaustively
+    /// on the enum so adding a new variant is a compile error downstream.
+    pub misbehavior_counts: Vec<MisbehaviorCounts>,
 }
 
 impl CommittedSubDag {
@@ -597,7 +598,7 @@ impl CommittedSubDag {
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
-        misbehavior_counts: Vec<MisbehaviorCountsV1>,
+        misbehavior_counts: Vec<MisbehaviorCounts>,
     ) -> Self {
         Self {
             base: SubDagBase {

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -239,7 +239,6 @@ impl CommitObserver {
             }
         };
 
-        let misbehavior_counts = self.dag_state.read().misbehavior_store().snapshot_totals();
         Some(CommittedSubDag::new(
             commit.leader(),
             vec![], // Empty headers for recovery
@@ -248,7 +247,7 @@ impl CommitObserver {
             commit.timestamp_ms(),
             commit.reference(),
             reputation_scores,
-            misbehavior_counts,
+            self.dag_state.read().misbehavior_store().snapshot_totals(),
         ))
     }
 

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -239,6 +239,7 @@ impl CommitObserver {
             }
         };
 
+        let misbehavior_counts = self.dag_state.read().misbehavior_store().snapshot_totals();
         Some(CommittedSubDag::new(
             commit.leader(),
             vec![], // Empty headers for recovery
@@ -247,6 +248,7 @@ impl CommitObserver {
             commit.timestamp_ms(),
             commit.reference(),
             reputation_scores,
+            misbehavior_counts,
         ))
     }
 

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -198,6 +198,11 @@ impl CommitSolidifier {
                 .map(|tx| tx.expect("Transaction must exist since we checked"))
                 .collect();
 
+            // If this subdag was delayed waiting for missing transactions, the
+            // snapshot reflects current store state, not state at leader-round
+            // commit time. Acceptable: counts are absolute and consumers
+            // merge-max, so a stale-by-newer snapshot only loses fidelity at
+            // intra-epoch granularity, not correctness.
             let misbehavior_counts = dag_state.misbehavior_store().snapshot_totals();
             Ok(CommittedSubDag::new(
                 subdag.leader,

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -198,11 +198,8 @@ impl CommitSolidifier {
                 .map(|tx| tx.expect("Transaction must exist since we checked"))
                 .collect();
 
-            // If this subdag was delayed waiting for missing transactions, the
-            // snapshot reflects current store state, not state at leader-round
-            // commit time. Acceptable: counts are absolute and consumers
-            // merge-max, so a stale-by-newer snapshot only loses fidelity at
-            // intra-epoch granularity, not correctness.
+            // Delayed subdags see current store state, not state at leader-round
+            // commit time. Safe: counts are absolute and consumers merge-max.
             let misbehavior_counts = dag_state.misbehavior_store().snapshot_totals();
             Ok(CommittedSubDag::new(
                 subdag.leader,

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -198,6 +198,7 @@ impl CommitSolidifier {
                 .map(|tx| tx.expect("Transaction must exist since we checked"))
                 .collect();
 
+            let misbehavior_counts = dag_state.misbehavior_store().snapshot_totals();
             Ok(CommittedSubDag::new(
                 subdag.leader,
                 subdag.base.headers.clone(),
@@ -206,6 +207,7 @@ impl CommitSolidifier {
                 subdag.timestamp_ms,
                 subdag.commit_ref,
                 subdag.reputation_scores_desc.clone(),
+                misbehavior_counts,
             ))
         } else {
             Err(missing)

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -676,6 +676,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .filter_map(|tx_ref| transactions_map.remove(tx_ref))
                 .collect();
 
+            let misbehavior_counts = inner.dag_state.read().misbehavior_store().snapshot_totals();
             committed_subdags.push(CommittedSubDag::new(
                 commit.leader(),
                 vec![], // headers - VerifiedBlockHeader, we don't have these in fast sync
@@ -684,6 +685,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 commit.timestamp_ms(),
                 commit.reference(),
                 reputation_scores,
+                misbehavior_counts,
             ));
         }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -662,6 +662,10 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // For fast commit sync, we use block headers refs and reputation scores from
         // the commit.
         let mut committed_subdags = Vec::new();
+        // Replayed commits share one snapshot of current store state; downstream
+        // consumers merge-max against their last-seen, so repeating absolute
+        // totals across the batch is a no-op after the first.
+        let misbehavior_counts = inner.dag_state.read().misbehavior_store().snapshot_totals();
         for commit in &commits {
             // Get block headers from the commit
             let committed_header_refs = commit.block_headers().to_vec();
@@ -676,7 +680,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .filter_map(|tx_ref| transactions_map.remove(tx_ref))
                 .collect();
 
-            let misbehavior_counts = inner.dag_state.read().misbehavior_store().snapshot_totals();
             committed_subdags.push(CommittedSubDag::new(
                 commit.leader(),
                 vec![], // headers - VerifiedBlockHeader, we don't have these in fast sync
@@ -685,7 +688,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 commit.timestamp_ms(),
                 commit.reference(),
                 reputation_scores,
-                misbehavior_counts,
+                misbehavior_counts.clone(),
             ));
         }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2678,7 +2678,11 @@ mod test {
         // Record traversed headers and sequenced transactions
         while let Some(sub_dag) = commit_receiver_own.recv().await {
             let sub_dag_leader_round = sub_dag.leader.round;
-            let CommittedSubDag { base, transactions } = sub_dag;
+            let CommittedSubDag {
+                base,
+                transactions,
+                misbehavior_counts: _,
+            } = sub_dag;
 
             for block_ref in &base.committed_header_refs {
                 existing_headers.insert(*block_ref);

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2683,9 +2683,6 @@ mod test {
                 transactions,
                 misbehavior_counts,
             } = sub_dag;
-
-            // Snapshot is one entry per committee member; non-zero misbehavior
-            // would surface elsewhere in this test, so just confirm shape.
             assert_eq!(misbehavior_counts.len(), committee_size);
 
             for block_ref in &base.committed_header_refs {

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2681,8 +2681,12 @@ mod test {
             let CommittedSubDag {
                 base,
                 transactions,
-                misbehavior_counts: _,
+                misbehavior_counts,
             } = sub_dag;
+
+            // Snapshot is one entry per committee member; non-zero misbehavior
+            // would surface elsewhere in this test, so just confirm shape.
+            assert_eq!(misbehavior_counts.len(), committee_size);
 
             for block_ref in &base.committed_header_refs {
                 existing_headers.insert(*block_ref);

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2503,7 +2503,6 @@ impl DagState {
         self.pending_acknowledgments = acknowledgments.into_iter().collect::<BTreeSet<_>>();
     }
 
-    #[cfg(test)]
     pub(crate) fn misbehavior_store(&self) -> &MisbehaviorStore {
         &self.misbehavior_store
     }

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -841,6 +841,7 @@ mod tests {
                 context.clock.timestamp_utc_ms(),
                 CommitRef::new(1, CommitDigest::MIN),
                 vec![],
+                vec![],
             )
             .base,
         ];
@@ -943,6 +944,7 @@ mod tests {
                 vec![], // Committed transactions are not important for this test.
                 context.clock.timestamp_utc_ms(),
                 last_commit.reference(),
+                vec![],
                 vec![],
             )
             .base,

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -69,8 +69,8 @@ pub use block_header::{
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use context::Clock;
+pub use misbehavior_store::{MisbehaviorCounts, MisbehaviorCountsV1};
 pub use network::tonic_network::to_socket_addr;
-pub use misbehavior_store::MisbehaviorCountsV1;
 #[cfg(msim)]
 pub use storage::delete_all_transactions_from_store;
 #[cfg(msim)]

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -70,6 +70,7 @@ pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use context::Clock;
 pub use network::tonic_network::to_socket_addr;
+pub use misbehavior_store::MisbehaviorCountsV1;
 #[cfg(msim)]
 pub use storage::delete_all_transactions_from_store;
 #[cfg(msim)]

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -164,10 +164,10 @@ impl MisbehaviorStore {
     }
 
     /// Returns an absolute per-authority snapshot of `persisted + in_memory`
-    /// counts for emission with `CommittedSubDag`. The sum is invariant
-    /// across the eviction-time move from `in_memory` to `persisted`, so the
-    /// snapshot is consistent regardless of when it is taken relative to
-    /// flush.
+    /// counts for emission with `CommittedSubDag`. Locks the two buckets
+    /// independently per authority; callers must hold `dag_state.read()` so
+    /// concurrent flush (which writes both buckets under `dag_state.write()`)
+    /// is excluded.
     pub(crate) fn snapshot_totals(&self) -> Vec<MisbehaviorCounts> {
         (0..self.in_memory.authorities.len())
             .map(|i| {

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -871,6 +871,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_snapshot_totals_sums_persisted_and_in_memory() {
+        let committee_size = 4;
+        let context = Arc::new(Context::new_for_test(committee_size).0);
+        let store = MisbehaviorStore::new(&context);
+        let a0 = AuthorityIndex::new_for_test(0);
+        let a1 = AuthorityIndex::new_for_test(1);
+        let provable = ConsensusError::TooManyAncestors(10, 5);
+
+        // Seed in_memory provable counts for authority 0 (2) and 1 (1).
+        store.record_faulty_block_header(a0, a0, &provable);
+        store.record_faulty_block_header(a0, a0, &provable);
+        store.record_faulty_block_header(a1, a1, &provable);
+
+        // Flush faulty buffer for authority 0 into persisted; leave authority 1
+        // unflushed so the snapshot must sum across both buckets.
+        let _ = store.update_misbehavior_counts_on_eviction(
+            a0,
+            &BTreeSet::new(),
+            0,
+            0,
+            1,
+            &context,
+        );
+
+        // Record 3 more provable faults on authority 0 — these stay in_memory.
+        for _ in 0..3 {
+            store.record_faulty_block_header(a0, a0, &provable);
+        }
+
+        let snapshot = store.snapshot_totals();
+        assert_eq!(snapshot.len(), committee_size);
+        // Authority 0: 2 flushed into persisted + 3 still in_memory = 5 total.
+        // Authority 1: 1 still in_memory (never flushed) = 1 total.
+        // Untouched authorities are zero across both buckets.
+        let provable_totals: Vec<u64> = snapshot
+            .iter()
+            .map(|c| match c {
+                MisbehaviorCounts::V1(v1) => v1.faulty_blocks_provable,
+            })
+            .collect();
+        assert_eq!(provable_totals, vec![5, 1, 0, 0]);
+    }
+
+    #[tokio::test]
     async fn test_provable_fault_charges_both_author_and_serving_peer() {
         // When a peer serves us a block with a valid signature but a protocol
         // violation, both parties are at fault: the author for creating a bad

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -168,18 +168,19 @@ impl MisbehaviorStore {
     /// across the eviction-time move from `in_memory` to `persisted`, so the
     /// snapshot is consistent regardless of when it is taken relative to
     /// flush.
-    pub(crate) fn snapshot_totals(&self) -> Vec<MisbehaviorCountsV1> {
+    pub(crate) fn snapshot_totals(&self) -> Vec<MisbehaviorCounts> {
         (0..self.in_memory.authorities.len())
             .map(|i| {
-                let p = self.persisted.snapshot(i);
-                let m = self.in_memory.snapshot(i);
-                MisbehaviorCountsV1 {
-                    faulty_blocks_provable: p.faulty_blocks_provable + m.faulty_blocks_provable,
-                    faulty_blocks_unprovable: p.faulty_blocks_unprovable
-                        + m.faulty_blocks_unprovable,
-                    missing_proposals: p.missing_proposals + m.missing_proposals,
-                    equivocations: p.equivocations + m.equivocations,
-                }
+                let persisted = self.persisted.snapshot(i);
+                let in_memory = self.in_memory.snapshot(i);
+                MisbehaviorCounts::V1(MisbehaviorCountsV1 {
+                    faulty_blocks_provable: persisted.faulty_blocks_provable
+                        + in_memory.faulty_blocks_provable,
+                    faulty_blocks_unprovable: persisted.faulty_blocks_unprovable
+                        + in_memory.faulty_blocks_unprovable,
+                    missing_proposals: persisted.missing_proposals + in_memory.missing_proposals,
+                    equivocations: persisted.equivocations + in_memory.equivocations,
+                })
             })
             .collect()
     }
@@ -430,7 +431,7 @@ fn calculate_misbehavior_counts_for_range(
 /// Versioned envelope for persisted scoring metrics. New versions are added as
 /// enum variants so existing RocksDB data deserializes without migration.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) enum MisbehaviorCounts {
+pub enum MisbehaviorCounts {
     V1(MisbehaviorCountsV1),
 }
 
@@ -886,14 +887,8 @@ mod tests {
 
         // Flush faulty buffer for authority 0 into persisted; leave authority 1
         // unflushed so the snapshot must sum across both buckets.
-        let _ = store.update_misbehavior_counts_on_eviction(
-            a0,
-            &BTreeSet::new(),
-            0,
-            0,
-            1,
-            &context,
-        );
+        let _ =
+            store.update_misbehavior_counts_on_eviction(a0, &BTreeSet::new(), 0, 0, 1, &context);
 
         // Record 3 more provable faults on authority 0 — these stay in_memory.
         for _ in 0..3 {

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -163,6 +163,27 @@ impl MisbehaviorStore {
         true
     }
 
+    /// Returns an absolute per-authority snapshot of `persisted + in_memory`
+    /// counts for emission with `CommittedSubDag`. The sum is invariant
+    /// across the eviction-time move from `in_memory` to `persisted`, so the
+    /// snapshot is consistent regardless of when it is taken relative to
+    /// flush.
+    pub(crate) fn snapshot_totals(&self) -> Vec<MisbehaviorCountsV1> {
+        (0..self.in_memory.authorities.len())
+            .map(|i| {
+                let p = self.persisted.snapshot(i);
+                let m = self.in_memory.snapshot(i);
+                MisbehaviorCountsV1 {
+                    faulty_blocks_provable: p.faulty_blocks_provable + m.faulty_blocks_provable,
+                    faulty_blocks_unprovable: p.faulty_blocks_unprovable
+                        + m.faulty_blocks_unprovable,
+                    missing_proposals: p.missing_proposals + m.missing_proposals,
+                    equivocations: p.equivocations + m.equivocations,
+                }
+            })
+            .collect()
+    }
+
     /// Records a faulty block header event detected during block header
     /// validation. Events are buffered in the in_memory bucket and moved
     /// to persisted on the next flush.
@@ -420,11 +441,11 @@ impl Default for MisbehaviorCounts {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
-pub(crate) struct MisbehaviorCountsV1 {
-    pub(crate) faulty_blocks_provable: u64,
-    pub(crate) faulty_blocks_unprovable: u64,
-    pub(crate) missing_proposals: u64,
-    pub(crate) equivocations: u64,
+pub struct MisbehaviorCountsV1 {
+    pub faulty_blocks_provable: u64,
+    pub faulty_blocks_unprovable: u64,
+    pub missing_proposals: u64,
+    pub equivocations: u64,
 }
 
 #[cfg(test)]

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -329,6 +329,7 @@ impl DagBuilder {
                 last_timestamp_ms,
                 commit.reference(),
                 vec![],
+                vec![],
             );
 
             self.committed_sub_dags.push((sub_dag, commit));


### PR DESCRIPTION
# Description of change

Stacks on top of #11531. Wires the producer-side misbehavior store
(landed in #10088 + #11531) into the consumer in `iota-core` so that
the `Scoreboard` / `ReportAggregator` (from #10779) finally receives
per-authority misbehavior signal from Starfish.

Each `CommittedSubDag` now carries a per-authority absolute snapshot of
`persisted + in_memory` counts from `MisbehaviorStore` at commit time.
Consumers diff against their own last-seen state if they want deltas —
that responsibility doesn't belong in Starfish, and the sum is invariant
across the eviction-time move between buckets, so the snapshot is
race-free relative to flush.

Producer (`starfish-core`):
- `MisbehaviorStore::snapshot_totals()` — returns the per-authority
  absolute totals.
- `CommittedSubDag` gets a new `misbehavior_counts: Vec<MisbehaviorCountsV1>`
  field, threaded at all three production `CommittedSubDag::new` call
  sites (`commit_solidifier`, `commit_observer`, `commit_syncer/fast`)
  via the `DagState`-owned `MisbehaviorStore`.
- `CommittedSubDag` is **not** serialized over the wire (local
  `CommitConsumer` channel only), so the added `Vec` is an in-process
  cost only.

Consumer (`iota-core`):
- Overrides `ConsensusOutputAPI::misbehavior_counts()` on
  `starfish_core::CommittedSubDag` to transpose the per-authority
  struct-of-fields snapshot into the four per-field vecs expected by
  `ConsensusOutputMisbehaviorCounts`. Downstream wiring in
  `consensus_handler` and the report aggregator was already in place
  and waiting for non-empty data.

Also folds in a standalone fix: `starfish-core` now declares its
`iota-sdk-types` `serde` feature explicitly. Workspace builds were
masking the missing feature via unification through `iota-types`;
`cargo check -p starfish-core` alone fails without it.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota-private/issues/406
Part of https://github.com/iotaledger/iota-private/issues/173

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Local verification:
- `cargo ci-clippy` — clean.
- `cargo nextest run -p starfish-core --lib` — new `test_snapshot_totals_sums_persisted_and_in_memory` passes; existing misbehavior tests pass.
- `cargo nextest run -p iota-core --lib consensus_output_api::tests` — new transpose + empty-snapshot tests pass.