### PR TITLE
chore(starfish): finalise hardening — naming and dashboard updates

### DIFF
--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -88,7 +88,7 @@ impl BaseCommitter {
         let leader_blocks = self
             .dag_state
             .read()
-            .get_uncommitted_block_headers_at_slot(leader);
+            .get_block_headers_at_slot_above_last_commit(leader);
         let mut leaders_with_enough_support: Vec<_> = leader_blocks
             .into_iter()
             .filter(|l| self.enough_leader_support(certifying_round, l))
@@ -194,7 +194,7 @@ impl BaseCommitter {
         let voting_round = leader_block.round() + 1;
         self.dag_state
             .read()
-            .get_uncommitted_block_headers_at_round(voting_round)
+            .get_block_headers_at_round_above_last_commit(voting_round)
             .into_iter()
             .filter(|voting_block| self.is_vote(voting_block, leader_block))
             .map(|voting_block| voting_block.reference())
@@ -233,7 +233,7 @@ impl BaseCommitter {
         let leader_blocks = self
             .dag_state
             .read()
-            .get_uncommitted_block_headers_at_slot(leader_slot);
+            .get_block_headers_at_slot_above_last_commit(leader_slot);
 
         // TODO: Re-evaluate this check once we have a better way to handle/track
         // byzantine authorities.
@@ -252,7 +252,7 @@ impl BaseCommitter {
         let potential_certificates = self
             .dag_state
             .read()
-            .ancestors_at_round(anchor, certifying_round);
+            .linked_block_headers_at_round_above_last_commit(anchor, certifying_round);
 
         // Use those potential certificates to determine which (if any) of the target
         // leader blocks can be committed.
@@ -286,7 +286,7 @@ impl BaseCommitter {
         let voting_blocks = self
             .dag_state
             .read()
-            .get_uncommitted_block_headers_at_round(voting_round);
+            .get_block_headers_at_round_above_last_commit(voting_round);
 
         let mut blame_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         for voting_block in &voting_blocks {
@@ -323,7 +323,7 @@ impl BaseCommitter {
         let decision_blocks = self
             .dag_state
             .read()
-            .get_uncommitted_block_headers_at_round(certifying_round);
+            .get_block_headers_at_round_above_last_commit(certifying_round);
 
         // Quickly reject if there isn't enough stake to support the leader from
         // the potential certificates.

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -252,7 +252,7 @@ impl BaseCommitter {
         let potential_certificates = self
             .dag_state
             .read()
-            .linked_block_headers_at_round_above_last_commit(anchor, certifying_round);
+            .reachable_headers_at_round_above_last_commit(anchor, certifying_round);
 
         // Use those potential certificates to determine which (if any) of the target
         // leader blocks can be committed.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1342,24 +1342,25 @@ impl DagState {
     /// from `later_block` through ancestor links (transitive closure stopped
     /// at the target round). The caller must ensure that the earlier round is
     /// strictly above last committed round.
-    pub(crate) fn linked_block_headers_at_round_above_last_commit(
+    pub(crate) fn reachable_headers_at_round_above_last_commit(
         &self,
         later_block: &VerifiedBlockHeader,
         earlier_round: Round,
     ) -> Vec<VerifiedBlockHeader> {
         // Iterate through ancestors of later_block in round descending order.
-        let mut linked: BTreeSet<BlockRef> = later_block.ancestors().iter().cloned().collect();
-        while !linked.is_empty() {
-            let round = linked.last().unwrap().round;
+        let mut reachable: BTreeSet<BlockRef> =
+            later_block.ancestors().iter().cloned().collect();
+        while !reachable.is_empty() {
+            let round = reachable.last().unwrap().round;
             // Stop after finishing traversal for ancestors above earlier_round.
             if round <= earlier_round {
                 break;
             }
-            let block_ref = linked.pop_last().unwrap();
+            let block_ref = reachable.pop_last().unwrap();
             let Some(block) = self.get_verified_block_header(&block_ref) else {
                 panic!("Block Header {block_ref:?} should exist in DAG!");
             };
-            linked.extend(
+            reachable.extend(
                 block
                     .ancestors()
                     .iter()
@@ -1368,7 +1369,7 @@ impl DagState {
             );
         }
         let block_headers =
-            self.get_verified_block_headers(&linked.iter().cloned().collect::<Vec<_>>());
+            self.get_verified_block_headers(&reachable.iter().cloned().collect::<Vec<_>>());
         block_headers
             .into_iter()
             .map(|opt| opt.unwrap_or_else(|| panic!("Block should exist in DAG!")))
@@ -2746,7 +2747,8 @@ mod test {
         }
 
         // Check ancestors connected to anchor.
-        let ancestors = dag_state.linked_block_headers_at_round_above_last_commit(&anchor, 11);
+        let ancestors =
+            dag_state.reachable_headers_at_round_above_last_commit(&anchor, 11);
         let mut ancestors_refs: Vec<BlockRef> = ancestors.iter().map(|b| b.reference()).collect();
         ancestors_refs.sort();
         let mut expected_refs = vec![

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1272,10 +1272,7 @@ impl DagState {
         shards
     }
 
-    /// Returns headers from `recent_block_headers` at `slot`. Permissive
-    /// lookup with no round bound; `accept_block_header` uses this to dedup
-    /// own slots at the just-committed round. Committer callers should use
-    /// `get_block_headers_at_slot_above_last_commit` instead.
+    /// Returns headers from `recent_block_headers` at `slot`.
     pub(crate) fn get_recent_block_headers_at_slot(&self, slot: Slot) -> Vec<VerifiedBlockHeader> {
         let mut block_headers = vec![];
         for (_block_ref, block_header) in self.recent_block_headers.range((
@@ -1296,8 +1293,8 @@ impl DagState {
     }
 
     /// Same as `get_recent_block_headers_at_slot` but asserts the slot is
-    /// strictly above `last_commit_round()`. Use from the committer where
-    /// the invariant holds.
+    /// strictly above last committed round. The caller, e.g. committer, must
+    /// ensure that the invariant holds.
     pub(crate) fn get_block_headers_at_slot_above_last_commit(
         &self,
         slot: Slot,
@@ -1310,7 +1307,7 @@ impl DagState {
         self.get_recent_block_headers_at_slot(slot)
     }
 
-    /// Returns headers from `recent_block_headers` at `round`. The caller MUST
+    /// Returns headers from `recent_block_headers` at `round`. The caller must
     /// pass `round > last_commit_round()` so the lookup stays inside the
     /// not-yet-committed portion of the DAG.
     pub(crate) fn get_block_headers_at_round_above_last_commit(
@@ -1343,9 +1340,8 @@ impl DagState {
 
     /// Returns block headers at exactly `earlier_round` that are reachable
     /// from `later_block` through ancestor links (transitive closure stopped
-    /// at the target round). The caller MUST pass
-    /// `earlier_round >= last_commit_round()` so the walk stays inside the
-    /// not-yet-committed portion of the DAG.
+    /// at the target round). The caller must ensure that the earlier round is
+    /// strictly above last committed round.
     pub(crate) fn linked_block_headers_at_round_above_last_commit(
         &self,
         later_block: &VerifiedBlockHeader,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -511,7 +511,7 @@ impl DagState {
         // TODO: Move this check to core
         // Ensure we don't write multiple blocks per slot for our own index
         if block_ref.author == self.context.own_index {
-            let existing_blocks = self.get_uncommitted_block_headers_at_slot(block_ref.into());
+            let existing_blocks = self.get_recent_block_headers_at_slot(block_ref.into());
             assert!(
                 existing_blocks.is_empty(),
                 "Block header Rejected! Attempted to add block header {block_header:#?} to own slot where \
@@ -1272,17 +1272,11 @@ impl DagState {
         shards
     }
 
-    /// Gets all uncommitted block headers in a slot.
-    /// Uncommitted block headers must exist in memory, so only in-memory block
-    /// headers are checked.
-    pub(crate) fn get_uncommitted_block_headers_at_slot(
-        &self,
-        slot: Slot,
-    ) -> Vec<VerifiedBlockHeader> {
-        // TODO: either panic below when the slot is at or below the last committed
-        // round, or support reading from storage while limiting storage reads
-        // to edge cases.
-
+    /// Returns headers from `recent_block_headers` at `slot`. Permissive
+    /// lookup with no round bound; `accept_block_header` uses this to dedup
+    /// own slots at the just-committed round. Committer callers should use
+    /// `get_block_headers_at_slot_above_last_commit` instead.
+    pub(crate) fn get_recent_block_headers_at_slot(&self, slot: Slot) -> Vec<VerifiedBlockHeader> {
         let mut block_headers = vec![];
         for (_block_ref, block_header) in self.recent_block_headers.range((
             Included(BlockRef::new(
@@ -1301,16 +1295,33 @@ impl DagState {
         block_headers
     }
 
-    /// Gets all uncommitted block headers in a round.
-    /// Uncommitted block headers must exist in memory, so only in-memory block
-    /// headers are checked.
-    pub(crate) fn get_uncommitted_block_headers_at_round(
+    /// Same as `get_recent_block_headers_at_slot` but asserts the slot is
+    /// strictly above `last_commit_round()`. Use from the committer where
+    /// the invariant holds.
+    pub(crate) fn get_block_headers_at_slot_above_last_commit(
+        &self,
+        slot: Slot,
+    ) -> Vec<VerifiedBlockHeader> {
+        assert!(
+            slot.round > self.last_commit_round(),
+            "slot {slot:?} must be above last commit round {}",
+            self.last_commit_round()
+        );
+        self.get_recent_block_headers_at_slot(slot)
+    }
+
+    /// Returns headers from `recent_block_headers` at `round`. The caller MUST
+    /// pass `round > last_commit_round()` so the lookup stays inside the
+    /// not-yet-committed portion of the DAG.
+    pub(crate) fn get_block_headers_at_round_above_last_commit(
         &self,
         round: Round,
     ) -> Vec<VerifiedBlockHeader> {
-        if round <= self.last_commit_round() {
-            panic!("Round {round} have committed block headers!");
-        }
+        assert!(
+            round > self.last_commit_round(),
+            "round {round} must be above last commit round {}",
+            self.last_commit_round()
+        );
 
         let mut block_headers = vec![];
         for (_block_ref, block_header) in self.recent_block_headers.range((
@@ -1330,8 +1341,12 @@ impl DagState {
         block_headers
     }
 
-    /// Gets all ancestors in the history of a block at a certain round.
-    pub(crate) fn ancestors_at_round(
+    /// Returns block headers at exactly `earlier_round` that are reachable
+    /// from `later_block` through ancestor links (transitive closure stopped
+    /// at the target round). The caller MUST pass
+    /// `earlier_round >= last_commit_round()` so the walk stays inside the
+    /// not-yet-committed portion of the DAG.
+    pub(crate) fn linked_block_headers_at_round_above_last_commit(
         &self,
         later_block: &VerifiedBlockHeader,
         earlier_round: Round,
@@ -2422,7 +2437,7 @@ impl DagState {
 
             // Since the wave length is 3 we expect to find a quorum in the
             // uncommitted rounds.
-            let blocks = self.get_uncommitted_block_headers_at_round(round);
+            let blocks = self.get_block_headers_at_round_above_last_commit(round);
             for block in &blocks {
                 if quorum.add(block.author(), &self.context.committee) {
                     return blocks;
@@ -2541,7 +2556,7 @@ mod test {
                         .to_authority_index(author as usize)
                         .unwrap(),
                 );
-                let block_headers = dag_state.get_uncommitted_block_headers_at_slot(slot);
+                let block_headers = dag_state.get_block_headers_at_slot_above_last_commit(slot);
 
                 // We only write one block per slot for own index
                 if AuthorityIndex::new_for_test(author) == own_index {
@@ -2567,13 +2582,13 @@ mod test {
         let slot = Slot::new(non_existent_round, AuthorityIndex::ZERO);
         assert!(
             dag_state
-                .get_uncommitted_block_headers_at_slot(slot)
+                .get_block_headers_at_slot_above_last_commit(slot)
                 .is_empty()
         );
 
         // Check rounds with uncommitted blocks.
         for round in 1..=num_rounds {
-            let block_headers = dag_state.get_uncommitted_block_headers_at_round(round);
+            let block_headers = dag_state.get_block_headers_at_round_above_last_commit(round);
             // Expect 3 blocks per authority except for own authority which should
             // have 1 block.
             assert_eq!(
@@ -2588,7 +2603,7 @@ mod test {
         // Check rounds without uncommitted block headers.
         assert!(
             dag_state
-                .get_uncommitted_block_headers_at_round(non_existent_round)
+                .get_block_headers_at_round_above_last_commit(non_existent_round)
                 .is_empty()
         );
     }
@@ -2735,7 +2750,7 @@ mod test {
         }
 
         // Check ancestors connected to anchor.
-        let ancestors = dag_state.ancestors_at_round(&anchor, 11);
+        let ancestors = dag_state.linked_block_headers_at_round_above_last_commit(&anchor, 11);
         let mut ancestors_refs: Vec<BlockRef> = ancestors.iter().map(|b| b.reference()).collect();
         ancestors_refs.sort();
         let mut expected_refs = vec![
@@ -3626,7 +3641,9 @@ mod test {
                 .write()
                 .accept_block_header(block_header, DataSource::Test);
 
-            let round_4_block_headers = dag_state.read().get_uncommitted_block_headers_at_round(4);
+            let round_4_block_headers = dag_state
+                .read()
+                .get_block_headers_at_round_above_last_commit(4);
 
             let last_quorum = dag_state.read().last_quorum();
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1348,8 +1348,7 @@ impl DagState {
         earlier_round: Round,
     ) -> Vec<VerifiedBlockHeader> {
         // Iterate through ancestors of later_block in round descending order.
-        let mut reachable: BTreeSet<BlockRef> =
-            later_block.ancestors().iter().cloned().collect();
+        let mut reachable: BTreeSet<BlockRef> = later_block.ancestors().iter().cloned().collect();
         while !reachable.is_empty() {
             let round = reachable.last().unwrap().round;
             // Stop after finishing traversal for ancestors above earlier_round.
@@ -2747,8 +2746,7 @@ mod test {
         }
 
         // Check ancestors connected to anchor.
-        let ancestors =
-            dag_state.reachable_headers_at_round_above_last_commit(&anchor, 11);
+        let ancestors = dag_state.reachable_headers_at_round_above_last_commit(&anchor, 11);
         let mut ancestors_refs: Vec<BlockRef> = ancestors.iter().map(|b| b.reference()).collect();
         ancestors_refs.sort();
         let mut expected_refs = vec![

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -7293,7 +7293,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "histogram_quantile(0.66, sum(rate(consensus_delay_in_sending_blocks_bucket[2m])) by (le)) / 1000",
+              "expr": "histogram_quantile(0.66, sum(rate(consensus_delay_in_sending_blocks_bucket[2m])) by (le, host)) / 1000",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -7879,11 +7879,11 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(consensus_sub_dags_per_commit_count_sum[2m])/rate(consensus_sub_dags_per_commit_count_count[2m])",
+              "expr": "sum by (host) (rate(consensus_sub_dags_per_commit_count_sum[2m])) / sum by (host) (rate(consensus_sub_dags_per_commit_count_count[2m]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "__auto",
+              "legendFormat": "{{host}}",
               "range": true,
               "refId": "A",
               "useBackend": false

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -14065,7 +14065,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Suspended-header dwell time, p50/p90/p99 per source authority. With GC eviction the long tail should be bounded; growing p99 indicates suspended state is not being evicted.",
+          "description": "Suspended-header dwell time, p50/p95 per source authority. With GC eviction the long tail should be bounded; growing p95 indicates suspended state is not being evicted.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -14159,26 +14159,14 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.9, sum by (le, authority) (rate(consensus_suspended_block_header_time_bucket[2m])))",
+              "expr": "histogram_quantile(0.95, sum by (le, authority) (rate(consensus_suspended_block_header_time_bucket[2m])))",
               "instant": false,
-              "legendFormat": "{{authority}} p90",
+              "legendFormat": "{{authority}} p95",
               "range": true,
               "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum by (le, authority) (rate(consensus_suspended_block_header_time_bucket[2m])))",
-              "instant": false,
-              "legendFormat": "{{authority}} p99",
-              "range": true,
-              "refId": "C"
             }
           ],
-          "title": "Suspended header dwell time (p50/p90/p99 by authority)",
+          "title": "Suspended header dwell time (p50/p95 by authority)",
           "type": "timeseries"
         },
         {

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -10197,9 +10197,9 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "rate(consensus_reconstruction_jobs_finished [2m])",
+              "expr": "sum by (host) (rate(consensus_reconstruction_jobs_finished[2m]))",
               "instant": false,
-              "legendFormat": "__auto",
+              "legendFormat": "{{host}}",
               "range": true,
               "refId": "A"
             }
@@ -10291,9 +10291,9 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "consensus_reconstruction_queue",
+              "expr": "sum by (host) (consensus_reconstruction_queue)",
               "instant": false,
-              "legendFormat": "__auto",
+              "legendFormat": "{{host}}",
               "range": true,
               "refId": "A"
             }
@@ -10385,9 +10385,9 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "consensus_shard_accumulators",
+              "expr": "sum by (host) (consensus_shard_accumulators)",
               "instant": false,
-              "legendFormat": "__auto",
+              "legendFormat": "{{host}}",
               "range": true,
               "refId": "A"
             }
@@ -10480,11 +10480,11 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, rate(consensus_reconstruction_lag_bucket[2m]))",
+              "expr": "histogram_quantile(0.99, sum by (le, host) (rate(consensus_reconstruction_lag_bucket[2m])))",
               "fullMetaSearch": false,
               "includeNullMetadata": false,
               "instant": false,
-              "legendFormat": "__auto",
+              "legendFormat": "{{host}}",
               "range": true,
               "refId": "A",
               "useBackend": false

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -5332,11 +5332,11 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sequencing_certificate_attempt",
+              "expr": "rate(sequencing_certificate_attempt[2m])",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "{{host}}/{{name}}",
+              "legendFormat": "{{host}}/{{tx_type}}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -5651,7 +5651,7 @@
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "{{host}}/{{name}}",
+              "legendFormat": "{{host}}/{{source}}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -7696,6 +7696,103 @@
             }
           ],
           "title": "Subdags per commit count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of skipped block proposals by reason. Reasons: no_quorum_subscriber, no_last_known_proposed_round, higher_last_known_proposed_round, behind_quorum_commit_round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 301
+          },
+          "id": 337,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "range": true,
+              "refId": "A",
+              "useBackend": false,
+              "expr": "avg by (reason) (rate(consensus_core_skipped_proposals[2m]))",
+              "legendFormat": "{{reason}}"
+            }
+          ],
+          "title": "Reason for skipping block creation",
           "type": "timeseries"
         }
       ],
@@ -13962,6 +14059,829 @@
           ],
           "title": "Top 5 Authorities Causing Missing Ancestors",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Suspended-header dwell time, p50/p90/p99 per source authority. With GC eviction the long tail should be bounded; growing p99 indicates suspended state is not being evicted.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 592
+          },
+          "id": 338,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.5, sum by (le, authority) (rate(consensus_suspended_block_header_time_bucket[2m])))",
+              "instant": false,
+              "legendFormat": "{{authority}} p50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.9, sum by (le, authority) (rate(consensus_suspended_block_header_time_bucket[2m])))",
+              "instant": false,
+              "legendFormat": "{{authority}} p90",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by (le, authority) (rate(consensus_suspended_block_header_time_bucket[2m])))",
+              "instant": false,
+              "legendFormat": "{{authority}} p99",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Suspended header dwell time (p50/p90/p99 by authority)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Last GC round floor applied by BlockManager. Suspended state at/below this round has been evicted.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 600
+          },
+          "id": 331,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "consensus_block_manager_gc_floor",
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GC floor",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of missing-ancestor entries dropped by the BlockManager GC sweep.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 600
+          },
+          "id": 332,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(consensus_block_manager_gc_evicted_missing_ancestors_total[5m])",
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GC evicted missing ancestors (rate)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of headers_to_fetch entries dropped by the BlockManager GC sweep.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 608
+          },
+          "id": 333,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(consensus_block_manager_gc_evicted_fetch_entries_total[5m])",
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GC evicted fetch entries (rate)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of headers unsuspended by the GC sweep because all their missing ancestors fell below the GC floor.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 608
+          },
+          "id": 334,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(consensus_block_manager_gc_unsuspended_total[5m])",
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GC unsuspended headers (rate)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of suspended_transactions entries dropped by the BlockManager GC sweep.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 616
+          },
+          "id": 335,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(consensus_block_manager_gc_evicted_suspended_transactions_total[5m])",
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GC evicted suspended transactions (rate)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of incoming block headers dropped because their round is at or below the GC floor.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byValue",
+                  "options": {
+                    "op": "gte",
+                    "reducer": "allIsZero",
+                    "value": 0
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 616
+          },
+          "id": 336,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(consensus_block_manager_gc_evicted_old_headers_total[5m])",
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GC evicted old incoming headers (rate)",
+          "type": "timeseries"
         }
       ],
       "title": "Block Manager",
@@ -13973,7 +14893,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 601
+        "y": 625
       },
       "id": 127,
       "panels": [
@@ -14040,7 +14960,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 601
+            "y": 625
           },
           "id": 128,
           "options": {
@@ -14136,7 +15056,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 601
+            "y": 625
           },
           "id": 129,
           "options": {
@@ -14232,7 +15152,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 609
+            "y": 633
           },
           "id": 130,
           "options": {
@@ -14328,7 +15248,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 609
+            "y": 633
           },
           "id": 133,
           "options": {
@@ -14424,7 +15344,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 617
+            "y": 641
           },
           "id": 131,
           "options": {
@@ -14520,7 +15440,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 617
+            "y": 641
           },
           "id": 134,
           "options": {
@@ -14616,7 +15536,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 625
+            "y": 649
           },
           "id": 330,
           "options": {
@@ -14661,7 +15581,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 634
+        "y": 658
       },
       "id": 67,
       "panels": [
@@ -14726,7 +15646,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 634
+            "y": 658
           },
           "id": 157,
           "options": {
@@ -14796,7 +15716,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 634
+            "y": 658
           },
           "id": 242,
           "options": {
@@ -14899,7 +15819,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 642
+            "y": 666
           },
           "id": 243,
           "options": {
@@ -15025,7 +15945,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 642
+            "y": 666
           },
           "id": 68,
           "options": {
@@ -15126,7 +16046,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 650
+            "y": 674
           },
           "id": 96,
           "options": {
@@ -15219,7 +16139,7 @@
             "h": 19,
             "w": 24,
             "x": 0,
-            "y": 657
+            "y": 681
           },
           "id": 74,
           "options": {
@@ -15265,7 +16185,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 677
+        "y": 701
       },
       "id": 7,
       "panels": [
@@ -15327,7 +16247,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 677
+            "y": 701
           },
           "id": 51,
           "options": {
@@ -15466,7 +16386,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 677
+            "y": 701
           },
           "id": 61,
           "options": {
@@ -15609,7 +16529,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 677
+            "y": 701
           },
           "id": 64,
           "options": {
@@ -15703,7 +16623,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 685
+            "y": 709
           },
           "id": 1,
           "options": {
@@ -15797,7 +16717,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 685
+            "y": 709
           },
           "id": 28,
           "options": {
@@ -15891,7 +16811,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 685
+            "y": 709
           },
           "id": 11,
           "options": {
@@ -15984,7 +16904,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 693
+            "y": 717
           },
           "id": 6,
           "options": {
@@ -16078,7 +16998,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 693
+            "y": 717
           },
           "id": 60,
           "options": {
@@ -16173,7 +17093,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 693
+            "y": 717
           },
           "id": 58,
           "options": {
@@ -16269,7 +17189,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 701
+            "y": 725
           },
           "id": 29,
           "options": {
@@ -16364,7 +17284,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 701
+            "y": 725
           },
           "id": 31,
           "options": {
@@ -16407,7 +17327,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 710
+        "y": 734
       },
       "id": 15,
       "panels": [
@@ -16474,7 +17394,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 710
+            "y": 734
           },
           "id": 18,
           "options": {
@@ -16570,7 +17490,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 710
+            "y": 734
           },
           "id": 13,
           "options": {
@@ -16671,7 +17591,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 710
+            "y": 734
           },
           "id": 16,
           "options": {
@@ -16772,7 +17692,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 718
+            "y": 742
           },
           "id": 19,
           "options": {
@@ -16868,7 +17788,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 718
+            "y": 742
           },
           "id": 14,
           "options": {
@@ -16969,7 +17889,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 718
+            "y": 742
           },
           "id": 17,
           "options": {
@@ -17070,7 +17990,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 726
+            "y": 750
           },
           "id": 42,
           "options": {
@@ -17166,7 +18086,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 726
+            "y": 750
           },
           "id": 59,
           "options": {
@@ -17262,7 +18182,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 726
+            "y": 750
           },
           "id": 50,
           "options": {
@@ -17304,7 +18224,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 735
+        "y": 759
       },
       "id": 44,
       "panels": [
@@ -17367,7 +18287,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 735
+            "y": 759
           },
           "id": 222,
           "options": {
@@ -17460,7 +18380,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 764
+            "y": 788
           },
           "id": 47,
           "options": {
@@ -17555,7 +18475,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 764
+            "y": 788
           },
           "id": 46,
           "options": {
@@ -17684,7 +18604,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 764
+            "y": 788
           },
           "id": 220,
           "options": {
@@ -17778,7 +18698,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 772
+            "y": 796
           },
           "id": 45,
           "options": {
@@ -17873,7 +18793,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 772
+            "y": 796
           },
           "id": 48,
           "options": {
@@ -18003,7 +18923,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 772
+            "y": 796
           },
           "id": 221,
           "options": {
@@ -18095,7 +19015,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 780
+            "y": 804
           },
           "id": 234,
           "options": {
@@ -18214,7 +19134,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 780
+            "y": 804
           },
           "id": 235,
           "options": {

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -9775,9 +9775,9 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "rate(consensus_rejected_blocks[2m])",
+              "expr": "sum by (host, reason) (rate(consensus_rejected_blocks[2m]))",
               "instant": false,
-              "legendFormat": "__auto",
+              "legendFormat": "{{host}} - {{reason}}",
               "range": true,
               "refId": "A"
             }

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -7788,8 +7788,8 @@
               "range": true,
               "refId": "A",
               "useBackend": false,
-              "expr": "avg by (reason) (rate(consensus_core_skipped_proposals[2m]))",
-              "legendFormat": "{{reason}}"
+              "expr": "rate(consensus_core_skipped_proposals[2m])",
+              "legendFormat": "{{host}}/{{reason}}"
             }
           ],
           "title": "Reason for skipping block creation",

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -1876,6 +1876,200 @@
       "type": "table"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Average reason for block creation across all validators",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 340,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg by (reason) (rate(consensus_proposed_blocks[2m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{reason}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Reason for block creation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Average reason for skipping block creation across all validators",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 341,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg by (reason) (rate(consensus_core_skipped_proposals[2m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{reason}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Reason for skipping block creation",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
@@ -7311,7 +7505,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Average reason for block creation",
+          "description": "Reason for block creation per validator",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -7391,10 +7585,10 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "avg by (reason) (rate(consensus_proposed_blocks[2m]))",
+              "expr": "sum by (host, reason) (rate(consensus_proposed_blocks[2m]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "legendFormat": "{{host}}",
+              "legendFormat": "{{host}}/{{reason}}",
               "range": true,
               "refId": "A",
               "useBackend": false


### PR DESCRIPTION
# Description of change

Finalises the starfish hardening feature branch. Two pieces: precondition-encoding renames in `DagState` (follow-ups from #11402's GC sweep) and Grafana panels for the new BlockManager GC paths.

Several `DagState` helpers carry an implicit "caller must stay above `last_commit_round()`" precondition that, after BlockManager started actively evicting sub-floor state, can no longer be papered over with a silent empty result. Their names did not say so, and one of them carried a TODO asking for the assertion to be added.

- Rename `ancestors_at_round` → `reachable_headers_at_round_above_last_commit`. The function does a transitive BFS through `block.ancestors()` links starting at a later block, descends in round order, and returns the *frontier* at the target round — not the direct ancestors a reader of `block.ancestors()` would expect. The new name (and the rewritten doc comment) make both the transitive semantics and the precondition explicit; `reachable_` reads more idiomatically than `linked_`.
- Rename `get_uncommitted_block_headers_at_round` → `get_block_headers_at_round_above_last_commit`. The pre-existing runtime `panic!(round <= last_commit_round)` is lifted into a clearer `assert!`. The word "uncommitted" is dropped since `above_last_commit` already implies it.
- Split `get_uncommitted_block_headers_at_slot` into two helpers. `accept_block_header`'s own-slot dedup runs at the just-committed round for non-leader authors, so it cannot enforce a strict bound — that caller now goes through a permissive `get_recent_block_headers_at_slot`. The asserting `get_block_headers_at_slot_above_last_commit` wraps it for `base_committer` (the two `try_direct_decide` / `try_indirect_decide` callers), where the invariant is strictly above last commit.

On the Grafana side, `dev-tools/grafana-local/dashboards/starfish-overview.json` gets:

- Six panels in the Block Manager row for the GC metrics introduced in #11402 — `consensus_block_manager_gc_floor`, `_gc_evicted_missing_ancestors_total`, `_gc_evicted_fetch_entries_total`, `_gc_unsuspended_total`, `_gc_evicted_suspended_transactions_total`, `_gc_evicted_old_headers_total`.
- A "Suspended header dwell time (p50/p95 by authority)" panel over `consensus_suspended_block_header_time_bucket`, so it is visible whether GC eviction keeps the tail of header suspension bounded. Trimmed from p50/p90/p99 to p50/p95 to keep the chart focused on the bound we actually care about.
- A "Reason for skipping block creation" panel in the Block information row surfacing `consensus_core_skipped_proposals` by `reason` (`NoQuorumSubscriber`, `NoLastKnownProposedRound`, `HigherLastKnownProposedRound`, `BehindQuorumCommitRound`).
- "Local delay in sending blocks" now groups its histogram quantile by `(le, host)` so the `{{host}}` legend resolves and each validator gets its own series instead of being collapsed into one aggregate line.
- Bug fixes on existing panels: the `sequencing_certificate_attempt` panel switches from raw counter to `rate(...[2m])` and its legend from `{{name}}` to `{{tx_type}}`; the `sequencing_certificate_processed` legend changes from `{{name}}` to `{{source}}` (those are the actual label names emitted by the metric).

## Links to any relevant issues

Fixes #11543

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- Dashboard JSON validates and all panel ids are unique