### PR TITLE
refactor(graphql-rpc)!: remove transaction signer filters

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/consistency/balances.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/balances.move
@@ -79,7 +79,7 @@ module P0::fake {
 //# run-graphql --cursors {"c":2,"t":1,"i":false}
 # Emulating viewing transaction blocks at checkpoint 2. Fake coin balance should be 700.
 {
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -102,7 +102,7 @@ module P0::fake {
 //# run-graphql --cursors {"c":3,"t":1,"i":false}
 # Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
 {
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -125,7 +125,7 @@ module P0::fake {
 //# run-graphql --cursors {"c":4,"t":1,"i":false}
 # Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
 {
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -152,7 +152,7 @@ module P0::fake {
 //# run-graphql --cursors {"c":2,"t":1,"i":false}
 # Emulating viewing transaction blocks at checkpoint 2. Fake coin balance should be 700.
 {
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -175,7 +175,7 @@ module P0::fake {
 //# run-graphql --cursors {"c":3,"t":1,"i":false}
 # Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
 {
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -198,7 +198,7 @@ module P0::fake {
 //# run-graphql --cursors {"c":4,"t":1,"i":false}
 # Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
 {
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -240,7 +240,7 @@ module P0::fake {
       sequenceNumber
     }
   }
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -263,7 +263,7 @@ module P0::fake {
 //# run-graphql --cursors {"c":3,"t":1,"i":false}
 # Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
 {
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -286,7 +286,7 @@ module P0::fake {
 //# run-graphql --cursors {"c":4,"t":1,"i":false}
 # Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
 {
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -334,7 +334,7 @@ module P0::fake {
       sequenceNumber
     }
   }
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -365,7 +365,7 @@ module P0::fake {
       sequenceNumber
     }
   }
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -396,7 +396,7 @@ module P0::fake {
       sequenceNumber
     }
   }
-  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.move
@@ -57,7 +57,7 @@ module Test::M1 {
   checkpoints {
     nodes {
       sequenceNumber
-      transactionBlocks(filter: { signAddress: "@{A}"}) {
+      transactionBlocks(filter: { sentAddress: "@{A}"}) {
         edges {
           cursor
           node {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
@@ -250,7 +250,7 @@ module Test::M1 {
   checkpoint {
     sequenceNumber
   }
-  with_cursor: transactionBlocks(after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+  with_cursor: transactionBlocks(after: "@{cursor_0}", filter: {sentAddress: "@{A}"}) {
     edges {
       cursor
       node {
@@ -265,7 +265,7 @@ module Test::M1 {
       }
     }
   }
-  without_cursor: transactionBlocks(filter: {signAddress: "@{A}"}) {
+  without_cursor: transactionBlocks(filter: {sentAddress: "@{A}"}) {
     edges {
       cursor
       node {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/tx_address_objects.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/tx_address_objects.move
@@ -72,7 +72,7 @@ module Test::M1 {
       }
     }
   }
-  latest_tx_at_checkpoint_3: transactionBlocks(last: 1, filter: {signAddress: "@{A}"}) {
+  latest_tx_at_checkpoint_3: transactionBlocks(last: 1, filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         objects_consistent_with_address_at_latest_checkpoint_4: objects(filter: {type: "@{Test}"}) {
@@ -136,7 +136,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  all_transactions: transactionBlocks(first: 4, filter: {signAddress: "@{A}"}) {
+  all_transactions: transactionBlocks(first: 4, filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         objects(filter: {type: "@{Test}"}) {
@@ -196,7 +196,7 @@ module Test::M1 {
       }
     }
   }
-  latest_tx_at_checkpoint_3: transactionBlocks(last: 1, filter: {signAddress: "@{A}"}) {
+  latest_tx_at_checkpoint_3: transactionBlocks(last: 1, filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         objects(filter: {type: "@{Test}"}) {
@@ -263,7 +263,7 @@ module Test::M1 {
 //# run-graphql
 # Regardless of the transaction block, the nested fields should yield the same data.
 {
-  all_transactions: transactionBlocks(first: 4, filter: {signAddress: "@{A}"}) {
+  all_transactions: transactionBlocks(first: 4, filter: {sentAddress: "@{A}"}) {
     nodes {
       sender {
         objects(filter: {type: "@{Test}"}) {

--- a/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.move
+++ b/crates/iota-graphql-e2e-tests/tests/event_connection/complexity.move
@@ -68,7 +68,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(filter: { signAddress: "@{A}" }) {
+  transactionBlocks(filter: { sentAddress: "@{A}" }) {
     nodes {
       effects{
         events {
@@ -88,7 +88,7 @@ module Test::M1 {
 //# run-graphql
 # This should fail due to the complexity of the query
 {
-  transactionBlocks(filter: { signAddress: "@{A}" }) {
+  transactionBlocks(filter: { sentAddress: "@{A}" }) {
     nodes {
       effects{
         events {
@@ -110,7 +110,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(filter: { signAddress: "@{A}" }) {
+  transactionBlocks(filter: { sentAddress: "@{A}" }) {
     nodes {
       effects{
         dependencies {
@@ -146,7 +146,7 @@ module Test::M1 {
 //# run-graphql
 # This should fail due to the complexity of the query
 {
-  transactionBlocks(filter: { signAddress: "@{A}" }) {
+  transactionBlocks(filter: { sentAddress: "@{A}" }) {
     nodes {
       effects{
         dependencies {
@@ -184,7 +184,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(filter: { signAddress: "@{A}" }) {
+  transactionBlocks(filter: { sentAddress: "@{A}" }) {
     nodes {
       effects{
         checkpoint {
@@ -211,7 +211,7 @@ module Test::M1 {
 //# run-graphql
 # This should fail due to the complexity of the query
 {
-  transactionBlocks(filter: { signAddress: "@{A}" }) {
+  transactionBlocks(filter: { sentAddress: "@{A}" }) {
     nodes {
       effects{
         checkpoint {

--- a/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/events.move
+++ b/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/events.move
@@ -38,7 +38,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(filter: { signAddress: "@{A}" }) {
+  transactionBlocks(filter: { sentAddress: "@{A}" }) {
     nodes {
       effects{
         events {
@@ -72,7 +72,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(first: 1, filter: { signAddress: "@{A}" }) {
+  transactionBlocks(first: 1, filter: { sentAddress: "@{A}" }) {
     nodes {
       effects {
         events(last: 1) {
@@ -93,7 +93,7 @@ module Test::M1 {
 
 //# run-graphql --cursors {"i":0,"c":1}
 {
-  transactionBlocks(last: 1, filter: { signAddress: "@{A}" }) {
+  transactionBlocks(last: 1, filter: { sentAddress: "@{A}" }) {
     nodes {
       effects {
         events(first: 2, after: "@{cursor_0}") {

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/kind.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/kind.move
@@ -55,7 +55,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 signAddress: "@{A}"}) {
+  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 sentAddress: "@{A}"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -75,7 +75,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 signAddress: "@{B}"}) {
+  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 sentAddress: "@{B}"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -95,7 +95,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 signAddress: "@{C}"}) {
+  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 sentAddress: "@{C}"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -115,7 +115,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 signAddress: "@{D}"}) {
+  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 sentAddress: "@{D}"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -135,7 +135,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 signAddress: "@{E}"}) {
+  transactionBlocks(first: 50 filter: {kind: PROGRAMMABLE_TX atCheckpoint: 2 sentAddress: "@{E}"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/sent.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/sent.move
@@ -5,7 +5,7 @@
 
 //# init --protocol-version 15 --addresses Test=0x0 --accounts A B --simulator
 
-// Confirm that the new `sentAddress` behaves like `signAddress`, and how the
+// Confirm that the new `sentAddress` behaves like `sentAddress`, and how the
 // two filters interact with each other.
 
 //# programmable --sender A --inputs 1000000 @B
@@ -23,42 +23,14 @@ query {
   bySentAddress: transactionBlocks(filter: { sentAddress: "@{A}" }) {
     nodes { ...CoinBalances }
   }
-  bySignAddress: transactionBlocks(filter: { signAddress: "@{A}" }) {
-    nodes { ...CoinBalances }
-  }
-  bothAddresses: transactionBlocks(filter: { sentAddress: "@{A}", signAddress: "@{A}" }) {
-    nodes { ...CoinBalances }
-  }
-  differentAddresses: transactionBlocks(filter: { sentAddress: "@{A}", signAddress: "@{B}" }) {
-    nodes { ...CoinBalances }
-  }
   compoundBySentAddress: transactionBlocks(filter: { sentAddress: "@{A}", kind: PROGRAMMABLE_TX }) {
     nodes { ...CoinBalances }
   }
-  compoundBySignAddress: transactionBlocks(filter: { signAddress: "@{A}", kind: PROGRAMMABLE_TX }) {
-    nodes { ...CoinBalances }
-  }
-  compoundBothAddresses: transactionBlocks(filter: {
-    sentAddress: "@{A}",
-    signAddress: "@{A}",
-    kind: PROGRAMMABLE_TX,
-  }) {
-    nodes { ...CoinBalances }
-  }
-  compoundDifferentAddresses: transactionBlocks(filter: {
-    sentAddress: "@{A}",
-    signAddress: "@{B}",
-    kind: PROGRAMMABLE_TX,
-  }) {
+  compoundBySignAddress: transactionBlocks(filter: { sentAddress: "@{A}", kind: PROGRAMMABLE_TX }) {
     nodes { ...CoinBalances }
   }
   sentViaAddress: address(address: "@{A}") {
     transactionBlocks(relation: SENT) {
-      nodes { ...CoinBalances }
-    }
-  }
-  signViaAddress: address(address: "@{A}") {
-    transactionBlocks(relation: SIGN) {
       nodes { ...CoinBalances }
     }
   }

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/sent.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/sent.snap
@@ -26,125 +26,11 @@ task 3, line 19:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 21-78:
+task 4, lines 21-50:
 //# run-graphql
 Response: {
   "data": {
-    "bothAddresses": {
-      "nodes": [
-        {
-          "effects": {
-            "objectChanges": {
-              "nodes": [
-                {
-                  "inputState": null,
-                  "outputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "1000000"
-                      }
-                    }
-                  }
-                },
-                {
-                  "inputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "300000000000000"
-                      }
-                    }
-                  },
-                  "outputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "299999996039200"
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
     "bySentAddress": {
-      "nodes": [
-        {
-          "effects": {
-            "objectChanges": {
-              "nodes": [
-                {
-                  "inputState": null,
-                  "outputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "1000000"
-                      }
-                    }
-                  }
-                },
-                {
-                  "inputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "300000000000000"
-                      }
-                    }
-                  },
-                  "outputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "299999996039200"
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    "bySignAddress": {
-      "nodes": [
-        {
-          "effects": {
-            "objectChanges": {
-              "nodes": [
-                {
-                  "inputState": null,
-                  "outputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "1000000"
-                      }
-                    }
-                  }
-                },
-                {
-                  "inputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "300000000000000"
-                      }
-                    }
-                  },
-                  "outputState": {
-                    "asMoveObject": {
-                      "asCoin": {
-                        "coinBalance": "299999996039200"
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    "compoundBothAddresses": {
       "nodes": [
         {
           "effects": {
@@ -258,53 +144,7 @@ Response: {
         }
       ]
     },
-    "compoundDifferentAddresses": {
-      "nodes": []
-    },
-    "differentAddresses": {
-      "nodes": []
-    },
     "sentViaAddress": {
-      "transactionBlocks": {
-        "nodes": [
-          {
-            "effects": {
-              "objectChanges": {
-                "nodes": [
-                  {
-                    "inputState": null,
-                    "outputState": {
-                      "asMoveObject": {
-                        "asCoin": {
-                          "coinBalance": "1000000"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "inputState": {
-                      "asMoveObject": {
-                        "asCoin": {
-                          "coinBalance": "300000000000000"
-                        }
-                      }
-                    },
-                    "outputState": {
-                      "asMoveObject": {
-                        "asCoin": {
-                          "coinBalance": "299999996039200"
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
-    },
-    "signViaAddress": {
       "transactionBlocks": {
         "nodes": [
           {

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/transaction_ids.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/transaction_ids.move
@@ -47,7 +47,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  transactionBlocks(filter: {signAddress: "@{A}" transactionIds: []}) {
+  transactionBlocks(filter: {sentAddress: "@{A}" transactionIds: []}) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/crates/iota-graphql-e2e-tests/tests/transactions/programmable.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/programmable.move
@@ -832,7 +832,7 @@ fragment ComprehensivePTB on ProgrammableTransactionBlock {
 //# run-graphql
 { # Conflicting filter and context
     address(address: "@{A}") {
-        transactionBlocks(last: 10, filter: { signAddress: "0x0" }) {
+        transactionBlocks(last: 10, filter: { sentAddress: "0x0" }) {
             nodes { kind { __typename } }
         }
     }

--- a/crates/iota-graphql-e2e-tests/tests/transactions/scan_limit/require.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/scan_limit/require.move
@@ -77,7 +77,7 @@ module Test::M1 {
 //# run-graphql
 # Don't need scanLimit with sender
 {
-  transactionBlocks(filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4}) {
+  transactionBlocks(filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -98,7 +98,7 @@ module Test::M1 {
 //# run-graphql
 # scanLimit required
 {
-  transactionBlocks(filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 function: "@{Test}::M1::create"}) {
+  transactionBlocks(filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 function: "@{Test}::M1::create"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -119,7 +119,7 @@ module Test::M1 {
 //# run-graphql
 # valid
 {
-  transactionBlocks(scanLimit: 50 filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 function: "@{Test}::M1::create"}) {
+  transactionBlocks(scanLimit: 50 filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 function: "@{Test}::M1::create"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -140,7 +140,7 @@ module Test::M1 {
 //# run-graphql
 # scanLimit required
 {
-  transactionBlocks(filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 kind: PROGRAMMABLE_TX}) {
+  transactionBlocks(filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 kind: PROGRAMMABLE_TX}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -161,7 +161,7 @@ module Test::M1 {
 //# run-graphql
 # valid
 {
-  transactionBlocks(scanLimit: 50 filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 kind: PROGRAMMABLE_TX}) {
+  transactionBlocks(scanLimit: 50 filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 kind: PROGRAMMABLE_TX}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -182,7 +182,7 @@ module Test::M1 {
 //# run-graphql
 # scanLimit required
 {
-  transactionBlocks(filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 inputObject: "@{obj_3_0}"}) {
+  transactionBlocks(filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 inputObject: "@{obj_3_0}"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -203,7 +203,7 @@ module Test::M1 {
 //# run-graphql
 # valid
 {
-  transactionBlocks(scanLimit: 50 filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 inputObject: "@{obj_3_0}"}) {
+  transactionBlocks(scanLimit: 50 filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 inputObject: "@{obj_3_0}"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -225,7 +225,7 @@ module Test::M1 {
 //# run-graphql
 # scanLimit required
 {
-  transactionBlocks(filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 changedObject: "@{obj_3_0}"}) {
+  transactionBlocks(filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 changedObject: "@{obj_3_0}"}) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -248,7 +248,7 @@ module Test::M1 {
 # Because scanLimit is specified, the boundary cursors should be at 2 and 11,
 # and both will indicate is_scan_limited
 {
-  transactionBlocks(scanLimit: 50 filter: {signAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 changedObject: "@{obj_3_0}"}) {
+  transactionBlocks(scanLimit: 50 filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 changedObject: "@{obj_3_0}"}) {
     pageInfo {
       hasPreviousPage
       hasNextPage

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -114,15 +114,6 @@ The possible relationship types for a transaction block: sent or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has sent. NOTE: this input filter has been
-	deprecated in favor of `SENT` which behaves identically but is named
-	more clearly. Both filters restrict transactions by their sender,
-	only, not signers in general.
-	
-	This filter will be removed after 6 months with the 1.24.0 release.
-	"""
-	SIGN @deprecated(reason: "Misleading semantics. Use `SENT` instead. This will be removed with the 1.24.0 release.")
-	"""
 	Transactions this address has sent.
 	"""
 	SENT
@@ -4577,15 +4568,6 @@ input TransactionBlockFilter {
 	Limit to transaction that occurred strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
-	"""
-	Limit to transactions that were sent by the given address. NOTE: this
-	input filter has been deprecated in favor of `sentAddress` which has
-	clearer semantics. Both filters restrict transactions by their sender,
-	only, not signers in general.
-	
-	This filter will be removed after 6 months with the 1.24.0 release.
-	"""
-	signAddress: IotaAddress @deprecated(reason: "Misleading semantics. Use `sentAddress` instead. This will be removed with the 1.24.0 release.")
 	"""
 	Limit to transactions that were sent by the given address.
 	"""

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -32,16 +32,6 @@ pub(crate) struct Address {
 /// The possible relationship types for a transaction block: sent or received.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum AddressTransactionBlockRelationship {
-    /// Transactions this address has sent. NOTE: this input filter has been
-    /// deprecated in favor of `SENT` which behaves identically but is named
-    /// more clearly. Both filters restrict transactions by their sender,
-    /// only, not signers in general.
-    ///
-    /// This filter will be removed after 6 months with the 1.24.0 release.
-    #[graphql(
-        deprecation = "Misleading semantics. Use `SENT` instead. This will be removed with the 1.24.0 release."
-    )]
-    Sign,
     /// Transactions this address has sent.
     Sent,
     /// Transactions that sent objects to this address.
@@ -200,7 +190,7 @@ impl Address {
 
         let Some(filter) = filter.unwrap_or_default().intersect(match relation {
             // Relationship defaults to "signer" if none is supplied.
-            Some(R::Sign) | Some(R::Sent) | None => TransactionBlockFilter {
+            Some(R::Sent) | None => TransactionBlockFilter {
                 sent_address: Some(self.address),
                 ..Default::default()
             },

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -30,16 +30,6 @@ pub(crate) struct TransactionBlockFilter {
     pub at_checkpoint: Option<UInt53>,
     /// Limit to transaction that occurred strictly before the given checkpoint.
     pub before_checkpoint: Option<UInt53>,
-    /// Limit to transactions that were sent by the given address. NOTE: this
-    /// input filter has been deprecated in favor of `sentAddress` which has
-    /// clearer semantics. Both filters restrict transactions by their sender,
-    /// only, not signers in general.
-    ///
-    /// This filter will be removed after 6 months with the 1.24.0 release.
-    #[graphql(
-        deprecation = "Misleading semantics. Use `sentAddress` instead. This will be removed with the 1.24.0 release."
-    )]
-    pub sign_address: Option<IotaAddress>,
     /// Limit to transactions that were sent by the given address.
     pub sent_address: Option<IotaAddress>,
     /// Limit to transactions that sent an object to the given address.
@@ -75,7 +65,6 @@ impl TransactionBlockFilter {
             at_checkpoint: intersect!(at_checkpoint, intersect::by_eq)?,
             before_checkpoint: intersect!(before_checkpoint, intersect::by_min)?,
 
-            sign_address: intersect!(sign_address, intersect::by_eq)?,
             sent_address: intersect!(sent_address, intersect::by_eq)?,
             recv_address: intersect!(recv_address, intersect::by_eq)?,
             input_object: intersect!(input_object, intersect::by_eq)?,
@@ -122,7 +111,7 @@ impl TransactionBlockFilter {
             && self.changed_object.is_none()
             && self.wrapped_or_deleted_object.is_none()
         {
-            self.sent_address.or(self.sign_address)
+            self.sent_address
         } else {
             None
         }
@@ -133,7 +122,6 @@ impl TransactionBlockFilter {
     pub(crate) fn has_filters(&self) -> bool {
         self.function.is_some()
             || self.kind.is_some()
-            || self.sign_address.is_some()
             || self.sent_address.is_some()
             || self.recv_address.is_some()
             || self.input_object.is_some()
@@ -158,16 +146,10 @@ impl TransactionBlockFilter {
             )
             // If SystemTx, sender if specified must be 0x0. Conversely, if sender is 0x0, kind must be SystemTx.
             || matches!(
-                (self.kind, self.sent_address.or(self.sign_address)),
-                (Some(kind), Some(signer))
+                (self.kind, self.sent_address),
+                (Some(kind), Some(sender))
                     if (kind == TransactionBlockKindInput::SystemTx)
-                        != (signer == IotaAddress::from(NativeIotaAddress::ZERO))
-            )
-            // Temporary while we deprecate `sign_address` in favor of `sent_address`.
-            || matches!(
-                (self.sign_address, self.sent_address),
-                (Some(signer), Some(sent))
-                    if signer != sent
+                        != (sender == IotaAddress::from(NativeIotaAddress::ZERO))
             )
     }
 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -325,7 +325,7 @@ fn min_option<T: Ord>(xs: impl IntoIterator<Item = Option<T>>) -> Option<T> {
 /// their own filter condition, plus optionally a sender, plus optionally tx/cp
 /// bounds.
 pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -> Option<RawQuery> {
-    let sender = filter.sent_address.or(filter.sign_address);
+    let sender = filter.sent_address;
 
     let mut subqueries = vec![];
 

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -118,15 +118,6 @@ The possible relationship types for a transaction block: sent or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has sent. NOTE: this input filter has been
-	deprecated in favor of `SENT` which behaves identically but is named
-	more clearly. Both filters restrict transactions by their sender,
-	only, not signers in general.
-	
-	This filter will be removed after 6 months with the 1.24.0 release.
-	"""
-	SIGN @deprecated(reason: "Misleading semantics. Use `SENT` instead. This will be removed with the 1.24.0 release.")
-	"""
 	Transactions this address has sent.
 	"""
 	SENT
@@ -4581,15 +4572,6 @@ input TransactionBlockFilter {
 	Limit to transaction that occurred strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
-	"""
-	Limit to transactions that were sent by the given address. NOTE: this
-	input filter has been deprecated in favor of `sentAddress` which has
-	clearer semantics. Both filters restrict transactions by their sender,
-	only, not signers in general.
-	
-	This filter will be removed after 6 months with the 1.24.0 release.
-	"""
-	signAddress: IotaAddress @deprecated(reason: "Misleading semantics. Use `sentAddress` instead. This will be removed with the 1.24.0 release.")
 	"""
 	Limit to transactions that were sent by the given address.
 	"""


### PR DESCRIPTION
# Description of change

Maintenance patch to remove GraphQL transaction signer filters that were deprecated with #9252.

## Links to any relevant issues

Fixes #11592 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

### Release Notes

- [x] GraphQL: :warning:  Removed `TransactionBlockFilter.signAddress` in favor of `TransactionBlockFilter.sentAddress` which behaves identically. Similarly `AddressTransactionBlockRelationship.SIGN` is removed in favor of `AddressTransactionBlockRelationship.SENT`.
