### PR TITLE
fix(graphql): include current epoch in apy calculation

### DIFF
--- a/crates/iota-graphql-rpc/src/types/validator.rs
+++ b/crates/iota-graphql-rpc/src/types/validator.rs
@@ -105,42 +105,20 @@ impl Loader<u64> for Db {
 
         let mut results = BTreeMap::new();
 
-        // The requested epoch is the epoch for which we want to compute the APY. For
-        // the current ongoing epoch we cannot compute an APY, so we compute it
-        // for epoch - 1. First need to check if that requested epoch is not the
-        // current running one. If it is, then subtract one as the APY cannot be
-        // computed for a running epoch. If no epoch is passed in the key, then
-        // we default to the latest epoch - 1 for the same reasons as above.
-        let epoch_to_filter_out = if let Some(epoch) = keys.first() {
-            if epoch == &latest_iota_system_state.epoch() {
-                *epoch - 1
-            } else {
-                *epoch
-            }
-        } else {
-            latest_iota_system_state.epoch() - 1
-        };
+        let requested_epoch = keys
+            .first()
+            .copied()
+            .unwrap_or_else(|| latest_iota_system_state.epoch());
 
-        // filter the exchange rates to only include data for the epochs that are less
-        // than or equal to the requested epoch. This enables us to get
-        // historical exchange rates accurately and pass this to the APY
-        // calculation function TODO we might even filter here by the epoch at
-        // which the stake subsidy started to avoid passing that to the
-        // `calculate_apy` function and doing another filter there
         for er in exchange_rates {
             results.insert(
                 er.address,
                 er.rates
                     .into_iter()
-                    .filter(|(epoch, _)| epoch <= &epoch_to_filter_out)
+                    .filter(|(epoch, _)| epoch <= &requested_epoch)
                     .collect(),
             );
         }
-
-        let requested_epoch = match keys.first() {
-            Some(x) => *x,
-            None => latest_iota_system_state.epoch(),
-        };
 
         let mut r = HashMap::new();
         r.insert(requested_epoch, results);


### PR DESCRIPTION
# Description of change

This patch fixes a long-standing inconsistency between GraphQL and JSON-RPC in calculating validator APY. Namely, GraphQL was pre-filtering out the current epoch's exchange rate while JSON-RPC has been using the full table.

Including the current epoch is safe: the rate stored for epoch `E` paired with `rates[E-1]` yields the APY for the just-completed epoch `E-1`. Dropping it shifted the 7-epoch window back by one and missed the most recent completed epoch.

## Links to any relevant issues

Fixes #11652

## How the change has been tested

Manual tests on `mainnet`.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: Includes the current epoch for validator APY calculation in consistency with the JSON-RPC API.
