### PR TITLE
chore(iota-protocol-config): add consensus block restrictions to v27 comment

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -145,6 +145,9 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             flags at runtime.
 // Version 27: Only sponsor Move authentication is performed pre-consensus in
 //             devnet.
+//             Enable consensus block restrictions on testnet and devnet:
+//             bound block-header size to O(committee_size) and enable
+//             garbage collection in the block manager.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 


### PR DESCRIPTION
# Description of change

The starfish hardening PR (#11529) bumped `MAX_PROTOCOL_VERSION` to 27 but did not update the protocol-version history comment at the top of `iota-protocol-config/src/lib.rs`. The `Version 27` entry only mentioned the sponsor pre-consensus authentication change. This adds the missing `consensus_block_restrictions` entry covering the block-header size bound and block-manager GC enabled on testnet/devnet.

## Links to any relevant issues

Follow-up to #11529

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes