### PR TITLE
feat(iota-core,starfish-core): expose validator scoring metrics

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -310,6 +310,9 @@ pub struct AuthorityMetrics {
     pub consensus_calculated_throughput: IntGauge,
     pub consensus_calculated_throughput_profile: IntGauge,
 
+    pub validator_scoreboard_scores: IntGaugeVec,
+    pub invalid_misbehavior_reports_by_authority: IntGaugeVec,
+
     pub limits_metrics: Arc<LimitsMetrics>,
 
     /// bytecode verifier metrics for tracking timeouts
@@ -683,6 +686,18 @@ impl AuthorityMetrics {
                 &["authority"],
                 registry,
             ).unwrap(),
+            validator_scoreboard_scores: register_int_gauge_vec_with_registry!(
+                "validator_scoreboard_scores",
+                "Per-authority validator scores published by the local Scoreboard after each consensus commit. Range [0, MAX_SCORE].",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            invalid_misbehavior_reports_by_authority: register_int_gauge_vec_with_registry!(
+                "invalid_misbehavior_reports_by_authority",
+                "Cumulative count of invalid misbehavior reports received from each reporting authority in the current epoch. Bumped when a `MisbehaviorReport` consensus transaction fails sender/authority match or payload validation. Snapshot republished after each consensus commit.",
+                &["authority"],
+                registry,
+            ).unwrap(),
             consensus_handler_deferred_transactions: register_int_counter_with_registry!(
                 "consensus_handler_deferred_transactions",
                 "Number of transactions deferred by consensus handler",
@@ -757,6 +772,8 @@ impl AuthorityMetrics {
     pub fn reset_on_reconfigure(&self) {
         self.consensus_committed_messages.reset();
         self.consensus_handler_scores.reset();
+        self.validator_scoreboard_scores.reset();
+        self.invalid_misbehavior_reports_by_authority.reset();
         self.consensus_committed_user_transactions.reset();
     }
 }

--- a/crates/iota-core/src/authority/report_aggregator.rs
+++ b/crates/iota-core/src/authority/report_aggregator.rs
@@ -107,6 +107,16 @@ impl ReportAggregator {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Per-authority snapshot of the cumulative invalid-report counts, indexed
+    /// by consensus `AuthorityIndex`. Used by the consensus handler to publish
+    /// the corresponding Prometheus gauge with hostname labels.
+    pub(crate) fn invalid_reports_counts(&self) -> Vec<u64> {
+        self.received_reports_state
+            .iter()
+            .map(|s| s.invalid_reports_count.load(Ordering::Relaxed))
+            .collect()
+    }
+
     #[cfg(test)]
     pub(crate) fn received_reports_state_per_authority_snapshot(
         &self,

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -158,6 +158,11 @@ impl<C> ConsensusHandler<C> {
         }
         let transaction_scheduler =
             AsyncTransactionScheduler::start(transaction_manager, epoch_store.clone());
+
+        // Seed the gauges so series exist from epoch start, not only after the
+        // first commit.
+        publish_scoring_gauges(&epoch_store, &committee, &metrics);
+
         Self {
             epoch_store,
             last_consensus_stats,
@@ -399,6 +404,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             .await
             .expect("Unrecoverable error in consensus handler");
 
+        publish_scoring_gauges(&self.epoch_store, &self.committee, &self.metrics);
+
         fail_point_if!("correlated-crash-after-consensus-commit-boundary", || {
             let key = [commit_sub_dag_index, self.epoch_store.epoch()];
             if iota_simulator::random::deterministic_probability_once(key, 0.01) {
@@ -411,6 +418,32 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         self.transaction_scheduler
             .schedule(transactions_to_schedule)
             .await;
+    }
+}
+
+/// Publishes the per-authority validator-scoring gauges sourced from
+/// `Scoreboard` and `ReportAggregator`. No-op when validator scores are
+/// disabled by protocol config.
+fn publish_scoring_gauges(
+    epoch_store: &AuthorityPerEpochStore,
+    committee: &ConsensusCommittee,
+    metrics: &AuthorityMetrics,
+) {
+    if !epoch_store.protocol_config().calculate_validator_scores() {
+        return;
+    }
+    let scores = epoch_store.scoreboard.current_scores();
+    let invalid_reports = epoch_store.report_aggregator.invalid_reports_counts();
+    for (i, authority) in committee.authorities() {
+        let labels = &[authority.hostname.as_str()];
+        metrics
+            .validator_scoreboard_scores
+            .with_label_values(labels)
+            .set(scores[i.value()] as i64);
+        metrics
+            .invalid_misbehavior_reports_by_authority
+            .with_label_values(labels)
+            .set(invalid_reports[i.value()] as i64);
     }
 }
 

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -249,8 +249,6 @@ pub(crate) struct NodeMetrics {
     pub(crate) faulty_blocks_unprovable_by_peer: IntGaugeVec,
     pub(crate) equivocations_by_authority: IntGaugeVec,
     pub(crate) missing_proposals_by_authority: IntGaugeVec,
-    #[expect(dead_code)]
-    pub(crate) invalid_misbehavior_reports_by_authority: IntCounterVec,
 }
 
 impl NodeMetrics {
@@ -1128,12 +1126,6 @@ impl NodeMetrics {
                 "missing_proposals_by_authority",
                 "Missing proposals per authority (source: persisted or in_memory)",
                 &["authority", "source"],
-                registry,
-            ).unwrap(),
-            invalid_misbehavior_reports_by_authority: register_int_counter_vec_with_registry!(
-                "invalid_misbehavior_reports_by_authority",
-                "Number of invalid misbehavior reports received from each authority",
-                &["authority"],
                 registry,
             ).unwrap(),
         }

--- a/dev-tools/grafana-local/dashboards/validator-dashboard-v2.json
+++ b/dev-tools/grafana-local/dashboards/validator-dashboard-v2.json
@@ -1,0 +1,469 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Validator-facing metrics for IOTA nodes. Initially focused on Starfish validator scoring and misbehavior tracking; intended to grow into the replacement for the legacy validator dashboard.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Validator Scoring",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "description": "Per-authority validator score published by the local Scoreboard after each consensus commit. Range [0, MAX_SCORE]; higher is better. Updates only when at least one misbehavior report has been received in the current epoch.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "editorMode": "code",
+          "expr": "validator_scoreboard_scores{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
+          "legendFormat": "{{host}} / {{authority}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scoreboard scores",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 10 },
+      "id": 3,
+      "panels": [],
+      "title": "Misbehavior — Block Faults",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "description": "Provably faulty blocks per authority. Header carries a valid signature but violates protocol rules — attributed to the block author. `in_memory` (faults observed since last flush) is stacked on top of `persisted` (cumulative on disk); the sum is the running total.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 11 },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "editorMode": "code",
+          "expr": "faulty_blocks_provable_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
+          "legendFormat": "{{host}} / {{authority}} ({{source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Provably faulty blocks (by author)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "description": "Unprovably faulty blocks per peer. Header rejected before/around signature verification (bad signature, pre-signature checks, malformed bytes) — author field can't be trusted, so attributed to the sending peer. `in_memory` stacked on `persisted`; sum is the running total.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 11 },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "editorMode": "code",
+          "expr": "faulty_blocks_unprovable_by_peer{network=\"$network\", host=~\"$validator\", peer=~\"$authority\"}",
+          "legendFormat": "{{host}} / {{peer}} ({{source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unprovably faulty blocks (by sending peer)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "id": 6,
+      "panels": [],
+      "title": "Misbehavior — DAG Faults",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "description": "Committed slots where an authority failed to propose. `in_memory` is recomputed wholesale over the current DAG window each flush; `persisted` accumulates from rounds that have been evicted from the window. The two never overlap, so the sum is the running total.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 21 },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "editorMode": "code",
+          "expr": "missing_proposals_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
+          "legendFormat": "{{host}} / {{authority}} ({{source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Missing proposals",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "description": "Slots where an authority signed conflicting blocks for the same (authority, round). Same `in_memory` (current window) vs `persisted` (evicted rounds) decomposition as missing proposals; the two are disjoint and stack to the running total.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 21 },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "editorMode": "code",
+          "expr": "equivocations_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
+          "legendFormat": "{{host}} / {{authority}} ({{source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Equivocations",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "id": 9,
+      "panels": [],
+      "title": "Misbehavior Reports",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "description": "Cumulative invalid misbehavior reports received from each reporting authority in the current epoch. Resets at reconfigure. Elevated values can indicate a faulty or adversarial reporter.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 31 },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": ["last", "sum"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "editorMode": "code",
+          "expr": "invalid_misbehavior_reports_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
+          "legendFormat": "{{host}} / {{authority}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Invalid misbehavior reports (cumulative)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "revision": 1,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["iota", "validator", "starfish", "scoring"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "Environment",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": false, "text": "local", "value": "local" },
+        "datasource": { "type": "prometheus", "uid": "${Environment}" },
+        "definition": "label_values(uptime,network)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Network",
+        "multi": false,
+        "name": "network",
+        "options": [],
+        "query": {
+          "query": "label_values(uptime,network)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+        "datasource": { "type": "prometheus", "uid": "${Environment}" },
+        "definition": "label_values(uptime{network=\"$network\"},host)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Validator (reporting host)",
+        "multi": true,
+        "name": "validator",
+        "options": [],
+        "query": {
+          "query": "label_values(uptime{network=\"$network\"},host)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+        "datasource": { "type": "prometheus", "uid": "${Environment}" },
+        "definition": "label_values(validator_scoreboard_scores{network=\"$network\"},authority)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Authority (subject)",
+        "multi": true,
+        "name": "authority",
+        "options": [],
+        "query": {
+          "query": "label_values(validator_scoreboard_scores{network=\"$network\"},authority)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "IOTA Validators v2",
+  "uid": "iota-validators-v2",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
# Description of change

Adds two per-authority Prometheus gauges in `AuthorityMetrics`, both labelled by hostname and published from `ConsensusHandler` after every consensus commit and seeded at construction so the series exist from epoch start:

- `validator_scoreboard_scores` — sourced from `Scoreboard::current_scores()`. Resolves the gap where Scoreboard scores were computed and consumed by the checkpoint service but not observable to operators.
- `invalid_misbehavior_reports_by_authority` — moved from `starfish-core::NodeMetrics` (where it was registered but never written) to `AuthorityMetrics`, switched to `IntGaugeVec`, and sourced from the new `ReportAggregator::invalid_reports_counts()` snapshot.

Both gauges are gated on `calculate_validator_scores()` and cleared in `reset_on_reconfigure`.

Adds `dev-tools/grafana-local/dashboards/validator-dashboard-v2.json` covering the new gauges alongside the existing starfish misbehavior metrics (provable/unprovable block faults, missing proposals, equivocations). The four misbehavior panels stack `in_memory` and `persisted` series so the sum is the running total. Intended to grow into the replacement for the legacy validator dashboard.

## Links to any relevant issues

Closes iotaledger/iota-private#282

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes