### PR TITLE
chore: Running heavy tests in PR on demand by clicking checkbox in PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default_external_contributors.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_external_contributors.md
@@ -26,6 +26,14 @@ Tick the boxes that are relevant to your changes, and delete any items that are 
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 
+## CI
+
+Tick a box below to trigger the corresponding workflow on this PR's current HEAD.
+Each box auto-unchecks once the run is dispatched — tick again to re-run.
+
+- [ ] Run heavy tests (only changed crates) <!-- ci-trigger: heavy_tests.yml -->
+- [ ] Run heavy tests (full workspace) <!-- ci-trigger: heavy_tests.yml test_only_changed_crates=false -->
+
 ### Release Notes
 
 Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

--- a/.github/PULL_REQUEST_TEMPLATE/default_external_contributors.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_external_contributors.md
@@ -28,11 +28,10 @@ Tick the boxes that are relevant to your changes, and delete any items that are 
 
 ## CI
 
-Tick a box below to trigger the corresponding workflow on this PR's current HEAD.
-Each box auto-unchecks once the run is dispatched — tick again to re-run.
+Tick the box below to dispatch the corresponding workflow on this PR's current HEAD.
+The box auto-unchecks once the run is dispatched — tick again to re-run.
 
-- [ ] Run heavy tests (only changed crates) <!-- ci-trigger: heavy_tests.yml -->
-- [ ] Run heavy tests (full workspace) <!-- ci-trigger: heavy_tests.yml test_only_changed_crates=false -->
+- [ ] Run heavy tests
 
 ### Release Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE/default_internal_contributors.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_internal_contributors.md
@@ -15,11 +15,10 @@ Be sure to reference any related issues by adding `fixes #(issue)`.
 
 ## CI
 
-Tick a box below to trigger the corresponding workflow on this PR's current HEAD.
-Each box auto-unchecks once the run is dispatched — tick again to re-run.
+Tick the box below to dispatch the corresponding workflow on this PR's current HEAD.
+The box auto-unchecks once the run is dispatched — tick again to re-run.
 
-- [ ] Run heavy tests (only changed crates) <!-- ci-trigger: heavy_tests.yml -->
-- [ ] Run heavy tests (full workspace) <!-- ci-trigger: heavy_tests.yml test_only_changed_crates=false -->
+- [ ] Run heavy tests
 
 ### Release Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE/default_internal_contributors.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_internal_contributors.md
@@ -13,6 +13,14 @@ Be sure to reference any related issues by adding `fixes #(issue)`.
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have checked that new and existing unit tests pass locally with my changes
 
+## CI
+
+Tick a box below to trigger the corresponding workflow on this PR's current HEAD.
+Each box auto-unchecks once the run is dispatched — tick again to re-run.
+
+- [ ] Run heavy tests (only changed crates) <!-- ci-trigger: heavy_tests.yml -->
+- [ ] Run heavy tests (full workspace) <!-- ci-trigger: heavy_tests.yml test_only_changed_crates=false -->
+
 ### Release Notes
 
 - [ ] Protocol:

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -23,6 +23,14 @@ Make sure to provide instructions for the maintainer as well as any relevant con
 - [ ] Deployment of services using Docker.
 - [ ] Verification of API backward compatibility.
 
+## CI
+
+Tick a box below to trigger the corresponding workflow on this PR's current HEAD.
+Each box auto-unchecks once the run is dispatched — tick again to re-run.
+
+- [ ] Run heavy tests (only changed crates) <!-- ci-trigger: heavy_tests.yml -->
+- [ ] Run heavy tests (full workspace) <!-- ci-trigger: heavy_tests.yml test_only_changed_crates=false -->
+
 ### Release Notes
 
 - [ ] Protocol:

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -25,11 +25,10 @@ Make sure to provide instructions for the maintainer as well as any relevant con
 
 ## CI
 
-Tick a box below to trigger the corresponding workflow on this PR's current HEAD.
-Each box auto-unchecks once the run is dispatched — tick again to re-run.
+Tick the box below to dispatch the corresponding workflow on this PR's current HEAD.
+The box auto-unchecks once the run is dispatched — tick again to re-run.
 
-- [ ] Run heavy tests (only changed crates) <!-- ci-trigger: heavy_tests.yml -->
-- [ ] Run heavy tests (full workspace) <!-- ci-trigger: heavy_tests.yml test_only_changed_crates=false -->
+- [ ] Run heavy tests
 
 ### Release Notes
 

--- a/.github/scripts/ci-trigger-dispatch.js
+++ b/.github/scripts/ci-trigger-dispatch.js
@@ -1,0 +1,121 @@
+// Dispatcher logic for `.github/workflows/ci_trigger.yml`. Extracted to a
+// separate file for proper JavaScript tooling (syntax highlighting, lint,
+// format). Invoked from the workflow via `actions/github-script` + `require`.
+//
+// Security model: the workflow uses `pull_request_target` and the
+// `actions/checkout` step there grabs the BASE ref by default, so this file
+// is always loaded from `develop` — a PR author can't replace the dispatcher
+// logic by editing this file in their PR branch. See the top-of-file comment
+// in `ci_trigger.yml` for the full design / security notes.
+
+// Closed-by-default map from a checkbox's visible label text to the workflow
+// file dispatched when the box is ticked. Any other checkbox in the body
+// (Basic tests, Release Notes, ...) is ignored. When adding an entry, also
+// extend the top-level `if:` filter in `ci_trigger.yml` and add the matching
+// `- [ ] <label>` line to the PR sub-template(s).
+const CHECKBOX_DISPATCHES = {
+  'Run heavy tests': 'heavy_tests.yml',
+};
+
+// Escape a literal string for use inside a regex.
+const reEscape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+module.exports = async ({ github, context, core }) => {
+  const pr = context.payload.pull_request;
+  const body = pr.body || '';
+
+  // For each known label: find its checked-line occurrence
+  // (`^- [x] <label>[ \t]*$`), queue it, and uncheck it in the working
+  // body. We collect everything first and PUT once below.
+  const triggered = [];
+  let newBody = body;
+  for (const [label, workflow] of Object.entries(CHECKBOX_DISPATCHES)) {
+    const re = new RegExp(
+      `^- \\[x\\] ${reEscape(label)}[ \\t]*$`,
+      'gm',
+    );
+    if (!re.test(newBody)) continue;
+    triggered.push({ label, workflow });
+    newBody = newBody.replace(re, `- [ ] ${label}`);
+  }
+
+  if (triggered.length === 0) {
+    core.info('No known ci-trigger checkbox ticked; nothing to do.');
+    return;
+  }
+
+  // Step 1: uncheck every triggered box in a single PUT, BEFORE dispatching
+  // anything. This guarantees no infinite loop — after our edit no
+  // `[x] <known-label>` line exists, so even if the resulting `edited`
+  // event reached us we'd no-op. (GitHub already suppresses workflow runs
+  // for events triggered by GITHUB_TOKEN, which is the primary loop guard;
+  // this is belt-and-suspenders.)
+  await github.rest.pulls.update({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: pr.number,
+    body: newBody,
+  });
+  core.info(`Unchecked ${triggered.length} ci-trigger checkbox(es).`);
+
+  // Step 2: dispatch each matched workflow. We continue past individual
+  // failures so a transient error on one doesn't block others.
+  //
+  // Before dispatching we also check whether a run of the same workflow
+  // already exists for the same SHA in a non-terminal state. If so we skip
+  // — the user just re-ticked while a previous request is still being
+  // handled, and we'd rather let in-flight progress finish than restart
+  // from scratch via heavy_tests.yml's `cancel-in-progress`.
+  const headSha = process.env.HEAD_SHA;
+  const prNumber = process.env.PR_NUMBER;
+  let failed = 0;
+  for (const { label, workflow } of triggered) {
+    // Best-effort active-run check. If the API call fails for any reason
+    // (workflow not on default branch yet, transient 5xx, rate limit) we
+    // fall through and dispatch anyway — better than silently dropping a
+    // user-requested run.
+    let activeRun = null;
+    try {
+      const { data } = await github.rest.actions.listWorkflowRuns({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        workflow_id: workflow,
+        head_sha: headSha,
+        per_page: 10,
+      });
+      activeRun = data.workflow_runs.find((r) => r.status !== 'completed');
+    } catch (err) {
+      core.warning(
+        `Couldn't list existing runs of ${workflow} for SHA ${headSha}: ${err.message}. ` +
+          `Proceeding with dispatch.`,
+      );
+    }
+    if (activeRun) {
+      core.notice(
+        `${workflow} is already active for ${headSha} ` +
+          `(run #${activeRun.id}, status: ${activeRun.status}) — skipping dispatch. ` +
+          `Wait for that run to finish, then tick the box again to re-run.`,
+      );
+      continue;
+    }
+
+    const inputs = {
+      pr_number: String(prNumber),
+      head_sha: headSha,
+    };
+    // >>> TEMP — REVERT BEFORE MERGE <<<
+    // Dry-run: log what WOULD be dispatched instead of actually calling
+    // createWorkflowDispatch. heavy_tests.yml isn't on `develop` yet so a
+    // real dispatch would 404. This still exercises the regex / uncheck /
+    // bot-loop guard / active-run check end-to-end. Restore the
+    // createWorkflowDispatch try/catch block (see git history) before
+    // merging.
+    core.notice(
+      `DRY-RUN: would dispatch ${workflow} (label: "${label}") ` +
+        `with inputs ${JSON.stringify(inputs)}`,
+    );
+  }
+  if (failed > 0) {
+    core.setFailed(`${failed} of ${triggered.length} dispatch(es) failed.`);
+  }
+};

--- a/.github/scripts/ci-trigger-dispatch.js
+++ b/.github/scripts/ci-trigger-dispatch.js
@@ -1,3 +1,10 @@
+// SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+// CI scripts here interact with GitHub Actions' security model; subtle
+// edits (regex change, broadened allowlist, removed permission gate)
+// can introduce critical supply-chain vulnerabilities. The full threat
+// model lives in the README's "ci_trigger.yml + ci-trigger-dispatch.js"
+// section.
+//
 // Dispatcher logic for `.github/workflows/ci_trigger.yml`. Extracted to a
 // separate file for proper JavaScript tooling (syntax highlighting, lint,
 // format). Invoked from the workflow via `actions/github-script` + `require`.
@@ -5,8 +12,7 @@
 // Security model: the workflow uses `pull_request_target` and the
 // `actions/checkout` step there grabs the BASE ref by default, so this file
 // is always loaded from `develop` — a PR author can't replace the dispatcher
-// logic by editing this file in their PR branch. See the top-of-file comment
-// in `ci_trigger.yml` for the full design / security notes.
+// logic by editing this file in their PR branch.
 
 // Closed-by-default map from a checkbox's visible label text to the workflow
 // file dispatched when the box is ticked. Any other checkbox in the body

--- a/.github/scripts/ci-trigger-dispatch.js
+++ b/.github/scripts/ci-trigger-dispatch.js
@@ -58,6 +58,38 @@ module.exports = async ({ github, context, core }) => {
   });
   core.info(`Unchecked ${triggered.length} ci-trigger checkbox(es).`);
 
+  // Permission gate: only repository collaborators with write+ access may
+  // actually dispatch. The tick of the checkbox itself is treated as the
+  // approval action — a maintainer ticking the box (their own PR or someone
+  // else's) means "I approve this run". A fork-PR author ticking their own
+  // checkbox is unchecked above but does NOT dispatch — a maintainer has to
+  // come in and tick it themselves to authorize. We err on the side of
+  // skipping when the API call fails (no permission → no dispatch).
+  const senderLogin = context.payload.sender.login;
+  const WRITE_PERMISSIONS = new Set(['admin', 'maintain', 'write']);
+  let senderPermission = null;
+  try {
+    const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      username: senderLogin,
+    });
+    senderPermission = data.permission;
+  } catch (err) {
+    core.warning(
+      `Couldn't fetch collaborator permission for @${senderLogin}: ${err.message}. ` +
+        `Treating as no write access.`,
+    );
+  }
+  if (!WRITE_PERMISSIONS.has(senderPermission)) {
+    core.notice(
+      `Skipping dispatch: @${senderLogin} (permission: ${senderPermission ?? 'unknown'}) ` +
+        `does not have write access. A repository maintainer needs to tick the ` +
+        `checkbox to dispatch this workflow.`,
+    );
+    return;
+  }
+
   // Step 2: dispatch each matched workflow. We continue past individual
   // failures so a transient error on one doesn't block others.
   //

--- a/.github/scripts/ci-trigger-dispatch.js
+++ b/.github/scripts/ci-trigger-dispatch.js
@@ -82,7 +82,7 @@ module.exports = async ({ github, context, core }) => {
     );
   }
   if (!WRITE_PERMISSIONS.has(senderPermission)) {
-    core.notice(
+    core.warning(
       `Skipping dispatch: @${senderLogin} (permission: ${senderPermission ?? 'unknown'}) ` +
         `does not have write access. A repository maintainer needs to tick the ` +
         `checkbox to dispatch this workflow.`,
@@ -117,13 +117,13 @@ module.exports = async ({ github, context, core }) => {
       });
       activeRun = data.workflow_runs.find((r) => r.status !== 'completed');
     } catch (err) {
-      core.warning(
+      core.info(
         `Couldn't list existing runs of ${workflow} for SHA ${headSha}: ${err.message}. ` +
           `Proceeding with dispatch.`,
       );
     }
     if (activeRun) {
-      core.notice(
+      core.warning(
         `${workflow} is already active for ${headSha} ` +
           `(run #${activeRun.id}, status: ${activeRun.status}) — skipping dispatch. ` +
           `Wait for that run to finish, then tick the box again to re-run.`,

--- a/.github/scripts/ci-trigger-dispatch.js
+++ b/.github/scripts/ci-trigger-dispatch.js
@@ -141,17 +141,25 @@ module.exports = async ({ github, context, core }) => {
       pr_number: String(prNumber),
       head_sha: headSha,
     };
-    // >>> TEMP — REVERT BEFORE MERGE <<<
-    // Dry-run: log what WOULD be dispatched instead of actually calling
-    // createWorkflowDispatch. heavy_tests.yml isn't on `develop` yet so a
-    // real dispatch would 404. This still exercises the regex / uncheck /
-    // bot-loop guard / active-run check end-to-end. Restore the
-    // createWorkflowDispatch try/catch block (see git history) before
-    // merging.
-    core.notice(
-      `DRY-RUN: would dispatch ${workflow} (label: "${label}") ` +
-        `with inputs ${JSON.stringify(inputs)}`,
+    core.info(
+      `Dispatching ${workflow} (label: "${label}") with ${JSON.stringify(inputs)}`,
     );
+    try {
+      await github.rest.actions.createWorkflowDispatch({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        workflow_id: workflow,
+        ref: 'develop',
+        inputs,
+      });
+    } catch (err) {
+      failed += 1;
+      core.warning(
+        `Failed to dispatch ${workflow}: ${err.message}. ` +
+          `Check that the workflow exists on \`develop\` and accepts ` +
+          `the inputs being passed (${Object.keys(inputs).join(', ')}).`,
+      );
+    }
   }
   if (failed > 0) {
     core.setFailed(`${failed} of ${triggered.length} dispatch(es) failed.`);

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,394 +1,153 @@
-# CI workflows: design and security guide
+# CI workflows: how to edit safely
 
-This directory contains GitHub Actions workflows for `iotaledger/iota`.
-**Read this guide before editing any workflow file.** Several of these
-workflows interact with GitHub's security model in subtle ways — small
-changes (a different trigger, a missing `persist-credentials: false`, an
-unpinned action) can introduce critical vulnerabilities or quietly break
-the intended invariants.
+**Read this before editing any workflow file here.** Some of these
+workflows run PR-author-controlled code with elevated privileges. A small
+change — a different trigger, a missing `persist-credentials: false`, an
+unpinned action — can turn a safe workflow into a remote-code-execution or
+secret-exfiltration hole, or silently make tests run against the wrong code.
 
-The guide is written for both humans and LLMs assisting with edits.
+Written for both humans and LLMs assisting with edits.
 
-## Table of contents
+## The rules (apply all of them)
 
-- [Why this matters](#why-this-matters)
-- [Trigger semantics](#trigger-semantics)
-- [Permissions](#permissions)
-- [Checkout settings](#checkout-settings)
-- [Action pinning](#action-pinning)
-- [Untrusted input handling](#untrusted-input-handling)
-- [Our architecture](#our-architecture)
-- [Dangerous changes — review carefully](#dangerous-changes--review-carefully)
-- [How to add a new on-demand workflow](#how-to-add-a-new-on-demand-workflow)
-- [References](#references)
-
-## Why this matters
-
-GitHub Actions has been the target of multiple high-profile attacks in
-2024–2026:
-
-- **tj-actions/changed-files** (Mar 2025, [CVE-2025-30066](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3))
-  — attacker rewrote version tags to point at malicious commit;
-  ~23,000 repos exposed CI secrets in logs.
-- **Trivy / trivy-action** (Feb–Mar 2026) — `pull_request_target` workflow
-  exploited to exfiltrate PAT; 75 of 76 version tags force-pushed.
-- **Ultralytics YOLO** (Dec 2024) — branch-name injection into `run:`
-  under `pull_request_target` led to RCE with secrets access.
-- **PostHog (Shai Hulud v2)** — `pull_request_target` workflow exploited
-  to leak npm publishing token; compromised SDK packages published.
-- **Spotbugs**, **Gluestack** ([CVE-2025-53104](https://www.sysdig.com/blog/cve-2025-53104-command-injection-via-github-actions-workflow-in-gluestack-ui)),
-  **Langflow** ([GHSA-87cc-65ph-2j4w](https://github.com/langflow-ai/langflow/security/advisories/GHSA-87cc-65ph-2j4w))
-  — various injection patterns through `pull_request_target`.
-
-Most of these exploited patterns that look innocent in isolation but are
-dangerous in combination — especially `pull_request_target` plus
-checkout-of-PR-code, or unpinned actions. The sections below are the
-playbook for avoiding each pattern.
-
-## Trigger semantics
-
-Three event types matter:
-
-| Event                 | When it fires                     | `github.ref` resolves to             | Workflow file loaded from | Fork PR: token / secrets             |
-| --------------------- | --------------------------------- | ------------------------------------ | ------------------------- | ------------------------------------ |
-| `pull_request`        | PR opened / sync / etc.           | merge-ref (`refs/pull/<N>/merge`)    | PR HEAD                   | **Read-only**, no secrets            |
-| `pull_request_target` | same PR events                    | BASE ref (e.g. `refs/heads/develop`) | BASE                      | **Full default**, secrets accessible |
-| `workflow_dispatch`   | API call or "Run workflow" button | The `ref` passed at dispatch         | That ref                  | **Full default**, secrets accessible |
-
-### When to use each
-
-- **`pull_request`** — most workflows. Runs PR code in a safe sandbox.
-  Suitable for "test this PR's code", linting, etc. GitHub auto-restricts
-  permissions/secrets for fork PRs, which is what makes this safe.
-- **`pull_request_target`** — ONLY for bot-like tasks that need write
-  permissions and DO NOT execute PR-author-controlled code. Examples:
-  labeling, commenting, dispatching other workflows. Never `actions/checkout`
-  PR HEAD here without explicit safeguards — that defeats the purpose.
-- **`workflow_dispatch`** — programmatic or manual triggers. Inherits the
-  repo's default GITHUB_TOKEN permissions; NOT fork-restricted. Use when
-  one workflow dispatches another (e.g., `ci_trigger.yml` →
-  `heavy_tests.yml`) or for manual maintainer-driven runs.
-
-### The "pwn request" pattern
-
-A workflow that uses `pull_request_target` AND checks out / executes
-PR-author-controlled code lets an attacker run arbitrary code with full
-repo permissions and secret access. This is the pattern behind most
-recent breaches. To avoid:
-
-- Don't combine `pull_request_target` with PR-code execution.
-- If you must (we do, via `ci_trigger.yml` → `heavy_tests.yml`):
-  - Narrow `permissions:` to the minimum.
-  - Set `persist-credentials: false` on every checkout.
-  - Require human approval before code execution (we use the
-    maintainer-tick gate in `ci-trigger-dispatch.js`).
-
-## Permissions
-
-### Principle of least privilege
-
-Set `permissions:` explicitly on every workflow that touches anything
-sensitive. The repo's default GITHUB_TOKEN permissions are often broader
-than necessary. Declaring `permissions: { ... }` overrides the default;
-unlisted scopes become `none`.
-
-For workflows that run PR-author-controlled code, narrow permissions are
-critical — they limit the blast radius if the token is exfiltrated. Our
-`heavy_tests.yml` is a good example:
-
-```yaml
-permissions:
-  contents: read # for actions/checkout + dorny/paths-filter
-  actions: write # for the rust-tests-cancel / rust-simtests-cancel jobs
-```
-
-Everything else (`pull-requests`, `issues`, `packages`, ...) is `none`.
-
-### How GitHub restricts token / secrets for fork PRs
-
-For `pull_request` events from forks, GitHub automatically:
-
-- Forces GITHUB_TOKEN to **read-only**, regardless of repo settings or
-  `permissions:` declarations.
-- Makes `${{ secrets.X }}` evaluate to empty.
-
-This protection is **bypassed** by `pull_request_target` and
-`workflow_dispatch`. If you use those for fork PRs, the workflow runs with
-full default privileges — narrow `permissions:` explicitly to compensate.
-
-### Token leakage paths
-
-A token can be exposed to running code via:
-
-- **`actions/checkout`** stores the token in `.git/config` by default.
-  Any code that runs after checkout can read it. Mitigation:
-  `persist-credentials: false`.
-- **Environment variables**: any step with `env: { TOKEN: ${{ github.token }} }`
-  exposes the token in `process.env` of every subprocess.
-- **Command-line arguments**: `gh ... --token=${{ github.token }}` puts
-  the token in `ps` / `/proc/<pid>/cmdline`.
-
-Only use these paths where strictly necessary, and only where the code
-running afterwards is trusted.
-
-## Checkout settings
-
-### `persist-credentials: false`
-
-Set this **whenever the checkout will be followed by execution of code
-that may be untrusted** (`cargo test`, npm scripts, shell scripts from
-the repo, etc.). It prevents the auth token from being written to
-`.git/config`.
-
-We use it everywhere in the heavy-tests path: `heavy_tests.yml.diff`,
-`crates-changes`, `external-changes`, every checkout in `_rust_tests.yml`
-and `_split_cluster*.yml`. The composite `.github/actions/diffs/action.yml`
-also sets it.
-
-### `ref:` and the `head_sha` contract
-
-`actions/checkout` defaults to `github.ref`. This works correctly under
-`pull_request` (ref = merge-ref includes PR code) but **NOT** under
-`workflow_dispatch` (ref = the dispatched ref, which is `develop` for our
-flow — not the PR).
-
-The heavy reusables (`_rust_tests.yml`, `_split_cluster*.yml`) declare an
-optional `head_sha` input. Callers **MUST** pass
-`head_sha: ${{ inputs.head_sha || github.sha }}` when invoking them so
-the inner checkout grabs the right code. `heavy_tests.yml` does this for
-its workflow_dispatch path; `nightly.yml` passes nothing (the input
-defaults are empty → fallback to `github.sha` = whatever ref nightly ran
-on, which is correct for the schedule/manual flow).
-
-If you add a new caller of one of these reusables and forget to pass
-`head_sha`, the reusable will check out the wrong code (and your tests
-will silently pass on the wrong revision).
-
-## Action pinning
-
-**SHA-pin every third-party action.** Version tags are mutable — an
-attacker who compromises an action's repository can force-push the tag to
-point at malicious code, and your workflow will silently pull it on the
-next run. This is what happened in the tj-actions and trivy-action
-incidents.
-
-```yaml
-# Good — full-length commit SHA + version comment for humans:
-- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-# Bad — mutable tag, can be force-pushed:
-- uses: actions/checkout@v6
-- uses: actions/checkout@v6.0.2
-```
-
-The SHA is the security boundary. The `# v6.0.2` comment is for humans /
-LLMs and is informational only.
-
-When bumping an action's version: look up the release tag's SHA in the
-action's repo, verify it matches a published release, and update both the
-SHA and the comment.
-
-## Untrusted input handling
-
-PR-author-controlled values include the PR title, body, branch name
-(`github.head_ref`), commit messages, label values, etc. These can be any
-string an attacker chooses.
-
-**Never interpolate them into a `run:` shell step:**
-
-```yaml
-# DANGEROUS — command injection via crafted branch name:
-- run: echo "Building ${{ github.head_ref }}"
-```
-
-**Always pass them through `env:`:**
-
-```yaml
-- run: echo "Building $HEAD_REF"
-  env:
-    HEAD_REF: ${{ github.head_ref }}
-```
-
-Real CVEs from this pattern: [CVE-2025-53104 (gluestack-ui)](https://www.sysdig.com/blog/cve-2025-53104-command-injection-via-github-actions-workflow-in-gluestack-ui),
-[GHSA-87cc-65ph-2j4w (langflow)](https://github.com/langflow-ai/langflow/security/advisories/GHSA-87cc-65ph-2j4w),
-[GHSA-xr6r-vj48-29f6 (Roo-Code)](https://github.com/RooCodeInc/Roo-Code/security/advisories/GHSA-xr6r-vj48-29f6).
-
-The same applies to PR body parsing in scripts: treat it as data, never
-as code. Our `ci-trigger-dispatch.js` only does regex matching and string
-replacement on the body — never `eval`, `new Function`, or template
-substitution back into shell.
-
-## Our architecture
-
-### Entry workflows vs reusables
-
-| Type     | Examples                                                                           | Has trigger events                        | Owns concurrency     |
-| -------- | ---------------------------------------------------------------------------------- | ----------------------------------------- | -------------------- |
-| Entry    | `hierarchy.yml`, `heavy_tests.yml`, `nightly.yml`, `ci_trigger.yml`, `pr_lint.yml` | Yes (`on: pull_request`, `schedule`, ...) | Yes (workflow-level) |
-| Reusable | `_rust_tests.yml`, `_split_cluster.yml`, `_rust_lints.yml`, `_typos.yml`, ...      | Only `workflow_call`                      | No (caller owns it)  |
-
-A reusable workflow's jobs run inside the caller's `workflow_run`. They
-share the same `github.run_id` and contexts. Cancelling the caller
-cancels everything inside.
-
-This is why reusables don't (and shouldn't) define their own
-`concurrency:` — they can't compute a correct key (it depends on the
-caller's trigger). Concurrency belongs at entry-workflow level.
-
-### ci_trigger.yml + ci-trigger-dispatch.js (the dispatcher)
-
-Triggered by `pull_request_target: [opened, edited]`. Logic in
-`.github/scripts/ci-trigger-dispatch.js` (loaded via `actions/checkout` +
-`require`). When a user ticks a checkbox in the PR description whose
-label matches the `CHECKBOX_DISPATCHES` map, the dispatcher unchecks the
-box, then dispatches the mapped workflow via `createWorkflowDispatch`.
-
-**Security invariants (don't break these without thinking):**
-
-1. **`pull_request_target`** — needs write permissions for `pulls.update`
-   and `createWorkflowDispatch`. Don't switch to `pull_request`.
-2. **`actions/checkout` without `ref:`** — pulls the dispatcher script
-   from the BASE branch. A PR author cannot replace the dispatcher logic
-   by editing this file in their PR branch.
-3. **Pre-filter `if:`** — `contains(body, '- [x] Run heavy tests')`. Keep
-   this in sync with `CHECKBOX_DISPATCHES` so the runner only spins up
-   for relevant edits.
-4. **Uncheck-before-dispatch** — guarantees no infinite loop even if a
-   later step fails. GitHub also suppresses workflow runs from
-   `GITHUB_TOKEN`-triggered events, but the uncheck-first ordering is the
-   load-bearing defense; don't rearrange.
-5. **`CHECKBOX_DISPATCHES` is a whitelist** — closed by default. A
-   marker pointing at any other workflow file would be rejected. Don't
-   replace this with substring matching or anything that broadens it.
-6. **Permission gate on `sender.login`** — only collaborators with
-   `write`/`maintain`/`admin` may dispatch. A fork-PR author ticking
-   their own box does NOT trigger (their box is unchecked above, but no
-   dispatch happens). A maintainer ticking the box is the approval action.
-
-### heavy_tests.yml (the heavy-tests entry point)
-
-Triggered by `workflow_dispatch` (from `ci_trigger.yml`) and `push` to
-long-lived branches. Has narrow `permissions: { contents: read, actions:
-write }`. Passes `head_sha` to its reusables so they check out the PR's
-code, not develop.
-
-Concurrency keyed per-PR for workflow_dispatch (newer dispatch supersedes
-older) and per-branch for push (develop queues to test every commit,
-testnet/mainnet/release cancel-in-progress).
-
-### nightly.yml
-
-A sibling entry point. Schedule-triggered (daily) plus manual
-`workflow_dispatch`. Calls the same reusables as `heavy_tests.yml` plus
-its own jobs (examples, cargo-deny, simtest). Does **not** go through
-`heavy_tests.yml`; the two are siblings because they have different
-parameter expectations, permissions, and triggers.
-
-### Permission gate vs Environment approval
-
-We use a permission-based gate in `ci-trigger-dispatch.js` (sender must
-have write+) instead of GitHub Environments with required reviewers.
-Both achieve "maintainer approves heavy runs"; the permission gate is
-simpler (code-only, no repo settings change) at the cost of less native
-approval UX. If you want explicit "Approve and run" buttons in the
-Actions UI, switch to Environment approvals on heavy_tests.yml.
-
-## Dangerous changes — review carefully
-
-Any of these in a PR deserves extra scrutiny — they're the patterns that
-turn safe workflows into vulnerabilities:
-
-- **Changing `on:` triggers** — especially `pull_request` ↔
-  `pull_request_target`. Tiny diff, huge security implications.
-- **Removing or weakening `permissions:`** — defaults are often too broad.
-- **Removing `persist-credentials: false`** — exposes the token to
-  running code via `.git/config`.
-- **Adding `ref: ${{ github.event.pull_request.head.X }}` to checkout in
-  a `pull_request_target` workflow** — the classic pwn-request pattern.
-- **Unpinning an action** (tag instead of full SHA) — opens the door to
-  tag-rewrite supply chain attacks.
-- **Adding `env: { X: ${{ secrets.Y }} }` anywhere in the heavy-tests
-  path** — exposes the secret to PR-author code.
-- **Editing `ci-trigger-dispatch.js`** — particularly the regex pattern,
-  the permission check, `CHECKBOX_DISPATCHES`, or the
-  uncheck-before-dispatch ordering. Whitelist + permission gate semantics
-  must be preserved.
-- **Adding a new dispatchable workflow** without updating
-  `CHECKBOX_DISPATCHES`, the `if:` pre-filter, and the PR template
-  (see next section).
-- **Changing the `ref:` on a reusable's checkout** — must keep the
-  `${{ inputs.head_sha || github.sha }}` pattern; otherwise heavy tests
-  may quietly test the wrong code.
-
-## How to add a new on-demand workflow
-
-Four places to touch:
-
-1. **The new workflow** (e.g., `e2e_tests.yml`):
-   - `on: workflow_dispatch:` with `pr_number` (string, optional) and
-     `head_sha` (string, required) inputs.
-   - Narrow `permissions:` — start from nothing and add only what's needed.
-   - Every `actions/checkout`: `ref: ${{ inputs.head_sha || github.sha }}`,
-     `persist-credentials: false`.
-
-2. **`.github/scripts/ci-trigger-dispatch.js`** — extend
-   `CHECKBOX_DISPATCHES`:
-
-   ```js
-   const CHECKBOX_DISPATCHES = {
-     'Run heavy tests': 'heavy_tests.yml',
-     'Run e2e tests': 'e2e_tests.yml',   // new
-   };
-   ```
-
-3. **`ci_trigger.yml`** — extend the pre-filter `if:` so the dispatcher
-   spins up only for relevant edits:
-
+1. **Pin every third-party action to a full-length commit SHA**, never a
+   tag. Tags are mutable; a compromised action repo can force-push a tag to
+   malicious code and your workflow pulls it on the next run.
    ```yaml
-   if: >-
-     github.event.sender.type != 'Bot'
-     && (contains(github.event.pull_request.body, '- [x] Run heavy tests')
-         || contains(github.event.pull_request.body, '- [x] Run e2e tests'))
+   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2  # good
+   - uses: actions/checkout@v6                                                  # bad
    ```
+   The SHA is the security boundary; the `# v6.0.2` comment is informational.
+   When bumping, look up the new release's SHA in the action's repo and
+   update both.
 
-4. **PR templates** in `.github/PULL_REQUEST_TEMPLATE/` — add the matching
-   checkbox line, e.g. `- [ ] Run e2e tests`, to each sub-template that
-   contributors use.
+2. **Set `persist-credentials: false` on every checkout** that is followed
+   by execution of repo code (`cargo test`, scripts, npm, ...). Otherwise
+   `actions/checkout` leaves the auth token in `.git/config`, where that
+   code can read it.
 
-If you skip step 2, the dispatcher will reject the marker (allowlist is
-closed by default — failure mode is safe). If you skip step 3, the
-dispatcher will run for unrelated description edits (extra runner cost,
-not a security issue). If you skip step 4, the checkbox won't appear in
-new PRs.
+3. **Declare explicit minimal `permissions:`** on any workflow that runs
+   untrusted code or holds write scopes. Listing `permissions:` overrides
+   the (often too broad) default; unlisted scopes become `none`.
+
+4. **Never interpolate PR-controlled values into a `run:` script.** PR
+   title, body, `github.head_ref`, commit messages, labels are
+   attacker-chosen. Pass them via `env:` and reference the shell variable:
+   ```yaml
+   - run: echo "Building $HEAD_REF"   # safe
+     env:
+       HEAD_REF: ${{ github.head_ref }}
+   ```
+   Direct `${{ github.head_ref }}` inside `run:` is shell injection. The
+   same goes for parsing PR body in scripts: treat it as data, never `eval`
+   it back into a shell.
+
+5. **Don't combine `pull_request_target` with checking out / running PR
+   code** (the "pwn request" pattern). If a flow genuinely must do both,
+   it needs all of: minimal `permissions:`, `persist-credentials: false`,
+   and human approval before execution.
+
+## Triggers — pick the right one
+
+| Event | `github.ref` points to | Workflow/script loaded from | Fork PR token/secrets |
+| --- | --- | --- | --- |
+| `pull_request` | merge-ref (PR HEAD) | PR HEAD | **read-only, no secrets** |
+| `pull_request_target` | BASE branch | BASE | full default, secrets |
+| `workflow_dispatch` | the dispatched ref | that ref | full default, secrets |
+
+- **`pull_request`** — the default for "test/lint this PR". GitHub
+  auto-restricts the token and hides secrets for fork PRs, which is what
+  makes running PR code safe.
+- **`pull_request_target`** — only for bot tasks that need write access and
+  do **not** run PR code (labeling, commenting, dispatching). It loads the
+  workflow/script from BASE, so a PR author can't alter the logic via their
+  branch.
+- **`workflow_dispatch`** — programmatic/manual. NOT fork-restricted, so it
+  runs with full default token unless you narrow `permissions:`.
+
+Key consequence: under `pull_request_target` and `workflow_dispatch`,
+fork-PR protections are **off** — narrow `permissions:` yourself.
+
+## The `head_sha` contract
+
+`actions/checkout` defaults to `github.ref`. Under `pull_request` that's
+the PR code, but under `workflow_dispatch` it's the dispatched ref
+(`develop` for our flow) — **not the PR**.
+
+So the heavy reusables (`_rust_tests.yml`, `_split_cluster*.yml`) take an
+optional `head_sha` input, and callers **must** pass
+`head_sha: ${{ inputs.head_sha || github.sha }}`. This applies both to
+`actions/checkout` (`ref:`) and to any script arg that names the
+commit-to-test. Forget it and the reusable silently tests the wrong code.
+`nightly.yml` passes nothing — the `|| github.sha` fallback is correct
+there since nightly runs on the ref it wants to test.
+
+## Architecture
+
+**Entry workflows** (`hierarchy.yml`, `heavy_tests.yml`, `nightly.yml`,
+`ci_trigger.yml`, ...) have `on:` triggers and own their `concurrency:`.
+**Reusables** (`_rust_tests.yml`, `_split_cluster.yml`, ...) are
+`workflow_call`-only. A reusable's jobs run inside the caller's run and
+share its `github.run_id`/context, so cancelling the caller cancels them —
+that's why reusables don't define their own `concurrency:` (they can't
+compute a correct key; it depends on the caller).
+
+### On-demand heavy tests: `ci_trigger.yml` + `ci-trigger-dispatch.js`
+
+`ci_trigger.yml` runs on `pull_request_target: [opened, edited]`. When a
+maintainer ticks a checkbox in the PR body, `ci-trigger-dispatch.js`
+unchecks it and dispatches the mapped workflow via `createWorkflowDispatch`
+(`ref: 'develop'`). `heavy_tests.yml` then runs the heavy suite against the
+PR's `head_sha`.
+
+**Invariants — don't break these:**
+
+- Keep `pull_request_target` (needs write for `pulls.update` +
+  `createWorkflowDispatch`); the checkout has no `ref:` so the script
+  always loads from BASE — a PR author can't swap the dispatcher logic.
+- `CHECKBOX_DISPATCHES` is a closed allowlist (label → workflow file).
+  Don't broaden it to substring/dynamic matching.
+- Uncheck happens **before** dispatch — the load-bearing infinite-loop
+  guard. Don't reorder.
+- Permission gate: only `write`/`maintain`/`admin` senders dispatch. The
+  maintainer's tick *is* the approval; a fork author ticking their own box
+  unchecks but does not dispatch. (We use this instead of GitHub
+  Environment approvals — code-only, no repo-settings change.)
+- `createWorkflowDispatch` uses `ref: 'develop'` so the dispatched workflow
+  is loaded trusted from BASE; the PR code is reached only via `head_sha`.
+- `heavy_tests.yml` holds narrow `permissions: { contents: read, actions:
+  write }` because it runs PR code under `workflow_dispatch` (not
+  fork-restricted).
+
+## Adding a new on-demand workflow
+
+Four edits, all required:
+
+1. **New workflow** — `on: workflow_dispatch` with `pr_number` (string,
+   optional) and `head_sha` (string, required) inputs; minimal
+   `permissions:`; every checkout uses
+   `ref: ${{ inputs.head_sha || github.sha }}` + `persist-credentials: false`.
+2. **`ci-trigger-dispatch.js`** — add `'Run X': 'x.yml'` to
+   `CHECKBOX_DISPATCHES`.
+3. **`ci_trigger.yml`** — extend the pre-filter `if:` with the new
+   `contains(body, '- [x] Run X')` so the runner only spins up when needed.
+4. **PR templates** in `.github/PULL_REQUEST_TEMPLATE/` — add the `- [ ] Run X`
+   checkbox line.
+
+Skipping step 2 fails safe (closed allowlist rejects the marker); skipping
+3 just wastes runner time; skipping 4 means the box never appears.
+
+## Changes that need extra review
+
+`on:` trigger changes (esp. `pull_request` ↔ `pull_request_target`) ·
+weakening `permissions:` · removing `persist-credentials: false` · adding
+`ref: ${{ github.event.pull_request.head.* }}` to a `pull_request_target`
+checkout · unpinning an action · adding `env:`/CLI secrets in the
+heavy-tests path · editing the dispatcher's regex, allowlist, permission
+gate, or uncheck ordering · dropping `head_sha` from a reusable's checkout
+or script args.
 
 ## References
 
-### GitHub Actions documentation
-
-- [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
 - [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
 - [Reusing workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
-- [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
-
-### Notable breaches & writeups
-
-- [tj-actions/changed-files (CVE-2025-30066)](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3)
-- [Wiz — How to Harden GitHub Actions: An Updated Guide](https://www.wiz.io/blog/github-actions-security-guide)
-- [Snyk — Trivy supply chain compromise](https://snyk.io/articles/trivy-github-actions-supply-chain-compromise/)
-- [Orca — pull_request_nightmare Part 2](https://orca.security/resources/blog/pull-request-nightmare-part-2-exploits/)
-- [Endor Labs — Lessons from Trivy](https://www.endorlabs.com/learn/github-actions-security-lessons-from-trivy)
-- [Unit 42 — tj-actions Supply Chain Attack](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/)
-
-### Linting / static analysis tools (consider adding)
-
-- [zizmor](https://github.com/zizmorcore/zizmor) — GitHub Actions linter
-  catching common security issues (unpinned actions, dangerous
-  triggers, script injection).
-- [OpenSSF Scorecard](https://github.com/ossf/scorecard) — automated
-  security review of repositories, including Actions checks.
-
-### Other security-related cheat-sheets
-
-- [GitGuardian — GitHub Actions Security Cheat Sheet](https://blog.gitguardian.com/github-actions-security-cheat-sheet/)
-- [Corgea — GitHub Actions Security Checklist](https://corgea.com/learn/github-actions-security-checklist)
-- [Aikido — Security Checklist for GitHub Actions](https://www.aikido.dev/blog/checklist-github-actions)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -381,7 +381,7 @@ new PRs.
 
 ### Linting / static analysis tools (consider adding)
 
-- [zizmor](https://github.com/woodruffw/zizmor) — GitHub Actions linter
+- [zizmor](https://github.com/zizmorcore/zizmor) — GitHub Actions linter
   catching common security issues (unpinned actions, dangerous
   triggers, script injection).
 - [OpenSSF Scorecard](https://github.com/ossf/scorecard) — automated

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ Written for both humans and LLMs assisting with edits.
    malicious code and your workflow pulls it on the next run.
    ```yaml
    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2  # good
-   - uses: actions/checkout@v6                                                  # bad
+   - uses: actions/checkout@v6 # bad
    ```
    The SHA is the security boundary; the `# v6.0.2` comment is informational.
    When bumping, look up the new release's SHA in the action's repo and
@@ -34,7 +34,7 @@ Written for both humans and LLMs assisting with edits.
    title, body, `github.head_ref`, commit messages, labels are
    attacker-chosen. Pass them via `env:` and reference the shell variable:
    ```yaml
-   - run: echo "Building $HEAD_REF"   # safe
+   - run: echo "Building $HEAD_REF" # safe
      env:
        HEAD_REF: ${{ github.head_ref }}
    ```
@@ -49,11 +49,11 @@ Written for both humans and LLMs assisting with edits.
 
 ## Triggers — pick the right one
 
-| Event | `github.ref` points to | Workflow/script loaded from | Fork PR token/secrets |
-| --- | --- | --- | --- |
-| `pull_request` | merge-ref (PR HEAD) | PR HEAD | **read-only, no secrets** |
-| `pull_request_target` | BASE branch | BASE | full default, secrets |
-| `workflow_dispatch` | the dispatched ref | that ref | full default, secrets |
+| Event                 | `github.ref` points to | Workflow/script loaded from | Fork PR token/secrets     |
+| --------------------- | ---------------------- | --------------------------- | ------------------------- |
+| `pull_request`        | merge-ref (PR HEAD)    | PR HEAD                     | **read-only, no secrets** |
+| `pull_request_target` | BASE branch            | BASE                        | full default, secrets     |
+| `workflow_dispatch`   | the dispatched ref     | that ref                    | full default, secrets     |
 
 - **`pull_request`** — the default for "test/lint this PR". GitHub
   auto-restricts the token and hides secrets for fork PRs, which is what
@@ -110,7 +110,7 @@ PR's `head_sha`.
 - Uncheck happens **before** dispatch — the load-bearing infinite-loop
   guard. Don't reorder.
 - Permission gate: only `write`/`maintain`/`admin` senders dispatch. The
-  maintainer's tick *is* the approval; a fork author ticking their own box
+  maintainer's tick _is_ the approval; a fork author ticking their own box
   unchecks but does not dispatch. (We use this instead of GitHub
   Environment approvals — code-only, no repo-settings change.)
 - `createWorkflowDispatch` uses `ref: 'develop'` so the dispatched workflow

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -373,7 +373,7 @@ new PRs.
 ### Notable breaches & writeups
 
 - [tj-actions/changed-files (CVE-2025-30066)](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3)
-- [Wiz — Hardening GitHub Actions: Lessons from Recent Attacks](https://www.wiz.io/blog/github-actions-security-guide)
+- [Wiz — How to Harden GitHub Actions: An Updated Guide](https://www.wiz.io/blog/github-actions-security-guide)
 - [Snyk — Trivy supply chain compromise](https://snyk.io/articles/trivy-github-actions-supply-chain-compromise/)
 - [Orca — pull_request_nightmare Part 2](https://orca.security/resources/blog/pull-request-nightmare-part-2-exploits/)
 - [Endor Labs — Lessons from Trivy](https://www.endorlabs.com/learn/github-actions-security-lessons-from-trivy)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -367,7 +367,7 @@ new PRs.
 
 - [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
 - [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
-- [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
+- [Reusing workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
 - [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
 
 ### Notable breaches & writeups

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,394 @@
+# CI workflows: design and security guide
+
+This directory contains GitHub Actions workflows for `iotaledger/iota`.
+**Read this guide before editing any workflow file.** Several of these
+workflows interact with GitHub's security model in subtle ways — small
+changes (a different trigger, a missing `persist-credentials: false`, an
+unpinned action) can introduce critical vulnerabilities or quietly break
+the intended invariants.
+
+The guide is written for both humans and LLMs assisting with edits.
+
+## Table of contents
+
+- [Why this matters](#why-this-matters)
+- [Trigger semantics](#trigger-semantics)
+- [Permissions](#permissions)
+- [Checkout settings](#checkout-settings)
+- [Action pinning](#action-pinning)
+- [Untrusted input handling](#untrusted-input-handling)
+- [Our architecture](#our-architecture)
+- [Dangerous changes — review carefully](#dangerous-changes--review-carefully)
+- [How to add a new on-demand workflow](#how-to-add-a-new-on-demand-workflow)
+- [References](#references)
+
+## Why this matters
+
+GitHub Actions has been the target of multiple high-profile attacks in
+2024–2026:
+
+- **tj-actions/changed-files** (Mar 2025, [CVE-2025-30066](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3))
+  — attacker rewrote version tags to point at malicious commit;
+  ~23,000 repos exposed CI secrets in logs.
+- **Trivy / trivy-action** (Feb–Mar 2026) — `pull_request_target` workflow
+  exploited to exfiltrate PAT; 75 of 76 version tags force-pushed.
+- **Ultralytics YOLO** (Dec 2024) — branch-name injection into `run:`
+  under `pull_request_target` led to RCE with secrets access.
+- **PostHog (Shai Hulud v2)** — `pull_request_target` workflow exploited
+  to leak npm publishing token; compromised SDK packages published.
+- **Spotbugs**, **Gluestack** ([CVE-2025-53104](https://www.sysdig.com/blog/cve-2025-53104-command-injection-via-github-actions-workflow-in-gluestack-ui)),
+  **Langflow** ([GHSA-87cc-65ph-2j4w](https://github.com/langflow-ai/langflow/security/advisories/GHSA-87cc-65ph-2j4w))
+  — various injection patterns through `pull_request_target`.
+
+Most of these exploited patterns that look innocent in isolation but are
+dangerous in combination — especially `pull_request_target` plus
+checkout-of-PR-code, or unpinned actions. The sections below are the
+playbook for avoiding each pattern.
+
+## Trigger semantics
+
+Three event types matter:
+
+| Event | When it fires | `github.ref` resolves to | Workflow file loaded from | Fork PR: token / secrets |
+|---|---|---|---|---|
+| `pull_request` | PR opened / sync / etc. | merge-ref (`refs/pull/<N>/merge`) | PR HEAD | **Read-only**, no secrets |
+| `pull_request_target` | same PR events | BASE ref (e.g. `refs/heads/develop`) | BASE | **Full default**, secrets accessible |
+| `workflow_dispatch` | API call or "Run workflow" button | The `ref` passed at dispatch | That ref | **Full default**, secrets accessible |
+
+### When to use each
+
+- **`pull_request`** — most workflows. Runs PR code in a safe sandbox.
+  Suitable for "test this PR's code", linting, etc. GitHub auto-restricts
+  permissions/secrets for fork PRs, which is what makes this safe.
+- **`pull_request_target`** — ONLY for bot-like tasks that need write
+  permissions and DO NOT execute PR-author-controlled code. Examples:
+  labeling, commenting, dispatching other workflows. Never `actions/checkout`
+  PR HEAD here without explicit safeguards — that defeats the purpose.
+- **`workflow_dispatch`** — programmatic or manual triggers. Inherits the
+  repo's default GITHUB_TOKEN permissions; NOT fork-restricted. Use when
+  one workflow dispatches another (e.g., `ci_trigger.yml` →
+  `heavy_tests.yml`) or for manual maintainer-driven runs.
+
+### The "pwn request" pattern
+
+A workflow that uses `pull_request_target` AND checks out / executes
+PR-author-controlled code lets an attacker run arbitrary code with full
+repo permissions and secret access. This is the pattern behind most
+recent breaches. To avoid:
+
+- Don't combine `pull_request_target` with PR-code execution.
+- If you must (we do, via `ci_trigger.yml` → `heavy_tests.yml`):
+  - Narrow `permissions:` to the minimum.
+  - Set `persist-credentials: false` on every checkout.
+  - Require human approval before code execution (we use the
+    maintainer-tick gate in `ci-trigger-dispatch.js`).
+
+## Permissions
+
+### Principle of least privilege
+
+Set `permissions:` explicitly on every workflow that touches anything
+sensitive. The repo's default GITHUB_TOKEN permissions are often broader
+than necessary. Declaring `permissions: { ... }` overrides the default;
+unlisted scopes become `none`.
+
+For workflows that run PR-author-controlled code, narrow permissions are
+critical — they limit the blast radius if the token is exfiltrated. Our
+`heavy_tests.yml` is a good example:
+
+```yaml
+permissions:
+  contents: read    # for actions/checkout + dorny/paths-filter
+  actions: write    # for the rust-tests-cancel / rust-simtests-cancel jobs
+```
+
+Everything else (`pull-requests`, `issues`, `packages`, ...) is `none`.
+
+### How GitHub restricts token / secrets for fork PRs
+
+For `pull_request` events from forks, GitHub automatically:
+
+- Forces GITHUB_TOKEN to **read-only**, regardless of repo settings or
+  `permissions:` declarations.
+- Makes `${{ secrets.X }}` evaluate to empty.
+
+This protection is **bypassed** by `pull_request_target` and
+`workflow_dispatch`. If you use those for fork PRs, the workflow runs with
+full default privileges — narrow `permissions:` explicitly to compensate.
+
+### Token leakage paths
+
+A token can be exposed to running code via:
+
+- **`actions/checkout`** stores the token in `.git/config` by default.
+  Any code that runs after checkout can read it. Mitigation:
+  `persist-credentials: false`.
+- **Environment variables**: any step with `env: { TOKEN: ${{ github.token }} }`
+  exposes the token in `process.env` of every subprocess.
+- **Command-line arguments**: `gh ... --token=${{ github.token }}` puts
+  the token in `ps` / `/proc/<pid>/cmdline`.
+
+Only use these paths where strictly necessary, and only where the code
+running afterwards is trusted.
+
+## Checkout settings
+
+### `persist-credentials: false`
+
+Set this **whenever the checkout will be followed by execution of code
+that may be untrusted** (`cargo test`, npm scripts, shell scripts from
+the repo, etc.). It prevents the auth token from being written to
+`.git/config`.
+
+We use it everywhere in the heavy-tests path: `heavy_tests.yml.diff`,
+`crates-changes`, `external-changes`, every checkout in `_rust_tests.yml`
+and `_split_cluster*.yml`. The composite `.github/actions/diffs/action.yml`
+also sets it.
+
+### `ref:` and the `head_sha` contract
+
+`actions/checkout` defaults to `github.ref`. This works correctly under
+`pull_request` (ref = merge-ref includes PR code) but **NOT** under
+`workflow_dispatch` (ref = the dispatched ref, which is `develop` for our
+flow — not the PR).
+
+The heavy reusables (`_rust_tests.yml`, `_split_cluster*.yml`) declare an
+optional `head_sha` input. Callers **MUST** pass
+`head_sha: ${{ inputs.head_sha || github.sha }}` when invoking them so
+the inner checkout grabs the right code. `heavy_tests.yml` does this for
+its workflow_dispatch path; `nightly.yml` passes nothing (the input
+defaults are empty → fallback to `github.sha` = whatever ref nightly ran
+on, which is correct for the schedule/manual flow).
+
+If you add a new caller of one of these reusables and forget to pass
+`head_sha`, the reusable will check out the wrong code (and your tests
+will silently pass on the wrong revision).
+
+## Action pinning
+
+**SHA-pin every third-party action.** Version tags are mutable — an
+attacker who compromises an action's repository can force-push the tag to
+point at malicious code, and your workflow will silently pull it on the
+next run. This is what happened in the tj-actions and trivy-action
+incidents.
+
+```yaml
+# Good — full-length commit SHA + version comment for humans:
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+# Bad — mutable tag, can be force-pushed:
+- uses: actions/checkout@v6
+- uses: actions/checkout@v6.0.2
+```
+
+The SHA is the security boundary. The `# v6.0.2` comment is for humans /
+LLMs and is informational only.
+
+When bumping an action's version: look up the release tag's SHA in the
+action's repo, verify it matches a published release, and update both the
+SHA and the comment.
+
+## Untrusted input handling
+
+PR-author-controlled values include the PR title, body, branch name
+(`github.head_ref`), commit messages, label values, etc. These can be any
+string an attacker chooses.
+
+**Never interpolate them into a `run:` shell step:**
+
+```yaml
+# DANGEROUS — command injection via crafted branch name:
+- run: echo "Building ${{ github.head_ref }}"
+```
+
+**Always pass them through `env:`:**
+
+```yaml
+- run: echo "Building $HEAD_REF"
+  env:
+    HEAD_REF: ${{ github.head_ref }}
+```
+
+Real CVEs from this pattern: [CVE-2025-53104 (gluestack-ui)](https://www.sysdig.com/blog/cve-2025-53104-command-injection-via-github-actions-workflow-in-gluestack-ui),
+[GHSA-87cc-65ph-2j4w (langflow)](https://github.com/langflow-ai/langflow/security/advisories/GHSA-87cc-65ph-2j4w),
+[GHSA-xr6r-vj48-29f6 (Roo-Code)](https://github.com/RooCodeInc/Roo-Code/security/advisories/GHSA-xr6r-vj48-29f6).
+
+The same applies to PR body parsing in scripts: treat it as data, never
+as code. Our `ci-trigger-dispatch.js` only does regex matching and string
+replacement on the body — never `eval`, `new Function`, or template
+substitution back into shell.
+
+## Our architecture
+
+### Entry workflows vs reusables
+
+| Type | Examples | Has trigger events | Owns concurrency |
+|---|---|---|---|
+| Entry | `hierarchy.yml`, `heavy_tests.yml`, `nightly.yml`, `ci_trigger.yml`, `pr_lint.yml` | Yes (`on: pull_request`, `schedule`, ...) | Yes (workflow-level) |
+| Reusable | `_rust_tests.yml`, `_split_cluster.yml`, `_rust_lints.yml`, `_typos.yml`, ... | Only `workflow_call` | No (caller owns it) |
+
+A reusable workflow's jobs run inside the caller's `workflow_run`. They
+share the same `github.run_id` and contexts. Cancelling the caller
+cancels everything inside.
+
+This is why reusables don't (and shouldn't) define their own
+`concurrency:` — they can't compute a correct key (it depends on the
+caller's trigger). Concurrency belongs at entry-workflow level.
+
+### ci_trigger.yml + ci-trigger-dispatch.js (the dispatcher)
+
+Triggered by `pull_request_target: [opened, edited]`. Logic in
+`.github/scripts/ci-trigger-dispatch.js` (loaded via `actions/checkout` +
+`require`). When a user ticks a checkbox in the PR description whose
+label matches the `CHECKBOX_DISPATCHES` map, the dispatcher unchecks the
+box, then dispatches the mapped workflow via `createWorkflowDispatch`.
+
+**Security invariants (don't break these without thinking):**
+
+1. **`pull_request_target`** — needs write permissions for `pulls.update`
+   and `createWorkflowDispatch`. Don't switch to `pull_request`.
+2. **`actions/checkout` without `ref:`** — pulls the dispatcher script
+   from the BASE branch. A PR author cannot replace the dispatcher logic
+   by editing this file in their PR branch.
+3. **Pre-filter `if:`** — `contains(body, '- [x] Run heavy tests')`. Keep
+   this in sync with `CHECKBOX_DISPATCHES` so the runner only spins up
+   for relevant edits.
+4. **Uncheck-before-dispatch** — guarantees no infinite loop even if a
+   later step fails. GitHub also suppresses workflow runs from
+   `GITHUB_TOKEN`-triggered events, but the uncheck-first ordering is the
+   load-bearing defense; don't rearrange.
+5. **`CHECKBOX_DISPATCHES` is a whitelist** — closed by default. A
+   marker pointing at any other workflow file would be rejected. Don't
+   replace this with substring matching or anything that broadens it.
+6. **Permission gate on `sender.login`** — only collaborators with
+   `write`/`maintain`/`admin` may dispatch. A fork-PR author ticking
+   their own box does NOT trigger (their box is unchecked above, but no
+   dispatch happens). A maintainer ticking the box is the approval action.
+
+### heavy_tests.yml (the heavy-tests entry point)
+
+Triggered by `workflow_dispatch` (from `ci_trigger.yml`) and `push` to
+long-lived branches. Has narrow `permissions: { contents: read, actions:
+write }`. Passes `head_sha` to its reusables so they check out the PR's
+code, not develop.
+
+Concurrency keyed per-PR for workflow_dispatch (newer dispatch supersedes
+older) and per-branch for push (develop queues to test every commit,
+testnet/mainnet/release cancel-in-progress).
+
+### nightly.yml
+
+A sibling entry point. Schedule-triggered (daily) plus manual
+`workflow_dispatch`. Calls the same reusables as `heavy_tests.yml` plus
+its own jobs (examples, cargo-deny, simtest). Does **not** go through
+`heavy_tests.yml`; the two are siblings because they have different
+parameter expectations, permissions, and triggers.
+
+### Permission gate vs Environment approval
+
+We use a permission-based gate in `ci-trigger-dispatch.js` (sender must
+have write+) instead of GitHub Environments with required reviewers.
+Both achieve "maintainer approves heavy runs"; the permission gate is
+simpler (code-only, no repo settings change) at the cost of less native
+approval UX. If you want explicit "Approve and run" buttons in the
+Actions UI, switch to Environment approvals on heavy_tests.yml.
+
+## Dangerous changes — review carefully
+
+Any of these in a PR deserves extra scrutiny — they're the patterns that
+turn safe workflows into vulnerabilities:
+
+- **Changing `on:` triggers** — especially `pull_request` ↔
+  `pull_request_target`. Tiny diff, huge security implications.
+- **Removing or weakening `permissions:`** — defaults are often too broad.
+- **Removing `persist-credentials: false`** — exposes the token to
+  running code via `.git/config`.
+- **Adding `ref: ${{ github.event.pull_request.head.X }}` to checkout in
+  a `pull_request_target` workflow** — the classic pwn-request pattern.
+- **Unpinning an action** (tag instead of full SHA) — opens the door to
+  tag-rewrite supply chain attacks.
+- **Adding `env: { X: ${{ secrets.Y }} }` anywhere in the heavy-tests
+  path** — exposes the secret to PR-author code.
+- **Editing `ci-trigger-dispatch.js`** — particularly the regex pattern,
+  the permission check, `CHECKBOX_DISPATCHES`, or the
+  uncheck-before-dispatch ordering. Whitelist + permission gate semantics
+  must be preserved.
+- **Adding a new dispatchable workflow** without updating
+  `CHECKBOX_DISPATCHES`, the `if:` pre-filter, and the PR template
+  (see next section).
+- **Changing the `ref:` on a reusable's checkout** — must keep the
+  `${{ inputs.head_sha || github.sha }}` pattern; otherwise heavy tests
+  may quietly test the wrong code.
+
+## How to add a new on-demand workflow
+
+Four places to touch:
+
+1. **The new workflow** (e.g., `e2e_tests.yml`):
+   - `on: workflow_dispatch:` with `pr_number` (string, optional) and
+     `head_sha` (string, required) inputs.
+   - Narrow `permissions:` — start from nothing and add only what's needed.
+   - Every `actions/checkout`: `ref: ${{ inputs.head_sha || github.sha }}`,
+     `persist-credentials: false`.
+
+2. **`.github/scripts/ci-trigger-dispatch.js`** — extend
+   `CHECKBOX_DISPATCHES`:
+
+   ```js
+   const CHECKBOX_DISPATCHES = {
+     'Run heavy tests': 'heavy_tests.yml',
+     'Run e2e tests': 'e2e_tests.yml',   // new
+   };
+   ```
+
+3. **`ci_trigger.yml`** — extend the pre-filter `if:` so the dispatcher
+   spins up only for relevant edits:
+
+   ```yaml
+   if: >-
+     github.event.sender.type != 'Bot'
+     && (contains(github.event.pull_request.body, '- [x] Run heavy tests')
+         || contains(github.event.pull_request.body, '- [x] Run e2e tests'))
+   ```
+
+4. **PR templates** in `.github/PULL_REQUEST_TEMPLATE/` — add the matching
+   checkbox line, e.g. `- [ ] Run e2e tests`, to each sub-template that
+   contributors use.
+
+If you skip step 2, the dispatcher will reject the marker (allowlist is
+closed by default — failure mode is safe). If you skip step 3, the
+dispatcher will run for unrelated description edits (extra runner cost,
+not a security issue). If you skip step 4, the checkbox won't appear in
+new PRs.
+
+## References
+
+### GitHub Actions documentation
+
+- [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+- [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
+- [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
+
+### Notable breaches & writeups
+
+- [tj-actions/changed-files (CVE-2025-30066)](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3)
+- [Wiz — Hardening GitHub Actions: Lessons from Recent Attacks](https://www.wiz.io/blog/github-actions-security-guide)
+- [Snyk — Trivy supply chain compromise](https://snyk.io/articles/trivy-github-actions-supply-chain-compromise/)
+- [Orca — pull_request_nightmare Part 2](https://orca.security/resources/blog/pull-request-nightmare-part-2-exploits/)
+- [Endor Labs — Lessons from Trivy](https://www.endorlabs.com/learn/github-actions-security-lessons-from-trivy)
+- [Unit 42 — tj-actions Supply Chain Attack](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/)
+
+### Linting / static analysis tools (consider adding)
+
+- [zizmor](https://github.com/woodruffw/zizmor) — GitHub Actions linter
+  catching common security issues (unpinned actions, dangerous
+  triggers, script injection).
+- [OpenSSF Scorecard](https://github.com/ossf/scorecard) — automated
+  security review of repositories, including Actions checks.
+
+### Other security-related cheat-sheets
+
+- [GitGuardian — GitHub Actions Security Cheat Sheet](https://blog.gitguardian.com/github-actions-security-cheat-sheet/)
+- [Corgea — GitHub Actions Security Checklist](https://corgea.com/learn/github-actions-security-checklist)
+- [Aikido — Security Checklist for GitHub Actions](https://www.aikido.dev/blog/checklist-github-actions)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,11 +49,11 @@ playbook for avoiding each pattern.
 
 Three event types matter:
 
-| Event | When it fires | `github.ref` resolves to | Workflow file loaded from | Fork PR: token / secrets |
-|---|---|---|---|---|
-| `pull_request` | PR opened / sync / etc. | merge-ref (`refs/pull/<N>/merge`) | PR HEAD | **Read-only**, no secrets |
-| `pull_request_target` | same PR events | BASE ref (e.g. `refs/heads/develop`) | BASE | **Full default**, secrets accessible |
-| `workflow_dispatch` | API call or "Run workflow" button | The `ref` passed at dispatch | That ref | **Full default**, secrets accessible |
+| Event                 | When it fires                     | `github.ref` resolves to             | Workflow file loaded from | Fork PR: token / secrets             |
+| --------------------- | --------------------------------- | ------------------------------------ | ------------------------- | ------------------------------------ |
+| `pull_request`        | PR opened / sync / etc.           | merge-ref (`refs/pull/<N>/merge`)    | PR HEAD                   | **Read-only**, no secrets            |
+| `pull_request_target` | same PR events                    | BASE ref (e.g. `refs/heads/develop`) | BASE                      | **Full default**, secrets accessible |
+| `workflow_dispatch`   | API call or "Run workflow" button | The `ref` passed at dispatch         | That ref                  | **Full default**, secrets accessible |
 
 ### When to use each
 
@@ -98,8 +98,8 @@ critical — they limit the blast radius if the token is exfiltrated. Our
 
 ```yaml
 permissions:
-  contents: read    # for actions/checkout + dorny/paths-filter
-  actions: write    # for the rust-tests-cancel / rust-simtests-cancel jobs
+  contents: read # for actions/checkout + dorny/paths-filter
+  actions: write # for the rust-tests-cancel / rust-simtests-cancel jobs
 ```
 
 Everything else (`pull-requests`, `issues`, `packages`, ...) is `none`.
@@ -222,10 +222,10 @@ substitution back into shell.
 
 ### Entry workflows vs reusables
 
-| Type | Examples | Has trigger events | Owns concurrency |
-|---|---|---|---|
-| Entry | `hierarchy.yml`, `heavy_tests.yml`, `nightly.yml`, `ci_trigger.yml`, `pr_lint.yml` | Yes (`on: pull_request`, `schedule`, ...) | Yes (workflow-level) |
-| Reusable | `_rust_tests.yml`, `_split_cluster.yml`, `_rust_lints.yml`, `_typos.yml`, ... | Only `workflow_call` | No (caller owns it) |
+| Type     | Examples                                                                           | Has trigger events                        | Owns concurrency     |
+| -------- | ---------------------------------------------------------------------------------- | ----------------------------------------- | -------------------- |
+| Entry    | `hierarchy.yml`, `heavy_tests.yml`, `nightly.yml`, `ci_trigger.yml`, `pr_lint.yml` | Yes (`on: pull_request`, `schedule`, ...) | Yes (workflow-level) |
+| Reusable | `_rust_tests.yml`, `_split_cluster.yml`, `_rust_lints.yml`, `_typos.yml`, ...      | Only `workflow_call`                      | No (caller owns it)  |
 
 A reusable workflow's jobs run inside the caller's `workflow_run`. They
 share the same `github.run_id` and contexts. Cancelling the caller

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -366,7 +366,7 @@ new PRs.
 ### GitHub Actions documentation
 
 - [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
-- [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+- [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
 - [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
 - [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -368,7 +368,7 @@ new PRs.
 - [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
 - [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
 - [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
-- [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
+- [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
 
 ### Notable breaches & writeups
 

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -1,3 +1,8 @@
+# SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+# CI workflows here interact with GitHub Actions' security model; subtle
+# edits (trigger change, missing `persist-credentials: false`, unpinned
+# action) can introduce critical supply-chain vulnerabilities.
+
 name: Rust
 
 on:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -5,14 +5,7 @@ on:
     inputs:
       isRust:
         type: boolean
-      isRustWorkspaceConfig:
-        type: boolean
-        default: false
       isRustExample:
-        type: boolean
-      isPgIntegration:
-        type: boolean
-      isMoveExampleUsedByOthers:
         type: boolean
       isNightly:
         type: boolean
@@ -49,55 +42,6 @@ jobs:
     with:
       isRust: ${{ inputs.isRust }}
       isRustExample: ${{ inputs.isRustExample }}
-      isNightly: ${{ inputs.isNightly }}
-
-  crates-changes:
-    needs: rust-lints
-    runs-on: [self-hosted-x64]
-    outputs:
-      components: ${{ steps.filter.outputs.changes }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          list-files: "json"
-          filters: .github/crates-filters.yml
-
-  external-changes:
-    needs: rust-lints
-    runs-on: [self-hosted-x64]
-    if: (!cancelled() && !failure())
-    outputs:
-      components: ${{ steps.filter.outputs.changes }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          list-files: "json"
-          filters: .github/external-crates-filters.yml
-
-  rust-tests:
-    if: (!cancelled() && !failure() && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers))
-    needs:
-      - crates-changes
-      - external-changes
-    uses: ./.github/workflows/_rust_tests.yml
-    with:
-      isRust: ${{ inputs.isRust }}
-      isPgIntegration: ${{ inputs.isPgIntegration }}
-      isMoveExampleUsedByOthers: ${{ inputs.isMoveExampleUsedByOthers }}
-      runSimtest: true
-      # Only test changed crates and their dependent crates if there were no workspace-level config changes,
-      # otherwise test all crates since workspace-level config changes can affect all crates.
-      testOnlyChangedCrates: ${{ !inputs.isRustWorkspaceConfig }}
-      changedCrates: ${{ join(fromJson(needs.crates-changes.outputs.components || '[]'), ' ') }}
-      changedExternalCrates: ${{ join(fromJson(needs.external-changes.outputs.components || '[]'), ' ') }}
       isNightly: ${{ inputs.isNightly }}
 
   execution-cut:

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -31,8 +31,9 @@ on:
 # No workflow-level `concurrency` here on purpose: a reusable workflow can't
 # compute a correct concurrency key (it depends on the caller's trigger
 # context). Concurrency is owned by the entry workflows that call this one
-# (`heavy_tests.yml`, `nightly.yml`); cancelling/superseding a parent run
-# cancels this reusable's jobs along with it.
+# (e.g. `heavy_tests.yml`); cancelling/superseding a parent run cancels
+# this reusable's jobs along with it. `nightly.yml` deliberately has none,
+# accepting parallel overlap on the rare cron+dispatch coincidence.
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -88,6 +88,8 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup db
         run: |
@@ -159,6 +161,8 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup db
         run: |
@@ -216,6 +220,8 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Cargo Udeps
         run: cargo +nightly-2026-01-07 ci-udeps ${{ matrix.flags }}
@@ -248,6 +254,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: doctests
         run: |

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -1,3 +1,10 @@
+# SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+# CI workflows here interact with GitHub Actions' security model; subtle
+# edits (trigger change, missing `persist-credentials: false`, unpinned
+# action) can introduce critical supply-chain vulnerabilities. This is a
+# reusable workflow that runs PR-author-controlled code — callers MUST
+# pass `head_sha` (see README's "head_sha contract" section).
+
 name: Rust tests
 
 on:

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -27,6 +27,10 @@ on:
       isNightly:
         type: boolean
         default: false
+      head_sha:
+        description: "Commit SHA to test. When unset, falls back to github.sha (which only makes sense for callers triggered by an event whose default ref already points to the right place, e.g. nightly on develop)."
+        type: string
+        required: false
 
 # No workflow-level `concurrency` here on purpose: a reusable workflow can't
 # compute a correct concurrency key (it depends on the caller's trigger
@@ -89,6 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.head_sha || github.sha }}
           persist-credentials: false
 
       - name: Setup db
@@ -162,6 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.head_sha || github.sha }}
           persist-credentials: false
 
       - name: Setup db
@@ -221,6 +227,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.head_sha || github.sha }}
           persist-credentials: false
 
       - name: Run Cargo Udeps
@@ -255,6 +262,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.head_sha || github.sha }}
           persist-credentials: false
 
       - name: doctests

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -28,9 +28,11 @@ on:
         type: boolean
         default: false
 
-concurrency:
-  group: rust-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+# No workflow-level `concurrency` here on purpose: a reusable workflow can't
+# compute a correct concurrency key (it depends on the caller's trigger
+# context). Concurrency is owned by the entry workflows that call this one
+# (`heavy_tests.yml`, `nightly.yml`); cancelling/superseding a parent run
+# cancels this reusable's jobs along with it.
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -7,8 +7,9 @@ on:
 # No workflow-level `concurrency` here on purpose: a reusable workflow can't
 # compute a correct concurrency key (it depends on the caller's trigger
 # context). Concurrency is owned by the entry workflows that call this one
-# (`heavy_tests.yml`, `nightly.yml`); cancelling/superseding a parent run
-# cancels this reusable's jobs along with it.
+# (e.g. `heavy_tests.yml`); cancelling/superseding a parent run cancels
+# this reusable's jobs along with it. `nightly.yml` deliberately has none,
+# accepting parallel overlap on the rare cron+dispatch coincidence.
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -4,9 +4,11 @@ on:
   workflow_dispatch:
   workflow_call:
 
-concurrency:
-  group: split-cluster-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+# No workflow-level `concurrency` here on purpose: a reusable workflow can't
+# compute a correct concurrency key (it depends on the caller's trigger
+# context). Concurrency is owned by the entry workflows that call this one
+# (`heavy_tests.yml`, `nightly.yml`); cancelling/superseding a parent run
+# cancels this reusable's jobs along with it.
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           WORKING_DIR=/tmp/mainnet-split-cluster-${{ github.run_id }} \
           IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet \
-          scripts/compatibility/split-cluster-check.sh origin/mainnet ${{ github.sha }}
+          scripts/compatibility/split-cluster-check.sh origin/mainnet ${{ inputs.head_sha || github.sha }}
 
       - name: Upload mainnet split cluster logs on failure
         if: failure()
@@ -73,7 +73,7 @@ jobs:
         run: |
           WORKING_DIR=/tmp/testnet-split-cluster-${{ github.run_id }} \
           IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=testnet \
-          scripts/compatibility/split-cluster-check.sh origin/testnet ${{ github.sha }}
+          scripts/compatibility/split-cluster-check.sh origin/testnet ${{ inputs.head_sha || github.sha }}
 
       - name: Upload testnet split cluster logs on failure
         if: failure()

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -3,6 +3,11 @@ name: Split Cluster Check
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      head_sha:
+        description: "Commit SHA to test. When unset, falls back to github.sha."
+        type: string
+        required: false
 
 # No workflow-level `concurrency` here on purpose: a reusable workflow can't
 # compute a correct concurrency key (it depends on the caller's trigger
@@ -25,6 +30,7 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.head_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -51,6 +57,7 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.head_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -1,3 +1,10 @@
+# SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+# CI workflows here interact with GitHub Actions' security model; subtle
+# edits (trigger change, missing `persist-credentials: false`, unpinned
+# action) can introduce critical supply-chain vulnerabilities. This is a
+# reusable workflow that runs PR-author-controlled code — callers MUST
+# pass `head_sha` (see README's "head_sha contract" section).
+
 name: Split Cluster Check
 
 on:

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run split cluster check script
         id: mn-split-cluster-check
@@ -51,6 +52,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run split cluster check script
         id: tn-split-cluster-check

--- a/.github/workflows/_split_cluster_sync_check.yml
+++ b/.github/workflows/_split_cluster_sync_check.yml
@@ -7,8 +7,9 @@ on:
 # No workflow-level `concurrency` here on purpose: a reusable workflow can't
 # compute a correct concurrency key (it depends on the caller's trigger
 # context). Concurrency is owned by the entry workflows that call this one
-# (`heavy_tests.yml`, `nightly.yml`); cancelling/superseding a parent run
-# cancels this reusable's jobs along with it.
+# (e.g. `heavy_tests.yml`); cancelling/superseding a parent run cancels
+# this reusable's jobs along with it. `nightly.yml` deliberately has none,
+# accepting parallel overlap on the rare cron+dispatch coincidence.
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/_split_cluster_sync_check.yml
+++ b/.github/workflows/_split_cluster_sync_check.yml
@@ -4,9 +4,11 @@ on:
   workflow_dispatch:
   workflow_call:
 
-concurrency:
-  group: split-cluster-sync-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+# No workflow-level `concurrency` here on purpose: a reusable workflow can't
+# compute a correct concurrency key (it depends on the caller's trigger
+# context). Concurrency is owned by the entry workflows that call this one
+# (`heavy_tests.yml`, `nightly.yml`); cancelling/superseding a parent run
+# cancels this reusable's jobs along with it.
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/_split_cluster_sync_check.yml
+++ b/.github/workflows/_split_cluster_sync_check.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           WORKING_DIR=/tmp/mainnet-split-cluster-sync-${{ github.run_id }} \
           IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet \
-          scripts/compatibility/split-cluster-sync-check.sh origin/mainnet ${{ github.sha }}
+          scripts/compatibility/split-cluster-sync-check.sh origin/mainnet ${{ inputs.head_sha || github.sha }}
       - name: Upload mainnet split cluster sync logs on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -77,7 +77,7 @@ jobs:
         run: |
           WORKING_DIR=/tmp/testnet-split-cluster-sync-${{ github.run_id }} \
           IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=testnet \
-          scripts/compatibility/split-cluster-sync-check.sh origin/testnet ${{ github.sha }}
+          scripts/compatibility/split-cluster-sync-check.sh origin/testnet ${{ inputs.head_sha || github.sha }}
       - name: Upload testnet split cluster sync logs on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/_split_cluster_sync_check.yml
+++ b/.github/workflows/_split_cluster_sync_check.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run split cluster sync check script
         id: mn-split-cluster-sync-check
         run: |
@@ -56,6 +57,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run split cluster sync check script
         id: tn-split-cluster-sync-check
         run: |

--- a/.github/workflows/_split_cluster_sync_check.yml
+++ b/.github/workflows/_split_cluster_sync_check.yml
@@ -1,3 +1,10 @@
+# SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+# CI workflows here interact with GitHub Actions' security model; subtle
+# edits (trigger change, missing `persist-credentials: false`, unpinned
+# action) can introduce critical supply-chain vulnerabilities. This is a
+# reusable workflow that runs PR-author-controlled code — callers MUST
+# pass `head_sha` (see README's "head_sha contract" section).
+
 name: Split Cluster Synchronization Check
 
 on:

--- a/.github/workflows/_split_cluster_sync_check.yml
+++ b/.github/workflows/_split_cluster_sync_check.yml
@@ -3,6 +3,11 @@ name: Split Cluster Synchronization Check
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      head_sha:
+        description: "Commit SHA to test. When unset, falls back to github.sha."
+        type: string
+        required: false
 
 # No workflow-level `concurrency` here on purpose: a reusable workflow can't
 # compute a correct concurrency key (it depends on the caller's trigger
@@ -25,6 +30,7 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.head_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Run split cluster sync check script
@@ -56,6 +62,7 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.head_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Run split cluster sync check script

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -206,10 +206,6 @@ jobs:
                 continue;
               }
               const extraInputs = parseExtraInputs(extras, allowedKeys);
-              // Trusted values go AFTER `...extraInputs` as defense in depth:
-              // the allowlist already strips `pr_number`/`head_sha` from the
-              // marker, but if a future refactor weakens that check, the
-              // trusted values still win the spread merge.
               const inputs = {
                 ...extraInputs,
                 pr_number: String(prNumber),

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -24,16 +24,25 @@ name: PR CI checkbox trigger
 #      `pr_number` (string, optional) and `head_sha` (string, required)
 #      inputs, plus any extra inputs you want to drive from the marker.
 #      Its jobs should check out `${{ inputs.head_sha || github.sha }}`.
-#   2. Add a checkbox line to the relevant PR sub-template(s) with the
+#   2. Register it in the `ALLOWED_MARKER_DISPATCHES` allowlist in the
+#      script below — name the workflow file and list which of its inputs
+#      may be set from a marker. Inputs not listed cannot be set by PR
+#      authors (closed by default).
+#   3. Add a checkbox line to the relevant PR sub-template(s) with the
 #      `<!-- ci-trigger: <workflow-file>.yml [key=value]... -->` marker.
 #
 # Security note: this uses `pull_request_target` so the trigger has full
 # `GITHUB_TOKEN` permissions even on fork PRs. We never check out or execute
-# PR-author-controlled code here. The dispatched workflows themselves are
-# resolved from the repo's `develop` branch (`ref: 'develop'`), so a fork
-# cannot smuggle in a new workflow file via the PR — only workflows that
-# already exist on `develop` can be dispatched, and only with the inputs
-# this trigger passes.
+# PR-author-controlled code here. Two layers protect against a malicious PR
+# description abusing the marker:
+#   * `ALLOWED_MARKER_DISPATCHES` is a whitelist of (workflow → marker-
+#     overridable inputs). Workflows not in the map are rejected; inputs
+#     not listed for an allowed workflow are stripped. So an attacker can't
+#     dispatch arbitrary workflow_dispatch workflows on `develop` (e.g.
+#     `release.yml`) and can't smuggle in dispatcher-controlled fields
+#     like `head_sha`/`pr_number`.
+#   * Dispatched workflows are loaded from `develop` (`ref: 'develop'`), so
+#     a fork can't ship a modified version of the workflow file via the PR.
 
 # >>> TEMP — REVERT BEFORE MERGE <<<
 # `pull_request_target` is replaced with `pull_request` so this PR's own
@@ -120,10 +129,30 @@ jobs:
             });
             core.info(`Unchecked ${matches.length} ci-trigger checkbox(es).`);
 
+            // Whitelist of (workflow_id -> marker-overridable input keys).
+            //
+            // Acts as a closed-by-default authorization layer for everything
+            // PR-author-controlled in the marker:
+            //   * a workflow_id that isn't a key in this map cannot be
+            //     dispatched from a marker (rejects e.g. `release.yml` even
+            //     if it has a workflow_dispatch trigger on `develop`);
+            //   * for each allowed workflow, only the listed input names can
+            //     be set from the marker — anything else is stripped. In
+            //     particular `pr_number`/`head_sha` are never listed because
+            //     those are dispatcher-controlled (the dispatcher always
+            //     supplies them from the PR event itself).
+            //
+            // When adding a new dispatchable workflow, add an entry here.
+            const ALLOWED_MARKER_DISPATCHES = {
+              'heavy_tests.yml': new Set(['test_only_changed_crates']),
+            };
+
             // Parse the optional extra-inputs blob into a {key: value} object.
             // Format is whitespace-separated `key=value` pairs; values cannot
             // contain spaces (matching shell-style argument expectations).
-            function parseExtraInputs(blob) {
+            // `allowedKeys` is the per-workflow input allowlist; anything not
+            // in it is rejected with a warning.
+            function parseExtraInputs(blob, allowedKeys) {
               const out = {};
               if (!blob) return out;
               for (const pair of blob.trim().split(/\s+/)) {
@@ -133,7 +162,15 @@ jobs:
                   core.warning(`Ignoring malformed marker input "${pair}" (expected key=value).`);
                   continue;
                 }
-                out[pair.slice(0, eq)] = pair.slice(eq + 1);
+                const key = pair.slice(0, eq);
+                if (!allowedKeys.has(key)) {
+                  core.warning(
+                    `Ignoring marker input "${key}=...": not in the marker-input ` +
+                    `allowlist for this workflow.`,
+                  );
+                  continue;
+                }
+                out[key] = pair.slice(eq + 1);
               }
               return out;
             }
@@ -158,11 +195,25 @@ jobs:
             const prNumber = process.env.PR_NUMBER;
             let failed = 0;
             for (const [, label, workflow, extras] of matches) {
-              const extraInputs = parseExtraInputs(extras);
+              // Closed-by-default workflow check — see ALLOWED_MARKER_DISPATCHES
+              // for the allowlist and rationale.
+              const allowedKeys = ALLOWED_MARKER_DISPATCHES[workflow];
+              if (!allowedKeys) {
+                core.warning(
+                  `Marker references "${workflow}" which is not in ` +
+                  `ALLOWED_MARKER_DISPATCHES. Skipping dispatch.`,
+                );
+                continue;
+              }
+              const extraInputs = parseExtraInputs(extras, allowedKeys);
+              // Trusted values go AFTER `...extraInputs` as defense in depth:
+              // the allowlist already strips `pr_number`/`head_sha` from the
+              // marker, but if a future refactor weakens that check, the
+              // trusted values still win the spread merge.
               const inputs = {
+                ...extraInputs,
                 pr_number: String(prNumber),
                 head_sha: headSha,
-                ...extraInputs,
               };
               const extraDesc = Object.keys(extraInputs).length
                 ? ` with ${JSON.stringify(extraInputs)}`

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -1,3 +1,11 @@
+# SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+# CI workflows here interact with GitHub Actions' security model; subtle
+# edits (trigger change, missing `persist-credentials: false`, unpinned
+# action) can introduce critical supply-chain vulnerabilities. This file
+# in particular is the on-demand-dispatch entry point — see the README's
+# "ci_trigger.yml + ci-trigger-dispatch.js" section for the full threat
+# model and invariants.
+
 name: PR CI checkbox trigger
 
 # Dispatcher for CI workflows triggered by checking a checkbox in the PR

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -53,11 +53,17 @@ concurrency:
 
 jobs:
   dispatch:
-    # Skip the bot's own edits (our own `pulls.update` re-fires `edited`),
-    # and skip if there are no ci-trigger markers in the body at all — saves
-    # spinning a runner for unrelated description edits.
+    # Skip the bot's own edits (our own `pulls.update` re-fires `edited`).
+    # The `'- [x] '` + `'ci-trigger:'` substring checks are a cheap pre-filter
+    # that prevents spinning a runner when there's no plausible ticked
+    # ci-trigger box in the body (in particular, on every `opened` event for
+    # a PR that just used the template with all boxes unchecked). It's a
+    # loose check (any `[x]` anywhere in the body passes, e.g. an unrelated
+    # checklist item), but the script below does the precise per-line regex
+    # match before doing anything — false positives just cost an empty run.
     if: >-
       github.event.sender.type != 'Bot'
+      && contains(github.event.pull_request.body, '- [x] ')
       && contains(github.event.pull_request.body, 'ci-trigger:')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -1,94 +1,82 @@
 name: PR CI checkbox trigger
 
-# Generic checkbox-based dispatcher for CI workflows on PRs.
+# Dispatcher for CI workflows triggered by checking a checkbox in the PR
+# description. The dispatcher knows which workflow to fire from the visible
+# label text next to the checkbox — see `CHECKBOX_DISPATCHES` below.
 #
 # How it works:
-#   * The PR description contains one or more checkboxes annotated with a
-#     hidden HTML-comment marker that names the workflow file to dispatch.
-#     The marker may also include extra workflow inputs as `key=value` pairs:
+#   * The PR description contains one or more checkbox lines whose label
+#     matches an entry in `CHECKBOX_DISPATCHES`, e.g.:
 #
-#       - [ ] Run heavy tests <!-- ci-trigger: heavy_tests.yml -->
-#       - [ ] Run heavy tests (full) <!-- ci-trigger: heavy_tests.yml test_only_changed_crates=false -->
+#       - [ ] Run heavy tests
 #
-#   * When a user ticks a box (PR description gets edited), this workflow
-#     finds every checked box matching the marker pattern, unchecks them all
-#     in one edit, and then dispatches each named workflow against the PR's
-#     current HEAD SHA — passing `pr_number` + `head_sha` plus any extra
-#     `key=value` inputs from the marker.
+#   * When a user ticks a box (PR description gets edited) this workflow
+#     finds every checked box whose label is in the allowlist, unchecks
+#     them all in one edit, and then dispatches each mapped workflow with
+#     the PR's `pr_number` and `head_sha`.
 #   * The unchecking is done BEFORE dispatching so an infinite loop is
-#     impossible — after our edit, the body matches no `[x]` markers, and
+#     impossible — after our edit no `[x]` matches a known label, and
 #     the next `edited` event from our own write does nothing.
 #
 # Adding a new on-demand workflow:
-#   1. Give it a `workflow_dispatch` trigger that declares (at minimum) the
-#      `pr_number` (string, optional) and `head_sha` (string, required)
-#      inputs, plus any extra inputs you want to drive from the marker.
-#      Its jobs should check out `${{ inputs.head_sha || github.sha }}`.
-#   2. Register it in the `ALLOWED_MARKER_DISPATCHES` allowlist in the
-#      script below — name the workflow file and list which of its inputs
-#      may be set from a marker. Inputs not listed cannot be set by PR
-#      authors (closed by default).
-#   3. Add a checkbox line to the relevant PR sub-template(s) with the
-#      `<!-- ci-trigger: <workflow-file>.yml [key=value]... -->` marker.
+#   1. Give it a `workflow_dispatch` trigger with `pr_number` (string,
+#      optional) and `head_sha` (string, required) inputs. Its jobs should
+#      check out `${{ inputs.head_sha || github.sha }}`.
+#   2. Add the `label → workflow_id` mapping to `CHECKBOX_DISPATCHES`
+#      below, extend the job-level `if:` so the dispatcher spins up only
+#      for relevant edits, and add the matching `- [ ] <label>` line to
+#      the PR sub-template(s).
 #
-# Security note: this uses `pull_request_target` so the trigger has full
-# `GITHUB_TOKEN` permissions even on fork PRs. We never check out or execute
-# PR-author-controlled code here. Two layers protect against a malicious PR
-# description abusing the marker:
-#   * `ALLOWED_MARKER_DISPATCHES` is a whitelist of (workflow → marker-
-#     overridable inputs). Workflows not in the map are rejected; inputs
-#     not listed for an allowed workflow are stripped. So an attacker can't
-#     dispatch arbitrary workflow_dispatch workflows on `develop` (e.g.
-#     `release.yml`) and can't smuggle in dispatcher-controlled fields
-#     like `head_sha`/`pr_number`.
-#   * Dispatched workflows are loaded from `develop` (`ref: 'develop'`), so
-#     a fork can't ship a modified version of the workflow file via the PR.
+# Security note: uses `pull_request_target` so the trigger has the
+# permissions to edit the PR body and dispatch even on fork PRs. It never
+# checks out or executes PR-author-controlled code. The CHECKBOX_DISPATCHES
+# map is closed-by-default — a PR author cannot trigger any workflow not
+# listed there, and the dispatcher passes only the dispatcher-controlled
+# `pr_number`/`head_sha` inputs (no PR-author-supplied values reach the
+# dispatched workflow). Dispatched workflows are loaded from `develop`
+# (`ref: 'develop'`), so a fork can't ship a modified workflow file via
+# the PR — only the version on the default branch runs.
 
 # >>> TEMP — REVERT BEFORE MERGE <<<
 # `pull_request_target` is replaced with `pull_request` so this PR's own
 # branch version of the workflow actually runs (pull_request_target always
-# uses the base-branch file, which doesn't have ci_trigger.yml yet). This is
-# only to test the checkbox/parse/uncheck logic on this PR. Revert to
-# `pull_request_target` before merging.
+# uses the base-branch file, which doesn't have ci_trigger.yml yet). This
+# is only to test the checkbox detection / uncheck / dispatch logic on
+# this PR. Revert to `pull_request_target` before merging.
 on:
   pull_request:
     types: [opened, edited]
 
-# If a user clicks twice quickly (or edits the description twice with the
-# box already ticked), let the newer run cancel the older one. Otherwise
-# both ci_trigger runs dispatch `heavy_tests.yml`: heavy_tests has its own
-# `cancel-in-progress: true` so only the second heavy run actually completes,
-# but the first still burns ~30-60s of self-hosted-x64 runner setup before
-# being cancelled. Cancelling the earlier ci_trigger run avoids that waste.
-# Theoretical downside: if the older run is killed in the millisecond window
-# between `pulls.update` and `createWorkflowDispatch`, the click is
-# "swallowed" — the box is unchecked but no dispatch happened. That race is
-# orders of magnitude narrower than the wasted-setup window, and the user
-# recovery (just tick again) is trivial.
+# If a user clicks twice quickly, let the newer run cancel the older one.
+# Otherwise both ci_trigger runs would dispatch the heavy workflow:
+# `heavy_tests.yml` has its own `cancel-in-progress: true` so only the
+# second heavy run completes, but the first still burns ~30-60s of self-
+# hosted runner setup before being cancelled. Cancelling the earlier
+# ci_trigger run avoids that waste. The narrow race window (older run
+# cancelled between `pulls.update` and `createWorkflowDispatch`) just
+# swallows the click; the user re-ticks.
 concurrency:
   group: ci-trigger-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   dispatch:
-    # Skip the bot's own edits (our own `pulls.update` re-fires `edited`).
-    # The `'- [x] '` + `'ci-trigger:'` substring checks are a cheap pre-filter
-    # that prevents spinning a runner when there's no plausible ticked
-    # ci-trigger box in the body (in particular, on every `opened` event for
-    # a PR that just used the template with all boxes unchecked). It's a
-    # loose check (any `[x]` anywhere in the body passes, e.g. an unrelated
-    # checklist item), but the script below does the precise per-line regex
-    # match before doing anything — false positives just cost an empty run.
+    # Pre-filter:
+    #   * skip the bot's own edits (our `pulls.update` re-fires `edited`);
+    #   * skip when no known ci-trigger label is ticked, so we don't spin
+    #     a runner on every unrelated PR description edit (the substring
+    #     match is conservative — `'- [x] Run heavy tests'` only).
+    # When adding a new label in CHECKBOX_DISPATCHES, extend the `||` chain
+    # below to keep the runner from booting up unnecessarily.
     if: >-
       github.event.sender.type != 'Bot'
-      && contains(github.event.pull_request.body, '- [x] ')
-      && contains(github.event.pull_request.body, 'ci-trigger:')
+      && contains(github.event.pull_request.body, '- [x] Run heavy tests')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       actions: write
     steps:
-      - name: Uncheck matched boxes and dispatch their workflows
+      - name: Uncheck matched checkboxes and dispatch their workflows
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -98,127 +86,68 @@ jobs:
             const pr = context.payload.pull_request;
             const body = pr.body || '';
 
-            // Match: "- [x] <label> <!-- ci-trigger: <workflow>.yml [extra inputs] -->"
-            // Captures:
-            //   1 = label (cosmetic, used for logs)
-            //   2 = workflow filename
-            //   3 = optional extra-inputs blob (e.g. "test_only_changed_crates=false foo=bar"),
-            //       leading/trailing whitespace included; empty for the default case.
-            const re = /- \[x\] (.+?) <!-- ci-trigger: ([\w._-]+\.yml)([^>]*?) -->/g;
-            const matches = [...body.matchAll(re)];
+            // Closed-by-default map from a checkbox's visible label text
+            // to the workflow file dispatched when the box is ticked. Any
+            // other checkbox in the body (Basic tests, Release Notes, ...)
+            // is ignored. When adding an entry: also extend the top-level
+            // `if:` filter above and add the matching `- [ ] <label>` line
+            // to the PR sub-template(s).
+            const CHECKBOX_DISPATCHES = {
+              'Run heavy tests': 'heavy_tests.yml',
+            };
 
-            if (matches.length === 0) {
-              core.info('No checked ci-trigger checkboxes; nothing to do.');
+            // Escape a literal string for use inside a regex.
+            const reEscape = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+            // For each known label: find its checked-line occurrence
+            // (`^- [x] <label>[ \t]*$`), queue it, and uncheck it in the
+            // working body. We collect everything first and PUT once below.
+            const triggered = [];
+            let newBody = body;
+            for (const [label, workflow] of Object.entries(CHECKBOX_DISPATCHES)) {
+              const re = new RegExp(
+                `^- \\[x\\] ${reEscape(label)}[ \\t]*$`, 'gm',
+              );
+              if (!re.test(newBody)) continue;
+              triggered.push({ label, workflow });
+              newBody = newBody.replace(re, `- [ ] ${label}`);
+            }
+
+            if (triggered.length === 0) {
+              core.info('No known ci-trigger checkbox ticked; nothing to do.');
               return;
             }
 
-            // Step 1: uncheck every matched box in a single PUT, before
-            // dispatching anything. This guarantees no infinite loop even
-            // if a dispatch step below fails partway. Captures 2 and 3
-            // round-trip unchanged so the marker (and any extra inputs) is
-            // preserved.
-            const newBody = body.replace(
-              re,
-              '- [ ] $1 <!-- ci-trigger: $2$3 -->',
-            );
+            // Step 1: uncheck every triggered box in a single PUT, BEFORE
+            // dispatching anything. This guarantees no infinite loop —
+            // after our edit no `[x] <known-label>` line exists, so the
+            // next `edited` event from our own write does nothing.
             await github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pr.number,
               body: newBody,
             });
-            core.info(`Unchecked ${matches.length} ci-trigger checkbox(es).`);
-
-            // Whitelist of (workflow_id -> marker-overridable input keys).
-            //
-            // Acts as a closed-by-default authorization layer for everything
-            // PR-author-controlled in the marker:
-            //   * a workflow_id that isn't a key in this map cannot be
-            //     dispatched from a marker (rejects e.g. `release.yml` even
-            //     if it has a workflow_dispatch trigger on `develop`);
-            //   * for each allowed workflow, only the listed input names can
-            //     be set from the marker — anything else is stripped. In
-            //     particular `pr_number`/`head_sha` are never listed because
-            //     those are dispatcher-controlled (the dispatcher always
-            //     supplies them from the PR event itself).
-            //
-            // When adding a new dispatchable workflow, add an entry here.
-            const ALLOWED_MARKER_DISPATCHES = {
-              'heavy_tests.yml': new Set(['test_only_changed_crates']),
-            };
-
-            // Parse the optional extra-inputs blob into a {key: value} object.
-            // Format is whitespace-separated `key=value` pairs; values cannot
-            // contain spaces (matching shell-style argument expectations).
-            // `allowedKeys` is the per-workflow input allowlist; anything not
-            // in it is rejected with a warning.
-            function parseExtraInputs(blob, allowedKeys) {
-              const out = {};
-              if (!blob) return out;
-              for (const pair of blob.trim().split(/\s+/)) {
-                if (!pair) continue;
-                const eq = pair.indexOf('=');
-                if (eq < 1 || eq === pair.length - 1) {
-                  core.warning(`Ignoring malformed marker input "${pair}" (expected key=value).`);
-                  continue;
-                }
-                const key = pair.slice(0, eq);
-                if (!allowedKeys.has(key)) {
-                  core.warning(
-                    `Ignoring marker input "${key}=...": not in the marker-input ` +
-                    `allowlist for this workflow.`,
-                  );
-                  continue;
-                }
-                out[key] = pair.slice(eq + 1);
-              }
-              return out;
-            }
+            core.info(`Unchecked ${triggered.length} ci-trigger checkbox(es).`);
 
             // Step 2: dispatch each matched workflow. We continue past
-            // individual failures so a typo in one marker doesn't block
-            // other valid dispatches.
+            // individual failures so a transient error on one doesn't
+            // block others.
             //
             // Before dispatching we also check whether a run of the same
             // workflow already exists for the same SHA in a non-terminal
-            // state (queued/in_progress/waiting/...). If so we skip — the
-            // user just re-ticked while a previous request is still being
-            // handled, and we'd rather let in-flight progress finish than
-            // restart from scratch via heavy_tests.yml's `cancel-in-progress`.
-            //
-            // Note this is a coarse "any active run blocks any new dispatch
-            // of the same workflow" — it also blocks legitimate variant
-            // switches (e.g. user wants to switch from changed-crates to
-            // full-workspace mid-run). If that becomes a problem we can
-            // refine the check to compare dispatch inputs.
+            // state. If so we skip — the user just re-ticked while a
+            // previous request is still being handled, and we'd rather
+            // let in-flight progress finish than restart from scratch via
+            // heavy_tests.yml's `cancel-in-progress`.
             const headSha = process.env.HEAD_SHA;
             const prNumber = process.env.PR_NUMBER;
             let failed = 0;
-            for (const [, label, workflow, extras] of matches) {
-              // Closed-by-default workflow check — see ALLOWED_MARKER_DISPATCHES
-              // for the allowlist and rationale.
-              const allowedKeys = ALLOWED_MARKER_DISPATCHES[workflow];
-              if (!allowedKeys) {
-                core.warning(
-                  `Marker references "${workflow}" which is not in ` +
-                  `ALLOWED_MARKER_DISPATCHES. Skipping dispatch.`,
-                );
-                continue;
-              }
-              const extraInputs = parseExtraInputs(extras, allowedKeys);
-              const inputs = {
-                ...extraInputs,
-                pr_number: String(prNumber),
-                head_sha: headSha,
-              };
-              const extraDesc = Object.keys(extraInputs).length
-                ? ` with ${JSON.stringify(extraInputs)}`
-                : '';
-
-              // Best-effort active-run check. If the API call fails for any
-              // reason (workflow not on default branch yet, transient 5xx,
-              // rate limit) we fall through and dispatch anyway — better
-              // than silently dropping a user-requested run.
+            for (const { label, workflow } of triggered) {
+              // Best-effort active-run check. If the API call fails for
+              // any reason (workflow not on default branch yet, transient
+              // 5xx, rate limit) we fall through and dispatch anyway —
+              // better than silently dropping a user-requested run.
               let activeRun = null;
               try {
                 const { data } = await github.rest.actions.listWorkflowRuns({
@@ -244,18 +173,22 @@ jobs:
                 continue;
               }
 
+              const inputs = {
+                pr_number: String(prNumber),
+                head_sha: headSha,
+              };
               // >>> TEMP — REVERT BEFORE MERGE <<<
               // Dry-run: log what WOULD be dispatched instead of actually
               // calling createWorkflowDispatch. heavy_tests.yml isn't on
               // `develop` yet so a real dispatch would 404. This still
-              // exercises the regex, uncheck, bot-loop guard and input
-              // parsing end-to-end. Restore the createWorkflowDispatch
+              // exercises the regex / uncheck / bot-loop guard / active-
+              // run check end-to-end. Restore the createWorkflowDispatch
               // try/catch block (see git history) before merging.
               core.notice(
-                `DRY-RUN: would dispatch ${workflow} (label: "${label.trim()}")${extraDesc} ` +
+                `DRY-RUN: would dispatch ${workflow} (label: "${label}") ` +
                 `with inputs ${JSON.stringify(inputs)}`,
               );
             }
             if (failed > 0) {
-              core.setFailed(`${failed} of ${matches.length} dispatch(es) failed.`);
+              core.setFailed(`${failed} of ${triggered.length} dispatch(es) failed.`);
             }

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -80,8 +80,9 @@ jobs:
       && contains(github.event.pull_request.body, '- [x] Run heavy tests')
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
-      actions: write
+      pull-requests: write   # to edit PR body (uncheck the box)
+      actions: write         # to dispatch heavy_tests.yml via the API
+      contents: read         # to look up the sender's collaborator permission
     steps:
       # Sparse-checkout just `.github/scripts/` so we can `require()` the
       # dispatcher module below. With `pull_request_target` the default ref

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -1,48 +1,55 @@
 name: PR CI checkbox trigger
 
 # Dispatcher for CI workflows triggered by checking a checkbox in the PR
-# description. The dispatcher knows which workflow to fire from the visible
-# label text next to the checkbox — see `CHECKBOX_DISPATCHES` below.
+# description. The dispatcher matches the visible label text next to the
+# checkbox against a closed-by-default allowlist; see
+# `.github/scripts/ci-trigger-dispatch.js` (CHECKBOX_DISPATCHES) for the
+# label → workflow map and the actual dispatch logic.
 #
-# How it works:
+# How it works (high level):
 #   * The PR description contains one or more checkbox lines whose label
-#     matches an entry in `CHECKBOX_DISPATCHES`, e.g.:
+#     matches an entry in the dispatch map, e.g.:
 #
 #       - [ ] Run heavy tests
 #
 #   * When a user ticks a box (PR description gets edited) this workflow
 #     finds every checked box whose label is in the allowlist, unchecks
-#     them all in one edit, and then dispatches each mapped workflow with
-#     the PR's `pr_number` and `head_sha`.
+#     them all in one PR-body edit, and then dispatches each mapped
+#     workflow with the PR's `pr_number` and `head_sha`.
 #   * The unchecking is done BEFORE dispatching so an infinite loop is
 #     impossible — after our edit no `[x]` matches a known label, and
-#     the next `edited` event from our own write does nothing.
+#     events triggered by GITHUB_TOKEN don't create workflow runs anyway.
 #
 # Adding a new on-demand workflow:
 #   1. Give it a `workflow_dispatch` trigger with `pr_number` (string,
 #      optional) and `head_sha` (string, required) inputs. Its jobs should
 #      check out `${{ inputs.head_sha || github.sha }}`.
-#   2. Add the `label → workflow_id` mapping to `CHECKBOX_DISPATCHES`
-#      below, extend the job-level `if:` so the dispatcher spins up only
-#      for relevant edits, and add the matching `- [ ] <label>` line to
-#      the PR sub-template(s).
+#   2. Add the `label → workflow_id` mapping to `CHECKBOX_DISPATCHES` in
+#      `.github/scripts/ci-trigger-dispatch.js`, extend the job-level `if:`
+#      filter below so the dispatcher spins up only for relevant edits, and
+#      add the matching `- [ ] <label>` line to the PR sub-template(s).
 #
 # Security note: uses `pull_request_target` so the trigger has the
 # permissions to edit the PR body and dispatch even on fork PRs. It never
-# checks out or executes PR-author-controlled code. The CHECKBOX_DISPATCHES
-# map is closed-by-default — a PR author cannot trigger any workflow not
-# listed there, and the dispatcher passes only the dispatcher-controlled
-# `pr_number`/`head_sha` inputs (no PR-author-supplied values reach the
-# dispatched workflow). Dispatched workflows are loaded from `develop`
-# (`ref: 'develop'`), so a fork can't ship a modified workflow file via
-# the PR — only the version on the default branch runs.
+# checks out or executes PR-author-controlled code: the `actions/checkout`
+# step below uses the default ref, which for `pull_request_target` resolves
+# to the BASE branch — so the dispatcher script is always loaded from
+# `develop`, never from the PR branch. The CHECKBOX_DISPATCHES map is
+# closed-by-default — a PR author cannot trigger any workflow not listed
+# there, and the dispatcher passes only the dispatcher-controlled
+# `pr_number`/`head_sha` inputs. Dispatched workflows are loaded from
+# `develop` too (`ref: 'develop'`), so a fork can't ship a modified
+# workflow file via the PR.
 
 # >>> TEMP — REVERT BEFORE MERGE <<<
 # `pull_request_target` is replaced with `pull_request` so this PR's own
 # branch version of the workflow actually runs (pull_request_target always
-# uses the base-branch file, which doesn't have ci_trigger.yml yet). This
-# is only to test the checkbox detection / uncheck / dispatch logic on
-# this PR. Revert to `pull_request_target` before merging.
+# uses the base-branch file, which doesn't have ci_trigger.yml yet). The
+# checkout step below also picks up the PR-branch version of the
+# dispatcher script under `pull_request` (default checkout = merged ref),
+# which is exactly what we want for testing this PR. Revert to
+# `pull_request_target` before merging — that will also switch the loaded
+# script back to the `develop` copy.
 on:
   pull_request:
     types: [opened, edited]
@@ -66,8 +73,8 @@ jobs:
     #   * skip when no known ci-trigger label is ticked, so we don't spin
     #     a runner on every unrelated PR description edit (the substring
     #     match is conservative — `'- [x] Run heavy tests'` only).
-    # When adding a new label in CHECKBOX_DISPATCHES, extend the `||` chain
-    # below to keep the runner from booting up unnecessarily.
+    # When adding a new label to CHECKBOX_DISPATCHES, extend the `||`
+    # chain below to keep the runner from booting up unnecessarily.
     if: >-
       github.event.sender.type != 'Bot'
       && contains(github.event.pull_request.body, '- [x] Run heavy tests')
@@ -76,119 +83,23 @@ jobs:
       pull-requests: write
       actions: write
     steps:
-      - name: Uncheck matched checkboxes and dispatch their workflows
+      # Sparse-checkout just `.github/scripts/` so we can `require()` the
+      # dispatcher module below. With `pull_request_target` the default ref
+      # resolves to the BASE branch (`develop`), so the script we load is
+      # always the version on `develop` — a PR author cannot replace the
+      # dispatcher by editing this file in their PR.
+      - name: Check out dispatcher script (from base branch)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: Run dispatcher
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
-            const pr = context.payload.pull_request;
-            const body = pr.body || '';
-
-            // Closed-by-default map from a checkbox's visible label text
-            // to the workflow file dispatched when the box is ticked. Any
-            // other checkbox in the body (Basic tests, Release Notes, ...)
-            // is ignored. When adding an entry: also extend the top-level
-            // `if:` filter above and add the matching `- [ ] <label>` line
-            // to the PR sub-template(s).
-            const CHECKBOX_DISPATCHES = {
-              'Run heavy tests': 'heavy_tests.yml',
-            };
-
-            // Escape a literal string for use inside a regex.
-            const reEscape = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-            // For each known label: find its checked-line occurrence
-            // (`^- [x] <label>[ \t]*$`), queue it, and uncheck it in the
-            // working body. We collect everything first and PUT once below.
-            const triggered = [];
-            let newBody = body;
-            for (const [label, workflow] of Object.entries(CHECKBOX_DISPATCHES)) {
-              const re = new RegExp(
-                `^- \\[x\\] ${reEscape(label)}[ \\t]*$`, 'gm',
-              );
-              if (!re.test(newBody)) continue;
-              triggered.push({ label, workflow });
-              newBody = newBody.replace(re, `- [ ] ${label}`);
-            }
-
-            if (triggered.length === 0) {
-              core.info('No known ci-trigger checkbox ticked; nothing to do.');
-              return;
-            }
-
-            // Step 1: uncheck every triggered box in a single PUT, BEFORE
-            // dispatching anything. This guarantees no infinite loop —
-            // after our edit no `[x] <known-label>` line exists, so the
-            // next `edited` event from our own write does nothing.
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              body: newBody,
-            });
-            core.info(`Unchecked ${triggered.length} ci-trigger checkbox(es).`);
-
-            // Step 2: dispatch each matched workflow. We continue past
-            // individual failures so a transient error on one doesn't
-            // block others.
-            //
-            // Before dispatching we also check whether a run of the same
-            // workflow already exists for the same SHA in a non-terminal
-            // state. If so we skip — the user just re-ticked while a
-            // previous request is still being handled, and we'd rather
-            // let in-flight progress finish than restart from scratch via
-            // heavy_tests.yml's `cancel-in-progress`.
-            const headSha = process.env.HEAD_SHA;
-            const prNumber = process.env.PR_NUMBER;
-            let failed = 0;
-            for (const { label, workflow } of triggered) {
-              // Best-effort active-run check. If the API call fails for
-              // any reason (workflow not on default branch yet, transient
-              // 5xx, rate limit) we fall through and dispatch anyway —
-              // better than silently dropping a user-requested run.
-              let activeRun = null;
-              try {
-                const { data } = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: workflow,
-                  head_sha: headSha,
-                  per_page: 10,
-                });
-                activeRun = data.workflow_runs.find(r => r.status !== 'completed');
-              } catch (err) {
-                core.warning(
-                  `Couldn't list existing runs of ${workflow} for SHA ${headSha}: ${err.message}. ` +
-                  `Proceeding with dispatch.`,
-                );
-              }
-              if (activeRun) {
-                core.notice(
-                  `${workflow} is already active for ${headSha} ` +
-                  `(run #${activeRun.id}, status: ${activeRun.status}) — skipping dispatch. ` +
-                  `Wait for that run to finish, then tick the box again to re-run.`,
-                );
-                continue;
-              }
-
-              const inputs = {
-                pr_number: String(prNumber),
-                head_sha: headSha,
-              };
-              // >>> TEMP — REVERT BEFORE MERGE <<<
-              // Dry-run: log what WOULD be dispatched instead of actually
-              // calling createWorkflowDispatch. heavy_tests.yml isn't on
-              // `develop` yet so a real dispatch would 404. This still
-              // exercises the regex / uncheck / bot-loop guard / active-
-              // run check end-to-end. Restore the createWorkflowDispatch
-              // try/catch block (see git history) before merging.
-              core.notice(
-                `DRY-RUN: would dispatch ${workflow} (label: "${label}") ` +
-                `with inputs ${JSON.stringify(inputs)}`,
-              );
-            }
-            if (failed > 0) {
-              core.setFailed(`${failed} of ${triggered.length} dispatch(es) failed.`);
-            }
+            const dispatch = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-trigger-dispatch.js`);
+            await dispatch({ github, context, core });

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -45,11 +45,20 @@ on:
   pull_request:
     types: [opened, edited]
 
-# Serialize trigger runs per PR — if a user clicks twice quickly, queue the
-# second run rather than cancelling the first (which could drop a dispatch).
+# If a user clicks twice quickly (or edits the description twice with the
+# box already ticked), let the newer run cancel the older one. Otherwise
+# both ci_trigger runs dispatch `heavy_tests.yml`: heavy_tests has its own
+# `cancel-in-progress: true` so only the second heavy run actually completes,
+# but the first still burns ~30-60s of self-hosted-x64 runner setup before
+# being cancelled. Cancelling the earlier ci_trigger run avoids that waste.
+# Theoretical downside: if the older run is killed in the millisecond window
+# between `pulls.update` and `createWorkflowDispatch`, the click is
+# "swallowed" — the box is unchecked but no dispatch happened. That race is
+# orders of magnitude narrower than the wasted-setup window, and the user
+# recovery (just tick again) is trivial.
 concurrency:
   group: ci-trigger-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   dispatch:

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -79,9 +79,9 @@ jobs:
       && contains(github.event.pull_request.body, '- [x] Run heavy tests')
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write   # to edit PR body (uncheck the box)
-      actions: write         # to dispatch heavy_tests.yml via the API
-      contents: read         # to look up the sender's collaborator permission
+      pull-requests: write # to edit PR body (uncheck the box)
+      actions: write # to dispatch heavy_tests.yml via the API
+      contents: read # to look up the sender's collaborator permission
     steps:
       # Sparse-checkout just `.github/scripts/` so we can `require()` the
       # dispatcher module below. With `pull_request_target` the default ref

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -1,0 +1,156 @@
+name: PR CI checkbox trigger
+
+# Generic checkbox-based dispatcher for CI workflows on PRs.
+#
+# How it works:
+#   * The PR description contains one or more checkboxes annotated with a
+#     hidden HTML-comment marker that names the workflow file to dispatch.
+#     The marker may also include extra workflow inputs as `key=value` pairs:
+#
+#       - [ ] Run heavy tests <!-- ci-trigger: heavy_tests.yml -->
+#       - [ ] Run heavy tests (full) <!-- ci-trigger: heavy_tests.yml test_only_changed_crates=false -->
+#
+#   * When a user ticks a box (PR description gets edited), this workflow
+#     finds every checked box matching the marker pattern, unchecks them all
+#     in one edit, and then dispatches each named workflow against the PR's
+#     current HEAD SHA — passing `pr_number` + `head_sha` plus any extra
+#     `key=value` inputs from the marker.
+#   * The unchecking is done BEFORE dispatching so an infinite loop is
+#     impossible — after our edit, the body matches no `[x]` markers, and
+#     the next `edited` event from our own write does nothing.
+#
+# Adding a new on-demand workflow:
+#   1. Give it a `workflow_dispatch` trigger that declares (at minimum) the
+#      `pr_number` (string, optional) and `head_sha` (string, required)
+#      inputs, plus any extra inputs you want to drive from the marker.
+#      Its jobs should check out `${{ inputs.head_sha || github.sha }}`.
+#   2. Add a checkbox line to the relevant PR sub-template(s) with the
+#      `<!-- ci-trigger: <workflow-file>.yml [key=value]... -->` marker.
+#
+# Security note: this uses `pull_request_target` so the trigger has full
+# `GITHUB_TOKEN` permissions even on fork PRs. We never check out or execute
+# PR-author-controlled code here. The dispatched workflows themselves are
+# resolved from the repo's `develop` branch (`ref: 'develop'`), so a fork
+# cannot smuggle in a new workflow file via the PR — only workflows that
+# already exist on `develop` can be dispatched, and only with the inputs
+# this trigger passes.
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+# Serialize trigger runs per PR — if a user clicks twice quickly, queue the
+# second run rather than cancelling the first (which could drop a dispatch).
+concurrency:
+  group: ci-trigger-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    # Skip the bot's own edits (our own `pulls.update` re-fires `edited`),
+    # and skip if there are no ci-trigger markers in the body at all — saves
+    # spinning a runner for unrelated description edits.
+    if: >-
+      github.event.sender.type != 'Bot'
+      && contains(github.event.pull_request.body, 'ci-trigger:')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: write
+    steps:
+      - name: Uncheck matched boxes and dispatch their workflows
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            // Match: "- [x] <label> <!-- ci-trigger: <workflow>.yml [extra inputs] -->"
+            // Captures:
+            //   1 = label (cosmetic, used for logs)
+            //   2 = workflow filename
+            //   3 = optional extra-inputs blob (e.g. "test_only_changed_crates=false foo=bar"),
+            //       leading/trailing whitespace included; empty for the default case.
+            const re = /- \[x\] (.+?) <!-- ci-trigger: ([\w._-]+\.yml)([^>]*?) -->/g;
+            const matches = [...body.matchAll(re)];
+
+            if (matches.length === 0) {
+              core.info('No checked ci-trigger checkboxes; nothing to do.');
+              return;
+            }
+
+            // Step 1: uncheck every matched box in a single PUT, before
+            // dispatching anything. This guarantees no infinite loop even
+            // if a dispatch step below fails partway. Captures 2 and 3
+            // round-trip unchanged so the marker (and any extra inputs) is
+            // preserved.
+            const newBody = body.replace(
+              re,
+              '- [ ] $1 <!-- ci-trigger: $2$3 -->',
+            );
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              body: newBody,
+            });
+            core.info(`Unchecked ${matches.length} ci-trigger checkbox(es).`);
+
+            // Parse the optional extra-inputs blob into a {key: value} object.
+            // Format is whitespace-separated `key=value` pairs; values cannot
+            // contain spaces (matching shell-style argument expectations).
+            function parseExtraInputs(blob) {
+              const out = {};
+              if (!blob) return out;
+              for (const pair of blob.trim().split(/\s+/)) {
+                if (!pair) continue;
+                const eq = pair.indexOf('=');
+                if (eq < 1 || eq === pair.length - 1) {
+                  core.warning(`Ignoring malformed marker input "${pair}" (expected key=value).`);
+                  continue;
+                }
+                out[pair.slice(0, eq)] = pair.slice(eq + 1);
+              }
+              return out;
+            }
+
+            // Step 2: dispatch each matched workflow. We continue past
+            // individual failures so a typo in one marker doesn't block
+            // other valid dispatches.
+            const headSha = process.env.HEAD_SHA;
+            const prNumber = process.env.PR_NUMBER;
+            let failed = 0;
+            for (const [, label, workflow, extras] of matches) {
+              const extraInputs = parseExtraInputs(extras);
+              const inputs = {
+                pr_number: String(prNumber),
+                head_sha: headSha,
+                ...extraInputs,
+              };
+              const extraDesc = Object.keys(extraInputs).length
+                ? ` with ${JSON.stringify(extraInputs)}`
+                : '';
+              core.info(`Dispatching ${workflow} (label: "${label.trim()}")${extraDesc}`);
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflow,
+                  ref: 'develop',
+                  inputs,
+                });
+              } catch (err) {
+                failed += 1;
+                core.warning(
+                  `Failed to dispatch ${workflow}: ${err.message}. ` +
+                  `Check that the workflow exists on \`develop\` and accepts ` +
+                  `the inputs being passed (${Object.keys(inputs).join(', ')}).`,
+                );
+              }
+            }
+            if (failed > 0) {
+              core.setFailed(`${failed} of ${matches.length} dispatch(es) failed.`);
+            }

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -141,6 +141,19 @@ jobs:
             // Step 2: dispatch each matched workflow. We continue past
             // individual failures so a typo in one marker doesn't block
             // other valid dispatches.
+            //
+            // Before dispatching we also check whether a run of the same
+            // workflow already exists for the same SHA in a non-terminal
+            // state (queued/in_progress/waiting/...). If so we skip — the
+            // user just re-ticked while a previous request is still being
+            // handled, and we'd rather let in-flight progress finish than
+            // restart from scratch via heavy_tests.yml's `cancel-in-progress`.
+            //
+            // Note this is a coarse "any active run blocks any new dispatch
+            // of the same workflow" — it also blocks legitimate variant
+            // switches (e.g. user wants to switch from changed-crates to
+            // full-workspace mid-run). If that becomes a problem we can
+            // refine the check to compare dispatch inputs.
             const headSha = process.env.HEAD_SHA;
             const prNumber = process.env.PR_NUMBER;
             let failed = 0;
@@ -154,6 +167,36 @@ jobs:
               const extraDesc = Object.keys(extraInputs).length
                 ? ` with ${JSON.stringify(extraInputs)}`
                 : '';
+
+              // Best-effort active-run check. If the API call fails for any
+              // reason (workflow not on default branch yet, transient 5xx,
+              // rate limit) we fall through and dispatch anyway — better
+              // than silently dropping a user-requested run.
+              let activeRun = null;
+              try {
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflow,
+                  head_sha: headSha,
+                  per_page: 10,
+                });
+                activeRun = data.workflow_runs.find(r => r.status !== 'completed');
+              } catch (err) {
+                core.warning(
+                  `Couldn't list existing runs of ${workflow} for SHA ${headSha}: ${err.message}. ` +
+                  `Proceeding with dispatch.`,
+                );
+              }
+              if (activeRun) {
+                core.notice(
+                  `${workflow} is already active for ${headSha} ` +
+                  `(run #${activeRun.id}, status: ${activeRun.status}) — skipping dispatch. ` +
+                  `Wait for that run to finish, then tick the box again to re-run.`,
+                );
+                continue;
+              }
+
               // >>> TEMP — REVERT BEFORE MERGE <<<
               // Dry-run: log what WOULD be dispatched instead of actually
               // calling createWorkflowDispatch. heavy_tests.yml isn't on

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -35,8 +35,14 @@ name: PR CI checkbox trigger
 # already exist on `develop` can be dispatched, and only with the inputs
 # this trigger passes.
 
+# >>> TEMP — REVERT BEFORE MERGE <<<
+# `pull_request_target` is replaced with `pull_request` so this PR's own
+# branch version of the workflow actually runs (pull_request_target always
+# uses the base-branch file, which doesn't have ci_trigger.yml yet). This is
+# only to test the checkbox/parse/uncheck logic on this PR. Revert to
+# `pull_request_target` before merging.
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited]
 
 # Serialize trigger runs per PR — if a user clicks twice quickly, queue the
@@ -133,23 +139,17 @@ jobs:
               const extraDesc = Object.keys(extraInputs).length
                 ? ` with ${JSON.stringify(extraInputs)}`
                 : '';
-              core.info(`Dispatching ${workflow} (label: "${label.trim()}")${extraDesc}`);
-              try {
-                await github.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: workflow,
-                  ref: 'develop',
-                  inputs,
-                });
-              } catch (err) {
-                failed += 1;
-                core.warning(
-                  `Failed to dispatch ${workflow}: ${err.message}. ` +
-                  `Check that the workflow exists on \`develop\` and accepts ` +
-                  `the inputs being passed (${Object.keys(inputs).join(', ')}).`,
-                );
-              }
+              // >>> TEMP — REVERT BEFORE MERGE <<<
+              // Dry-run: log what WOULD be dispatched instead of actually
+              // calling createWorkflowDispatch. heavy_tests.yml isn't on
+              // `develop` yet so a real dispatch would 404. This still
+              // exercises the regex, uncheck, bot-loop guard and input
+              // parsing end-to-end. Restore the createWorkflowDispatch
+              // try/catch block (see git history) before merging.
+              core.notice(
+                `DRY-RUN: would dispatch ${workflow} (label: "${label.trim()}")${extraDesc} ` +
+                `with inputs ${JSON.stringify(inputs)}`,
+              );
             }
             if (failed > 0) {
               core.setFailed(`${failed} of ${matches.length} dispatch(es) failed.`);

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -49,17 +49,8 @@ name: PR CI checkbox trigger
 # `develop` too (`ref: 'develop'`), so a fork can't ship a modified
 # workflow file via the PR.
 
-# >>> TEMP — REVERT BEFORE MERGE <<<
-# `pull_request_target` is replaced with `pull_request` so this PR's own
-# branch version of the workflow actually runs (pull_request_target always
-# uses the base-branch file, which doesn't have ci_trigger.yml yet). The
-# checkout step below also picks up the PR-branch version of the
-# dispatcher script under `pull_request` (default checkout = merged ref),
-# which is exactly what we want for testing this PR. Revert to
-# `pull_request_target` before merging — that will also switch the loaded
-# script back to the `develop` copy.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 # If a user clicks twice quickly, let the newer run cancel the older one.

--- a/.github/workflows/heavy_tests.yml
+++ b/.github/workflows/heavy_tests.yml
@@ -58,11 +58,6 @@ concurrency:
   group: heavy-tests-${{ inputs.pr_number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.ref != 'refs/heads/develop' }}
 
-env:
-  CARGO_TERM_COLOR: always
-  RUST_LOG: "error"
-  RUST_BACKTRACE: short
-
 jobs:
   diff:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/heavy_tests.yml
+++ b/.github/workflows/heavy_tests.yml
@@ -47,6 +47,21 @@ concurrency:
   group: heavy-tests-${{ inputs.pr_number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.ref != 'refs/heads/develop' }}
 
+# Hard-limit GITHUB_TOKEN to the minimum this workflow needs:
+#   * `contents: read`  — for `actions/checkout` (and dorny/paths-filter API
+#     calls that compare branches).
+#   * `actions: write`  — for the `rust-tests-cancel` / `rust-simtests-cancel`
+#     jobs in `_rust_tests.yml` which call `gh run cancel`.
+# All other permissions default to `none`. This matters because we run
+# PR-author-controlled code (`cargo test` against `inputs.head_sha`) under
+# a `workflow_dispatch` event, which is NOT fork-restricted the way
+# `pull_request` is — so the token here would otherwise be the repo's
+# default permissions. Narrowing it caps blast radius if a malicious test
+# tries to exfiltrate the token.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   diff:
     runs-on: [ubuntu-latest]
@@ -61,6 +76,11 @@ jobs:
         with:
           ref: ${{ inputs.head_sha || github.sha }}
           fetch-depth: 0
+          # Don't leave the auth token in `.git/config` — `_rust_tests.yml`
+          # runs `cargo test` on this checkout, and a malicious test could
+          # scrape the token from there. We don't push anything from the
+          # heavy-tests path, so anonymous git access is fine.
+          persist-credentials: false
       - name: Detect Changes (diff)
         uses: "./.github/actions/diffs"
         id: diff

--- a/.github/workflows/heavy_tests.yml
+++ b/.github/workflows/heavy_tests.yml
@@ -85,7 +85,6 @@ jobs:
   # Only needed in change-filtered mode — push events and the "full
   # workspace" workflow_dispatch variant skip this and exercise everything.
   crates-changes:
-    needs: diff
     if: github.event_name == 'workflow_dispatch' && inputs.test_only_changed_crates
     runs-on: [self-hosted-x64]
     outputs:
@@ -102,7 +101,6 @@ jobs:
           filters: .github/crates-filters.yml
 
   external-changes:
-    needs: diff
     if: github.event_name == 'workflow_dispatch' && inputs.test_only_changed_crates
     runs-on: [self-hosted-x64]
     outputs:

--- a/.github/workflows/heavy_tests.yml
+++ b/.github/workflows/heavy_tests.yml
@@ -1,0 +1,158 @@
+name: Heavy tests
+
+# Runs the resource-intensive CI suite (Rust tests + simtests, split-cluster
+# compatibility checks).
+#
+# On PRs this workflow is NOT triggered automatically — it is dispatched
+# only by `ci_trigger.yml` when a user ticks one of the "Run heavy tests"
+# checkboxes in the PR description (one-shot opt-in, auto-unchecked).
+# Two flavors are exposed via the `test_only_changed_crates` input:
+#   * `true`  (default): test only crates that changed in the PR plus their
+#                        reverse-dependents. Faster, recommended.
+#   * `false`           : test the whole workspace. Slower, comprehensive.
+# As a safety override, when workspace-level Rust config has changed (e.g.
+# root `Cargo.toml`/`Cargo.lock`), we ignore `true` and run the whole
+# workspace anyway — a workspace-level change can affect every crate.
+#
+# On the long-lived branches (`develop`, `devnet`, `testnet`, `mainnet`,
+# release branches) heavy tests still run on every push and always cover
+# the whole workspace — those branches need full coverage on every merge.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number (for log context only)"
+        required: false
+        type: string
+      head_sha:
+        description: "Commit SHA to test (PR HEAD)"
+        required: true
+        type: string
+      test_only_changed_crates:
+        description: "If true, test only changed crates and their dependents. If false, test the whole workspace."
+        type: boolean
+        default: true
+        required: false
+  push:
+    branches:
+      - "develop"
+      - "devnet"
+      - "testnet"
+      - "mainnet"
+      - "releases/iota-*-release"
+
+# Concurrency is keyed per-PR (workflow_dispatch) or per-branch (push) — NOT
+# per-SHA: heavy tests only ever make sense for a PR's latest commit, so a
+# newer dispatch for the same PR should supersede an in-flight one (this also
+# means the "changed crates" and "full workspace" variants never run in
+# parallel — the later-dispatched one wins).
+#
+# `cancel-in-progress`:
+#   * workflow_dispatch (PR): true  — newer request wins (changed vs full,
+#                                     or just a re-run).
+#   * push to a long-lived branch: keep the original behavior — never cancel
+#     on `develop` (every merged commit must be fully tested, runs queue),
+#     but cancel on devnet/testnet/mainnet/release branches (latest only).
+concurrency:
+  group: heavy-tests-${{ inputs.pr_number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.ref != 'refs/heads/develop' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_LOG: "error"
+  RUST_BACKTRACE: short
+
+jobs:
+  diff:
+    runs-on: [ubuntu-latest]
+    outputs:
+      isRust: ${{ steps.diff.outputs.isRust }}
+      isRustWorkspaceConfig: ${{ steps.diff.outputs.isRustWorkspaceConfig }}
+      isPgIntegration: ${{ steps.diff.outputs.isPgIntegration }}
+      isMoveExampleUsedByOthers: ${{ steps.diff.outputs.isMoveExampleUsedByOthers }}
+      isStarfishSynchronization: ${{ steps.diff.outputs.isStarfishSynchronization }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.head_sha || github.sha }}
+          fetch-depth: 0
+      - name: Detect Changes (diff)
+        uses: "./.github/actions/diffs"
+        id: diff
+
+  # Paths-filter pass that produces the list of crates touched by the PR.
+  # Only needed in change-filtered mode — push events and the "full
+  # workspace" workflow_dispatch variant skip this and exercise everything.
+  crates-changes:
+    needs: diff
+    if: github.event_name == 'workflow_dispatch' && inputs.test_only_changed_crates
+    runs-on: [self-hosted-x64]
+    outputs:
+      components: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          list-files: "json"
+          filters: .github/crates-filters.yml
+
+  external-changes:
+    needs: diff
+    if: github.event_name == 'workflow_dispatch' && inputs.test_only_changed_crates
+    runs-on: [self-hosted-x64]
+    outputs:
+      components: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          list-files: "json"
+          filters: .github/external-crates-filters.yml
+
+  rust-tests:
+    needs: [diff, crates-changes, external-changes]
+    # `!cancelled() && !failure()` is required because `crates-changes` /
+    # `external-changes` are deliberately skipped in full-workspace mode —
+    # default `success()` would propagate that as "needs not satisfied".
+    if: >-
+      !cancelled() && !failure()
+      && (needs.diff.outputs.isRust == 'true'
+          || needs.diff.outputs.isPgIntegration == 'true'
+          || needs.diff.outputs.isMoveExampleUsedByOthers == 'true')
+    uses: ./.github/workflows/_rust_tests.yml
+    with:
+      isRust: ${{ needs.diff.outputs.isRust == 'true' }}
+      isPgIntegration: ${{ needs.diff.outputs.isPgIntegration == 'true' }}
+      isMoveExampleUsedByOthers: ${{ needs.diff.outputs.isMoveExampleUsedByOthers == 'true' }}
+      runSimtest: true
+      # Filter to changed crates only when the user opted in AND no
+      # workspace-level config changed (the latter can affect every crate,
+      # so we expand to the whole workspace as a safety net).
+      testOnlyChangedCrates: >-
+        ${{ github.event_name == 'workflow_dispatch'
+            && inputs.test_only_changed_crates
+            && needs.diff.outputs.isRustWorkspaceConfig != 'true' }}
+      # When `crates-changes`/`external-changes` were skipped these resolve
+      # to '' via the `|| '[]'` fallback; `_rust_tests.yml` ignores
+      # `--changed-crates` when `--test-only-changed-crates` isn't set.
+      changedCrates: ${{ join(fromJson(needs.crates-changes.outputs.components || '[]'), ' ') }}
+      changedExternalCrates: ${{ join(fromJson(needs.external-changes.outputs.components || '[]'), ' ') }}
+
+  split-cluster:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    uses: ./.github/workflows/_split_cluster.yml
+
+  split-cluster-sync-check:
+    needs: diff
+    if: needs.diff.outputs.isStarfishSynchronization == 'true'
+    uses: ./.github/workflows/_split_cluster_sync_check.yml

--- a/.github/workflows/heavy_tests.yml
+++ b/.github/workflows/heavy_tests.yml
@@ -56,8 +56,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.ref != 'refs/heads/develop' }}
 
 permissions:
-  contents: read    # actions/checkout + dorny/paths-filter
-  actions: write    # gh run cancel in _rust_tests.yml
+  contents: read # actions/checkout + dorny/paths-filter
+  actions: write # gh run cancel in _rust_tests.yml
 
 jobs:
   diff:

--- a/.github/workflows/heavy_tests.yml
+++ b/.github/workflows/heavy_tests.yml
@@ -4,15 +4,12 @@ name: Heavy tests
 # compatibility checks).
 #
 # On PRs this workflow is NOT triggered automatically — it is dispatched
-# only by `ci_trigger.yml` when a user ticks one of the "Run heavy tests"
-# checkboxes in the PR description (one-shot opt-in, auto-unchecked).
-# Two flavors are exposed via the `test_only_changed_crates` input:
-#   * `true`  (default): test only crates that changed in the PR plus their
-#                        reverse-dependents. Faster, recommended.
-#   * `false`           : test the whole workspace. Slower, comprehensive.
-# As a safety override, when workspace-level Rust config has changed (e.g.
-# root `Cargo.toml`/`Cargo.lock`), we ignore `true` and run the whole
-# workspace anyway — a workspace-level change can affect every crate.
+# only by `ci_trigger.yml` when a user ticks the "Run heavy tests" checkbox
+# in the PR description (one-shot opt-in, auto-unchecked). Tests are
+# filtered to the crates that changed in the PR plus their reverse-
+# dependents. As a safety override, when workspace-level Rust config has
+# changed (root `Cargo.toml`/`Cargo.lock`) we expand to the whole workspace
+# — a workspace-level change can affect every crate.
 #
 # On the long-lived branches (`develop`, `devnet`, `testnet`, `mainnet`,
 # release branches) heavy tests still run on every push and always cover
@@ -29,11 +26,6 @@ on:
         description: "Commit SHA to test (PR HEAD)"
         required: true
         type: string
-      test_only_changed_crates:
-        description: "If true, test only changed crates and their dependents. If false, test the whole workspace."
-        type: boolean
-        default: true
-        required: false
   push:
     branches:
       - "develop"
@@ -44,13 +36,10 @@ on:
 
 # Concurrency is keyed per-PR (workflow_dispatch) or per-branch (push) — NOT
 # per-SHA: heavy tests only ever make sense for a PR's latest commit, so a
-# newer dispatch for the same PR should supersede an in-flight one (this also
-# means the "changed crates" and "full workspace" variants never run in
-# parallel — the later-dispatched one wins).
+# newer dispatch for the same PR should supersede an in-flight one.
 #
 # `cancel-in-progress`:
-#   * workflow_dispatch (PR): true  — newer request wins (changed vs full,
-#                                     or just a re-run).
+#   * workflow_dispatch (PR): true  — newer request wins (e.g. re-run).
 #   * push to a long-lived branch: keep the original behavior — never cancel
 #     on `develop` (every merged commit must be fully tested, runs queue),
 #     but cancel on devnet/testnet/mainnet/release branches (latest only).
@@ -77,10 +66,10 @@ jobs:
         id: diff
 
   # Paths-filter pass that produces the list of crates touched by the PR.
-  # Only needed in change-filtered mode — push events and the "full
-  # workspace" workflow_dispatch variant skip this and exercise everything.
+  # Only needed in change-filtered mode (PR dispatch); push events to long-
+  # lived branches skip this and exercise the whole workspace.
   crates-changes:
-    if: github.event_name == 'workflow_dispatch' && inputs.test_only_changed_crates
+    if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted-x64]
     outputs:
       components: ${{ steps.filter.outputs.changes }}
@@ -96,7 +85,7 @@ jobs:
           filters: .github/crates-filters.yml
 
   external-changes:
-    if: github.event_name == 'workflow_dispatch' && inputs.test_only_changed_crates
+    if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted-x64]
     outputs:
       components: ${{ steps.filter.outputs.changes }}
@@ -127,16 +116,17 @@ jobs:
       isPgIntegration: ${{ needs.diff.outputs.isPgIntegration == 'true' }}
       isMoveExampleUsedByOthers: ${{ needs.diff.outputs.isMoveExampleUsedByOthers == 'true' }}
       runSimtest: true
-      # Filter to changed crates only when the user opted in AND no
-      # workspace-level config changed (the latter can affect every crate,
-      # so we expand to the whole workspace as a safety net).
+      # Filter to changed crates on PR dispatch UNLESS workspace-level Rust
+      # config has changed — the latter can affect every crate, so we expand
+      # to the whole workspace as a safety net. Pushes to long-lived
+      # branches always run the whole workspace.
       testOnlyChangedCrates: >-
         ${{ github.event_name == 'workflow_dispatch'
-            && inputs.test_only_changed_crates
             && needs.diff.outputs.isRustWorkspaceConfig != 'true' }}
-      # When `crates-changes`/`external-changes` were skipped these resolve
-      # to '' via the `|| '[]'` fallback; `_rust_tests.yml` ignores
-      # `--changed-crates` when `--test-only-changed-crates` isn't set.
+      # On push to long-lived branches `crates-changes`/`external-changes`
+      # are skipped, so these resolve to '' via the `|| '[]'` fallback;
+      # `_rust_tests.yml` ignores `--changed-crates` when
+      # `--test-only-changed-crates` isn't set.
       changedCrates: ${{ join(fromJson(needs.crates-changes.outputs.components || '[]'), ' ') }}
       changedExternalCrates: ${{ join(fromJson(needs.external-changes.outputs.components || '[]'), ' ') }}
 

--- a/.github/workflows/heavy_tests.yml
+++ b/.github/workflows/heavy_tests.yml
@@ -132,6 +132,10 @@ jobs:
           || needs.diff.outputs.isMoveExampleUsedByOthers == 'true')
     uses: ./.github/workflows/_rust_tests.yml
     with:
+      # Without `head_sha` the reusable's checkout falls back to `github.sha`
+      # which under workflow_dispatch is the dispatch ref (develop), not the
+      # PR. Pass the PR HEAD explicitly so the reusable tests the PR's code.
+      head_sha: ${{ inputs.head_sha || github.sha }}
       isRust: ${{ needs.diff.outputs.isRust == 'true' }}
       isPgIntegration: ${{ needs.diff.outputs.isPgIntegration == 'true' }}
       isMoveExampleUsedByOthers: ${{ needs.diff.outputs.isMoveExampleUsedByOthers == 'true' }}
@@ -154,8 +158,12 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     uses: ./.github/workflows/_split_cluster.yml
+    with:
+      head_sha: ${{ inputs.head_sha || github.sha }}
 
   split-cluster-sync-check:
     needs: diff
     if: needs.diff.outputs.isStarfishSynchronization == 'true'
     uses: ./.github/workflows/_split_cluster_sync_check.yml
+    with:
+      head_sha: ${{ inputs.head_sha || github.sha }}

--- a/.github/workflows/heavy_tests.yml
+++ b/.github/workflows/heavy_tests.yml
@@ -1,3 +1,11 @@
+# SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+# CI workflows here interact with GitHub Actions' security model; subtle
+# edits (trigger change, missing `persist-credentials: false`, unpinned
+# action) can introduce critical supply-chain vulnerabilities. This file
+# runs PR-author-controlled code under `workflow_dispatch` (which is NOT
+# fork-restricted), so its narrow `permissions:` and `head_sha` plumbing
+# are load-bearing — see the README's "heavy_tests.yml" section.
+
 name: Heavy tests
 
 # Runs the resource-intensive CI suite (Rust tests + simtests, split-cluster
@@ -47,20 +55,9 @@ concurrency:
   group: heavy-tests-${{ inputs.pr_number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.ref != 'refs/heads/develop' }}
 
-# Hard-limit GITHUB_TOKEN to the minimum this workflow needs:
-#   * `contents: read`  — for `actions/checkout` (and dorny/paths-filter API
-#     calls that compare branches).
-#   * `actions: write`  — for the `rust-tests-cancel` / `rust-simtests-cancel`
-#     jobs in `_rust_tests.yml` which call `gh run cancel`.
-# All other permissions default to `none`. This matters because we run
-# PR-author-controlled code (`cargo test` against `inputs.head_sha`) under
-# a `workflow_dispatch` event, which is NOT fork-restricted the way
-# `pull_request` is — so the token here would otherwise be the repo's
-# default permissions. Narrowing it caps blast radius if a malicious test
-# tries to exfiltrate the token.
 permissions:
-  contents: read
-  actions: write
+  contents: read    # actions/checkout + dorny/paths-filter
+  actions: write    # gh run cancel in _rust_tests.yml
 
 jobs:
   diff:
@@ -76,10 +73,6 @@ jobs:
         with:
           ref: ${{ inputs.head_sha || github.sha }}
           fetch-depth: 0
-          # Don't leave the auth token in `.git/config` — `_rust_tests.yml`
-          # runs `cargo test` on this checkout, and a malicious test could
-          # scrape the token from there. We don't push anything from the
-          # heavy-tests path, so anonymous git access is fine.
           persist-credentials: false
       - name: Detect Changes (diff)
         uses: "./.github/actions/diffs"
@@ -132,9 +125,6 @@ jobs:
           || needs.diff.outputs.isMoveExampleUsedByOthers == 'true')
     uses: ./.github/workflows/_rust_tests.yml
     with:
-      # Without `head_sha` the reusable's checkout falls back to `github.sha`
-      # which under workflow_dispatch is the dispatch ref (develop), not the
-      # PR. Pass the PR HEAD explicitly so the reusable tests the PR's code.
       head_sha: ${{ inputs.head_sha || github.sha }}
       isRust: ${{ needs.diff.outputs.isRust == 'true' }}
       isPgIntegration: ${{ needs.diff.outputs.isPgIntegration == 'true' }}

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -97,10 +97,7 @@ jobs:
     secrets: inherit
     with:
       isRust: ${{ needs.diff.outputs.isRust == 'true' }}
-      isRustWorkspaceConfig: ${{ needs.diff.outputs.isRustWorkspaceConfig == 'true' }}
       isRustExample: ${{ needs.diff.outputs.isRustExample == 'true' }}
-      isPgIntegration: ${{ needs.diff.outputs.isPgIntegration == 'true' }}
-      isMoveExampleUsedByOthers: ${{ needs.diff.outputs.isMoveExampleUsedByOthers == 'true' }}
 
   move-ide:
     needs:
@@ -111,19 +108,7 @@ jobs:
     if: (!cancelled() && !failure() && needs.diff.outputs.isExternalCrates == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_move_ide.yml
 
-  split-cluster:
-    needs:
-      - diff
-      - dprint-format
-      - license-check
-      - typos
-      - rust
-    if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
-    uses: ./.github/workflows/_split_cluster.yml
-
-  split-cluster-sync-check:
-    needs:
-      - diff
-      - rust
-    if: (!cancelled() && !failure() && needs.diff.outputs.isStarfishSynchronization == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
-    uses: ./.github/workflows/_split_cluster_sync_check.yml
+  # Heavy jobs (split-cluster, split-cluster-sync-check, and the rust-tests /
+  # rust-simtests chain) live in `heavy_tests.yml` and are gated by the
+  # "Run heavy tests" checkbox in the PR description (see
+  # `heavy_tests_trigger.yml`). They also run on push to long-lived branches.

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -1,3 +1,8 @@
+# SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+# CI workflows here interact with GitHub Actions' security model; subtle
+# edits (trigger change, missing `persist-credentials: false`, unpinned
+# action) can introduce critical supply-chain vulnerabilities.
+
 name: Hierarchy
 
 on:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,15 +36,6 @@ on:
         required: false
         default: false
 
-# Owns concurrency for the heavy reusable workflows it calls
-# (`_rust_tests.yml`, `_split_cluster*.yml`) — those no longer define
-# their own. Here we don't cancel a running nightly when a new one is scheduled or
-# manually dispatched: nightly is full-coverage, let it finish and queue the
-# next one.
-concurrency:
-  group: nightly-${{ github.ref }}
-  cancel-in-progress: false
-
 env:
   CARGO_TERM_COLOR: always
   RUST_LOG: "error"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,3 +1,8 @@
+# SECURITY-SENSITIVE: read .github/workflows/README.md before editing.
+# CI workflows here interact with GitHub Actions' security model; subtle
+# edits (trigger change, missing `persist-credentials: false`, unpinned
+# action) can introduce critical supply-chain vulnerabilities.
+
 name: Nightly checks
 
 on:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,6 +36,15 @@ on:
         required: false
         default: false
 
+# Owns concurrency for the heavy reusable workflows it calls
+# (`_rust_tests.yml`, `_split_cluster*.yml`) — those no longer define
+# their own. Here we don't cancel a running nightly when a new one is scheduled or
+# manually dispatched: nightly is full-coverage, let it finish and queue the
+# next one.
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   RUST_LOG: "error"


### PR DESCRIPTION
# Description of change

## Motivation

The repository runs both light CI (lint, format, typos, license, compile checks) and heavy CI (Rust tests, Rust simtests, split-cluster compatibility checks). Heavy tests are slow and consume the self-hosted runner pool heavily.

Heavy tests currently run automatically on every non-draft PR push. When contributors push several commits in a row, the runner pool gets saturated by heavy tests for work that isn't ready for that level of verification yet - starving other PRs and develop.

A previous proposal (#11263) gated heavy tests behind a ready label. In practice that approach turned out to be very hard to make robust: it accumulated a large number of edge cases - label added before vs. after leaving draft, draft↔ready toggles while heavy tests are mid-run, "remove the label to cancel", re-adding the label re-running everything from scratch, concurrency interactions, and so on - and the fixes for these kept overlapping and breaking one another, so a clean, predictable UX was very difficult to reach. On top of that, a label is persistent state: it is easy to leave on a stale PR, to forget to remove, or to accidentally re-trigger on every subsequent push.

So, instead of the label-based gate, this PR introduces an explicit "button" model: heavy tests on a PR run only when a contributor explicitly asks for them by ticking a checkbox in the PR description. The checkbox auto-unchecks immediately, so every run is a deliberate one-shot opt-in - there is no lingering state to forget. Behavior on long-lived branches (develop, devnet, testnet, mainnet, release branches) and nightly is unchanged: those still get full heavy coverage automatically.

Fixes #11253.

## How it works

1. PR templates contains a checkbox:

- [ ] Run heavy tests

1. The marker is invisible in the rendered description; the user only sees "Run heavy tests (…)".
2. ci_trigger.yml (generic dispatcher) runs on pull_request_target: [opened, edited]. When a box is ticked it:
  - finds every checked box matching the marker pattern;
  - unchecks them all in a single PR-body edit, before dispatching anything (this, plus a bot-sender filter, makes an infinite re-trigger loop impossible);
  - resolves each (workflow, inputs) against the ALLOWED_MARKER_DISPATCHES allowlist - workflows not registered there,  and input keys not listed for an allowed workflow, are dropped with a warning;
  - skips the dispatch if a run of that workflow is already active for the same HEAD SHA (don't restart in-flight progress when the user just re-ticked);
  - dispatches each surviving (workflow, inputs) via workflow_dispatch, passing pr_number, head_sha, and the allowlisted marker inputs.
3. heavy_tests.yml is the heavy-CI entry point. Triggers:
  - workflow_dispatch - from the checkbox dispatcher, or manually from the Actions UI with a head_sha,
  - push to long-lived branches - unchanged "full coverage on every merge" behavior.
It exposes a test_only_changed_crates input (default true) backing the two checkbox variants: changed crates only (fast) vs full workspace (comprehensive). Safety override: if workspace-level Rust config changed (root Cargo.toml/Cargo.lock), it always expands to the full workspace.
4. Concurrency redesign. The heavy reusable workflows previously each defined their own concurrency group derived from  github.event.pull_request.number. That field only exists on pull_request events; when these workflows are reached via workflow_dispatch it collapses to a constant, so every PR's heavy run collided into one global group and serialized cross-PR - defeating the 10-runner pool. A reusable workflow fundamentally cannot compute a correct concurrency key (it depends on the caller's trigger), so concurrency was moved to the entry workflows that own the trigger.

## Behavior

On a PR (the new part):
- PR opened / pushed → light CI (hierarchy.yml) runs as before (existing draft gate kept); heavy CI does not run.
- Contributor ticks a "Run heavy tests" checkbox → heavy_tests.yml is dispatched for the PR's current HEAD; the checkbox auto-unchecks immediately.
- If a heavy run is already active for this PR's HEAD SHA, ticking any "Run heavy tests" checkbox is a no-op and logs a notice — wait for that run to finish before re-triggering. Variant switching mid-run (e.g. "changed" → "full") is not supported on purpose: it would mean killing in-flight progress.
- Heavy runs targeting a different SHA (e.g. a new push) still supersede older in-flight runs via heavy_tests.yml's own concurrency, since testing the latest commit is always what we want.
- Two different PRs requesting heavy at the same time → run in parallel, bounded only by the runner pool (no cross-PR serialization).

Unchanged:
- Push to develop → heavy CI runs for every commit (queued, never cancelled).
- Push to devnet / testnet / mainnet / release branches → heavy CI runs, latest commit only.
- Nightly schedule → unchanged.

## Changes

### New
- .github/workflows/ci_trigger.yml - generic checkbox→workflow dispatcher (marker parsing, batch uncheck, loop guard, extra-input passthrough).
- .github/workflows/heavy_tests.yml - heavy CI entry point; workflow_dispatch + push to long-lived branches; test_only_changed_crates changed/full modes with workspace-config safety override.

### Modified
- hierarchy.yml - removed split-cluster and split-cluster-sync-check (moved into heavy_tests.yml); trimmed the now-unused inputs passed to _rust.yml. Light jobs and their draft gate are unchanged.
- _rust.yml - removed the heavy chain (rust-tests sub-job calling _rust_tests.yml, and the crates-changes/external-changes filters that only fed it) and the inputs only it used; kept rust-lints + execution-cut.
- _rust_tests.yml, _split_cluster.yml, _split_cluster_sync_check.yml - removed their workflow-level concurrency blocks (now owned by the entry workflows; comment added explaining why a reusable can't own concurrency).
- nightly.yml - added a concurrency block (nightly-${{ github.ref }}, cancel-in-progress: false) to preserve the nightly de-dup it previously inherited from the reusables.
- .github/PULL_REQUEST_TEMPLATE/{default_internal_contributors,default_external_contributors,infra}.md - added the "## CI" section with the two checkboxes.

## Adding a new on-demand workflow later

1. Give the workflow a workflow_dispatch trigger with pr_number (string, optional) and head_sha (string, required) inputs (plus any extra inputs you want marker-driven), and check out ${{ inputs.head_sha || github.sha }}.
2. Register the workflow in ALLOWED_MARKER_DISPATCHES in ci_trigger.yml, listing which of its inputs may be set from a  marker. Workflows not in the map (and inputs not listed for an allowed workflow) are closed by default.
3. Add a checkbox line to the PR sub-template(s): - [ ] <label> <!-- ci-trigger: <file>.yml [key=value]... -->.

## Security

ci_trigger.yml uses pull_request_target so it has the permissions needed to edit the PR body and dispatch even on fork  PRs. It never checks out or executes PR-author-controlled code. Two complementary layers limit what a malicious PR description can do via the marker:

* ALLOWED_MARKER_DISPATCHES is a closed-by-default allowlist of (workflow → marker-overridable inputs). A marker pointing at a workflow not in the map is rejected; input keys not listed for an allowed workflow are stripped. This blocks both "dispatch an arbitrary workflow_dispatch workflow on develop" (e.g. release.yml) and "smuggle dispatcher-controlled inputs like head_sha".
* Dispatched workflows are resolved from develop (ref: 'develop'), so a fork can't ship a modified workflow file via the PR — only the version on the default branch runs.

## ⚠️ Before merge

This branch contains a temporary dry-run commit for pre-merge testing (ci_trigger.yml: pull_request_target→pull_request, and createWorkflowDispatch→core.notice log, both flagged # >>> TEMP - REVERT BEFORE MERGE <<<). It exists because pull_request_target always uses the base-branch file and workflow_dispatch requires the workflow to exist on the default branch, so the full end-to-end flow can only be exercised after merge. Revert that commit before merging. The full cross-workflow dispatch + heavy_tests.yml wiring should be verified on a test PR once this is on develop.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## CI

Tick a box below to trigger the corresponding workflow on this PR's current HEAD.
Each box auto-unchecks once the run is dispatched — tick again to re-run.

- [ ] Run heavy tests