### PR TITLE
feat(consensus): metrics for StarfishSpeed strong-vote and adaptive-ack

### DIFF
--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -946,6 +946,26 @@ impl Core {
             }
         }
 
+        // Strong-vote payload metrics: distribution of the `missing` set size,
+        // and per-leader counter when the payload is a blame (non-empty).
+        if let Some(sv) = strong_vote.as_ref() {
+            let node_metrics = &self.context.metrics.node_metrics;
+            node_metrics
+                .strong_vote_missing_authorities
+                .observe(sv.missing.len() as f64);
+            if !sv.missing.is_empty() {
+                let leader = &self
+                    .context
+                    .committee
+                    .authority(sv.leader_authority)
+                    .hostname;
+                node_metrics
+                    .strong_blames_emitted_for_leader
+                    .with_label_values(&[leader])
+                    .inc();
+            }
+        }
+
         self.context
             .metrics
             .node_metrics

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1598,6 +1598,13 @@ impl Core {
             let Some(strong_vote) = block.strong_vote() else {
                 continue;
             };
+            let voter = &self.context.committee.authority(block.author()).hostname;
+            self.context
+                .metrics
+                .node_metrics
+                .strong_blames_received_from_voter
+                .with_label_values(&[voter])
+                .inc();
             dag_state.record_strong_vote_complaint(
                 block.author(),
                 leader_round,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2200,14 +2200,23 @@ impl DagState {
                 self.pending_acknowledgments.remove(&last_ack);
             }
         } else {
+            let mut dropped: u64 = 0;
             for ack in self.pending_acknowledgments.iter() {
                 if taken.len() >= limit || ack.round >= clock_round {
                     break;
                 }
                 if exclude.contains(ack.author) {
+                    dropped += 1;
                     continue;
                 }
                 taken.push(*ack);
+            }
+            if dropped > 0 {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .adaptive_ack_acks_dropped
+                    .inc_by(dropped);
             }
             for ack in &taken {
                 self.pending_acknowledgments.remove(ack);
@@ -2651,6 +2660,11 @@ impl DagState {
                 mask.insert(AuthorityIndex::from(auth as u8));
             }
         }
+        self.context
+            .metrics
+            .node_metrics
+            .adaptive_ack_excluded_authorities
+            .set(mask.len() as i64);
         mask
     }
 }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -49,6 +49,19 @@ const NUM_BUCKETS: &[f64] = &[
     1_000_000.0,
 ];
 
+/// Integer-aligned buckets for committee-size-bounded counts (e.g. the size
+/// of a strong-blame set). Each cumulative bucket `le=N.5` captures exactly
+/// the integer value N — so 0 and 1 land in different buckets, which is what
+/// `histogram_quantile` / heatmap visualisations need to distinguish a clean
+/// strong vote (`missing.len() == 0`) from a single-authority blame
+/// (`missing.len() == 1`). Boundaries cover the full `AuthorityIndex: u8`
+/// range; fine-grained at the low end where the common case lives, coarser
+/// for outliers.
+const COMMITTEE_COUNT_BUCKETS: &[f64] = &[
+    0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 12.5, 15.5, 20.5, 30.5, 50.5, 100.5,
+    256.5,
+];
+
 const LATENCY_SEC_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9,
     1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5,
@@ -1151,7 +1164,7 @@ impl NodeMetrics {
             strong_vote_missing_authorities: register_histogram_with_registry!(
                 "strong_vote_missing_authorities",
                 "Size of the `missing` set in the strong-vote payload of each proposed block: authorities whose transactions are not locally available among the leader and its acknowledgments. 0 means a clean strong vote; >0 means strong blame. Observed only when consensus_starfish_speed is enabled.",
-                NUM_BUCKETS.to_vec(),
+                COMMITTEE_COUNT_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
             strong_blames_emitted_for_leader: register_int_counter_vec_with_registry!(

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -254,6 +254,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) strong_vote_extra_wait_seconds: Histogram,
     pub(crate) strong_vote_missing_authorities: Histogram,
     pub(crate) strong_blames_emitted_for_leader: IntCounterVec,
+    pub(crate) strong_blames_received_from_voter: IntCounterVec,
 }
 
 impl NodeMetrics {
@@ -1155,6 +1156,12 @@ impl NodeMetrics {
                 "strong_blames_emitted_for_leader",
                 "Number of proposed blocks that strong-blame the leader (non-empty `missing` set), labeled by leader authority.",
                 &["leader"],
+                registry,
+            ).unwrap(),
+            strong_blames_received_from_voter: register_int_counter_vec_with_registry!(
+                "strong_blames_received_from_voter",
+                "Number of strong blames received against this node (when acting as leader), labeled by the voter authority that emitted the blame.",
+                &["voter"],
                 registry,
             ).unwrap(),
         }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -255,6 +255,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) strong_vote_missing_authorities: Histogram,
     pub(crate) strong_blames_emitted_for_leader: IntCounterVec,
     pub(crate) strong_blames_received_from_voter: IntCounterVec,
+    pub(crate) adaptive_ack_excluded_authorities: IntGauge,
+    pub(crate) adaptive_ack_acks_dropped: IntCounter,
 }
 
 impl NodeMetrics {
@@ -1162,6 +1164,16 @@ impl NodeMetrics {
                 "strong_blames_received_from_voter",
                 "Number of strong blames received against this node (when acting as leader), labeled by the voter authority that emitted the blame.",
                 &["voter"],
+                registry,
+            ).unwrap(),
+            adaptive_ack_excluded_authorities: register_int_gauge_with_registry!(
+                "adaptive_ack_excluded_authorities",
+                "Number of authorities currently in the adaptive-ack exclusion set, as observed at the most recent leader block proposal. Empty when consensus_starfish_speed or enable_starfish_speed_adaptive_acknowledgments is off.",
+                registry,
+            ).unwrap(),
+            adaptive_ack_acks_dropped: register_int_counter_with_registry!(
+                "adaptive_ack_acks_dropped",
+                "Total pending acknowledgments skipped because their author was in the adaptive-ack exclusion set at proposal time. Skipped refs remain pending and may be included later if the author leaves the exclusion set.",
                 registry,
             ).unwrap(),
         }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -252,6 +252,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) syncer_paused_by_fast_sync: IntCounterVec,
     pub(crate) uptime: Histogram,
     pub(crate) strong_vote_extra_wait_seconds: Histogram,
+    pub(crate) strong_vote_missing_authorities: Histogram,
+    pub(crate) strong_blames_emitted_for_leader: IntCounterVec,
 }
 
 impl NodeMetrics {
@@ -1141,6 +1143,18 @@ impl NodeMetrics {
                 "strong_vote_extra_wait_seconds",
                 "Extra wait at block proposal time imposed by the StarfishSpeed strong-vote condition: time between when the ordinary (base Starfish) propose condition first became satisfiable for the current clock round and when the proposal actually happened. Observed only when consensus_starfish_speed is enabled.",
                 FINE_GRAINED_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            strong_vote_missing_authorities: register_histogram_with_registry!(
+                "strong_vote_missing_authorities",
+                "Size of the `missing` set in the strong-vote payload of each proposed block: authorities whose transactions are not locally available among the leader and its acknowledgments. 0 means a clean strong vote; >0 means strong blame. Observed only when consensus_starfish_speed is enabled.",
+                NUM_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            strong_blames_emitted_for_leader: register_int_counter_vec_with_registry!(
+                "strong_blames_emitted_for_leader",
+                "Number of proposed blocks that strong-blame the leader (non-empty `missing` set), labeled by leader authority.",
+                &["leader"],
                 registry,
             ).unwrap(),
         }

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -19378,6 +19378,604 @@
       ],
       "title": "Inbound / Outbound Network Metrics",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 820
+      },
+      "id": 400,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Extra wait at block proposal time imposed by the StarfishSpeed strong-vote condition: time between when the ordinary (base Starfish) propose condition first became satisfiable and when the proposal actually happened. Observed only when consensus_starfish_speed is enabled.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 821
+          },
+          "id": 401,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.5, sum by(le) (rate(consensus_strong_vote_extra_wait_seconds_bucket[5m])))",
+              "legendFormat": "p50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(consensus_strong_vote_extra_wait_seconds_bucket[5m])))",
+              "legendFormat": "p95",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by(le) (rate(consensus_strong_vote_extra_wait_seconds_bucket[5m])))",
+              "legendFormat": "p99",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Strong-vote extra wait",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Distribution of the `missing` set size in the strong-vote payload of each proposed block. 0 means a clean strong vote; >0 means strong blame.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 821
+          },
+          "id": 402,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.5, sum by(le) (rate(consensus_strong_vote_missing_authorities_bucket[5m])))",
+              "legendFormat": "p50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(consensus_strong_vote_missing_authorities_bucket[5m])))",
+              "legendFormat": "p95",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by(le) (rate(consensus_strong_vote_missing_authorities_bucket[5m])))",
+              "legendFormat": "p99",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Missing authorities in strong vote",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of proposed blocks that strong-blame the leader (non-empty `missing` set), by leader authority.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 829
+          },
+          "id": 403,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by(leader) (rate(consensus_strong_blames_emitted_for_leader[5m]))",
+              "legendFormat": "{{leader}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Strong blames emitted (by leader)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of strong blames received against this node (when acting as leader), by voter authority.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 829
+          },
+          "id": 404,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by(voter) (rate(consensus_strong_blames_received_from_voter[5m]))",
+              "legendFormat": "{{voter}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Strong blames received (by voter)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Number of authorities currently in the adaptive-ack exclusion set, as observed at the most recent leader block proposal.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "stepBefore",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 837
+          },
+          "id": 405,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "consensus_adaptive_ack_excluded_authorities",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Adaptive-ack excluded authorities",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of pending acknowledgments skipped because their author was in the adaptive-ack exclusion set at leader proposal time.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 837
+          },
+          "id": 406,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(consensus_adaptive_ack_acks_dropped[5m])",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Adaptive-ack acks dropped",
+          "type": "timeseries"
+        }
+      ],
+      "title": "StarfishSpeed",
+      "type": "row"
     }
   ],
   "refresh": "5s",

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -19506,53 +19506,19 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Distribution of the `missing` set size in the strong-vote payload of each proposed block. 0 means a clean strong vote; >0 means strong blame.",
+          "description": "Distribution of the `missing` set size in the strong-vote payload of each proposed block. Each cell shows the rate of proposals whose `missing.len()` fell in the bucket on the Y axis. Bucket `le=0.5` = clean strong vote (no blame); `le=1.5` = single-authority blame; etc. Buckets are integer-aligned (boundaries at N.5) so 0 and 1 are separable. Observed only when consensus_starfish_speed is enabled.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
               "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
                 }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "short"
+              }
             },
             "overrides": []
           },
@@ -19564,54 +19530,62 @@
           },
           "id": 402,
           "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 64
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-09
+            },
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
             },
             "tooltip": {
               "mode": "single",
-              "sort": "desc"
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false
             }
           },
+          "pluginVersion": "11.2.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "prometheus"
               },
+              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "histogram_quantile(0.5, sum by(le) (rate(consensus_strong_vote_missing_authorities_bucket[5m])))",
-              "legendFormat": "p50",
+              "exemplar": false,
+              "expr": "sum by(le) (rate(consensus_strong_vote_missing_authorities_bucket[5m]))",
+              "format": "heatmap",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
               "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum by(le) (rate(consensus_strong_vote_missing_authorities_bucket[5m])))",
-              "legendFormat": "p95",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum by(le) (rate(consensus_strong_vote_missing_authorities_bucket[5m])))",
-              "legendFormat": "p99",
-              "range": true,
-              "refId": "C"
+              "refId": "A",
+              "useBackend": false
             }
           ],
           "title": "Missing authorities in strong vote",
-          "type": "timeseries"
+          "type": "heatmap"
         },
         {
           "datasource": {


### PR DESCRIPTION
# Description of change

Adds five observability metrics for StarfishSpeed: distribution and
per-leader count of outbound strong blames at proposal time, per-voter
count of inbound blames received as leader, and gauges/counters for
adaptive-ack exclusion of authorities from leader-block acknowledgments.
Wires the metrics into the starfish-overview Grafana dashboard under a
new StarfishSpeed section.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
