### PR TITLE
fix(iota-framework-snapshot): update manifest for v27

### DIFF
--- a/crates/iota-framework-snapshot/manifest.json
+++ b/crates/iota-framework-snapshot/manifest.json
@@ -690,7 +690,7 @@
     ]
   },
   "27": {
-    "git_revision": "2f81916f7ea5403aeb00cebe24feb473cc98c62a",
+    "git_revision": "34824a6fbe7071a8e4044b768a3294f8a4a34e5e",
     "packages": [
       {
         "name": "MoveStdlib",


### PR DESCRIPTION
# Description of change

Updates the manifest to point to the correct commit hash.
