### PR TITLE
feat(graphql): make backward-history max-lookback configurable

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -277,6 +277,7 @@ impl Cluster for LocalNewCluster {
                 None,
                 None,
                 None,
+                None,
             );
 
             start_graphql_server_with_fn_rpc(

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -54,6 +54,16 @@ pub struct ConnectionConfig {
     /// to connect to, on start-up.
     #[arg(long, default_value_t = ConnectionConfig::default().skip_migration_consistency_check)]
     pub skip_migration_consistency_check: bool,
+    /// Maximum number of checkpoints to look back for consistent view queries.
+    /// Directly influences the `availableRange` size. Larger values let
+    /// pagination cursors stay valid for longer, downside is that older cursors
+    /// have higher DB cost.
+    #[arg(
+        long,
+        default_value_t = ConnectionConfig::default().backward_history_max_lookback,
+        env = "BACKWARD_HISTORY_MAX_LOOKBACK",
+    )]
+    pub backward_history_max_lookback: u64,
 }
 
 /// Configuration on features supported by the GraphQL service, passed in a
@@ -359,6 +369,7 @@ impl ConnectionConfig {
         prom_host: Option<String>,
         prom_port: Option<u16>,
         skip_migration_consistency_check: Option<bool>,
+        backward_history_max_lookback: Option<u64>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -370,6 +381,8 @@ impl ConnectionConfig {
             prom_port: prom_port.unwrap_or(default.prom_port),
             skip_migration_consistency_check: skip_migration_consistency_check
                 .unwrap_or(default.skip_migration_consistency_check),
+            backward_history_max_lookback: backward_history_max_lookback
+                .unwrap_or(default.backward_history_max_lookback),
         }
     }
 
@@ -474,6 +487,7 @@ impl Default for ConnectionConfig {
             prom_host: "0.0.0.0".to_string(),
             prom_port: 9184,
             skip_migration_consistency_check: false,
+            backward_history_max_lookback: 9_000,
         }
     }
 }

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -60,10 +60,10 @@ pub struct ConnectionConfig {
     /// have higher DB cost.
     #[arg(
         long,
-        default_value_t = ConnectionConfig::default().backward_history_max_lookback,
-        env = "BACKWARD_HISTORY_MAX_LOOKBACK",
+        default_value_t = ConnectionConfig::default().max_available_range,
+        env = "MAX_AVAILABLE_RANGE",
     )]
-    pub backward_history_max_lookback: u64,
+    pub max_available_range: u64,
 }
 
 /// Configuration on features supported by the GraphQL service, passed in a
@@ -369,7 +369,7 @@ impl ConnectionConfig {
         prom_host: Option<String>,
         prom_port: Option<u16>,
         skip_migration_consistency_check: Option<bool>,
-        backward_history_max_lookback: Option<u64>,
+        max_available_range: Option<u64>,
     ) -> Self {
         let default = Self::default();
         Self {
@@ -381,8 +381,7 @@ impl ConnectionConfig {
             prom_port: prom_port.unwrap_or(default.prom_port),
             skip_migration_consistency_check: skip_migration_consistency_check
                 .unwrap_or(default.skip_migration_consistency_check),
-            backward_history_max_lookback: backward_history_max_lookback
-                .unwrap_or(default.backward_history_max_lookback),
+            max_available_range: max_available_range.unwrap_or(default.max_available_range),
         }
     }
 
@@ -487,7 +486,7 @@ impl Default for ConnectionConfig {
             prom_host: "0.0.0.0".to_string(),
             prom_port: 9184,
             skip_migration_consistency_check: false,
-            backward_history_max_lookback: 9_000,
+            max_available_range: 9_000,
         }
     }
 }

--- a/crates/iota-graphql-rpc/src/data/pg.rs
+++ b/crates/iota-graphql-rpc/src/data/pg.rs
@@ -23,6 +23,9 @@ pub(crate) struct PgExecutor {
     pub inner: IndexerReader,
     pub limits: Limits,
     pub metrics: Metrics,
+    /// Cap on how far back a consistent view can be requested
+    /// (`BACKWARD_HISTORY_MAX_LOOKBACK`).
+    pub backward_history_max_lookback: u64,
 }
 
 pub(crate) struct PgConnection<'c> {
@@ -33,11 +36,17 @@ pub(crate) struct PgConnection<'c> {
 pub(crate) struct ByteaLiteral<'a>(pub &'a [u8]);
 
 impl PgExecutor {
-    pub(crate) fn new(inner: IndexerReader, limits: Limits, metrics: Metrics) -> Self {
+    pub(crate) fn new(
+        inner: IndexerReader,
+        limits: Limits,
+        metrics: Metrics,
+        backward_history_max_lookback: u64,
+    ) -> Self {
         Self {
             inner,
             limits,
             metrics,
+            backward_history_max_lookback,
         }
     }
 }

--- a/crates/iota-graphql-rpc/src/data/pg.rs
+++ b/crates/iota-graphql-rpc/src/data/pg.rs
@@ -23,9 +23,10 @@ pub(crate) struct PgExecutor {
     pub inner: IndexerReader,
     pub limits: Limits,
     pub metrics: Metrics,
-    /// Cap on how far back a consistent view can be requested
-    /// (`BACKWARD_HISTORY_MAX_LOOKBACK`).
-    pub backward_history_max_lookback: u64,
+    /// Maximum size of the `availableRange` window (`MAX_AVAILABLE_RANGE`).
+    /// Caps how many checkpoints below `latest` a consistent view can be
+    /// requested for.
+    pub max_available_range: u64,
 }
 
 pub(crate) struct PgConnection<'c> {
@@ -40,13 +41,13 @@ impl PgExecutor {
         inner: IndexerReader,
         limits: Limits,
         metrics: Metrics,
-        backward_history_max_lookback: u64,
+        max_available_range: u64,
     ) -> Self {
         Self {
             inner,
             limits,
             metrics,
-            backward_history_max_lookback,
+            max_available_range,
         }
     }
 }

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -463,6 +463,7 @@ impl ServerBuilder {
             reader.clone(),
             config.service.limits.clone(),
             metrics.clone(),
+            config.connection.backward_history_max_lookback,
         );
         let loader = DataLoader::new(db.clone());
         let pg_conn_pool = PgManager::new(reader.clone());
@@ -826,6 +827,7 @@ pub mod tests {
             reader.clone(),
             service_config.limits.clone(),
             metrics.clone(),
+            connection_config.backward_history_max_lookback,
         );
         let loader = DataLoader::new(db.clone());
         let pg_conn_pool = PgManager::new(reader);

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -463,7 +463,7 @@ impl ServerBuilder {
             reader.clone(),
             config.service.limits.clone(),
             metrics.clone(),
-            config.connection.backward_history_max_lookback,
+            config.connection.max_available_range,
         );
         let loader = DataLoader::new(db.clone());
         let pg_conn_pool = PgManager::new(reader.clone());
@@ -827,7 +827,7 @@ pub mod tests {
             reader.clone(),
             service_config.limits.clone(),
             metrics.clone(),
-            connection_config.backward_history_max_lookback,
+            connection_config.max_available_range,
         );
         let loader = DataLoader::new(db.clone());
         let pg_conn_pool = PgManager::new(reader);

--- a/crates/iota-graphql-rpc/src/types/available_range.rs
+++ b/crates/iota-graphql-rpc/src/types/available_range.rs
@@ -36,10 +36,12 @@ impl AvailableRange {
 
 impl AvailableRange {
     /// Look up the available range when viewing the data consistently at
-    /// `checkpoint_viewed_at`.
+    /// `checkpoint_viewed_at`. Uses the executor's configured
+    /// `backward_history_max_lookback`.
     pub(crate) async fn query(db: &Db, checkpoint_viewed_at: u64) -> Result<Self, Error> {
+        let max_lookback = db.backward_history_max_lookback;
         let Some(range): Option<Self> = db
-            .execute(move |conn| Self::result(conn, checkpoint_viewed_at))
+            .execute(move |conn| Self::result(conn, checkpoint_viewed_at, max_lookback))
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch available range: {e}")))?
         else {
@@ -52,20 +54,21 @@ impl AvailableRange {
         Ok(range)
     }
 
-    /// Maximum number of checkpoints to look back for backward diff queries.
-    /// Limits how far back a consistent view can be requested, for performance
-    /// reasons (the further back, the more backward history entries to
-    /// traverse).
-    const BACKWARD_HISTORY_MAX_LOOKBACK: u64 = 900;
-
     /// Computes the backward-diff retention window. Returns `Some(range)`
     /// when `checkpoint_viewed_at` falls inside it, `None` otherwise. The
     /// lower bound is the greater of the backward history watermark
-    /// (`min_available_cp`) and `latest_checkpoint -
-    /// BACKWARD_HISTORY_MAX_LOOKBACK`; the upper bound is
-    /// `checkpoint_viewed_at` itself, so the returned range never extends
-    /// past the request's captured watermark.
-    pub(crate) fn result(conn: &mut Conn, checkpoint_viewed_at: u64) -> QueryResult<Option<Self>> {
+    /// (`min_available_cp`) and `latest_checkpoint - max_lookback`; the
+    /// upper bound is `checkpoint_viewed_at` itself, so the returned range
+    /// never extends past the request's captured watermark.
+    ///
+    /// `max_lookback` caps how far back a consistent view can be requested,
+    /// for performance reasons (the further back, the more backward history
+    /// entries to traverse).
+    pub(crate) fn result(
+        conn: &mut Conn,
+        checkpoint_viewed_at: u64,
+        max_lookback: u64,
+    ) -> QueryResult<Option<Self>> {
         use checkpoints::dsl as cp;
         use watermarks::dsl as wm;
 
@@ -93,7 +96,7 @@ impl AvailableRange {
 
         let last = last.unwrap_or(0) as u64;
         let watermark_first = watermark_first.unwrap_or(0) as u64;
-        let lag_first = last.saturating_sub(Self::BACKWARD_HISTORY_MAX_LOOKBACK);
+        let lag_first = last.saturating_sub(max_lookback);
         let first = watermark_first.max(lag_first);
 
         if checkpoint_viewed_at < first || checkpoint_viewed_at > last {
@@ -110,7 +113,8 @@ impl AvailableRange {
     pub(crate) fn is_checkpoint_in_backward_history_range(
         conn: &mut Conn,
         checkpoint_viewed_at: u64,
+        max_lookback: u64,
     ) -> QueryResult<bool> {
-        Ok(Self::result(conn, checkpoint_viewed_at)?.is_some())
+        Ok(Self::result(conn, checkpoint_viewed_at, max_lookback)?.is_some())
     }
 }

--- a/crates/iota-graphql-rpc/src/types/available_range.rs
+++ b/crates/iota-graphql-rpc/src/types/available_range.rs
@@ -37,11 +37,11 @@ impl AvailableRange {
 impl AvailableRange {
     /// Look up the available range when viewing the data consistently at
     /// `checkpoint_viewed_at`. Uses the executor's configured
-    /// `backward_history_max_lookback`.
+    /// `max_available_range`.
     pub(crate) async fn query(db: &Db, checkpoint_viewed_at: u64) -> Result<Self, Error> {
-        let max_lookback = db.backward_history_max_lookback;
+        let max_available_range = db.max_available_range;
         let Some(range): Option<Self> = db
-            .execute(move |conn| Self::result(conn, checkpoint_viewed_at, max_lookback))
+            .execute(move |conn| Self::result(conn, checkpoint_viewed_at, max_available_range))
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch available range: {e}")))?
         else {
@@ -57,17 +57,17 @@ impl AvailableRange {
     /// Computes the backward-diff retention window. Returns `Some(range)`
     /// when `checkpoint_viewed_at` falls inside it, `None` otherwise. The
     /// lower bound is the greater of the backward history watermark
-    /// (`min_available_cp`) and `latest_checkpoint - max_lookback`; the
+    /// (`min_available_cp`) and `latest_checkpoint - max_available_range`; the
     /// upper bound is `checkpoint_viewed_at` itself, so the returned range
     /// never extends past the request's captured watermark.
     ///
-    /// `max_lookback` caps how far back a consistent view can be requested,
-    /// for performance reasons (the further back, the more backward history
-    /// entries to traverse).
+    /// `max_available_range` caps how far back a consistent view can be
+    /// requested, for performance reasons (the further back, the more
+    /// backward history entries to traverse).
     pub(crate) fn result(
         conn: &mut Conn,
         checkpoint_viewed_at: u64,
-        max_lookback: u64,
+        max_available_range: u64,
     ) -> QueryResult<Option<Self>> {
         use checkpoints::dsl as cp;
         use watermarks::dsl as wm;
@@ -96,7 +96,7 @@ impl AvailableRange {
 
         let last = last.unwrap_or(0) as u64;
         let watermark_first = watermark_first.unwrap_or(0) as u64;
-        let lag_first = last.saturating_sub(max_lookback);
+        let lag_first = last.saturating_sub(max_available_range);
         let first = watermark_first.max(lag_first);
 
         if checkpoint_viewed_at < first || checkpoint_viewed_at > last {
@@ -113,8 +113,8 @@ impl AvailableRange {
     pub(crate) fn is_checkpoint_in_backward_history_range(
         conn: &mut Conn,
         checkpoint_viewed_at: u64,
-        max_lookback: u64,
+        max_available_range: u64,
     ) -> QueryResult<bool> {
-        Ok(Self::result(conn, checkpoint_viewed_at, max_lookback)?.is_some())
+        Ok(Self::result(conn, checkpoint_viewed_at, max_available_range)?.is_some())
     }
 }

--- a/crates/iota-graphql-rpc/src/types/balance.rs
+++ b/crates/iota-graphql-rpc/src/types/balance.rs
@@ -81,13 +81,13 @@ impl Balance {
         coin_type: TypeTag,
         checkpoint_viewed_at: u64,
     ) -> Result<Option<Balance>, Error> {
-        let max_lookback = db.backward_history_max_lookback;
+        let max_available_range = db.max_available_range;
         let stored: Option<StoredBalance> = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
-                    max_lookback,
+                    max_available_range,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 }
@@ -119,14 +119,14 @@ impl Balance {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let max_lookback = db.backward_history_max_lookback;
+        let max_available_range = db.max_available_range;
 
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
-                    max_lookback,
+                    max_available_range,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 }

--- a/crates/iota-graphql-rpc/src/types/balance.rs
+++ b/crates/iota-graphql-rpc/src/types/balance.rs
@@ -81,11 +81,13 @@ impl Balance {
         coin_type: TypeTag,
         checkpoint_viewed_at: u64,
     ) -> Result<Option<Balance>, Error> {
+        let max_lookback = db.backward_history_max_lookback;
         let stored: Option<StoredBalance> = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
+                    max_lookback,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 }
@@ -117,11 +119,14 @@ impl Balance {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
+        let max_lookback = db.backward_history_max_lookback;
+
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
+                    max_lookback,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 }

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -349,14 +349,14 @@ impl Coin {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let max_lookback = db.backward_history_max_lookback;
+        let max_available_range = db.max_available_range;
 
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
-                    max_lookback,
+                    max_available_range,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 };

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -349,11 +349,14 @@ impl Coin {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
+        let max_lookback = db.backward_history_max_lookback;
+
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
+                    max_lookback,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 };

--- a/crates/iota-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/iota-graphql-rpc/src/types/dynamic_field.rs
@@ -201,11 +201,14 @@ impl DynamicField {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
+        let max_lookback = db.backward_history_max_lookback;
+
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
+                    max_lookback,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 };

--- a/crates/iota-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/iota-graphql-rpc/src/types/dynamic_field.rs
@@ -201,14 +201,14 @@ impl DynamicField {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let max_lookback = db.backward_history_max_lookback;
+        let max_available_range = db.max_available_range;
 
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
-                    max_lookback,
+                    max_available_range,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 };

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -492,7 +492,7 @@ impl IotaNames {
     ) -> Result<Option<NameExpiration>, Error> {
         let config: &IotaNamesConfig = ctx.data_unchecked();
         let db: &Db = ctx.data_unchecked();
-        let max_lookback = db.backward_history_max_lookback;
+        let max_available_range = db.max_available_range;
         // Construct the list of `object_id`s to look up. The first element is the
         // name's `NameRecord`. If the name is a subname, there will be a
         // second element for the parent's `NameRecord`.
@@ -528,7 +528,7 @@ impl IotaNames {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
-                    max_lookback,
+                    max_available_range,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 };

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -492,6 +492,7 @@ impl IotaNames {
     ) -> Result<Option<NameExpiration>, Error> {
         let config: &IotaNamesConfig = ctx.data_unchecked();
         let db: &Db = ctx.data_unchecked();
+        let max_lookback = db.backward_history_max_lookback;
         // Construct the list of `object_id`s to look up. The first element is the
         // name's `NameRecord`. If the name is a subname, there will be a
         // second element for the parent's `NameRecord`.
@@ -527,6 +528,7 @@ impl IotaNames {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
+                    max_lookback,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 };

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -868,14 +868,14 @@ impl Object {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let max_lookback = db.backward_history_max_lookback;
+        let max_available_range = db.max_available_range;
 
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
-                    max_lookback,
+                    max_available_range,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 };
@@ -1793,7 +1793,7 @@ impl Loader<LatestAtKey> for Db {
                 .insert(key.id);
         }
 
-        let max_lookback = self.backward_history_max_lookback;
+        let max_available_range = self.max_available_range;
 
         // Issue concurrent reads for each group of keys.
         let futures =
@@ -1804,7 +1804,7 @@ impl Loader<LatestAtKey> for Db {
                         if !AvailableRange::is_checkpoint_in_backward_history_range(
                             conn,
                             checkpoint_viewed_at,
-                            max_lookback,
+                            max_available_range,
                         )? {
                             return Ok::<Vec<(u64, StoredHistoryObject)>, diesel::result::Error>(
                                 vec![],

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -868,11 +868,14 @@ impl Object {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
+        let max_lookback = db.backward_history_max_lookback;
+
         let Some((prev, next, results)) = db
             .execute_repeatable(move |conn| {
                 if !AvailableRange::is_checkpoint_in_backward_history_range(
                     conn,
                     checkpoint_viewed_at,
+                    max_lookback,
                 )? {
                     return Ok::<_, diesel::result::Error>(None);
                 };
@@ -1790,6 +1793,8 @@ impl Loader<LatestAtKey> for Db {
                 .insert(key.id);
         }
 
+        let max_lookback = self.backward_history_max_lookback;
+
         // Issue concurrent reads for each group of keys.
         let futures =
             keys_by_cursor_and_parent_version
@@ -1799,6 +1804,7 @@ impl Loader<LatestAtKey> for Db {
                         if !AvailableRange::is_checkpoint_in_backward_history_range(
                             conn,
                             checkpoint_viewed_at,
+                            max_lookback,
                         )? {
                             return Ok::<Vec<(u64, StoredHistoryObject)>, diesel::result::Error>(
                                 vec![],


### PR DESCRIPTION
# Description of change

The consistent-views lookback window was a hardcoded constant `BACKWARD_HISTORY_MAX_LOOKBACK = 900` in
`crates/iota-graphql-rpc/src/types/available_range.rs`. Mainnet today runs with `--objects-snapshot-min-checkpoint-lag` set to ~9000, giving operators a ~30-min consistent-views window; the hardcoded 900 would collapse it to ~3 min.

Expose the cap as a CLI argument + env var on `iota-graphql-rpc start-server`, mirroring the indexer's `SnapshotLagConfig` mechanics:

- `--max-available-range` / env `MAX_AVAILABLE_RANGE`
- Default `9_000` (matches current mainnet behaviour)

The value is stored on `PgExecutor` (`Db`) so all consistent-view query paths that already use the `Db` can read it without passing around extra arguments.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11565

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
