### PR TITLE
fix(node): Call shrink_to_fit on HashMaps in PeerHeights

### DIFF
--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -256,10 +256,15 @@ impl PeerHeights {
     }
 
     pub fn cleanup_old_checkpoints(&mut self, sequence_number: CheckpointSequenceNumber) {
+        // `retain` leaves tombstones that count toward the load factor; without
+        // the follow-up `shrink_to_fit`, the bucket array keeps doubling on
+        // subsequent inserts during long syncs.
         self.unprocessed_checkpoints
             .retain(|_digest, checkpoint| *checkpoint.sequence_number() > sequence_number);
+        self.unprocessed_checkpoints.shrink_to_fit();
         self.sequence_number_to_digest
             .retain(|&s, _digest| s > sequence_number);
+        self.sequence_number_to_digest.shrink_to_fit();
     }
 
     // TODO: also record who gives this checkpoint info for peer quality


### PR DESCRIPTION
# Description of change

Call shrink_to_fit() on both PeerHeights maps (unprocessed_checkpoints, sequence_number_to_digest) after retain.

PeerHeights is periodically trimmed by `cleanup_old_checkpoints` every 10,000 verified checkpoints. The trim uses HashMap::retain, which removes entries logically but does not shrink the underlying bucket array — removed slots are turned into tombstones.

So in a long sync, each insert/retain cycle pushes the bucket array up by a doubling, even though the live set stays small. On a fullnode syncing from genesis we observed this on PeerHeights by jemalloc heap profiles taken mid-sync, with the allocation backtraces pointing at the hashbrown rehash path from insert_checkpoint.

shrink_to_fit rebuilds each map to fit only the live entries, dropping all tombstones.

For a node starting from a recent snapshot, the catch-up window to the tip is typically small, so this fires only a handful of times before the node is at the tip. Once it's synced, there is no sync_to_checkpoint task running, so the call doesn't fire at all.



## Links to any relevant issues

Part of #11412

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes


