### PR TITLE
chore: remove `Command` and subcommands re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7832,6 +7832,7 @@ dependencies = [
  "iota-execution",
  "iota-macros",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "tracing",
 ]

--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -7,10 +7,11 @@ use std::{collections::BTreeSet, sync::Arc};
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
 use iota_data_ingestion_core::Worker;
+use iota_sdk_types::Command;
 use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
-    transaction::{Command, TransactionDataAPI, TransactionKind, TransactionKindExt},
+    transaction::{TransactionDataAPI, TransactionKind, TransactionKindExt},
 };
 use tokio::sync::Mutex;
 use tracing::error;

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, fs::File, io::Write, str::FromStr};
 
 use clap::*;
 use iota_sdk_types::{
-    ChangeEpoch, Identifier, StructTag, TypeTag,
+    ChangeEpoch, Command, Identifier, StructTag, TypeTag,
     crypto::{Intent, IntentMessage, PersonalMessage},
 };
 use iota_types::{
@@ -43,7 +43,7 @@ use iota_types::{
     signature::GenericSignature,
     storage::DeleteKind,
     transaction::{
-        Argument, CallArg, Command, EndOfEpochTransactionKind, GenesisObject, GenesisTransaction,
+        Argument, CallArg, EndOfEpochTransactionKind, GenesisObject, GenesisTransaction,
         ProgrammableTransaction, RandomnessStateUpdate, SenderSignedData, SharedObjectRef,
         Transaction, TransactionData, TransactionDataAPI, TransactionExpiration, TransactionKind,
     },

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -16,7 +16,7 @@ use iota_macros::sim_test;
 use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
-use iota_sdk_types::{Identifier, StructTag, TypeTag};
+use iota_sdk_types::{Command, Identifier, StructTag, TypeTag};
 use iota_types::{
     base_types::{
         AuthorityName, IotaAddress, TxContext, dbg_addr, dbg_object_id, random_object_ref,

--- a/crates/iota-core/src/unit_tests/gas_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::Identifier;
+use iota_sdk_types::{Command, Identifier};
 use iota_types::{
     base_types::dbg_addr,
     crypto::{AccountKeyPair, get_key_pair},

--- a/crates/iota-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_integration_tests.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashSet, env, path::PathBuf, str::FromStr};
 
 use iota_move_build::{BuildConfig, IotaPackageHooks};
-use iota_sdk_types::{Identifier, StructTag, TypeTag};
+use iota_sdk_types::{Command, Identifier, StructTag, TypeTag};
 use iota_types::{
     base_types::{RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR},
     crypto::{AccountKeyPair, get_key_pair},

--- a/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use iota_core::authority::AuthorityState;
 use iota_macros::*;
+use iota_sdk_types::Command;
 use iota_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
@@ -23,7 +24,7 @@ use iota_types::{
     object::{Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     storage::ObjectStore,
-    transaction::{Argument, CallArg, Command, ProgrammableTransaction},
+    transaction::{Argument, CallArg, ProgrammableTransaction},
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use test_cluster::{TestCluster, TestClusterBuilder};

--- a/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/simulate.rs
@@ -7,13 +7,13 @@ use iota_grpc_client::{
 };
 use iota_grpc_types::v1::transaction_execution_service::simulated_transaction::ExecutionResult;
 use iota_macros::sim_test;
-use iota_sdk_types::Transaction;
+use iota_sdk_types::{Command, Transaction};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     base_types::IotaAddress,
     effects::TransactionEffectsAPI,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{CallArg, Command, TransactionData, TransactionDataAPI},
+    transaction::{CallArg, TransactionData, TransactionDataAPI},
 };
 use tonic::Code;
 

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
@@ -17,6 +17,7 @@ use iota_grpc_types::{
     },
 };
 use iota_macros::sim_test;
+use iota_sdk_types::Command;
 use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{CallArg, TransactionData, TransactionDataAPI},
@@ -255,10 +256,7 @@ async fn simulate_transaction_readmask_scenarios() {
         .obj(CallArg::ImmutableOrOwned(*obj_to_split))
         .unwrap();
     let amount = builder.pure(1000u64).unwrap();
-    let split_result = builder.command(iota_types::transaction::Command::new_split_coins(
-        gas_coin_arg,
-        vec![amount],
-    ));
+    let split_result = builder.command(Command::new_split_coins(gas_coin_arg, vec![amount]));
     builder.transfer_arg(sender, split_result);
     let pt = builder.finish();
 
@@ -286,7 +284,7 @@ async fn simulate_transaction_readmask_scenarios() {
         .obj(CallArg::ImmutableOrOwned(*obj_to_split))
         .unwrap();
     let huge_amount = failing_builder.pure(u64::MAX).unwrap();
-    failing_builder.command(iota_types::transaction::Command::new_split_coins(
+    failing_builder.command(Command::new_split_coins(
         failing_coin_arg,
         vec![huge_amount],
     ));

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -66,7 +66,7 @@ mod sim_only_tests {
     use iota_macros::*;
     use iota_move_build::{BuildConfig, CompiledPackage};
     use iota_protocol_config::Chain;
-    use iota_sdk_types::Identifier;
+    use iota_sdk_types::{Command, Identifier, MoveCall};
     use iota_types::{
         base_types::{ConciseableName, IotaAddress, ObjectID, ObjectRef, SequenceNumber},
         digests::TransactionDigest,
@@ -81,8 +81,8 @@ mod sim_only_tests {
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         supported_protocol_versions::SupportedProtocolVersions,
         transaction::{
-            CallArg, Command, ProgrammableMoveCall, ProgrammableTransaction,
-            TEST_ONLY_GAS_UNIT_FOR_GENERIC, TransactionData, TransactionDataAPI, TransactionKind,
+            CallArg, ProgrammableTransaction, TEST_ONLY_GAS_UNIT_FOR_GENERIC, TransactionData,
+            TransactionDataAPI, TransactionKind,
         },
     };
     use move_binary_format::CompiledModule;
@@ -443,7 +443,7 @@ mod sim_only_tests {
         assert_eq!(
             dev_inspect_call(
                 &cluster,
-                ProgrammableMoveCall {
+                MoveCall {
                     package: iota_extra,
                     module: Identifier::new_unchecked("msim_extra_1"),
                     function: Identifier::new_unchecked("canary"),
@@ -473,7 +473,7 @@ mod sim_only_tests {
     async fn call_canary(cluster: &TestCluster) -> u64 {
         dev_inspect_call(
             cluster,
-            ProgrammableMoveCall {
+            MoveCall {
                 package: ObjectID::SYSTEM,
                 module: Identifier::new_unchecked("msim_extra_1"),
                 function: Identifier::new_unchecked("canary"),
@@ -543,7 +543,7 @@ mod sim_only_tests {
         .reference
     }
 
-    async fn dev_inspect_call(cluster: &TestCluster, call: ProgrammableMoveCall) -> u64 {
+    async fn dev_inspect_call(cluster: &TestCluster, call: MoveCall) -> u64 {
         let client = cluster.rpc_client();
         let sender = cluster.get_address_0();
 

--- a/crates/iota-e2e-tests/tests/tx_bytes_validity_check.rs
+++ b/crates/iota-e2e-tests/tests/tx_bytes_validity_check.rs
@@ -6,7 +6,7 @@ use iota_json_rpc_api::WriteApiClient;
 use iota_json_rpc_types::{IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolVersion;
-use iota_sdk_types::Identifier;
+use iota_sdk_types::{Command, Identifier};
 use iota_types::{
     base_types::ObjectID,
     transaction::{CallArg, ProgrammableTransaction, TransactionKind},
@@ -39,7 +39,7 @@ fn build_faulty_transaction_byte_sequence() -> Base64 {
     // Even if there is no easy interface for such things, we must protect against
     // as long as there are user facing interfaces that can accept raw transactional
     // bytes.
-    let commands = vec![iota_types::transaction::Command::new_move_call(
+    let commands = vec![Command::new_move_call(
         ObjectID::FRAMEWORK,
         Identifier::new_unchecked("_"),
         Identifier::new_unchecked("timestamp_ms"),

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -31,7 +31,7 @@ use iota_framework::{BuiltInFramework, SystemPackage};
 use iota_genesis_common::{execute_genesis_transaction, get_genesis_protocol_config};
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
-    Identifier, StructTag,
+    Command, Identifier, StructTag,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 use iota_types::{
@@ -67,8 +67,7 @@ use iota_types::{
         timelocked_staked_iota::TimelockedStakedIota,
     },
     transaction::{
-        CallArg, CheckedInputObjects, Command, GenesisObject, InputObjectKind, ObjectReadResult,
-        Transaction,
+        CallArg, CheckedInputObjects, GenesisObject, InputObjectKind, ObjectReadResult, Transaction,
     },
 };
 use move_binary_format::CompiledModule;

--- a/crates/iota-genesis-builder/src/stardust/migration/executor.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/executor.rs
@@ -17,7 +17,7 @@ use iota_framework::BuiltInFramework;
 use iota_move_build::CompiledPackage;
 use iota_move_natives_latest::all_natives;
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
-use iota_sdk_types::Identifier;
+use iota_sdk_types::{Command, Identifier};
 use iota_stardust_types::block::output::{
     AliasOutput as StardustAliasOutput, BasicOutput as StardustBasicOutput, FoundryOutput,
     NativeTokens, NftOutput as StardustNftOutput, OutputId, TokenId,
@@ -40,8 +40,8 @@ use iota_types::{
         output::{Alias, AliasOutput, BasicOutput, Nft, NftOutput},
     },
     transaction::{
-        Argument, CallArg, CheckedInputObjects, Command, InputObjectKind, InputObjects,
-        ObjectReadResult, ProgrammableTransaction,
+        Argument, CallArg, CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult,
+        ProgrammableTransaction,
     },
 };
 use move_vm_runtime_latest::move_vm::MoveVM;

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -7,9 +7,11 @@ use async_graphql::{
     *,
 };
 use iota_json_rpc_types::IotaArgument;
+use iota_sdk_types::{
+    Command as NativeProgrammableTransaction, MoveCall as NativeMoveCallTransaction,
+};
 use iota_types::transaction::{
-    Argument as NativeArgument, CallArg as NativeCallArg, Command as NativeProgrammableTransaction,
-    ProgrammableMoveCall as NativeMoveCallTransaction,
+    Argument as NativeArgument, CallArg as NativeCallArg,
     ProgrammableTransaction as NativeProgrammableTransactionBlock, SharedObjectRef,
 };
 

--- a/crates/iota-grpc-server/src/transaction_filter.rs
+++ b/crates/iota-grpc-server/src/transaction_filter.rs
@@ -4,13 +4,14 @@
 
 use iota_grpc_types::v1::filter as proto_filter;
 use iota_metrics::monitored_scope;
+use iota_sdk_types::Command;
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
     execution_status::ExecutionStatus,
     full_checkpoint_content::CheckpointTransaction,
     object::Owner,
-    transaction::{Command, TransactionDataAPI},
+    transaction::TransactionDataAPI,
 };
 use serde::{Deserialize, Serialize};
 
@@ -479,11 +480,8 @@ impl TransactionFilter {
 
 #[cfg(test)]
 mod tests {
-    use iota_sdk_types::Identifier;
-    use iota_types::{
-        base_types::ObjectID,
-        transaction::{Argument, Command},
-    };
+    use iota_sdk_types::{Command, Identifier};
+    use iota_types::{base_types::ObjectID, transaction::Argument};
 
     use super::*;
 

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -23,7 +23,7 @@ use iota_json_rpc_types::{
     IotaTransactionBlockResponseQueryV2, IotaTransactionKind, ObjectsPage, TransactionFilter,
     TransactionFilterV2,
 };
-use iota_sdk_types::{Identifier, StructTag, TypeTag};
+use iota_sdk_types::{Command, Identifier, StructTag, TypeTag};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
@@ -32,7 +32,7 @@ use iota_types::{
     gas_coin::GAS,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     quorum_driver_types::ExecuteTransactionRequestType,
-    transaction::{CallArg, Command, TransactionData, TransactionDataAPI},
+    transaction::{CallArg, TransactionData, TransactionDataAPI},
     utils::to_sender_signed_transaction,
 };
 use itertools::Itertools;

--- a/crates/iota-json-rpc-tests/tests/indexer_api.rs
+++ b/crates/iota-json-rpc-tests/tests/indexer_api.rs
@@ -13,7 +13,7 @@ use iota_json_rpc_types::{
 };
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Identifier, StructTag, TypeTag};
+use iota_sdk_types::{Command, Identifier, StructTag, TypeTag};
 use iota_swarm_config::genesis_config::AccountConfig;
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
@@ -28,7 +28,7 @@ use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     quorum_driver_types::ExecuteTransactionRequestType,
     stardust::output::{Irc27Metadata, Nft},
-    transaction::{CallArg, Command, TransactionData, TransactionDataAPI},
+    transaction::{CallArg, TransactionData, TransactionDataAPI},
 };
 use move_core_types::annotated_value::MoveValue;
 use test_cluster::TestClusterBuilder;

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -10,7 +10,7 @@ use futures::{Stream, StreamExt, stream::FuturesOrdered};
 use iota_json::{IotaJsonValue, primitive_type};
 use iota_metrics::monitored_scope;
 use iota_package_resolver::{CleverError, ErrorConstants, PackageStore, Resolver};
-use iota_sdk_types::{Identifier, TypeTag};
+use iota_sdk_types::{Command, Identifier, MoveCall, TransferObjects, TypeTag};
 use iota_types::{
     base_types::{EpochId, IotaAddress, ObjectID, ObjectRef, SequenceNumber, TransactionDigest},
     crypto::IotaSignature,
@@ -33,10 +33,9 @@ use iota_types::{
     signature::GenericSignature,
     storage::{DeleteKind, WriteKind},
     transaction::{
-        Argument, CallArg, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command,
-        EndOfEpochTransactionKind, GenesisObject, InputObjectKind, ProgrammableMoveCall,
-        ProgrammableTransaction, SenderSignedData, SharedObjectRef, TransactionData,
-        TransactionDataAPI, TransactionKind, TransferObjects,
+        Argument, CallArg, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,
+        EndOfEpochTransactionKind, GenesisObject, InputObjectKind, ProgrammableTransaction,
+        SenderSignedData, SharedObjectRef, TransactionData, TransactionDataAPI, TransactionKind,
     },
 };
 use move_binary_format::CompiledModule;
@@ -2340,9 +2339,9 @@ impl Display for IotaProgrammableMoveCall {
     }
 }
 
-impl From<ProgrammableMoveCall> for IotaProgrammableMoveCall {
-    fn from(value: ProgrammableMoveCall) -> Self {
-        let ProgrammableMoveCall {
+impl From<MoveCall> for IotaProgrammableMoveCall {
+    fn from(value: MoveCall) -> Self {
+        let MoveCall {
             package,
             module,
             function,

--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -10,13 +10,13 @@ use std::{
 };
 
 use async_trait::async_trait;
-use iota_sdk_types::{Identifier, StructTag, TypeTag};
+use iota_sdk_types::{Command, Identifier, MakeMoveVector, StructTag, TypeTag};
 use iota_types::{
     base_types::{IotaAddress, SequenceNumber, is_primitive_type_tag},
     iota_sdk_types_conversions::{struct_tag_sdk_to_core, type_tag_core_to_sdk},
     move_package::{MovePackage, TypeOrigin},
     object::Object,
-    transaction::{Argument, CallArg, Command, MakeMoveVector, ProgrammableTransaction},
+    transaction::{Argument, CallArg, ProgrammableTransaction},
 };
 use lru::LruCache;
 use move_binary_format::{

--- a/crates/iota-replay/src/displays/transaction_displays.rs
+++ b/crates/iota-replay/src/displays/transaction_displays.rs
@@ -8,12 +8,12 @@ use std::{
 };
 
 use iota_execution::Executor;
-use iota_sdk_types::TypeTag;
+use iota_sdk_types::{Command, MoveCall, TypeTag};
 use iota_types::{
     execution::ExecutionResult,
     object::bounded_visitor::BoundedVisitor,
     sdk_types::utils::write_sep,
-    transaction::{Argument, CallArg, Command, ProgrammableMoveCall, ProgrammableTransaction},
+    transaction::{Argument, CallArg, ProgrammableTransaction},
 };
 use move_core_types::annotated_value::{MoveTypeLayout, MoveValue};
 use tabled::{
@@ -210,10 +210,10 @@ impl Display for Pretty<'_, Command> {
     }
 }
 
-impl Display for Pretty<'_, ProgrammableMoveCall> {
+impl Display for Pretty<'_, MoveCall> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Pretty(move_call) = self;
-        let ProgrammableMoveCall {
+        let MoveCall {
             package,
             module,
             function,

--- a/crates/iota-replay/src/fuzz_mutations/shuffle_command_inputs.rs
+++ b/crates/iota-replay/src/fuzz_mutations/shuffle_command_inputs.rs
@@ -2,10 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::transaction::{
-    Command, MakeMoveVector, MergeCoins, ProgrammableMoveCall, SplitCoins, TransactionKind,
-    TransferObjects,
-};
+use iota_sdk_types::{Command, MakeMoveVector, MergeCoins, MoveCall, SplitCoins, TransferObjects};
+use iota_types::transaction::TransactionKind;
 use rand::seq::SliceRandom;
 use tracing::info;
 
@@ -26,7 +24,7 @@ impl ShuffleCommandInputs {
             })
             | Command::SplitCoins(SplitCoins { amounts: args, .. })
             | Command::TransferObjects(TransferObjects { objects: args, .. })
-            | Command::MoveCall(ProgrammableMoveCall {
+            | Command::MoveCall(MoveCall {
                 arguments: args, ..
             }) => {
                 args.shuffle(&mut self.rng);

--- a/crates/iota-replay/src/fuzz_mutations/shuffle_types.rs
+++ b/crates/iota-replay/src/fuzz_mutations/shuffle_types.rs
@@ -2,7 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::transaction::{Command, TransactionKind};
+use iota_sdk_types::Command;
+use iota_types::transaction::TransactionKind;
 use rand::seq::SliceRandom;
 use tracing::info;
 

--- a/crates/iota-sdk/examples/transaction_builder/consolidate.rs
+++ b/crates/iota-sdk/examples/transaction_builder/consolidate.rs
@@ -15,11 +15,10 @@ use iota_sdk::{
     types::{
         base_types::ObjectRef,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::{
-            Argument, CallArg, Command, TransactionData, TransactionDataAPI, TransactionKind,
-        },
+        transaction::{Argument, CallArg, TransactionData, TransactionDataAPI, TransactionKind},
     },
 };
+use iota_sdk_types::Command;
 use utils::{setup_for_write, sign_and_execute_transaction};
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/transaction_builder/function_move_call.rs
+++ b/crates/iota-sdk/examples/transaction_builder/function_move_call.rs
@@ -14,12 +14,10 @@ use iota_sdk::{
         base_types::ObjectID,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
-        transaction::{
-            Argument, CallArg, Command, Transaction, TransactionData, TransactionDataAPI,
-        },
+        transaction::{Argument, CallArg, Transaction, TransactionData, TransactionDataAPI},
     },
 };
-use iota_sdk_types::{Identifier, crypto::Intent};
+use iota_sdk_types::{Command, Identifier, crypto::Intent};
 use utils::setup_for_write;
 
 // This example shows how to use programmable transactions to chain multiple

--- a/crates/iota-sdk/examples/transaction_builder/programmable_transactions_api.rs
+++ b/crates/iota-sdk/examples/transaction_builder/programmable_transactions_api.rs
@@ -22,8 +22,9 @@ mod utils;
 
 use iota_sdk::types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{Argument, Command, TransactionData, TransactionDataAPI},
+    transaction::{Argument, TransactionData, TransactionDataAPI},
 };
+use iota_sdk_types::Command;
 use utils::{setup_for_write, sign_and_execute_transaction};
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/utils.rs
+++ b/crates/iota-sdk/examples/utils.rs
@@ -25,11 +25,11 @@ use iota_sdk::{
         digests::TransactionDigest,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
-        transaction::{Argument, Command, Transaction, TransactionData, TransactionDataAPI},
+        transaction::{Argument, Transaction, TransactionData, TransactionDataAPI},
     },
     wallet_context::WalletContext,
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Command, crypto::Intent};
 use reqwest::Client;
 use serde_json::json;
 use tracing::info;

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -14,7 +14,7 @@ use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
     IotaObjectDataOptions, IotaObjectResponse, IotaTypeTag, PtbInput, RPCTransactionRequestParams,
 };
-use iota_sdk_types::{Identifier, StructTag};
+use iota_sdk_types::{Command, Identifier, StructTag};
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
     coin,
@@ -23,8 +23,8 @@ use iota_types::{
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
-        CallArg, Command, InputObjectKind, ProgrammableTransactionExt, TransactionData,
-        TransactionDataAPI, TransactionKind, TransactionKindExt,
+        CallArg, InputObjectKind, ProgrammableTransactionExt, TransactionData, TransactionDataAPI,
+        TransactionKind, TransactionKindExt,
     },
 };
 

--- a/crates/iota-transaction-builder/src/package.rs
+++ b/crates/iota-transaction-builder/src/package.rs
@@ -21,7 +21,7 @@ use crate::TransactionBuilder;
 
 impl TransactionBuilder {
     /// Build a [`TransactionKind::Programmable`] that contains
-    /// [`iota_types::transaction::Command::Publish`] for the provided package.
+    /// [`iota_sdk_types::Command::Publish`] for the provided package.
     pub async fn publish_tx_kind(
         &self,
         sender: IotaAddress,
@@ -61,7 +61,7 @@ impl TransactionBuilder {
     }
 
     /// Build a [`TransactionKind::Programmable`] that contains
-    /// [`iota_types::transaction::Command::Upgrade`] for the provided package.
+    /// [`iota_sdk_types::Command::Upgrade`] for the provided package.
     pub async fn upgrade_tx_kind(
         &self,
         package_id: ObjectID,

--- a/crates/iota-transaction-builder/src/stake.rs
+++ b/crates/iota-transaction-builder/src/stake.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Ok, anyhow, bail, ensure};
-use iota_sdk_types::Identifier;
+use iota_sdk_types::{Command, Identifier};
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectType},
     governance::{ADD_STAKE_MUL_COIN_FUN_NAME, WITHDRAW_STAKE_FUN_NAME},
@@ -11,7 +11,7 @@ use iota_types::{
     timelock::timelocked_staking::{
         ADD_TIMELOCKED_STAKE_FUN_NAME, WITHDRAW_TIMELOCKED_STAKE_FUN_NAME,
     },
-    transaction::{CallArg, Command, TransactionData, TransactionDataAPI},
+    transaction::{CallArg, TransactionData, TransactionDataAPI},
 };
 
 use crate::TransactionBuilder;

--- a/crates/iota-transaction-checks/Cargo.toml
+++ b/crates/iota-transaction-checks/Cargo.toml
@@ -15,6 +15,7 @@ iota-config.workspace = true
 iota-execution.workspace = true
 iota-macros.workspace = true
 iota-protocol-config.workspace = true
+iota-sdk-types.workspace = true
 iota-types.workspace = true
 
 [lints]

--- a/crates/iota-transaction-checks/src/deny.rs
+++ b/crates/iota-transaction-checks/src/deny.rs
@@ -3,14 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_config::transaction_deny_config::TransactionDenyConfig;
+use iota_sdk_types::Command;
 use iota_types::{
     base_types::ObjectRef,
     error::{IotaError, IotaResult, UserInputError},
     signature::GenericSignature,
     storage::BackingPackageStore,
-    transaction::{
-        Command, InputObjectKind, TransactionData, TransactionDataAPI, TransactionKindExt,
-    },
+    transaction::{InputObjectKind, TransactionData, TransactionDataAPI, TransactionKindExt},
 };
 use tracing::instrument;
 macro_rules! deny_if_true {

--- a/crates/iota-transactional-test-runner/src/programmable_transaction_test_parser/parser.rs
+++ b/crates/iota-transactional-test-runner/src/programmable_transaction_test_parser/parser.rs
@@ -5,11 +5,9 @@
 use std::{borrow::BorrowMut, marker::PhantomData, str::FromStr};
 
 use anyhow::{Context, Result, bail};
-use iota_sdk_types::Identifier;
+use iota_sdk_types::{Command, Identifier, MoveCall};
 use iota_types::{
-    base_types::ObjectID,
-    iota_sdk_types_conversions::type_tag_core_to_sdk,
-    transaction::{Argument, Command, ProgrammableMoveCall},
+    base_types::ObjectID, iota_sdk_types_conversions::type_tag_core_to_sdk, transaction::Argument,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -390,7 +388,7 @@ impl ParsedMoveCall {
     pub fn into_move_call(
         self,
         address_mapping: &impl Fn(&str) -> Option<AccountAddress>,
-    ) -> Result<ProgrammableMoveCall> {
+    ) -> Result<MoveCall> {
         let Self {
             package,
             module,
@@ -409,7 +407,7 @@ impl ParsedMoveCall {
             })
             .collect::<Result<_>>()?;
 
-        Ok(ProgrammableMoveCall {
+        Ok(MoveCall {
             package: ObjectID::new(package.into_bytes()),
             module,
             function,

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -33,7 +33,7 @@ use iota_json_rpc_types::{
 };
 use iota_node_storage::GrpcStateReader;
 use iota_protocol_config::{Chain, ProtocolConfig};
-use iota_sdk_types::{Identifier, TypeTag};
+use iota_sdk_types::{Command, Identifier, TypeTag};
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
 };
@@ -62,7 +62,7 @@ use iota_types::{
     signature::GenericSignature,
     storage::{ObjectStore, ReadStore},
     transaction::{
-        Argument, CallArg, Command, ProgrammableTransaction, Transaction, TransactionData,
+        Argument, CallArg, ProgrammableTransaction, Transaction, TransactionData,
         TransactionDataAPI, TransactionKind, VerifiedTransaction,
     },
     utils::{
@@ -788,10 +788,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 let gas_price: u64 = gas_price.unwrap_or(self.gas_price);
                 let transaction = self.sign_txn(sender, |sender, gas| {
                     let rec_arg = builder.pure(recipient).unwrap();
-                    builder.command(iota_types::transaction::Command::new_transfer_objects(
-                        vec![obj_arg],
-                        rec_arg,
-                    ));
+                    builder.command(Command::new_transfer_objects(vec![obj_arg], rec_arg));
                     let pt = builder.finish();
                     TransactionData::new_programmable(sender, gas, pt, gas_budget, gas_price)
                 });

--- a/crates/iota-types/src/auth_context/fields_v1.rs
+++ b/crates/iota-types/src/auth_context/fields_v1.rs
@@ -56,7 +56,7 @@ pub struct MoveProgrammableMoveCall {
 // MoveCommand
 // ---------------------------------------------------------------------------
 
-/// Mirrors [`crate::transaction::Command`], substituting [`TypeTag`] for
+/// Mirrors [`iota_sdk_types::Command`], substituting [`TypeTag`] for
 /// a string in `MoveCall` and `MakeMoveVec` so that
 /// the type matches the BCS layout expected by the Move-side
 /// `ptb_command::Command`.

--- a/crates/iota-types/src/auth_context/fields_v1.rs
+++ b/crates/iota-types/src/auth_context/fields_v1.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::TypeTag;
+use iota_sdk_types::{Command, TypeTag};
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -10,7 +10,7 @@ use crate::{
     IOTA_FRAMEWORK_ADDRESS,
     base_types::{ObjectID, ObjectRef, SequenceNumber},
     iota_serde::TypeName,
-    transaction::{Argument, CallArg, Command},
+    transaction::{Argument, CallArg},
 };
 
 // ---------------------------------------------------------------------------
@@ -37,7 +37,7 @@ pub const UPGRADE_DATA_STRUCT_NAME: &IdentStr = ident_str!("UpgradeData");
 // MoveProgrammableMoveCall
 // ---------------------------------------------------------------------------
 
-/// Mirrors [`crate::transaction::ProgrammableMoveCall`] for use in
+/// Mirrors [`iota_sdk_types::MoveCall`] for use in
 /// [`MoveCommand`], substituting [`TypeTag`] for a string in the type arguments
 /// so that the type matches the BCS layout expected by the Move-side
 /// `ptb_command::ProgrammableMoveCall`.
@@ -194,7 +194,7 @@ mod tests {
     use super::*;
     use crate::{
         base_types::{IotaAddress, ObjectDigest, ObjectID, SequenceNumber},
-        transaction::{Argument, CallArg, Command, SharedObjectRef},
+        transaction::{Argument, CallArg, SharedObjectRef},
     };
 
     // ── helpers ─────────────────────────────────────────────────────────────

--- a/crates/iota-types/src/auth_context/mod.rs
+++ b/crates/iota-types/src/auth_context/mod.rs
@@ -225,12 +225,12 @@ pub fn is_auth_context(
 
 #[cfg(test)]
 mod tests {
-    use iota_sdk_types::{Identifier, TypeTag};
+    use iota_sdk_types::{Command, Identifier, TypeTag};
 
     use super::*;
     use crate::{
         base_types::ObjectID,
-        transaction::{Argument, CallArg, Command, ProgrammableTransaction},
+        transaction::{Argument, CallArg, ProgrammableTransaction},
     };
 
     #[test]

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -450,7 +450,7 @@ impl MoveAuthenticatorV1 {
         // Type arguments validity check.
         //
         // Each type argument is checked for validity in the same way as it is done for
-        // `ProgrammableMoveCall`.
+        // `MoveCall`.
         let mut type_arguments_count = 0;
         self.type_arguments().iter().try_for_each(|type_arg| {
             crate::transaction::type_tag_validity_check(type_arg, config, &mut type_arguments_count)

--- a/crates/iota-types/src/programmable_transaction_builder.rs
+++ b/crates/iota-types/src/programmable_transaction_builder.rs
@@ -7,12 +7,12 @@
 
 use anyhow::Context;
 use indexmap::IndexMap;
-use iota_sdk_types::{Identifier, TypeTag};
+use iota_sdk_types::{Command, Identifier, TypeTag};
 use serde::Serialize;
 
 use crate::{
     base_types::{IotaAddress, ObjectID, ObjectRef},
-    transaction::{Argument, CallArg, Command, ProgrammableTransaction, SharedObjectRef},
+    transaction::{Argument, CallArg, ProgrammableTransaction, SharedObjectRef},
 };
 
 #[derive(PartialEq, Eq, Hash)]

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -706,10 +706,12 @@ impl TestCheckpointDataBuilder {
 mod tests {
     use std::str::FromStr;
 
+    use iota_sdk_types::Command;
+
     use super::*;
     use crate::{
         ObjectID,
-        transaction::{Command, TransactionDataAPI, TransactionKindExt},
+        transaction::{TransactionDataAPI, TransactionKindExt},
     };
     #[test]
     fn test_basic_checkpoint_builder() {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -17,15 +17,15 @@ use anyhow::bail;
 use fastcrypto::{encoding::Base64, hash::HashFunction};
 use iota_protocol_config::ProtocolConfig;
 pub use iota_sdk_types::{
-    Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command,
-    EndOfEpochTransactionKind, GasPayment as GasData, GenesisObject, GenesisTransaction,
-    MakeMoveVector, MergeCoins, MoveCall as ProgrammableMoveCall, ProgrammableTransaction, Publish,
-    RandomnessStateUpdate, SharedObjectReference as SharedObjectRef, SplitCoins, SystemPackage,
+    Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, EndOfEpochTransactionKind,
+    GasPayment as GasData, GenesisObject, GenesisTransaction, ProgrammableTransaction,
+    RandomnessStateUpdate, SharedObjectReference as SharedObjectRef, SystemPackage,
     Transaction as TransactionData, TransactionExpiration, TransactionKind,
-    TransactionV1 as TransactionDataV1, TransferObjects, Upgrade,
+    TransactionV1 as TransactionDataV1,
 };
 use iota_sdk_types::{
-    Digest, Identifier, Input, ObjectId, TypeTag,
+    Command, Digest, Identifier, Input, MakeMoveVector, MergeCoins, MoveCall, ObjectId, Publish,
+    SplitCoins, TransferObjects, TypeTag, Upgrade,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 use itertools::Either;
@@ -339,18 +339,18 @@ fn add_type_tag_packages(packages: &mut BTreeSet<ObjectID>, type_argument: &Type
     }
 }
 
-mod programmable_move_call_ext {
+mod move_call_ext {
     pub trait Sealed {}
-    impl Sealed for super::ProgrammableMoveCall {}
+    impl Sealed for super::MoveCall {}
 }
 
-pub trait ProgrammableMoveCallExt: Sized + programmable_move_call_ext::Sealed {
+pub trait MoveCallExt: Sized + move_call_ext::Sealed {
     fn input_objects(&self) -> Vec<InputObjectKind>;
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult;
     fn is_input_arg_used(&self, arg: u16) -> bool;
 }
 
-impl ProgrammableMoveCallExt for ProgrammableMoveCall {
+impl MoveCallExt for MoveCall {
     fn input_objects(&self) -> Vec<InputObjectKind> {
         let mut packages = BTreeSet::from([self.package]);
         for type_argument in &self.type_arguments {

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -12,7 +12,7 @@ use iota_json_rpc_types::{IotaObjectData, IotaObjectDataOptions, IotaRawData};
 use iota_move::manage_package::resolve_lock_file_path;
 use iota_move_build::CompiledPackage;
 use iota_sdk::apis::ReadApi;
-use iota_sdk_types::{Identifier, TypeTag};
+use iota_sdk_types::{Command, Identifier, TypeTag};
 use iota_types::{
     base_types::{IotaAddress, ObjectID, TxContext, TxContextKind, is_primitive_type_tag},
     iota_sdk_types_conversions::type_tag_core_to_sdk,
@@ -860,7 +860,7 @@ impl<'a> PTBBuilder<'a> {
                 }
                 self.last_command = Some(
                     self.ptb
-                        .command(Tx::Command::new_transfer_objects(transfer_args, to_arg)),
+                        .command(Command::new_transfer_objects(transfer_args, to_arg)),
                 );
             }
             ParsedPTBCommand::Assign(sp!(ident_loc, i), None) => {
@@ -903,7 +903,7 @@ impl<'a> PTBBuilder<'a> {
                 }
                 let res = self
                     .ptb
-                    .command(Tx::Command::new_make_move_vector(Some(ty_arg), vec_args));
+                    .command(Command::new_make_move_vector(Some(ty_arg), vec_args));
                 self.last_command = Some(res);
             }
             ParsedPTBCommand::SplitCoins(pre_coin, sp!(_, amounts)) => {
@@ -913,7 +913,7 @@ impl<'a> PTBBuilder<'a> {
                     let arg = self.resolve(arg, ToPure::new(TypeTag::U64)).await?;
                     args.push(arg);
                 }
-                let res = self.ptb.command(Tx::Command::new_split_coins(coin, args));
+                let res = self.ptb.command(Command::new_split_coins(coin, args));
                 self.last_command = Some(res);
             }
             ParsedPTBCommand::MergeCoins(pre_coin, sp!(_, coins)) => {
@@ -923,7 +923,7 @@ impl<'a> PTBBuilder<'a> {
                     let arg = self.resolve(arg, ToObject::default()).await?;
                     args.push(arg);
                 }
-                let res = self.ptb.command(Tx::Command::new_merge_coins(coin, args));
+                let res = self.ptb.command(Command::new_merge_coins(coin, args));
                 self.last_command = Some(res);
             }
             ParsedPTBCommand::MoveCall(
@@ -974,7 +974,7 @@ impl<'a> PTBBuilder<'a> {
                         mod_access_loc,
                     )
                     .await?;
-                let res = self.ptb.command(Tx::Command::new_move_call(
+                let res = self.ptb.command(Command::new_move_call(
                     package_id,
                     module_name.value,
                     function_name.value,
@@ -1077,7 +1077,7 @@ impl<'a> PTBBuilder<'a> {
                     // .to_vec() is necessary to get the length prefix
                     .pure(package_digest.to_vec())
                     .map_err(|e| err!(cmd_span, "{e}"))?;
-                let upgrade_ticket = self.ptb.command(Tx::Command::new_move_call(
+                let upgrade_ticket = self.ptb.command(Command::new_move_call(
                     ObjectID::FRAMEWORK,
                     Identifier::PACKAGE_MODULE,
                     Identifier::from_static("authorize_upgrade"),
@@ -1094,7 +1094,7 @@ impl<'a> PTBBuilder<'a> {
                         .collect(),
                     compiled_modules,
                 );
-                let res = self.ptb.command(Tx::Command::new_move_call(
+                let res = self.ptb.command(Command::new_move_call(
                     ObjectID::FRAMEWORK,
                     Identifier::PACKAGE_MODULE,
                     Identifier::from_static("commit_upgrade"),

--- a/crates/transaction-fuzzer/src/programmable_transaction_gen.rs
+++ b/crates/transaction-fuzzer/src/programmable_transaction_gen.rs
@@ -5,11 +5,11 @@
 use std::cmp;
 
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::Identifier;
+use iota_sdk_types::{Command, Identifier};
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{Argument, CallArg, Command, ProgrammableTransaction},
+    transaction::{Argument, CallArg, ProgrammableTransaction},
 };
 use once_cell::sync::Lazy;
 use proptest::{collection::vec, prelude::*};

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -3011,6 +3011,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-natives-latest",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "iota-verifier-latest",
  "leb128",
@@ -3030,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "futures",
  "iota-macros",
@@ -3045,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3072,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
@@ -3096,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3108,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3123,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3133,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "bytes",
  "http",
@@ -3153,11 +3154,12 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
  "fastcrypto",
+ "iota-sdk-types",
  "iota-types",
  "move-binary-format",
  "move-bytecode-utils",
@@ -3169,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3188,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3203,6 +3205,7 @@ dependencies = [
  "iota-names",
  "iota-package-resolver",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
  "json_to_table",
@@ -3223,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3243,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3253,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3278,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3308,6 +3311,7 @@ dependencies = [
  "fastcrypto-zkp",
  "indexmap 2.14.0",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "move-binary-format",
  "move-core-types",
@@ -3322,10 +3326,11 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
+ "iota-sdk-types",
  "iota-types",
  "serde",
  "thiserror 1.0.69",
@@ -3333,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -3362,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3372,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3384,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -3399,10 +3404,11 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
+ "iota-sdk-types",
  "iota-types",
  "lru",
  "move-binary-format",
@@ -3413,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3423,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3437,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3446,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3505,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3526,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3535,13 +3541,14 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "move-binary-format",
 ]
 
 [[package]]
 name = "iota-types"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3602,6 +3609,7 @@ name = "iota-verifier-latest"
 version = "0.1.0"
 dependencies = [
  "bcs",
+ "iota-sdk-types",
  "iota-types",
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5487,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7608,7 +7616,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.24.0-alpha"
+version = "1.25.0-alpha"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/docs/examples/rust/abstract_account/authenticator-inputs-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-inputs-cryptographic-protection.rs
@@ -22,12 +22,13 @@ use iota_sdk::{
     IotaClient, IotaClientBuilder,
     rpc_types::{IotaTransactionBlockEffectsAPI, ObjectChange},
     types::{
-        base_types::{Identifier, ObjectID, TypeTag},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         transaction::{Argument, Transaction},
     },
 };
+use iota_sdk_types::{Identifier, TypeTag};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     crypto::PublicKey,

--- a/docs/examples/rust/abstract_account/authenticator-shared-object-swap.rs
+++ b/docs/examples/rust/abstract_account/authenticator-shared-object-swap.rs
@@ -21,12 +21,13 @@ use iota_sdk::{
     IotaClient, IotaClientBuilder,
     rpc_types::{IotaTransactionBlockEffectsAPI, ObjectChange},
     types::{
-        base_types::{Identifier, ObjectID, TypeTag},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         transaction::{Argument, Transaction},
     },
 };
+use iota_sdk_types::{Identifier, TypeTag};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     crypto::PublicKey,

--- a/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
@@ -15,8 +15,9 @@ use iota_keys::keystore::{AccountKeystore, InMemKeystore};
 use iota_sdk::{
     IotaClient, IotaClientBuilder, rpc_types::ObjectChange, types::crypto::SignatureScheme::ED25519,
 };
+use iota_sdk_types::{Identifier, TypeTag};
 use iota_types::{
-    base_types::{Identifier, IotaAddress, ObjectID, ObjectRef, TypeTag},
+    base_types::{IotaAddress, ObjectID, ObjectRef},
     object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     signature::GenericSignature,

--- a/docs/examples/rust/stardust/address-unlock-condition.rs
+++ b/docs/examples/rust/stardust/address-unlock-condition.rs
@@ -18,7 +18,7 @@ use iota_sdk::{
         IotaTransactionBlockResponseOptions,
     },
     types::{
-        base_types::{Identifier, ObjectID, TypeTag},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         dynamic_field::DynamicFieldName,
         gas_coin::GAS,
@@ -28,7 +28,7 @@ use iota_sdk::{
         transaction::{Argument, CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs

--- a/docs/examples/rust/stardust/alias-migration.rs
+++ b/docs/examples/rust/stardust/alias-migration.rs
@@ -15,7 +15,7 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaData, IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        base_types::{Identifier, ObjectID, TypeTag},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -24,7 +24,7 @@ use iota_sdk::{
         transaction::{Argument, CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/alias-output-claim.rs
+++ b/docs/examples/rust/stardust/alias-output-claim.rs
@@ -14,7 +14,7 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaData, IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        base_types::{Identifier, ObjectID, TypeTag},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -23,7 +23,7 @@ use iota_sdk::{
         transaction::{Argument, CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/basic-output-claim.rs
+++ b/docs/examples/rust/stardust/basic-output-claim.rs
@@ -14,7 +14,7 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaData, IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        base_types::{Identifier, ObjectID, TypeTag},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -23,7 +23,7 @@ use iota_sdk::{
         transaction::{Argument, CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/foundry-output-claim.rs
+++ b/docs/examples/rust/stardust/foundry-output-claim.rs
@@ -14,7 +14,7 @@ use iota_sdk::{
         IotaObjectDataOptions, IotaObjectResponseQuery, IotaTransactionBlockResponseOptions,
     },
     types::{
-        base_types::{Identifier, ObjectID, StructTag, TypeTag},
+        base_types::ObjectID,
         coin_manager::CoinManagerTreasuryCap,
         crypto::SignatureScheme::ED25519,
         dynamic_field::DynamicFieldName,
@@ -24,7 +24,7 @@ use iota_sdk::{
         transaction::{Argument, CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, StructTag, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs

--- a/docs/examples/rust/stardust/iota-self-sponsor.rs
+++ b/docs/examples/rust/stardust/iota-self-sponsor.rs
@@ -15,7 +15,7 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        base_types::{Identifier, ObjectID},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -23,7 +23,7 @@ use iota_sdk::{
         transaction::{Argument, CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 pub const IOTA_COIN_TYPE: u32 = 4218;

--- a/docs/examples/rust/stardust/nft-migration.rs
+++ b/docs/examples/rust/stardust/nft-migration.rs
@@ -12,7 +12,7 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        base_types::{Identifier, ObjectID},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -20,7 +20,7 @@ use iota_sdk::{
         transaction::{Argument, CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/nft-output-claim.rs
+++ b/docs/examples/rust/stardust/nft-output-claim.rs
@@ -14,7 +14,7 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaData, IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        base_types::{Identifier, ObjectID, TypeTag},
+        base_types::ObjectID,
         crypto::SignatureScheme::ED25519,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -23,7 +23,7 @@ use iota_sdk::{
         transaction::{Argument, CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/examples/tic-tac-toe/cli/src/client.rs
+++ b/examples/tic-tac-toe/cli/src/client.rs
@@ -17,9 +17,9 @@ use iota_sdk::{
     },
     wallet_context::WalletContext,
 };
-use iota_sdk_types::crypto::Intent;
+use iota_sdk_types::{Identifier, StructTag, crypto::Intent};
 use iota_types::{
-    base_types::{Identifier, IotaAddress, ObjectID, ObjectRef, StructTag},
+    base_types::{IotaAddress, ObjectID, ObjectRef},
     crypto::PublicKey,
     multisig::{MultiSig, MultiSigPublicKey},
     object::Owner,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -16,7 +16,7 @@ mod checked {
 
     use iota_move_natives::all_natives;
     use iota_protocol_config::{LimitThresholdCrossed, ProtocolConfig, check_limit_by_meter};
-    use iota_sdk_types::Identifier;
+    use iota_sdk_types::{Command, Identifier};
     #[cfg(msim)]
     use iota_types::iota_system_state::advance_epoch_result_injection::maybe_modify_result;
     use iota_types::{
@@ -48,7 +48,7 @@ mod checked {
         storage::{BackingStore, Storage},
         transaction::{
             Argument, CallArg, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,
-            CheckedInputObjects, Command, EndOfEpochTransactionKind, GasData, GenesisTransaction,
+            CheckedInputObjects, EndOfEpochTransactionKind, GasData, GenesisTransaction,
             InputObjects, ProgrammableTransaction, RandomnessStateUpdate, SharedObjectRef,
             SystemPackage, TransactionKind, TransactionKindExt,
         },

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -16,7 +16,7 @@ mod checked {
 
     use iota_move_natives::object_runtime::ObjectRuntime;
     use iota_protocol_config::ProtocolConfig;
-    use iota_sdk_types::{Identifier, StructTag, TypeTag};
+    use iota_sdk_types::{Command, Identifier, StructTag, TypeTag};
     use iota_types::{
         auth_context,
         base_types::{
@@ -37,7 +37,7 @@ mod checked {
         },
         object::OBJECT_START_VERSION,
         storage::{PackageObject, get_package_objects},
-        transaction::{Command, ProgrammableTransaction},
+        transaction::ProgrammableTransaction,
         transfer::RESOLVED_RECEIVING_STRUCT,
     };
     use iota_verifier::{


### PR DESCRIPTION
# Description of change

`Command`, `MakeMoveVector`, `MergeCoins`, `MoveCall` (previously aliased
as `ProgrammableMoveCall`), `Publish`, `SplitCoins`, `TransferObjects`
and `Upgrade` are client-visible types that live in `iota-rust-sdk`
(`iota-sdk-types`). `crates/iota-types/` used to re-export them, which
encouraged callers to depend on `iota-types` for things that really
belong to the SDK and blurred the boundary between node-internal and
client-visible types.

This PR removes those re-exports and updates every call site across the
workspace to import the types directly from `iota_sdk_types`. The
`MoveCall as ProgrammableMoveCall` alias is dropped; callers now use
`MoveCall` directly, and the internal `ProgrammableMoveCallExt` trait
and `programmable_move_call_ext` module in `iota-types` are renamed to
`MoveCallExt` / `move_call_ext` to match. Crates that didn't already
depend on `iota-sdk-types` get a direct dependency added
(`iota-transaction-checks`).

This is a mechanical change — no behavior is affected. It's a step in
the ongoing direction of pushing client-visible types out of
`iota-types` and keeping `iota-types` for genuinely cross-crate
node-internal types only (see `CLAUDE.md` → "Where types live").

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/11567

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage) — N/A, mechanical refactor
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A
- [x] I have checked that new and existing unit tests pass locally with my changes