### PR TITLE
feat(consensus): version-flag check for Commit V3 and BlockHeader

### DIFF
--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -9,7 +9,8 @@ use tracing::instrument;
 use crate::{
     Transaction,
     block_header::{
-        BlockHeaderAPI, BlockRef, GENESIS_ROUND, SignedBlockHeader, genesis_block_headers,
+        BlockHeader, BlockHeaderAPI, BlockRef, GENESIS_ROUND, SignedBlockHeader,
+        genesis_block_headers,
     },
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -88,6 +89,33 @@ impl SignedBlockVerifier {
     }
 }
 
+/// Rejects a deserialized `BlockHeader` whose variant does not match the local
+/// `consensus_starfish_speed` configuration. The flag is uniform across the
+/// network within an epoch, so any mismatch implies either a malicious peer
+/// or a misconfigured upgrade path. V2 is gated by `consensus_starfish_speed`;
+/// V1 is the only legal variant when the flag is off.
+pub(crate) fn check_block_header_version_matches_flag(
+    header: &BlockHeader,
+    protocol_config: &iota_protocol_config::ProtocolConfig,
+) -> ConsensusResult<()> {
+    let starfish_speed = protocol_config.consensus_starfish_speed();
+    let variant_matches_flag = matches!(
+        (header, starfish_speed),
+        (BlockHeader::V1(_), false) | (BlockHeader::V2(_), true)
+    );
+    if !variant_matches_flag {
+        let actual = match header {
+            BlockHeader::V1(_) => "V1",
+            BlockHeader::V2(_) => "V2",
+        };
+        return Err(ConsensusError::WrongBlockHeaderVersionForFlag {
+            actual,
+            starfish_speed,
+        });
+    }
+    Ok(())
+}
+
 // All block verification logic are implemented below.
 impl BlockVerifier for SignedBlockVerifier {
     #[instrument(level = "trace", skip_all)]
@@ -105,6 +133,10 @@ impl BlockVerifier for SignedBlockVerifier {
             return Err(ConsensusError::UnexpectedGenesisHeader);
         }
         ConsensusError::quick_validation_authority_indices(&[block.author()], committee)?;
+
+        // Reject blocks whose header variant does not match the local
+        // `consensus_starfish_speed` configuration.
+        check_block_header_version_matches_flag(block, &self.context.protocol_config)?;
 
         // Verify the block's signature.
         block.verify_signature(&self.context)?;
@@ -474,6 +506,70 @@ pub(crate) mod test {
             assert!(matches!(
                 verifier.verify(&signed_block),
                 Err(ConsensusError::DuplicatedAncestorsAuthority(_))
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_block_version_flag() {
+        use crate::block_header::BlockHeader;
+
+        let ancestors = vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+            BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+        ];
+
+        // V1 block reaching a flag-on receiver -> WrongBlockHeaderVersionForFlag.
+        {
+            let (mut context, keypairs) = Context::new_for_test(4);
+            context
+                .protocol_config
+                .set_consensus_fast_commit_sync_for_testing(true);
+            context
+                .protocol_config
+                .set_consensus_starfish_speed_for_testing(true);
+            let context = Arc::new(context);
+            let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+
+            let block = TestBlockHeader::new(10, 2)
+                .set_ancestors(ancestors.clone())
+                .build();
+            let signed_block = SignedBlockHeader::new(block, &keypairs[2].1).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::WrongBlockHeaderVersionForFlag {
+                    actual: "V1",
+                    starfish_speed: true,
+                })
+            ));
+        }
+
+        // V2 block reaching a flag-off receiver -> WrongBlockHeaderVersionForFlag.
+        {
+            let (context, keypairs) = Context::new_for_test(4);
+            let context = Arc::new(context);
+            let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+
+            let v2 = crate::block_header::BlockHeaderV2::new(
+                0,
+                10,
+                AuthorityIndex::new_for_test(2),
+                0,
+                ancestors,
+                vec![],
+                vec![],
+                crate::block_header::TransactionsCommitment::DEFAULT_FOR_TEST,
+                None,
+            );
+            let signed_block = SignedBlockHeader::new(BlockHeader::V2(v2), &keypairs[2].1).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::WrongBlockHeaderVersionForFlag {
+                    actual: "V2",
+                    starfish_speed: false,
+                })
             ));
         }
     }

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -837,58 +837,33 @@ mod tests {
         .map(|_| ())
     }
 
+    #[rstest::rstest]
+    // Wire-format mismatches that PRs A/B already covered.
+    #[case::v2_with_fast_off(Commit::V2(CommitV2::default()), false, false, "V2")]
+    #[case::v1_with_fast_on(Commit::V1(CommitV1::default()), true, false, "V1")]
+    // StarfishSpeed-era cases added by PR C. `consensus_starfish_speed`
+    // requires `consensus_fast_commit_sync` (asserted in protocol_config), so
+    // the V3-without-starfish case keeps fast_commit_sync on.
+    #[case::v3_with_starfish_off(Commit::V3(CommitV3::default()), true, false, "V3")]
+    #[case::v1_with_starfish_on(Commit::V1(CommitV1::default()), true, true, "V1")]
     #[tokio::test]
-    async fn verify_commits_rejects_v2_commit_when_fast_commit_sync_disabled() {
-        let result = run_verify(Commit::V2(CommitV2::default()), false, false);
-        assert!(matches!(
-            result,
-            Err(ConsensusError::WrongCommitVersionForFlags {
-                actual: "V2",
-                fast_commit_sync: false,
-                starfish_speed: false,
-            })
-        ));
-    }
-
-    #[tokio::test]
-    async fn verify_commits_rejects_v1_commit_when_fast_commit_sync_enabled() {
-        let result = run_verify(Commit::V1(CommitV1::default()), true, false);
-        assert!(matches!(
-            result,
-            Err(ConsensusError::WrongCommitVersionForFlags {
-                actual: "V1",
-                fast_commit_sync: true,
-                starfish_speed: false,
-            })
-        ));
-    }
-
-    #[tokio::test]
-    async fn verify_commits_rejects_v3_commit_when_starfish_speed_disabled() {
-        // Need fast_commit_sync ON because the consensus_starfish_speed
-        // accessor asserts the dependency; setting both to (true, false)
-        // simulates "we're a fast-commit-sync node, peer sent us a V3".
-        let result = run_verify(Commit::V3(CommitV3::default()), true, false);
-        assert!(matches!(
-            result,
-            Err(ConsensusError::WrongCommitVersionForFlags {
-                actual: "V3",
-                fast_commit_sync: true,
-                starfish_speed: false,
-            })
-        ));
-    }
-
-    #[tokio::test]
-    async fn verify_commits_rejects_v1_commit_when_starfish_speed_enabled() {
-        let result = run_verify(Commit::V1(CommitV1::default()), true, true);
-        assert!(matches!(
-            result,
-            Err(ConsensusError::WrongCommitVersionForFlags {
-                actual: "V1",
-                fast_commit_sync: true,
-                starfish_speed: true,
-            })
-        ));
+    async fn verify_commits_rejects_wrong_version(
+        #[case] commit: Commit,
+        #[case] fast_commit_sync_on: bool,
+        #[case] starfish_speed_on: bool,
+        #[case] expected_variant: &'static str,
+    ) {
+        let result = run_verify(commit, fast_commit_sync_on, starfish_speed_on);
+        let Err(ConsensusError::WrongCommitVersionForFlags {
+            actual,
+            fast_commit_sync,
+            starfish_speed,
+        }) = result
+        else {
+            panic!("expected WrongCommitVersionForFlags, got {result:?}");
+        };
+        assert_eq!(actual, expected_variant);
+        assert_eq!(fast_commit_sync, fast_commit_sync_on);
+        assert_eq!(starfish_speed, starfish_speed_on);
     }
 }

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -835,10 +835,12 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case::v2_with_fast_off(Commit::V2(CommitV2::default()), false, false, "V2")]
     #[case::v1_with_fast_on(Commit::V1(CommitV1::default()), true, false, "V1")]
-    #[case::v3_with_starfish_off(Commit::V3(CommitV3::default()), true, false, "V3")]
     #[case::v1_with_starfish_on(Commit::V1(CommitV1::default()), true, true, "V1")]
+    #[case::v2_with_fast_off(Commit::V2(CommitV2::default()), false, false, "V2")]
+    #[case::v2_with_starfish_on(Commit::V2(CommitV2::default()), true, true, "V2")]
+    #[case::v3_with_fast_off(Commit::V3(CommitV3::default()), false, false, "V3")]
+    #[case::v3_with_starfish_off(Commit::V3(CommitV3::default()), true, false, "V3")]
     #[tokio::test]
     async fn verify_commits_rejects_wrong_version(
         #[case] commit: Commit,

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -221,12 +221,9 @@ pub(crate) fn check_commit_version_matches_flags(
 ) -> ConsensusResult<()> {
     let fast_commit_sync = protocol_config.consensus_fast_commit_sync();
     let starfish_speed = protocol_config.consensus_starfish_speed();
-    // V3 is gated by `consensus_starfish_speed`, which implies
-    // `consensus_fast_commit_sync` per the protocol-config assertion, so the
-    // `fast_commit_sync` value in the V3 arm is irrelevant.
     let variant_matches_flags = matches!(
         (commit, fast_commit_sync, starfish_speed),
-        (Commit::V1(_), false, false) | (Commit::V2(_), true, false) | (Commit::V3(_), _, true)
+        (Commit::V1(_), false, false) | (Commit::V2(_), true, false) | (Commit::V3(_), true, true)
     );
     if !variant_matches_flags {
         let actual = match commit {
@@ -838,12 +835,8 @@ mod tests {
     }
 
     #[rstest::rstest]
-    // Wire-format mismatches that PRs A/B already covered.
     #[case::v2_with_fast_off(Commit::V2(CommitV2::default()), false, false, "V2")]
     #[case::v1_with_fast_on(Commit::V1(CommitV1::default()), true, false, "V1")]
-    // StarfishSpeed-era cases added by PR C. `consensus_starfish_speed`
-    // requires `consensus_fast_commit_sync` (asserted in protocol_config), so
-    // the V3-without-starfish case keeps fast_commit_sync on.
     #[case::v3_with_starfish_off(Commit::V3(CommitV3::default()), true, false, "V3")]
     #[case::v1_with_starfish_on(Commit::V1(CommitV1::default()), true, true, "V1")]
     #[tokio::test]

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -220,18 +220,24 @@ pub(crate) fn check_commit_version_matches_flags(
     protocol_config: &iota_protocol_config::ProtocolConfig,
 ) -> ConsensusResult<()> {
     let fast_commit_sync = protocol_config.consensus_fast_commit_sync();
+    let starfish_speed = protocol_config.consensus_starfish_speed();
+    // V3 is gated by `consensus_starfish_speed`, which implies
+    // `consensus_fast_commit_sync` per the protocol-config assertion, so the
+    // `fast_commit_sync` value in the V3 arm is irrelevant.
     let variant_matches_flags = matches!(
-        (commit, fast_commit_sync),
-        (Commit::V1(_), false) | (Commit::V2(_), true)
+        (commit, fast_commit_sync, starfish_speed),
+        (Commit::V1(_), false, false) | (Commit::V2(_), true, false) | (Commit::V3(_), _, true)
     );
     if !variant_matches_flags {
         let actual = match commit {
             Commit::V1(_) => "V1",
             Commit::V2(_) => "V2",
+            Commit::V3(_) => "V3",
         };
         return Err(ConsensusError::WrongCommitVersionForFlags {
             actual,
             fast_commit_sync,
+            starfish_speed,
         });
     }
     Ok(())
@@ -798,18 +804,25 @@ mod tests {
     use super::*;
     use crate::{
         block_verifier::NoopBlockVerifier,
-        commit::{CommitV1, CommitV2},
+        commit::{CommitV1, CommitV2, CommitV3},
     };
 
     /// Builds a single-commit byte stream from `commit` and runs it through
-    /// `verify_commits` with `consensus_fast_commit_sync` set to
-    /// `fast_commit_sync_on`. The version check fires before the index
-    /// check, so the default commit index of 0 is fine here.
-    fn run_verify(commit: Commit, fast_commit_sync_on: bool) -> ConsensusResult<()> {
+    /// `verify_commits` with the two protocol flags set as specified. The
+    /// version check fires before the index check, so the default commit
+    /// index of 0 is fine here.
+    fn run_verify(
+        commit: Commit,
+        fast_commit_sync_on: bool,
+        starfish_speed_on: bool,
+    ) -> ConsensusResult<()> {
         let (mut context, _) = Context::new_for_test(4);
         context
             .protocol_config
             .set_consensus_fast_commit_sync_for_testing(fast_commit_sync_on);
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(starfish_speed_on);
         let context = Arc::new(context);
         let serialized = commit.serialize().unwrap();
         verify_commits(
@@ -826,24 +839,55 @@ mod tests {
 
     #[tokio::test]
     async fn verify_commits_rejects_v2_commit_when_fast_commit_sync_disabled() {
-        let result = run_verify(Commit::V2(CommitV2::default()), false);
+        let result = run_verify(Commit::V2(CommitV2::default()), false, false);
         assert!(matches!(
             result,
             Err(ConsensusError::WrongCommitVersionForFlags {
                 actual: "V2",
                 fast_commit_sync: false,
+                starfish_speed: false,
             })
         ));
     }
 
     #[tokio::test]
     async fn verify_commits_rejects_v1_commit_when_fast_commit_sync_enabled() {
-        let result = run_verify(Commit::V1(CommitV1::default()), true);
+        let result = run_verify(Commit::V1(CommitV1::default()), true, false);
         assert!(matches!(
             result,
             Err(ConsensusError::WrongCommitVersionForFlags {
                 actual: "V1",
                 fast_commit_sync: true,
+                starfish_speed: false,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_commits_rejects_v3_commit_when_starfish_speed_disabled() {
+        // Need fast_commit_sync ON because the consensus_starfish_speed
+        // accessor asserts the dependency; setting both to (true, false)
+        // simulates "we're a fast-commit-sync node, peer sent us a V3".
+        let result = run_verify(Commit::V3(CommitV3::default()), true, false);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::WrongCommitVersionForFlags {
+                actual: "V3",
+                fast_commit_sync: true,
+                starfish_speed: false,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_commits_rejects_v1_commit_when_starfish_speed_enabled() {
+        let result = run_verify(Commit::V1(CommitV1::default()), true, true);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::WrongCommitVersionForFlags {
+                actual: "V1",
+                fast_commit_sync: true,
+                starfish_speed: true,
             })
         ));
     }

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -327,11 +327,12 @@ pub(crate) enum ConsensusError {
     },
 
     #[error(
-        "Commit variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync})"
+        "Commit variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync}, consensus_starfish_speed={starfish_speed})"
     )]
     WrongCommitVersionForFlags {
         actual: &'static str,
         fast_commit_sync: bool,
+        starfish_speed: bool,
     },
 
     #[error("Block has strong_vote field but consensus_starfish_speed is disabled")]

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -350,6 +350,14 @@ pub(crate) enum ConsensusError {
         leader_round: Round,
         leader_authority: AuthorityIndex,
     },
+
+    #[error(
+        "BlockHeader variant {actual} does not match protocol flag (consensus_starfish_speed={starfish_speed})"
+    )]
+    WrongBlockHeaderVersionForFlag {
+        actual: &'static str,
+        starfish_speed: bool,
+    },
 }
 
 impl ConsensusError {


### PR DESCRIPTION
# Description of change

A peer can send a block header or commit whose tagged-enum variant does
not match the local `consensus_starfish_speed` flag. The bytes parse
cleanly today and no version check rejects them, leaving room for state
divergence between the receiver and the rest of the network.

This PR adds two consistency checks at the network-reception entry
points:

- `Commit`: extend `check_commit_version_matches_flags` so the existing
  V1/V2 check also rejects `Commit::V3` outside `consensus_starfish_speed`.
  `WrongCommitVersionForFlags` gains a `starfish_speed: bool` field.
- `BlockHeader`: new `check_block_header_version_matches_flag` helper
  wired into `SignedBlockVerifier::verify`, with a new
  `WrongBlockHeaderVersionForFlag` error variant.

Adversarial tests on both surfaces; commit-side tests parametrised via
`#[rstest]`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
