### PR TITLE
chore(graphql): deprecate WrappedOrDeleted object status

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -3197,7 +3197,7 @@ enum ObjectKind {
 	The object is deleted or wrapped and only partial information can be
 	loaded from the indexer.
 	"""
-	WRAPPED_OR_DELETED @deprecated(reason: "will be removed with v1.26, as such objects can be construed as non-existent")
+	WRAPPED_OR_DELETED @deprecated(reason: "will be removed with v1.26, as such objects can be considered non-existent")
 }
 
 """

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -3197,7 +3197,7 @@ enum ObjectKind {
 	The object is deleted or wrapped and only partial information can be
 	loaded from the indexer.
 	"""
-	WRAPPED_OR_DELETED
+	WRAPPED_OR_DELETED @deprecated(reason: "will be removed with v1.26, as such objects can be construed as non-existent")
 }
 
 """

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -113,7 +113,7 @@ pub enum ObjectStatus {
     /// The object is deleted or wrapped and only partial information can be
     /// loaded from the indexer.
     #[graphql(
-        deprecation = "will be removed with v1.26, as such objects can be construed as non-existent"
+        deprecation = "will be removed with v1.26, as such objects can be considered non-existent"
     )]
     WrappedOrDeleted,
 }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -112,6 +112,9 @@ pub enum ObjectStatus {
     Indexed,
     /// The object is deleted or wrapped and only partial information can be
     /// loaded from the indexer.
+    #[graphql(
+        deprecation = "will be removed with v1.26, as such objects can be construed as non-existent"
+    )]
     WrappedOrDeleted,
 }
 

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3201,7 +3201,7 @@ enum ObjectKind {
 	The object is deleted or wrapped and only partial information can be
 	loaded from the indexer.
 	"""
-	WRAPPED_OR_DELETED
+	WRAPPED_OR_DELETED @deprecated(reason: "will be removed with v1.26, as such objects can be construed as non-existent")
 }
 
 """

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -3201,7 +3201,7 @@ enum ObjectKind {
 	The object is deleted or wrapped and only partial information can be
 	loaded from the indexer.
 	"""
-	WRAPPED_OR_DELETED @deprecated(reason: "will be removed with v1.26, as such objects can be construed as non-existent")
+	WRAPPED_OR_DELETED @deprecated(reason: "will be removed with v1.26, as such objects can be considered non-existent")
 }
 
 """


### PR DESCRIPTION
# Description of change

Patch that prepares the removal of the `WrappedOrDeleted` object status from the GraphQL API.

## Links to any relevant issues

Part of #11619

### Release Notes

- [x] GraphQL: :warning: Deprecates `WRAPPED_OR_DELETED` variant of `ObjectKind`. This kind of objects will be treated as non-existent. The variant will be removed with the v1.26 release.
