### PR TITLE
feat(iota-data-ingestion-core): support checkpoint filters for gRPC source

### DIFF
--- a/crates/iota-data-ingestion-core/src/errors.rs
+++ b/crates/iota-data-ingestion-core/src/errors.rs
@@ -25,7 +25,7 @@ pub enum IngestionError {
     #[error("grpc error: `{0}`")]
     Grpc(String),
 
-    #[error("Register at least one worker pool")]
+    #[error("register at least one worker pool")]
     EmptyWorkerPool,
 
     #[error("{component} shutdown error: `{msg}`")]
@@ -63,6 +63,9 @@ pub enum IngestionError {
 
     #[error(transparent)]
     Sdk(#[from] iota_types::iota_sdk_types_conversions::SdkTypeConversionError),
+
+    #[error("unsupported operation: `{0}`")]
+    Unsupported(String),
 }
 
 impl From<iota_grpc_types::proto::TryFromProtoError> for IngestionError {

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -17,6 +17,7 @@ use tracing::info;
 
 use crate::{
     DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
+    config::CheckpointReaderConfigExt,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
     reader::v2::{CheckpointReader, CheckpointReaderConfig, RemoteUrl},
     worker_pool::{WorkerPool, WorkerPoolStatus},
@@ -246,6 +247,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     ) -> IngestionResult<()> {
         self.progress_store.save(task_name, watermark).await
     }
+
     pub async fn read_watermark(
         &mut self,
         task_name: String,
@@ -261,10 +263,11 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     /// registered.
     pub async fn run_with_config(
         mut self,
-        config: CheckpointReaderConfig,
+        config: impl Into<CheckpointReaderConfigExt>,
     ) -> IngestionResult<ExecutorProgress> {
         let reader_checkpoint_number = self.progress_store.min_watermark()?;
-        let checkpoint_reader = CheckpointReader::new(reader_checkpoint_number, config).await?;
+        let checkpoint_reader =
+            CheckpointReader::new(reader_checkpoint_number, config.into()).await?;
 
         self.run_executor_loop(reader_checkpoint_number, checkpoint_reader)
             .await

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -50,7 +50,7 @@ pub use executor::{
 use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
-pub use reader::ReaderOptions;
+pub use reader::{ReaderOptions, config, filters};
 pub use reducer::Reducer;
 pub use util::{create_remote_store_client, create_remote_store_client_with_ops};
 pub use worker_pool::WorkerPool;

--- a/crates/iota-data-ingestion-core/src/reader/config.rs
+++ b/crates/iota-data-ingestion-core/src/reader/config.rs
@@ -35,23 +35,19 @@ pub use crate::{
 /// ```rust
 /// use iota_data_ingestion_core::{
 ///     ReaderOptions,
-///     filters::fullnode::{ExecutionStatusFilter, TransactionFilter},
+///     filters::fullnode::TransactionFilter,
 ///     reader::config::{CheckpointReaderConfig, CheckpointReaderConfigExt, RemoteUrl},
 /// };
 ///
-/// let filter = TransactionFilter::default()
-///     .with_execution_status(ExecutionStatusFilter::default().with_success(true));
-///
 /// let config = CheckpointReaderConfigExt::new(ReaderOptions::default())
 ///     .with_remote_store_url(RemoteUrl::Fullnode("http://127.0.0.1:50051".into()))
-///     .with_fullnode_transaction_filter(filter);
+///     .with_fullnode_transaction_filter(TransactionFilter::new().execution_status(true));
 /// ```
 /// # Example with an existing [`CheckpointReaderConfig`]
-///
 /// ```rust
 /// use iota_data_ingestion_core::{
 ///     ReaderOptions,
-///     filters::fullnode::{ExecutionStatusFilter, TransactionFilter},
+///     filters::fullnode::TransactionFilter,
 ///     reader::config::{CheckpointReaderConfig, CheckpointReaderConfigExt, RemoteUrl},
 /// };
 ///
@@ -61,10 +57,8 @@ pub use crate::{
 ///     ..Default::default()
 /// };
 ///
-/// let filter = TransactionFilter::default()
-///     .with_execution_status(ExecutionStatusFilter::default().with_success(true));
-/// let config =
-///     CheckpointReaderConfigExt::from(base_config).with_fullnode_transaction_filter(filter);
+/// let config = CheckpointReaderConfigExt::from(base_config)
+///     .with_fullnode_transaction_filter(TransactionFilter::new().execution_status(true));
 /// ```
 #[derive(Clone, Default)]
 pub struct CheckpointReaderConfigExt {

--- a/crates/iota-data-ingestion-core/src/reader/config.rs
+++ b/crates/iota-data-ingestion-core/src/reader/config.rs
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration types for the checkpoint reader.
+//!
+//! The two main types are:
+//!
+//! - [`CheckpointReaderConfig`]: the base configuration for the checkpoint
+//!   reader. Suited for most default use cases.
+//! - [`CheckpointReaderConfigExt`]: extends [`CheckpointReaderConfig`] with
+//!   opt-in configuration toggles beyond the base, such as server-side
+//!   transaction filters for fullnode connections.
+//!
+//! [`CheckpointReaderConfigExt`] wraps [`CheckpointReaderConfig`] and exposes
+//! a builder for the extra toggles. A `From<CheckpointReaderConfig>` impl is
+//! provided so existing [`CheckpointReaderConfig`] values can be converted
+//! to [`CheckpointReaderConfigExt`].
+
+use std::path::PathBuf;
+
+use crate::filters::fullnode::TransactionFilter;
+pub use crate::{
+    ReaderOptions,
+    reader::v2::{CheckpointReaderConfig, RemoteUrl},
+};
+
+/// Extends [`CheckpointReaderConfig`] with opt-in configuration toggles.
+///
+/// Use this type when you need framework features beyond what the base
+/// [`CheckpointReaderConfig`] exposes (e.g. server-side transaction filtering
+/// for fullnode connections).
+///
+/// # Example
+///
+/// ```rust
+/// use iota_data_ingestion_core::{
+///     ReaderOptions,
+///     filters::fullnode::{ExecutionStatusFilter, TransactionFilter},
+///     reader::config::{CheckpointReaderConfig, CheckpointReaderConfigExt, RemoteUrl},
+/// };
+///
+/// let filter = TransactionFilter::default()
+///     .with_execution_status(ExecutionStatusFilter::default().with_success(true));
+///
+/// let config = CheckpointReaderConfigExt::new(ReaderOptions::default())
+///     .with_remote_store_url(RemoteUrl::Fullnode("http://127.0.0.1:50051".into()))
+///     .with_fullnode_transaction_filter(filter);
+/// ```
+/// # Example with an existing [`CheckpointReaderConfig`]
+///
+/// ```rust
+/// use iota_data_ingestion_core::{
+///     ReaderOptions,
+///     filters::fullnode::{ExecutionStatusFilter, TransactionFilter},
+///     reader::config::{CheckpointReaderConfig, CheckpointReaderConfigExt, RemoteUrl},
+/// };
+///
+/// let base_config = CheckpointReaderConfig {
+///     reader_options: ReaderOptions::default(),
+///     remote_store_url: Some(RemoteUrl::Fullnode("http://127.0.0.1:50051".into())),
+///     ..Default::default()
+/// };
+///
+/// let filter = TransactionFilter::default()
+///     .with_execution_status(ExecutionStatusFilter::default().with_success(true));
+/// let config =
+///     CheckpointReaderConfigExt::from(base_config).with_fullnode_transaction_filter(filter);
+/// ```
+#[derive(Clone, Default)]
+pub struct CheckpointReaderConfigExt {
+    /// The base configuration for the checkpoint reader.
+    pub(crate) base: CheckpointReaderConfig,
+    /// Filter applied to transactions within a checkpoint.
+    pub(crate) fullnode_transaction_filter: Option<TransactionFilter>,
+}
+
+impl From<CheckpointReaderConfig> for CheckpointReaderConfigExt {
+    fn from(config: CheckpointReaderConfig) -> Self {
+        Self {
+            base: config,
+            ..Default::default()
+        }
+    }
+}
+
+impl CheckpointReaderConfigExt {
+    /// Constructs a new configuration with the given [`ReaderOptions`].
+    pub fn new(reader_options: ReaderOptions) -> Self {
+        Self {
+            base: CheckpointReaderConfig {
+                reader_options,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// Sets the local path where checkpoints will be ingested from.
+    ///
+    /// If not provided, checkpoints will be ingested from a temporary
+    /// directory.
+    pub fn with_ingestion_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.base.ingestion_path = Some(path.into());
+        self
+    }
+
+    /// Sets the remote source from which checkpoints are downloaded.
+    pub fn with_remote_store_url(mut self, url: RemoteUrl) -> Self {
+        self.base.remote_store_url = Some(url);
+        self
+    }
+
+    /// Enables server-side filtering of transactions within each checkpoint.
+    ///
+    /// When set, the remote source will only return checkpoints containing
+    /// transactions that match the provided [`TransactionFilter`].
+    ///
+    /// # Errors
+    ///
+    /// Using this filter with any source other than [`RemoteUrl::Fullnode`]
+    /// will cause the executor to return an error when started.
+    pub fn with_fullnode_transaction_filter(mut self, filter: TransactionFilter) -> Self {
+        self.fullnode_transaction_filter = Some(filter);
+        self
+    }
+}

--- a/crates/iota-data-ingestion-core/src/reader/filters/fullnode.rs
+++ b/crates/iota-data-ingestion-core/src/reader/filters/fullnode.rs
@@ -1,19 +1,868 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Server-side filtering logic for Fullnode gRPC connections.
+//! Server-side filters for fullnode gRPC connections.
 //!
-//! These filters operate at the content level (transactions and events)
-//! within each checkpoint.
-pub use iota_grpc_types::v1::{
-    filter::{
-        AddressFilter, AllEventFilter, AllTransactionFilter, AnyEventFilter, AnyTransactionFilter,
-        CommandFilter, EventFilter, ExecutionStatusFilter, MakeMoveVecCommandFilter,
-        MergeCoinsCommandFilter, MoveCallCommandFilter, MoveEventTypeFilter,
-        MovePackageAndModuleFilter, NotEventFilter, NotTransactionFilter, ObjectIdFilter,
-        PublishCommandFilter, SplitCoinsCommandFilter, TransactionFilter, TransactionKind,
-        TransactionKindsFilter, TransferObjectsCommandFilter, UpgradeCommandFilter, command_filter,
-        event_filter, transaction_filter,
-    },
-    types::{Address, ObjectId, ObjectReference},
-};
+//! Filters tell the fullnode which transactions to include in each
+//! checkpoint payload. Filtering happens entirely on the server-side, the
+//! ingestion framework performs no client-side filtering.
+//!
+//! # Filter types
+//!
+//! - [`TransactionFilter`]: applied to a checkpoint's transactions.
+//! - [`EventFilter`]: matches a transaction by its emitted events. Used as
+//!   input to [`TransactionFilter::event`].
+//! - [`CommandFilter`]: matches a command within a programmable transaction.
+//!   Used as input to [`TransactionFilter::command`].
+//!
+//! # Composition
+//!
+//! [`TransactionFilter`] and [`EventFilter`] use a chained builder pattern:
+//! each leaf method (e.g. `TransactionFilter::new().kinds().sender()`)
+//! implicitly `AND`s the new condition with everything accumulated so far.
+//! Explicit `OR` composition is available via the [`or`](TransactionFilter::or)
+//! method on each type. `NOT` is available via
+//! [`negate`](TransactionFilter::negate), the `!` operator, or `.not()` when
+//! [`std::ops::Not`] is in scope.
+//!
+//! [`CommandFilter`] is composed only at the [`TransactionFilter`] level by
+//! passing each command to [`TransactionFilter::command`] within a chain.
+//! Multiple [`command`](TransactionFilter::command) calls implicitly `AND`,
+//! while `OR` and `NOT` follow the rules described above.
+//!
+//! # Examples
+//!
+//! Successful programmable transactions:
+//!
+//! ```rust
+//! use iota_data_ingestion_core::filters::fullnode::{TransactionFilter, TransactionKind};
+//!
+//! let filter = TransactionFilter::new()
+//!     .kinds([TransactionKind::Programmable])
+//!     .execution_status(true);
+//! ```
+//!
+//! Transactions emitting a specific event type:
+//!
+//! ```rust
+//! use iota_data_ingestion_core::filters::fullnode::{EventFilter, TransactionFilter};
+//!
+//! let filter =
+//!     TransactionFilter::new().event(EventFilter::new().event_type("0xabcd::my_module::Foo"));
+//! ```
+//!
+//! Transactions NOT sent by a specific address:
+//!
+//! ```ignore
+//! let filter = !TransactionFilter::new().sender(some_address);
+//! ```
+
+use std::ops::Not;
+
+use iota_grpc_types::v1::{filter as proto, types::ObjectReference};
+use iota_types::base_types::{IotaAddress, ObjectDigest, ObjectID, SequenceNumber};
+
+/// Available transaction kinds for filtering.
+pub type TransactionKind = proto::TransactionKind;
+
+/// Filter applied to transactions in a fullnode checkpoint stream.
+///
+/// Built with a chained builder pattern. Start from [`TransactionFilter::new`]
+/// and add leaves with the named methods (e.g. [`TransactionFilter::kinds`],
+/// [`TransactionFilter::sender`], [`TransactionFilter::execution_status`]).
+///
+/// Each leaf implicitly `AND`s with everything accumulated so far. Use
+/// [`TransactionFilter::or`] for `OR` composition and
+/// [`TransactionFilter::negate`] (or the `!` operator) for `NOT`.
+///
+/// # Example
+///
+/// Implicit AND composition
+///
+/// ```rust
+/// use iota_data_ingestion_core::filters::fullnode::{TransactionFilter, TransactionKind};
+///
+/// let filter = TransactionFilter::new()
+///     .kinds([TransactionKind::Programmable])
+///     .execution_status(true);
+/// ```
+/// Composition with AND, OR and NOT:
+///
+/// ```ignore
+/// // (Programmable AND success AND sender == Alice) OR NOT(receiver == Bob)
+/// let filter = TransactionFilter::new()
+///     .kinds([TransactionKind::Programmable])
+///     .execution_status(true)
+///     .sender(alice)
+///     .or(!TransactionFilter::new().receiver(bob));
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct TransactionFilter(proto::TransactionFilter);
+
+impl TransactionFilter {
+    /// Creates an empty filter.
+    ///
+    /// An empty filter is rejected by the fullnode. Add at least one leaf via
+    /// the builder methods (e.g. [`TransactionFilter::kinds`],
+    /// [`TransactionFilter::sender`]) before passing the filter to the
+    /// ingestion framework.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use iota_data_ingestion_core::filters::fullnode::{TransactionFilter, TransactionKind};
+    ///
+    /// let filter = TransactionFilter::new().kinds([TransactionKind::Programmable]);
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pushes a leaf into self via implicit `AND`, flattening when self is
+    /// already an `All`.
+    fn and_with(self, leaf: proto::TransactionFilter) -> Self {
+        match self.0.filter {
+            None => Self(leaf),
+            Some(proto::transaction_filter::Filter::All(mut all)) => {
+                all.filters.push(leaf);
+                Self(proto::TransactionFilter::default().with_all(all))
+            }
+            Some(_) => {
+                Self(proto::TransactionFilter::default().with_all(
+                    proto::AllTransactionFilter::default().with_filters(vec![self.0, leaf]),
+                ))
+            }
+        }
+    }
+
+    /// Combines self with `leaf` via `OR`, flattening when self is already an
+    /// `Any`.
+    fn or_with(self, leaf: proto::TransactionFilter) -> Self {
+        match self.0.filter {
+            None => Self(leaf),
+            Some(proto::transaction_filter::Filter::Any(mut any)) => {
+                any.filters.push(leaf);
+                Self(proto::TransactionFilter::default().with_any(any))
+            }
+            Some(_) => {
+                Self(proto::TransactionFilter::default().with_any(
+                    proto::AnyTransactionFilter::default().with_filters(vec![self.0, leaf]),
+                ))
+            }
+        }
+    }
+
+    /// Matches transactions of any of the given [`TransactionKind`]s.
+    ///
+    /// Passing an empty iterator produces a filter that matches no
+    /// transactions (it is accepted by the fullnode but yields no results).
+    /// Pass at least one [`TransactionKind`].
+    pub fn kinds(self, kinds: impl IntoIterator<Item = TransactionKind>) -> Self {
+        let transaction_kinds_filter =
+            kinds
+                .into_iter()
+                .fold(proto::TransactionKindsFilter::default(), |mut acc, kind| {
+                    acc.push_kinds(kind);
+                    acc
+                });
+
+        self.and_with(
+            proto::TransactionFilter::default().with_transaction_kinds(transaction_kinds_filter),
+        )
+    }
+
+    /// Matches transactions by execution status.
+    ///
+    /// - `true` for successful transactions.
+    /// - `false` for failed transactions.
+    pub fn execution_status(self, success: bool) -> Self {
+        self.and_with(
+            proto::TransactionFilter::default().with_execution_status(
+                proto::ExecutionStatusFilter::default().with_success(success),
+            ),
+        )
+    }
+
+    /// Matches transactions sent by the given address.
+    pub fn sender(self, address: IotaAddress) -> Self {
+        self.and_with(
+            proto::TransactionFilter::default()
+                .with_sender(proto::AddressFilter::default().with_address(address)),
+        )
+    }
+
+    /// Matches transactions whose recipient is the given address.
+    pub fn receiver(self, address: IotaAddress) -> Self {
+        self.and_with(
+            proto::TransactionFilter::default()
+                .with_receiver(proto::AddressFilter::default().with_address(address)),
+        )
+    }
+
+    /// Matches transactions that touch the given object id.
+    pub fn affected_object(self, object_id: ObjectID) -> Self {
+        let object_ref = ObjectReference::default().with_object_id(object_id);
+        self.and_with(
+            proto::TransactionFilter::default()
+                .with_affected_object(proto::ObjectIdFilter::default().with_object_ref(object_ref)),
+        )
+    }
+
+    /// Matches transactions that touch the given object id and version.
+    pub fn affected_object_version(self, object_id: ObjectID, version: SequenceNumber) -> Self {
+        let object_ref = ObjectReference::default()
+            .with_object_id(object_id)
+            .with_version(version.as_u64());
+        self.and_with(
+            proto::TransactionFilter::default()
+                .with_affected_object(proto::ObjectIdFilter::default().with_object_ref(object_ref)),
+        )
+    }
+
+    /// Matches transactions that touch the given object digest.
+    pub fn affected_object_digest(self, object_digest: ObjectDigest) -> Self {
+        let object_ref = ObjectReference::default().with_digest(object_digest);
+        self.and_with(
+            proto::TransactionFilter::default()
+                .with_affected_object(proto::ObjectIdFilter::default().with_object_ref(object_ref)),
+        )
+    }
+
+    /// Matches transactions containing a command that satisfies the given
+    /// [`CommandFilter`].
+    pub fn command(self, filter: CommandFilter) -> Self {
+        self.and_with(proto::TransactionFilter::default().with_command(filter))
+    }
+
+    /// Matches transactions that contain at least one event satisfying the
+    /// given [`EventFilter`].
+    pub fn event(self, filter: EventFilter) -> Self {
+        self.and_with(proto::TransactionFilter::default().with_event(filter))
+    }
+
+    /// Logical `OR` with another filter.
+    pub fn or(self, other: Self) -> Self {
+        self.or_with(other.0)
+    }
+
+    /// Logical `NOT` of this filter.
+    ///
+    /// Equivalent to `!self` (via [`std::ops::Not`]).
+    ///
+    /// # Scoping
+    ///
+    /// `negate` wraps the entire filter accumulated so far, not just the most
+    /// recent leaf. This follows from the chained builder pattern: each step
+    /// transforms `self` into a new accumulated filter, and `negate` always
+    /// operates on whatever `self` represents at that point.
+    ///
+    /// The two snippets below produce different filters because of where
+    /// `negate` is placed in the chain:
+    ///
+    /// ```ignore
+    /// // (NOT kinds) AND sender(alice)
+    /// TransactionFilter::new()
+    ///     .kinds([TransactionKind::Programmable])
+    ///     .negate()
+    ///     .sender(alice);
+    ///
+    /// // NOT (kinds AND sender(alice))
+    /// TransactionFilter::new()
+    ///     .kinds([TransactionKind::Programmable])
+    ///     .sender(alice)
+    ///     .negate();
+    /// ```
+    ///
+    /// For complex expressions where the scoping is not visually obvious,
+    /// build sub-filters as named bindings and combine them with
+    /// [`TransactionFilter::or`].
+    pub fn negate(self) -> Self {
+        Self(
+            proto::TransactionFilter::default()
+                .with_negation(proto::NotTransactionFilter::default().with_filter(self.0)),
+        )
+    }
+}
+
+impl Not for TransactionFilter {
+    type Output = Self;
+    fn not(self) -> Self {
+        self.negate()
+    }
+}
+
+impl From<TransactionFilter> for proto::TransactionFilter {
+    fn from(value: TransactionFilter) -> Self {
+        value.0
+    }
+}
+
+/// Filter for commands within a programmable transaction.
+///
+/// Used as input to [`TransactionFilter::command`].
+#[derive(Clone, Debug)]
+pub struct CommandFilter(proto::CommandFilter);
+
+impl CommandFilter {
+    /// Matches any `MoveCall` to the given package.
+    pub fn move_call(package_id: ObjectID) -> Self {
+        Self(
+            proto::CommandFilter::default().with_move_call(
+                proto::MoveCallCommandFilter::default().with_package_id(package_id),
+            ),
+        )
+    }
+
+    /// Matches any `MoveCall` to the given package and module.
+    pub fn move_call_in_module(package_id: ObjectID, module: impl Into<String>) -> Self {
+        Self(
+            proto::CommandFilter::default().with_move_call(
+                proto::MoveCallCommandFilter::default()
+                    .with_package_id(package_id)
+                    .with_module(module),
+            ),
+        )
+    }
+
+    /// Matches a specific `MoveCall` to the given package, module and
+    /// function.
+    pub fn move_call_to(
+        package_id: ObjectID,
+        module: impl Into<String>,
+        function: impl Into<String>,
+    ) -> Self {
+        Self(
+            proto::CommandFilter::default().with_move_call(
+                proto::MoveCallCommandFilter::default()
+                    .with_package_id(package_id)
+                    .with_module(module)
+                    .with_function(function),
+            ),
+        )
+    }
+
+    /// Matches any `TransferObjects` command.
+    pub fn transfer_objects() -> Self {
+        Self(
+            proto::CommandFilter::default()
+                .with_transfer_objects(proto::TransferObjectsCommandFilter::default()),
+        )
+    }
+
+    /// Matches any `SplitCoins` command.
+    pub fn split_coins() -> Self {
+        Self(
+            proto::CommandFilter::default()
+                .with_split_coins(proto::SplitCoinsCommandFilter::default()),
+        )
+    }
+
+    /// Matches any `MergeCoins` command.
+    pub fn merge_coins() -> Self {
+        Self(
+            proto::CommandFilter::default()
+                .with_merge_coins(proto::MergeCoinsCommandFilter::default()),
+        )
+    }
+
+    /// Matches any `Publish` command.
+    pub fn publish() -> Self {
+        Self(proto::CommandFilter::default().with_publish(proto::PublishCommandFilter::default()))
+    }
+
+    /// Matches any `MakeMoveVec` command.
+    pub fn make_move_vec() -> Self {
+        Self(
+            proto::CommandFilter::default()
+                .with_make_move_vec(proto::MakeMoveVecCommandFilter::default()),
+        )
+    }
+
+    /// Matches any `Upgrade` command.
+    pub fn upgrade() -> Self {
+        Self(proto::CommandFilter::default().with_upgrade(proto::UpgradeCommandFilter::default()))
+    }
+
+    /// Matches an `Upgrade` command for the given package.
+    pub fn upgrade_of(package_id: ObjectID) -> Self {
+        Self(
+            proto::CommandFilter::default()
+                .with_upgrade(proto::UpgradeCommandFilter::default().with_package_id(package_id)),
+        )
+    }
+}
+
+impl From<CommandFilter> for proto::CommandFilter {
+    fn from(value: CommandFilter) -> Self {
+        value.0
+    }
+}
+
+/// Filter for events emitted by transactions.
+///
+/// Used as input to [`TransactionFilter::event`] to match transactions that
+/// contain at least one event satisfying this filter.
+///
+/// Built with a chained builder pattern. Start from [`EventFilter::new`] and
+/// add leaves with the named methods (e.g. [`EventFilter::event_type`],
+/// [`EventFilter::sender`], [`EventFilter::emitted_in`]).
+///
+/// Each leaf implicitly `AND`s with everything accumulated so far. Use
+/// [`EventFilter::or`] for `OR` composition and [`EventFilter::negate`] (or the
+/// `!` operator) for `NOT`.
+///
+/// # Example
+///
+/// ```rust
+/// use iota_data_ingestion_core::filters::fullnode::EventFilter;
+///
+/// let filter = EventFilter::new().event_type("0xabcd::my_module::Foo");
+/// ```
+///
+/// More complex composition with OR and NOT
+///
+/// ```rust,ignore
+/// use iota_data_ingestion_core::filters::fullnode::EventFilter;
+///
+/// // NOT (sender == Alice OR sender == Bob)
+/// let filter = EventFilter::new()
+///     .sender(alice)
+///     .or(EventFilter::new().sender(bob))
+///     .negate();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct EventFilter(proto::EventFilter);
+
+impl EventFilter {
+    /// Creates an empty filter.
+    ///
+    /// An empty filter is rejected by the fullnode. Add at least one leaf via
+    /// the builder methods (e.g. [`EventFilter::event_type`]) before passing
+    /// the filter to the ingestion framework.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use iota_data_ingestion_core::filters::fullnode::EventFilter;
+    ///
+    /// let filter = EventFilter::new().event_type("0xabcd::my_module::Foo");
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn and_with(self, leaf: proto::EventFilter) -> Self {
+        match self.0.filter {
+            None => Self(leaf),
+            Some(proto::event_filter::Filter::All(mut all)) => {
+                all.filters.push(leaf);
+                Self(proto::EventFilter::default().with_all(all))
+            }
+            Some(_) => Self(
+                proto::EventFilter::default()
+                    .with_all(proto::AllEventFilter::default().with_filters(vec![self.0, leaf])),
+            ),
+        }
+    }
+
+    fn or_with(self, leaf: proto::EventFilter) -> Self {
+        match self.0.filter {
+            None => Self(leaf),
+            Some(proto::event_filter::Filter::Any(mut any)) => {
+                any.filters.push(leaf);
+                Self(proto::EventFilter::default().with_any(any))
+            }
+            Some(_) => Self(
+                proto::EventFilter::default()
+                    .with_any(proto::AnyEventFilter::default().with_filters(vec![self.0, leaf])),
+            ),
+        }
+    }
+
+    /// Matches events whose enclosing transaction was sent by the given
+    /// address.
+    pub fn sender(self, address: IotaAddress) -> Self {
+        self.and_with(
+            proto::EventFilter::default()
+                .with_sender(proto::AddressFilter::default().with_address(address)),
+        )
+    }
+
+    /// Matches events emitted by a transaction whose top-level `MoveCall`
+    /// targets the given package.
+    ///
+    /// This matches the package the event was *emitted from*,
+    /// not where the event struct is defined. For the latter, use
+    /// [`EventFilter::defined_in`] / [`EventFilter::defined_in_module`].
+    pub fn emitted_in(self, package_id: ObjectID) -> Self {
+        self.and_with(proto::EventFilter::default().with_move_package_and_module(
+            proto::MovePackageAndModuleFilter::default().with_package_id(package_id),
+        ))
+    }
+
+    /// Matches events emitted by a transaction whose top-level `MoveCall`
+    /// targets the given package and module.
+    ///
+    /// This matches the package and module the event was *emitted from*,
+    /// not where the event struct is defined. For the latter, use
+    /// [`EventFilter::defined_in`] / [`EventFilter::defined_in_module`].
+    pub fn emitted_in_module(self, package_id: ObjectID, module: impl Into<String>) -> Self {
+        self.and_with(
+            proto::EventFilter::default().with_move_package_and_module(
+                proto::MovePackageAndModuleFilter::default()
+                    .with_package_id(package_id)
+                    .with_module(module),
+            ),
+        )
+    }
+
+    /// Matches events whose struct is defined in the given package.
+    ///
+    /// This matches the package the event struct is *defined
+    /// in*, not where it was emitted from. For the latter, use
+    /// [`EventFilter::emitted_in`] / [`EventFilter::emitted_in_module`].
+    pub fn defined_in(self, package_id: ObjectID) -> Self {
+        self.and_with(
+            proto::EventFilter::default().with_move_event_package_and_module(
+                proto::MovePackageAndModuleFilter::default().with_package_id(package_id),
+            ),
+        )
+    }
+
+    /// Matches events whose struct is defined in the given package and module.
+    ///
+    /// This matches the package and module the event struct is *defined
+    /// in*, not where it was emitted from. For the latter, use
+    /// [`EventFilter::emitted_in`] / [`EventFilter::emitted_in_module`].
+    pub fn defined_in_module(self, package_id: ObjectID, module: impl Into<String>) -> Self {
+        self.and_with(
+            proto::EventFilter::default().with_move_event_package_and_module(
+                proto::MovePackageAndModuleFilter::default()
+                    .with_package_id(package_id)
+                    .with_module(module),
+            ),
+        )
+    }
+
+    /// Matches events with the given Move event struct tag (e.g.
+    /// `"0xabcd::my_module::Foo"`).
+    pub fn event_type(self, struct_tag: impl Into<String>) -> Self {
+        self.and_with(proto::EventFilter::default().with_move_event_type(
+            proto::MoveEventTypeFilter::default().with_struct_tag(struct_tag),
+        ))
+    }
+
+    /// Logical `OR` with another filter.
+    pub fn or(self, other: Self) -> Self {
+        self.or_with(other.0)
+    }
+
+    /// Logical `NOT` of this filter.
+    ///
+    /// Equivalent to `!self` (via [`std::ops::Not`]).
+    ///
+    /// # Scoping
+    ///
+    /// `negate` wraps the entire filter accumulated so far, not just the most
+    /// recent leaf. This follows from the chained builder pattern: each step
+    /// transforms `self` into a new accumulated filter, and `negate` always
+    /// operates on whatever `self` represents at that point.
+    ///
+    /// The two snippets below produce different filters because of where
+    /// `negate` is placed in the chain:
+    ///
+    /// ```rust,ignore
+    /// use iota_data_ingestion_core::filters::fullnode::EventFilter;
+    ///
+    /// // (NOT event_type Foo) AND sender(alice)
+    /// EventFilter::new()
+    ///     .event_type("0xabcd::my_module::Foo")
+    ///     .negate()
+    ///     .sender(alice);
+    ///
+    /// // NOT (event_type Foo AND sender(alice))
+    /// EventFilter::new()
+    ///     .event_type("0xabcd::my_module::Foo")
+    ///     .sender(alice)
+    ///     .negate();
+    /// ```
+    ///
+    /// For complex expressions where the scoping is not visually obvious,
+    /// build sub-filters as named bindings and combine them with
+    /// [`EventFilter::or`].
+    pub fn negate(self) -> Self {
+        Self(
+            proto::EventFilter::default()
+                .with_negation(proto::NotEventFilter::default().with_filter(self.0)),
+        )
+    }
+}
+
+impl Not for EventFilter {
+    type Output = Self;
+    fn not(self) -> Self {
+        self.negate()
+    }
+}
+
+impl From<EventFilter> for proto::EventFilter {
+    fn from(value: EventFilter) -> Self {
+        value.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::reader::filters::fullnode::*;
+
+    #[test]
+    fn and_chain_flattens() {
+        let f = TransactionFilter::new()
+            .kinds([TransactionKind::Programmable])
+            .execution_status(true)
+            .sender(IotaAddress::ZERO);
+
+        let expected = proto::TransactionFilter::default().with_all(
+            proto::AllTransactionFilter::default().with_filters(vec![
+                proto::TransactionFilter::default().with_transaction_kinds({
+                    let mut k = proto::TransactionKindsFilter::default();
+                    k.push_kinds(proto::TransactionKind::Programmable);
+                    k
+                }),
+                proto::TransactionFilter::default().with_execution_status(
+                    proto::ExecutionStatusFilter::default().with_success(true),
+                ),
+                proto::TransactionFilter::default()
+                    .with_sender(proto::AddressFilter::default().with_address(IotaAddress::ZERO)),
+            ]),
+        );
+
+        assert_eq!(proto::TransactionFilter::from(f), expected);
+    }
+
+    #[test]
+    fn or_chain_flattens() {
+        let f = TransactionFilter::new()
+            .sender(IotaAddress::ZERO)
+            .or(TransactionFilter::new().sender(IotaAddress::ZERO))
+            .or(TransactionFilter::new().sender(IotaAddress::ZERO));
+
+        let expected = proto::TransactionFilter::default().with_any(
+            proto::AnyTransactionFilter::default().with_filters(vec![
+                proto::TransactionFilter::default()
+                    .with_sender(proto::AddressFilter::default().with_address(IotaAddress::ZERO)),
+                proto::TransactionFilter::default()
+                    .with_sender(proto::AddressFilter::default().with_address(IotaAddress::ZERO)),
+                proto::TransactionFilter::default()
+                    .with_sender(proto::AddressFilter::default().with_address(IotaAddress::ZERO)),
+            ]),
+        );
+
+        assert_eq!(proto::TransactionFilter::from(f), expected);
+    }
+
+    #[test]
+    fn negation_wraps_filter() {
+        let f = !TransactionFilter::new().sender(IotaAddress::ZERO);
+
+        let expected = proto::TransactionFilter::default().with_negation(
+            proto::NotTransactionFilter::default().with_filter(
+                proto::TransactionFilter::default()
+                    .with_sender(proto::AddressFilter::default().with_address(IotaAddress::ZERO)),
+            ),
+        );
+
+        assert_eq!(proto::TransactionFilter::from(f), expected);
+    }
+
+    #[test]
+    fn complex_nested_composition_matches_proto() {
+        let pkg = ObjectID::ZERO;
+        let alice = IotaAddress::ZERO;
+        let bob = IotaAddress::ZERO;
+
+        // (Programmable AND success AND command(MoveCall pkg::events))
+        // OR (sender(alice) AND event(event_type OR emitted_in_module))
+        // OR NOT(receiver(bob))
+        let wrapper = TransactionFilter::new()
+            .kinds([TransactionKind::Programmable])
+            .execution_status(true)
+            .command(CommandFilter::move_call_in_module(pkg, "events"))
+            .or(TransactionFilter::new().sender(alice).event(
+                EventFilter::new()
+                    .event_type("0x1::events::Foo")
+                    .or(EventFilter::new().emitted_in_module(pkg, "events")),
+            ))
+            .or(!TransactionFilter::new().receiver(bob));
+
+        let expected = proto::TransactionFilter::default().with_any(
+            proto::AnyTransactionFilter::default().with_filters(vec![
+                // Branch 1: ALL [kinds, success, command]
+                proto::TransactionFilter::default().with_all(
+                    proto::AllTransactionFilter::default().with_filters(vec![
+                        proto::TransactionFilter::default().with_transaction_kinds({
+                            let mut k = proto::TransactionKindsFilter::default();
+                            k.push_kinds(proto::TransactionKind::Programmable);
+                            k
+                        }),
+                        proto::TransactionFilter::default().with_execution_status(
+                            proto::ExecutionStatusFilter::default().with_success(true),
+                        ),
+                        proto::TransactionFilter::default().with_command(
+                            proto::CommandFilter::default().with_move_call(
+                                proto::MoveCallCommandFilter::default()
+                                    .with_package_id(pkg)
+                                    .with_module("events"),
+                            ),
+                        ),
+                    ]),
+                ),
+                // Branch 2: ALL [sender, event(Any[event_type, emitted_in_module])]
+                proto::TransactionFilter::default().with_all(
+                    proto::AllTransactionFilter::default().with_filters(vec![
+                        proto::TransactionFilter::default()
+                            .with_sender(proto::AddressFilter::default().with_address(alice)),
+                        proto::TransactionFilter::default().with_event(
+                            proto::EventFilter::default().with_any(
+                                proto::AnyEventFilter::default().with_filters(vec![
+                                    proto::EventFilter::default().with_move_event_type(
+                                        proto::MoveEventTypeFilter::default()
+                                            .with_struct_tag("0x1::events::Foo"),
+                                    ),
+                                    proto::EventFilter::default().with_move_package_and_module(
+                                        proto::MovePackageAndModuleFilter::default()
+                                            .with_package_id(pkg)
+                                            .with_module("events"),
+                                    ),
+                                ]),
+                            ),
+                        ),
+                    ]),
+                ),
+                // Branch 3: NOT receiver(bob)
+                proto::TransactionFilter::default().with_negation(
+                    proto::NotTransactionFilter::default().with_filter(
+                        proto::TransactionFilter::default()
+                            .with_receiver(proto::AddressFilter::default().with_address(bob)),
+                    ),
+                ),
+            ]),
+        );
+
+        assert_eq!(proto::TransactionFilter::from(wrapper), expected);
+    }
+
+    #[test]
+    fn negate_in_middle_negates_only_accumulated() {
+        // .kinds().negate().execution_status() => (NOT kinds) AND status
+        let f = TransactionFilter::new()
+            .kinds([TransactionKind::Programmable])
+            .negate()
+            .execution_status(true);
+
+        let kinds_leaf = proto::TransactionFilter::default().with_transaction_kinds({
+            let mut k = proto::TransactionKindsFilter::default();
+            k.push_kinds(proto::TransactionKind::Programmable);
+            k
+        });
+        let status_leaf = proto::TransactionFilter::default()
+            .with_execution_status(proto::ExecutionStatusFilter::default().with_success(true));
+        let negated_kinds = proto::TransactionFilter::default()
+            .with_negation(proto::NotTransactionFilter::default().with_filter(kinds_leaf));
+        let expected = proto::TransactionFilter::default().with_all(
+            proto::AllTransactionFilter::default().with_filters(vec![negated_kinds, status_leaf]),
+        );
+
+        assert_eq!(proto::TransactionFilter::from(f), expected);
+    }
+
+    #[test]
+    fn negate_at_end_wraps_full_chain() {
+        // .kinds().execution_status().negate() => NOT (kinds AND status)
+        let f = TransactionFilter::new()
+            .kinds([TransactionKind::Programmable])
+            .execution_status(true)
+            .negate();
+
+        let kinds_leaf = proto::TransactionFilter::default().with_transaction_kinds({
+            let mut k = proto::TransactionKindsFilter::default();
+            k.push_kinds(proto::TransactionKind::Programmable);
+            k
+        });
+        let status_leaf = proto::TransactionFilter::default()
+            .with_execution_status(proto::ExecutionStatusFilter::default().with_success(true));
+        let all_filter = proto::TransactionFilter::default().with_all(
+            proto::AllTransactionFilter::default().with_filters(vec![kinds_leaf, status_leaf]),
+        );
+        let expected = proto::TransactionFilter::default()
+            .with_negation(proto::NotTransactionFilter::default().with_filter(all_filter));
+
+        assert_eq!(proto::TransactionFilter::from(f), expected);
+    }
+
+    #[test]
+    fn negate_method_and_not_operator_are_equivalent() {
+        // .negate() and !filter must produce the same proto.
+        use std::ops::Not;
+
+        let via_method = TransactionFilter::new().sender(IotaAddress::ZERO).negate();
+        let via_operator = TransactionFilter::new().sender(IotaAddress::ZERO).not();
+
+        assert_eq!(
+            proto::TransactionFilter::from(via_method),
+            proto::TransactionFilter::from(via_operator),
+        );
+    }
+
+    #[test]
+    fn negate_after_or_wraps_the_or() {
+        // .sender(a).or(.sender(b)).negate() => NOT (sender(a) OR sender(b))
+        let f = TransactionFilter::new()
+            .sender(IotaAddress::ZERO)
+            .or(TransactionFilter::new().sender(IotaAddress::ZERO))
+            .negate();
+
+        let inner_any = proto::TransactionFilter::default().with_any(
+            proto::AnyTransactionFilter::default().with_filters(vec![
+                proto::TransactionFilter::default()
+                    .with_sender(proto::AddressFilter::default().with_address(IotaAddress::ZERO)),
+                proto::TransactionFilter::default()
+                    .with_sender(proto::AddressFilter::default().with_address(IotaAddress::ZERO)),
+            ]),
+        );
+        let expected = proto::TransactionFilter::default()
+            .with_negation(proto::NotTransactionFilter::default().with_filter(inner_any));
+
+        assert_eq!(proto::TransactionFilter::from(f), expected);
+    }
+
+    #[test]
+    fn continue_chaining_after_negate() {
+        // .negate() returns a TransactionFilter that can be further chained.
+        // Confirms that the post-negate self acts as a normal accumulator.
+        let f = TransactionFilter::new()
+            .sender(IotaAddress::ZERO)
+            .negate() // wraps sender in Negation
+            .execution_status(true) // ANDs status on top
+            .receiver(IotaAddress::ZERO); // ANDs receiver on top
+
+        // Expected: All([Negation(sender), status, receiver])
+        let sender_leaf = proto::TransactionFilter::default()
+            .with_sender(proto::AddressFilter::default().with_address(IotaAddress::ZERO));
+        let negated_sender = proto::TransactionFilter::default()
+            .with_negation(proto::NotTransactionFilter::default().with_filter(sender_leaf));
+        let status_leaf = proto::TransactionFilter::default()
+            .with_execution_status(proto::ExecutionStatusFilter::default().with_success(true));
+        let receiver_leaf = proto::TransactionFilter::default()
+            .with_receiver(proto::AddressFilter::default().with_address(IotaAddress::ZERO));
+        let expected = proto::TransactionFilter::default().with_all(
+            proto::AllTransactionFilter::default().with_filters(vec![
+                negated_sender,
+                status_leaf,
+                receiver_leaf,
+            ]),
+        );
+
+        assert_eq!(proto::TransactionFilter::from(f), expected);
+    }
+}

--- a/crates/iota-data-ingestion-core/src/reader/filters/fullnode.rs
+++ b/crates/iota-data-ingestion-core/src/reader/filters/fullnode.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Server-side filtering logic for Fullnode gRPC connections.
+//!
+//! These filters operate at the content level (transactions and events)
+//! within each checkpoint.
+pub use iota_grpc_types::v1::{
+    filter::{
+        AddressFilter, AllEventFilter, AllTransactionFilter, AnyEventFilter, AnyTransactionFilter,
+        CommandFilter, EventFilter, ExecutionStatusFilter, MakeMoveVecCommandFilter,
+        MergeCoinsCommandFilter, MoveCallCommandFilter, MoveEventTypeFilter,
+        MovePackageAndModuleFilter, NotEventFilter, NotTransactionFilter, ObjectIdFilter,
+        PublishCommandFilter, SplitCoinsCommandFilter, TransactionFilter, TransactionKind,
+        TransactionKindsFilter, TransferObjectsCommandFilter, UpgradeCommandFilter, command_filter,
+        event_filter, transaction_filter,
+    },
+    types::{Address, ObjectId, ObjectReference},
+};

--- a/crates/iota-data-ingestion-core/src/reader/filters/mod.rs
+++ b/crates/iota-data-ingestion-core/src/reader/filters/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types and utilities for checkpoint filtering.
+//!
+//! These filters allow consumers to reduce network load by requesting only
+//! specific data from remote sources.
+
+pub mod fullnode;

--- a/crates/iota-data-ingestion-core/src/reader/mod.rs
+++ b/crates/iota-data-ingestion-core/src/reader/mod.rs
@@ -1,8 +1,12 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! Types and utilities for fetching checkpoints from local and remote sources.
+
 pub(crate) mod common;
+pub mod config;
 pub(crate) mod fetch;
+pub mod filters;
 pub mod v2;
 
 pub use common::ReaderOptions;

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -33,7 +33,9 @@ use tracing::{debug, error, info};
 #[cfg(not(target_os = "macos"))]
 use crate::reader::fetch::init_watcher;
 use crate::{
-    IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, create_remote_store_client,
+    IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS,
+    config::CheckpointReaderConfigExt,
+    create_remote_store_client,
     history::reader::HistoricalReader,
     reader::{
         ReaderOptions,
@@ -41,6 +43,7 @@ use crate::{
         fetch::{
             GRPC_MAX_DECODING_MESSAGE_SIZE_BYTES, LocalRead, ReadSource, fetch_from_object_store,
         },
+        filters::fullnode::TransactionFilter,
     },
 };
 
@@ -196,6 +199,8 @@ struct CheckpointReaderActor {
     reader_options: ReaderOptions,
     /// Limit the amount of downloaded checkpoints held in memory to avoid OOM.
     data_limiter: DataLimiter,
+    /// Filter applied to transactions within a checkpoint.
+    fullnode_transaction_filter: Option<TransactionFilter>,
 }
 
 impl LocalRead for CheckpointReaderActor {
@@ -324,7 +329,7 @@ impl CheckpointReaderActor {
                 Some(self.current_checkpoint_number),
                 None,
                 Some(iota_grpc_client::CHECKPOINT_RESPONSE_CHECKPOINT_DATA.into()),
-                None,
+                self.fullnode_transaction_filter.clone(),
                 None,
             )
             .await
@@ -550,17 +555,25 @@ pub(crate) struct CheckpointReader {
 impl CheckpointReader {
     pub(crate) async fn new(
         starting_checkpoint_number: CheckpointSequenceNumber,
-        config: CheckpointReaderConfig,
+        config: CheckpointReaderConfigExt,
     ) -> IngestionResult<Self> {
+        if config.fullnode_transaction_filter.is_some()
+            && !matches!(config.base.remote_store_url, Some(RemoteUrl::Fullnode(_)))
+        {
+            return Err(IngestionError::Unsupported(
+                "filter is only supported on `RemoteUrl::Fullnode` connections".into(),
+            ));
+        }
+
         let (checkpoint_tx, checkpoint_rx) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (gc_signal_tx, gc_signal_rx) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
 
-        let remote_store = if let Some(url) = config.remote_store_url {
+        let remote_store = if let Some(url) = config.base.remote_store_url {
             Some(Arc::new(
                 RemoteStore::new(
                     url,
-                    config.reader_options.batch_size,
-                    config.reader_options.timeout_secs,
+                    config.base.reader_options.batch_size,
+                    config.base.reader_options.timeout_secs,
                 )
                 .await?,
             ))
@@ -568,7 +581,7 @@ impl CheckpointReader {
             None
         };
 
-        let path = match config.ingestion_path {
+        let path = match config.base.ingestion_path {
             Some(p) => p,
             None => tempfile::tempdir()?.keep(),
         };
@@ -581,8 +594,9 @@ impl CheckpointReader {
             gc_signal_rx,
             remote_store,
             token: token.clone(),
-            data_limiter: DataLimiter::new(config.reader_options.data_limit),
-            reader_options: config.reader_options,
+            data_limiter: DataLimiter::new(config.base.reader_options.data_limit),
+            reader_options: config.base.reader_options,
+            fullnode_transaction_filter: config.fullnode_transaction_filter,
         };
 
         let handle = spawn_monitored_task!(reader.run());

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -329,7 +329,7 @@ impl CheckpointReaderActor {
                 Some(self.current_checkpoint_number),
                 None,
                 Some(iota_grpc_client::CHECKPOINT_RESPONSE_CHECKPOINT_DATA.into()),
-                self.fullnode_transaction_filter.clone(),
+                self.fullnode_transaction_filter.clone().map(Into::into),
                 None,
             )
             .await

--- a/crates/iota-data-ingestion-core/src/reducer.rs
+++ b/crates/iota-data-ingestion-core/src/reducer.rs
@@ -114,14 +114,23 @@ pub trait Reducer<Mapper: Worker>: Send + Sync {
 
     /// Determines if the current batch should be closed and committed.
     ///
-    /// This method is called for each new message to determine if the current
-    /// batch should be committed before adding the new message.
+    /// This method is called by the framework in two situations:
+    ///
+    /// - **`next_item = Some(msg)`**: a new message is about to be added to the
+    ///   batch. Returning `true` triggers a commit of the existing batch first.
+    ///   The `msg` is added to a new batch. Returning `false` appends `msg` to
+    ///   the current batch without committing.
+    ///
+    /// - **`next_item = None`**: the current chunk from the upstream stream has
+    ///   been fully consumed and there are no more messages to add in this
+    ///   iteration (the stream itself may still produce more chunks later).
+    ///   Returning `true` flushes the partial batch. Returning `false` leaves
+    ///   the batch in memory until the next chunk arrives.
     ///
     /// # Default Implementation
     ///
-    /// By default, returns `true` only when there are no more messages
-    /// (`next_item` is `None`), effectively creating a single batch for all
-    /// messages.
+    /// Returns `true` only when `next_item` is `None`, so each chunk's
+    /// remaining batch is flushed at the chunk boundary.
     fn should_close_batch(
         &self,
         _batch: &[Mapper::Message],
@@ -154,7 +163,7 @@ pub trait Reducer<Mapper: Worker>: Send + Sync {
 pub(crate) async fn reduce<W: Worker>(
     task_name: String,
     mut current_checkpoint_number: CheckpointSequenceNumber,
-    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, Option<W::Message>)>,
     executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
     reducer: Box<dyn Reducer<W>>,
     backoff: Arc<ExponentialBackoff>,
@@ -180,7 +189,15 @@ pub(crate) async fn reduce<W: Worker>(
         unprocessed.extend(update_batch);
         // Process messages sequentially based on checkpoint sequence number.
         // This ensures in-order processing and maintains progress integrity.
-        while let Some(message) = unprocessed.remove(&current_checkpoint_number) {
+        while let Some(maybe_worker_message) = unprocessed.remove(&current_checkpoint_number) {
+            let Some(message) = maybe_worker_message else {
+                current_checkpoint_number += 1;
+                if batch.is_empty() {
+                    progress_update = Some(current_checkpoint_number);
+                }
+                continue;
+            };
+
             // reducer is configured, collect messages in batch based on
             // `reducer.should_close_batch` policy, once a batch is collected it gets
             // committed and a new batch is created with the current message.

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -44,9 +44,14 @@ pub enum WorkerPoolStatus {
 #[derive(Debug, Clone, Copy)]
 enum WorkerStatus<M> {
     /// Message with information (e.g. `(<worker-id>`,
-    /// `checkpoint_sequence_number`, [`Worker::Message`]) about the ingestion
-    /// progress.
-    Running((WorkerID, CheckpointSequenceNumber, M)),
+    /// `checkpoint_sequence_number`, Option<[`Worker::Message`]>) about the
+    /// ingestion progress.
+    ///
+    /// The `Option<M>` is used to indicate that the worker skipped
+    /// processing the checkpoint. Useful for filtered checkpoints where non
+    /// matching checkpoints should not be forwarded to worker. In this case the
+    /// `checkpoint_sequence_number` is needed to track the progress.
+    Running((WorkerID, CheckpointSequenceNumber, Option<M>)),
     /// Message with information (e.g. `<worker-id>`) about shutdown status.
     Shutdown(WorkerID),
 }
@@ -279,7 +284,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
         let (watermark_sender, watermark_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let mut idle: BTreeSet<_> = (0..self.concurrency).collect();
         let mut checkpoints = VecDeque::new();
-        let mut workers_shutdown_signals = vec![];
+        let mut workers_shutdown_signals = Vec::with_capacity(self.concurrency);
         let (workers, workers_join_handles) = self.spawn_workers(progress_sender, token.clone());
         // Spawn a task that tracks checkpoint processing progress. The task:
         // - Receives (checkpoint_number, message) pairs from workers.
@@ -328,10 +333,14 @@ impl<W: Worker + 'static> WorkerPool<W> {
                     if sequence_number < watermark {
                         continue;
                     }
-                    self.worker
-                        .preprocess_hook(checkpoint.clone())
-                        .map_err(|err| IngestionError::CheckpointHookProcessing(err.to_string()))
-                        .expect("failed to preprocess task");
+
+                    if !Self::should_skip_filtered_checkpoint(&checkpoint) {
+                        self.worker
+                            .preprocess_hook(checkpoint.clone())
+                            .map_err(|err| IngestionError::CheckpointHookProcessing(err.to_string()))
+                            .expect("failed to preprocess task");
+                    }
+
                     if idle.is_empty() {
                         checkpoints.push_back(checkpoint);
                     } else {
@@ -390,9 +399,12 @@ impl<W: Worker + 'static> WorkerPool<W> {
                         },
                         Some(checkpoint) = worker_recv.recv() => {
                             let sequence_number = checkpoint.checkpoint_summary.sequence_number;
-                            info!("received checkpoint for processing {} for workflow {}", sequence_number, task_name);
+                            info!("received checkpoint for processing {sequence_number} for workflow {task_name}", );
                             let start_time = Instant::now();
                             let status = Self::process_checkpoint_with_retry(worker_id, &worker, checkpoint, reset_backoff(&backoff), &token).await;
+                            if matches!(status, WorkerStatus::Running((_,_, None))) {
+                                info!("checkpoint {sequence_number} for workflow {task_name} filtered out");
+                            }
                             let trigger_shutdown = matches!(status, WorkerStatus::Shutdown(_));
                             if cloned_progress_sender.send(status).await.is_err() || trigger_shutdown {
                                 break;
@@ -409,6 +421,18 @@ impl<W: Worker + 'static> WorkerPool<W> {
             workers_join_handles.push(join_handle);
         }
         (worker_senders, workers_join_handles)
+    }
+
+    /// Returns `true` if the checkpoint was entirely stripped of its
+    /// transactions by a server-side filter, indicating a filtered-out
+    /// checkpoint.
+    ///
+    /// The fullnode's gRPC `stream_checkpoints` endpoint applies configured
+    /// `TransactionFilter`s to the expanded `transactions` payload but
+    /// leaves `checkpoint_contents` (the list of all transaction digests in
+    /// the original checkpoint) completely untouched.
+    fn should_skip_filtered_checkpoint(checkpoint: &CheckpointData) -> bool {
+        !checkpoint.checkpoint_contents.inner().is_empty() && checkpoint.transactions.is_empty()
     }
 
     /// Attempts to process a checkpoint with exponential backoff retries on
@@ -442,14 +466,26 @@ impl<W: Worker + 'static> WorkerPool<W> {
         token: &CancellationToken,
     ) -> WorkerStatus<W::Message> {
         let sequence_number = checkpoint.checkpoint_summary.sequence_number;
+
+        if Self::should_skip_filtered_checkpoint(&checkpoint) {
+            return if token.is_cancelled() {
+                WorkerStatus::Shutdown(worker_id)
+            } else {
+                WorkerStatus::Running((worker_id, sequence_number, None))
+            };
+        }
+
         loop {
             // check for cancellation before attempting processing.
             if token.is_cancelled() {
                 return WorkerStatus::Shutdown(worker_id);
             }
+
             // attempt to process checkpoint.
             match worker.process_checkpoint(checkpoint.clone()).await {
-                Ok(message) => return WorkerStatus::Running((worker_id, sequence_number, message)),
+                Ok(message) => {
+                    return WorkerStatus::Running((worker_id, sequence_number, Some(message)));
+                }
                 Err(err) => {
                     let err = IngestionError::CheckpointProcessing(err.to_string());
                     warn!(
@@ -491,7 +527,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
     fn spawn_watermark_tracking(
         &mut self,
         watermark: CheckpointSequenceNumber,
-        watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+        watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, Option<W::Message>)>,
         executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
         token: CancellationToken,
     ) -> JoinHandle<Result<(), IngestionError>> {
@@ -527,7 +563,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
         workers_join_handles: Vec<JoinHandle<()>>,
         watermark_handle: JoinHandle<Result<(), IngestionError>>,
         executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
-        watermark_sender: mpsc::Sender<(u64, <W as Worker>::Message)>,
+        watermark_sender: mpsc::Sender<(CheckpointSequenceNumber, Option<<W as Worker>::Message>)>,
     ) {
         for worker in workers_join_handles {
             _ = worker
@@ -556,7 +592,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
 async fn simple_watermark_tracking<W: Worker>(
     task_name: String,
     mut current_checkpoint_number: CheckpointSequenceNumber,
-    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, Option<W::Message>)>,
     executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
 ) -> IngestionResult<()> {
     // convert to a stream of MAX_CHECKPOINTS_IN_PROGRESS size. This way, each


### PR DESCRIPTION
# Description of change

This PR implements the feature of supporting filtered checkpoints for the fullnode's gRPC checkpoint stream source.

- #11436
- #11476
- #11560

## Links to any relevant issues

fixes #11418 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

- Consult the squashed commits for further information on testing.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This patch does not affect the normal operation of the index, thus no further tests were conducted.

### Release Notes

- [x] Indexer: `iota-data-ingestion-core`: support filtered checkpoints for fullnode remote source (`RemoteUrl::Fullnode`). Filters can be provided through the `CheckpointReaderConfigExt::with_fullnode_transaction_filter`. For more information consult the  `iota-data-ingestion-core::{config, reader::filters}` module documentation.
