### PR TITLE
fix(iota-types): align `assert!` and `debug-assert!`

### DIFF
--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -184,12 +184,14 @@ impl MoveObjectExt for MoveObject {
     }
 
     /// Update the `timestamp_ms: u64` field of the `Clock` type.
-    ///
-    /// Panics if the object isn't a `Clock`.
+    /// Useful for updating the clock without deserializing the object into a
+    /// Move value. It is the caller's responsibility to check that `self` is a
+    /// `Clock`.
+    /// This function may panic or do something unexpected otherwise.
     fn set_clock_timestamp_ms_unchecked(&mut self, timestamp_ms: u64) {
-        assert!(self.struct_tag().is_clock());
+        debug_assert!(self.struct_tag().is_clock());
         // 32 bytes for object ID, 8 for timestamp
-        assert!(self.contents().len() == 40);
+        debug_assert!(self.contents().len() == 40);
 
         let mut new_contents = self.contents().to_vec();
         new_contents[ID_END_INDEX..].copy_from_slice(&timestamp_ms.to_le_bytes());


### PR DESCRIPTION
# Description

Fixes an issue that surfaced during the SDK type replacements.

This was clauded with :heart: 

## Links to any relevant issues

Fixes #11482 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
