### PR TITLE
fix(typed-store,starfish-core): port upstream storage iterator and VecDeque fixes

### DIFF
--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -311,8 +311,12 @@ impl Store for MemStore {
             refs.push_front(BlockRef::new(round, author, digest));
         }
 
-        // Read and combine transactions and headers
-        let results = self.read_blocks(refs.as_slices().0)?;
+        // Read and combine transactions and headers.
+        // Use make_contiguous() rather than as_slices().0 to ensure all refs are read
+        // when the VecDeque ring buffer wraps; otherwise trailing entries would be
+        // silently dropped.
+        let refs_slice = refs.make_contiguous();
+        let results = self.read_blocks(refs_slice)?;
         let mut blocks = vec![];
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -659,7 +659,11 @@ impl Store for RocksDBStore {
             let ((author, round, digest), _) = kv?;
             refs.push_front(BlockRef::new(round, author, digest));
         }
-        let results = self.read_blocks(refs.as_slices().0)?;
+        // Use make_contiguous() rather than as_slices().0 so all refs are read
+        // when the VecDeque ring buffer wraps; otherwise trailing entries would
+        // be silently dropped.
+        let refs_slice = refs.make_contiguous();
+        let results = self.read_blocks(refs_slice)?;
         let mut blocks = vec![];
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -565,6 +565,42 @@ async fn test_range_iter() {
 }
 
 #[tokio::test]
+async fn test_safe_range_iter_exclusive_lower_bound_at_max() {
+    use std::ops::Bound;
+
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<u8, String> = open_map(tmp_dir.path(), None);
+    db.insert(&100u8, &"100".to_string()).unwrap();
+    db.insert(&u8::MAX, &"max".to_string()).unwrap();
+
+    let results: Vec<_> =
+        get_range_iter(&db, (Bound::Excluded(u8::MAX), Bound::Unbounded)).collect();
+    assert_eq!(
+        Vec::<(u8, String)>::new(),
+        results,
+        "Range (Excluded(u8::MAX), Unbounded) must yield no entries -- there is no key strictly greater than u8::MAX",
+    );
+}
+
+#[tokio::test]
+async fn test_safe_range_iter_exclusive_lower_bound_at_max_with_inclusive_upper() {
+    use std::ops::Bound;
+
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<u8, String> = open_map(tmp_dir.path(), None);
+    db.insert(&100u8, &"100".to_string()).unwrap();
+    db.insert(&u8::MAX, &"max".to_string()).unwrap();
+
+    let results: Vec<_> =
+        get_range_iter(&db, (Bound::Excluded(u8::MAX), Bound::Included(u8::MAX))).collect();
+    assert_eq!(
+        Vec::<(u8, String)>::new(),
+        results,
+        "Range (Excluded(u8::MAX), Included(u8::MAX)) must yield no entries -- the lower bound excludes the only candidate",
+    );
+}
+
+#[tokio::test]
 async fn test_is_empty() {
     let tmp_dir = iota_common::tempdir();
     let db: DBMap<i32, String> = open_map(tmp_dir.path(), Some("table"));

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -565,6 +565,38 @@ async fn test_range_iter() {
 }
 
 #[tokio::test]
+async fn test_safe_range_iter_inclusive_upper_bound_at_max() {
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<u8, String> = open_map(tmp_dir.path(), None);
+    db.insert(&100u8, &"100".to_string()).unwrap();
+    db.insert(&u8::MAX, &"max".to_string()).unwrap();
+
+    let results: Vec<_> = get_range_iter(&db, 100u8..=u8::MAX).collect();
+    assert_eq!(
+        vec![(100u8, "100".to_string()), (u8::MAX, "max".to_string())],
+        results,
+        "Range ..=u8::MAX must include the entry at u8::MAX",
+    );
+}
+
+#[tokio::test]
+async fn test_reversed_safe_iter_inclusive_upper_bound_at_max() {
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<u8, String> = open_map(tmp_dir.path(), None);
+    db.insert(&100u8, &"100".to_string()).unwrap();
+    db.insert(&u8::MAX, &"max".to_string()).unwrap();
+
+    let results: Vec<_> = get_reverse_iter(&db, None, Some(u8::MAX))
+        .map(|item| item.unwrap())
+        .collect();
+    assert_eq!(
+        vec![(u8::MAX, "max".to_string()), (100u8, "100".to_string())],
+        results,
+        "reversed_safe_iter_with_bounds upper=u8::MAX must include the entry at u8::MAX",
+    );
+}
+
+#[tokio::test]
 async fn test_safe_range_iter_exclusive_lower_bound_at_max() {
     use std::ops::Bound;
 

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -46,8 +46,16 @@ where
         Bound::Excluded(lower_bound) => {
             let mut key_buf = be_fix_int_ser(&lower_bound);
 
-            // Since we want exclusive, we need to increment the key to exclude the previous
-            big_endian_saturating_add_one(&mut key_buf);
+            if is_max(&key_buf) {
+                // No representable key strictly greater than the maximum at this byte
+                // length. Append a zero byte so the lower bound is lexicographically
+                // greater than any same-length key, ensuring the iterator yields
+                // nothing — matching the user's intent of excluding the max key.
+                key_buf.push(0);
+            } else {
+                // Since we want exclusive, we need to increment the key to exclude the previous
+                big_endian_saturating_add_one(&mut key_buf);
+            }
             Some(key_buf)
         }
         Bound::Unbounded => None,


### PR DESCRIPTION
# Description of change

Ports three upstream correctness fixes touching storage iterators and consensus block scanning. Each commit corresponds to a separate upstream PR.

## Upstream PRs ported

- **`fix(starfish-core): handle VecDeque wraparound …`** — port of MystenLabs/sui#24745. `scan_last_blocks_by_author` in `MemStore` and `RocksDBStore` used `VecDeque::as_slices().0`, which only covers the first contiguous segment of the ring buffer; when the deque storage wraps, the trailing `BlockRef`s are silently dropped. Calls `make_contiguous()` before slicing. Public API and ordering unchanged.

- **`fix(typed-store): exclude max key when safe_range_iter lower bound is Excluded`** — port of MystenLabs/sui#26469. `iterator_bounds_with_range`'s `Bound::Excluded(lower_bound)` arm called `big_endian_saturating_add_one`, which is a no-op when the encoded key is all `0xFF`. RocksDB then receives the unchanged max key as its (inclusive) lower bound and yields the entry the caller asked to exclude. Mirrors the `is_max` short-circuit already used on the upper-bound arm: appends a zero byte so the bound is lexicographically greater than any same-length stored key. Includes regression tests for `(Excluded(MAX), Unbounded)` and `(Excluded(MAX), Included(MAX))`.

- **`test(typed-store): add regression coverage for safe_range_iter inclusive upper bound at max`** — test-only port of MystenLabs/sui#26456. The upstream PR also fixed a `util.rs` bug in the `Bound::Included(upper_bound)` arm; IOTA's existing port of this code was already correct (the `if is_max { None } else { Some(...) }` short-circuit was there from the start), so only the regression tests are imported.

## IOTA-specific note on the bound symmetry

- **Upper bound (`Bound::Included` at max key):** the original upstream code (April 2025) was buggy. IOTA's port (March 2026) was written as `if !is_max { ...Some... } else { None }` from the start — so IOTA was never affected. The new tests guard against regression rather than fixing a live bug.
- **Lower bound (`Bound::Excluded` at max key):** the original upstream code (April 2025) was buggy. IOTA's port copied the buggy version verbatim, so IOTA *was* and *is* affected by the symmetric latent bug until this PR lands.

Net: IOTA's upper-bound arm has always been correct; the lower-bound arm has always been wrong (latent — no current caller constructs `(Bound::Excluded(K), _)` with `K` serializing to `0xFF…`, because Rust's standard range syntax always yields `Bound::Included` lower bounds). This PR fixes the lower bound and adds regression tests for both arms.

## Links to any relevant issues

- Upstream: MystenLabs/sui#24745, MystenLabs/sui#26456, MystenLabs/sui#26469

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes