### PR TITLE
feat(iota-core): persist ReportAggregator state across restarts

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1094,6 +1094,9 @@ impl AuthorityPerEpochStore {
         let report_version = MisbehaviorReportVersion::from_protocol(&protocol_config);
         let misbehavior_monitor = MisbehaviorMonitor::new(name, report_version, committee_size);
         let report_aggregator = ReportAggregator::new(report_version, committee_size);
+        report_aggregator
+            .restore_from_tables(&tables)
+            .expect("AuthorityEpochTables should contain valid ReportAggregator state");
         let voting_power = committee.members().map(|(_, v)| *v).collect::<Vec<u64>>();
         let scoreboard = Scoreboard::new(voting_power, &protocol_config);
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -836,6 +836,17 @@ pub struct AuthorityEpochTables {
 
     /// Accumulated per-object debts for randomness congestion control.
     congestion_control_randomness_object_debts: DBMap<ObjectID, CongestionPerObjectDebt>,
+
+    /// Per-validator received misbehavior reports state. Keyed by the
+    /// reporter's `AuthorityIndex` (the in-memory `Vec` index used by
+    /// `ReportAggregator`). Each entry is the merged-max observation set plus
+    /// invalid-report counter, snapshotted from the live aggregator when its
+    /// state changes inside a consensus commit. Written atomically with the
+    /// rest of `ConsensusCommitOutput::write_to_batch`. Survives restart;
+    /// `ReportAggregator::restore_from_tables` loads it during epoch-store
+    /// construction.
+    pub(crate) received_reports_state:
+        DBMap<u32, report_aggregator::DBReceivedReportsStatePerAuthority>,
 }
 
 fn signed_transactions_table_default_config() -> DBOptions {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -838,15 +838,15 @@ pub struct AuthorityEpochTables {
     congestion_control_randomness_object_debts: DBMap<ObjectID, CongestionPerObjectDebt>,
 
     /// Per-validator received misbehavior reports state. Keyed by the
-    /// reporter's `AuthorityIndex` (the in-memory `Vec` index used by
-    /// `ReportAggregator`). Each entry is the merged-max observation set plus
+    /// reporter's `AuthorityIndex` truncated to `u8` (committees are bounded
+    /// at 256 by Starfish). Each entry is the merged-max observation set plus
     /// invalid-report counter, snapshotted from the live aggregator when its
     /// state changes inside a consensus commit. Written atomically with the
     /// rest of `ConsensusCommitOutput::write_to_batch`. Survives restart;
     /// `ReportAggregator::restore_from_tables` loads it during epoch-store
     /// construction.
     pub(crate) received_reports_state:
-        DBMap<u32, report_aggregator::DBReceivedReportsStatePerAuthority>,
+        DBMap<u8, report_aggregator::DBReceivedReportsStatePerAuthority>,
 }
 
 fn signed_transactions_table_default_config() -> DBOptions {
@@ -4222,8 +4222,10 @@ impl AuthorityPerEpochStore {
                     .committee
                     .authority_index(&report.authority)
                     .expect("authority in committee");
-                self.report_aggregator
+                let snapshot = self
+                    .report_aggregator
                     .process_report(authority_index, report);
+                output.record_report_state_snapshot(authority_index, snapshot);
 
                 Ok(ConsensusCertificateResult::ConsensusMessage)
             }

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -23,6 +23,7 @@ use typed_store::{Map, rocks::DBBatch};
 use super::*;
 use crate::{
     authority::{
+        authority_per_epoch_store::report_aggregator::DBReceivedReportsStatePerAuthority,
         shared_object_congestion_tracker::CongestionPerObjectDebt,
         shared_object_version_manager::AssignedTxAndVersions,
     },
@@ -70,6 +71,13 @@ pub(crate) struct ConsensusCommitOutput {
     dkg_processed_messages: BTreeMap<PartyId, VersionedProcessedMessage>,
     dkg_used_message: Option<VersionedUsedProcessedMessages>,
     dkg_output: Option<dkg_v1::Output<PkG, EncG>>,
+
+    // misbehavior report state — per-authority post-merge snapshot captured
+    // at `process_report` time. The on-disk row for commit N is exactly the
+    // state produced by commit N's processing of that authority's reports;
+    // last-writer-wins handles multiple reports from the same authority
+    // within one commit.
+    report_state_snapshots: BTreeMap<u8, DBReceivedReportsStatePerAuthority>,
 }
 
 impl ConsensusCommitOutput {
@@ -131,6 +139,17 @@ impl ConsensusCommitOutput {
 
     pub fn record_consensus_message_processed(&mut self, key: SequencedConsensusTransactionKey) {
         self.consensus_messages_processed.insert(key);
+    }
+
+    pub(crate) fn record_report_state_snapshot(
+        &mut self,
+        authority_index: crate::consensus_types::AuthorityIndex,
+        snapshot: DBReceivedReportsStatePerAuthority,
+    ) {
+        // Truncate to `u8` at the storage boundary; committees are bounded at
+        // 256 by Starfish.
+        self.report_state_snapshots
+            .insert(authority_index as u8, snapshot);
     }
 
     pub fn set_next_shared_object_versions(
@@ -298,6 +317,13 @@ impl ConsensusCommitOutput {
                     )
                 }),
         )?;
+
+        if !self.report_state_snapshots.is_empty() {
+            batch.insert_batch(
+                &tables.received_reports_state,
+                self.report_state_snapshots.iter(),
+            )?;
+        }
 
         Ok(())
     }

--- a/crates/iota-core/src/authority/report_aggregator.rs
+++ b/crates/iota-core/src/authority/report_aggregator.rs
@@ -8,6 +8,7 @@ use std::sync::{
 
 use arc_swap::ArcSwapOption;
 use iota_types::messages_consensus::{MisbehaviorObservations, VersionedMisbehaviorReport};
+use typed_store::Map;
 
 use crate::authority::authority_per_epoch_store::misbehavior::{
     MisbehaviorReportVersion, merge_max,
@@ -96,6 +97,46 @@ impl ReportAggregator {
                 None => incoming.clone(),
             }))
         });
+    }
+
+    /// Repopulates the in-memory aggregator from persisted rows. Authorities
+    /// without a row keep their default (empty) state. Returns an error if a
+    /// row's key is out of range for the configured committee size — that
+    /// would indicate cross-epoch table contamination.
+    pub(crate) fn restore_from_iter(
+        &self,
+        rows: impl Iterator<Item = (u32, DBReceivedReportsStatePerAuthority)>,
+    ) -> iota_types::error::IotaResult<()> {
+        let committee_size = self.received_reports_state.len();
+        for (authority_index, db_state) in rows {
+            let idx = authority_index as usize;
+            if idx >= committee_size {
+                return Err(iota_types::error::IotaError::Storage(format!(
+                    "received_reports_state row for authority {authority_index} \
+                     is out of range for committee size {committee_size}"
+                )));
+            }
+            let slot = &self.received_reports_state[idx];
+            if let Some(observations) = db_state.received_metrics {
+                slot.received_metrics.store(Some(Arc::new(observations)));
+            }
+            slot.invalid_reports_count
+                .store(db_state.invalid_reports_count, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+
+    /// Production restore: streams every row of
+    /// `AuthorityEpochTables::received_reports_state` into the aggregator.
+    pub(crate) fn restore_from_tables(
+        &self,
+        tables: &super::AuthorityEpochTables,
+    ) -> iota_types::error::IotaResult<()> {
+        let rows = tables
+            .received_reports_state
+            .safe_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        self.restore_from_iter(rows.into_iter())
     }
 
     /// Increments the invalid report counter for the given authority.
@@ -293,6 +334,61 @@ mod tests {
         let aggregator = mock_aggregator(3);
         let report = report_v1(&[vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9], vec![0, 0, 0]]);
         assert!(aggregator.validate_report(&report).is_ok());
+    }
+
+    #[test]
+    fn test_restore_from_iter_populates_in_memory_state() {
+        let aggregator = mock_aggregator(3);
+
+        // Simulate restored DB rows: authority 0 has observations, authority 2
+        // has only an invalid-count bump, authority 1 has no row at all.
+        let rows = vec![
+            (
+                0u32,
+                DBReceivedReportsStatePerAuthority {
+                    received_metrics: Some(MisbehaviorObservations::V1(
+                        MisbehaviorObservationsV1 {
+                            faulty_blocks_provable: vec![1, 2, 3],
+                            faulty_blocks_unprovable: vec![0, 0, 0],
+                            missing_proposals: vec![0, 0, 0],
+                            equivocations: vec![0, 0, 0],
+                        },
+                    )),
+                    invalid_reports_count: 5,
+                },
+            ),
+            (
+                2u32,
+                DBReceivedReportsStatePerAuthority {
+                    received_metrics: None,
+                    invalid_reports_count: 9,
+                },
+            ),
+        ];
+
+        aggregator
+            .restore_from_iter(rows.into_iter())
+            .expect("restore");
+
+        let snapshot = full_snapshot(&aggregator, 3);
+        assert_eq!(snapshot[0].invalid_reports_count, 5);
+        assert!(snapshot[0].received_metrics.is_some());
+        assert_eq!(snapshot[1], empty_state());
+        assert_eq!(snapshot[2].invalid_reports_count, 9);
+        assert!(snapshot[2].received_metrics.is_none());
+    }
+
+    #[test]
+    fn test_restore_from_iter_rejects_out_of_range_authority() {
+        let aggregator = mock_aggregator(3);
+        let rows = vec![(
+            7u32, // committee size is 3, so 7 is out of range
+            DBReceivedReportsStatePerAuthority {
+                received_metrics: None,
+                invalid_reports_count: 1,
+            },
+        )];
+        assert!(aggregator.restore_from_iter(rows.into_iter()).is_err());
     }
 
     #[test]

--- a/crates/iota-core/src/authority/report_aggregator.rs
+++ b/crates/iota-core/src/authority/report_aggregator.rs
@@ -10,8 +10,9 @@ use arc_swap::ArcSwapOption;
 use iota_types::messages_consensus::{MisbehaviorObservations, VersionedMisbehaviorReport};
 use typed_store::Map;
 
-use crate::authority::authority_per_epoch_store::misbehavior::{
-    MisbehaviorReportVersion, merge_max,
+use crate::{
+    authority::authority_per_epoch_store::misbehavior::{MisbehaviorReportVersion, merge_max},
+    consensus_types::AuthorityIndex,
 };
 
 /// Reasons a peer-submitted report fails `validate_report`. Surfaced in the
@@ -84,11 +85,18 @@ impl ReportAggregator {
 
     /// Processes a validated report from a peer: performs a monotone merge
     /// (element-wise max) with any previously received observations from the
-    /// same authority.
+    /// same authority. Returns the **post-merge** snapshot for the touched
+    /// authority — callers persist this verbatim against the active
+    /// `ConsensusCommitOutput`, so the on-disk row for commit N is exactly
+    /// the aggregator state produced by commit N's processing.
     ///
     /// Uses `rcu` so the load + merge + store is atomic against concurrent
     /// callers; the closure may run more than once under contention.
-    pub(crate) fn process_report(&self, authority: u32, report: &VersionedMisbehaviorReport) {
+    pub(crate) fn process_report(
+        &self,
+        authority: AuthorityIndex,
+        report: &VersionedMisbehaviorReport,
+    ) -> DBReceivedReportsStatePerAuthority {
         let incoming = &report.payload;
         let state = &self.received_reports_state[authority as usize];
         state.received_metrics.rcu(|current| {
@@ -97,6 +105,7 @@ impl ReportAggregator {
                 None => incoming.clone(),
             }))
         });
+        state.to_serializable()
     }
 
     /// Repopulates the in-memory aggregator from persisted rows. Authorities
@@ -105,7 +114,7 @@ impl ReportAggregator {
     /// would indicate cross-epoch table contamination.
     pub(crate) fn restore_from_iter(
         &self,
-        rows: impl Iterator<Item = (u32, DBReceivedReportsStatePerAuthority)>,
+        rows: impl Iterator<Item = (AuthorityIndex, DBReceivedReportsStatePerAuthority)>,
     ) -> iota_types::error::IotaResult<()> {
         let committee_size = self.received_reports_state.len();
         for (authority_index, db_state) in rows {
@@ -128,6 +137,8 @@ impl ReportAggregator {
 
     /// Production restore: streams every row of
     /// `AuthorityEpochTables::received_reports_state` into the aggregator.
+    /// Widens the on-disk `u8` key to the in-memory `AuthorityIndex` at this
+    /// storage boundary.
     pub(crate) fn restore_from_tables(
         &self,
         tables: &super::AuthorityEpochTables,
@@ -135,14 +146,20 @@ impl ReportAggregator {
         let rows = tables
             .received_reports_state
             .safe_iter()
+            .map(|res| res.map(|(idx, state)| (AuthorityIndex::from(idx), state)))
             .collect::<Result<Vec<_>, _>>()?;
         self.restore_from_iter(rows.into_iter())
     }
 
     /// Increments the invalid report counter for the given authority.
     ///
-    /// On this branch the counter is in-memory only and resets on restart.
-    pub(crate) fn increment_invalid_reports_count(&self, authority: u32) {
+    /// Called from `verify_consensus_transaction`, which runs outside the
+    /// per-commit `ConsensusCommitOutput` scope. The bump updates the
+    /// in-memory `AtomicU64` correctly, but the persisted row is only
+    /// refreshed when a subsequent `process_report` for the same authority
+    /// captures a fresh snapshot. The counter is observability-only, so
+    /// losing isolated bumps across crashes is acceptable.
+    pub(crate) fn increment_invalid_reports_count(&self, authority: AuthorityIndex) {
         self.received_reports_state[authority as usize]
             .invalid_reports_count
             .fetch_add(1, Ordering::Relaxed);
@@ -151,7 +168,7 @@ impl ReportAggregator {
     #[cfg(test)]
     pub(crate) fn received_reports_state_per_authority_snapshot(
         &self,
-        authority_index: u32,
+        authority_index: AuthorityIndex,
     ) -> DBReceivedReportsStatePerAuthority {
         self.received_reports_state[authority_index as usize].to_serializable()
     }
@@ -213,11 +230,14 @@ mod tests {
         MisbehaviorObservations, MisbehaviorObservationsV1, VersionedMisbehaviorReport,
     };
 
-    use crate::authority::authority_per_epoch_store::{
-        misbehavior::MisbehaviorReportVersion,
-        report_aggregator::{
-            DBReceivedReportsStatePerAuthority, ReportAggregator, ReportValidationError,
+    use crate::{
+        authority::authority_per_epoch_store::{
+            misbehavior::MisbehaviorReportVersion,
+            report_aggregator::{
+                DBReceivedReportsStatePerAuthority, ReportAggregator, ReportValidationError,
+            },
         },
+        consensus_types::AuthorityIndex,
     };
 
     fn mock_protocol_config() -> ProtocolConfig {
@@ -342,9 +362,9 @@ mod tests {
 
         // Simulate restored DB rows: authority 0 has observations, authority 2
         // has only an invalid-count bump, authority 1 has no row at all.
-        let rows = vec![
+        let rows: Vec<(AuthorityIndex, DBReceivedReportsStatePerAuthority)> = vec![
             (
-                0u32,
+                0,
                 DBReceivedReportsStatePerAuthority {
                     received_metrics: Some(MisbehaviorObservations::V1(
                         MisbehaviorObservationsV1 {
@@ -358,7 +378,7 @@ mod tests {
                 },
             ),
             (
-                2u32,
+                2,
                 DBReceivedReportsStatePerAuthority {
                     received_metrics: None,
                     invalid_reports_count: 9,
@@ -381,8 +401,8 @@ mod tests {
     #[test]
     fn test_restore_from_iter_rejects_out_of_range_authority() {
         let aggregator = mock_aggregator(3);
-        let rows = vec![(
-            7u32, // committee size is 3, so 7 is out of range
+        let rows: Vec<(AuthorityIndex, DBReceivedReportsStatePerAuthority)> = vec![(
+            7, // committee size is 3, so 7 is out of range
             DBReceivedReportsStatePerAuthority {
                 received_metrics: None,
                 invalid_reports_count: 1,
@@ -406,5 +426,53 @@ mod tests {
             aggregator.validate_report(&report),
             Err(ReportValidationError::PayloadShape)
         );
+    }
+
+    #[tokio::test]
+    async fn test_restore_round_trip_through_dbmap() {
+        use iota_types::base_types::EpochId;
+
+        use crate::authority::authority_per_epoch_store::AuthorityEpochTables;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let epoch: EpochId = 0;
+        let tables = AuthorityEpochTables::open(epoch, tempdir.path(), None);
+
+        // Original aggregator: process a report for authority 0 and bump
+        // invalid-reports count for authority 2.
+        let original = mock_aggregator(3);
+        let report = report_v1(&[vec![1, 2, 3], vec![0, 0, 0], vec![0, 0, 0], vec![0, 0, 0]]);
+        original.process_report(0, &report);
+        original.increment_invalid_reports_count(2);
+
+        // Write what `ConsensusCommitOutput::write_to_batch` would write for
+        // dirty authorities {0, 2}: snapshot current state, insert into DBMap.
+        // DBMap key is `u8`; truncate at this storage boundary.
+        let dirty: std::collections::BTreeSet<AuthorityIndex> = [0, 2].into_iter().collect();
+        let mut batch = tables.received_reports_state.batch();
+        let rows: Vec<(u8, DBReceivedReportsStatePerAuthority)> = dirty
+            .iter()
+            .map(|&i| {
+                (
+                    i as u8,
+                    original.received_reports_state_per_authority_snapshot(i),
+                )
+            })
+            .collect();
+        batch
+            .insert_batch(&tables.received_reports_state, rows)
+            .unwrap();
+        batch.write().unwrap();
+
+        // Restore into a fresh aggregator from the same tables.
+        let restored = mock_aggregator(3);
+        restored.restore_from_tables(&tables).unwrap();
+
+        let snap = full_snapshot(&restored, 3);
+        assert!(snap[0].received_metrics.is_some());
+        assert_eq!(snap[0].invalid_reports_count, 0);
+        assert_eq!(snap[1], empty_state());
+        assert!(snap[2].received_metrics.is_none());
+        assert_eq!(snap[2].invalid_reports_count, 1);
     }
 }

--- a/crates/iota-core/src/authority/report_aggregator.rs
+++ b/crates/iota-core/src/authority/report_aggregator.rs
@@ -148,31 +148,17 @@ pub(crate) struct ReceivedReportsStatePerAuthority {
 }
 
 impl ReceivedReportsStatePerAuthority {
-    #[cfg(test)]
-    pub fn invalid_reports_count_snapshot(&self) -> u64 {
-        self.invalid_reports_count.load(Ordering::Relaxed)
-    }
-
-    #[cfg(test)]
-    pub fn received_metrics_snapshot(&self) -> Option<MisbehaviorObservations> {
-        self.received_metrics.load().as_deref().cloned()
-    }
-
-    #[cfg(test)]
     pub fn to_serializable(&self) -> DBReceivedReportsStatePerAuthority {
         DBReceivedReportsStatePerAuthority {
-            received_metrics: self.received_metrics_snapshot(),
-            invalid_reports_count: self.invalid_reports_count_snapshot(),
+            received_metrics: self.received_metrics.load().as_deref().cloned(),
+            invalid_reports_count: self.invalid_reports_count.load(Ordering::Relaxed),
         }
     }
 }
 
 /// Serializable snapshot of a single authority's received-reports state.
-/// Scaffolding for the storage layer of `ReportAggregator`: a future PR will
-/// persist these records via `DBMap<u32, DBReceivedReportsStatePerAuthority>`
-/// in `AuthorityEpochTables`, enabling report state to survive restarts.
-/// Until then, this struct is only used in tests.
-#[cfg(test)]
+/// Persisted to `AuthorityEpochTables::received_reports_state` so the
+/// aggregator survives restarts.
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub(crate) struct DBReceivedReportsStatePerAuthority {
     pub received_metrics: Option<MisbehaviorObservations>,


### PR DESCRIPTION
# Description of change

Persists `ReportAggregator` state to RocksDB so per-validator received-reports tallies survive node restarts. Stacks on top of #11534.

Refs https://github.com/iotaledger/iota/pull/10366 (the original implementation by @oliviasaa, which we couldn't reasonably rebase post-Starfish migration).

## What gets persisted

- `DBReceivedReportsStatePerAuthority { received_metrics, invalid_reports_count }` for each authority that has changed state in this epoch.
- New column family on `AuthorityEpochTables`: `received_reports_state: DBMap<u32, DBReceivedReportsStatePerAuthority>`.

## How writes work

When `process_report` mutates the aggregator for authority X, it returns the post-merge snapshot. The consensus handler stashes that snapshot into `ConsensusCommitOutput.report_state_snapshots[X]` (a `BTreeMap`, last-writer-wins). When the quarantine flushes the commit's `DBBatch`, the captured snapshots get written atomically with the rest of the commit's effects.

This means the persisted row written under commit N's batch is **exactly** "aggregator state for that authority after commit N's processing" — independent of when quarantine flushes the batch, and matching what `scoreboard.update_scores` saw at end of N. Cross-validator determinism preserved.

## How restore works

`AuthorityPerEpochStore::new` calls `ReportAggregator::restore_from_tables(&tables)` immediately after constructing the aggregator. The existing consensus-handler replay path then reprocesses any committed-but-unflushed commits; merge-max idempotency reproduces the same end state.

## Explicit non-goals

- **Score-update optimization** (recalc only when ≥1 report seen in commit) — tracked separately.
- **Verify-time invalid-count durability**. `verify_consensus_transaction`-time `increment_invalid_reports_count` bumps stay in-memory only. They land on disk the next time a `process_report` for the same authority captures a fresh snapshot. Counter is observability-only; replay re-runs verify on the recovery path, so correctness is preserved. Documented in code.
- **Separate replay logic for unflushed commits**. Not needed — the existing consensus-handler recovery path replays for free, and merge-max is idempotent.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota-private/issues/310

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Local verification:
- `cargo ci-clippy` — clean.
- `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib` — 562 tests pass.
- New tests:
  - `test_restore_from_iter_populates_in_memory_state`
  - `test_restore_from_iter_rejects_out_of_range_authority`
  - `test_process_report_returns_post_merge_snapshot`
  - `test_restore_round_trip_through_dbmap` — full persist→restore round trip via `AuthorityEpochTables::open` with a tempdir.