### PR TITLE
feat(iota-kvstore): support address-transaction relation

### DIFF
--- a/crates/iota-kvstore/init.sh
+++ b/crates/iota-kvstore/init.sh
@@ -19,7 +19,7 @@ elif [[ -n $PROJECT_ID ]]; then
   command+=(-project "$PROJECT_ID")
 fi
 
-for table in objects transactions checkpoints checkpoints_by_digest watermark; do
+for table in objects transactions checkpoints checkpoints_by_digest watermark transactions_by_address; do
   (
     set -x
     "${command[@]}" createtable $table

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -44,6 +44,8 @@ pub const EFFECTS_COLUMN_QUALIFIER: &str = "fx";
 pub const EVENTS_COLUMN_QUALIFIER: &str = "evtx";
 pub const TRANSACTION_TO_CHECKPOINT: &str = "tx2c";
 
+pub type TransactionSequenceNumber = u64;
+
 #[async_trait]
 impl KeyValueStoreWriter for BigTableClient {
     type Error = anyhow::Error;
@@ -108,10 +110,7 @@ impl KeyValueStoreWriter for BigTableClient {
         let rows = entries
             .into_iter()
             .map(|(address, seq, transaction_digest)| {
-                let key = encode_transaction_by_address_key(
-                    &address,
-                    TransactionSequenceNumber::new(seq),
-                );
+                let key = encode_transaction_by_address_key(&address, seq.into());
                 let cells = [Cell::new(
                     DEFAULT_COLUMN_QUALIFIER.as_bytes().into(),
                     transaction_digest.inner().into(),
@@ -223,11 +222,8 @@ impl KeyValueStoreReader for BigTableClient {
 
         let cursor = cursor.into();
 
-        let newest =
-            encode_transaction_by_address_key(&address, TransactionSequenceNumber::new(u64::MAX))
-                .to_vec();
-        let oldest =
-            encode_transaction_by_address_key(&address, TransactionSequenceNumber::new(0)).to_vec();
+        let newest = encode_transaction_by_address_key(&address, u64::MAX.into()).to_vec();
+        let oldest = encode_transaction_by_address_key(&address, 0.into()).to_vec();
 
         let (start_key, end_key) = match (cursor, order) {
             // no cursor: whole address block, direction handled by order.
@@ -239,23 +235,28 @@ impl KeyValueStoreReader for BigTableClient {
             (Some(cursor), TransactionsOrder::NewestFirst) => {
                 // no transactions can have seq < 0, the scan would be empty
                 // and BigTable rejects empty ranges.
-                if cursor.get() == 0 {
+                if cursor == 0 {
                     return Ok(vec![]);
                 }
-                let k = encode_transaction_by_address_key(&address, cursor).to_vec();
+                let k = encode_transaction_by_address_key(&address, cursor.into()).to_vec();
                 (StartKey::StartKeyOpen(k), EndKey::EndKeyClosed(oldest))
             }
             // oldest-first, continue past cursor: tx seq > cursor.
             (Some(cursor), TransactionsOrder::OldestFirst) => {
                 // no transactions can have seq > u64::MAX, the scan would be
                 // empty and BigTable rejects empty ranges.
-                if cursor.get() == u64::MAX {
+                if cursor == u64::MAX {
                     return Ok(vec![]);
                 }
-                let k = encode_transaction_by_address_key(&address, cursor).to_vec();
+                let k = encode_transaction_by_address_key(&address, cursor.into()).to_vec();
                 (StartKey::StartKeyClosed(newest), EndKey::EndKeyOpen(k))
             }
         };
+
+        // row keys are encoded as `address || ReverseSequenceNumber`, so a
+        // forward scan already returns newest-first. OldestFirst requires a
+        // reverse scan.
+        let descending = matches!(order, TransactionsOrder::OldestFirst);
 
         let rows = self
             .range_scan(
@@ -263,7 +264,7 @@ impl KeyValueStoreReader for BigTableClient {
                 Some(start_key),
                 Some(end_key),
                 limit.get(),
-                order.is_reversed(),
+                descending,
                 Some(RowFilter {
                     filter: Some(Filter::ColumnQualifierRegexFilter(
                         format!("^{DEFAULT_COLUMN_QUALIFIER}$").into_bytes(),
@@ -277,7 +278,7 @@ impl KeyValueStoreReader for BigTableClient {
             .map(|(key, cell)| -> Result<_, anyhow::Error> {
                 let (_addr, seq) = decode_transaction_by_address_key(&key)?;
                 let digest = TransactionDigest::from_bytes(&cell.value)?;
-                Ok((seq, digest))
+                Ok((u64::from(seq), digest))
             })
             .collect()
     }
@@ -356,67 +357,52 @@ pub enum TransactionsOrder {
     OldestFirst,
 }
 
-impl TransactionsOrder {
-    /// Returns `true` if range scan is in reverse (oldest first), `false` if
-    /// newest first.
-    pub(crate) fn is_reversed(self) -> bool {
-        matches!(self, Self::OldestFirst)
+/// A sequence number stored as its bitwise complement (`!seq`), so that
+/// BigTable's ascending lexicographic row-key order yields newest-first
+/// results on a forward range scan.
+///
+/// By storing the complement, higher original sequence numbers map to
+/// smaller byte representations and therefore sort earlier. This turns
+/// "newest first" into a cheap forward scan instead of an expensive
+/// reverse one.
+///
+/// # Conversions
+/// - `From<u64>`: produces a `ReverseSequenceNumber` holding `!seq`.
+/// - `Into<u64>`: returns the original `seq` from the wrapped `!seq`.
+/// - [`ReverseSequenceNumber::to_be_bytes`]: encodes the stored value as
+///   big-endian bytes for BigTable storage.
+/// - [`ReverseSequenceNumber::from_be_bytes`]: decodes the stored value from
+///   big-endian bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ReverseSequenceNumber(u64);
+
+impl ReverseSequenceNumber {
+    pub const LENGTH: usize = std::mem::size_of::<u64>();
+
+    /// Encodes the reversed sequence number into a big-endian byte array.
+    pub fn to_be_bytes(self) -> [u8; Self::LENGTH] {
+        self.0.to_be_bytes()
+    }
+
+    /// Decodes a reversed sequence number from a big-endian byte array.
+    pub fn from_be_bytes(bytes: [u8; Self::LENGTH]) -> Self {
+        Self(u64::from_be_bytes(bytes))
     }
 }
 
-/// A transaction sequence number, with a BigTable byte encoding that
-/// preserves *descending* order under lexicographic row-key comparison.
-///
-/// BigTable scans keys in ascending lexicographic order. To make "newest
-/// transactions for an address" a cheap forward range scan, the
-/// per-address index stores each sequence number's complement
-/// (`u64::MAX - seq`) in the key, so higher seq sorts earlier.
-///
-/// - Encode with [`TransactionSequenceNumber::to_complement_be_bytes`].
-/// - Decode with [`TransactionSequenceNumber::from_complement_be_bytes`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct TransactionSequenceNumber(u64);
-
-impl TransactionSequenceNumber {
-    pub const LENGTH: usize = std::mem::size_of::<u64>();
-
-    /// Creates a new [`TransactionSequenceNumber`] from the given sequence
-    /// number.
-    pub fn new(seq: u64) -> Self {
-        Self(seq)
+impl From<u64> for ReverseSequenceNumber {
+    fn from(seq: u64) -> Self {
+        Self(!seq)
     }
-
-    /// Returns a copy of the contained sequence number.
-    pub fn get(&self) -> u64 {
-        self.0
-    }
-
-    /// Returns the complement (`u64::MAX - seq`) of the sequence number,
-    /// encoded as a big-endian byte array.
-    ///
-    /// # Lexicographical Ordering
-    /// Storing the complement ensures that BigTable's lexicographical sorting
-    /// orders entries by **descending** sequence number. This allows for
-    /// efficient forward scans to retrieve the most recent transactions
-    /// first.
-    pub fn to_complement_be_bytes(&self) -> [u8; Self::LENGTH] {
-        (u64::MAX - self.0).to_be_bytes()
-    }
-
-    /// Reconstructs a [`TransactionSequenceNumber`] from its complement
-    /// byte array representation.
-    ///
-    /// This is the inverse of
-    /// [`TransactionSequenceNumber::to_complement_be_bytes`]. It reads the
-    /// stored complement bytes and restores the original sequence number by
-    /// applying `u64::MAX - stored_value`.
-    pub fn from_complement_be_bytes(bytes: [u8; Self::LENGTH]) -> Self {
-        Self(u64::MAX - u64::from_be_bytes(bytes))
+}
+impl From<ReverseSequenceNumber> for u64 {
+    fn from(rev: ReverseSequenceNumber) -> u64 {
+        !rev.0
     }
 }
 
 /// The length of an address-to-transaction row key, in bytes.
-pub const ADDRESS_TX_KEY_LEN: usize = IotaAddress::LENGTH + TransactionSequenceNumber::LENGTH;
+pub const ADDRESS_TX_KEY_LEN: usize = IotaAddress::LENGTH + ReverseSequenceNumber::LENGTH;
 
 /// Encodes a row key for the address-to-transaction index.
 ///
@@ -429,28 +415,26 @@ pub const ADDRESS_TX_KEY_LEN: usize = IotaAddress::LENGTH + TransactionSequenceN
 /// See [`decode_transaction_by_address_key`] for the inverse operation.
 pub fn encode_transaction_by_address_key(
     address: &IotaAddress,
-    transaction_sequence_number: TransactionSequenceNumber,
+    sequence_number: ReverseSequenceNumber,
 ) -> [u8; ADDRESS_TX_KEY_LEN] {
     let mut key = [0u8; ADDRESS_TX_KEY_LEN];
     key[..IotaAddress::LENGTH].copy_from_slice(address.as_ref());
-    key[IotaAddress::LENGTH..]
-        .copy_from_slice(&transaction_sequence_number.to_complement_be_bytes());
+    key[IotaAddress::LENGTH..].copy_from_slice(&sequence_number.to_be_bytes());
     key
 }
 
 /// Decodes an address-to-transaction row key.
 ///
 /// This is the inverse of [`encode_transaction_by_address_key`]. It
-/// extracts the address and restores the original sequence number from
-/// the stored complement.
+/// extracts the address and restores the reversed sequence number.
 pub fn decode_transaction_by_address_key(
     key: &[u8],
-) -> Result<(IotaAddress, TransactionSequenceNumber), anyhow::Error> {
+) -> Result<(IotaAddress, ReverseSequenceNumber), anyhow::Error> {
     anyhow::ensure!(key.len() == ADDRESS_TX_KEY_LEN, "invalid key length");
     let address = IotaAddress::from_bytes(&key[..IotaAddress::LENGTH])?;
-    let transaction_sequence_number =
-        TransactionSequenceNumber::from_complement_be_bytes(key[IotaAddress::LENGTH..].try_into()?);
-    Ok((address, transaction_sequence_number))
+    let reversed_tx_sequence =
+        ReverseSequenceNumber::from_be_bytes(key[IotaAddress::LENGTH..].try_into()?);
+    Ok((address, reversed_tx_sequence))
 }
 
 #[cfg(test)]
@@ -458,13 +442,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn transaction_sequence_number_roundtrip() {
-        for seq in [0, 1, 42, u64::MAX - 1, u64::MAX] {
-            let n = TransactionSequenceNumber::new(seq);
-            assert_eq!(
-                TransactionSequenceNumber::from_complement_be_bytes(n.to_complement_be_bytes()),
-                n,
-            );
+    fn reverse_sequence_number_round_trips_through_bytes() {
+        for seq in [0u64, 1, 42, u64::MAX - 1, u64::MAX] {
+            let rev = ReverseSequenceNumber::from(seq);
+            let recovered = ReverseSequenceNumber::from_be_bytes(rev.to_be_bytes());
+            assert_eq!(u64::from(recovered), seq);
         }
     }
 
@@ -472,13 +454,13 @@ mod tests {
     fn transaction_sequence_number_orders_descending() {
         // higher seq must sort earlier (smaller bytes) so forward range scans
         // return newest transactions first.
-        let older = TransactionSequenceNumber::new(1).to_complement_be_bytes();
-        let newer = TransactionSequenceNumber::new(2).to_complement_be_bytes();
+        let older = ReverseSequenceNumber::from(1).to_be_bytes();
+        let newer = ReverseSequenceNumber::from(2).to_be_bytes();
         assert!(newer < older);
 
         // boundary: u64::MAX (newest possible) sorts before 0 (oldest possible).
-        let newest = TransactionSequenceNumber::new(u64::MAX).to_complement_be_bytes();
-        let oldest = TransactionSequenceNumber::new(0).to_complement_be_bytes();
+        let newest = ReverseSequenceNumber::from(u64::MAX).to_be_bytes();
+        let oldest = ReverseSequenceNumber::from(0).to_be_bytes();
         assert!(newest < oldest);
         assert_eq!(newest, [0; 8]);
         assert_eq!(oldest, [0xFF; 8]);
@@ -487,23 +469,21 @@ mod tests {
     #[test]
     fn transaction_by_address_key_encode() {
         let address = IotaAddress::random();
-        let transaction_sequence_number = TransactionSequenceNumber::new(42);
+        let transaction_sequence_number = ReverseSequenceNumber::from(42);
         let key = encode_transaction_by_address_key(&address, transaction_sequence_number);
         assert_eq!(key[..IotaAddress::LENGTH], address.into_bytes());
-        assert_eq!(
-            key[IotaAddress::LENGTH..],
-            transaction_sequence_number.to_complement_be_bytes()
-        );
+        assert_eq!(key[IotaAddress::LENGTH..], (u64::MAX - 42).to_be_bytes());
     }
 
     #[test]
     fn transaction_by_address_key_decode() {
         let address = IotaAddress::random();
-        let transaction_sequence_number = TransactionSequenceNumber::new(42);
+        let transaction_sequence_number = ReverseSequenceNumber::from(42);
         let key = encode_transaction_by_address_key(&address, transaction_sequence_number);
         let (decoded_address, decoded_sequence_number) =
             decode_transaction_by_address_key(&key).unwrap();
         assert_eq!(decoded_address, address);
         assert_eq!(decoded_sequence_number, transaction_sequence_number);
+        assert_eq!(u64::from(decoded_sequence_number), 42);
     }
 }

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -3,9 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use iota_bigtable::{BigTableClient, Cell, Row};
+use iota_bigtable::{
+    BigTableClient, Cell, Row,
+    proto::bigtable::v2::{
+        RowFilter,
+        row_filter::Filter,
+        row_range::{EndKey, StartKey},
+    },
+};
 use iota_types::{
-    base_types::TransactionDigest,
+    base_types::{IotaAddress, TransactionDigest},
     digests::CheckpointDigest,
     effects::{TransactionEffects, TransactionEvents},
     full_checkpoint_content::CheckpointData,
@@ -24,6 +31,7 @@ pub const OBJECTS_TABLE: &str = "objects";
 pub const TRANSACTIONS_TABLE: &str = "transactions";
 pub const CHECKPOINTS_TABLE: &str = "checkpoints";
 pub const CHECKPOINTS_BY_DIGEST_TABLE: &str = "checkpoints_by_digest";
+pub const TRANSACTIONS_BY_ADDRESS_TABLE: &str = "transactions_by_address";
 
 pub const DEFAULT_COLUMN_QUALIFIER: &str = "";
 pub const CHECKPOINT_SUMMARY_COLUMN_QUALIFIER: &str = "cs";
@@ -85,6 +93,27 @@ impl KeyValueStoreWriter for BigTableClient {
             rows.push(Row::new(transaction.digest().inner().to_vec(), cells));
         }
         self.multi_set(TRANSACTIONS_TABLE, rows)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn save_transactions_by_address<I>(&mut self, entries: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = (IotaAddress, u64, TransactionDigest)> + Send,
+        I::IntoIter: Send,
+    {
+        let rows = entries
+            .into_iter()
+            .map(|(address, seq, transaction_digest)| {
+                let key = encode_transaction_by_address_key(&address, seq);
+                let cells = [Cell::new(
+                    DEFAULT_COLUMN_QUALIFIER.as_bytes().into(),
+                    transaction_digest.inner().into(),
+                )];
+                Row::new(key.into(), cells.into())
+            });
+
+        self.multi_set(TRANSACTIONS_BY_ADDRESS_TABLE, rows)
             .await
             .map_err(Into::into)
     }
@@ -175,6 +204,36 @@ impl KeyValueStoreReader for BigTableClient {
         Ok(result)
     }
 
+    async fn get_transaction_digests_by_address(
+        &mut self,
+        address: IotaAddress,
+    ) -> Result<Vec<TransactionDigest>, Self::Error> {
+        let newest = encode_transaction_by_address_key(&address, u64::MAX).to_vec();
+        let oldest = encode_transaction_by_address_key(&address, 0).to_vec();
+
+        let limit = 0;
+        let rows = self
+            .range_scan(
+                TRANSACTIONS_BY_ADDRESS_TABLE,
+                Some(StartKey::StartKeyClosed(newest)),
+                Some(EndKey::EndKeyClosed(oldest)),
+                limit,
+                false,
+                Some(RowFilter {
+                    filter: Some(Filter::ColumnQualifierRegexFilter(
+                        format!("^{DEFAULT_COLUMN_QUALIFIER}$").into_bytes(),
+                    )),
+                }),
+            )
+            .await?;
+
+        rows.into_iter()
+            .filter_map(|row| row.cells.into_iter().next())
+            .map(|cell| TransactionDigest::from_bytes(&cell.value))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
     async fn get_checkpoints(
         &mut self,
         sequence_numbers: &[CheckpointSequenceNumber],
@@ -237,4 +296,41 @@ pub fn raw_object_key(object_key: &ObjectKey) -> Vec<u8> {
     let mut raw_key = object_key.0.as_bytes().to_vec();
     raw_key.extend(object_key.1.as_u64().to_be_bytes());
     raw_key
+}
+
+/// The length of an address-to-transaction row key, in bytes.
+pub const ADDRESS_TX_KEY_LEN: usize = IotaAddress::LENGTH + std::mem::size_of::<u64>();
+
+/// Encodes a row key for the address-to-transaction index.
+///
+/// Layout: `address (32 bytes) || complement (8 bytes)`.
+///
+/// The `complement` is calculated as `u64::MAX - transaction_sequence_number`,
+/// encoded in big-endian byte order. Storing the complement ensures that
+/// transactions are ordered lexicographically by descending sequence number,
+/// allowing for efficient forward scans when retrieving the most recent
+/// transactions for an address.
+///
+/// See [`decode_transaction_by_address_key`] for the inverse operation.
+pub fn encode_transaction_by_address_key(
+    address: &IotaAddress,
+    transaction_sequence_number: u64,
+) -> [u8; ADDRESS_TX_KEY_LEN] {
+    let mut key = [0u8; ADDRESS_TX_KEY_LEN];
+    key[..IotaAddress::LENGTH].copy_from_slice(address.as_ref());
+    key[IotaAddress::LENGTH..]
+        .copy_from_slice(&(u64::MAX - transaction_sequence_number).to_be_bytes());
+    key
+}
+
+/// Decodes an address-to-transaction row key.
+///
+/// This is the inverse of [`encode_transaction_by_address_key`]. It
+/// extracts the address and restores the original sequence number from
+/// the stored complement (`u64::MAX - stored_complement`).
+pub fn decode_transaction_by_address_key(key: &[u8]) -> Result<(IotaAddress, u64), anyhow::Error> {
+    anyhow::ensure!(key.len() == ADDRESS_TX_KEY_LEN, "invalid key length");
+    let address = IotaAddress::from_bytes(&key[..IotaAddress::LENGTH])?;
+    let tx_seq = u64::MAX - u64::from_be_bytes(key[IotaAddress::LENGTH..].try_into()?);
+    Ok((address, tx_seq))
 }

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -458,7 +458,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_transaction_sequence_number_roundtrip() {
+    fn transaction_sequence_number_roundtrip() {
         for seq in [0, 1, 42, u64::MAX - 1, u64::MAX] {
             let n = TransactionSequenceNumber::new(seq);
             assert_eq!(
@@ -469,7 +469,7 @@ mod tests {
     }
 
     #[test]
-    fn test_transaction_sequence_number_orders_descending() {
+    fn transaction_sequence_number_orders_descending() {
         // higher seq must sort earlier (smaller bytes) so forward range scans
         // return newest transactions first.
         let older = TransactionSequenceNumber::new(1).to_complement_be_bytes();
@@ -485,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_transaction_by_address_key() {
+    fn transaction_by_address_key_encode() {
         let address = IotaAddress::random();
         let transaction_sequence_number = TransactionSequenceNumber::new(42);
         let key = encode_transaction_by_address_key(&address, transaction_sequence_number);
@@ -497,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_transaction_by_address_key() {
+    fn transaction_by_address_key_decode() {
         let address = IotaAddress::random();
         let transaction_sequence_number = TransactionSequenceNumber::new(42);
         let key = encode_transaction_by_address_key(&address, transaction_sequence_number);

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroUsize;
+
 use async_trait::async_trait;
 use iota_bigtable::{
     BigTableClient, Cell, Row,
@@ -211,21 +213,57 @@ impl KeyValueStoreReader for BigTableClient {
     async fn get_transaction_digests_by_address(
         &mut self,
         address: IotaAddress,
-    ) -> Result<Vec<TransactionDigest>, Self::Error> {
+        cursor: impl Into<Option<TransactionSequenceNumber>> + Send,
+        limit: impl TryInto<NonZeroUsize> + Send,
+        order: TransactionsOrder,
+    ) -> Result<Vec<(TransactionSequenceNumber, TransactionDigest)>, Self::Error> {
+        let limit = limit
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("limit must be greater than 0"))?;
+
+        let cursor = cursor.into();
+
         let newest =
             encode_transaction_by_address_key(&address, TransactionSequenceNumber::new(u64::MAX))
                 .to_vec();
         let oldest =
             encode_transaction_by_address_key(&address, TransactionSequenceNumber::new(0)).to_vec();
 
-        let limit = 0;
+        let (start_key, end_key) = match (cursor, order) {
+            // no cursor: whole address block, direction handled by order.
+            (None, _) => (
+                StartKey::StartKeyClosed(newest),
+                EndKey::EndKeyClosed(oldest),
+            ),
+            // newest-first, continue past cursor: tx seq < cursor.
+            (Some(cursor), TransactionsOrder::NewestFirst) => {
+                // no transactions can have seq < 0, the scan would be empty
+                // and BigTable rejects empty ranges.
+                if cursor.get() == 0 {
+                    return Ok(vec![]);
+                }
+                let k = encode_transaction_by_address_key(&address, cursor).to_vec();
+                (StartKey::StartKeyOpen(k), EndKey::EndKeyClosed(oldest))
+            }
+            // oldest-first, continue past cursor: tx seq > cursor.
+            (Some(cursor), TransactionsOrder::OldestFirst) => {
+                // no transactions can have seq > u64::MAX, the scan would be
+                // empty and BigTable rejects empty ranges.
+                if cursor.get() == u64::MAX {
+                    return Ok(vec![]);
+                }
+                let k = encode_transaction_by_address_key(&address, cursor).to_vec();
+                (StartKey::StartKeyClosed(newest), EndKey::EndKeyOpen(k))
+            }
+        };
+
         let rows = self
             .range_scan(
                 TRANSACTIONS_BY_ADDRESS_TABLE,
-                Some(StartKey::StartKeyClosed(newest)),
-                Some(EndKey::EndKeyClosed(oldest)),
-                limit,
-                false,
+                Some(start_key),
+                Some(end_key),
+                limit.get(),
+                order.is_reversed(),
                 Some(RowFilter {
                     filter: Some(Filter::ColumnQualifierRegexFilter(
                         format!("^{DEFAULT_COLUMN_QUALIFIER}$").into_bytes(),
@@ -235,10 +273,13 @@ impl KeyValueStoreReader for BigTableClient {
             .await?;
 
         rows.into_iter()
-            .filter_map(|row| row.cells.into_iter().next())
-            .map(|cell| TransactionDigest::from_bytes(&cell.value))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Into::into)
+            .filter_map(|row| row.cells.into_iter().next().map(|cell| (row.key, cell)))
+            .map(|(key, cell)| -> Result<_, anyhow::Error> {
+                let (_addr, seq) = decode_transaction_by_address_key(&key)?;
+                let digest = TransactionDigest::from_bytes(&cell.value)?;
+                Ok((seq, digest))
+            })
+            .collect()
     }
 
     async fn get_checkpoints(
@@ -303,6 +344,24 @@ pub fn raw_object_key(object_key: &ObjectKey) -> Vec<u8> {
     let mut raw_key = object_key.0.as_bytes().to_vec();
     raw_key.extend(object_key.1.as_u64().to_be_bytes());
     raw_key
+}
+
+/// Represents the order of transactions returned by a BigTable range scan.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize,
+)]
+pub enum TransactionsOrder {
+    #[default]
+    NewestFirst,
+    OldestFirst,
+}
+
+impl TransactionsOrder {
+    /// Returns `true` if range scan is in reverse (oldest first), `false` if
+    /// newest first.
+    pub(crate) fn is_reversed(self) -> bool {
+        matches!(self, Self::OldestFirst)
+    }
 }
 
 /// A transaction sequence number, with a BigTable byte encoding that

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -23,6 +23,7 @@ use iota_types::{
     storage::ObjectKey,
     transaction::Transaction,
 };
+use serde::{Deserialize, Serialize};
 use tracing::error;
 
 use crate::{Checkpoint, KeyValueStoreReader, KeyValueStoreWriter, TransactionData};
@@ -105,7 +106,10 @@ impl KeyValueStoreWriter for BigTableClient {
         let rows = entries
             .into_iter()
             .map(|(address, seq, transaction_digest)| {
-                let key = encode_transaction_by_address_key(&address, seq);
+                let key = encode_transaction_by_address_key(
+                    &address,
+                    TransactionSequenceNumber::new(seq),
+                );
                 let cells = [Cell::new(
                     DEFAULT_COLUMN_QUALIFIER.as_bytes().into(),
                     transaction_digest.inner().into(),
@@ -208,8 +212,11 @@ impl KeyValueStoreReader for BigTableClient {
         &mut self,
         address: IotaAddress,
     ) -> Result<Vec<TransactionDigest>, Self::Error> {
-        let newest = encode_transaction_by_address_key(&address, u64::MAX).to_vec();
-        let oldest = encode_transaction_by_address_key(&address, 0).to_vec();
+        let newest =
+            encode_transaction_by_address_key(&address, TransactionSequenceNumber::new(u64::MAX))
+                .to_vec();
+        let oldest =
+            encode_transaction_by_address_key(&address, TransactionSequenceNumber::new(0)).to_vec();
 
         let limit = 0;
         let rows = self
@@ -298,28 +305,77 @@ pub fn raw_object_key(object_key: &ObjectKey) -> Vec<u8> {
     raw_key
 }
 
+/// A transaction sequence number, with a BigTable byte encoding that
+/// preserves *descending* order under lexicographic row-key comparison.
+///
+/// BigTable scans keys in ascending lexicographic order. To make "newest
+/// transactions for an address" a cheap forward range scan, the
+/// per-address index stores each sequence number's complement
+/// (`u64::MAX - seq`) in the key, so higher seq sorts earlier.
+///
+/// - Encode with [`TransactionSequenceNumber::to_complement_be_bytes`].
+/// - Decode with [`TransactionSequenceNumber::from_complement_be_bytes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TransactionSequenceNumber(u64);
+
+impl TransactionSequenceNumber {
+    pub const LENGTH: usize = std::mem::size_of::<u64>();
+
+    /// Creates a new [`TransactionSequenceNumber`] from the given sequence
+    /// number.
+    pub fn new(seq: u64) -> Self {
+        Self(seq)
+    }
+
+    /// Returns a copy of the contained sequence number.
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+
+    /// Returns the complement (`u64::MAX - seq`) of the sequence number,
+    /// encoded as a big-endian byte array.
+    ///
+    /// # Lexicographical Ordering
+    /// Storing the complement ensures that BigTable's lexicographical sorting
+    /// orders entries by **descending** sequence number. This allows for
+    /// efficient forward scans to retrieve the most recent transactions
+    /// first.
+    pub fn to_complement_be_bytes(&self) -> [u8; Self::LENGTH] {
+        (u64::MAX - self.0).to_be_bytes()
+    }
+
+    /// Reconstructs a [`TransactionSequenceNumber`] from its complement
+    /// byte array representation.
+    ///
+    /// This is the inverse of
+    /// [`TransactionSequenceNumber::to_complement_be_bytes`]. It reads the
+    /// stored complement bytes and restores the original sequence number by
+    /// applying `u64::MAX - stored_value`.
+    pub fn from_complement_be_bytes(bytes: [u8; Self::LENGTH]) -> Self {
+        Self(u64::MAX - u64::from_be_bytes(bytes))
+    }
+}
+
 /// The length of an address-to-transaction row key, in bytes.
-pub const ADDRESS_TX_KEY_LEN: usize = IotaAddress::LENGTH + std::mem::size_of::<u64>();
+pub const ADDRESS_TX_KEY_LEN: usize = IotaAddress::LENGTH + TransactionSequenceNumber::LENGTH;
 
 /// Encodes a row key for the address-to-transaction index.
 ///
 /// Layout: `address (32 bytes) || complement (8 bytes)`.
 ///
-/// The `complement` is calculated as `u64::MAX - transaction_sequence_number`,
-/// encoded in big-endian byte order. Storing the complement ensures that
-/// transactions are ordered lexicographically by descending sequence number,
-/// allowing for efficient forward scans when retrieving the most recent
-/// transactions for an address.
+/// Storing the complement ensures that transactions are ordered
+/// lexicographically by descending sequence number, allowing for efficient
+/// forward scans when retrieving the most recent transactions for an address.
 ///
 /// See [`decode_transaction_by_address_key`] for the inverse operation.
 pub fn encode_transaction_by_address_key(
     address: &IotaAddress,
-    transaction_sequence_number: u64,
+    transaction_sequence_number: TransactionSequenceNumber,
 ) -> [u8; ADDRESS_TX_KEY_LEN] {
     let mut key = [0u8; ADDRESS_TX_KEY_LEN];
     key[..IotaAddress::LENGTH].copy_from_slice(address.as_ref());
     key[IotaAddress::LENGTH..]
-        .copy_from_slice(&(u64::MAX - transaction_sequence_number).to_be_bytes());
+        .copy_from_slice(&transaction_sequence_number.to_complement_be_bytes());
     key
 }
 
@@ -327,10 +383,68 @@ pub fn encode_transaction_by_address_key(
 ///
 /// This is the inverse of [`encode_transaction_by_address_key`]. It
 /// extracts the address and restores the original sequence number from
-/// the stored complement (`u64::MAX - stored_complement`).
-pub fn decode_transaction_by_address_key(key: &[u8]) -> Result<(IotaAddress, u64), anyhow::Error> {
+/// the stored complement.
+pub fn decode_transaction_by_address_key(
+    key: &[u8],
+) -> Result<(IotaAddress, TransactionSequenceNumber), anyhow::Error> {
     anyhow::ensure!(key.len() == ADDRESS_TX_KEY_LEN, "invalid key length");
     let address = IotaAddress::from_bytes(&key[..IotaAddress::LENGTH])?;
-    let tx_seq = u64::MAX - u64::from_be_bytes(key[IotaAddress::LENGTH..].try_into()?);
-    Ok((address, tx_seq))
+    let transaction_sequence_number =
+        TransactionSequenceNumber::from_complement_be_bytes(key[IotaAddress::LENGTH..].try_into()?);
+    Ok((address, transaction_sequence_number))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transaction_sequence_number_roundtrip() {
+        for seq in [0, 1, 42, u64::MAX - 1, u64::MAX] {
+            let n = TransactionSequenceNumber::new(seq);
+            assert_eq!(
+                TransactionSequenceNumber::from_complement_be_bytes(n.to_complement_be_bytes()),
+                n,
+            );
+        }
+    }
+
+    #[test]
+    fn test_transaction_sequence_number_orders_descending() {
+        // higher seq must sort earlier (smaller bytes) so forward range scans
+        // return newest transactions first.
+        let older = TransactionSequenceNumber::new(1).to_complement_be_bytes();
+        let newer = TransactionSequenceNumber::new(2).to_complement_be_bytes();
+        assert!(newer < older);
+
+        // boundary: u64::MAX (newest possible) sorts before 0 (oldest possible).
+        let newest = TransactionSequenceNumber::new(u64::MAX).to_complement_be_bytes();
+        let oldest = TransactionSequenceNumber::new(0).to_complement_be_bytes();
+        assert!(newest < oldest);
+        assert_eq!(newest, [0; 8]);
+        assert_eq!(oldest, [0xFF; 8]);
+    }
+
+    #[test]
+    fn test_encode_transaction_by_address_key() {
+        let address = IotaAddress::random();
+        let transaction_sequence_number = TransactionSequenceNumber::new(42);
+        let key = encode_transaction_by_address_key(&address, transaction_sequence_number);
+        assert_eq!(key[..IotaAddress::LENGTH], address.into_bytes());
+        assert_eq!(
+            key[IotaAddress::LENGTH..],
+            transaction_sequence_number.to_complement_be_bytes()
+        );
+    }
+
+    #[test]
+    fn test_decode_transaction_by_address_key() {
+        let address = IotaAddress::random();
+        let transaction_sequence_number = TransactionSequenceNumber::new(42);
+        let key = encode_transaction_by_address_key(&address, transaction_sequence_number);
+        let (decoded_address, decoded_sequence_number) =
+            decode_transaction_by_address_key(&key).unwrap();
+        assert_eq!(decoded_address, address);
+        assert_eq!(decoded_sequence_number, transaction_sequence_number);
+    }
 }

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -2,11 +2,14 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
-use iota_types::full_checkpoint_content::CheckpointData;
+use iota_types::{
+    base_types::IotaAddress, effects::TransactionEffectsExt,
+    full_checkpoint_content::CheckpointData, object::Owner, transaction::TransactionDataAPI,
+};
 
 use crate::{BigTableClient, KeyValueStoreWriter, TransactionData};
 
@@ -26,6 +29,7 @@ impl Worker for KvWorker {
         let mut client = self.client.clone();
         let mut objects = vec![];
         let mut transactions = Vec::with_capacity(checkpoint.transactions.len());
+
         for transaction in &checkpoint.transactions {
             for object in &transaction.output_objects {
                 objects.push(object);
@@ -35,8 +39,36 @@ impl Worker for KvWorker {
                 checkpoint.checkpoint_summary.sequence_number,
             ));
         }
+
         client.save_objects(&objects).await?;
         client.save_transactions(&transactions).await?;
+
+        let entries_by_address = checkpoint
+            .checkpoint_contents
+            .enumerate_transactions(&checkpoint.checkpoint_summary)
+            .zip(&checkpoint.transactions)
+            .flat_map(|((seq, exec_digest), tx)| {
+                let digest = exec_digest.transaction;
+                let tx_data = tx.transaction.transaction_data();
+
+                let affected = std::iter::once(tx_data.sender())
+                    .chain(std::iter::once(tx_data.gas_owner()))
+                    .chain(tx.effects.all_changed_objects().into_iter().filter_map(
+                        |(_object_ref, owner, _write_kind)| match owner {
+                            Owner::Address(a) => Some(a),
+                            _ => None,
+                        },
+                    ))
+                    .collect::<HashSet<IotaAddress>>();
+
+                affected
+                    .into_iter()
+                    .map(move |address| (address, seq, digest))
+            });
+
+        client
+            .save_transactions_by_address(entries_by_address)
+            .await?;
         client.save_checkpoint(&checkpoint).await?;
 
         Ok(())

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroUsize;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use iota_types::{
@@ -24,6 +26,8 @@ mod bigtable;
 pub use bigtable::{client, worker::KvWorker};
 pub use iota_bigtable::{BigTableClient, Cell, Row, proto};
 
+use crate::bigtable::client::{TransactionSequenceNumber, TransactionsOrder};
+
 /// Read key-value data from a persistent store, such as objects, transactions,
 /// and checkpoints.
 #[async_trait]
@@ -43,14 +47,27 @@ pub trait KeyValueStoreReader {
         transactions: &[TransactionDigest],
     ) -> Result<Vec<TransactionData>, Self::Error>;
 
-    /// Fetches a list of transaction digests affected by a given address in
-    /// order of execution.
+    /// Fetches a list `(sequence number, digest)` pairs for transactions
+    /// affecting the given address, ordered by [`TransactionsOrder`] and capped
+    /// at `limit`.
     ///
-    /// Not found transactions are omitted from the output list.
+    /// # Pagination
+    /// `cursor` is **exclusive**.
+    ///
+    /// - [`TransactionsOrder::NewestFirst`]: returns entries with `tx_seq <
+    ///   cursor`.
+    /// - [`TransactionsOrder::OldestFirst`]: returns entries with `tx_seq >
+    ///   cursor`.
+    ///
+    /// When `None`, the scan starts from the beginning of the requested
+    /// [`TransactionsOrder`].
     async fn get_transaction_digests_by_address(
         &mut self,
         address: IotaAddress,
-    ) -> Result<Vec<TransactionDigest>, Self::Error>;
+        cursor: impl Into<Option<TransactionSequenceNumber>> + Send,
+        limit: impl TryInto<NonZeroUsize> + Send,
+        order: TransactionsOrder,
+    ) -> Result<Vec<(TransactionSequenceNumber, TransactionDigest)>, Self::Error>;
 
     /// Fetches a list of checkpoints by their sequence numbers.
     ///

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use iota_types::{
+    base_types::IotaAddress,
     digests::{CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEvents},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
@@ -42,6 +43,15 @@ pub trait KeyValueStoreReader {
         transactions: &[TransactionDigest],
     ) -> Result<Vec<TransactionData>, Self::Error>;
 
+    /// Fetches a list of transaction digests affected by a given address in
+    /// order of execution.
+    ///
+    /// Not found transactions are omitted from the output list.
+    async fn get_transaction_digests_by_address(
+        &mut self,
+        address: IotaAddress,
+    ) -> Result<Vec<TransactionDigest>, Self::Error>;
+
     /// Fetches a list of checkpoints by their sequence numbers.
     ///
     /// Not found checkpoints are omitted from the output list.
@@ -73,6 +83,16 @@ pub trait KeyValueStoreWriter {
         &mut self,
         transactions: &[TransactionData],
     ) -> Result<(), Self::Error>;
+
+    /// Persists a mapping of `(` [`IotaAddress`], `transaction_sequence_number`
+    /// `)` to `TransactionDigest` for every affected address.
+    ///
+    /// An address is considered "affected" if it appears as the sender, a
+    /// recipient, or the gas payer.
+    async fn save_transactions_by_address<I>(&mut self, entries: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = (IotaAddress, u64, TransactionDigest)> + Send,
+        I::IntoIter: Send;
 
     /// Persists a checkpoint to the store.
     async fn save_checkpoint(&mut self, checkpoint: &CheckpointData) -> Result<(), Self::Error>;


### PR DESCRIPTION
# Description of change

This PR introduces the `transactions_by_address` table, providing a secondary index that allows efficient lookup of transaction digests by addresses that participated in a transaction as sender, recipient, or gas payer.

More info on the design are contained in the issue description.

This change includes the necessary Bigtable client logic read/write and ingestion worker updates.

> [!NOTE]
This PR covers the database schema and ingestion logic. Historical backfill and REST API exposure are tracked separately in follow-up issues:

- #11328 
- #11676 .

## Links to any relevant issues

fixes #11659 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Tested manually the correctness of the new patch. Started a bigtable instance, for more information consult the `README.md` in the `iota-kvstore` crate.
<details>
<summary>TEST CASES</summary>

```rust
#[cfg(test)]
mod tests {
    use std::collections::HashSet;

    use iota_bigtable::BigTableClient;
    use iota_data_ingestion_core::Worker;
    use iota_types::{
        base_types::IotaAddress, digests::TransactionDigest, effects::TransactionEffectsExt,
        full_checkpoint_content::CheckpointData, object::Owner,
        test_checkpoint_data_builder::TestCheckpointDataBuilder, transaction::TransactionDataAPI,
    };

    use crate::{
        KeyValueStoreReader, KeyValueStoreWriter, KvWorker,
        client::{
            TRANSACTIONS_BY_ADDRESS_TABLE, TransactionSequenceNumber, TransactionsOrder,
            decode_transaction_by_address_key,
        },
    };

    /// Build a small checkpoint covering interesting affected-address cases:
    ///   tx 0: sender 0 creates an object kept by sender 0
    ///         → affected = {addr_0}
    ///   tx 1: sender 0 transfers object 0 to addr 1
    ///         → affected = {addr_0, addr_1}
    ///   tx 2: sender 2 creates object 1 then transfers it to addr 3
    ///         → affected = {addr_2, addr_3}
    fn build_test_checkpoint() -> CheckpointData {
        TestCheckpointDataBuilder::new(1)
            // tx 0: sender 0 creates object 0 (owned by sender 0)
            //   → affected = {addr_0}
            .start_transaction(0)
            .create_owned_object(0)
            .finish_transaction()
            // tx 1: sender 0 transfers object 0 to addr 1
            //   → affected = {addr_0, addr_1}
            .start_transaction(0)
            .transfer_object(0, 1)
            .finish_transaction()
            // tx 2: sender 2 creates object 1 (owned by sender 2)
            //   → affected = {addr_2}
            .start_transaction(2)
            .create_owned_object(1)
            .finish_transaction()
            // tx 3: sender 2 transfers object 1 to addr 3
            //   → affected = {addr_2, addr_3}
            .start_transaction(2)
            .transfer_object(1, 3)
            .finish_transaction()
            .build_checkpoint()
    }

    /// extract (address, tx seq, digest) rows the way the worker will.
    fn extract_affected_rows(
        checkpoint: &CheckpointData,
    ) -> Vec<(IotaAddress, u64, TransactionDigest)> {
        checkpoint
            .checkpoint_contents
            .enumerate_transactions(&checkpoint.checkpoint_summary)
            .zip(&checkpoint.transactions)
            .flat_map(|((seq, exec_digest), tx)| {
                let tx_data = tx.transaction.transaction_data();
                let affected: HashSet<IotaAddress> = std::iter::once(tx_data.sender())
                    .chain(std::iter::once(tx_data.gas_owner()))
                    .chain(tx.effects.all_changed_objects().into_iter().filter_map(
                        |(_, owner, _)| match owner {
                            Owner::Address(a) => Some(a),
                            _ => None,
                        },
                    ))
                    .collect();
                let digest = exec_digest.transaction;
                affected.into_iter().map(move |addr| (addr, seq, digest))
            })
            .collect()
    }

    #[test]
    fn affected_addresses_per_transaction() {
        let checkpoint = build_test_checkpoint();
        let addr = TestCheckpointDataBuilder::derive_address;

        let rows = extract_affected_rows(&checkpoint);
        let by_tx: HashSet<(u64, IotaAddress)> =
            rows.iter().map(|(a, seq, _)| (*seq, *a)).collect();

        let first_seq = rows.iter().map(|(_, s, _)| *s).min().unwrap();
        let s0 = first_seq;
        let s1 = first_seq + 1;
        let s2 = first_seq + 2;
        let s3 = first_seq + 3;

        // tx 0: only sender 0 (sender == payer == sole recipient)
        assert!(by_tx.contains(&(s0, addr(0))));
        assert_eq!(by_tx.iter().filter(|(s, _)| *s == s0).count(), 1);

        // tx 1: sender 0 (also payer) + recipient 1
        assert!(by_tx.contains(&(s1, addr(0))));
        assert!(by_tx.contains(&(s1, addr(1))));
        assert_eq!(by_tx.iter().filter(|(s, _)| *s == s1).count(), 2);

        // tx 2: only sender 2
        assert!(by_tx.contains(&(s2, addr(2))));
        assert_eq!(by_tx.iter().filter(|(s, _)| *s == s2).count(), 1);

        // tx 3: sender 2 (also payer) + recipient 3
        assert!(by_tx.contains(&(s3, addr(2))));
        assert!(by_tx.contains(&(s3, addr(3))));
        assert_eq!(by_tx.iter().filter(|(s, _)| *s == s3).count(), 2);
    }

    #[tokio::test]
    async fn process_checkpoint() {
        use std::collections::HashMap;

        let checkpoint = build_test_checkpoint();
        let addr = TestCheckpointDataBuilder::derive_address;

        // capture expected (address -> set of digests) BEFORE the checkpoint is moved.
        let expected_rows = extract_affected_rows(&checkpoint);
        let mut expected_by_address: HashMap<
            IotaAddress,
            HashMap<TransactionSequenceNumber, TransactionDigest>,
        > = HashMap::new();
        for (address, seq, digest) in &expected_rows {
            expected_by_address
                .entry(*address)
                .or_default()
                .insert(*seq, *digest);
        }

        std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost:8086");
        let client = BigTableClient::new_local("iota", "iota").await.unwrap();
        let mut read_client = client.clone();
        let kv_worker = KvWorker { client };

        // write to BigTable: run the worker on the checkpoint.
        kv_worker
            .process_checkpoint(checkpoint.into())
            .await
            .unwrap();

        // read back from BigTable and compare per affected address.
        for (address, expected_digests) in &expected_by_address {
            let fetched: HashMap<TransactionSequenceNumber, TransactionDigest> = read_client
                .get_transaction_digests_by_address(*address, None, 10, Default::default())
                .await
                .unwrap()
                .into_iter()
                .collect();

            assert_eq!(
                &fetched, expected_digests,
                "digests stored for {address:?} do not match expected",
            );
        }

        // addresses we never used should return nothing.
        let unused = addr(99);
        let fetched = read_client
            .get_transaction_digests_by_address(unused, None, 10, Default::default())
            .await
            .unwrap();

        assert!(
            fetched.is_empty() || !expected_by_address.contains_key(&unused),
            "unrelated address {unused:?} unexpectedly has stored digests",
        );
    }

    #[tokio::test]
    async fn dump_transactions_by_address() {
        std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost:8086");
        let mut client = BigTableClient::new_local("iota", "iota").await.unwrap();

        let rows = client
            .range_scan(TRANSACTIONS_BY_ADDRESS_TABLE, None, None, 0, false, None)
            .await
            .unwrap();

        println!("\n{} rows in {}", rows.len(), TRANSACTIONS_BY_ADDRESS_TABLE);
        println!("{:-<96}", "");

        for row in rows {
            let (address, tx_seq) = decode_transaction_by_address_key(&row.key).unwrap();
            let digest = row
                .cells
                .into_iter()
                .next()
                .map(|c| TransactionDigest::from_bytes(&c.value).unwrap());

            println!(
                "Key [address={} || tx_seq={:?}] => VALUE [digest={}]",
                address,
                tx_seq,
                digest
                    .as_ref()
                    .map(|d| d.to_string())
                    .unwrap_or_else(|| "<missing>".into()),
            );
        }
    }

    #[tokio::test]
    async fn paginates_newest_first() {
        std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost:8086");
        let mut client = BigTableClient::new_local("iota", "iota").await.unwrap();

        let address = IotaAddress::random();
        let seqs = [10u64, 20, 30, 40, 50];
        let digests: Vec<TransactionDigest> = (0..seqs.len())
            .map(|_| TransactionDigest::random())
            .collect();
        let entries: Vec<_> = seqs
            .iter()
            .zip(digests.iter())
            .map(|(s, d)| (address, *s, *d))
            .collect();
        client.save_transactions_by_address(entries).await.unwrap();

        // page 1: 3 newest, in newest-first order.
        let page1 = client
            .get_transaction_digests_by_address(address, None, 3, TransactionsOrder::NewestFirst)
            .await
            .unwrap();
        assert_eq!(
            page1,
            vec![(50, digests[4]), (40, digests[3]), (30, digests[2])]
        );

        // page 2: continue past seq 30, no overlap with page 1.
        let page2 = client
            .get_transaction_digests_by_address(
                address,
                Some(30),
                10,
                TransactionsOrder::NewestFirst,
            )
            .await
            .unwrap();
        assert_eq!(page2, vec![(20, digests[1]), (10, digests[0])]);
    }

    #[tokio::test]
    async fn paginates_oldest_first() {
        std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost:8086");
        let mut client = BigTableClient::new_local("iota", "iota").await.unwrap();

        let address = IotaAddress::random();
        let seqs = [10u64, 20, 30, 40, 50];
        let digests: Vec<TransactionDigest> = (0..seqs.len())
            .map(|_| TransactionDigest::random())
            .collect();
        let entries: Vec<_> = seqs
            .iter()
            .zip(digests.iter())
            .map(|(s, d)| (address, *s, *d))
            .collect();
        client.save_transactions_by_address(entries).await.unwrap();

        // page 1: 3 oldest, in oldest-first order.
        let page1 = client
            .get_transaction_digests_by_address(address, None, 3, TransactionsOrder::OldestFirst)
            .await
            .unwrap();
        assert_eq!(
            page1,
            vec![(10, digests[0]), (20, digests[1]), (30, digests[2])]
        );

        // page 2: continue past seq 30, no overlap with page 1.
        let page2 = client
            .get_transaction_digests_by_address(
                address,
                Some(30),
                10,
                TransactionsOrder::OldestFirst,
            )
            .await
            .unwrap();
        assert_eq!(page2, vec![(40, digests[3]), (50, digests[4])]);
    }

    #[tokio::test]
    async fn order_flip_is_exact_reverse() {
        std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost:8086");
        let mut client = BigTableClient::new_local("iota", "iota").await.unwrap();

        let address = IotaAddress::random();
        let seqs = [10u64, 20, 30, 50];
        let digests: Vec<TransactionDigest> = (0..seqs.len())
            .map(|_| TransactionDigest::random())
            .collect();
        let entries: Vec<_> = seqs
            .iter()
            .zip(digests.iter())
            .map(|(s, d)| (address, *s, *d))
            .collect();
        client.save_transactions_by_address(entries).await.unwrap();

        let newest_first = client
            .get_transaction_digests_by_address(address, None, 10, TransactionsOrder::NewestFirst)
            .await
            .unwrap();
        let oldest_first = client
            .get_transaction_digests_by_address(address, None, 10, TransactionsOrder::OldestFirst)
            .await
            .unwrap();

        assert_eq!(
            newest_first,
            vec![
                (50, digests[3]),
                (30, digests[2]),
                (20, digests[1]),
                (10, digests[0])
            ]
        );
        assert_eq!(
            oldest_first,
            vec![
                (10, digests[0]),
                (20, digests[1]),
                (30, digests[2]),
                (50, digests[3])
            ]
        );
        let mut reversed = oldest_first.clone();
        reversed.reverse();
        assert_eq!(newest_first, reversed);
    }

    #[tokio::test]
    async fn empty_range_guards_return_ok_empty() {
        std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost:8086");
        let mut client = BigTableClient::new_local("iota", "iota").await.unwrap();

        // Address need not exist: the guards short-circuit before hitting BigTable.
        let address = IotaAddress::random();

        // NewestFirst with cursor = 0: nothing is older than seq 0.
        // BigTable would reject the empty range; the guard must return Ok(vec![]).
        let res = client
            .get_transaction_digests_by_address(
                address,
                Some(0),
                10,
                TransactionsOrder::NewestFirst,
            )
            .await
            .unwrap();
        assert!(res.is_empty());

        // OldestFirst with cursor = u64::MAX: nothing is newer than u64::MAX.
        let res = client
            .get_transaction_digests_by_address(
                address,
                Some(u64::MAX),
                10,
                TransactionsOrder::OldestFirst,
            )
            .await
            .unwrap();
        assert!(res.is_empty());
    }
}

```

</details>

<details>
<summary>TABLE CONTENT</summary>

```text
6 rows in transactions_by_address
------------------------------------------------------------------------------------------------
Key [address=0x0000000000000000000000000000000000000000000000000000000000000000 || tx_seq=1] => VALUE [digest=EsmyXKmKv77oPzhXTdbFGZqX27uzCE4MghsjtTzrmHWe]
Key [address=0x0000000000000000000000000000000000000000000000000000000000000000 || tx_seq=0] => VALUE [digest=9RFLBNRfDPQTS74EMyq5yQXWErX5TwE1ZELY51HR2peP]
Key [address=0x0101010101010101010101010101010101010101010101010101010101010101 || tx_seq=1] => VALUE [digest=EsmyXKmKv77oPzhXTdbFGZqX27uzCE4MghsjtTzrmHWe]
Key [address=0x0202020202020202020202020202020202020202020202020202020202020202 || tx_seq=3] => VALUE [digest=GE6ZhGYeafUyAhwKwYnMuYc96Yb3MeQxr3JSvy3EcVnY]
Key [address=0x0202020202020202020202020202020202020202020202020202020202020202 || tx_seq=2] => VALUE [digest=44MkBK7waUTYxTqjh4nWgZ9SNMM66EZVWmM2hbD3DwqQ]
Key [address=0x0303030303030303030303030303030303030303030303030303030303030303 || tx_seq=3] => VALUE [digest=GE6ZhGYeafUyAhwKwYnMuYc96Yb3MeQxr3JSvy3EcVnY]
test bigtable::client::tests::dump_transactions_by_address ... ok
```

</details>

- All test cases passed and the table content does follow the order of most recent transaction sequence number per address  

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

>[!NOTE]
> This patch does not affect the normal operation of the indexer, thus no further tests were conducted.