### PR TITLE
refactor(iota-graphql-rpc): allow subscriptions on every chain

### DIFF
--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -3,7 +3,7 @@
 
 use std::num::NonZeroUsize;
 
-use async_graphql::{Context, OutputType, ResultExt, SimpleObject, Subscription, Union};
+use async_graphql::{Context, OutputType, SimpleObject, Subscription, Union};
 use futures::{Stream, StreamExt, TryStreamExt, future};
 use iota_indexer::read::IndexerReader;
 use iota_indexer_streaming::{
@@ -12,7 +12,7 @@ use iota_indexer_streaming::{
     metrics::InMemoryStreamMetrics,
 };
 use iota_json_rpc_types::Filter;
-use iota_types::{digests::TransactionDigest, supported_protocol_versions::Chain};
+use iota_types::digests::TransactionDigest;
 use prometheus::Registry;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tracing::warn;
@@ -20,7 +20,6 @@ use tracing::warn;
 use crate::{
     error::Error,
     types::{
-        chain_identifier::ChainIdentifierCache,
         digest::Digest,
         event::Event,
         subscription::filter::{SubscriptionEventFilter, SubscriptionTransactionFilter},
@@ -80,27 +79,8 @@ impl Subscription {
         filter: Option<SubscriptionTransactionFilter>,
     ) -> async_graphql::Result<impl Stream<Item = Result<SubscriptionItem<TransactionBlock>, Error>>>
     {
-        let chain_id_cache: &ChainIdentifierCache = ctx.data_unchecked();
-
-        let db = ctx.data_unchecked();
-        let metrics = ctx.data_unchecked();
-        let chain = chain_id_cache
-            .read(db, metrics)
-            .await
-            .extend()?
-            .into_inner()
-            .chain();
-
-        if !matches!(chain, Chain::Unknown) {
-            return Err(Error::UnsupportedFeature(format!(
-                "Subscriptions are not yet supported on {}",
-                chain.as_str()
-            )))
-            .extend();
-        }
-
-        let streams = ctx.data_unchecked::<GraphQLStream>();
-        Ok(streams.subscribe_transactions(start_after, filter))
+        let stream = ctx.data_unchecked::<GraphQLStream>();
+        Ok(stream.subscribe_transactions(start_after, filter))
     }
 
     /// Subscribe to incoming events from the IOTA network.
@@ -131,27 +111,8 @@ impl Subscription {
         start_after: Option<Digest>,
         filter: Option<SubscriptionEventFilter>,
     ) -> async_graphql::Result<impl Stream<Item = Result<SubscriptionItem<Event>, Error>>> {
-        let chain_id_cache: &ChainIdentifierCache = ctx.data_unchecked();
-
-        let db = ctx.data_unchecked();
-        let metrics = ctx.data_unchecked();
-        let chain = chain_id_cache
-            .read(db, metrics)
-            .await
-            .extend()?
-            .into_inner()
-            .chain();
-
-        if !matches!(chain, Chain::Unknown) {
-            return Err(Error::UnsupportedFeature(format!(
-                "Subscriptions are not yet supported on {}",
-                chain.as_str()
-            )))
-            .extend();
-        }
-
-        let streams = ctx.data_unchecked::<GraphQLStream>();
-        Ok(streams.subscribe_events(start_after, filter))
+        let stream = ctx.data_unchecked::<GraphQLStream>();
+        Ok(stream.subscribe_events(start_after, filter))
     }
 }
 


### PR DESCRIPTION
# Description of change

This PR allows the GraphQL Subscriptions support for all chains.

## Links to any relevant issues

fixes #11555 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Started graphql server on `mainnet` network, executed a subscription query, was receiving data.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal operations of the indexer, thus no further tests were conducted.

### Release Notes

- [x] GraphQL:  Add Subscription support for `Event` and `TransactionBlock`.It does accept an optional `startAfter`
transaction digest to resume receiving transactions and events from a specific point. For more detailed information consult the graphql schema.
