### PR TITLE
fix(graphql-rpc): include all dryRunTransactionBlock argument types in query cost evaluation

### DIFF
--- a/crates/iota-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/iota-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -626,7 +626,10 @@ impl<'a> TxArgValue<'a> {
             GraphQL(V::Number(n)) | Resolved(CV::Number(n)) => {
                 ValueCostReport::new(n.as_str().len())
             }
-            GraphQL(V::Enum(e)) | Resolved(CV::Enum(e)) => ValueCostReport::new(e.as_str().len()),
+            GraphQL(V::Enum(e)) | Resolved(CV::Enum(e)) => {
+                // Pay for the string, plus the quotes around it.
+                ValueCostReport::new(e.as_str().len() + 2)
+            }
             GraphQL(V::List(vs)) => {
                 // Pay for the opening and closing brackets and every comma up-front so that
                 // deeply nested lists are not free.

--- a/crates/iota-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/iota-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -623,8 +623,9 @@ impl<'a> TxArgValue<'a> {
                 // Pay for the string, plus the quotes around it.
                 ValueCostReport::new(s.len() + 2)
             }
-            GraphQL(V::Number(n)) => ValueCostReport::new(n.as_str().len()),
-            Resolved(CV::Number(n)) => ValueCostReport::new(n.as_str().len()),
+            GraphQL(V::Number(n)) | Resolved(CV::Number(n)) => {
+                ValueCostReport::new(n.as_str().len())
+            }
             GraphQL(V::Enum(e)) | Resolved(CV::Enum(e)) => ValueCostReport::new(e.as_str().len()),
             GraphQL(V::List(vs)) => {
                 // Pay for the opening and closing brackets and every comma up-front so that

--- a/crates/iota-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/iota-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -623,6 +623,9 @@ impl<'a> TxArgValue<'a> {
                 // Pay for the string, plus the quotes around it.
                 ValueCostReport::new(s.len() + 2)
             }
+            GraphQL(V::Number(n)) => ValueCostReport::new(n.to_string().len()),
+            Resolved(CV::Number(n)) => ValueCostReport::new(n.to_string().len()),
+            GraphQL(V::Enum(e)) | Resolved(CV::Enum(e)) => ValueCostReport::new(e.as_str().len()),
             GraphQL(V::List(vs)) => {
                 // Pay for the opening and closing brackets and every comma up-front so that
                 // deeply nested lists are not free.
@@ -640,6 +643,25 @@ impl<'a> TxArgValue<'a> {
                 }
                 cost
             }
+            GraphQL(V::Object(obj)) => {
+                // Pay for braces, commas between entries, and the `"name":` overhead per
+                // entry (quotes + colon, matching the JSON variable encoding).
+                let mut cost = ValueCostReport::new(obj.len().saturating_sub(1) + 2);
+                for (name, value) in obj {
+                    cost.gross += name.as_str().len() + 3;
+                    cost.merge_report(Self(ParsedValue::GraphQL(value)).cost_report(variables));
+                }
+                cost
+            }
+            Resolved(CV::Object(obj)) => {
+                // Follows the `GraphQL` object evaluation.
+                let mut cost = ValueCostReport::new(obj.len().saturating_sub(1) + 2);
+                for (name, value) in obj {
+                    cost.gross += name.as_str().len() + 3;
+                    cost.merge_report(Self(ParsedValue::Resolved(value)).cost_report(variables));
+                }
+                cost
+            }
             GraphQL(V::Variable(name)) => {
                 if let Some(value) = variables.get(name) {
                     let mut cost = Self(ParsedValue::Resolved(value)).cost_report(variables);
@@ -648,8 +670,10 @@ impl<'a> TxArgValue<'a> {
                 }
                 Default::default()
             }
-            _ => {
-                // Transaction payloads cannot be any of these types.
+            GraphQL(V::Null | V::Binary(_) | V::Boolean(_))
+            | Resolved(CV::Null | CV::Binary(_) | CV::Boolean(_)) => {
+                // `Null`, `Binary`, or `Boolean` are not expected as argument types
+                // for inputs contributing to the transaction payload size.
                 //
                 // From a limits perspective, it is safe to ignore these
                 // values here, because they will still

--- a/crates/iota-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/iota-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -623,8 +623,8 @@ impl<'a> TxArgValue<'a> {
                 // Pay for the string, plus the quotes around it.
                 ValueCostReport::new(s.len() + 2)
             }
-            GraphQL(V::Number(n)) => ValueCostReport::new(n.to_string().len()),
-            Resolved(CV::Number(n)) => ValueCostReport::new(n.to_string().len()),
+            GraphQL(V::Number(n)) => ValueCostReport::new(n.as_str().len()),
+            Resolved(CV::Number(n)) => ValueCostReport::new(n.as_str().len()),
             GraphQL(V::Enum(e)) | Resolved(CV::Enum(e)) => ValueCostReport::new(e.as_str().len()),
             GraphQL(V::List(vs)) => {
                 // Pay for the opening and closing brackets and every comma up-front so that

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -2061,12 +2061,12 @@ pub mod tests {
                     "txMeta": {
                         "gasBudget": null,
                         "gasPrice": 1000,
-                        "gasSponsor": "0x2b4a2ee4a1cb67c2ae7a6215784a26bb9c5051ea3f9aa5f60ccc58613a94f70b",
-                        "sender":     "0x2b4a2ee4a1cb67c2ae7a6215784a26bb9c5051ea3f9aa5f60ccc58613a94f70b",
+                        "gasSponsor": "0x2c4a2ee4a1cb67c2ae7a6215784a26bb9c5051ea3f9aa5f60ccc58613a94f70b",
+                        "sender":     "0x2c4a2ee4a1cb67c2ae7a6215784a26bb9c5051ea3f9aa5f60ccc58613a94f70b",
                         "gasObjects": [
-                            { "address": "0x0d49b390361c7b85f50ea436dd2f78d07794450162fa543d9b37d4fd5d3c9884", "digest": "3Hij17jtvK4o7VxarnBJkX31LYLtV7KDecLBhmBJuapU", "version": 3 },
-                            { "address": "0x105d51e2df3dae3fcb4a8d71ea9e357cec509e2f8e2f604eea53bb7abcd68c2b", "digest": "9t4C9FXKFdpgpZa8L968KtgkCPHwRA2QFHz6gVrymVJu", "version": 3 },
-                            { "address": "0x13c9d0de646c02aaea280eb4aafabbc6855cf6efb7c423714428318c42fb35be", "digest": "FguxMqj4pLitqCQLhGrEja65HT5r7749h8CPd3JzSnnk", "version": 3 }
+                            { "address": "0x0f49b390361c7b85f50ea436dd2f78d07794450162fa543d9b37d4fd5d3c9884", "digest": "3Hij17jtvK4o7VxarnBJkX31LYLtV7KDecLBhmBJuapU", "version": 3 },
+                            { "address": "0x115d51e2df3dae3fcb4a8d71ea9e357cec509e2f8e2f604eea53bb7abcd68c2b", "digest": "9t4C9FXKFdpgpZa8L968KtgkCPHwRA2QFHz6gVrymVJu", "version": 3 },
+                            { "address": "0x18c9d0de646c02aaea280eb4aafabbc6855cf6efb7c423714428318c42fb35be", "digest": "FguxMqj4pLitqCQLhGrEja65HT5r7749h8CPd3JzSnnk", "version": 3 }
                         ]
                     }
                 })))

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -2022,4 +2022,60 @@ pub mod tests {
              bytes or fewer."
         );
     }
+
+    pub async fn test_payload_object_input_dry_run_exceeded_impl() {
+        // Object input arguments (e.g. `txMeta`) and their nested lists of
+        // objects (e.g. `gasObjects`) must contribute to the transaction
+        // payload budget. Passing them via a variable does not exempt them
+        // from the limit.
+        assert_eq!(
+            execute_for_error(
+                Limits {
+                    max_tx_payload_size: 500,
+                    max_query_payload_size: 10_000,
+                    ..Default::default()
+                },
+                Request::new(
+                    r#"
+                    query DryRunQuery(
+                        $txBytes: String!,
+                        $skipChecks: Boolean!,
+                        $txMeta: TransactionMetadata
+                    ) {
+                        dryRunTransactionBlock(
+                            txBytes: $txBytes,
+                            skipChecks: $skipChecks,
+                            txMeta: $txMeta
+                        ) {
+                            error
+                            transaction {
+                                digest
+                            }
+                        }
+                    }
+                    "#,
+                )
+                .variables(Variables::from_json(json!({
+                    "txBytes": "AAIAINdb/wdoZKClk3YWgTp2SRpvVYkX9XUMu0Im6dGMv5g1AAjoAwAAAAAAAAICAAEBAQABAQIAAAEAAA==",
+                    "skipChecks": false,
+                    "txMeta": {
+                        "gasBudget": null,
+                        "gasPrice": 1000,
+                        "gasSponsor": "0x2b4a2ee4a1cb67c2ae7a6215784a26bb9c5051ea3f9aa5f60ccc58613a94f70b",
+                        "sender":     "0x2b4a2ee4a1cb67c2ae7a6215784a26bb9c5051ea3f9aa5f60ccc58613a94f70b",
+                        "gasObjects": [
+                            { "address": "0x0d49b390361c7b85f50ea436dd2f78d07794450162fa543d9b37d4fd5d3c9884", "digest": "3Hij17jtvK4o7VxarnBJkX31LYLtV7KDecLBhmBJuapU", "version": 3 },
+                            { "address": "0x105d51e2df3dae3fcb4a8d71ea9e357cec509e2f8e2f604eea53bb7abcd68c2b", "digest": "9t4C9FXKFdpgpZa8L968KtgkCPHwRA2QFHz6gVrymVJu", "version": 3 },
+                            { "address": "0x13c9d0de646c02aaea280eb4aafabbc6855cf6efb7c423714428318c42fb35be", "digest": "FguxMqj4pLitqCQLhGrEja65HT5r7749h8CPd3JzSnnk", "version": 3 }
+                        ]
+                    }
+                })))
+            )
+            .await,
+            "Transaction payload too large. Requests are limited to 500 bytes or fewer on \
+             transaction payloads (all inputs to executeTransactionBlock or \
+             dryRunTransactionBlock) and the rest of the request (the query part) must be 10000 \
+             bytes or fewer."
+        );
+    }
 }

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -1121,6 +1121,12 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn test_payload_object_input_dry_run_exceeded() {
+        test_payload_object_input_dry_run_exceeded_impl().await;
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn test_payload_using_vars_mutation_passes() {
         let _guard = telemetry_subscribers::TelemetryConfig::new()
             .with_env()


### PR DESCRIPTION
# Description of change

With #9152, we only considered `txBytes` as the eligible argument to contribute to tx-payload size, but clearly this is not the case if also `txMeta` is provided in `Query.dryRunTransactionBlock`. It is reminded that `txBytes` might represent either [TransactionData](https://iotaledger.github.io/iota/iota_types/transaction/enum.TransactionData.html) (the richer value) or [TransactionKind](https://iotaledger.github.io/iota/iota_types/transaction/enum.TransactionKind.html). If the user passes `txMeta` the latter is assumed. Thus, including `txMeta` is an eligible candidate for the transaction size.

This patch extends the cost evaluation for arguments pertaining to transaction execution and fixes this issue.

## Links to any relevant issues

Fixes #11578 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Also ran manual tests with the query reported in the parent issue.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

This patch does not affect ingestion or the API.

### Release Notes

- [x] GraphQL: Fixes an issue where passing `txMeta` input in `Query.dryRunTransactionBlock` could lead to errors due to query limit checks.
