### PR TITLE
feat(iota-core): skip scoreboard.update_scores on no-report commits

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1099,6 +1099,16 @@ impl AuthorityPerEpochStore {
             .expect("AuthorityEpochTables should contain valid ReportAggregator state");
         let voting_power = committee.members().map(|(_, v)| *v).collect::<Vec<u64>>();
         let scoreboard = Scoreboard::new(voting_power, &protocol_config);
+        // Prime the published score vector from any restored aggregator state.
+        // Without this, a freshly constructed Scoreboard starts at [MAX_SCORE;
+        // committee_size], so the next no-report commit (which both restored
+        // and never-restarted validators skip) would publish different vectors
+        // across the network. `update_scores` is a no-op when the aggregator
+        // is empty (no `received_metrics` rows restored), so this is also
+        // correct for the fresh-epoch path.
+        if protocol_config.calculate_validator_scores() {
+            scoreboard.update_scores(&report_aggregator);
+        }
 
         let s = Arc::new(Self {
             name,
@@ -3195,7 +3205,14 @@ impl AuthorityPerEpochStore {
         // reports and snapshotting. This avoids cross-thread reads of the
         // aggregator — the checkpoint service only reads the published score
         // snapshot (`ArcSwap<Vec<u64>>`).
-        if self.protocol_config().calculate_validator_scores() {
+        //
+        // Skip the recompute entirely when no `process_report` ran this commit:
+        // the aggregator state didn't change, so the score vector can't either.
+        // All validators see the same `report_state_snapshots` emptiness, so
+        // they all skip / run in lock-step — `current_scores` stays consistent
+        // across the network.
+        if self.protocol_config().calculate_validator_scores() && output.has_report_state_changes()
+        {
             self.scoreboard.update_scores(&self.report_aggregator);
         }
         self.process_user_signatures(

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -152,6 +152,13 @@ impl ConsensusCommitOutput {
             .insert(authority_index as u8, snapshot);
     }
 
+    /// Returns `true` if at least one `process_report` ran during this commit.
+    /// Used by the consensus handler to skip `Scoreboard::update_scores` on
+    /// commits that can't change the score vector.
+    pub(crate) fn has_report_state_changes(&self) -> bool {
+        !self.report_state_snapshots.is_empty()
+    }
+
     pub fn set_next_shared_object_versions(
         &mut self,
         next_versions: HashMap<ObjectID, SequenceNumber>,


### PR DESCRIPTION
# Description of change

Skip the per-commit `Scoreboard::update_scores(&report_aggregator)` recompute when no `MisbehaviorReport` was processed in the commit. Stacks on top of #11561 (which introduces `ConsensusCommitOutput.report_state_snapshots` — the signal we gate on).

## How the gate works

- `ConsensusCommitOutput::has_report_state_changes()` returns `true` iff at least one `process_report` ran during this commit (i.e. `report_state_snapshots` is non-empty).
- In `process_consensus_transactions_and_commit_boundary`, the existing call becomes:
  ```rust
  if self.protocol_config().calculate_validator_scores() && output.has_report_state_changes() {
      self.scoreboard.update_scores(&self.report_aggregator);
  }
  ```

## Why this is safe (cross-validator determinism)

- `Scoreboard::update_scores` is a pure function of `(voting_power, aggregator.reporters_with_voting_power())`. Same inputs → same output across validators.
- All validators see the same `report_state_snapshots` emptiness (consensus is deterministic), so all skip / run in lock-step.
- When all skip, `current_scores` retains its prior `Arc<Vec<u64>>` — same across validators because the previous `update_scores` ran on the same aggregator state.
- `invalid_reports_count` bumps don't affect scores (`reporters_with_voting_power` reads only `received_metrics`), so verify-time bumps that don't mark dirty are also score-irrelevant.

## Startup bootstrap

A freshly constructed `Scoreboard` starts at `[MAX_SCORE; committee_size]`, but a never-restarted peer's reflects accumulated updates. Without a fix, the next no-report commit would skip on both, diverging the published vector. So `AuthorityPerEpochStore::new` now calls `scoreboard.update_scores(&report_aggregator)` once, immediately after `restore_from_tables`. If the restored aggregator is empty (fresh epoch), `update_scores` returns `None` and leaves the default — correct for the fresh-epoch path too.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Local verification:
- `cargo ci-clippy` — clean.
- `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib` — 564 tests pass.
- New tests in `scorer.rs`:
  - `test_skipped_update_leaves_current_scores_unchanged` — proves the skip path preserves `current_scores` bit-for-bit.
  - `test_bootstrap_from_restored_aggregator_matches_live_path` — proves a restored-and-bootstrapped scoreboard publishes the same vector as a never-restarted peer's, given the same aggregator state.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota-private/issues/408