### PR TITLE
fix(gRPC): fix waiting for `checkpoint_inclusion_timeout_ms`

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2424,18 +2424,31 @@ impl AuthorityPerEpochStore {
                 .map(|(i, reg)| async move { (i, reg.await) })
                 .collect();
 
+            // Drain notifications until either every pending registration has
+            // resolved or the deadline expires.
+            //
+            // `biased;` polls branches in source order, so a notification that
+            // is already ready always wins over a deadline that fires in the
+            // same poll — we'd rather report inclusion than time out at the
+            // boundary.
+            //
+            // We match `Some`/`None` explicitly instead of using `else => break`
+            // because `else` only fires when *all* named branches are disabled.
+            // With `Some(...) = in_flight.next()` and a still-pending `deadline`,
+            // a `Ready(None)` from an empty `in_flight` disables only that one
+            // branch — the loop would then park on `deadline` and wait the full
+            // timeout even though every notification had already resolved.
             loop {
                 tokio::select! {
-                    Some((i, seq_and_ts)) = in_flight.next() => {
-                        results[i] = Some(seq_and_ts);
+                    biased;
+                    next_result = in_flight.next() => {
+                        match next_result {
+                            Some((i, seq_and_ts)) => results[i] = Some(seq_and_ts),
+                            // All pending registrations resolved before the deadline.
+                            None => break,
+                        }
                     }
-                    () = &mut deadline => {
-                        break;
-                    }
-                    else => {
-                        // All futures completed before the deadline.
-                        break;
-                    }
+                    () = &mut deadline => break,
                 }
             }
         }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use iota_types::base_types::TransactionDigest;
 use tokio::time::timeout;
@@ -61,4 +61,87 @@ async fn test_notify_read_executed_transactions_to_checkpoint() {
     assert_eq!(result[0].unwrap(), checkpoint_sequence_1);
     assert_eq!(result[1].unwrap(), checkpoint_sequence_2);
     assert_eq!(result[2].unwrap(), checkpoint_sequence_2);
+}
+
+#[tokio::test]
+async fn wait_for_transactions_in_checkpoint_returns_promptly_on_notify() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+
+    // Two digests: the first is already in the DB before the wait starts and
+    // should resolve via the `get_timestamp` closure; the second is inserted
+    // after the wait registers and should resolve via the notification path.
+    let preexisting_digest = TransactionDigest::random();
+    let pending_digest = TransactionDigest::random();
+    let preexisting_seq = 3;
+    let preexisting_ts_via_closure = 42;
+    let pending_seq = 7;
+    let pending_ts = 1_700_000_000_000;
+
+    // Pre-populate the first digest before the wait registers.
+    store
+        .insert_finalized_transactions(&[preexisting_digest], preexisting_seq, 0)
+        .expect("insert_finalized_transactions should succeed");
+
+    let waiter_store = store.clone();
+    let waiter_digests = vec![preexisting_digest, pending_digest];
+    let waiter = tokio::spawn(async move {
+        waiter_store
+            .wait_for_transactions_in_checkpoint_with_timeout(
+                &waiter_digests,
+                Duration::from_secs(30),
+                |_seq| preexisting_ts_via_closure,
+            )
+            .await
+    });
+
+    // Give the waiter a moment to register before firing the notification.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    store
+        .insert_finalized_transactions(&[pending_digest], pending_seq, pending_ts)
+        .expect("insert_finalized_transactions should succeed");
+
+    // With the bug, this hangs for the full 30s timeout and trips the outer 2s
+    // timeout; with the fix, the call returns in milliseconds.
+    let results = timeout(Duration::from_secs(2), waiter)
+        .await
+        .expect("wait did not return promptly after notification")
+        .expect("waiter task panicked")
+        .expect("wait_for_transactions_in_checkpoint_with_timeout returned error");
+
+    assert_eq!(results.len(), 2);
+    // Already-checkpointed: timestamp resolved by closure.
+    assert_eq!(
+        results[0],
+        Some((preexisting_seq, preexisting_ts_via_closure))
+    );
+    // Notified during the wait: timestamp comes from the notification payload.
+    assert_eq!(results[1], Some((pending_seq, pending_ts)));
+}
+
+#[tokio::test]
+async fn wait_for_transactions_in_checkpoint_times_out_without_notify() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+
+    let digests = vec![TransactionDigest::random(), TransactionDigest::random()];
+    let wait_timeout = Duration::from_millis(200);
+
+    let started = Instant::now();
+    let results = store
+        .wait_for_transactions_in_checkpoint_with_timeout(&digests, wait_timeout, |_seq| 0)
+        .await
+        .expect("wait_for_transactions_in_checkpoint_with_timeout returned error");
+    let elapsed = started.elapsed();
+
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(Option::is_none));
+    assert!(
+        elapsed >= wait_timeout,
+        "expected to wait at least the full timeout, waited {elapsed:?}"
+    );
+    assert!(
+        elapsed < wait_timeout * 5,
+        "wait took unreasonably long: {elapsed:?}"
+    );
 }


### PR DESCRIPTION
# Description of change

If a gRPC client passed `checkpoint_inclusion_timeout_ms` in an execute transaction request, the waiting loop got stuck until the timeout had passed. It was not covered by the existing tests, because the tests only tested if the response is correct, but not for the actual time that passed.

This PR fixes the bug.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] gRPC: fix `execute_transactions` waiting the full `checkpoint_inclusion_timeout_ms` after the transaction was already checkpointed