### PR TITLE
upstream(iota-core): replace NotifyOnce with CancellationToken in within_alive_epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5721,6 +5721,7 @@ dependencies = [
  "thiserror 1.0.64",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.4.13",
  "tracing",
  "twox-hash 1.6.3",

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -54,6 +54,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "net", "tracing"] }
 tokio-stream.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 twox-hash = "1.6"
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -14,8 +14,8 @@ use enum_dispatch::enum_dispatch;
 use fastcrypto::{groups::bls12381, traits::ToFromBytes};
 use fastcrypto_tbls::{dkg_v1, nodes::PartyId};
 use futures::{
-    FutureExt, StreamExt,
-    future::{Either, join_all, select},
+    StreamExt,
+    future::{Either, join_all},
     stream::FuturesUnordered,
 };
 use iota_common::{
@@ -70,6 +70,7 @@ use prometheus::IntCounter;
 use serde::{Deserialize, Serialize};
 use tap::TapOptional;
 use tokio::{sync::OnceCell, time::Instant};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::{
     DBMapUtils, Map,
@@ -620,8 +621,9 @@ pub struct AuthorityPerEpochStore {
 
     executed_digests_notify_read: NotifyRead<TransactionKey, TransactionDigest>,
 
-    /// This is used to notify all epoch specific tasks that epoch has ended.
-    epoch_alive_notify: NotifyOnce,
+    /// Cancellation token used to signal epoch termination to all in-flight
+    /// tasks.
+    epoch_alive_token: CancellationToken,
 
     /// Used to notify all epoch specific tasks that user certs are closed.
     user_certs_closed_notify: NotifyOnce,
@@ -1013,7 +1015,7 @@ impl AuthorityPerEpochStore {
             .load_reconfig_state()
             .expect("Load reconfig state at initialization cannot fail");
 
-        let epoch_alive_notify = NotifyOnce::new();
+        let epoch_alive_token = CancellationToken::new();
         let pending_consensus_transactions = tables.get_all_pending_consensus_transactions()?;
         let pending_consensus_certificates: HashSet<_> = pending_consensus_transactions
             .iter()
@@ -1099,7 +1101,7 @@ impl AuthorityPerEpochStore {
             parent_path: parent_path.to_path_buf(),
             db_options,
             reconfig_state_mem: RwLock::new(reconfig_state),
-            epoch_alive_notify,
+            epoch_alive_token,
             user_certs_closed_notify: NotifyOnce::new(),
             epoch_alive: tokio::sync::RwLock::new(true),
             consensus_notify_read: NotifyRead::new(),
@@ -2723,10 +2725,8 @@ impl AuthorityPerEpochStore {
 
     /// Notify epoch is terminated, can only be called once on epoch store
     pub async fn epoch_terminated(&self) {
-        // Notify interested tasks that epoch has ended
-        self.epoch_alive_notify
-            .notify()
-            .expect("epoch_terminated called twice on same epoch store");
+        // Signal all in-flight tasks that epoch has ended.
+        self.epoch_alive_token.cancel();
         // This `write` acts as a barrier - it waits for futures executing in
         // `within_alive_epoch` to terminate before we can continue here
         debug!("Epoch terminated - waiting for pending tasks to complete");
@@ -2736,7 +2736,7 @@ impl AuthorityPerEpochStore {
 
     /// Waits for the notification about epoch termination
     pub async fn wait_epoch_terminated(&self) {
-        self.epoch_alive_notify.wait().await
+        self.epoch_alive_token.cancelled().await
     }
 
     /// This function executes given future until epoch_terminated is called
@@ -2753,11 +2753,12 @@ impl AuthorityPerEpochStore {
         if !*guard {
             return Err(());
         }
-        let terminated = self.wait_epoch_terminated().boxed();
-        let f = f.boxed();
-        match select(terminated, f).await {
-            Either::Left((_, _f)) => Err(()),
-            Either::Right((result, _)) => Ok(result),
+        // The hot path here -- epoch is alive, future resolves first -- is now a
+        // single atomic load inside CancellationToken's `cancelled()` future,
+        // instead of mutex + Arc clone + two `.boxed()` heap allocations per call.
+        tokio::select! {
+            _ = self.epoch_alive_token.cancelled() => Err(()),
+            result = f => Ok(result),
         }
     }
 


### PR DESCRIPTION
# Description of change

Port of MystenLabs/sui#26430 ("Optimize `within_alive_epoch`: replace `NotifyOnce` with `CancellationToken`").

`within_alive_epoch` is called on every transaction this validator handles, to gate work on the epoch lifetime. The previous implementation paid, per call, a mutex lock + `Arc` clone inside `NotifyOnce`'s registration, two heap allocations from `.boxed()`, and the per-poll overhead of `futures::future::select`. For >99.99% of calls the inner future resolves before the epoch ends, so this overhead is paid on every call but only meaningful on epoch-end.

`epoch_alive_notify: NotifyOnce` → `epoch_alive_token: CancellationToken`. The hot path becomes:

```rust
tokio::select! {
    _ = self.epoch_alive_token.cancelled() => Err(()),
    result = f => Ok(result),
}
```

`CancellationToken::cancelled()` is an atomic load + a registered waiter; no mutex, no `Arc` clone, no `.boxed()`. `tokio::select!` polls the inner `f` in place without wrapping.

Behaviour is preserved: `epoch_terminated()` still acquires the `epoch_alive` write lock as a barrier; `wait_epoch_terminated()` still wakes exactly once; in-flight `within_alive_epoch` calls still race the cancellation against their inner future.

Adds `tokio-util` to `iota-core`'s dependencies. The Sui PR also drops a tracing span level from `error` to `debug` in `authority_server.rs::wait_for_effects_response`; IOTA has no such function (mysticeti-fastpath-specific), so that part doesn't apply.

## Links to any relevant issues

- Upstream: MystenLabs/sui#26430

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes