### PR TITLE
fix(starfish-core): emit persisted-only missing_proposals in subdag

### DIFF
--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -163,23 +163,43 @@ impl MisbehaviorStore {
         true
     }
 
-    /// Returns an absolute per-authority snapshot of `persisted + in_memory`
-    /// counts for emission with `CommittedSubDag`. Locks the two buckets
-    /// independently per authority; callers must hold `dag_state.read()` so
-    /// concurrent flush (which writes both buckets under `dag_state.write()`)
-    /// is excluded.
+    /// Returns the per-authority snapshot for emission with `CommittedSubDag`.
+    ///
+    /// Most fields sum `persisted + in_memory`, but `missing_proposals`
+    /// reports `persisted` only. Rationale, field by field:
+    ///
+    /// - `faulty_blocks_provable` / `faulty_blocks_unprovable`: additive in
+    ///   `in_memory` (drained to `persisted` on every flush, never recomputed
+    ///   downward). Safe to sum.
+    /// - `equivocations`: recomputed in `in_memory` from cached refs, but the
+    ///   recompute can only INCREASE — a non-zero count requires two distinct
+    ///   block refs at the same `(author, round)` in `recent_refs`, and refs
+    ///   never leave `recent_refs` except via eviction (which advances
+    ///   `persisted` accordingly). Safe to sum.
+    /// - `missing_proposals`: recomputed in `in_memory` from cached refs and
+    ///   CAN DECREASE — a previously-missing round becomes "proposed" the
+    ///   moment a late block arrives. Including the `in_memory` value here
+    ///   would propagate a potentially-transient over-count into
+    ///   `MisbehaviorMonitor::update_from_consensus_output`, whose `merge_max`
+    ///   defense would permanently latch it for the rest of the epoch. Emit
+    ///   `persisted` only so the reported value is a settled fact that cannot
+    ///   be revised downward later.
+    ///
+    /// Locks both buckets per authority. Callers must hold
+    /// `dag_state.read()` so concurrent flush (which writes both buckets
+    /// under `dag_state.write()`) is excluded.
     pub(crate) fn snapshot_totals(&self) -> Vec<MisbehaviorCounts> {
-        (0..self.in_memory.authorities.len())
+        (0..self.persisted.authorities.len())
             .map(|i| {
-                let persisted = self.persisted.snapshot(i);
-                let in_memory = self.in_memory.snapshot(i);
+                let p = self.persisted.snapshot(i);
+                let m = self.in_memory.snapshot(i);
                 MisbehaviorCounts::V1(MisbehaviorCountsV1 {
-                    faulty_blocks_provable: persisted.faulty_blocks_provable
-                        + in_memory.faulty_blocks_provable,
-                    faulty_blocks_unprovable: persisted.faulty_blocks_unprovable
-                        + in_memory.faulty_blocks_unprovable,
-                    missing_proposals: persisted.missing_proposals + in_memory.missing_proposals,
-                    equivocations: persisted.equivocations + in_memory.equivocations,
+                    faulty_blocks_provable: p.faulty_blocks_provable + m.faulty_blocks_provable,
+                    faulty_blocks_unprovable: p.faulty_blocks_unprovable
+                        + m.faulty_blocks_unprovable,
+                    // Persisted only — see method docs.
+                    missing_proposals: p.missing_proposals,
+                    equivocations: p.equivocations + m.equivocations,
                 })
             })
             .collect()
@@ -881,41 +901,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_snapshot_totals_sums_persisted_and_in_memory() {
+    async fn test_snapshot_totals_excludes_in_memory_missing_only() {
+        // Snapshot semantics:
+        // - faulty_blocks_* and equivocations: sum persisted + in_memory.
+        // - missing_proposals: persisted only (in_memory excluded because it can be
+        //   revised downward by late block arrival).
         let committee_size = 4;
         let context = Arc::new(Context::new_for_test(committee_size).0);
         let store = MisbehaviorStore::new(&context);
         let a0 = AuthorityIndex::new_for_test(0);
-        let a1 = AuthorityIndex::new_for_test(1);
+
+        // Seed persisted directly with non-zero values for all four fields.
+        store.persisted.set_block_faults(0, 7, 3);
+        store.persisted.set_dag_faults(0, 11, 4);
+
+        // Seed in_memory with non-zero values for all four fields.
         let provable = ConsensusError::TooManyAncestors(10, 5);
-
-        // Seed in_memory provable counts for authority 0 (2) and 1 (1).
+        let unprovable = ConsensusError::WrongEpoch {
+            expected: 1,
+            actual: 2,
+        };
         store.record_faulty_block_header(a0, a0, &provable);
         store.record_faulty_block_header(a0, a0, &provable);
-        store.record_faulty_block_header(a1, a1, &provable);
-
-        // Flush faulty buffer for authority 0 into persisted; leave authority 1
-        // unflushed so the snapshot must sum across both buckets.
-        let _ =
-            store.update_misbehavior_counts_on_eviction(a0, &BTreeSet::new(), 0, 0, 1, &context);
-
-        // Record 3 more provable faults on authority 0 — these stay in_memory.
-        for _ in 0..3 {
-            store.record_faulty_block_header(a0, a0, &provable);
-        }
+        // Charge a0 as the sending peer for an unprovable fault.
+        store.record_faulty_block_header(a0, a0, &unprovable);
+        store.in_memory.set_dag_faults(0, 9, 2);
 
         let snapshot = store.snapshot_totals();
-        assert_eq!(snapshot.len(), committee_size);
-        // Authority 0: 2 flushed into persisted + 3 still in_memory = 5 total.
-        // Authority 1: 1 still in_memory (never flushed) = 1 total.
-        // Untouched authorities are zero across both buckets.
-        let provable_totals: Vec<u64> = snapshot
-            .iter()
-            .map(|c| match c {
-                MisbehaviorCounts::V1(v1) => v1.faulty_blocks_provable,
-            })
-            .collect();
-        assert_eq!(provable_totals, vec![5, 1, 0, 0]);
+        let MisbehaviorCounts::V1(c) = &snapshot[0];
+
+        // faulty_blocks_*: persisted + in_memory.
+        assert_eq!(c.faulty_blocks_provable, 7 + 2, "provable should sum");
+        assert_eq!(c.faulty_blocks_unprovable, 3 + 1, "unprovable should sum");
+        // equivocations: persisted + in_memory.
+        assert_eq!(c.equivocations, 4 + 2, "equivocations should sum");
+        // missing_proposals: persisted only (the 9 from in_memory is excluded).
+        assert_eq!(
+            c.missing_proposals, 11,
+            "missing_proposals must be persisted-only"
+        );
     }
 
     #[tokio::test]

--- a/dev-tools/grafana-local/dashboards/validator-dashboard-v2.json
+++ b/dev-tools/grafana-local/dashboards/validator-dashboard-v2.json
@@ -30,18 +30,28 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "panels": [],
       "title": "Validator Scoring",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
       "description": "Per-authority validator score published by the local Scoreboard after each consensus commit. Range [0, MAX_SCORE]; higher is better. Updates only when at least one misbehavior report has been received in the current epoch.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -51,34 +61,59 @@
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           }
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
       "id": 2,
       "options": {
         "legend": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
           "editorMode": "code",
           "expr": "validator_scoreboard_scores{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
           "legendFormat": "{{host}} / {{authority}}",
@@ -91,18 +126,28 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 10 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
       "id": 3,
       "panels": [],
-      "title": "Misbehavior — Block Faults",
+      "title": "Misbehavior \u2014 Block Faults",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${Environment}" },
-      "description": "Provably faulty blocks per authority. Header carries a valid signature but violates protocol rules — attributed to the block author. `in_memory` (faults observed since last flush) is stacked on top of `persisted` (cumulative on disk); the sum is the running total.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Provably faulty blocks per authority. Header carries a valid signature but violates protocol rules \u2014 attributed to the block author. `in_memory` (faults observed since last flush) is stacked on top of `persisted` (cumulative on disk); the sum is the running total.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -111,37 +156,62 @@
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           }
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 11 },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
       "id": 4,
       "options": {
         "legend": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
           "editorMode": "code",
-          "expr": "faulty_blocks_provable_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
-          "legendFormat": "{{host}} / {{authority}} ({{source}})",
+          "expr": "sum by (host, authority) (consensus_faulty_blocks_provable_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"})",
+          "legendFormat": "{{host}} / {{authority}}",
           "range": true,
           "refId": "A"
         }
@@ -150,11 +220,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${Environment}" },
-      "description": "Unprovably faulty blocks per peer. Header rejected before/around signature verification (bad signature, pre-signature checks, malformed bytes) — author field can't be trusted, so attributed to the sending peer. `in_memory` stacked on `persisted`; sum is the running total.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
+      "description": "Unprovably faulty blocks per peer. Header rejected before/around signature verification (bad signature, pre-signature checks, malformed bytes) \u2014 author field can't be trusted, so attributed to the sending peer. `in_memory` stacked on `persisted`; sum is the running total.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -163,37 +238,62 @@
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           }
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 11 },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
           "editorMode": "code",
-          "expr": "faulty_blocks_unprovable_by_peer{network=\"$network\", host=~\"$validator\", peer=~\"$authority\"}",
-          "legendFormat": "{{host}} / {{peer}} ({{source}})",
+          "expr": "sum by (host, peer) (consensus_faulty_blocks_unprovable_by_peer{network=\"$network\", host=~\"$validator\", peer=~\"$authority\"})",
+          "legendFormat": "{{host}} / {{peer}}",
           "range": true,
           "refId": "A"
         }
@@ -203,18 +303,28 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
       "id": 6,
       "panels": [],
-      "title": "Misbehavior — DAG Faults",
+      "title": "Misbehavior \u2014 DAG Faults",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
       "description": "Committed slots where an authority failed to propose. `in_memory` is recomputed wholesale over the current DAG window each flush; `persisted` accumulates from rounds that have been evicted from the window. The two never overlap, so the sum is the running total.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -223,37 +333,62 @@
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           }
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 21 },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
           "editorMode": "code",
-          "expr": "missing_proposals_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
-          "legendFormat": "{{host}} / {{authority}} ({{source}})",
+          "expr": "sum by (host, authority) (consensus_missing_proposals_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"})",
+          "legendFormat": "{{host}} / {{authority}}",
           "range": true,
           "refId": "A"
         }
@@ -262,11 +397,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
       "description": "Slots where an authority signed conflicting blocks for the same (authority, round). Same `in_memory` (current window) vs `persisted` (evicted rounds) decomposition as missing proposals; the two are disjoint and stack to the running total.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -275,37 +415,62 @@
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           }
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 21 },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
           "editorMode": "code",
-          "expr": "equivocations_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
-          "legendFormat": "{{host}} / {{authority}} ({{source}})",
+          "expr": "sum by (host, authority) (consensus_equivocations_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"})",
+          "legendFormat": "{{host}} / {{authority}}",
           "range": true,
           "refId": "A"
         }
@@ -315,18 +480,28 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
       "id": 9,
       "panels": [],
       "title": "Misbehavior Reports",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Environment}"
+      },
       "description": "Cumulative invalid misbehavior reports received from each reporting authority in the current epoch. Resets at reconfigure. Elevated values can indicate a faulty or adversarial reporter.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -335,35 +510,61 @@
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 31 },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["last", "sum"],
+          "calcs": [
+            "last",
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Environment}"
+          },
           "editorMode": "code",
           "expr": "invalid_misbehavior_reports_by_authority{network=\"$network\", host=~\"$validator\", authority=~\"$authority\"}",
           "legendFormat": "{{host}} / {{authority}}",
@@ -379,11 +580,20 @@
   "revision": 1,
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["iota", "validator", "starfish", "scoring"],
+  "tags": [
+    "iota",
+    "validator",
+    "starfish",
+    "scoring"
+  ],
   "templating": {
     "list": [
       {
-        "current": { "selected": false, "text": "Prometheus", "value": "prometheus" },
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -398,8 +608,15 @@
         "type": "datasource"
       },
       {
-        "current": { "selected": false, "text": "local", "value": "local" },
-        "datasource": { "type": "prometheus", "uid": "${Environment}" },
+        "current": {
+          "selected": false,
+          "text": "local",
+          "value": "local"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${Environment}"
+        },
         "definition": "label_values(uptime,network)",
         "hide": 0,
         "includeAll": false,
@@ -418,8 +635,19 @@
         "type": "query"
       },
       {
-        "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
-        "datasource": { "type": "prometheus", "uid": "${Environment}" },
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${Environment}"
+        },
         "definition": "label_values(uptime{network=\"$network\"},host)",
         "hide": 0,
         "includeAll": true,
@@ -438,8 +666,19 @@
         "type": "query"
       },
       {
-        "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
-        "datasource": { "type": "prometheus", "uid": "${Environment}" },
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${Environment}"
+        },
         "definition": "label_values(validator_scoreboard_scores{network=\"$network\"},authority)",
         "hide": 0,
         "includeAll": true,
@@ -459,11 +698,14 @@
       }
     ]
   },
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
-  "title": "IOTA Validators v2",
-  "uid": "iota-validators-v2",
+  "title": "Committee Misbehavior Tracking",
+  "uid": "committee-misbehavior-tracking",
   "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

`MisbehaviorStore::snapshot_totals` currently sums `persisted + in_memory` for all four fields, and the result is propagated to `MisbehaviorMonitor::update_from_consensus_output` via `CommittedSubDag`. The `in_memory` `missing_proposals` is recomputed from the live cache window on every flush — so it can **decrease** when a block that was previously counted as missing arrives late (e.g. a peer reconnect that delivers buffered blocks). The downstream `merge_max` in `MisbehaviorMonitor` then permanently latches whichever value was highest, locking a transient over-count into the score for the rest of the epoch.

This change makes `missing_proposals` in the snapshot return `persisted` only. The other three fields (`faulty_blocks_provable`, `faulty_blocks_unprovable`, `equivocations`) are still summed because their `in_memory` value can only ever increase:

- `faulty_blocks_*` are additive in `in_memory` (drained to `persisted` on every flush, never recomputed).
- `equivocations` recomputes in `in_memory` but the recompute can only INCREASE — a non-zero count requires two distinct refs at the same `(author, round)` in `recent_refs`, and refs only leave `recent_refs` via eviction.

Only `missing_proposals` has the dip-and-latch failure mode, so only `missing_proposals` is constrained.

## Observed behavior that motivated this

While running a private network with a validator restart, the dashboard showed `missing_proposals` for the restarted validator jump to ~131 (in_memory inflated by in-flight blocks) and then drop to ~55 once the cache reconciled. The 131 value had already been captured in a commit snapshot and merge-locked in `current_local_observations` — so the report submitted minutes later carried 131, not the corrected 55. For `missing_proposals` the production thresholds (allowance 48k, max 160k) absorb the difference, but the principle is wrong, and reasoning about merge-max correctness gets cleaner when the upstream into it is guaranteed monotone.

## What's changed

- `snapshot_totals` builds a `MisbehaviorCountsV1` field-by-field: sums for `faulty_blocks_*` and `equivocations`, persisted-only for `missing_proposals`.
- Doc comment explains the rationale per field.
- Test renamed and tightened: `test_snapshot_totals_excludes_in_memory_missing_only` — seeds non-zero values in both buckets for every field and asserts the per-field semantics.

## Test plan

- [x] `cargo test -p starfish-core --lib test_snapshot_totals` passes
- [x] `cargo clippy -p starfish-core --no-deps` clean
- [x] `cargo +nightly fmt -p starfish-core` clean
- [ ] Reviewer to sanity-check the `equivocations` reasoning (refs leave `recent_refs` only via eviction)