### PR TITLE
chore: allow `namee` typo

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -44,6 +44,7 @@ cpy = "cpy"
 AAS = "AAS"
 # actual typos purposely used in tests
 assing = "assing"
+namee = "namee"
 tring = "tring"
 # better suggestions for typos
 transferer = "transferrer"


### PR DESCRIPTION
Anticipating a CI failure that would otherwise occur tomorrow after having rebuilt the runner images which would update the `typos` version, raising an error.

The allowed typo is intentional to test an error behaviour.
