### PR TITLE
upstream(core): Port latest traffic controller

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -215,7 +215,10 @@ pub struct NodeConfig {
     pub run_with_range: Option<RunWithRange>,
 
     // For killswitch use None
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default = "default_traffic_controller_policy_config"
+    )]
     pub policy_config: Option<PolicyConfig>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1280,6 +1283,10 @@ impl Default for AuthorityOverloadConfig {
 
 fn default_authority_overload_config() -> AuthorityOverloadConfig {
     AuthorityOverloadConfig::default()
+}
+
+fn default_traffic_controller_policy_config() -> Option<PolicyConfig> {
+    Some(PolicyConfig::default_dos_protection_policy())
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -120,6 +120,7 @@ use iota_types::{
     supported_protocol_versions::{
         ProtocolConfig, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
+    traffic_control::{PolicyConfig, RemoteFirewallConfig, TrafficControlReconfigParams},
     transaction::*,
     transaction_executor::{SimulateTransactionResult, VmChecks},
 };
@@ -180,6 +181,7 @@ use crate::{
     overload_monitor::{AuthorityOverloadInfo, overload_monitor_accept_tx},
     stake_aggregator::StakeAggregator,
     subscription_handler::SubscriptionHandler,
+    traffic_controller::{TrafficController, metrics::TrafficControllerMetrics},
     transaction_input_loader::TransactionInputLoader,
     transaction_manager::TransactionManager,
     transaction_outputs::TransactionOutputs,
@@ -827,6 +829,9 @@ pub struct AuthorityState {
     chain_identifier: ChainIdentifier,
 
     pub(crate) congestion_tracker: Arc<CongestionTracker>,
+
+    /// Traffic controller for IOTA core servers (json-rpc, validator service)
+    pub traffic_controller: Option<Arc<TrafficController>>,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures
@@ -1504,6 +1509,19 @@ impl AuthorityState {
                 .observe(effects.gas_cost_summary().computation_cost as f64 / elapsed);
         };
         Ok((effects, execution_error_opt))
+    }
+
+    pub async fn reconfigure_traffic_control(
+        &self,
+        params: TrafficControlReconfigParams,
+    ) -> Result<TrafficControlReconfigParams, IotaError> {
+        if let Some(traffic_controller) = self.traffic_controller.as_ref() {
+            traffic_controller.admin_reconfigure(params).await
+        } else {
+            Err(IotaError::InvalidAdminRequest(
+                "Traffic controller is not configured on this node".to_string(),
+            ))
+        }
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -3047,6 +3065,7 @@ impl AuthorityState {
     }
 
     #[expect(clippy::disallowed_methods)] // allow unbounded_channel()
+    #[expect(clippy::too_many_arguments)]
     pub async fn new(
         name: AuthorityName,
         secret: StableSyncAuthoritySigner,
@@ -3067,6 +3086,8 @@ impl AuthorityState {
         chain_identifier: ChainIdentifier,
         pruner_db: Option<Arc<AuthorityPrunerTables>>,
         checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
+        policy_config: Option<PolicyConfig>,
+        firewall_config: Option<RemoteFirewallConfig>,
     ) -> Arc<Self> {
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
 
@@ -3107,6 +3128,20 @@ impl AuthorityState {
             TransactionInputLoader::new(execution_cache_trait_pointers.object_cache_reader.clone());
         let epoch = epoch_store.epoch();
         let rgp = epoch_store.reference_gas_price();
+        let traffic_controller_metrics =
+            Arc::new(TrafficControllerMetrics::new(prometheus_registry));
+        let traffic_controller = if let Some(policy_config) = policy_config {
+            Some(Arc::new(
+                TrafficController::init(
+                    policy_config,
+                    traffic_controller_metrics,
+                    firewall_config.clone(),
+                )
+                .await,
+            ))
+        } else {
+            None
+        };
         let state = Arc::new(AuthorityState {
             name,
             secret,
@@ -3131,6 +3166,7 @@ impl AuthorityState {
             validator_tx_finalizer,
             chain_identifier,
             congestion_tracker: Arc::new(CongestionTracker::new(rgp)),
+            traffic_controller,
         });
 
         // Start a task to execute ready certificates.

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -358,6 +358,8 @@ impl<'a> TestAuthorityBuilder<'a> {
         config.authority_store_pruning_config = pruning_config;
 
         let chain_identifier = ChainIdentifier::from(*genesis.checkpoint().digest());
+        let policy_config = config.policy_config.clone();
+        let firewall_config = config.firewall_config.clone();
 
         let state = AuthorityState::new(
             name,
@@ -379,6 +381,8 @@ impl<'a> TestAuthorityBuilder<'a> {
             chain_identifier,
             pruner_db,
             None,
+            policy_config,
+            firewall_config,
         )
         .await;
 

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -41,8 +41,9 @@ use iota_types::{
 };
 use nonempty::{NonEmpty, nonempty};
 use prometheus::{
-    Histogram, IntCounter, IntCounterVec, Registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    Gauge, Histogram, IntCounter, IntCounterVec, Registry, register_gauge_with_registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry,
 };
 use tap::TapFallible;
 use tonic::{
@@ -191,6 +192,7 @@ pub struct ValidatorServiceMetrics {
     forwarded_header_invalid: IntCounter,
     forwarded_header_not_included: IntCounter,
     client_id_source_config_mismatch: IntCounter,
+    x_forwarded_for_num_hops: Gauge,
 }
 
 impl ValidatorServiceMetrics {
@@ -340,6 +342,12 @@ impl ValidatorServiceMetrics {
             client_id_source_config_mismatch: register_int_counter_with_registry!(
                 "validator_service_client_id_source_config_mismatch",
                 "Number of times detected that client id source config doesn't agree with x-forwarded-for header",
+                registry,
+            )
+            .unwrap(),
+            x_forwarded_for_num_hops: register_gauge_with_registry!(
+                "validator_service_x_forwarded_for_num_hops",
+                "Number of hops in x-forwarded-for header",
                 registry,
             )
             .unwrap(),
@@ -1020,6 +1028,17 @@ impl ValidatorService {
         request: &tonic::Request<T>,
         source: &ClientIdSource,
     ) -> Option<IpAddr> {
+        let forwarded_header = request.metadata().get_all("x-forwarded-for").iter().next();
+
+        if let Some(header) = forwarded_header {
+            let num_hops = header
+                .to_str()
+                .map(|h| h.split(',').count().saturating_sub(1))
+                .unwrap_or(0);
+
+            self.metrics.x_forwarded_for_num_hops.set(num_hops as f64);
+        }
+
         match source {
             ClientIdSource::SocketAddr => {
                 let socket_addr: Option<SocketAddr> = request.remote_addr();

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -36,7 +36,7 @@ use iota_types::{
         TransactionInfoResponse,
     },
     multiaddr::Multiaddr,
-    traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight},
+    traffic_control::{ClientIdSource, Weight},
     transaction::*,
 };
 use nonempty::{NonEmpty, nonempty};
@@ -59,9 +59,7 @@ use crate::{
         ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
     },
     starfish_adapter::LazyStarfishClient,
-    traffic_controller::{
-        TrafficController, metrics::TrafficControllerMetrics, parse_ip, policies::TrafficTally,
-    },
+    traffic_controller::{TrafficController, parse_ip, policies::TrafficTally},
 };
 
 #[cfg(test)]
@@ -377,22 +375,15 @@ impl ValidatorService {
         state: Arc<AuthorityState>,
         consensus_adapter: Arc<ConsensusAdapter>,
         validator_metrics: Arc<ValidatorServiceMetrics>,
-        traffic_controller_metrics: TrafficControllerMetrics,
-        policy_config: Option<PolicyConfig>,
-        firewall_config: Option<RemoteFirewallConfig>,
+        client_id_source: Option<ClientIdSource>,
     ) -> Self {
+        let traffic_controller = state.traffic_controller.clone();
         Self {
             state,
             consensus_adapter,
             metrics: validator_metrics,
-            traffic_controller: policy_config.clone().map(|policy| {
-                Arc::new(TrafficController::init(
-                    policy,
-                    traffic_controller_metrics,
-                    firewall_config,
-                ))
-            }),
-            client_id_source: policy_config.map(|policy| policy.client_id_source),
+            traffic_controller,
+            client_id_source,
         }
     }
 

--- a/crates/iota-core/src/traffic_controller/metrics.rs
+++ b/crates/iota-core/src/traffic_controller/metrics.rs
@@ -29,6 +29,7 @@ pub struct TrafficControllerMetrics {
     pub error_client_threshold: IntGauge,
     pub spam_proxied_client_threshold: IntGauge,
     pub error_proxied_client_threshold: IntGauge,
+    pub dry_run_enabled: IntGauge,
 }
 
 impl TrafficControllerMetrics {
@@ -155,6 +156,12 @@ impl TrafficControllerMetrics {
             error_proxied_client_threshold: register_int_gauge_with_registry!(
                 "error_proxied_client_threshold",
                 "Error proxied client threshold",
+                registry
+            )
+            .unwrap(),
+            dry_run_enabled: register_int_gauge_with_registry!(
+                "dry_run_enabled",
+                "If 1, dry run mode is enabled and traffic will not be blocked",
                 registry
             )
             .unwrap(),

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -18,7 +18,7 @@ use std::{
 
 use dashmap::DashMap;
 use fs::File;
-use iota_common::{debug_fatal, fatal};
+use iota_common::fatal;
 use iota_metrics::spawn_monitored_task;
 use iota_types::{
     error::IotaError,
@@ -332,7 +332,7 @@ impl TrafficController {
                     // that clearly the system is overloaded
                 }
                 Err(TrySendError::Closed(_)) => {
-                    debug_fatal!("TrafficController tally channel closed unexpectedly");
+                    warn!("TrafficController tally channel closed unexpectedly");
                 }
                 Ok(_) => {}
             }

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -419,9 +419,8 @@ impl TrafficController {
                 _ => (true, false),
             }
         };
-        if should_remove {
+        if should_remove && blocklist.remove(client).is_some() {
             blocklist_len_gauge.dec();
-            blocklist.remove(client);
         }
         !should_block
     }

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -216,16 +216,20 @@ impl TrafficController {
     pub async fn check(&self, client: &Option<IpAddr>, proxied_client: &Option<IpAddr>) -> bool {
         let check_with_dry_run_maybe = |allowed| -> bool {
             match (allowed, self.dry_run_mode()) {
-                // check succeeded
+                // request allowed
                 (true, _) => true,
-                // check failed while in dry-run mode
+                // request blocked while in dry-run mode
                 (false, true) => {
                     debug!("Dry run mode: Blocked request from client {:?}", client);
                     self.metrics.num_dry_run_blocked_requests.inc();
                     true
                 }
-                // check failed
-                (false, false) => false,
+                // request blocked
+                (false, false) => {
+                    debug!("Blocked request from client {:?}", client);
+                    self.metrics.requests_blocked_at_protocol.inc();
+                    false
+                }
             }
         };
 
@@ -549,8 +553,7 @@ async fn handle_policy_response(
             .is_none()
         {
             // Only increment the metric if the client was not already blocked
-            debug!("Blocking client: {:?}", client);
-            metrics.requests_blocked_at_protocol.inc();
+            debug!("Adding client {:?} to blocklist", client);
             metrics.connection_ip_blocklist_len.inc();
         }
     }
@@ -564,8 +567,7 @@ async fn handle_policy_response(
             .is_none()
         {
             // Only increment the metric if the client was not already blocked
-            debug!("Blocking proxied client: {:?}", client);
-            metrics.requests_blocked_at_protocol.inc();
+            debug!("Adding proxied client {:?} to blocklist", client);
             metrics.proxy_ip_blocklist_len.inc();
         }
     }

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -18,12 +18,19 @@ use std::{
 
 use dashmap::DashMap;
 use fs::File;
+use iota_common::{debug_fatal, fatal};
 use iota_metrics::spawn_monitored_task;
-use iota_types::traffic_control::{PolicyConfig, PolicyType, RemoteFirewallConfig, Weight};
+use iota_types::{
+    error::IotaError,
+    traffic_control::{
+        PolicyConfig, PolicyType, RemoteFirewallConfig, TrafficControlReconfigParams, Weight,
+    },
+};
+use parking_lot::Mutex as ParkingLotMutex;
 use prometheus::IntGauge;
 use rand::Rng;
 use tokio::{
-    sync::{mpsc, mpsc::error::TrySendError},
+    sync::{Mutex, RwLock, mpsc, mpsc::error::TrySendError},
     time,
 };
 use tracing::{debug, error, info, trace, warn};
@@ -40,13 +47,13 @@ pub const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 300;
 type Blocklist = Arc<DashMap<IpAddr, SystemTime>>;
 
 #[derive(Clone)]
-struct Blocklists {
+pub struct Blocklists {
     clients: Blocklist,
     proxied_clients: Blocklist,
 }
 
 #[derive(Clone)]
-enum Acl {
+pub enum Acl {
     Blocklists(Blocklists),
     /// If this variant is set, then we do no tallying or running
     /// of background tasks, and instead simply block all IPs not
@@ -57,10 +64,13 @@ enum Acl {
 
 #[derive(Clone)]
 pub struct TrafficController {
-    tally_channel: Option<mpsc::Sender<TrafficTally>>,
+    tally_channel: Arc<ParkingLotMutex<Option<mpsc::Sender<TrafficTally>>>>,
     acl: Acl,
     metrics: Arc<TrafficControllerMetrics>,
-    dry_run_mode: bool,
+    spam_policy: Option<Arc<Mutex<TrafficControlPolicy>>>,
+    error_policy: Option<Arc<Mutex<TrafficControlPolicy>>>,
+    policy_config: Arc<RwLock<PolicyConfig>>,
+    fw_config: Option<RemoteFirewallConfig>,
 }
 
 impl Debug for TrafficController {
@@ -84,79 +94,203 @@ impl Debug for TrafficController {
 }
 
 impl TrafficController {
-    pub fn init(
+    pub async fn init(
         policy_config: PolicyConfig,
-        metrics: TrafficControllerMetrics,
+        metrics: Arc<TrafficControllerMetrics>,
         fw_config: Option<RemoteFirewallConfig>,
     ) -> Self {
         metrics.dry_run_enabled.set(policy_config.dry_run as i64);
-        match policy_config.allow_list {
+        match policy_config.allow_list.clone() {
             Some(allow_list) => {
                 let allowlist = allow_list
                     .into_iter()
                     .map(|ip_str| {
                         parse_ip(&ip_str).unwrap_or_else(|| {
-                            panic!("Failed to parse allowlist IP address: {ip_str:?}")
+                            fatal!("Failed to parse allowlist IP address: {ip_str:?}")
                         })
                     })
                     .collect();
                 Self {
-                    tally_channel: None,
+                    tally_channel: Arc::new(ParkingLotMutex::new(None)),
                     acl: Acl::Allowlist(allowlist),
-                    metrics: Arc::new(metrics),
-                    dry_run_mode: policy_config.dry_run,
+                    metrics,
+                    policy_config: Arc::new(RwLock::new(policy_config)),
+                    fw_config,
+                    spam_policy: None,
+                    error_policy: None,
                 }
             }
-            None => Self::spawn(policy_config, metrics, fw_config),
+            None => {
+                let spam_policy = Arc::new(Mutex::new(
+                    TrafficControlPolicy::from_spam_config(policy_config.clone()).await,
+                ));
+                let error_policy = Arc::new(Mutex::new(
+                    TrafficControlPolicy::from_error_config(policy_config.clone()).await,
+                ));
+                let this = Self {
+                    tally_channel: Arc::new(ParkingLotMutex::new(None)),
+                    acl: Acl::Blocklists(Blocklists {
+                        clients: Arc::new(DashMap::new()),
+                        proxied_clients: Arc::new(DashMap::new()),
+                    }),
+                    metrics,
+                    policy_config: Arc::new(RwLock::new(policy_config)),
+                    fw_config,
+                    spam_policy: Some(spam_policy),
+                    error_policy: Some(error_policy),
+                };
+                this.spawn().await;
+                this
+            }
         }
     }
 
-    fn spawn(
+    pub async fn init_for_test(
         policy_config: PolicyConfig,
-        metrics: TrafficControllerMetrics,
         fw_config: Option<RemoteFirewallConfig>,
     ) -> Self {
-        let metrics = Arc::new(metrics);
-        Self::set_policy_config_metrics(&policy_config, metrics.clone());
+        let metrics = Arc::new(TrafficControllerMetrics::new(&prometheus::Registry::new()));
+        Self::init(policy_config, metrics, fw_config).await
+    }
+
+    async fn spawn(&self) {
+        let policy_config = { self.policy_config.read().await.clone() };
+        Self::set_policy_config_metrics(&policy_config, self.metrics.clone());
         let (tx, rx) = mpsc::channel(policy_config.channel_capacity);
         // Memoized drainfile existence state. This is passed into delegation
         // functions to prevent them from continuing to populate blocklists
         // if drain is set, as otherwise it will grow without bounds
         // without the firewall running to periodically clear it.
-        let mem_drainfile_present = fw_config
+        let mem_drainfile_present = self
+            .fw_config
             .as_ref()
             .map(|config| config.drain_path.exists())
             .unwrap_or(false);
-        metrics
+        self.metrics
             .deadmans_switch_enabled
             .set(mem_drainfile_present as i64);
-        let blocklists = Blocklists {
-            clients: Arc::new(DashMap::new()),
-            proxied_clients: Arc::new(DashMap::new()),
+        let blocklists = match self.acl.clone() {
+            Acl::Blocklists(blocklists) => blocklists,
+            Acl::Allowlist(_) => fatal!("Allowlist ACL should not exist on spawn"),
         };
         let tally_loop_blocklists = blocklists.clone();
-        let clear_loop_blocklists = blocklists.clone();
-        let tally_loop_metrics = metrics.clone();
-        let clear_loop_metrics = metrics.clone();
-        let dry_run_mode = policy_config.dry_run;
+        let tally_loop_metrics = self.metrics.clone();
+        let clear_loop_metrics = self.metrics.clone();
+        let tally_loop_fw_config = self.fw_config.clone();
+
+        let spam_policy = self
+            .spam_policy
+            .clone()
+            .expect("spam policy should exist on spawn");
+        let error_policy = self
+            .error_policy
+            .clone()
+            .expect("error policy should exist on spawn");
+
         spawn_monitored_task!(run_tally_loop(
             rx,
             policy_config,
-            fw_config,
+            spam_policy,
+            error_policy,
+            tally_loop_fw_config,
             tally_loop_blocklists,
             tally_loop_metrics,
             mem_drainfile_present,
         ));
-        spawn_monitored_task!(run_clear_blocklists_loop(
-            clear_loop_blocklists,
-            clear_loop_metrics,
-        ));
-        Self {
-            tally_channel: Some(tx),
-            acl: Acl::Blocklists(blocklists),
-            metrics,
-            dry_run_mode,
+        spawn_monitored_task!(run_clear_blocklists_loop(blocklists, clear_loop_metrics));
+        self.open_tally_channel(tx);
+    }
+
+    pub async fn get_current_state(&self) -> TrafficControlReconfigParams {
+        let mut result = TrafficControlReconfigParams {
+            error_threshold: None,
+            spam_threshold: None,
+            dry_run: None,
+        };
+
+        if let Some(error_policy) = self.error_policy.as_ref() {
+            if let TrafficControlPolicy::FreqThreshold(ref policy) = *error_policy.lock().await {
+                result.error_threshold = Some(policy.client_threshold);
+            }
         }
+
+        if let Some(spam_policy) = self.spam_policy.as_ref() {
+            if let TrafficControlPolicy::FreqThreshold(ref policy) = *spam_policy.lock().await {
+                result.spam_threshold = Some(policy.client_threshold);
+            }
+        }
+
+        result.dry_run = Some(self.policy_config.read().await.dry_run);
+        result
+    }
+
+    pub async fn admin_reconfigure(
+        &self,
+        params: TrafficControlReconfigParams,
+    ) -> Result<TrafficControlReconfigParams, IotaError> {
+        let TrafficControlReconfigParams {
+            error_threshold,
+            spam_threshold,
+            dry_run,
+        } = params;
+        if let Some(error_threshold) = error_threshold {
+            self.metrics
+                .error_client_threshold
+                .set(error_threshold as i64);
+            Self::update_policy_threshold(
+                self.error_policy.as_ref().unwrap(),
+                error_threshold,
+                dry_run,
+            )
+            .await?;
+        }
+        if let Some(spam_threshold) = spam_threshold {
+            self.metrics
+                .spam_client_threshold
+                .set(spam_threshold as i64);
+            Self::update_policy_threshold(
+                self.spam_policy.as_ref().unwrap(),
+                spam_threshold,
+                dry_run,
+            )
+            .await?;
+        }
+        if let Some(dry_run) = dry_run {
+            self.metrics.dry_run_enabled.set(dry_run as i64);
+            self.policy_config.write().await.dry_run = dry_run;
+        }
+
+        Ok(self.get_current_state().await)
+    }
+
+    async fn update_policy_threshold(
+        policy: &Arc<Mutex<TrafficControlPolicy>>,
+        threshold: u64,
+        dry_run: Option<bool>,
+    ) -> Result<(), IotaError> {
+        match *policy.lock().await {
+            TrafficControlPolicy::FreqThreshold(ref mut policy) => {
+                policy.client_threshold = threshold;
+                if let Some(dry_run) = dry_run {
+                    policy.config.dry_run = dry_run;
+                }
+                Ok(())
+            }
+            TrafficControlPolicy::TestNConnIP(ref mut policy) => {
+                policy.threshold = threshold;
+                if let Some(dry_run) = dry_run {
+                    policy.config.dry_run = dry_run;
+                }
+                Ok(())
+            }
+            _ => Err(IotaError::InvalidAdminRequest(
+                "Unsupported prior policy type during traffic control reconfiguration".to_string(),
+            )),
+        }
+    }
+
+    fn open_tally_channel(&self, tx: mpsc::Sender<TrafficTally>) {
+        self.tally_channel.lock().replace(tx);
     }
 
     fn set_policy_config_metrics(
@@ -181,16 +315,8 @@ impl TrafficController {
         }
     }
 
-    pub fn init_for_test(
-        policy_config: PolicyConfig,
-        fw_config: Option<RemoteFirewallConfig>,
-    ) -> Self {
-        let metrics = TrafficControllerMetrics::new(&prometheus::Registry::new());
-        Self::init(policy_config, metrics, fw_config)
-    }
-
     pub fn tally(&self, tally: TrafficTally) {
-        if let Some(channel) = self.tally_channel.as_ref() {
+        if let Some(channel) = self.tally_channel.lock().as_ref() {
             // Use try_send rather than send mainly to avoid creating backpressure
             // on the caller if the channel is full, which may slow down the critical
             // path. Dropping the tally on the floor should be ok, as in this case
@@ -206,17 +332,20 @@ impl TrafficController {
                     // that clearly the system is overloaded
                 }
                 Err(TrySendError::Closed(_)) => {
-                    panic!("TrafficController tally channel closed unexpectedly");
+                    debug_fatal!("TrafficController tally channel closed unexpectedly");
                 }
                 Ok(_) => {}
             }
+        } else {
+            warn!("TrafficController not yet accepting tally requests.");
         }
     }
 
     /// Handle check with dry-run mode considered
     pub async fn check(&self, client: &Option<IpAddr>, proxied_client: &Option<IpAddr>) -> bool {
+        let policy_config = { self.policy_config.read().await.clone() };
         let check_with_dry_run_maybe = |allowed| -> bool {
-            match (allowed, self.dry_run_mode()) {
+            match (allowed, policy_config.dry_run) {
                 // request allowed
                 (true, _) => true,
                 // request blocked while in dry-run mode
@@ -268,10 +397,6 @@ impl TrafficController {
         let (client_check, proxied_client_check) =
             futures::future::join(client_check, proxied_client_check).await;
         client_check && proxied_client_check
-    }
-
-    pub fn dry_run_mode(&self) -> bool {
-        self.dry_run_mode
     }
 
     async fn check_and_clear_blocklist(
@@ -328,13 +453,13 @@ async fn run_clear_blocklists_loop(blocklists: Blocklists, metrics: Arc<TrafficC
 async fn run_tally_loop(
     mut receiver: mpsc::Receiver<TrafficTally>,
     policy_config: PolicyConfig,
+    spam_policy: Arc<Mutex<TrafficControlPolicy>>,
+    error_policy: Arc<Mutex<TrafficControlPolicy>>,
     fw_config: Option<RemoteFirewallConfig>,
     blocklists: Blocklists,
     metrics: Arc<TrafficControllerMetrics>,
     mut mem_drainfile_present: bool,
 ) {
-    let mut spam_policy = TrafficControlPolicy::from_spam_config(policy_config.clone()).await;
-    let mut error_policy = TrafficControlPolicy::from_error_config(policy_config.clone()).await;
     let spam_blocklists = Arc::new(blocklists.clone());
     let error_blocklists = Arc::new(blocklists);
     let node_fw_client = fw_config
@@ -355,7 +480,7 @@ async fn run_tally_loop(
                     Some(tally) => {
                         // TODO: spawn a task to handle tallying concurrently
                         if let Err(err) = handle_spam_tally(
-                            &mut spam_policy,
+                            spam_policy.clone(),
                             &policy_config,
                             &node_fw_client,
                             &fw_config,
@@ -368,7 +493,7 @@ async fn run_tally_loop(
                             warn!("Error handling spam tally: {}", err);
                         }
                         if let Err(err) = handle_error_tally(
-                            &mut error_policy,
+                            error_policy.clone(),
                             &policy_config,
                             &node_fw_client,
                             &fw_config,
@@ -408,7 +533,8 @@ async fn run_tally_loop(
         // every N seconds, we update metrics and logging that would be too
         // spammy to be handled while processing each tally
         if metric_timer.elapsed() > Duration::from_secs(METRICS_INTERVAL_SECS) {
-            if let TrafficControlPolicy::FreqThreshold(spam_policy) = &spam_policy {
+            if let TrafficControlPolicy::FreqThreshold(ref spam_policy) = *spam_policy.lock().await
+            {
                 if let Some(highest_direct_rate) = spam_policy.highest_direct_rate() {
                     metrics
                         .highest_direct_spam_rate
@@ -425,7 +551,9 @@ async fn run_tally_loop(
                     );
                 }
             }
-            if let TrafficControlPolicy::FreqThreshold(error_policy) = &error_policy {
+            if let TrafficControlPolicy::FreqThreshold(ref error_policy) =
+                *error_policy.lock().await
+            {
                 if let Some(highest_direct_rate) = error_policy.highest_direct_rate() {
                     metrics
                         .highest_direct_error_rate
@@ -451,7 +579,7 @@ async fn run_tally_loop(
 }
 
 async fn handle_error_tally(
-    policy: &mut TrafficControlPolicy,
+    policy: Arc<Mutex<TrafficControlPolicy>>,
     policy_config: &PolicyConfig,
     nodefw_client: &Option<NodeFWClient>,
     fw_config: &Option<RemoteFirewallConfig>,
@@ -474,7 +602,7 @@ async fn handle_error_tally(
         .tally_error_types
         .with_label_values(&[error_type.as_str()])
         .inc();
-    let resp = policy.handle_tally(tally);
+    let resp = policy.lock().await.handle_tally(tally);
     metrics.error_tally_handled.inc();
     if let Some(fw_config) = fw_config {
         if fw_config.delegate_error_blocking && !mem_drainfile_present {
@@ -496,7 +624,7 @@ async fn handle_error_tally(
 }
 
 async fn handle_spam_tally(
-    policy: &mut TrafficControlPolicy,
+    policy: Arc<Mutex<TrafficControlPolicy>>,
     policy_config: &PolicyConfig,
     nodefw_client: &Option<NodeFWClient>,
     fw_config: &Option<RemoteFirewallConfig>,
@@ -508,7 +636,7 @@ async fn handle_spam_tally(
     if !(tally.spam_weight.is_sampled() && policy_config.spam_sample_rate.is_sampled()) {
         return Ok(());
     }
-    let resp = policy.handle_tally(tally.clone());
+    let resp = policy.lock().await.handle_tally(tally.clone());
     metrics.tally_handled.inc();
     if let Some(fw_config) = fw_config {
         if fw_config.delegate_spam_blocking && !mem_drainfile_present {
@@ -698,7 +826,7 @@ impl TrafficSim {
         assert!(per_client_tps > 0);
         assert!(duration.as_secs() > 0);
 
-        let controller = TrafficController::init_for_test(policy.clone(), None);
+        let controller = TrafficController::init_for_test(policy.clone(), None).await;
         let tasks = (0..num_clients).map(|task_num| {
             tokio::spawn(Self::run_single_client(
                 controller.clone(),

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -89,6 +89,7 @@ impl TrafficController {
         metrics: TrafficControllerMetrics,
         fw_config: Option<RemoteFirewallConfig>,
     ) -> Self {
+        metrics.dry_run_enabled.set(policy_config.dry_run as i64);
         match policy_config.allow_list {
             Some(allow_list) => {
                 let allowlist = allow_list

--- a/crates/iota-core/src/traffic_controller/policies.rs
+++ b/crates/iota-core/src/traffic_controller/policies.rs
@@ -327,10 +327,10 @@ impl TrafficControlPolicy {
 ////////////// *** Policy definitions *** //////////////
 
 pub struct FreqThresholdPolicy {
-    config: PolicyConfig,
+    pub config: PolicyConfig,
+    pub client_threshold: u64,
+    pub proxied_client_threshold: u64,
     sketch: TrafficSketch,
-    client_threshold: u64,
-    proxied_client_threshold: u64,
     /// Unique salt to be added to all keys in the sketch. This
     /// ensures that false positives are not correlated across
     /// all nodes at the same time. For IOTA validators for example,
@@ -447,9 +447,9 @@ impl NoOpPolicy {
 
 #[derive(Clone)]
 pub struct TestNConnIPPolicy {
-    config: PolicyConfig,
+    pub threshold: u64,
+    pub config: PolicyConfig,
     frequencies: Arc<RwLock<HashMap<IpAddr, u64>>>,
-    threshold: u64,
 }
 
 impl TestNConnIPPolicy {

--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -27,7 +27,8 @@ use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,
     traffic_control::{
-        FreqThresholdConfig, PolicyConfig, PolicyType, RemoteFirewallConfig, Weight,
+        FreqThresholdConfig, PolicyConfig, PolicyType, RemoteFirewallConfig,
+        TrafficControlReconfigParams, Weight,
     },
 };
 use jsonrpsee::{core::client::ClientT, rpc_params};
@@ -279,6 +280,76 @@ async fn test_validator_traffic_control_error_blocked() -> Result<(), anyhow::Er
         tokio::task::yield_now().await;
     }
     panic!("Expected error policy to trigger within {n} requests");
+}
+
+#[tokio::test]
+async fn test_validator_traffic_control_error_blocked_with_policy_reconfig()
+-> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let n = 5;
+    let policy_config = PolicyConfig {
+        connection_blocklist_ttl_sec: 100,
+        error_policy_type: PolicyType::TestNConnIP(n - 1),
+        dry_run: true,
+        ..Default::default()
+    };
+    let network_config = ConfigBuilder::new_with_temp_dir()
+        .committee_size(NonZeroUsize::new(4).unwrap())
+        .with_policy_config(Some(policy_config))
+        .build();
+    let committee = network_config.committee_with_network();
+    let test_cluster = TestClusterBuilder::new()
+        .set_network_config(network_config)
+        .build()
+        .await;
+    let local_clients = make_network_authority_clients_with_network_config(
+        &committee,
+        &default_iota_network_config(),
+    );
+    let (_, auth_client) = local_clients.first_key_value().unwrap();
+
+    let mut txns = batch_make_transfer_transactions(&test_cluster.wallet, n as usize).await;
+    let mut tx = txns.swap_remove(0);
+    let signatures = tx.tx_signatures_mut_for_testing();
+    signatures.pop();
+    signatures.push(GenericSignature::Signature(
+        iota_types::crypto::Signature::Ed25519IotaSignature(Ed25519IotaSignature::default()),
+    ));
+
+    // Before reconfiguring the policy, we should not block any requests due to dry
+    // run mode, even after far exceeding the threshold. However the blocklist
+    // should be updated.
+    for _ in 0..(2 * n) {
+        let response = auth_client.handle_transaction(tx.clone(), None).await;
+        if let Err(err) = response {
+            assert!(
+                !err.to_string().contains("Too many requests"),
+                "Expected no blocked requests due to dry run mode"
+            );
+        }
+    }
+    // Reconfigure traffic control to disable dry run mode
+    for node in test_cluster.all_validator_handles() {
+        node.state()
+            .reconfigure_traffic_control(TrafficControlReconfigParams {
+                error_threshold: None,
+                spam_threshold: None,
+                dry_run: Some(false),
+            })
+            .await
+            .unwrap();
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    // If Node and TrafficController has not crashed, blocklist and policy freq
+    // state should still be intact. A single additional erroneous request from
+    // the client should trigger enforcement.
+    let response = auth_client.handle_transaction(tx.clone(), None).await;
+    if let Err(err) = response {
+        if err.to_string().contains("Too many requests") {
+            return Ok(());
+        }
+    }
+    panic!("Expected error policy to trigger on next requests after reconfiguration");
 }
 
 #[tokio::test]
@@ -607,13 +678,11 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
         delegate_error_blocking: false,
         destination_port: 9000,
         drain_path: drain_path.clone(),
-        drain_timeout_secs: 10,
+        drain_timeout_secs: 6,
     };
 
-    // NOTE: we need to hold onto this tc handle to ensure we don't inadvertently
-    // close the receive channel (this would cause traffic controller to exit
-    // the loop and thus we will never engage the dead mans switch)
-    let _tc = TrafficController::init_for_test(policy_config, Some(firewall_config));
+    let tc = TrafficController::init_for_test(policy_config.clone(), Some(firewall_config.clone()))
+        .await;
     assert!(
         !drain_path.exists(),
         "Expected drain file to not exist after startup unless previously set",
@@ -621,7 +690,7 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
 
     // after n seconds with no traffic, the dead mans switch should be engaged
     let mut drain_enabled = false;
-    for _ in 0..10 {
+    for _ in 0..4 {
         if drain_path.exists() {
             drain_enabled = true;
             break;
@@ -632,6 +701,8 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
 
     // if we drop traffic controller and re-instantiate, drain file should remain
     // set
+    drop(tc);
+    let _tc = TrafficController::init_for_test(policy_config, Some(firewall_config)).await;
     for _ in 0..3 {
         assert!(
             drain_path.exists(),

--- a/crates/iota-json-rpc/src/axum_router.rs
+++ b/crates/iota-json-rpc/src/axum_router.rs
@@ -13,13 +13,11 @@ use axum::{
     response::Response,
 };
 use hyper::{HeaderMap, header::HeaderValue};
-use iota_core::traffic_controller::{
-    TrafficController, metrics::TrafficControllerMetrics, parse_ip, policies::TrafficTally,
-};
+use iota_core::traffic_controller::{TrafficController, parse_ip, policies::TrafficTally};
 use iota_json_rpc_api::{
     CLIENT_TARGET_API_VERSION_HEADER, TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
 };
-use iota_types::traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight};
+use iota_types::traffic_control::{ClientIdSource, PolicyConfig, Weight};
 use jsonrpsee::{
     BoundedSubscriptions, ConnectionId, Extensions, MethodCallback, MethodKind, MethodResponse,
     core::server::{Methods, helpers::MethodSink},
@@ -59,9 +57,8 @@ impl<L> JsonRpcService<L> {
         methods: Methods,
         rpc_router: RpcRouter,
         logger: L,
-        remote_fw_config: Option<RemoteFirewallConfig>,
+        traffic_controller: Option<Arc<TrafficController>>,
         policy_config: Option<PolicyConfig>,
-        traffic_controller_metrics: TrafficControllerMetrics,
         extensions: Extensions,
     ) -> Self {
         Self {
@@ -70,13 +67,7 @@ impl<L> JsonRpcService<L> {
             logger,
             extensions,
             id_provider: Arc::new(RandomIntegerIdProvider),
-            traffic_controller: policy_config.clone().map(|policy| {
-                Arc::new(TrafficController::init(
-                    policy,
-                    traffic_controller_metrics,
-                    remote_fw_config,
-                ))
-            }),
+            traffic_controller,
             client_id_source: policy_config.map(|policy| policy.client_id_source),
         }
     }

--- a/crates/iota-json-rpc/src/lib.rs
+++ b/crates/iota-json-rpc/src/lib.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, net::SocketAddr, str::FromStr};
+use std::{env, net::SocketAddr, str::FromStr, sync::Arc};
 
 use axum::{
     body::Body,
@@ -14,12 +14,12 @@ use hyper::{
     header::{HeaderName, HeaderValue},
 };
 pub use iota_config::node::ServerType;
-use iota_core::traffic_controller::metrics::TrafficControllerMetrics;
+use iota_core::traffic_controller::TrafficController;
 use iota_json_rpc_api::{
     CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER, CLIENT_TARGET_API_VERSION_HEADER,
 };
 use iota_open_rpc::{Module, Project};
-use iota_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
+use iota_types::traffic_control::PolicyConfig;
 use jsonrpsee::{Extensions, RpcModule, types::ErrorObjectOwned};
 pub use object_changes::*;
 use prometheus::Registry;
@@ -62,8 +62,8 @@ pub struct JsonRpcServerBuilder {
     module: RpcModule<()>,
     rpc_doc: Project,
     registry: Registry,
+    traffic_controller: Option<Arc<TrafficController>>,
     policy_config: Option<PolicyConfig>,
-    firewall_config: Option<RemoteFirewallConfig>,
 }
 
 pub fn iota_rpc_doc(version: &str) -> Project {
@@ -83,15 +83,15 @@ impl JsonRpcServerBuilder {
     pub fn new(
         version: &str,
         prometheus_registry: &Registry,
+        traffic_controller: Option<Arc<TrafficController>>,
         policy_config: Option<PolicyConfig>,
-        firewall_config: Option<RemoteFirewallConfig>,
     ) -> Self {
         Self {
             module: RpcModule::new(()),
             rpc_doc: iota_rpc_doc(version),
             registry: prometheus_registry.clone(),
+            traffic_controller,
             policy_config,
-            firewall_config,
         }
     }
 
@@ -168,7 +168,6 @@ impl JsonRpcServerBuilder {
         let methods_names = module.method_names().collect::<Vec<_>>();
 
         let metrics_logger = MetricsLogger::new(&self.registry, &methods_names);
-        let traffic_controller_metrics = TrafficControllerMetrics::new(&self.registry);
 
         let middleware = tower::ServiceBuilder::new()
             .layer(Self::trace_layer())
@@ -178,9 +177,8 @@ impl JsonRpcServerBuilder {
             module.into(),
             rpc_router,
             metrics_logger,
-            self.firewall_config.clone(),
+            self.traffic_controller.clone(),
             self.policy_config.clone(),
-            traffic_controller_metrics,
             Extensions::new(),
         );
 

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -17,6 +17,7 @@ use iota_types::{
     base_types::AuthorityName,
     crypto::{RandomnessPartialSignature, RandomnessRound, RandomnessSignature},
     error::IotaError,
+    traffic_control::TrafficControlReconfigParams,
 };
 use serde::Deserialize;
 use telemetry_subscribers::{TelemetryError, TracingHandle};
@@ -70,6 +71,10 @@ use crate::IotaNode;
 // Inject a full signature from another node, bypassing validity checks.
 //
 //  $ curl 'http://127.0.0.1:1337/randomness-inject-full-sig?round=123&sigs=base64encodedsig'
+//
+// Reconfigure traffic control policy
+//
+//  $ curl 'http://127.0.0.1:1337/traffic-control?error_threshold=100&spam_threshold=100&dry_run=true'
 
 const LOGGING_ROUTE: &str = "/logging";
 const TRACING_ROUTE: &str = "/enable-tracing";
@@ -83,6 +88,7 @@ const RANDOMNESS_PARTIAL_SIGS_ROUTE: &str = "/randomness-partial-sigs";
 const RANDOMNESS_INJECT_PARTIAL_SIGS_ROUTE: &str = "/randomness-inject-partial-sigs";
 const RANDOMNESS_INJECT_FULL_SIG_ROUTE: &str = "/randomness-inject-full-sig";
 const FLAMEGRAPH_ROUTE: &str = "/flamegraph";
+const TRAFFIC_CONTROL: &str = "/traffic-control";
 
 struct AppState {
     node: Arc<IotaNode>,
@@ -127,6 +133,7 @@ pub async fn run_admin_server(
             post(randomness_inject_full_sig),
         )
         .route(FLAMEGRAPH_ROUTE, get(flamegraph))
+        .route(TRAFFIC_CONTROL, post(traffic_control))
         .with_state(Arc::new(app_state));
 
     info!(
@@ -552,5 +559,25 @@ async fn flamegraph(State(state): State<Arc<AppState>>, query: Query<Flamegraph>
             "Flamegraphs are not enabled (re-run iota-node with TRACE_FLAMEGRAPH=1)\n",
         )
             .into_response()
+    }
+}
+
+async fn traffic_control(
+    State(state): State<Arc<AppState>>,
+    args: Query<TrafficControlReconfigParams>,
+) -> (StatusCode, String) {
+    let Query(params) = args;
+    match state.node.state().reconfigure_traffic_control(params).await {
+        Ok(updated_state) => (
+            StatusCode::OK,
+            format!(
+                "Traffic control configured with:\n\
+                 Error threshold: {:?}\n\
+                 Spam threshold: {:?}\n\
+                 Dry run: {:?}\n",
+                updated_state.error_threshold, updated_state.spam_threshold, updated_state.dry_run
+            ),
+        ),
+        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -75,7 +75,6 @@ use iota_core::{
     safe_client::SafeClientMetricsBase,
     signature_verifier::SignatureVerifierMetrics,
     storage::{GrpcReadStore, RocksDbStore},
-    traffic_controller::metrics::TrafficControllerMetrics,
     transaction_orchestrator::TransactionOrchestrator,
     validator_tx_finalizer::ValidatorTxFinalizer,
 };
@@ -621,6 +620,8 @@ impl IotaNode {
             chain_identifier,
             pruner_db,
             Some(checkpoint_progress_tracker.clone()),
+            config.policy_config.clone(),
+            config.firewall_config.clone(),
         )
         .await;
 
@@ -1411,9 +1412,7 @@ impl IotaNode {
             state,
             consensus_adapter,
             Arc::new(ValidatorServiceMetrics::new(prometheus_registry)),
-            TrafficControllerMetrics::new(prometheus_registry),
-            config.policy_config.clone(),
-            config.firewall_config.clone(),
+            config.policy_config.clone().map(|p| p.client_id_source),
         );
 
         let mut server_conf = iota_network_stack::config::Config::new();
@@ -2339,11 +2338,12 @@ pub async fn build_http_server(
     let mut router = axum::Router::new();
 
     let json_rpc_router = {
+        let traffic_controller = state.traffic_controller.clone();
         let mut server = JsonRpcServerBuilder::new(
             env!("CARGO_PKG_VERSION"),
             prometheus_registry,
+            traffic_controller,
             config.policy_config.clone(),
-            config.firewall_config.clone(),
         );
 
         let kv_store = build_kv_store(&state, config, prometheus_registry)?;

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -684,6 +684,9 @@ pub enum IotaError {
 
     #[error("The request did not contain a certificate")]
     NoCertificateProvided,
+
+    #[error("Invalid admin request: {0}")]
+    InvalidAdminRequest(String),
 }
 
 #[repr(u64)]

--- a/crates/iota-types/src/traffic_control.rs
+++ b/crates/iota-types/src/traffic_control.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Deserializer};
 use serde_with::serde_as;
 
 // These values set to loosely attempt to limit
@@ -104,6 +104,15 @@ impl Weight {
         let sample = rand::distributions::Uniform::new(0.0, 1.0).sample(&mut rng);
         sample <= self.value()
     }
+}
+
+fn validate_sample_rate<'de, D>(deserializer: D) -> Result<Weight, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = f32::deserialize(deserializer)?;
+    Weight::new(value)
+        .map_err(|_| serde::de::Error::custom("spam-sample-rate must be between 0.0 and 1.0"))
 }
 
 impl PartialEq for Weight {
@@ -217,6 +226,7 @@ pub enum PolicyType {
     /// Blocks connection_ip after reaching a tally frequency (tallies per
     /// second) of `threshold`, as calculated over an average window of
     /// `window_size_secs` with granularity of `update_interval_secs`
+    #[serde(rename = "freq-threshold", alias = "FreqThreshold")]
     FreqThreshold(FreqThresholdConfig),
 
     // Below this point are test policies, and thus should not be used in production
@@ -246,7 +256,10 @@ pub struct PolicyConfig {
     pub error_policy_type: PolicyType,
     #[serde(default = "default_channel_capacity")]
     pub channel_capacity: usize,
-    #[serde(default = "default_spam_sample_rate")]
+    #[serde(
+        default = "default_spam_sample_rate",
+        deserialize_with = "validate_sample_rate"
+    )]
     /// Note that this sample policy is applied on top of the
     /// endpoint-specific sample policy (not configurable) which
     /// weighs endpoints by the relative effort required to serve
@@ -274,6 +287,30 @@ impl Default for PolicyConfig {
             spam_sample_rate: default_spam_sample_rate(),
             dry_run: default_dry_run(),
             allow_list: None,
+        }
+    }
+}
+
+impl PolicyConfig {
+    pub fn default_dos_protection_policy() -> Self {
+        Self {
+            client_id_source: ClientIdSource::SocketAddr,
+            spam_policy_type: PolicyType::FreqThreshold(FreqThresholdConfig {
+                client_threshold: 500,
+                window_size_secs: 5,
+                update_interval_secs: 1,
+                ..FreqThresholdConfig::default()
+            }),
+            error_policy_type: PolicyType::FreqThreshold(FreqThresholdConfig {
+                client_threshold: 50,
+                window_size_secs: 5,
+                update_interval_secs: 1,
+                ..FreqThresholdConfig::default()
+            }),
+            channel_capacity: 6000,
+            spam_sample_rate: Weight::new(1.0).unwrap(),
+            dry_run: true,
+            ..PolicyConfig::default()
         }
     }
 }

--- a/crates/iota-types/src/traffic_control.rs
+++ b/crates/iota-types/src/traffic_control.rs
@@ -303,7 +303,7 @@ impl PolicyConfig {
         Self {
             client_id_source: ClientIdSource::SocketAddr,
             spam_policy_type: PolicyType::FreqThreshold(FreqThresholdConfig {
-                client_threshold: 500,
+                client_threshold: 1000,
                 window_size_secs: 5,
                 update_interval_secs: 1,
                 ..FreqThresholdConfig::default()

--- a/crates/iota-types/src/traffic_control.rs
+++ b/crates/iota-types/src/traffic_control.rs
@@ -76,6 +76,13 @@ pub enum ClientIdSource {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TrafficControlReconfigParams {
+    pub error_threshold: Option<u64>,
+    pub spam_threshold: Option<u64>,
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Weight(f32);
 
 impl Weight {


### PR DESCRIPTION
## Description of change

- Port commits:
  - [MystenLabs/sui@9006185](https://github.com/MystenLabs/sui/commit/9006185009afa2fe239fec771a7d067437814a42) — [TrafficControl] Enable DOS protection by default (dryRun) (#22143)
  - [MystenLabs/sui@13950175](https://github.com/MystenLabs/sui/commit/13950175c3) — [Traffic Control] Fix blocked metric (#20590)
  - [MystenLabs/sui@ef1bb1e0](https://github.com/MystenLabs/sui/commit/ef1bb1e0d3) — [traffic controller] show dry run status via metric (#22363)
  - [MystenLabs/sui@264d7664](https://github.com/MystenLabs/sui/commit/264d7664b3) — [Traffic Control] Add dynamic config via admin api (#20887)
  - [MystenLabs/sui@6427b4d6](https://github.com/MystenLabs/sui/commit/6427b4d628) — [traffic controller] fix race condition in blocklist metric dec() call (#22771)
  - [MystenLabs/sui@4e30d3b3](https://github.com/MystenLabs/sui/commit/4e30d3b35b) — [traffic controller] downgrade shutdown error case to warn! log (#22782)
  - [MystenLabs/sui@f5d1b6c9](https://github.com/MystenLabs/sui/commit/f5d1b6c935) — [dos protection] increase the default spam threshold (#23301)
- Description:

Ports a series of upstream traffic-control improvements:

- **Enable DoS protection by default (dryRun)** (#22143): Turns the traffic controller on in dry-run mode by default. No traffic is actually blocked — only tallying and metrics collection.
- **Fix blocked metric** (#20590): Corrects the blocked-requests metric so it no longer increments in dry-run mode, removing the false impression that requests were being blocked.
- **Show dry run status via metric** (#22363): Adds a metric so operators can discern whether dry-run is enabled or disabled on a given node.
- **Add dynamic config via admin api** (#20887): Adds an admin API endpoint to hot-reconfigure the traffic control policy without clearing blocklists or the count-min sketch. Only works on nodes already running traffic control with a non-allowlist policy.
- **Fix race condition in blocklist metric dec() call** (#22771): Fixes a race where `check_and_clear_blocklist` could be called in parallel for the same IP, causing the blocklist length metric to be decremented multiple times for a single removal (sometimes producing negative values).
- **Downgrade shutdown error case to warn! log** (#22782): Downgrades a noisy error log to `warn!` when tally processing fails during shutdown, since it isn't actionable.
- **Increase the default spam threshold** (#23301): Raises the default spam threshold in `default_dos_protection_policy()` to better fit observed traffic patterns.

## Links to any relevant issues

Part of #11643

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Release notes

- [x] Nodes (Validators and Full nodes): 
  - DoS protection is enabled in dryRun mode by default for validators. 
  - A new admin API endpoint allows hot-reconfiguration of the traffic control policy without clearing blocklists. 
  - A new metric exposes whether dry-run is enabled, and the blocked-requests / blocklist-length metrics are now accurate.
