### PR TITLE
upstream(iota-core): cache signed_effects_digests in memory

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1264,7 +1264,7 @@ impl AuthorityState {
         // We could be re-executing a previously executed but uncommitted transaction,
         // perhaps after restarting with a new binary. In this situation, if
         // we have published an effects signature, we must be sure not to
-        // equivocate. TODO: read from cache instead of DB
+        // equivocate.
         let expected_effects_digest =
             expected_effects_digest.or(epoch_store.get_signed_effects_digest(tx_digest)?);
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use arc_swap::ArcSwapOption;
+use dashmap::DashMap;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::{groups::bls12381, traits::ToFromBytes};
 use fastcrypto_tbls::{dkg_v1, nodes::PartyId};
@@ -19,7 +20,7 @@ use futures::{
     stream::FuturesUnordered,
 };
 use iota_common::{
-    fatal,
+    fatal, in_test_configuration,
     sync::{notify_once::NotifyOnce, notify_read::NotifyRead},
 };
 use iota_config::node::ExpensiveSafetyCheckConfig;
@@ -621,6 +622,13 @@ pub struct AuthorityPerEpochStore {
 
     executed_digests_notify_read: NotifyRead<TransactionKey, TransactionDigest>,
 
+    /// In-memory cache of signed effects digests. Populated from disk at
+    /// startup, updated on insert, and pruned on checkpoint finalization.
+    /// `get_signed_effects_digest` is called on every transaction; this
+    /// avoids a disk read on the hot path where the vast majority of
+    /// lookups return `None`. Writes still go to disk for crash recovery.
+    signed_effects_digests_cache: DashMap<TransactionDigest, TransactionEffectsDigest>,
+
     /// Cancellation token used to signal epoch termination to all in-flight
     /// tasks.
     epoch_alive_token: CancellationToken,
@@ -1015,6 +1023,15 @@ impl AuthorityPerEpochStore {
             .load_reconfig_state()
             .expect("Load reconfig state at initialization cannot fail");
 
+        // Populate the in-memory cache of signed effects digests from disk. The set is
+        // bounded by uncommitted (not-yet-checkpoint-finalized) transactions in the
+        // current epoch.
+        let signed_effects_digests_cache = DashMap::new();
+        for item in tables.signed_effects_digests.safe_iter() {
+            let (tx_digest, effects_digest) = item?;
+            signed_effects_digests_cache.insert(tx_digest, effects_digest);
+        }
+
         let epoch_alive_token = CancellationToken::new();
         let pending_consensus_transactions = tables.get_all_pending_consensus_transactions()?;
         let pending_consensus_certificates: HashSet<_> = pending_consensus_transactions
@@ -1110,6 +1127,7 @@ impl AuthorityPerEpochStore {
             checkpoint_state_notify_read: NotifyRead::new(),
             running_root_notify_read: NotifyRead::new(),
             executed_digests_notify_read: NotifyRead::new(),
+            signed_effects_digests_cache,
             end_of_publish: Mutex::new(end_of_publish),
             pending_consensus_certificates: RwLock::new(pending_consensus_certificates),
             mutex_table: MutexTable::new(MUTEX_TABLE_SIZE),
@@ -1488,6 +1506,8 @@ impl AuthorityPerEpochStore {
             [(tx_digest, effects_digest)],
         )?;
         batch.write()?;
+        self.signed_effects_digests_cache
+            .insert(*tx_digest, *effects_digest);
         Ok(())
     }
 
@@ -1529,8 +1549,22 @@ impl AuthorityPerEpochStore {
         &self,
         tx_digest: &TransactionDigest,
     ) -> IotaResult<Option<TransactionEffectsDigest>> {
-        let tables = self.tables()?;
-        Ok(tables.signed_effects_digests.get(tx_digest)?)
+        let cached = self.signed_effects_digests_cache.get(tx_digest).map(|r| *r);
+        if in_test_configuration() {
+            let from_db = self.tables()?.signed_effects_digests.get(tx_digest)?;
+            if cached != from_db {
+                // Cache and DB writes are not atomic, so retry after a brief delay to
+                // allow eventual consistency before panicking.
+                std::thread::sleep(std::time::Duration::from_secs(1));
+                let from_db = self.tables()?.signed_effects_digests.get(tx_digest)?;
+                let cached = self.signed_effects_digests_cache.get(tx_digest).map(|r| *r);
+                assert_eq!(
+                    cached, from_db,
+                    "signed_effects_digests cache inconsistency for {tx_digest}"
+                );
+            }
+        }
+        Ok(cached)
     }
 
     pub fn get_transaction_cert_sig(
@@ -1679,6 +1713,10 @@ impl AuthorityPerEpochStore {
         let mut quarantine = self.consensus_quarantine.write();
         quarantine.update_highest_executed_checkpoint(seq, self, &mut batch)?;
         batch.write()?;
+
+        for digest in digests {
+            self.signed_effects_digests_cache.remove(digest);
+        }
 
         self.consensus_output_cache
             .remove_executed_in_epoch(digests);


### PR DESCRIPTION
# Description of change

Port of MystenLabs/sui#26431 ("Cache `signed_effects_digests` in memory to avoid disk reads").

`get_signed_effects_digest(&tx_digest)` is called on every transaction this validator processes and reads from the RocksDB `signed_effects_digests` column family. The cardinality of that table is bounded by the set of transactions for which the validator has signed effects but which haven't yet been finalized in a checkpoint — small (hundreds to low thousands), but the call is high-frequency and the vast majority of lookups return `None`.

Adds `signed_effects_digests_cache: DashMap<TransactionDigest, TransactionEffectsDigest>`:

- Populated from disk at epoch startup (one-time scan of the column family).
- Updated on every successful write to disk.
- Pruned at the same time as the on-disk batch delete in the finalized-checkpoint path.
- `get_signed_effects_digest` reads only from the in-memory map.

Disk writes are unchanged — crash recovery still re-populates the cache from disk on next startup.

A test-mode-gated consistency check compares cache vs disk on every read, with a one-second retry to handle the write-before-cache-insert race (the disk batch is flushed first, then the cache is inserted; a concurrent read in the millisecond window between would otherwise spuriously panic). On divergence, the assertion panics with the offending tx digest.

The patch mirrors upstream almost line-for-line. IOTA's `AuthorityPerEpochStore::new` returns `IotaResult<Arc<Self>>` (not bare `Arc<Self>`), and the cleanup function is `notify_commit_of_finalized_checkpoint` (not `handle_finalized_checkpoint`) — code mapped accordingly.

## Links to any relevant issues

- Upstream: MystenLabs/sui#26431

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes