### PR TITLE
fix(consensus): restore starfish-core compile in isolation

### DIFF
--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -52,7 +52,7 @@ iota-macros.workspace = true
 iota-metrics.workspace = true
 iota-network-stack.workspace = true
 iota-protocol-config.workspace = true
-iota-sdk-types.workspace = true
+iota-sdk-types = { workspace = true, features = ["serde"] }
 iota-tls.workspace = true
 starfish-config.workspace = true
 typed-store.workspace = true


### PR DESCRIPTION
# Description of change

`cargo check -p starfish-core` fails on `develop` because `IntentMessage<T>`'s `Serialize` impl is gated on `iota-sdk-types`'s `serde` feature. Full-workspace builds happen to keep working via transitive activation from `iota-types`. One-line fix in `crates/starfish/core/Cargo.toml`.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
