### PR TITLE
fix(starfish-core): propose at latest possible round after restart

### DIFF
--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -312,7 +312,13 @@ impl CoreThread {
                     let round = *self.rx_last_known_proposed_round.borrow();
                     self.core.set_last_known_proposed_round(round);
                     if !self.fast_sync_ongoing {
-                        self.core.new_block(round + 1, ReasonToCreateBlock::KnownLastBlock)?;
+                        // The locally stored last proposed block may already be at a higher
+                        // round than the synced `round` (e.g. after a crash where the block
+                        // was persisted but not yet broadcast). Passing `Round::MAX` defers
+                        // the actual round choice to the threshold clock inside `Core`, so
+                        // we always propose at the highest available round instead of
+                        // skipping the call because `last_proposed_round() >= round + 1`.
+                        self.core.new_block(Round::MAX, ReasonToCreateBlock::KnownLastBlock)?;
                     }
                 }
                 _ = self.rx_quorum_subscribers_exists.changed() => {

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -552,21 +552,24 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::time::Duration;
+
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::{Mutex, RwLock};
-    use tokio::time::Instant;
+    use tokio::time::{Instant, timeout};
 
     use super::*;
     use crate::{
         CommitConsumer, VerifiedBlockHeader,
+        block_header::{BlockHeaderAPI, TestBlockHeader, VerifiedBlock, genesis_blocks},
         block_manager::BlockManager,
         commit_observer::CommitObserver,
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
-        core::CoreSignals,
+        core::{Core, CoreSignals},
         dag_state::DagState,
         leader_schedule::LeaderSchedule,
-        storage::mem_store::MemStore,
+        storage::{Store, WriteBatch, mem_store::MemStore},
         transaction::{TransactionClient, TransactionConsumer},
     };
 
@@ -837,5 +840,136 @@ pub(crate) mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    // Regression test for the restart-liveness fix in the
+    // `rx_last_known_proposed_round.changed()` handler.
+    //
+    // Scenario: validator restarts with a local last-proposed block at round 2
+    // (persisted to disk before broadcast). The synced last-known-proposed-round
+    // value the network reports is lower than the local round. The buggy handler
+    // called `core.new_block(synced + 1, ...)` which short-circuited because
+    // `last_proposed_round() >= synced + 1`, leaving the validator idle when
+    // it should be proposing at the threshold-clock round. The fix passes
+    // `Round::MAX` so `Core` defers the round choice to the threshold clock.
+    #[tokio::test]
+    async fn test_last_known_sync_wakes_threshold_clock_round() {
+        telemetry_subscribers::init_for_testing();
+
+        let (context, mut key_pairs) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+
+        // Build blocks at rounds 1 and 2 for ALL authorities, including own_index.
+        // Own_index having a block at round 2 is the precondition of the bug.
+        let mut last_round_blocks = genesis_blocks(&context);
+        let mut all_blocks = last_round_blocks.clone();
+        for round in 1..=2 {
+            let mut this_round_blocks = Vec::new();
+            for (index, _authority) in context.committee.authorities() {
+                let block = TestBlockHeader::new(round, index.value() as u8)
+                    .set_ancestors(last_round_blocks.iter().map(|b| b.reference()).collect())
+                    .build();
+                this_round_blocks.push(VerifiedBlock::new_for_test(block));
+            }
+            all_blocks.extend(this_round_blocks.clone());
+            last_round_blocks = this_round_blocks;
+        }
+        let (block_headers, block_transactions) = all_blocks
+            .into_iter()
+            .map(|b| (b.verified_block_header, b.verified_transactions))
+            .unzip();
+        store
+            .write(
+                WriteBatch::default()
+                    .block_headers(block_headers)
+                    .transactions(block_transactions),
+                context.clone(),
+            )
+            .expect("Storage error");
+
+        // After loading the store, DagState should report local last proposed at 2
+        // and threshold clock at 3 (round 2 has a quorum from all 4 authorities).
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        assert_eq!(dag_state.read().get_last_proposed_block_header().round(), 2);
+        assert_eq!(dag_state.read().threshold_clock_round(), 3);
+
+        let block_manager = BlockManager::new(context.clone(), dag_state.clone());
+        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
+            context.clone(),
+            dag_state.clone(),
+        ));
+        let (sender, _commit_receiver) = unbounded_channel("consensus_output");
+        let commit_observer = CommitObserver::new(
+            context.clone(),
+            CommitConsumer::new(sender.clone(), 0),
+            dag_state.clone(),
+            store.clone(),
+            leader_schedule.clone(),
+        );
+
+        let (signals, signal_receivers) = CoreSignals::new(context.clone());
+        let mut block_receiver = signal_receivers.block_broadcast_receiver();
+
+        // `sync_last_known_own_block = true` gates proposing on
+        // `set_last_known_proposed_round`, which is the runtime condition this
+        // test simulates.
+        let core = Core::new(
+            context.clone(),
+            leader_schedule,
+            transaction_consumer,
+            block_manager,
+            true,
+            commit_observer,
+            signals,
+            key_pairs.remove(context.own_index.value()).1,
+            dag_state.clone(),
+            true,
+            Arc::new(CommitVoteMonitor::new(context.clone())),
+        );
+
+        let (core_dispatcher, handle) =
+            ChannelCoreThreadDispatcher::start(context.clone(), core, false);
+
+        // Before the last-known sync arrives, no new block should be proposed
+        // (the validator is waiting on the gate). A round-3 block leaking through
+        // here would mean `sync_last_known_own_block` isn't actually gating.
+        assert!(
+            timeout(Duration::from_millis(200), async {
+                loop {
+                    let block = block_receiver.recv().await.expect("block broadcast closed");
+                    if block.round() == 3 {
+                        return block;
+                    }
+                }
+            })
+            .await
+            .is_err(),
+            "round 3 must not be proposed before last-known sync completes",
+        );
+
+        // Network reports synced round = 1; locally we are at round 2. The buggy
+        // handler would call `core.new_block(1 + 1 = 2, ...)` which short-circuits
+        // because `last_proposed_round() >= 2`. The fix passes `Round::MAX` so
+        // `Core` runs `try_propose` at the threshold-clock round (3).
+        core_dispatcher
+            .set_last_known_proposed_round(1)
+            .expect("core thread should be running");
+
+        let proposed_block = timeout(Duration::from_secs(5), async {
+            loop {
+                let block = block_receiver.recv().await.expect("block broadcast closed");
+                if block.round() == 3 {
+                    return block;
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for threshold-clock proposal at round 3");
+        assert_eq!(proposed_block.author(), context.own_index);
+
+        handle.stop().await;
     }
 }


### PR DESCRIPTION
# Description of change

Port of upstream PR #26720.

When the validator's locally persisted last-proposed block is at a higher round than the synced `last_known_proposed_round` (e.g. after a crash where a block was written to disk but not yet broadcast), the existing handler in `core_thread.rs` called `core.new_block(round + 1, ...)`. `Core::new_block` rejects that request because `last_proposed_round() >= round + 1` already holds, so the validator silently skips proposing at the next available round and relies on subsequent signals to wake it up.

Pass `Round::MAX` instead so `Core` defers the actual round choice to the threshold clock, matching the pattern already used in the `rx_quorum_subscribers_exists.changed()` arm a few lines below.

A regression test is added that sets up four authorities with stored block headers at rounds 1 and 2 (so the local validator's `last_proposed_round()` is 2 on `DagState` recovery), starts `Core` with `sync_last_known_own_block = true`, and confirms that after `set_last_known_proposed_round(1)` the validator proposes a block at round 3. Without the fix the test times out waiting for the round-3 proposal.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes