### PR TITLE
fix(consensus): sort committed_transactions in optimistic commit path

### DIFF
--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -156,6 +156,10 @@ impl Linearizer {
                     refs.clone(),
                 ));
             }
+            // The order in which transactions are added to the committed_transactions
+            // in above loop is not deterministic and depends on local state of validator,
+            // so we need to sort them.
+            committed_transactions.sort();
         }
 
         // Check that there are no duplicates in the committed transactions


### PR DESCRIPTION
# Description of change

In the optimistic commit path, the iteration of `strong_voters` produces a non-deterministic order across runs (the upstream `Vec<AuthorityIndex>` is built from a `HashSet`, and the set itself can also differ per validator), which leaks into the order of `committed_transactions`. Sort the vector after the optimistic extend so the committed-transaction order is deterministic within a node.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
