### PR TITLE
fix(move-analyzer): skip module-name UseDef from a different file

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
@@ -675,7 +675,6 @@ impl<'a> ParsingAnalysisContext<'a> {
             return;
         };
         self.use_defs.insert(
-            mod_name_start.line,
             UseDef::new(
                 self.references,
                 &BTreeMap::new(),
@@ -739,7 +738,7 @@ impl<'a> ParsingAnalysisContext<'a> {
                     alias_start,
                     alias.loc.file_hash(),
                 );
-                self.use_defs.insert(alias_start.line, ud);
+                self.use_defs.insert(ud);
             }
             return;
         }
@@ -767,7 +766,7 @@ impl<'a> ParsingAnalysisContext<'a> {
                     alias_start,
                     alias.loc.file_hash(),
                 );
-                self.use_defs.insert(alias_start.line, ud);
+                self.use_defs.insert(ud);
             }
         }
     }

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -156,21 +156,30 @@ impl TypingAnalysisContext<'_> {
             return;
         };
         // insert use of the const's module
+        //
+        // Only add a use-def for the module name when it was written at the use
+        // site (same file as the constant name). For implicit references, where
+        // `mod_name.loc()` is synthesized to the module's declaration site in a
+        // different file, inserting that position into the current module's
+        // UseDefMap would mis-associate it with an unrelated location in the
+        // current file.
         let mod_name = module_ident.module;
-        if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
-            // a module will not be present if a constant belongs to an implicit module
-            self.use_defs.insert(
-                mod_name_start.line,
-                UseDef::new(
-                    self.references,
-                    self.alias_lengths,
-                    mod_name.loc().file_hash(),
-                    mod_name_start,
-                    mod_defs.name_loc,
-                    &mod_name.value(),
-                    None,
-                ),
-            );
+        if mod_name.loc().file_hash() == use_pos.file_hash() {
+            if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
+                // a module will not be present if a constant belongs to an implicit module
+                self.use_defs.insert(
+                    mod_name_start.line,
+                    UseDef::new(
+                        self.references,
+                        self.alias_lengths,
+                        mod_name.loc().file_hash(),
+                        mod_name_start,
+                        mod_defs.name_loc,
+                        &mod_name.value(),
+                        None,
+                    ),
+                );
+            }
         }
 
         let Some(name_start) = self.file_start_position_opt(&use_pos) else {
@@ -298,20 +307,29 @@ impl TypingAnalysisContext<'_> {
             return None;
         };
         // insert use of the functions's module
-        if let Some(mod_name_start) = mod_name_start_opt {
-            // a module will not be present if a function belongs to an implicit module
-            self.use_defs.insert(
-                mod_name_start.line,
-                UseDef::new(
-                    self.references,
-                    self.alias_lengths,
-                    mod_name.loc().file_hash(),
-                    mod_name_start,
-                    mod_defs.name_loc,
-                    &mod_name.value(),
-                    None,
-                ),
-            );
+        //
+        // Only add a use-def for the module name when it was written at the use
+        // site (same file as the function name). For implicit references (e.g.,
+        // built-in types like `vector` resolved via dot-calls), `mod_name.loc()`
+        // is synthesized to the module's declaration site in a different file,
+        // and inserting that position into the current module's UseDefMap would
+        // mis-associate it with an unrelated location in the current file.
+        if mod_name.loc().file_hash() == use_pos.file_hash() {
+            if let Some(mod_name_start) = mod_name_start_opt {
+                // a module will not be present if a function belongs to an implicit module
+                self.use_defs.insert(
+                    mod_name_start.line,
+                    UseDef::new(
+                        self.references,
+                        self.alias_lengths,
+                        mod_name.loc().file_hash(),
+                        mod_name_start,
+                        mod_defs.name_loc,
+                        &mod_name.value(),
+                        None,
+                    ),
+                );
+            }
         }
 
         let mut use_defs = std::mem::replace(&mut self.use_defs, UseDefMap::new());
@@ -347,20 +365,28 @@ impl TypingAnalysisContext<'_> {
         };
         // insert use of the struct's module
         let mod_name = mident.value.module;
-        if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
-            // a module will not be present if a struct belongs to an implicit module
-            self.use_defs.insert(
-                mod_name_start.line,
-                UseDef::new(
-                    self.references,
-                    self.alias_lengths,
-                    mod_name.loc().file_hash(),
-                    mod_name_start,
-                    mod_defs.name_loc,
-                    &mod_name.value(),
-                    None,
-                ),
-            );
+        // Only add a use-def for the module name when it was written at the use
+        // site (same file as the datatype name). For implicit references (e.g.,
+        // built-in types like `vector` resolved via dot-calls), `mod_name.loc()`
+        // is synthesized to the module's declaration site in a different file,
+        // and inserting that position into the current module's UseDefMap would
+        // mis-associate it with an unrelated location in the current file.
+        if mod_name.loc().file_hash() == use_name.loc().file_hash() {
+            if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
+                // a module will not be present if a struct belongs to an implicit module
+                self.use_defs.insert(
+                    mod_name_start.line,
+                    UseDef::new(
+                        self.references,
+                        self.alias_lengths,
+                        mod_name.loc().file_hash(),
+                        mod_name_start,
+                        mod_defs.name_loc,
+                        &mod_name.value(),
+                        None,
+                    ),
+                );
+            }
         }
 
         let mut use_defs = std::mem::replace(&mut self.use_defs, UseDefMap::new());

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -127,7 +127,6 @@ impl TypingAnalysisContext<'_> {
         let ident_type_def_loc = def_info_to_type_def_loc(self.mod_outer_defs, &type_def_info);
 
         self.use_defs.insert(
-            start.line,
             UseDef::new(
                 self.references,
                 self.alias_lengths,
@@ -168,7 +167,6 @@ impl TypingAnalysisContext<'_> {
             if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
                 // a module will not be present if a constant belongs to an implicit module
                 self.use_defs.insert(
-                    mod_name_start.line,
                     UseDef::new(
                         self.references,
                         self.alias_lengths,
@@ -190,7 +188,6 @@ impl TypingAnalysisContext<'_> {
             let const_info = self.def_info.get(&const_def.name_loc).unwrap();
             let ident_type_def_loc = def_info_to_type_def_loc(self.mod_outer_defs, const_info);
             self.use_defs.insert(
-                name_start.line,
                 UseDef::new(
                     self.references,
                     self.alias_lengths,
@@ -235,7 +232,6 @@ impl TypingAnalysisContext<'_> {
         // enter self-definition for def name
         let ident_type_def_loc = type_def_loc(self.mod_outer_defs, &def_type);
         self.use_defs.insert(
-            name_start.line,
             UseDef::new(
                 self.references,
                 self.alias_lengths,
@@ -265,7 +261,6 @@ impl TypingAnalysisContext<'_> {
         if let Some(local_def) = self.expression_scope.get(use_name) {
             let ident_type_def_loc = type_def_loc(self.mod_outer_defs, &local_def.def_type);
             self.use_defs.insert(
-                name_start.line,
                 UseDef::new(
                     self.references,
                     self.alias_lengths,
@@ -318,7 +313,6 @@ impl TypingAnalysisContext<'_> {
             if let Some(mod_name_start) = mod_name_start_opt {
                 // a module will not be present if a function belongs to an implicit module
                 self.use_defs.insert(
-                    mod_name_start.line,
                     UseDef::new(
                         self.references,
                         self.alias_lengths,
@@ -332,7 +326,7 @@ impl TypingAnalysisContext<'_> {
             }
         }
 
-        let mut use_defs = std::mem::replace(&mut self.use_defs, UseDefMap::new());
+        let mut use_defs = std::mem::replace(&mut self.use_defs, UseDefMap::empty());
         let mut refs = std::mem::take(self.references);
         let result = add_member_use_def(
             fun_def_name,
@@ -375,7 +369,6 @@ impl TypingAnalysisContext<'_> {
             if let Some(mod_name_start) = self.file_start_position_opt(&mod_name.loc()) {
                 // a module will not be present if a struct belongs to an implicit module
                 self.use_defs.insert(
-                    mod_name_start.line,
                     UseDef::new(
                         self.references,
                         self.alias_lengths,
@@ -389,7 +382,7 @@ impl TypingAnalysisContext<'_> {
             }
         }
 
-        let mut use_defs = std::mem::replace(&mut self.use_defs, UseDefMap::new());
+        let mut use_defs = std::mem::replace(&mut self.use_defs, UseDefMap::empty());
         let mut refs = std::mem::take(self.references);
         add_member_use_def(
             &use_name.value(),
@@ -468,7 +461,6 @@ impl TypingAnalysisContext<'_> {
         };
 
         self.use_defs.insert(
-            name_start.line,
             UseDef::new(
                 self.references,
                 self.alias_lengths,
@@ -545,7 +537,6 @@ impl TypingAnalysisContext<'_> {
                 let field_info = self.def_info.get(&fdef.loc).unwrap();
                 let ident_type_def_loc = def_info_to_type_def_loc(self.mod_outer_defs, field_info);
                 self.use_defs.insert(
-                    name_start.line,
                     UseDef::new(
                         self.references,
                         self.alias_lengths,
@@ -725,7 +716,6 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
         let struct_info = self.def_info.get(&struct_name.loc()).unwrap();
         let struct_type_def = def_info_to_type_def_loc(self.mod_outer_defs, struct_info);
         self.use_defs.insert(
-            name_start.line,
             UseDef::new(
                 self.references,
                 self.alias_lengths,
@@ -754,7 +744,6 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
                     let ident_type_def_loc =
                         def_info_to_type_def_loc(self.mod_outer_defs, &field_info);
                     self.use_defs.insert(
-                        start.line,
                         UseDef::new(
                             self.references,
                             self.alias_lengths,
@@ -786,7 +775,6 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
         let enum_info = self.def_info.get(&enum_name.loc()).unwrap();
         let enum_type_def = def_info_to_type_def_loc(self.mod_outer_defs, enum_info);
         self.use_defs.insert(
-            name_start.line,
             UseDef::new(
                 self.references,
                 self.alias_lengths,
@@ -822,7 +810,6 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
         let variant_info = self.def_info.get(&variant_name.loc()).unwrap();
         let vtype_def = def_info_to_type_def_loc(self.mod_outer_defs, variant_info);
         self.use_defs.insert(
-            vname_start.line,
             UseDef::new(
                 self.references,
                 self.alias_lengths,
@@ -845,7 +832,6 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
                     let ident_type_def_loc =
                         def_info_to_type_def_loc(self.mod_outer_defs, &field_info);
                     self.use_defs.insert(
-                        start.line,
                         UseDef::new(
                             self.references,
                             self.alias_lengths,
@@ -878,7 +864,6 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
         let const_info = self.def_info.get(&loc).unwrap();
         let ident_type_def_loc = def_info_to_type_def_loc(self.mod_outer_defs, const_info);
         self.use_defs.insert(
-            name_start.line,
             UseDef::new(
                 self.references,
                 self.alias_lengths,
@@ -921,7 +906,7 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
             fun_type_def,
         );
 
-        self.use_defs.insert(name_start.line, use_def);
+        self.use_defs.insert(use_def);
 
         // Get symbols for a function definition
         for tp in &fdef.signature.type_parameters {
@@ -1219,7 +1204,6 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
                 };
                 let ident_type_def_loc = type_def_loc(self.mod_outer_defs, ty);
                 self.use_defs.insert(
-                    name_start.line,
                     UseDef::new(
                         self.references,
                         self.alias_lengths,
@@ -1271,7 +1255,16 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
                 let fun_def_name = fun_def.value();
                 let fun_def_loc = fun_def.loc();
                 self.add_fun_use_def(&module_ident, &fun_def_name, use_name, &use_loc);
-                self.add_fun_use_def(&module_ident, &fun_def_name, &fun_def_name, &fun_def_loc);
+                // Self-use-def at the function's definition site. Only emit
+                // when the definition lives in the file we're currently
+                // analysing — otherwise the analyser for the defining module
+                // already produced the same `UseDef`, and inserting a
+                // duplicate here would file coordinates from another file
+                // under the current module's `UseDefMap` (the structural
+                // safety net would drop it, but better not to create it).
+                if fun_def_loc.file_hash() == self.use_defs.file_hash() {
+                    self.add_fun_use_def(&module_ident, &fun_def_name, &fun_def_name, &fun_def_loc);
+                }
             }
         }
     }

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -381,10 +381,19 @@ pub enum DefInfo {
     ),
 }
 
-/// Information about both the use identifier (source file is specified wherever
-/// an instance of this struct is used) and the definition identifier
+/// Information about both the use identifier and the definition identifier.
+///
+/// A `UseDef` is self-describing about *where* the use is: the `use_fhash`
+/// and `use_line` fields identify the file and line of the use position.
+/// This invariant is enforced by [`UseDefMap::insert`] (debug-only assertion)
+/// so the use coordinates of a `UseDef` always match the file the containing
+/// map is for. Violating it was the root cause of issue #2421.
 #[derive(Debug, Clone, Eq)]
 pub struct UseDef {
+    /// File hash of the use position
+    use_fhash: FileHash,
+    /// Line where the (use) identifier location starts (0-indexed)
+    use_line: u32,
     /// Column where the (use) identifier location starts on a given line (use
     /// this field for sorting uses on the line)
     col_start: u32,
@@ -698,9 +707,18 @@ pub enum CursorDefinition {
 type LineOffset = u32;
 
 /// Maps a line number to a list of use-def-s on a given line (use-def set is
-/// sorted by col_start)
+/// sorted by col_start).
+///
+/// The map carries the `FileHash` of the file it describes. Every `UseDef`
+/// inserted must have `use_fhash` matching `file_hash`; this is enforced by
+/// a debug-only assertion in [`UseDefMap::insert`] / [`UseDefMap::extend`].
+/// Use [`UseDefMap::empty`] to obtain a placeholder for short-lived swaps
+/// (e.g. `std::mem::replace`) where the map is never inserted into.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct UseDefMap(BTreeMap<LineOffset, BTreeSet<UseDef>>);
+pub struct UseDefMap {
+    file_hash: FileHash,
+    map: BTreeMap<LineOffset, BTreeSet<UseDef>>,
+}
 
 pub type References = BTreeMap<Loc, BTreeSet<UseLoc>>;
 pub type DefMap = BTreeMap<Loc, DefInfo>;
@@ -1701,6 +1719,8 @@ impl UseDef {
 
         references.entry(def_loc).or_default().insert(use_loc);
         Self {
+            use_fhash,
+            use_line: use_start.line,
             col_start: use_start.character,
             col_end,
             def_loc,
@@ -1717,6 +1737,8 @@ impl UseDef {
         new_start: Position,
         new_fhash: FileHash,
     ) {
+        self.use_fhash = new_fhash;
+        self.use_line = new_start.line;
         self.col_start = new_start.character;
         self.col_end = new_start.character + new_name.len() as u32;
         let new_use_loc = UseLoc {
@@ -1729,6 +1751,14 @@ impl UseDef {
             .entry(self.def_loc)
             .or_default()
             .insert(new_use_loc);
+    }
+
+    pub fn use_fhash(&self) -> FileHash {
+        self.use_fhash
+    }
+
+    pub fn use_line(&self) -> u32 {
+        self.use_line
     }
 
     pub fn col_start(&self) -> u32 {
@@ -1753,6 +1783,8 @@ impl UseDef {
         def_file_content: &str,
     ) -> std::io::Result<()> {
         let UseDef {
+            use_fhash: _,
+            use_line: _,
             col_start,
             col_end,
             def_loc,
@@ -1826,37 +1858,88 @@ impl PartialEq for UseDef {
     }
 }
 
-impl Default for UseDefMap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl UseDefMap {
-    pub fn new() -> Self {
-        Self(BTreeMap::new())
+    /// Construct a map for `file_hash`. Every `UseDef` later inserted must
+    /// have `use_fhash == file_hash`.
+    pub fn new(file_hash: FileHash) -> Self {
+        Self {
+            file_hash,
+            map: BTreeMap::new(),
+        }
     }
 
-    pub fn insert(&mut self, key: u32, val: UseDef) {
-        self.0.entry(key).or_default().insert(val);
+    /// Construct a placeholder map with no associated file. Useful for
+    /// short-lived swaps via `std::mem::replace` where the map is replaced
+    /// before any insert happens. Inserts on an empty map will trigger the
+    /// debug assertion in [`UseDefMap::insert`].
+    pub fn empty() -> Self {
+        Self::new(FileHash::empty())
+    }
+
+    pub fn file_hash(&self) -> FileHash {
+        self.file_hash
+    }
+
+    /// Insert a `UseDef`. The map line key is derived from `ud.use_line()`.
+    ///
+    /// If `ud.use_fhash()` does not match this map's `file_hash`, the
+    /// `UseDef` is silently dropped (and, in debug builds, a warning is
+    /// printed). This is the safety net for the class of cross-file
+    /// confusion that issue #2421 exposed — a `UseDef` whose coordinates
+    /// describe a different file getting filed under this one. The
+    /// individual `add_*_use_def` helpers should already guard against
+    /// inserting such `UseDef`s; this catches anything that slips through.
+    pub fn insert(&mut self, ud: UseDef) {
+        if ud.use_fhash() != self.file_hash {
+            log_cross_file_drop(&ud, self.file_hash);
+            return;
+        }
+        self.map.entry(ud.use_line()).or_default().insert(ud);
     }
 
     pub fn get(&self, key: u32) -> Option<BTreeSet<UseDef>> {
-        self.0.get(&key).cloned()
+        self.map.get(&key).cloned()
     }
 
     pub fn elements(self) -> BTreeMap<u32, BTreeSet<UseDef>> {
-        self.0
+        self.map
     }
 
     pub fn count(&self) -> usize {
-        self.0.len()
+        self.map.len()
     }
 
     pub fn extend(&mut self, use_defs: BTreeMap<u32, BTreeSet<UseDef>>) {
         for (k, v) in use_defs {
-            self.0.entry(k).or_default().extend(v);
+            let entry = self.map.entry(k).or_default();
+            for ud in v {
+                if ud.use_fhash() != self.file_hash {
+                    log_cross_file_drop(&ud, self.file_hash);
+                    continue;
+                }
+                entry.insert(ud);
+            }
         }
+    }
+}
+
+/// Log a dropped cross-file `UseDef`. Off by default; enable by setting
+/// `MOVE_ANALYZER_VERBOSE_USEDEF=1` in the environment to surface every
+/// drop (useful when tracking down bugs like issue #2421). In production
+/// the dropped `UseDef` would silently corrupt hover/goto-def results;
+/// dropping it is the safe choice.
+fn log_cross_file_drop(ud: &UseDef, map_file_hash: FileHash) {
+    if std::env::var_os("MOVE_ANALYZER_VERBOSE_USEDEF").is_some() {
+        eprintln!(
+            "move-analyzer: dropping cross-file UseDef \
+             (use_fhash={:?}, map_fhash={:?}, line={}, col {}-{}, def={:?})",
+            ud.use_fhash(),
+            map_file_hash,
+            ud.use_line(),
+            ud.col_start(),
+            ud.col_end(),
+            ud.def_loc(),
+        );
     }
 }
 
@@ -2362,7 +2445,7 @@ fn run_parsing_analysis(
         files: &compiled_pkg_info.mapped_files,
         references: &mut computation_data.references,
         def_info: &mut computation_data.def_info,
-        use_defs: UseDefMap::new(),
+        use_defs: UseDefMap::empty(),
         current_mod_ident_str: None,
         alias_lengths: BTreeMap::new(),
         pkg_addresses: &NamedAddressMap::new(),
@@ -2417,7 +2500,7 @@ fn run_typing_analysis(
         files: mapped_files,
         references: &mut computation_data.references,
         def_info: &mut computation_data.def_info,
-        use_defs: UseDefMap::new(),
+        use_defs: UseDefMap::empty(),
         current_mod_ident_str: None,
         alias_lengths: &BTreeMap::new(),
         traverse_only: false,
@@ -2451,7 +2534,10 @@ fn update_file_use_defs(
             .unwrap();
         let fpath = match mapped_files.file_name_mapping().get(&module_defs.fhash) {
             Some(p) => p.as_path().to_string_lossy().to_string(),
-            None => return,
+            // Skip this module, but keep processing the rest — the original
+            // code used `return` here which silently dropped every module that
+            // happened to iterate after one with a missing file mapping.
+            None => continue,
         };
 
         let fpath_buffer =
@@ -2459,7 +2545,7 @@ fn update_file_use_defs(
 
         file_use_defs
             .entry(fpath_buffer)
-            .or_default()
+            .or_insert_with(|| UseDefMap::new(module_defs.fhash))
             .extend(use_defs.clone().elements());
     }
 }
@@ -2778,7 +2864,7 @@ fn process_typed_modules<'a>(
         typing_symbolicator.alias_lengths = mod_to_alias_lengths.get(&mod_ident_str).unwrap();
         typing_symbolicator.visit_module(module_ident, module_def);
 
-        let use_defs = std::mem::replace(&mut typing_symbolicator.use_defs, UseDefMap::new());
+        let use_defs = std::mem::replace(&mut typing_symbolicator.use_defs, UseDefMap::empty());
         mod_use_defs.insert(mod_ident_str, use_defs);
     }
 }
@@ -3177,7 +3263,7 @@ fn get_mod_outer_defs(
         def_info.insert(name_loc, fun_info);
     }
 
-    let mut use_def_map = UseDefMap::new();
+    let mut use_def_map = UseDefMap::new(fhash);
 
     let ident = mod_ident.value;
     let doc_string = mod_def.doc.comment().map(|d| d.value.to_owned());
@@ -3199,18 +3285,15 @@ fn get_mod_outer_defs(
     // insert use of the module name in the definition itself
     let mod_name = ident.module;
     if let Some(mod_name_start) = loc_start_to_lsp_position_opt(files, &mod_name.loc()) {
-        use_def_map.insert(
-            mod_name_start.line,
-            UseDef::new(
-                references,
-                &BTreeMap::new(),
-                mod_name.loc().file_hash(),
-                mod_name_start,
-                mod_defs.name_loc,
-                &mod_name.value(),
-                None,
-            ),
-        );
+        use_def_map.insert(UseDef::new(
+            references,
+            &BTreeMap::new(),
+            mod_name.loc().file_hash(),
+            mod_name_start,
+            mod_defs.name_loc,
+            &mod_name.value(),
+            None,
+        ));
         def_info.insert(
             mod_defs.name_loc,
             DefInfo::Module(mod_ident_to_ide_string(&ident, None, false), doc_string),
@@ -3263,7 +3346,7 @@ pub fn add_member_use_def(
             use_name,
             ident_type_def_loc,
         );
-        use_defs.insert(name_start.line, ud.clone());
+        use_defs.insert(ud.clone());
         return Some(ud);
     }
     None

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -119,16 +119,17 @@ impl UseDefTest {
         writeln!(output, "use line: {use_line}, use_ndx: {use_ndx}")?;
         let lsp_use_line = use_line - 1; // 0th-based
         let Some(uses) = mod_symbols.get(lsp_use_line) else {
-            writeln!(
-                output,
-                "ERROR: No use_line {use_line} in mod_symbols {mod_symbols:#?} for file {use_file}"
-            )?;
+            // Intentionally terse: the map dump used to be included here, but
+            // it bloats snapshots and changes whenever the map's `Debug` impl
+            // changes. Tests that probe "no entry at line N" should expect
+            // only this single line.
+            writeln!(output, "ERROR: No uses at line {use_line} in {use_file}")?;
             return Ok(());
         };
         let Some(use_def) = uses.iter().nth(*use_ndx) else {
             writeln!(
                 output,
-                "ERROR: No use_line {use_ndx} in uses {uses:#?} for file {use_file}"
+                "ERROR: No use at ndx {use_ndx} on line {use_line} in {use_file}"
             )?;
             return Ok(());
         };

--- a/external-crates/move/crates/move-analyzer/tests/macros.ide
+++ b/external-crates/move/crates/move-analyzer/tests/macros.ide
@@ -35,6 +35,28 @@
           "use_line": 7,
           "use_ndx": 2
         },
+        // Regression guard for issue #2421. The macro body at line 8
+        // (`        $body($i)`) has real UseDefs for `$body` (col 8) and
+        // `$i` (col 14). The pre-fix analyser also inserted a bogus
+        // `UseDef` for `std::vector` here whose col_start (12) sorted
+        // between the two real entries, derived from the position of
+        // `vector` inside `module std::vector;` in vector.move. Querying
+        // `use_ndx 0..2` covers all real entries; if a regression
+        // re-introduces the cross-file leak, a third entry appears and
+        // the snapshot shifts (the test catches it even with the IOTA
+        // license header present).
+        {
+          "use_line": 8,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 8,
+          "use_ndx": 1
+        },
+        {
+          "use_line": 8,
+          "use_ndx": 2
+        },
         {
           "use_line": 15,
           "use_ndx": 0

--- a/external-crates/move/crates/move-analyzer/tests/macros.snap
+++ b/external-crates/move/crates/move-analyzer/tests/macros.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/move-analyzer/tests/ide_testsuite.rs
+assertion_line: 685
 ---
 == fun_type.move ========================================================
 -- test 0 -------------------
@@ -63,6 +64,18 @@ On Hover:
 $body: |u64| -> u64
 
 -- test 3 -------------------
+use line: 8, use_ndx: 0
+ERROR: No uses at line 8 in macros.move
+
+-- test 4 -------------------
+use line: 8, use_ndx: 1
+ERROR: No uses at line 8 in macros.move
+
+-- test 5 -------------------
+use line: 8, use_ndx: 2
+ERROR: No uses at line 8 in macros.move
+
+-- test 6 -------------------
 use line: 15, use_ndx: 0
 Use: 'bar', start: 14, end: 17
 Def: 'bar', line: 14, def char: 14
@@ -73,7 +86,7 @@ macro fun Macros::macros::bar(
 	$body: |Macros::macros::SomeStruct| -> Macros::macros::SomeStruct
 ): Macros::macros::SomeStruct
 
--- test 4 -------------------
+-- test 7 -------------------
 use line: 15, use_ndx: 1
 Use: '$i', start: 18, end: 20
 Def: '$i', line: 14, def char: 18
@@ -81,7 +94,7 @@ TypeDef: 'SomeStruct', line: 2, char: 18
 On Hover:
 $i: Macros::macros::SomeStruct
 
--- test 5 -------------------
+-- test 8 -------------------
 use line: 15, use_ndx: 2
 Use: 'SomeStruct', start: 22, end: 32
 Def: 'SomeStruct', line: 2, def char: 18
@@ -91,7 +104,7 @@ public struct Macros::macros::SomeStruct has drop {
 	some_field: u64
 }
 
--- test 6 -------------------
+-- test 9 -------------------
 use line: 15, use_ndx: 3
 Use: '$body', start: 34, end: 39
 Def: '$body', line: 14, def char: 34
@@ -99,7 +112,7 @@ TypeDef: no info
 On Hover:
 $body: |Macros::macros::SomeStruct| -> Macros::macros::SomeStruct
 
--- test 7 -------------------
+-- test 10 -------------------
 use line: 15, use_ndx: 4
 Use: 'SomeStruct', start: 42, end: 52
 Def: 'SomeStruct', line: 2, def char: 18
@@ -109,7 +122,7 @@ public struct Macros::macros::SomeStruct has drop {
 	some_field: u64
 }
 
--- test 8 -------------------
+-- test 11 -------------------
 use line: 15, use_ndx: 5
 Use: 'SomeStruct', start: 57, end: 67
 Def: 'SomeStruct', line: 2, def char: 18
@@ -119,7 +132,7 @@ public struct Macros::macros::SomeStruct has drop {
 	some_field: u64
 }
 
--- test 9 -------------------
+-- test 12 -------------------
 use line: 15, use_ndx: 6
 Use: 'SomeStruct', start: 70, end: 80
 Def: 'SomeStruct', line: 2, def char: 18
@@ -129,7 +142,7 @@ public struct Macros::macros::SomeStruct has drop {
 	some_field: u64
 }
 
--- test 10 -------------------
+-- test 13 -------------------
 use line: 19, use_ndx: 0
 Use: 'for_each', start: 14, end: 22
 Def: 'for_each', line: 18, def char: 14
@@ -140,7 +153,7 @@ macro fun Macros::macros::for_each<$T>(
 	$body: |&$T| -> ()
 )
 
--- test 11 -------------------
+-- test 14 -------------------
 use line: 19, use_ndx: 1
 Use: '$T', start: 23, end: 25
 Def: '$T', line: 18, def char: 23
@@ -148,7 +161,7 @@ TypeDef: no info
 On Hover:
 $T
 
--- test 12 -------------------
+-- test 15 -------------------
 use line: 19, use_ndx: 2
 Use: '$v', start: 27, end: 29
 Def: '$v', line: 18, def char: 27
@@ -156,7 +169,7 @@ TypeDef: no info
 On Hover:
 let $v: &vector<u64>
 
--- test 13 -------------------
+-- test 16 -------------------
 use line: 19, use_ndx: 3
 Use: '$T', start: 39, end: 41
 Def: '$T', line: 18, def char: 23
@@ -164,7 +177,7 @@ TypeDef: no info
 On Hover:
 $T
 
--- test 14 -------------------
+-- test 17 -------------------
 use line: 19, use_ndx: 4
 Use: '$body', start: 44, end: 49
 Def: '$body', line: 18, def char: 44
@@ -172,7 +185,7 @@ TypeDef: no info
 On Hover:
 $body: |&$T| -> ()
 
--- test 15 -------------------
+-- test 18 -------------------
 use line: 19, use_ndx: 5
 Use: '$T', start: 53, end: 55
 Def: '$T', line: 18, def char: 23
@@ -180,7 +193,7 @@ TypeDef: no info
 On Hover:
 $T
 
--- test 16 -------------------
+-- test 19 -------------------
 use line: 33, use_ndx: 0
 Use: 'macros', start: 16, end: 22
 Def: 'macros', line: 0, def char: 15
@@ -188,7 +201,7 @@ TypeDef: no info
 On Hover:
 module Macros::macros
 
--- test 17 -------------------
+-- test 20 -------------------
 use line: 33, use_ndx: 1
 Use: 'foo', start: 24, end: 27
 Def: 'foo', line: 6, def char: 14
@@ -199,7 +212,7 @@ macro fun Macros::macros::foo(
 	$body: |u64| -> u64
 ): u64
 
--- test 18 -------------------
+-- test 21 -------------------
 use line: 33, use_ndx: 2
 Use: 'p', start: 29, end: 30
 Def: 'p', line: 31, def char: 12
@@ -207,7 +220,7 @@ TypeDef: no info
 On Hover:
 let p: u64
 
--- test 19 -------------------
+-- test 22 -------------------
 use line: 33, use_ndx: 3
 Use: 'x', start: 33, end: 34
 Def: 'x', line: 32, def char: 33
@@ -215,7 +228,7 @@ TypeDef: no info
 On Hover:
 let x: u64
 
--- test 20 -------------------
+-- test 23 -------------------
 use line: 33, use_ndx: 4
 Use: 'x', start: 36, end: 37
 Def: 'x', line: 32, def char: 33
@@ -223,7 +236,7 @@ TypeDef: no info
 On Hover:
 let x: u64
 
--- test 21 -------------------
+-- test 24 -------------------
 use line: 38, use_ndx: 5
 Use: 'y', start: 49, end: 50
 Def: 'y', line: 37, def char: 49
@@ -231,7 +244,7 @@ TypeDef: no info
 On Hover:
 let y: u64
 
--- test 22 -------------------
+-- test 25 -------------------
 use line: 38, use_ndx: 7
 Use: 'foo', start: 68, end: 71
 Def: 'foo', line: 6, def char: 14
@@ -242,7 +255,7 @@ macro fun Macros::macros::foo(
 	$body: |u64| -> u64
 ): u64
 
--- test 23 -------------------
+-- test 26 -------------------
 use line: 38, use_ndx: 8
 Use: 'y', start: 73, end: 74
 Def: 'y', line: 37, def char: 49
@@ -250,7 +263,7 @@ TypeDef: no info
 On Hover:
 let y: u64
 
--- test 24 -------------------
+-- test 27 -------------------
 use line: 38, use_ndx: 9
 Use: 'z', start: 77, end: 78
 Def: 'z', line: 37, def char: 77
@@ -258,7 +271,7 @@ TypeDef: no info
 On Hover:
 let z: u64
 
--- test 25 -------------------
+-- test 28 -------------------
 use line: 38, use_ndx: 10
 Use: 'z', start: 80, end: 81
 Def: 'z', line: 37, def char: 77
@@ -266,7 +279,7 @@ TypeDef: no info
 On Hover:
 let z: u64
 
--- test 26 -------------------
+-- test 29 -------------------
 use line: 44, use_ndx: 4
 Use: 'sum', start: 48, end: 51
 Def: 'sum', line: 42, def char: 16
@@ -274,7 +287,7 @@ TypeDef: no info
 On Hover:
 let mut sum: u64
 
--- test 27 -------------------
+-- test 30 -------------------
 use line: 45, use_ndx: 0
 Use: 'es', start: 8, end: 10
 Def: 'es', line: 41, def char: 12
@@ -282,7 +295,7 @@ TypeDef: no info
 On Hover:
 let es: vector<u64>
 
--- test 28 -------------------
+-- test 31 -------------------
 use line: 45, use_ndx: 1
 Use: 'feach', start: 11, end: 16
 Def: 'for_each', line: 18, def char: 14
@@ -293,7 +306,7 @@ macro fun Macros::macros::for_each<$T>(
 	$body: |&$T| -> ()
 )
 
--- test 29 -------------------
+-- test 32 -------------------
 use line: 52, use_ndx: 2
 Use: 'SomeStruct', start: 34, end: 44
 Def: 'SomeStruct', line: 2, def char: 18


### PR DESCRIPTION
# Description of change

- The `move-analyzer` hover would occasionally point at an unrelated module (e.g., `std::vector`) when the user hovered on a position that doesn't even contain an identifier.
- The Move compiler's typed AST gives resolved module identifiers the  **declaration-site** `Loc`. The analyzer in `add_fun_use_def`, `add_datatype_use_def` and `add_const_use_def` was using `mod_name.loc()` as if it were the use-site position, then inserting a `UseDef` into the *current* module's `UseDefMap`. `UseDef` only stores `col_start`/`col_end` (no file hash), so when the declaration sits in a different file the coordinates got reinterpreted against the wrong file's content — usually harmless, occasionally aligning with a real query position.
- The reported symptom was that `tests/macros.ide` produced a different result depending on whether the IOTA license header was present in `move-stdlib/sources/vector.move` — the header just shifted the bogus entry off the line the test queries, hiding the bug.

## Fix
Gate the module-name `UseDef` insertion on mod_name.loc().file_hash() == use_pos.file_hash()`. If the module name wasn't actually written in the same file as the use (e.g., dot calls like `v.length()` where the receiver type's module is synthesized), skip the insertion instead of poisoning the current module's map.

## Caveats
- Aliased imports (`use std::vector as Vec; Vec::length(...)`) and the second `add_fun_use_def(..., &fun_def_loc)` call in `visit_use_funs` are not addressed here; a complete fix would have `UseDef` carry an explicit use-site `file_hash` and enforce it at construction. Filed as follow-up.

## Links to any relevant issues
fixes #2421

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

