### PR TITLE
feat(iota-data-ingestion, iota-kvstore): allow backfilling for `iota-kv-store` worker type.

### DIFF
--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, path::PathBuf, time::Duration};
+use std::{collections::HashSet, env, path::PathBuf, time::Duration};
 
 use anyhow::{Result, anyhow};
 use iota_data_ingestion::{
@@ -15,7 +15,7 @@ use iota_data_ingestion_core::{
     reader::v2::{CheckpointReaderConfig, RemoteUrl},
 };
 use iota_grpc_client::Client;
-use iota_kvstore::{BigTableClient, KvWorker};
+use iota_kvstore::{BigTableClient, BigtableTable, KvWorker};
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
@@ -39,6 +39,8 @@ struct BigTableTaskConfig {
     timeout_secs: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     emulator_host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tables: Option<HashSet<BigtableTable>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -232,6 +234,10 @@ async fn main() -> Result<()> {
                     Default::default(),
                 );
                 executor.register(worker_pool).await?;
+
+                if let Some(end_checkpoint) = config.end_checkpoint {
+                    executor.with_ingestion_limit(IngestionLimit::MaxCheckpoint(end_checkpoint));
+                }
             }
             Task::Kv(kv_config) => {
                 let worker_pool = WorkerPool::new(
@@ -257,10 +263,6 @@ async fn main() -> Result<()> {
                 executor.register(worker_pool).await?;
             }
         };
-    }
-
-    if let Some(end_checkpoint) = config.end_checkpoint {
-        executor.with_ingestion_limit(IngestionLimit::MaxCheckpoint(end_checkpoint));
     }
 
     let reader_options = ReaderOptions {

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -10,11 +10,13 @@ use iota_data_ingestion::{
     HistoricalWriterConfig, KVStoreTaskConfig, KVStoreWorker, RelayWorker, common,
 };
 use iota_data_ingestion_core::{
-    DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, WorkerPool,
+    DataIngestionMetrics, FileProgressStore, IndexerExecutor, IngestionLimit, ReaderOptions,
+    WorkerPool,
     reader::v2::{CheckpointReaderConfig, RemoteUrl},
 };
 use iota_grpc_client::Client;
 use iota_kvstore::{BigTableClient, KvWorker};
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
@@ -54,6 +56,12 @@ struct IndexerConfig {
     path: PathBuf,
     tasks: Vec<TaskConfig>,
     progress_store_path: String,
+    /// The sequence number of the checkpoint to start ingestion from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_checkpoint: Option<CheckpointSequenceNumber>,
+    /// The inclusive sequence number of the checkpoint to end ingestion at.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_checkpoint: Option<CheckpointSequenceNumber>,
     #[serde(skip_serializing_if = "Option::is_none")]
     remote_store_url: Option<String>,
     #[serde(default = "default_remote_read_batch_size")]
@@ -193,6 +201,12 @@ async fn main() -> Result<()> {
                 executor.register(worker_pool).await?;
             }
             Task::BigTableKv(kv_config) => {
+                if let Some(start_checkpoint) = config.start_checkpoint {
+                    executor
+                        .update_watermark(task_config.name.clone(), start_checkpoint)
+                        .await?;
+                }
+
                 let client = if let Some(emulator_host) = kv_config.emulator_host {
                     std::env::set_var("BIGTABLE_EMULATOR_HOST", &emulator_host);
                     BigTableClient::new_local(
@@ -212,7 +226,7 @@ async fn main() -> Result<()> {
                     .await?
                 };
                 let worker_pool = WorkerPool::new(
-                    KvWorker { client },
+                    KvWorker::new(client, kv_config.tables),
                     task_config.name,
                     task_config.concurrency,
                     Default::default(),
@@ -243,6 +257,10 @@ async fn main() -> Result<()> {
                 executor.register(worker_pool).await?;
             }
         };
+    }
+
+    if let Some(end_checkpoint) = config.end_checkpoint {
+        executor.with_ingestion_limit(IngestionLimit::MaxCheckpoint(end_checkpoint));
     }
 
     let reader_options = ReaderOptions {

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, env, path::PathBuf, time::Duration};
+use std::{collections::BTreeSet, env, path::PathBuf, time::Duration};
 
 use anyhow::{Result, anyhow};
 use iota_data_ingestion::{
@@ -15,7 +15,7 @@ use iota_data_ingestion_core::{
     reader::v2::{CheckpointReaderConfig, RemoteUrl},
 };
 use iota_grpc_client::Client;
-use iota_kvstore::{BigTableClient, BigtableTable, KvWorker};
+use iota_kvstore::{BigTableClient, KvWorker, Table};
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ struct BigTableTaskConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     emulator_host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tables: Option<HashSet<BigtableTable>>,
+    tables: Option<BTreeSet<Table>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -227,8 +227,14 @@ async fn main() -> Result<()> {
                     )
                     .await?
                 };
+
+                let kv_worker = match kv_config.tables.filter(|s| !s.is_empty()) {
+                    Some(tables) => KvWorker::new_selective(client, tables),
+                    None => KvWorker::new(client),
+                };
+
                 let worker_pool = WorkerPool::new(
-                    KvWorker::new(client, kv_config.tables),
+                    kv_worker,
                     task_config.name,
                     task_config.concurrency,
                     Default::default(),

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -137,14 +137,27 @@ impl KeyValueStoreWriter for BigTableClient {
                 bcs::to_bytes(contents)?,
             ),
         ];
-        let row = Row::new(key.clone(), cells);
-        self.multi_set(CHECKPOINTS_TABLE, [row]).await?;
+        let row = Row::new(key, cells);
+        self.multi_set(CHECKPOINTS_TABLE, [row])
+            .await
+            .map_err(Into::into)
+    }
 
-        let cells = vec![Cell::new(DEFAULT_COLUMN_QUALIFIER.as_bytes().to_vec(), key)];
-        let row = Row::new(
-            checkpoint.checkpoint_summary.digest().inner().to_vec(),
-            cells,
-        );
+    async fn save_checkpoint_by_digest(
+        &mut self,
+        checkpoint: &CheckpointData,
+    ) -> Result<(), Self::Error> {
+        let key = checkpoint.checkpoint_summary.digest().inner();
+
+        let value = checkpoint
+            .checkpoint_summary
+            .sequence_number()
+            .to_be_bytes();
+
+        let cells = [Cell::new(DEFAULT_COLUMN_QUALIFIER.into(), value.into())];
+
+        let row = Row::new(key.into(), cells.into());
+
         self.multi_set(CHECKPOINTS_BY_DIGEST_TABLE, [row])
             .await
             .map_err(Into::into)
@@ -318,16 +331,20 @@ impl KeyValueStoreReader for BigTableClient {
         Ok(checkpoints)
     }
 
-    async fn get_checkpoints_by_digest(
+    async fn get_checkpoint_sequence_numbers<I>(
         &mut self,
-        digests: &[CheckpointDigest],
-    ) -> Result<Vec<Checkpoint>, Self::Error> {
+        digests: I,
+    ) -> Result<Vec<CheckpointSequenceNumber>, Self::Error>
+    where
+        I: IntoIterator<Item = CheckpointDigest> + Send,
+        I::IntoIter: Send,
+    {
         let keys = digests
-            .iter()
+            .into_iter()
             .map(|digest| digest.inner().to_vec())
             .collect::<Vec<_>>();
-        let seq_nums = self
-            .multi_get(CHECKPOINTS_BY_DIGEST_TABLE, keys, None)
+
+        self.multi_get(CHECKPOINTS_BY_DIGEST_TABLE, keys, None)
             .await?
             .into_iter()
             .filter_map(|row| {
@@ -336,8 +353,20 @@ impl KeyValueStoreReader for BigTableClient {
                     .next()
                     .map(|cell| cell.value.as_slice().try_into().map(u64::from_be_bytes))
             })
-            .collect::<Result<Vec<_>, _>>()?;
-        self.get_checkpoints(&seq_nums).await
+            .collect::<Result<Vec<CheckpointSequenceNumber>, _>>()
+            .map_err(Into::into)
+    }
+
+    async fn get_checkpoints_by_digest<I>(
+        &mut self,
+        digests: I,
+    ) -> Result<Vec<Checkpoint>, Self::Error>
+    where
+        I: IntoIterator<Item = CheckpointDigest> + Send,
+        I::IntoIter: Send,
+    {
+        let sequence_numbers = self.get_checkpoint_sequence_numbers(digests).await?;
+        self.get_checkpoints(&sequence_numbers).await
     }
 }
 

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -10,14 +10,71 @@ use iota_types::{
     base_types::IotaAddress, effects::TransactionEffectsExt,
     full_checkpoint_content::CheckpointData, object::Owner, transaction::TransactionDataAPI,
 };
+use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
 
 use crate::{BigTableClient, KeyValueStoreWriter, TransactionData};
+
+/// Represents the BigTable tables used by the KvWorker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, strum::EnumIter)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum BigtableTable {
+    Objects,
+    Transactions,
+    TransactionsByAddress,
+    Checkpoints,
+}
 
 /// This worker implementation is responsible for processing checkpoints by
 /// storing its data as Key-Value pairs. The Key-Value pairs are stored in a
 /// BigTableDB.
 pub struct KvWorker {
     pub client: BigTableClient,
+    /// The tables enabled for writing by this worker.
+    pub enabled_tables: Vec<BigtableTable>,
+}
+
+impl KvWorker {
+    /// Creates a new KvWorker with the specified BigTable client and enabled
+    /// tables the user wishes to write to.
+    ///
+    /// If `tables` is `None`, all available tables will be enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use iota_kvstore::KvWorker;
+    /// # use iota_kvstore::{BigtableTable, BigTableClient};
+    /// # use std::collections::HashSet;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let client = BigTableClient::new_local("instance_id", "column_family")
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// /// Write all available tables to BigTable.
+    /// let worker = KvWorker::new(client.clone(), None);
+    ///
+    /// /// Write only the `Objects` table to BigTable.
+    /// let worker = KvWorker::new(client.clone(), HashSet::from([BigtableTable::Objects]));
+    ///
+    /// # drop(worker);
+    /// # }
+    /// ```
+    pub fn new(client: BigTableClient, tables: impl Into<Option<HashSet<BigtableTable>>>) -> Self {
+        let tables = tables.into();
+        // handle the case where the user provided an empty set of tables.
+        let tables = tables.filter(|s| !s.is_empty());
+        let enabled_tables = BigtableTable::iter()
+            .filter(|t| tables.as_ref().is_none_or(|set| set.contains(t)))
+            .collect();
+        Self {
+            client,
+            enabled_tables,
+        }
+    }
 }
 
 #[async_trait]
@@ -27,50 +84,60 @@ impl Worker for KvWorker {
 
     async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> anyhow::Result<()> {
         let mut client = self.client.clone();
-        let mut objects = vec![];
-        let mut transactions = Vec::with_capacity(checkpoint.transactions.len());
 
-        for transaction in &checkpoint.transactions {
-            for object in &transaction.output_objects {
-                objects.push(object);
+        for table in &self.enabled_tables {
+            match table {
+                BigtableTable::Objects => {
+                    let objects = checkpoint
+                        .transactions
+                        .iter()
+                        .flat_map(|t| &t.output_objects)
+                        .collect::<Vec<_>>();
+                    client.save_objects(&objects).await?;
+                }
+                BigtableTable::Transactions => {
+                    let transactions = checkpoint
+                        .transactions
+                        .iter()
+                        .map(|t| {
+                            TransactionData::new(t, checkpoint.checkpoint_summary.sequence_number)
+                        })
+                        .collect::<Vec<_>>();
+                    client.save_transactions(&transactions).await?;
+                }
+                BigtableTable::TransactionsByAddress => {
+                    let entries_by_address = checkpoint
+                        .checkpoint_contents
+                        .enumerate_transactions(&checkpoint.checkpoint_summary)
+                        .zip(&checkpoint.transactions)
+                        .flat_map(|((seq, exec_digest), tx)| {
+                            let digest = exec_digest.transaction;
+                            let tx_data = tx.transaction.transaction_data();
+
+                            let affected = std::iter::once(tx_data.sender())
+                                .chain(std::iter::once(tx_data.gas_owner()))
+                                .chain(tx.effects.all_changed_objects().into_iter().filter_map(
+                                    |(_object_ref, owner, _write_kind)| match owner {
+                                        Owner::Address(a) => Some(a),
+                                        _ => None,
+                                    },
+                                ))
+                                .collect::<HashSet<IotaAddress>>();
+
+                            affected
+                                .into_iter()
+                                .map(move |address| (address, seq, digest))
+                        });
+
+                    client
+                        .save_transactions_by_address(entries_by_address)
+                        .await?;
+                }
+                BigtableTable::Checkpoints => {
+                    client.save_checkpoint(&checkpoint).await?;
+                }
             }
-            transactions.push(TransactionData::new(
-                transaction,
-                checkpoint.checkpoint_summary.sequence_number,
-            ));
         }
-
-        client.save_objects(&objects).await?;
-        client.save_transactions(&transactions).await?;
-
-        let entries_by_address = checkpoint
-            .checkpoint_contents
-            .enumerate_transactions(&checkpoint.checkpoint_summary)
-            .zip(&checkpoint.transactions)
-            .flat_map(|((seq, exec_digest), tx)| {
-                let digest = exec_digest.transaction;
-                let tx_data = tx.transaction.transaction_data();
-
-                let affected = std::iter::once(tx_data.sender())
-                    .chain(std::iter::once(tx_data.gas_owner()))
-                    .chain(tx.effects.all_changed_objects().into_iter().filter_map(
-                        |(_object_ref, owner, _write_kind)| match owner {
-                            Owner::Address(a) => Some(a),
-                            _ => None,
-                        },
-                    ))
-                    .collect::<HashSet<IotaAddress>>();
-
-                affected
-                    .into_iter()
-                    .map(move |address| (address, seq, digest))
-            });
-
-        client
-            .save_transactions_by_address(entries_by_address)
-            .await?;
-        client.save_checkpoint(&checkpoint).await?;
-
         Ok(())
     }
 }

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
@@ -16,14 +19,36 @@ use strum::IntoEnumIterator;
 use crate::{BigTableClient, KeyValueStoreWriter, TransactionData};
 
 /// Represents the BigTable tables used by the KvWorker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, strum::EnumIter)]
+
+// Variants are declared in write order; the BTreeSet<Table> field
+// iterates by derived Ord, which follows declaration order.
+//
+// Order matters: data tables (Objects, Transactions, Checkpoints)
+// are written before their indexes (TransactionsByAddress,
+// CheckpointsByDigest), so a reader that sees an index entry can
+// always resolve the underlying row. Reordering variants will
+// reorder writes and may break that read-after-write invariant.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    strum::EnumIter,
+)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-pub enum BigtableTable {
+pub enum Table {
     Objects,
     Transactions,
     TransactionsByAddress,
     Checkpoints,
+    CheckpointsByDigest,
 }
 
 /// This worker implementation is responsible for processing checkpoints by
@@ -32,47 +57,70 @@ pub enum BigtableTable {
 pub struct KvWorker {
     pub client: BigTableClient,
     /// The tables enabled for writing by this worker.
-    pub enabled_tables: Vec<BigtableTable>,
+    pub enabled_tables: BTreeSet<Table>,
 }
 
 impl KvWorker {
-    /// Creates a new KvWorker with the specified BigTable client and enabled
-    /// tables the user wishes to write to.
+    /// Creates a new KvWorker that writes data to all tables.
     ///
-    /// If `tables` is `None`, all available tables will be enabled.
+    /// For selective writing, use [`KvWorker::new_selective`].
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use iota_kvstore::KvWorker;
-    /// # use iota_kvstore::{BigtableTable, BigTableClient};
-    /// # use std::collections::HashSet;
+    /// # use iota_kvstore::{Table, BigTableClient};
     ///
     /// # #[tokio::main]
     /// # async fn main() {
+    /// # std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost");
     /// let client = BigTableClient::new_local("instance_id", "column_family")
     ///     .await
     ///     .unwrap();
     ///
     /// /// Write all available tables to BigTable.
-    /// let worker = KvWorker::new(client.clone(), None);
-    ///
-    /// /// Write only the `Objects` table to BigTable.
-    /// let worker = KvWorker::new(client.clone(), HashSet::from([BigtableTable::Objects]));
+    /// let worker = KvWorker::new(client);
     ///
     /// # drop(worker);
     /// # }
     /// ```
-    pub fn new(client: BigTableClient, tables: impl Into<Option<HashSet<BigtableTable>>>) -> Self {
-        let tables = tables.into();
-        // handle the case where the user provided an empty set of tables.
-        let tables = tables.filter(|s| !s.is_empty());
-        let enabled_tables = BigtableTable::iter()
-            .filter(|t| tables.as_ref().is_none_or(|set| set.contains(t)))
-            .collect();
+    pub fn new(client: BigTableClient) -> Self {
         Self {
             client,
-            enabled_tables,
+            // All tables are enabled by default.
+            enabled_tables: Table::iter().collect(),
+        }
+    }
+
+    /// Creates a new KvWorker that writes only to the specified tables.
+    ///
+    /// # NOTE
+    /// Passing an empty iterator yields a worker that performs no writes.
+    /// Use [`KvWorker::new`] to write to all tables.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use iota_kvstore::KvWorker;
+    /// # use iota_kvstore::{Table, BigTableClient};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost");
+    /// let client = BigTableClient::new_local("instance_id", "column_family")
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// /// Write only the `Objects` table to BigTable.
+    /// let worker = KvWorker::new_selective(client, [Table::Objects]);
+    ///
+    /// # drop(worker);
+    /// # }
+    /// ```
+    pub fn new_selective(client: BigTableClient, tables: impl IntoIterator<Item = Table>) -> Self {
+        Self {
+            client,
+            enabled_tables: BTreeSet::from_iter(tables),
         }
     }
 }
@@ -87,7 +135,7 @@ impl Worker for KvWorker {
 
         for table in &self.enabled_tables {
             match table {
-                BigtableTable::Objects => {
+                Table::Objects => {
                     let objects = checkpoint
                         .transactions
                         .iter()
@@ -95,7 +143,7 @@ impl Worker for KvWorker {
                         .collect::<Vec<_>>();
                     client.save_objects(&objects).await?;
                 }
-                BigtableTable::Transactions => {
+                Table::Transactions => {
                     let transactions = checkpoint
                         .transactions
                         .iter()
@@ -105,7 +153,7 @@ impl Worker for KvWorker {
                         .collect::<Vec<_>>();
                     client.save_transactions(&transactions).await?;
                 }
-                BigtableTable::TransactionsByAddress => {
+                Table::TransactionsByAddress => {
                     let entries_by_address = checkpoint
                         .checkpoint_contents
                         .enumerate_transactions(&checkpoint.checkpoint_summary)
@@ -133,8 +181,11 @@ impl Worker for KvWorker {
                         .save_transactions_by_address(entries_by_address)
                         .await?;
                 }
-                BigtableTable::Checkpoints => {
+                Table::Checkpoints => {
                     client.save_checkpoint(&checkpoint).await?;
+                }
+                Table::CheckpointsByDigest => {
+                    client.save_checkpoint_by_digest(&checkpoint).await?;
                 }
             }
         }

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -23,7 +23,10 @@ use serde::{Deserialize, Serialize};
 /// BigTable Key Value store implementation.
 mod bigtable;
 
-pub use bigtable::{client, worker::KvWorker};
+pub use bigtable::{
+    client,
+    worker::{BigtableTable, KvWorker},
+};
 pub use iota_bigtable::{BigTableClient, Cell, Row, proto};
 
 use crate::bigtable::client::{TransactionSequenceNumber, TransactionsOrder};

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -25,7 +25,7 @@ mod bigtable;
 
 pub use bigtable::{
     client,
-    worker::{BigtableTable, KvWorker},
+    worker::{KvWorker, Table},
 };
 pub use iota_bigtable::{BigTableClient, Cell, Row, proto};
 
@@ -83,10 +83,24 @@ pub trait KeyValueStoreReader {
     /// Fetches a list of checkpoints by their digests.
     ///
     /// Not found checkpoints are omitted from the output list.
-    async fn get_checkpoints_by_digest(
+    async fn get_checkpoints_by_digest<I>(
         &mut self,
-        digests: &[CheckpointDigest],
-    ) -> Result<Vec<Checkpoint>, Self::Error>;
+        digests: I,
+    ) -> Result<Vec<Checkpoint>, Self::Error>
+    where
+        I: IntoIterator<Item = CheckpointDigest> + Send,
+        I::IntoIter: Send;
+
+    /// Fetches a list of checkpoint sequence numbers by their digests.
+    ///
+    /// Not found checkpoints are omitted from the output list.
+    async fn get_checkpoint_sequence_numbers<I>(
+        &mut self,
+        digests: I,
+    ) -> Result<Vec<CheckpointSequenceNumber>, Self::Error>
+    where
+        I: IntoIterator<Item = CheckpointDigest> + Send,
+        I::IntoIter: Send;
 }
 
 /// Writing key-value data to a persistent store, such as objects, transactions,
@@ -116,6 +130,13 @@ pub trait KeyValueStoreWriter {
 
     /// Persists a checkpoint to the store.
     async fn save_checkpoint(&mut self, checkpoint: &CheckpointData) -> Result<(), Self::Error>;
+
+    /// Persists a checkpoint digest to its corresponding sequence number to the
+    /// store.
+    async fn save_checkpoint_by_digest(
+        &mut self,
+        checkpoint: &CheckpointData,
+    ) -> Result<(), Self::Error>;
 }
 
 /// Represents all stored Key-Value data associated to a checkpoint containing

--- a/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
+++ b/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
@@ -66,3 +66,18 @@ tasks:
       column-family: "iota"
       timeout-secs: 60
       # emulator-host: "localhost:8086"
+
+      # Subset of BigTable tables this worker writes to.
+      #
+      # Default (field omitted or empty list): writes every supported
+      # table. Production deployments should leave this unset.
+      #
+      # Set to a list of tables when running a backfill that should
+      # populate only those tables, without re-writing data the main
+      # ingestion pipeline already owns.
+      #
+      # tables:
+      #   - objects
+      #   - transactions
+      #   - transactions-by-address
+      #   - checkpoints

--- a/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
+++ b/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
@@ -29,6 +29,17 @@ remote-store-url: "http://localhost:50051"
 #
 progress-store-path: "/iota/output/kv_ingestion_progress.json"
 
+# The starting checkpoint for the ingestion pipeline (inclusive).
+# If omitted, the pipeline resumes from the latest watermark stored in 'progress-store-path'.
+# If provided, the pipeline starts from the specified checkpoint (e.g., 0 for genesis).
+#
+# start-checkpoint: 0
+
+# The ending checkpoint for the ingestion pipeline (inclusive).
+# If omitted, the pipeline continues indefinitely until the end of the data stream.
+#
+# end-checkpoint: 1000000
+
 metrics-port: 8084
 
 # Workers Configs

--- a/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
+++ b/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
@@ -81,3 +81,4 @@ tasks:
       #   - transactions
       #   - transactions-by-address
       #   - checkpoints
+      #   - checkpoints-by-digest


### PR DESCRIPTION
# Description of change

This PR introduces two primary improvements to the `iota-kvstore` & `iota-data-ingestion`'s `iota-kv-store` worker type ingestion pipeline:

- **Configurable Table Selection**: Added the ability to specify a subset of tables for ingestion. This allows for targeted historical backfilling and reduces unnecessary write operations.

- **Flexible Checkpoint Resumption**: Fixed logic handling to allow starting the ingestion pipeline from a specific checkpoint (e.g., resuming from a mid-stream checkpoint rather than always defaulting to 0 or the latest watermark). This is a critical requirement for historical backfills and lays a clean foundation for other worker types to support custom start/end ranges with minimal refactoring.

## Links to any relevant issues

fixes #11328 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Tested manually the correctness of the new patch. Started a bigtable instance, for more information consult the `README.md` in the `iota-kvstore` crate.
- Started locally the `local-kv-storage` by using the `bigtable.yaml` config from the `iota/dev-tool/iota-data-ingestion/kv-store/config`.

### Validation Steps:

- **Checkpoint Resumption**: Verified that setting `start-checkpoint` allows the pipeline to skip genesis and start at a custom sequence.

    - Result: Configured `start-checkpoint: 1` and `end-checkpoint: 1499`. Confirmed the pipeline stopped correctly at 1500 and the watermark updated accordingly.

- **Table Filtering**: Verified that the tables configuration correctly limits the scope of ingested data.

    - Result: Ran ingestion with **objects** excluded from the tables list. Confirmed that while other tables populated correctly, the objects table remained empty.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

>[!NOTE]
> This patch does not affect the normal operation of the indexer, thus no further tests were conducted.