### PR TITLE
feat(iota-data-ingestion-core): skip filtered checkpoints

### DIFF
--- a/crates/iota-data-ingestion-core/src/reducer.rs
+++ b/crates/iota-data-ingestion-core/src/reducer.rs
@@ -114,14 +114,23 @@ pub trait Reducer<Mapper: Worker>: Send + Sync {
 
     /// Determines if the current batch should be closed and committed.
     ///
-    /// This method is called for each new message to determine if the current
-    /// batch should be committed before adding the new message.
+    /// This method is called by the framework in two situations:
+    ///
+    /// - **`next_item = Some(msg)`**: a new message is about to be added to the
+    ///   batch. Returning `true` triggers a commit of the existing batch first.
+    ///   The `msg` is added to a new batch. Returning `false` appends `msg` to
+    ///   the current batch without committing.
+    ///
+    /// - **`next_item = None`**: the current chunk from the upstream stream has
+    ///   been fully consumed and there are no more messages to add in this
+    ///   iteration (the stream itself may still produce more chunks later).
+    ///   Returning `true` flushes the partial batch. Returning `false` leaves
+    ///   the batch in memory until the next chunk arrives.
     ///
     /// # Default Implementation
     ///
-    /// By default, returns `true` only when there are no more messages
-    /// (`next_item` is `None`), effectively creating a single batch for all
-    /// messages.
+    /// Returns `true` only when `next_item` is `None`, so each chunk's
+    /// remaining batch is flushed at the chunk boundary.
     fn should_close_batch(
         &self,
         _batch: &[Mapper::Message],
@@ -154,7 +163,7 @@ pub trait Reducer<Mapper: Worker>: Send + Sync {
 pub(crate) async fn reduce<W: Worker>(
     task_name: String,
     mut current_checkpoint_number: CheckpointSequenceNumber,
-    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, Option<W::Message>)>,
     executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
     reducer: Box<dyn Reducer<W>>,
     backoff: Arc<ExponentialBackoff>,
@@ -180,7 +189,15 @@ pub(crate) async fn reduce<W: Worker>(
         unprocessed.extend(update_batch);
         // Process messages sequentially based on checkpoint sequence number.
         // This ensures in-order processing and maintains progress integrity.
-        while let Some(message) = unprocessed.remove(&current_checkpoint_number) {
+        while let Some(maybe_worker_message) = unprocessed.remove(&current_checkpoint_number) {
+            let Some(message) = maybe_worker_message else {
+                current_checkpoint_number += 1;
+                if batch.is_empty() {
+                    progress_update = Some(current_checkpoint_number);
+                }
+                continue;
+            };
+
             // reducer is configured, collect messages in batch based on
             // `reducer.should_close_batch` policy, once a batch is collected it gets
             // committed and a new batch is created with the current message.

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -466,14 +466,19 @@ impl<W: Worker + 'static> WorkerPool<W> {
         token: &CancellationToken,
     ) -> WorkerStatus<W::Message> {
         let sequence_number = checkpoint.checkpoint_summary.sequence_number;
+
+        if Self::should_skip_filtered_checkpoint(&checkpoint) {
+            return if token.is_cancelled() {
+                WorkerStatus::Shutdown(worker_id)
+            } else {
+                WorkerStatus::Running((worker_id, sequence_number, None))
+            };
+        }
+
         loop {
             // check for cancellation before attempting processing.
             if token.is_cancelled() {
                 return WorkerStatus::Shutdown(worker_id);
-            }
-
-            if Self::should_skip_filtered_checkpoint(&checkpoint) {
-                return WorkerStatus::Running((worker_id, sequence_number, None));
             }
 
             // attempt to process checkpoint.

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -432,7 +432,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
     /// leaves `checkpoint_contents` (the list of all transaction digests in
     /// the original checkpoint) completely untouched.
     fn should_skip_filtered_checkpoint(checkpoint: &CheckpointData) -> bool {
-        checkpoint.checkpoint_contents.iter().next().is_some() && checkpoint.transactions.is_empty()
+        !checkpoint.checkpoint_contents.inner().is_empty() && checkpoint.transactions.is_empty()
     }
 
     /// Attempts to process a checkpoint with exponential backoff retries on

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -44,9 +44,14 @@ pub enum WorkerPoolStatus {
 #[derive(Debug, Clone, Copy)]
 enum WorkerStatus<M> {
     /// Message with information (e.g. `(<worker-id>`,
-    /// `checkpoint_sequence_number`, [`Worker::Message`]) about the ingestion
-    /// progress.
-    Running((WorkerID, CheckpointSequenceNumber, M)),
+    /// `checkpoint_sequence_number`, Option<[`Worker::Message`]>) about the
+    /// ingestion progress.
+    ///
+    /// The `Option<M>` is used to indicate that the worker skipped
+    /// processing the checkpoint. Useful for filtered checkpoints where non
+    /// matching checkpoints should not be forwarded to worker. In this case the
+    /// `checkpoint_sequence_number` is needed to track the progress.
+    Running((WorkerID, CheckpointSequenceNumber, Option<M>)),
     /// Message with information (e.g. `<worker-id>`) about shutdown status.
     Shutdown(WorkerID),
 }
@@ -279,7 +284,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
         let (watermark_sender, watermark_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let mut idle: BTreeSet<_> = (0..self.concurrency).collect();
         let mut checkpoints = VecDeque::new();
-        let mut workers_shutdown_signals = vec![];
+        let mut workers_shutdown_signals = Vec::with_capacity(self.concurrency);
         let (workers, workers_join_handles) = self.spawn_workers(progress_sender, token.clone());
         // Spawn a task that tracks checkpoint processing progress. The task:
         // - Receives (checkpoint_number, message) pairs from workers.
@@ -328,10 +333,14 @@ impl<W: Worker + 'static> WorkerPool<W> {
                     if sequence_number < watermark {
                         continue;
                     }
-                    self.worker
-                        .preprocess_hook(checkpoint.clone())
-                        .map_err(|err| IngestionError::CheckpointHookProcessing(err.to_string()))
-                        .expect("failed to preprocess task");
+
+                    if !Self::should_skip_filtered_checkpoint(&checkpoint) {
+                        self.worker
+                            .preprocess_hook(checkpoint.clone())
+                            .map_err(|err| IngestionError::CheckpointHookProcessing(err.to_string()))
+                            .expect("failed to preprocess task");
+                    }
+
                     if idle.is_empty() {
                         checkpoints.push_back(checkpoint);
                     } else {
@@ -390,9 +399,12 @@ impl<W: Worker + 'static> WorkerPool<W> {
                         },
                         Some(checkpoint) = worker_recv.recv() => {
                             let sequence_number = checkpoint.checkpoint_summary.sequence_number;
-                            info!("received checkpoint for processing {} for workflow {}", sequence_number, task_name);
+                            info!("received checkpoint for processing {sequence_number} for workflow {task_name}", );
                             let start_time = Instant::now();
                             let status = Self::process_checkpoint_with_retry(worker_id, &worker, checkpoint, reset_backoff(&backoff), &token).await;
+                            if matches!(status, WorkerStatus::Running((_,_, None))) {
+                                info!("checkpoint {sequence_number} for workflow {task_name} filtered out");
+                            }
                             let trigger_shutdown = matches!(status, WorkerStatus::Shutdown(_));
                             if cloned_progress_sender.send(status).await.is_err() || trigger_shutdown {
                                 break;
@@ -409,6 +421,18 @@ impl<W: Worker + 'static> WorkerPool<W> {
             workers_join_handles.push(join_handle);
         }
         (worker_senders, workers_join_handles)
+    }
+
+    /// Returns `true` if the checkpoint was entirely stripped of its
+    /// transactions by a server-side filter, indicating a filtered-out
+    /// checkpoint.
+    ///
+    /// The fullnode's gRPC `stream_checkpoints` endpoint applies configured
+    /// `TransactionFilter`s to the expanded `transactions` payload but
+    /// leaves `checkpoint_contents` (the list of all transaction digests in
+    /// the original checkpoint) completely untouched.
+    fn should_skip_filtered_checkpoint(checkpoint: &CheckpointData) -> bool {
+        checkpoint.checkpoint_contents.iter().next().is_some() && checkpoint.transactions.is_empty()
     }
 
     /// Attempts to process a checkpoint with exponential backoff retries on
@@ -447,9 +471,16 @@ impl<W: Worker + 'static> WorkerPool<W> {
             if token.is_cancelled() {
                 return WorkerStatus::Shutdown(worker_id);
             }
+
+            if Self::should_skip_filtered_checkpoint(&checkpoint) {
+                return WorkerStatus::Running((worker_id, sequence_number, None));
+            }
+
             // attempt to process checkpoint.
             match worker.process_checkpoint(checkpoint.clone()).await {
-                Ok(message) => return WorkerStatus::Running((worker_id, sequence_number, message)),
+                Ok(message) => {
+                    return WorkerStatus::Running((worker_id, sequence_number, Some(message)));
+                }
                 Err(err) => {
                     let err = IngestionError::CheckpointProcessing(err.to_string());
                     warn!(
@@ -491,7 +522,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
     fn spawn_watermark_tracking(
         &mut self,
         watermark: CheckpointSequenceNumber,
-        watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+        watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, Option<W::Message>)>,
         executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
         token: CancellationToken,
     ) -> JoinHandle<Result<(), IngestionError>> {
@@ -527,7 +558,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
         workers_join_handles: Vec<JoinHandle<()>>,
         watermark_handle: JoinHandle<Result<(), IngestionError>>,
         executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
-        watermark_sender: mpsc::Sender<(u64, <W as Worker>::Message)>,
+        watermark_sender: mpsc::Sender<(CheckpointSequenceNumber, Option<<W as Worker>::Message>)>,
     ) {
         for worker in workers_join_handles {
             _ = worker
@@ -556,7 +587,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
 async fn simple_watermark_tracking<W: Worker>(
     task_name: String,
     mut current_checkpoint_number: CheckpointSequenceNumber,
-    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, Option<W::Message>)>,
     executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
 ) -> IngestionResult<()> {
     // convert to a stream of MAX_CHECKPOINTS_IN_PROGRESS size. This way, each


### PR DESCRIPTION
# Description of change

This PR implements skipping of filtered checkpoints for fullnode checkpoint streams. 

The implementation follows the original design outlined in [issue #11419 comment](https://github.com/iotaledger/iota/issues/11419#issuecomment-4441622545).

## Links to any relevant issues

fixes #11419 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Tests were conducted manually even though we will create an issue to add e2e tests for gRPC and hybrid checkpoint streams but it would extend the scope of this PR.

We used the `remote_reader.rs` custom indexer connected to `devnet`. A filter was applied to skip checkpoints containing `Programmable` transaction kinds. To avoid downloading the genesis checkpoint which is very heavy we started from checkpoint 1.

The following log snippet shows the checkpoints received by the workers. Note the non-sequential progression (e.g., jumping from `12498` to `27366`), which confirms that filtered checkpoints without relevant matching data are being correctly stripped and skipped by the framework:

```log
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 9771, content_digest: FQgvR4hkhR4eb2khr8kkN6cv5otQK6NoLvg6iPeeteM9,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800, storage_rebate: 0, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 9775, content_digest: 5ncwQ5NTK2uhV2kwc2ahnvYefsvf7wGsS13NXD4RwmsA,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 2000000, computation_cost_burned: 2000000, storage_cost: 3921600, storage_rebate: 980400, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 10287, content_digest: 7awz27Q7KswDyxdeAHP5iNzBS1VRzzWeUSKkDiDZJjfH,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, computation_cost_burned: 3000000, storage_cost: 5882400, storage_rebate: 1960800, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 10291, content_digest: 5Jmq9AKpqTmKsHrjEw65CKwNae9aA2cJRh3WwwErvrem,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 4000000, computation_cost_burned: 4000000, storage_cost: 7843200, storage_rebate: 2941200, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 10294, content_digest: 23MiAQ3cmKPPLRb1yxjgWNgz4Xz9xnQz4rSeAmbdEJnd,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 5000000, computation_cost_burned: 5000000, storage_cost: 9804000, storage_rebate: 3921600, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 10300, content_digest: XMXb4Z4mrCom4tLoHma193qkpZhiPRXTwDkBxNVcVtQ,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 6000000, computation_cost_burned: 6000000, storage_cost: 11764800, storage_rebate: 4902000, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 10314, content_digest: 5RmmipEMXKLjidQBTGJfDGmcPZ8tTnvHhLbYe27zkxmy,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 8000000, computation_cost_burned: 8000000, storage_cost: 125073200, storage_rebate: 5882400, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 10320, content_digest: 3P2EvsuYKa3ZHnmXoZqu2suiuowczrxVxJLxTg4VHLaf,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 9000000, computation_cost_burned: 9000000, storage_cost: 140835600, storage_rebate: 6862800, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 10326, content_digest: B3GAiEGEBBK1pvnNYp4E96tFgNEHZdGQv48dkEJdABwg,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 10000000, computation_cost_burned: 10000000, storage_cost: 142796400, storage_rebate: 7843200, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 12498, content_digest: JAHy8t1Sb4XoxDaCZDHvHdNVbaUxHoYfNy7SuoGiU2YJ,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 11000000, computation_cost_burned: 11000000, storage_cost: 144757200, storage_rebate: 8823600, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 27366, content_digest: 5XnVhs5Vwr38CgWTCZRxb4XmxwEnEpWuhkgFrpwGY1Y8,
            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 12000000, computation_cost_burned: 12000000, storage_cost: 146718000, storage_rebate: 9804000, non_refundable_storage_fee: 0 }}
Processing checkpoint: CheckpointSummary { epoch: 0, seq: 27374, content_digest: Ggb5ZqsKrLsSZAAS5ikp3FjNE1cYs548ehURSRxBWq2Q,
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> The following patch does not affect the normal operation of the indexer, thus no further tests were conducted.