### PR TITLE
feat(graphql): dedupe DF ids before correlating MAX subquery

### DIFF
--- a/crates/iota-graphql-rpc/src/backward_view/dynamic_fields.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/dynamic_fields.rs
@@ -126,24 +126,43 @@ fn dynamic_fields_from_checkpointed_objects(
 /// records every real version, including tombstone versions). When
 /// `target_v` lands on a tombstone version, no Active state row exists at
 /// that key — the candidate naturally drops out of the result.
+///
+/// The query is shaped so the correlated `MAX(object_version)` subquery
+/// is keyed off a **deduped** set of DF `object_id`s (one row per DF) —
+/// not the un-deduped owner scan of `objects_backward_history` (which for
+/// a parent with deep DF history can have hundreds of thousands of rows
+/// for the same DF). The dedupe inner query relies on the partial index
+/// `objects_backward_history_owner_df` on
+/// `(owner_id, object_id) WHERE owner_type = 2 AND df_kind IS NOT NULL`.
 fn dynamic_fields_from_historical_objects(
     parent_version: i64,
     page: &Page<Cursor>,
     filter_fn: &impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
-    let history_filtered = filter_fn(query!(format!(
-        "SELECT {HISTORY_COLUMNS} FROM objects_backward_history"
-    )));
+    // Distinct DF object_ids owned by the parent. `filter_fn` adds the
+    // `owner_id = $parent AND owner_type = 2 AND df_kind IS NOT NULL`
+    // predicate, which together with the partial index lets Postgres do
+    // an Index Only Scan to find these ids.
+    let df_ids = filter_fn(query!(
+        "SELECT DISTINCT object_id FROM objects_backward_history"
+    ));
 
-    let with_target = filter!(
-        history_filtered,
-        format!(
-            "object_version = (\
-                 SELECT MAX(object_version) FROM objects_version ov \
-                 WHERE ov.object_id = objects_backward_history.object_id \
-                   AND ov.object_version <= {parent_version})"
-        )
+    // For each distinct DF, fetch the backward-history row at target_v
+    // via the correlated MAX subquery.
+    let (df_ids_sql, df_ids_binds) = df_ids.finish();
+    let sql = format!(
+        "SELECT {HISTORY_COLUMNS} FROM ( \
+             SELECT objects_backward_history.* \
+             FROM ({df_ids_sql}) df_ids \
+             JOIN objects_backward_history \
+                 ON objects_backward_history.object_id = df_ids.object_id \
+             WHERE objects_backward_history.object_version = ( \
+                 SELECT MAX(object_version) FROM objects_version \
+                 WHERE object_id = df_ids.object_id \
+                   AND object_version <= {parent_version}) \
+         ) AS objects_backward_history"
     );
+    let with_target = RawQuery::new(sql, df_ids_binds);
 
     let source = query!("SELECT candidates.* FROM ({}) candidates", with_target);
     page.apply::<StoredBackwardObject>(source)

--- a/crates/iota-graphql-rpc/src/backward_view/dynamic_fields.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/dynamic_fields.rs
@@ -127,13 +127,17 @@ fn dynamic_fields_from_checkpointed_objects(
 /// `target_v` lands on a tombstone version, no Active state row exists at
 /// that key — the candidate naturally drops out of the result.
 ///
-/// The query is shaped so the correlated `MAX(object_version)` subquery
-/// is keyed off a **deduped** set of DF `object_id`s (one row per DF) —
-/// not the un-deduped owner scan of `objects_backward_history` (which for
-/// a parent with deep DF history can have hundreds of thousands of rows
-/// for the same DF). The dedupe inner query relies on the partial index
-/// `objects_backward_history_owner_df` on
-/// `(owner_id, object_id) WHERE owner_type = 2 AND df_kind IS NOT NULL`.
+/// The query is shaped so that DF `object_id`s from
+/// `objects_backward_history` that match the DF filter
+/// (`owner_id = parent AND owner_type = Object AND df_kind IS NOT NULL`)
+/// are first deduplicated. Without the dedupe, the `MAX(object_version)`
+/// subquery would be evaluated once per version instead of once per found
+/// object, which for objects with many historical versions can kill the
+/// performance.
+///
+/// The dedupe step relies on the partial index
+/// `objects_backward_history_owner_df` on `(owner_id, object_id) WHERE
+/// owner_type = 2 AND df_kind IS NOT NULL`.
 fn dynamic_fields_from_historical_objects(
     parent_version: i64,
     page: &Page<Cursor>,

--- a/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-04-07-120000_objects_backward_history/up.sql
@@ -28,6 +28,15 @@ CREATE INDEX objects_backward_history_owner
     ON objects_backward_history (superseded_at_checkpoint, owner_type, owner_id)
     WHERE owner_type >= 1 AND owner_type <= 2 AND owner_id IS NOT NULL;
 
+-- Supports the dedupe step of the DF listing path in
+-- `backward_view/dynamic_fields.rs` and `consistent.rs` (with
+-- `apply_filter`): an Index Only Scan that enumerates distinct DF
+-- `object_id`s owned by a given parent without scanning every
+-- backward-history row of those DFs. See issue #11535.
+CREATE INDEX objects_backward_history_owner_df
+    ON objects_backward_history (owner_id, object_id)
+    WHERE owner_type = 2 AND df_kind IS NOT NULL;
+
 CREATE INDEX objects_backward_history_owner_package_module_name_full_type
     ON objects_backward_history (superseded_at_checkpoint, owner_id, object_type_package, object_type_module, object_type_name, object_type);
 


### PR DESCRIPTION
# Description of change

Source B of `dynamic_fields::query` evaluated the correlated `MAX(object_version)` subquery per backward-history row (loops = N rows, not N distinct DFs), pushing latency to 3-4 s on staging for parents whose DFs have many historical versions.

Rewrite to dedupe DF ids first, then correlate. Add partial index `objects_backward_history_owner_df` so the dedupe is an Index Only Scan.

Worst case query time down from **4 747 ms** to **59 ms** on staging (#11500).

## Links to any relevant issues

fixes #11535

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage) - **built graphql rpc and tested performance on staging, speedup confirmed**

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

