### PR TITLE
refactor(snapshot): insert partition to generic database

### DIFF
--- a/crates/iota-snapshot/src/database.rs
+++ b/crates/iota-snapshot/src/database.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+//! Logic and abstractions for supporting different databases that the snapshot
+//! can restore.
+
+use std::future::Future;
+
+use anyhow::Result;
+use bytes::Bytes;
+use iota_core::authority::{AuthorityStore, authority_store_tables::AuthorityPerpetualTables};
+use iota_storage::SHA3_BYTES;
+
+use crate::{FileMetadata, reader::LiveObjectIter};
+
+/// A trait for databases that can be restored from a formal snapshot.
+pub trait Database {
+    /// Inserts a partition of live objects.
+    ///
+    /// The checksum of the partition can be computed as the SHA3 hash of all
+    /// objects' digests included. Then it can be verified against the given
+    /// expected value.
+    fn insert_partition(
+        &self,
+        file_metadata: FileMetadata,
+        bytes: Bytes,
+        expected_checksum: &[u8; SHA3_BYTES],
+    ) -> impl Future<Output = Result<()>> + Send;
+}
+
+impl Database for AuthorityPerpetualTables {
+    async fn insert_partition(
+        &self,
+        file_metadata: FileMetadata,
+        bytes: Bytes,
+        expected_checksum: &[u8; SHA3_BYTES],
+    ) -> Result<()> {
+        let live_objects = LiveObjectIter::new(&file_metadata, bytes)?;
+        AuthorityStore::bulk_insert_live_objects(self, live_objects, expected_checksum)
+            .expect("Failed to insert live objects");
+        Ok(())
+    }
+}

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -7,6 +7,7 @@
 #[cfg(test)]
 mod tests;
 
+pub mod database;
 pub mod reader;
 pub mod uploader;
 mod writer;

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -7,8 +7,8 @@
 #[cfg(test)]
 mod tests;
 
-pub mod database;
 pub mod reader;
+pub mod restore;
 pub mod uploader;
 mod writer;
 

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -4,8 +4,7 @@
 
 use std::{
     collections::BTreeMap,
-    fs,
-    fs::File,
+    fs::{self, File},
     io::{BufReader, Read, Seek, SeekFrom},
     num::NonZeroUsize,
     path::PathBuf,
@@ -27,10 +26,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use integer_encoding::VarIntReader;
 use iota_common::stream_ext::TrySpawnStreamExt;
 use iota_config::object_storage_config::ObjectStoreConfig;
-use iota_core::authority::{
-    AuthorityStore,
-    authority_store_tables::{AuthorityPerpetualTables, LiveObject},
-};
+use iota_core::authority::authority_store_tables::{AuthorityPerpetualTables, LiveObject};
 use iota_storage::{
     blob::{Blob, BlobEncoding},
     object_store::{
@@ -54,6 +50,7 @@ use tracing::{error, info};
 use crate::{
     FileMetadata, FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC, Manifest, OBJECT_FILE_MAGIC,
     OBJECT_ID_BYTES, OBJECT_REF_BYTES, REFERENCE_FILE_MAGIC, SEQUENCE_NUM_BYTES, SHA3_BYTES,
+    database::Database,
 };
 
 pub type SnapshotChecksums = (DigestByBucketAndPartition, GlobalStateHash);
@@ -222,6 +219,27 @@ impl StateSnapshotReaderV1 {
         abort_registration: AbortRegistration,
         sender: Option<tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>>,
     ) -> Result<()> {
+        self.read_to_db(perpetual_db, abort_registration, sender)
+            .await
+    }
+
+    /// The main entrypoint of the [StateSnapshotReaderV1].
+    ///
+    /// This method encapsulates the logic for several operations:
+    ///
+    /// 1. Computing the partition checksums of the respective `*.ref` files.
+    /// 2. Computing the partition elliptic-curve multiset hash (ECMH) in the
+    ///    background, and sending the result through the given `sender` to the
+    ///    caller. This allows to compute and verify the root hash of the live
+    ///    objects encoded in the snapshot. See [`GlobalStateHash`].
+    /// 3. Reading, inserting, and verifying all encoded live objects to the
+    ///    given `database`.
+    pub async fn read_to_db(
+        &mut self,
+        database: &impl Database,
+        abort_registration: AbortRegistration,
+        sender: Option<tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>>,
+    ) -> Result<()> {
         // This computes and stores the sha3 digest of object references in REFERENCE
         // file for each bucket partition. When downloading objects, we will
         // compare sha3 digest of object references per *.obj file against this.
@@ -305,8 +323,8 @@ impl StateSnapshotReaderV1 {
             sender.map(|sender| self.spawn_accumulation_tasks(sender, num_part_files));
 
         // Downloads all object files from remote in parallel and inserts the objects
-        // into the AuthorityPerpetualTables
-        self.sync_live_objects(perpetual_db, abort_registration, sha3_digests)
+        // into the database of choice
+        self.sync_live_objects(database, abort_registration, sha3_digests)
             .await?;
 
         if let Some(handle) = accum_handle {
@@ -416,10 +434,10 @@ impl StateSnapshotReaderV1 {
     }
 
     /// Downloads all object files from remote in parallel and inserts the
-    /// objects into the AuthorityPerpetualTables.
+    /// objects into the given database.
     async fn sync_live_objects(
         &self,
-        perpetual_db: &AuthorityPerpetualTables,
+        database: &impl Database,
         abort_registration: AbortRegistration,
         sha3_digests: Arc<Mutex<DigestByBucketAndPartition>>,
     ) -> Result<(), anyhow::Error> {
@@ -516,27 +534,24 @@ impl StateSnapshotReaderV1 {
                     .boxed()
                     .buffer_unordered(concurrency)
                     .try_for_each(|(bytes, file_metadata, sha3_digest)| {
-                        let bytes_len = bytes.len();
-                        // Inserts live objects into the AuthorityStore
-                        let result: Result<(), anyhow::Error> =
-                            LiveObjectIter::new(&file_metadata, bytes).map(|obj_iter| {
-                                AuthorityStore::bulk_insert_live_objects(
-                                    perpetual_db,
-                                    obj_iter,
-                                    &sha3_digest,
-                                )
-                                .expect("Failed to insert live objects");
-                            });
-                        downloaded_bytes.fetch_add(bytes_len, Ordering::Relaxed);
-                        // Updates the progress bar
-                        obj_progress_bar_clone.inc(1);
-                        obj_progress_bar_clone.set_message(format!(
-                            "Download speed: {} MiB/s",
-                            downloaded_bytes.load(Ordering::Relaxed) as f64
-                                / (1024 * 1024) as f64
-                                / instant.elapsed().as_secs_f64(),
-                        ));
-                        futures::future::ready(result)
+                        let downloaded_bytes = &downloaded_bytes;
+                        let obj_progress_bar = &obj_progress_bar_clone;
+                        let instant = &instant;
+                        async move {
+                            let bytes_len = bytes.len();
+                            database
+                                .insert_partition(file_metadata, bytes, &sha3_digest)
+                                .await?;
+                            downloaded_bytes.fetch_add(bytes_len, Ordering::Relaxed);
+                            obj_progress_bar.inc(1);
+                            obj_progress_bar.set_message(format!(
+                                "Download speed: {} MiB/s",
+                                downloaded_bytes.load(Ordering::Relaxed) as f64
+                                    / (1024 * 1024) as f64
+                                    / instant.elapsed().as_secs_f64(),
+                            ));
+                            Ok(())
+                        }
                     })
                     .await
             },

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -50,7 +50,7 @@ use tracing::{error, info};
 use crate::{
     FileMetadata, FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC, Manifest, OBJECT_FILE_MAGIC,
     OBJECT_ID_BYTES, OBJECT_REF_BYTES, REFERENCE_FILE_MAGIC, SEQUENCE_NUM_BYTES, SHA3_BYTES,
-    database::Database,
+    restore::Restore,
 };
 
 pub type SnapshotChecksums = (DigestByBucketAndPartition, GlobalStateHash);
@@ -236,7 +236,7 @@ impl StateSnapshotReaderV1 {
     ///    given `database`.
     pub async fn read_to_db(
         &mut self,
-        database: &impl Database,
+        database: &impl Restore,
         abort_registration: AbortRegistration,
         sender: Option<tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>>,
     ) -> Result<()> {
@@ -437,7 +437,7 @@ impl StateSnapshotReaderV1 {
     /// objects into the given database.
     async fn sync_live_objects(
         &self,
-        database: &impl Database,
+        database: &impl Restore,
         abort_registration: AbortRegistration,
         sha3_digests: Arc<Mutex<DigestByBucketAndPartition>>,
     ) -> Result<(), anyhow::Error> {

--- a/crates/iota-snapshot/src/restore.rs
+++ b/crates/iota-snapshot/src/restore.rs
@@ -14,7 +14,7 @@ use iota_storage::SHA3_BYTES;
 use crate::{FileMetadata, reader::LiveObjectIter};
 
 /// A trait for databases that can be restored from a formal snapshot.
-pub trait Database {
+pub trait Restore {
     /// Inserts a partition of live objects.
     ///
     /// The checksum of the partition can be computed as the SHA3 hash of all
@@ -28,7 +28,7 @@ pub trait Database {
     ) -> impl Future<Output = Result<()>> + Send;
 }
 
-impl Database for AuthorityPerpetualTables {
+impl Restore for AuthorityPerpetualTables {
     async fn insert_partition(
         &self,
         file_metadata: FileMetadata,


### PR DESCRIPTION
# Description of change

This patch refactors `iota-snapshot` so that to extend support for insertion of object partitions to databases other than node database. The motivation was to allow restoring the IOTA Indexer with formal snapshots.

See #11308 for more context.

## Links to any relevant issues

Fixes #11308 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

