### PR TITLE
refactor(consensus): Pass context to Store trait methods

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -123,7 +123,7 @@ impl ConsensusAuthority {
         let network_client = network_manager.client();
 
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
-        let store = Arc::new(RocksDBStore::new(store_path, context.clone()));
+        let store = Arc::new(RocksDBStore::new(store_path));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1779,7 +1779,7 @@ mod tests {
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
 
         let network_client = Arc::new(FakeNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -1865,7 +1865,7 @@ mod tests {
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
 
         let network_client = Arc::new(FakeNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -1960,7 +1960,7 @@ mod tests {
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
 
         let network_client = Arc::new(FakeNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -2048,7 +2048,7 @@ mod tests {
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
 
         let network_client = Arc::new(FakeNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2186,7 +2186,7 @@ mod tests {
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
 
         let network_client = Arc::new(FakeNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2269,7 +2269,7 @@ mod tests {
         let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
 
         let network_client = Arc::new(FakeNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2464,7 +2464,7 @@ mod tests {
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
         ));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -2631,7 +2631,7 @@ mod tests {
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
         ));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -2814,7 +2814,7 @@ mod tests {
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
         ));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -3143,7 +3143,7 @@ mod tests {
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
         ));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -3285,7 +3285,7 @@ mod tests {
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
         ));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -3449,7 +3449,7 @@ mod tests {
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
         ));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -3646,7 +3646,7 @@ mod tests {
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
         ));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 
@@ -3872,7 +3872,7 @@ mod tests {
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
         ));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
 

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -607,7 +607,7 @@ mod tests {
         // GIVEN
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
@@ -679,7 +679,7 @@ mod tests {
     async fn try_accept_block_returns_missing_blocks() {
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
@@ -724,7 +724,7 @@ mod tests {
         // GIVEN
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
@@ -788,7 +788,7 @@ mod tests {
         for seed in 0..100u8 {
             all_block_headers.shuffle(&mut StdRng::from_seed([seed; 32]));
 
-            let store = Arc::new(MemStore::new(context.clone()));
+            let store = Arc::new(MemStore::new());
             let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
             let mut block_manager = BlockManager::new(context.clone(), dag_state);
@@ -844,7 +844,7 @@ mod tests {
             .map(|block| block.reference())
             .collect::<BTreeSet<_>>();
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let mut block_manager = BlockManager::new(context, dag_state);
@@ -916,7 +916,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Create BlockManager.
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let mut block_manager = BlockManager::new(context, dag_state);
         // Try to accept blocks from round 2 ~ 5 into block manager. All of them should
@@ -957,7 +957,7 @@ mod tests {
         // GIVEN
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
@@ -1071,7 +1071,7 @@ mod tests {
         // GIVEN
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -1233,7 +1233,7 @@ mod tests {
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Plant a commit with leader round large enough that gc_floor > 0.
@@ -1277,7 +1277,7 @@ mod tests {
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let commit_leader_round = gc_depth * 2 + 200;
         plant_last_commit(&dag_state, &context, commit_leader_round);
@@ -1360,7 +1360,7 @@ mod tests {
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
 
@@ -1394,7 +1394,7 @@ mod tests {
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let commit_leader_round = gc_depth * 2 + 200;
         plant_last_commit(&dag_state, &context, commit_leader_round);
@@ -1425,7 +1425,7 @@ mod tests {
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let commit_leader_round = gc_depth * 2 + 200;
         plant_last_commit(&dag_state, &context, commit_leader_round);
@@ -1464,7 +1464,7 @@ mod tests {
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -1007,7 +1007,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_committed_subdag_from_commit() {
         let context = Arc::new(Context::new_for_test(4).0);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut encoder = create_encoder(&context);
 
         // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
@@ -1131,7 +1131,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_pending_subdag_from_commit() {
         let context = Arc::new(Context::new_for_test(4).0);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
         let first_wave_rounds: u32 = WAVE_LENGTH;
         let num_authorities: u8 = 4;

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -646,7 +646,7 @@ mod tests {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
-        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let mem_store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             mem_store.clone(),
@@ -763,7 +763,7 @@ mod tests {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
-        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let mem_store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             mem_store.clone(),
@@ -910,7 +910,7 @@ mod tests {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
-        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let mem_store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             mem_store.clone(),
@@ -994,7 +994,7 @@ mod tests {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
-        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let mem_store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             mem_store.clone(),
@@ -1219,7 +1219,7 @@ mod tests {
             clock,
         ));
 
-        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let mem_store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             mem_store.clone(),

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -249,7 +249,7 @@ mod tests {
             let context = Arc::new(context);
             let dag_state = Arc::new(RwLock::new(DagState::new(
                 context.clone(),
-                Arc::new(crate::storage::mem_store::MemStore::new(context.clone())),
+                Arc::new(crate::storage::mem_store::MemStore::new()),
             )));
             let mut dag_builder = DagBuilder::new(context.clone());
             dag_builder
@@ -279,7 +279,7 @@ mod tests {
         ) -> Arc<RwLock<DagState>> {
             let selective_dag_state = Arc::new(RwLock::new(DagState::new(
                 self.context.clone(),
-                Arc::new(MemStore::new(self.context.clone())),
+                Arc::new(MemStore::new()),
             )));
 
             let mut state = selective_dag_state.write();

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -979,7 +979,7 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(FakeNetworkClient::default());
-        let store: Arc<dyn Store> = Arc::new(MemStore::new(context.clone()));
+        let store: Arc<dyn Store> = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0));
@@ -1102,7 +1102,7 @@ mod tests {
             let block_verifier = Arc::new(NoopBlockVerifier {});
             let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
             let network_client = Arc::new(FakeNetworkClient::default());
-            let store: Arc<dyn Store> = Arc::new(MemStore::new(context.clone()));
+            let store: Arc<dyn Store> = Arc::new(MemStore::new());
             let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
             let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
             let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0));

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1225,7 +1225,7 @@ mod tests {
         let byzantine_index = AuthorityIndex::new_for_test(3);
         let (context, _key_pairs) = Context::new_for_test(validators);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         // Set up DAG with blocks from all validators.
@@ -1432,7 +1432,7 @@ mod tests {
         let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
         let context = Arc::new(context);
         let final_round: Round = MAX_ROUND_GAP_FOR_USEFUL_PARTS / 2;
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
         // Report useful info to connection knowledge corresponding to to_whom_index

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1571,10 +1571,10 @@ impl CoreTextFixture {
 
         let context = Arc::new(context);
         let store: Arc<dyn Store> = if !with_rocksdb {
-            Arc::new(MemStore::new(context.clone()))
+            Arc::new(MemStore::new())
         } else {
             let store_path = context.parameters.db_path.as_path().to_str().unwrap();
-            Arc::new(RocksDBStore::new(store_path, context.clone()))
+            Arc::new(RocksDBStore::new(store_path))
         };
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
@@ -1669,7 +1669,7 @@ mod test {
             .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let mut block_status_subscriptions = FuturesUnordered::new();
@@ -1798,7 +1798,7 @@ mod test {
 
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
 
@@ -1930,7 +1930,7 @@ mod test {
 
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -2089,7 +2089,7 @@ mod test {
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -2251,7 +2251,7 @@ mod test {
             ..Default::default()
         }));
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -2468,7 +2468,7 @@ mod test {
         telemetry_subscribers::init_for_testing();
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
@@ -3336,7 +3336,7 @@ mod test {
 
         let context = Arc::new(context);
 
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let mut block_status_subscriptions = FuturesUnordered::new();

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -733,7 +733,7 @@ pub(crate) mod tests {
         telemetry_subscribers::init_for_testing();
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2491,7 +2491,7 @@ mod test {
     async fn test_get_block_header() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
         let own_index = AuthorityIndex::new_for_test(0);
 
@@ -2609,7 +2609,7 @@ mod test {
         // Initialize DagState.
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
 
         // Populate DagState.
@@ -2772,7 +2772,7 @@ mod test {
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
 
         // Create test block headers for round 1 ~ 10
@@ -2842,7 +2842,7 @@ mod test {
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         // Create test block headers for round 1 ~ 10
@@ -2916,7 +2916,7 @@ mod test {
         context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         // Create test block headers for authority 0
@@ -2954,7 +2954,7 @@ mod test {
     async fn test_get_block_headers_in_cache_or_store() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
 
         // Create test block headers for round 1 ~ 10
@@ -3058,7 +3058,7 @@ mod test {
             .protocol_config
             .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
 
         // Create test blocks and commits for round 1 ~ 10
@@ -3260,7 +3260,7 @@ mod test {
         context.parameters.dag_state_cached_rounds = 5;
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         // Create no block headers for authority 0
@@ -3402,7 +3402,7 @@ mod test {
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         // Create no block headers for authority 0
@@ -3548,7 +3548,7 @@ mod test {
         context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         // Create no block headers for authority 0
@@ -3593,7 +3593,7 @@ mod test {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // WHEN no block headers exist, then genesis should be returned
@@ -3652,7 +3652,7 @@ mod test {
         // GIVEN
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // WHEN no block headers exist, then genesis should be returned
@@ -3718,7 +3718,7 @@ mod test {
             .protocol_config
             .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
 
         // Create test blocks for round 1 ~ 10
@@ -3820,7 +3820,7 @@ mod test {
         let (context, _) = Context::new_for_test(4);
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         let future_timestamp = context.clock.timestamp_utc_ms() + 100_000;
@@ -3852,7 +3852,7 @@ mod test {
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
         context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         // Create test blocks and commits for round 1 ~ 200
@@ -4044,7 +4044,7 @@ mod test {
         context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
 
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         let authority_to_skip = AuthorityIndex::new_for_test((COMMITTEE_SIZE - 2) as u8);
@@ -4137,7 +4137,7 @@ mod test {
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
         context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         let num_rounds: u32 = 200;
@@ -4205,7 +4205,7 @@ mod test {
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
         context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         let num_rounds: u32 = 200;
@@ -4258,7 +4258,7 @@ mod test {
     async fn test_accept_block_not_panics_when_timestamp_is_ahead() {
         // GIVEN
         let context = Arc::new(Context::new_for_test(4).0);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
         // Set a timestamp for the block that is ahead of the current time
         let block_timestamp = context.clock.timestamp_utc_ms() + 5_000;
@@ -4275,7 +4275,7 @@ mod test {
     async fn test_skip_acknowledgments_all_empty_transactions() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
 
         // Create test blocks for round 1 ~ 10
@@ -4303,7 +4303,7 @@ mod test {
     async fn test_skip_acknowledgments_some_contain_transactions() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut encoder = create_encoder(&context);
         let mut dag_state = DagState::new(context.clone(), store);
 
@@ -4355,7 +4355,7 @@ mod test {
             .set_consensus_block_restrictions_for_testing(true);
         let gc_depth = context.protocol_config.gc_depth();
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
 
         // The threshold is driven by `last_known_quorum_commit_index`,
@@ -4383,7 +4383,7 @@ mod test {
 
         // Field defaults to GENESIS_COMMIT_INDEX (= 0): saturating sub gives 0,
         // pivot = (1, MIN), so all index >= 1 are kept (no real eviction).
-        let mut unset = DagState::new(context.clone(), Arc::new(MemStore::new(context)));
+        let mut unset = DagState::new(context, Arc::new(MemStore::new()));
         let votes: Vec<CommitRef> = (1..=10)
             .map(|i| CommitRef::new(i, CommitDigest::MIN))
             .collect();
@@ -4397,8 +4397,7 @@ mod test {
             .protocol_config
             .set_consensus_block_restrictions_for_testing(false);
         let context_off = Arc::new(context_off);
-        let mut dag_state_off =
-            DagState::new(context_off.clone(), Arc::new(MemStore::new(context_off)));
+        let mut dag_state_off = DagState::new(context_off, Arc::new(MemStore::new()));
         dag_state_off.set_last_known_quorum_commit_index(1_000);
         let votes: Vec<CommitRef> = (1..=10)
             .map(|i| CommitRef::new(i, CommitDigest::MIN))

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -2114,7 +2114,7 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let network_client = Arc::new(MockNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2183,7 +2183,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2267,7 +2267,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let transactions_synchronizer = TransactionsSynchronizer::start(
             network_client.clone(),
@@ -2378,7 +2378,7 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2515,7 +2515,7 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2667,7 +2667,7 @@ mod tests {
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let our_index = AuthorityIndex::new_for_test(0);
         let transactions_synchronizer = TransactionsSynchronizer::start(
@@ -2912,7 +2912,7 @@ mod tests {
             // 1) Setup 10‐node context and in‐mem DAG
             let (ctx, _) = Context::new_for_test(10);
             let context = Arc::new(ctx);
-            let store = Arc::new(MemStore::new(context.clone()));
+            let store = Arc::new(MemStore::new());
             let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
             let inflight = InflightBlockHeadersMap::new();
 
@@ -3003,7 +3003,7 @@ mod tests {
         // 1) Setup a 10-node context, in-memory DAG, and inflight map
         let (ctx, _) = Context::new_for_test(10);
         let context = Arc::new(ctx);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let inflight = InflightBlockHeadersMap::new();
         let network_client = Arc::new(MockNetworkClient::default());
@@ -3175,7 +3175,7 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let (commands_sender, _commands_receiver) =
             monitored_mpsc::channel("consensus_synchronizer_commands", 1000);

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -655,7 +655,7 @@ mod tests {
             .protocol_config
             .set_consensus_bad_nodes_stake_threshold_for_testing(33);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
 
         // Populate fully connected test blocks for round 0 ~ 11, authorities 0 ~ 3.
         let mut dag_builder = DagBuilder::new(context.clone());
@@ -737,7 +737,7 @@ mod tests {
             .protocol_config
             .set_consensus_bad_nodes_stake_threshold_for_testing(33);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
 
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
@@ -766,7 +766,7 @@ mod tests {
             .protocol_config
             .set_consensus_bad_nodes_stake_threshold_for_testing(33);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
 
         // Populate fully connected test blocks for round 0 ~ 2, authorities 0 ~ 3.
         let mut dag_builder = DagBuilder::new(context.clone());
@@ -830,7 +830,7 @@ mod tests {
 
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let unscored_subdags = vec![
             CommittedSubDag::new(
@@ -865,7 +865,7 @@ mod tests {
         ));
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
 
         // Populate fully connected test blocks for round 0 ~ 4, authorities 0 ~ 3.

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -300,7 +300,7 @@ mod tests {
             dispatcher.clone(),
             Arc::new(RwLock::new(DagState::new(
                 context.clone(),
-                Arc::new(MemStore::new(context.clone())),
+                Arc::new(MemStore::new()),
             ))),
         );
 
@@ -394,7 +394,7 @@ mod tests {
             dispatcher.clone(),
             Arc::new(RwLock::new(DagState::new(
                 context.clone(),
-                Arc::new(MemStore::new(context.clone())),
+                Arc::new(MemStore::new()),
             ))),
         );
 

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -527,7 +527,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),
@@ -605,7 +605,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         const NUM_OF_COMMITS_PER_SCHEDULE: u64 = 10;
         let leader_schedule = Arc::new(
@@ -677,7 +677,7 @@ mod tests {
 
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),
@@ -809,7 +809,7 @@ mod tests {
         let context = Arc::new(context);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),
@@ -955,7 +955,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),
@@ -1020,7 +1020,7 @@ mod tests {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let ancestors = vec![
             VerifiedBlockHeader::new_for_test(

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -657,7 +657,7 @@ mod tests {
         fn new(committee_size: usize) -> Self {
             let (context, _) = Context::new_for_test(committee_size);
             let context = Arc::new(context);
-            let store = Arc::new(MemStore::new(context.clone()));
+            let store = Arc::new(MemStore::new());
             let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
             let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
             let handle =

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -31,7 +31,6 @@ use crate::{
 /// In-memory storage for testing.
 pub(crate) struct MemStore {
     inner: RwLock<Inner>,
-    context: Arc<Context>,
 }
 
 struct Inner {
@@ -52,7 +51,7 @@ struct Inner {
 }
 
 impl MemStore {
-    pub(crate) fn new(context: Arc<Context>) -> Self {
+    pub(crate) fn new() -> Self {
         MemStore {
             inner: RwLock::new(Inner {
                 transactions: BTreeMap::new(),
@@ -66,7 +65,6 @@ impl MemStore {
                 voting_block_headers: BTreeMap::new(),
                 fast_sync_ongoing: false,
             }),
-            context,
         }
     }
 }
@@ -205,13 +203,17 @@ impl Store for MemStore {
 
     // TODO: Do we need this method or will DAGState always try to read both headers
     // and transactions separately?
-    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
+    fn read_blocks(
+        &self,
+        refs: &[BlockRef],
+        context: Arc<Context>,
+    ) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
         // Ensure we have a read lock on the inner state across reading both headers and
         // transactions reads
         let inner = self.inner.read();
         // Get both headers and transactions for the given references
         let headers = self.read_verified_block_headers(refs)?;
-        let tx_refs = if self.context.protocol_config.consensus_fast_commit_sync() {
+        let tx_refs = if context.protocol_config.consensus_fast_commit_sync() {
             headers
                 .iter()
                 .map(|vh| {
@@ -268,6 +270,7 @@ impl Store for MemStore {
         &self,
         author: AuthorityIndex,
         start_round: Round,
+        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let inner = self.inner.read();
         let mut refs = vec![];
@@ -277,7 +280,7 @@ impl Store for MemStore {
         )) {
             refs.push(BlockRef::new(round, author, digest));
         }
-        let results = self.read_blocks(refs.as_slice())?;
+        let results = self.read_blocks(refs.as_slice(), context)?;
         let mut blocks = Vec::with_capacity(refs.len());
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(
@@ -292,6 +295,7 @@ impl Store for MemStore {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
+        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let before_round = before_round.unwrap_or(Round::MAX);
         let mut refs = VecDeque::new();
@@ -316,7 +320,7 @@ impl Store for MemStore {
         // when the VecDeque ring buffer wraps; otherwise trailing entries would be
         // silently dropped.
         let refs_slice = refs.make_contiguous();
-        let results = self.read_blocks(refs_slice)?;
+        let results = self.read_blocks(refs_slice, context)?;
         let mut blocks = vec![];
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -30,7 +30,11 @@ pub(crate) trait Store: Send + Sync {
 
     /// Reads complete blocks by combining transactions and headers for the
     /// given refs.
-    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
+    fn read_blocks(
+        &self,
+        refs: &[BlockRef],
+        context: Arc<Context>,
+    ) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
 
     /// Read and get verified block headers for the given refs.
     fn read_verified_block_headers(
@@ -72,6 +76,7 @@ pub(crate) trait Store: Send + Sync {
         &self,
         authority: AuthorityIndex,
         start_round: Round,
+        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
     // The method returns the last `num_of_rounds` rounds blocks by author in round
@@ -84,6 +89,7 @@ pub(crate) trait Store: Send + Sync {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
+        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
     fn scan_block_references_by_author(

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -54,10 +54,6 @@ pub(crate) struct RocksDBStore {
     voting_block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
 
     fast_commit_sync_flag: DBMap<(), ()>,
-
-    /// Context to access protocol configuration
-    #[cfg_attr(not(test), allow(dead_code))]
-    context: Arc<Context>,
 }
 
 impl RocksDBStore {
@@ -74,7 +70,7 @@ impl RocksDBStore {
     const FAST_COMMIT_SYNC_FLAG_CF: &'static str = "fast_commit_sync_flag";
 
     /// Creates a new instance of RocksDB storage.
-    pub(crate) fn new(path: &str, context: Arc<Context>) -> Self {
+    pub(crate) fn new(path: &str) -> Self {
         // Consensus data has high write throughput (all transactions) and is rarely
         // read (only during recovery and when helping peers catch up).
         let db_options = default_db_options().optimize_db_for_write_throughput(2);
@@ -162,7 +158,6 @@ impl RocksDBStore {
             commit_info,
             voting_block_headers,
             fast_commit_sync_flag,
-            context,
         }
     }
 }
@@ -315,10 +310,14 @@ impl Store for RocksDBStore {
         Ok(())
     }
 
-    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
+    fn read_blocks(
+        &self,
+        refs: &[BlockRef],
+        context: Arc<Context>,
+    ) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
         // Get both headers and transactions for the given references
         let headers = self.read_verified_block_headers(refs)?;
-        let tx_refs = if self.context.protocol_config.consensus_fast_commit_sync() {
+        let tx_refs = if context.protocol_config.consensus_fast_commit_sync() {
             headers
                 .iter()
                 .map(|vh| {
@@ -617,6 +616,7 @@ impl Store for RocksDBStore {
         &self,
         author: AuthorityIndex,
         start_round: Round,
+        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let mut refs = vec![];
         for kv in self.digests_by_authorities.safe_range_iter((
@@ -626,7 +626,7 @@ impl Store for RocksDBStore {
             let ((author, round, digest), _) = kv?;
             refs.push(BlockRef::new(round, author, digest));
         }
-        let results = self.read_blocks(refs.as_slice())?;
+        let results = self.read_blocks(refs.as_slice(), context)?;
         let mut blocks = Vec::with_capacity(refs.len());
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(
@@ -645,6 +645,7 @@ impl Store for RocksDBStore {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
+        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let before_round = before_round.unwrap_or(Round::MAX);
         let mut refs = std::collections::VecDeque::new();
@@ -663,7 +664,7 @@ impl Store for RocksDBStore {
         // when the VecDeque ring buffer wraps; otherwise trailing entries would
         // be silently dropped.
         let refs_slice = refs.make_contiguous();
-        let results = self.read_blocks(refs_slice)?;
+        let results = self.read_blocks(refs_slice, context)?;
         let mut blocks = vec![];
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(
@@ -859,7 +860,6 @@ impl RocksDBStore {
             db_path
                 .to_str()
                 .expect("consensus DB path should be valid UTF-8"),
-            context,
         );
         store.delete_all_transactions()
     }

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -59,7 +59,7 @@ fn new_rocksdb_teststore(consensus_fast_commit_sync: bool) -> TestStore {
     context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
     let temp_dir = TempDir::new().unwrap();
     TestStore::RocksDB((
-        RocksDBStore::new(temp_dir.path().to_str().unwrap(), Arc::new(context)),
+        RocksDBStore::new(temp_dir.path().to_str().unwrap()),
         temp_dir,
         consensus_fast_commit_sync,
     ))
@@ -71,10 +71,7 @@ fn new_mem_teststore(consensus_fast_commit_sync: bool) -> TestStore {
         .protocol_config
         .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
     context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
-    TestStore::Mem(
-        MemStore::new(Arc::from(context.clone())),
-        consensus_fast_commit_sync,
-    )
+    TestStore::Mem(MemStore::new(), consensus_fast_commit_sync)
 }
 
 #[rstest]
@@ -281,7 +278,7 @@ async fn scan_block_headers(
                         .map(|b| b.verified_transactions.clone())
                         .collect(),
                 ),
-            context,
+            context.clone(),
         )
         .unwrap();
     {
@@ -303,7 +300,7 @@ async fn scan_block_headers(
 
     {
         let scanned_blocks = store
-            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 2, None)
+            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 2, None, context.clone())
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 2, "{scanned_blocks:?}");
         assert_eq!(
@@ -312,7 +309,7 @@ async fn scan_block_headers(
         );
 
         let scanned_blocks = store
-            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 0, None)
+            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 0, None, context)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 0);
     }

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -360,7 +360,7 @@ mod test {
         let context = Arc::new(context);
         let authority_service = Arc::new(Mutex::new(TestService::new()));
         let network_client = Arc::new(SubscriberTestClient::new());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let subscriber = Subscriber::new(
             context.clone(),

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -59,7 +59,7 @@ use crate::{
 /// };
 /// let dag_state = Arc::new(RwLock::new(DagState::new(
 ///     dag_builder.context.clone(),
-///     Arc::new(MemStore::new(context.clone())),
+///     Arc::new(MemStore::new()),
 /// )));
 /// let context = Arc::new(Context::new_for_test(4).0);
 /// let dag_builder = DagBuilder::new(context);
@@ -80,7 +80,7 @@ use crate::{
 /// let dag_builder = DagBuilder::new(context);
 /// let dag_state = Arc::new(RwLock::new(DagState::new(
 ///     dag_builder.context.clone(),
-///     Arc::new(MemStore::new(context.clone())),
+///     Arc::new(MemStore::new()),
 /// )));
 ///
 /// dag_builder.layer(1).build();

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -19,7 +19,7 @@ async fn direct_commit() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context, dag_state.clone()).build();
 
@@ -68,7 +68,7 @@ async fn direct_skip() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context, dag_state.clone()).build();
 
@@ -112,7 +112,7 @@ async fn direct_undecided() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context, dag_state.clone()).build();
 
@@ -156,7 +156,7 @@ async fn indirect_commit() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context, dag_state.clone()).build();
 
@@ -264,7 +264,7 @@ async fn indirect_skip() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context, dag_state.clone()).build();
 

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -25,7 +25,7 @@ async fn try_direct_commit() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
@@ -81,7 +81,7 @@ async fn idempotence() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
@@ -125,7 +125,7 @@ async fn multiple_direct_commit() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
@@ -166,7 +166,7 @@ async fn direct_skip() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
@@ -218,7 +218,7 @@ async fn indirect_commit() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
@@ -362,7 +362,7 @@ async fn indirect_skip() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
@@ -492,7 +492,7 @@ async fn undecided() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 
@@ -581,7 +581,7 @@ async fn test_byzantine_direct_commit() {
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
 

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -782,7 +782,7 @@ fn basic_test_setup() -> (
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let leader_schedule = Arc::new(LeaderSchedule::new(
         context.clone(),

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -215,7 +215,7 @@ fn authority_setup(num_authorities: usize, authority_index: u8) -> AuthorityTest
     ));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
 
     // Create committer with pipelining and only 1 leader per leader round

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -250,7 +250,7 @@ async fn direct_skip_no_leader_votes() {
     let dag_builder = parse_dag(dag_str).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
-        Arc::new(MemStore::new(dag_builder.context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let leader_schedule = Arc::new(LeaderSchedule::new(
         dag_builder.context.clone(),
@@ -366,7 +366,7 @@ async fn indirect_commit() {
     let dag_builder = parse_dag(dag_str).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
-        Arc::new(MemStore::new(dag_builder.context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let leader_schedule = Arc::new(LeaderSchedule::new(
         dag_builder.context.clone(),
@@ -444,7 +444,7 @@ async fn indirect_skip() {
     let dag_builder = parse_dag(dag_str).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
-        Arc::new(MemStore::new(dag_builder.context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let leader_schedule = Arc::new(LeaderSchedule::new(
         dag_builder.context.clone(),
@@ -526,7 +526,7 @@ async fn undecided() {
     let dag_builder = parse_dag(dag_str).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
-        Arc::new(MemStore::new(dag_builder.context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let leader_schedule = Arc::new(LeaderSchedule::new(
         dag_builder.context.clone(),
@@ -719,7 +719,7 @@ fn basic_test_setup() -> (
     let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
-        Arc::new(MemStore::new(context.clone())),
+        Arc::new(MemStore::new()),
     )));
     let leader_schedule = Arc::new(LeaderSchedule::new(
         context.clone(),
@@ -747,11 +747,11 @@ struct TestSetup {
 fn basic_dag_builder_test_setup() -> TestSetup {
     telemetry_subscribers::init_for_testing();
     let context = Arc::new(Context::new_for_test(4).0);
-    let dag_builder = DagBuilder::new(context.clone());
+    let dag_builder = DagBuilder::new(context);
 
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
-        Arc::new(MemStore::new(context)),
+        Arc::new(MemStore::new()),
     )));
     let leader_schedule = Arc::new(LeaderSchedule::new(
         dag_builder.context.clone(),

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1200,7 +1200,7 @@ mod tests {
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Start the transactions synchronizer
@@ -1316,7 +1316,7 @@ mod tests {
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Start the transactions synchronizer
@@ -1445,7 +1445,7 @@ mod tests {
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Start the transactions synchronizer
@@ -1585,7 +1585,7 @@ mod tests {
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Start the transactions synchronizer
@@ -1714,7 +1714,7 @@ mod tests {
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Start the transactions synchronizer
@@ -1847,7 +1847,7 @@ mod tests {
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Start the transactions synchronizer
@@ -1976,7 +1976,7 @@ mod tests {
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Start the transactions synchronizer


### PR DESCRIPTION
# Description of change
Moves `Arc<Context>` out of the consensus Store implementations and threads it through the trait methods that actually need it, matching the convention already used by `Store::write`. And keeps the store as a pure-DBMap struct. 
No on-disk format change. context was runtime state only — never serialized, never part of any column family.

This unblocks adopting #[derive(DBMapUtils)] later (the derive panics on non-DBMap fields), which is introduced in upstream commit: https://github.com/MystenLabs/sui/commit/e0ff9c28f2843b0eae62eb982302328c3537d377


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes