### PR TITLE
chore: improve error messages for unhandled enum variants

### DIFF
--- a/crates/iota-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/iota-cluster-test/src/test_case/coin_index_test.rs
@@ -105,7 +105,9 @@ impl TestCaseImpl for CoinIndexTest {
         let validator_addr = match ctx.get_latest_iota_system_state().await {
             IotaSystemStateSummary::V1(v1) => v1.active_validators,
             IotaSystemStateSummary::V2(v2) => v2.active_validators,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         }
         .first()
         .unwrap()

--- a/crates/iota-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/iota-cluster-test/src/test_case/coin_index_test.rs
@@ -105,7 +105,7 @@ impl TestCaseImpl for CoinIndexTest {
         let validator_addr = match ctx.get_latest_iota_system_state().await {
             IotaSystemStateSummary::V1(v1) => v1.active_validators,
             IotaSystemStateSummary::V2(v2) => v2.active_validators,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         }
         .first()
         .unwrap()

--- a/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
@@ -218,7 +218,9 @@ impl StressTestRunner {
         let pre_epoch = match self.system_state() {
             IotaSystemStateSummary::V1(v1) => v1.epoch,
             IotaSystemStateSummary::V2(v2) => v2.epoch,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
 
         self.test_cluster.force_new_epoch().await;
@@ -226,7 +228,9 @@ impl StressTestRunner {
         let post_epoch = match self.system_state() {
             IotaSystemStateSummary::V1(v1) => v1.epoch,
             IotaSystemStateSummary::V2(v2) => v2.epoch,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
 
         info!("Changing epoch from {} to {}", pre_epoch, post_epoch);

--- a/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
@@ -218,7 +218,7 @@ impl StressTestRunner {
         let pre_epoch = match self.system_state() {
             IotaSystemStateSummary::V1(v1) => v1.epoch,
             IotaSystemStateSummary::V2(v2) => v2.epoch,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         };
 
         self.test_cluster.force_new_epoch().await;
@@ -226,7 +226,7 @@ impl StressTestRunner {
         let post_epoch = match self.system_state() {
             IotaSystemStateSummary::V1(v1) => v1.epoch,
             IotaSystemStateSummary::V2(v2) => v2.epoch,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         };
 
         info!("Changing epoch from {} to {}", pre_epoch, post_epoch);

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -550,7 +550,7 @@ async fn test_validator_candidate_pool_read() {
             match &system_state_summary {
                 IotaSystemStateSummary::V1(v1) => v1.validator_candidates_id,
                 IotaSystemStateSummary::V2(v2) => v2.validator_candidates_id,
-                _ => panic!("unsupported IotaSystemStateSummary"),
+                _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
             },
             &address,
             Some(system_state.protocol_version()),
@@ -1103,7 +1103,7 @@ async fn safe_mode_reconfig_test() {
     {
         IotaSystemStateSummary::V1(v1) => (v1.system_state_version, v1.epoch),
         IotaSystemStateSummary::V2(v2) => (v2.system_state_version, v2.epoch),
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     };
 
     // On startup, we should be at V1.
@@ -1307,7 +1307,7 @@ async fn add_validator_candidate(
         {
             IotaSystemStateSummary::V1(v1) => v1.validator_candidates_size,
             IotaSystemStateSummary::V2(v2) => v2.validator_candidates_size,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         }
     });
     let address = (&new_validator.account_key_pair.public()).into();
@@ -1336,7 +1336,7 @@ async fn add_validator_candidate(
         let validator_candidates_size = match system_state_summary {
             IotaSystemStateSummary::V1(v1) => v1.validator_candidates_size,
             IotaSystemStateSummary::V2(v2) => v2.validator_candidates_size,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         };
         assert_eq!(validator_candidates_size, cur_validator_candidate_count + 1);
     });
@@ -1352,7 +1352,7 @@ async fn execute_remove_validator_tx(test_cluster: &TestCluster, handle: &IotaNo
         {
             IotaSystemStateSummary::V1(v1) => v1.pending_removals,
             IotaSystemStateSummary::V2(v2) => v2.pending_removals,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         }
         .len()
     });
@@ -1382,7 +1382,7 @@ async fn execute_remove_validator_tx(test_cluster: &TestCluster, handle: &IotaNo
         let pending_removals = match system_state.into_iota_system_state_summary() {
             IotaSystemStateSummary::V1(v1) => v1.pending_removals,
             IotaSystemStateSummary::V2(v2) => v2.pending_removals,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         };
         assert_eq!(pending_removals.len(), cur_pending_removals + 1);
     });

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -550,7 +550,9 @@ async fn test_validator_candidate_pool_read() {
             match &system_state_summary {
                 IotaSystemStateSummary::V1(v1) => v1.validator_candidates_id,
                 IotaSystemStateSummary::V2(v2) => v2.validator_candidates_id,
-                _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+                _ => unimplemented!(
+                    "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+                ),
             },
             &address,
             Some(system_state.protocol_version()),
@@ -1103,7 +1105,9 @@ async fn safe_mode_reconfig_test() {
     {
         IotaSystemStateSummary::V1(v1) => (v1.system_state_version, v1.epoch),
         IotaSystemStateSummary::V2(v2) => (v2.system_state_version, v2.epoch),
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     };
 
     // On startup, we should be at V1.
@@ -1307,7 +1311,9 @@ async fn add_validator_candidate(
         {
             IotaSystemStateSummary::V1(v1) => v1.validator_candidates_size,
             IotaSystemStateSummary::V2(v2) => v2.validator_candidates_size,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         }
     });
     let address = (&new_validator.account_key_pair.public()).into();
@@ -1336,7 +1342,9 @@ async fn add_validator_candidate(
         let validator_candidates_size = match system_state_summary {
             IotaSystemStateSummary::V1(v1) => v1.validator_candidates_size,
             IotaSystemStateSummary::V2(v2) => v2.validator_candidates_size,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
         assert_eq!(validator_candidates_size, cur_validator_candidate_count + 1);
     });
@@ -1352,7 +1360,9 @@ async fn execute_remove_validator_tx(test_cluster: &TestCluster, handle: &IotaNo
         {
             IotaSystemStateSummary::V1(v1) => v1.pending_removals,
             IotaSystemStateSummary::V2(v2) => v2.pending_removals,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         }
         .len()
     });
@@ -1382,7 +1392,9 @@ async fn execute_remove_validator_tx(test_cluster: &TestCluster, handle: &IotaNo
         let pending_removals = match system_state.into_iota_system_state_summary() {
             IotaSystemStateSummary::V1(v1) => v1.pending_removals,
             IotaSystemStateSummary::V2(v2) => v2.pending_removals,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
         assert_eq!(pending_removals.len(), cur_pending_removals + 1);
     });

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -110,7 +110,7 @@ impl TransactionBlockEffects {
         Some(match self.native().status() {
             NativeExecutionStatus::Success => ExecutionStatus::Success,
             NativeExecutionStatus::Failure { .. } => ExecutionStatus::Failure,
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new ExecutionStatus enum variant was added and needs to be handled"),
         })
     }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -110,7 +110,9 @@ impl TransactionBlockEffects {
         Some(match self.native().status() {
             NativeExecutionStatus::Success => ExecutionStatus::Success,
             NativeExecutionStatus::Failure { .. } => ExecutionStatus::Failure,
-            _ => unimplemented!("a new ExecutionStatus enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new ExecutionStatus enum variant was added and needs to be handled"
+            ),
         })
     }
 

--- a/crates/iota-indexer/src/models/system_state.rs
+++ b/crates/iota-indexer/src/models/system_state.rs
@@ -887,7 +887,9 @@ impl From<IotaSystemStateSummary> for StoredSystemState {
         match native {
             IotaSystemStateSummary::V1(inner) => StoredSystemState::V1(inner.into()),
             IotaSystemStateSummary::V2(inner) => StoredSystemState::V2(inner.into()),
-            _ => panic!("unsupported native system state"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         }
     }
 }

--- a/crates/iota-indexer/tests/rpc-tests/governance_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/governance_api.rs
@@ -67,7 +67,9 @@ fn test_staking() {
         let validator = match iota_system_state {
             IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
             IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
 
         // Delegate some IOTA
@@ -148,7 +150,9 @@ fn test_unstaking() {
         let validator = match iota_system_state {
             IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
             IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
 
         // Delegate some IOTA
@@ -285,7 +289,9 @@ fn test_timelocked_staking() {
             let validator = match iota_system_state {
                 IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
                 IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-                _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+                _ => unimplemented!(
+                    "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+                ),
             };
 
             let validator = builder.pure(validator).unwrap();
@@ -401,7 +407,9 @@ fn test_timelocked_unstaking() {
             let validator = match iota_system_state {
                 IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
                 IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-                _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+                _ => unimplemented!(
+                    "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+                ),
             };
 
             let validator = builder.pure(validator).unwrap();

--- a/crates/iota-indexer/tests/rpc-tests/governance_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/governance_api.rs
@@ -67,7 +67,7 @@ fn test_staking() {
         let validator = match iota_system_state {
             IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
             IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         };
 
         // Delegate some IOTA
@@ -148,7 +148,7 @@ fn test_unstaking() {
         let validator = match iota_system_state {
             IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
             IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-            _ => panic!("unsupported IotaSystemStateSummary"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         };
 
         // Delegate some IOTA
@@ -285,7 +285,7 @@ fn test_timelocked_staking() {
             let validator = match iota_system_state {
                 IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
                 IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-                _ => panic!("unsupported IotaSystemStateSummary"),
+                _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
             };
 
             let validator = builder.pure(validator).unwrap();
@@ -401,7 +401,7 @@ fn test_timelocked_unstaking() {
             let validator = match iota_system_state {
                 IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
                 IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-                _ => panic!("unsupported IotaSystemStateSummary"),
+                _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
             };
 
             let validator = builder.pure(validator).unwrap();

--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -891,7 +891,7 @@ async fn get_validator(client: &HttpClient) -> IotaAddress {
     match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     }
 }
 

--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -891,7 +891,9 @@ async fn get_validator(client: &HttpClient) -> IotaAddress {
     match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     }
 }
 

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1592,7 +1592,7 @@ fn dry_run_request_add_stake() {
         let validator = match client.get_latest_iota_system_state_v2().await.unwrap() {
             IotaSystemStateSummary::V1(s) => s.active_validators[0].iota_address,
             IotaSystemStateSummary::V2(s) => s.active_validators[0].iota_address,
-            _ => unimplemented!("there is a new system state summary variant that must be handled"),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         };
 
         let tx_bytes: TransactionBlockBytes = client

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1592,7 +1592,9 @@ fn dry_run_request_add_stake() {
         let validator = match client.get_latest_iota_system_state_v2().await.unwrap() {
             IotaSystemStateSummary::V1(s) => s.active_validators[0].iota_address,
             IotaSystemStateSummary::V2(s) => s.active_validators[0].iota_address,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
 
         let tx_bytes: TransactionBlockBytes = client

--- a/crates/iota-json-rpc-tests/tests/coin_api.rs
+++ b/crates/iota-json-rpc-tests/tests/coin_api.rs
@@ -351,7 +351,9 @@ async fn staking_multiple_coins() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     };
 
     // Delegate some IOTA

--- a/crates/iota-json-rpc-tests/tests/coin_api.rs
+++ b/crates/iota-json-rpc-tests/tests/coin_api.rs
@@ -351,7 +351,7 @@ async fn staking_multiple_coins() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     };
 
     // Delegate some IOTA

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -63,7 +63,9 @@ async fn execute_add_validator_transactions(
         match system_state {
             IotaSystemStateSummary::V1(inner) => inner.validator_candidates_size,
             IotaSystemStateSummary::V2(inner) => inner.validator_candidates_size,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         }
     });
     let address = (&new_validator.account_key_pair.public()).into();
@@ -92,7 +94,9 @@ async fn execute_add_validator_transactions(
         let validator_candidates_size = match system_state {
             IotaSystemStateSummary::V1(inner) => inner.validator_candidates_size,
             IotaSystemStateSummary::V2(inner) => inner.validator_candidates_size,
-            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
         assert_eq!(validator_candidates_size, cur_validator_candidate_count + 1);
     });
@@ -310,7 +314,9 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     };
 
     let coin = objects.data[0].object()?.object_id;
@@ -394,7 +400,9 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     };
 
     // Delegate some IOTA
@@ -578,7 +586,9 @@ async fn test_timelocked_staking() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     };
 
     let transaction_bytes: TransactionBlockBytes = http_client
@@ -733,7 +743,9 @@ async fn test_timelocked_unstaking() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     };
 
     let transaction_bytes: TransactionBlockBytes = http_client

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -63,7 +63,7 @@ async fn execute_add_validator_transactions(
         match system_state {
             IotaSystemStateSummary::V1(inner) => inner.validator_candidates_size,
             IotaSystemStateSummary::V2(inner) => inner.validator_candidates_size,
-            _ => unimplemented!(),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         }
     });
     let address = (&new_validator.account_key_pair.public()).into();
@@ -92,7 +92,7 @@ async fn execute_add_validator_transactions(
         let validator_candidates_size = match system_state {
             IotaSystemStateSummary::V1(inner) => inner.validator_candidates_size,
             IotaSystemStateSummary::V2(inner) => inner.validator_candidates_size,
-            _ => unimplemented!(),
+            _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
         };
         assert_eq!(validator_candidates_size, cur_validator_candidate_count + 1);
     });
@@ -310,7 +310,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     };
 
     let coin = objects.data[0].object()?.object_id;
@@ -394,7 +394,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     };
 
     // Delegate some IOTA
@@ -578,7 +578,7 @@ async fn test_timelocked_staking() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     };
 
     let transaction_bytes: TransactionBlockBytes = http_client
@@ -733,7 +733,7 @@ async fn test_timelocked_unstaking() -> Result<(), anyhow::Error> {
     let validator = match iota_system_state {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].iota_address,
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].iota_address,
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     };
 
     let transaction_bytes: TransactionBlockBytes = http_client

--- a/crates/iota-json-rpc-types/src/iota_system_state_summary.rs
+++ b/crates/iota-json-rpc-types/src/iota_system_state_summary.rs
@@ -72,7 +72,7 @@ impl From<NativeSystemStateSummary> for IotaSystemStateSummary {
                 IotaSystemStateSummary::V2(summary_v2.into())
             }
             _ => unimplemented!(
-                "a new IotaSystemStateSummary variant was added and needs to be handled"
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
             ),
         }
     }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -1592,7 +1592,7 @@ impl From<ExecutionStatus> for IotaExecutionStatus {
             } => Self::Failure {
                 error: format!("{error} in command {idx}"),
             },
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new ExecutionStatus enum variant was added and needs to be handled"),
         }
     }
 }
@@ -1897,8 +1897,8 @@ impl From<ConsensusDeterminedVersionAssignments> for IotaConsensusDeterminedVers
                     })
                     .collect(),
             ),
-            _ => unreachable!(
-                "a new ConsensusDeterminedVersionAssignments variant was added and needs to be handled"
+            _ => unimplemented!(
+                "a new ConsensusDeterminedVersionAssignments enum variant was added and needs to be handled"
             ),
         }
     }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -1592,7 +1592,9 @@ impl From<ExecutionStatus> for IotaExecutionStatus {
             } => Self::Failure {
                 error: format!("{error} in command {idx}"),
             },
-            _ => unimplemented!("a new ExecutionStatus enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new ExecutionStatus enum variant was added and needs to be handled"
+            ),
         }
     }
 }

--- a/crates/iota-proxy/src/peers.rs
+++ b/crates/iota-proxy/src/peers.rs
@@ -229,7 +229,7 @@ impl IotaNodeProvider {
                                     IotaSystemStateSummary::V2(system_state) => {
                                         system_state.pending_active_validators_id
                                     }
-                                    _ => panic!("unsupported IotaSystemStateSummary"),
+                                    _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
                                 };
 
                                 match Self::get_pending_validators(

--- a/crates/iota-proxy/src/peers.rs
+++ b/crates/iota-proxy/src/peers.rs
@@ -229,7 +229,9 @@ impl IotaNodeProvider {
                                     IotaSystemStateSummary::V2(system_state) => {
                                         system_state.pending_active_validators_id
                                     }
-                                    _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+                                    _ => unimplemented!(
+                                        "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+                                    ),
                                 };
 
                                 match Self::get_pending_validators(

--- a/crates/iota-sdk/examples/transaction_builder/stake.rs
+++ b/crates/iota-sdk/examples/transaction_builder/stake.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), anyhow::Error> {
     {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].clone(),
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].clone(),
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     }
     .iota_address;
 

--- a/crates/iota-sdk/examples/transaction_builder/stake.rs
+++ b/crates/iota-sdk/examples/transaction_builder/stake.rs
@@ -39,7 +39,9 @@ async fn main() -> Result<(), anyhow::Error> {
     {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].clone(),
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].clone(),
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     }
     .iota_address;
 

--- a/crates/iota-sdk/examples/transaction_builder/timelocked_stake.rs
+++ b/crates/iota-sdk/examples/transaction_builder/timelocked_stake.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), anyhow::Error> {
     {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].clone(),
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].clone(),
-        _ => panic!("unsupported IotaSystemStateSummary"),
+        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
     }
     .iota_address;
 

--- a/crates/iota-sdk/examples/transaction_builder/timelocked_stake.rs
+++ b/crates/iota-sdk/examples/transaction_builder/timelocked_stake.rs
@@ -82,7 +82,9 @@ async fn main() -> Result<(), anyhow::Error> {
     {
         IotaSystemStateSummary::V1(v1) => v1.active_validators[0].clone(),
         IotaSystemStateSummary::V2(v2) => v2.active_validators[0].clone(),
-        _ => unimplemented!("a new IotaSystemStateSummary enum variant was added and needs to be handled"),
+        _ => unimplemented!(
+            "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+        ),
     }
     .iota_address;
 

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -254,7 +254,9 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         let active_validators = match system_state_summary {
             IotaSystemStateSummary::V1(inner) => inner.active_validators,
             IotaSystemStateSummary::V2(inner) => inner.active_validators,
-            _ => unimplemented!(),
+            _ => unimplemented!(
+                "a new IotaSystemStateSummary enum variant was added and needs to be handled"
+            ),
         };
 
         Ok(active_validators

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -1903,7 +1903,9 @@ impl IotaTestAdapter {
                     "Transaction Effects Status: {error}\n{execution_msg}",
                 )))
             }
-            _ => unimplemented!("a new ExecutionStatus enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new ExecutionStatus enum variant was added and needs to be handled"
+            ),
         }
     }
 

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -1435,7 +1435,7 @@ impl IotaTestAdapter {
                     "abstract: account must be an object representing the abstract account"
                 ));
             }
-            _ => unimplemented!("a new CallArg variant was added and needs to be handled"),
+            _ => unimplemented!("a new CallArg enum variant was added and needs to be handled"),
         };
 
         Ok((
@@ -1903,7 +1903,7 @@ impl IotaTestAdapter {
                     "Transaction Effects Status: {error}\n{execution_msg}",
                 )))
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new ExecutionStatus enum variant was added and needs to be handled"),
         }
     }
 

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -254,7 +254,9 @@ impl TryFrom<TransactionEffects> for crate::effects::TransactionEffects {
 
                 Ok(effects)
             }
-            _ => unimplemented!("a new TransactionEffects enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new TransactionEffects enum variant was added and needs to be handled"
+            ),
         }
     }
 }
@@ -497,7 +499,9 @@ impl From<CheckpointCommitment> for crate::messages_checkpoint::CheckpointCommit
                     digest: crate::digests::Digest::new(digest.into_inner()),
                 })
             }
-            _ => unimplemented!("a new CheckpointCommitment enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new CheckpointCommitment enum variant was added and needs to be handled"
+            ),
         }
     }
 }

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -203,7 +203,7 @@ impl TryFrom<TransactionEffects> for crate::effects::TransactionEffects {
                                                 (version, digest),
                                                 owner,
                                             )),
-                                            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                                            _ => unimplemented!("a new ObjectIn enum variant was added and needs to be handled"),
                                         },
                                         output_state: match obj.output_state {
                                             ObjectOut::Missing => {
@@ -221,7 +221,7 @@ impl TryFrom<TransactionEffects> for crate::effects::TransactionEffects {
                                                     digest,
                                                 ))
                                             }
-                                            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                                            _ => unimplemented!("a new ObjectOut enum variant was added and needs to be handled"),
                                         },
                                         id_operation: match obj.id_operation {
                                             IdOperation::None => crate::effects::IDOperation::None,
@@ -231,7 +231,7 @@ impl TryFrom<TransactionEffects> for crate::effects::TransactionEffects {
                                             IdOperation::Deleted => {
                                                 crate::effects::IDOperation::Deleted
                                             }
-                                            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+                                            _ => unimplemented!("a new IdOperation enum variant was added and needs to be handled"),
                                         },
                                     },
                                 )
@@ -254,7 +254,7 @@ impl TryFrom<TransactionEffects> for crate::effects::TransactionEffects {
 
                 Ok(effects)
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionEffects enum variant was added and needs to be handled"),
         }
     }
 }
@@ -497,7 +497,7 @@ impl From<CheckpointCommitment> for crate::messages_checkpoint::CheckpointCommit
                     digest: crate::digests::Digest::new(digest.into_inner()),
                 })
             }
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new CheckpointCommitment enum variant was added and needs to be handled"),
         }
     }
 }

--- a/crates/iota-types/src/programmable_transaction_builder.rs
+++ b/crates/iota-types/src/programmable_transaction_builder.rs
@@ -117,7 +117,7 @@ impl ProgrammableTransactionBuilder {
             CallArg::ImmutableOrOwned(_) | CallArg::Shared(_) | CallArg::Receiving(_) => {
                 self.obj(call_arg)
             }
-            _ => unimplemented!("a new CallArg variant was added and needs to be handled"),
+            _ => unimplemented!("a new CallArg enum variant was added and needs to be handled"),
         }
     }
 

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1260,28 +1260,28 @@ impl TransactionDataAPI for TransactionData {
     fn sender(&self) -> IotaAddress {
         match self {
             Self::V1(v1) => v1.sender,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
     fn kind(&self) -> &TransactionKind {
         match self {
             Self::V1(v1) => &v1.kind,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
     fn kind_mut(&mut self) -> &mut TransactionKind {
         match self {
             Self::V1(v1) => &mut v1.kind,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
     fn into_kind(self) -> TransactionKind {
         match self {
             Self::V1(v1) => v1.kind,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
@@ -1296,7 +1296,7 @@ impl TransactionDataAPI for TransactionData {
     fn gas_data(&self) -> &GasData {
         match self {
             Self::V1(v1) => &v1.gas_payment,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
@@ -1319,7 +1319,7 @@ impl TransactionDataAPI for TransactionData {
     fn expiration(&self) -> &TransactionExpiration {
         match self {
             Self::V1(v1) => &v1.expiration,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
@@ -1395,21 +1395,21 @@ impl TransactionDataAPI for TransactionData {
     fn sender_mut_for_testing(&mut self) -> &mut IotaAddress {
         match self {
             Self::V1(v1) => &mut v1.sender,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
     fn gas_data_mut(&mut self) -> &mut GasData {
         match self {
             Self::V1(v1) => &mut v1.gas_payment,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
     fn expiration_mut_for_testing(&mut self) -> &mut TransactionExpiration {
         match self {
             Self::V1(v1) => &mut v1.expiration,
-            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
@@ -1805,7 +1805,7 @@ impl TransactionDataAPI for TransactionData {
         match self {
             TransactionData::V1(_) => 1,
             _ => unimplemented!(
-                "a new TransactionData enum variant was added and needs to be handled"
+                "a new Transaction enum variant was added and needs to be handled"
             ),
         }
     }

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -292,7 +292,7 @@ impl CallArgExt for CallArg {
                 mutable: *mutable,
             }),
             CallArg::Pure(_) | CallArg::Receiving(_) => None,
-            _ => unimplemented!("a new CallArg variant was added and needs to be handled"),
+            _ => unimplemented!("a new CallArg enum variant was added and needs to be handled"),
         }
     }
 
@@ -310,7 +310,7 @@ impl CallArgExt for CallArg {
             CallArg::ImmutableOrOwned(_) | CallArg::Shared(_) | CallArg::Receiving(_) => {
                 // No validation needed for these variants
             }
-            _ => unimplemented!("a new CallArg variant was added and needs to be handled"),
+            _ => unimplemented!("a new CallArg enum variant was added and needs to be handled"),
         }
         Ok(())
     }
@@ -675,7 +675,7 @@ impl ProgrammableTransactionExt for ProgrammableTransaction {
         self.inputs.iter().filter_map(|arg| match arg {
             CallArg::Shared(shared) => Some(*shared),
             CallArg::Pure(_) | CallArg::Receiving(_) | CallArg::ImmutableOrOwned(_) => None,
-            _ => unimplemented!("a new CallArg variant was added and needs to be handled"),
+            _ => unimplemented!("a new CallArg enum variant was added and needs to be handled"),
         })
     }
 
@@ -1260,28 +1260,28 @@ impl TransactionDataAPI for TransactionData {
     fn sender(&self) -> IotaAddress {
         match self {
             Self::V1(v1) => v1.sender,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
     fn kind(&self) -> &TransactionKind {
         match self {
             Self::V1(v1) => &v1.kind,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
     fn kind_mut(&mut self) -> &mut TransactionKind {
         match self {
             Self::V1(v1) => &mut v1.kind,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
     fn into_kind(self) -> TransactionKind {
         match self {
             Self::V1(v1) => v1.kind,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
@@ -1296,7 +1296,7 @@ impl TransactionDataAPI for TransactionData {
     fn gas_data(&self) -> &GasData {
         match self {
             Self::V1(v1) => &v1.gas_payment,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
@@ -1319,7 +1319,7 @@ impl TransactionDataAPI for TransactionData {
     fn expiration(&self) -> &TransactionExpiration {
         match self {
             Self::V1(v1) => &v1.expiration,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
@@ -1395,21 +1395,21 @@ impl TransactionDataAPI for TransactionData {
     fn sender_mut_for_testing(&mut self) -> &mut IotaAddress {
         match self {
             Self::V1(v1) => &mut v1.sender,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
     fn gas_data_mut(&mut self) -> &mut GasData {
         match self {
             Self::V1(v1) => &mut v1.gas_payment,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
     fn expiration_mut_for_testing(&mut self) -> &mut TransactionExpiration {
         match self {
             Self::V1(v1) => &mut v1.expiration,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new TransactionData enum variant was added and needs to be handled"),
         }
     }
 
@@ -2039,7 +2039,7 @@ impl SenderSignedData {
             TransactionExpiration::None => false,
             TransactionExpiration::Epoch(exp_poch) => *exp_poch < epoch,
             _ => unimplemented!(
-                "a new TransactionExpiration variant was added and needs to be handled"
+                "a new TransactionExpiration enum variant was added and needs to be handled"
             ),
         } {
             return Err(IotaError::TransactionExpired);

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1804,9 +1804,7 @@ impl TransactionDataAPI for TransactionData {
     fn message_version(&self) -> u64 {
         match self {
             TransactionData::V1(_) => 1,
-            _ => unimplemented!(
-                "a new Transaction enum variant was added and needs to be handled"
-            ),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -794,7 +794,7 @@ impl<'a> PTBBuilder<'a> {
                                 .await
                             }
                             _ => unimplemented!(
-                                "a new enum variant was added and needs to be handled"
+                                "a new Argument enum variant was added and needs to be handled"
                             ),
                         }
                     }


### PR DESCRIPTION
## Description

Fixes https://github.com/iotaledger/iota/issues/10402

This PR improves error messages across the codebase by making `unimplemented!()` messages more specific and consistent when handling enum variants. The changes clarify which enum type is missing a handler, making it easier to debug when new variants are added to enums.

### Changes

- Updated `unimplemented!()` messages to explicitly name the enum type (e.g., `"a new CallArg enum variant was added..."` instead of generic `"a new enum variant was added..."`)
- Applied consistent message format across all files: `"a new {EnumName} enum variant was added and needs to be handled"`
- Replaced some `panic!()` calls with `unimplemented!()` for consistency (e.g., in `IotaSystemStateSummary` handling)
- Changed one `unreachable!()` to `unimplemented!()` in `ConsensusDeterminedVersionAssignments` conversion where the code path is actually reachable

### Benefits

- **Better debugging**: When a new enum variant is added and a match statement is incomplete, the error message now clearly identifies which enum needs updating
- **Consistency**: All unhandled variant messages follow the same format across the codebase
- **Maintainability**: Developers adding new enum variants can quickly identify all locations that need updates

## Test Plan

No testing needed — this is a message-only change that improves error reporting without altering behavior. All existing tests continue to pass.

https://claude.ai/code/session_01VephWxQMzvF9zhyYxEd7zQ