### PR TITLE
upstream(core): Fix incorrect handling of the flag in argparse

### DIFF
--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -21,7 +21,7 @@ parser.add_argument(
     default=int(subprocess.check_output(["date", "+%s"]).decode("utf-8").strip()) * 1000
 )
 parser.add_argument('--concurrency', type=int, help='Number of concurrent tests to run', default=os.cpu_count())
-parser.add_argument('--no-build', type=bool, help='Skip building the test binary', default=False)
+parser.add_argument('--no-build', action='store_true', help='Skip building the test binary')
 args = parser.parse_args()
 
 def run_command(command, env_vars):


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.49.2, v1.50.1)
- Port commit:
  - https://github.com/MystenLabs/sui/commit/189059f9211265d196bbf86f9b534cb16c26dca3
- Description:

Updated the `--no-build` argument handling in argparse to use
`action='store_true'` instead of `type=bool`. The previous approach
caused unexpected behavior when parsing `'True'` or `'False'` as
booleans, leading to incorrect results.

Now, the flag works as expected—if `--no-build` is provided, it sets the
value to `True`; if not, it remains `False`. This ensures proper
behavior when handling this argument.

## Links to any relevant issues

Part of #11322

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes