### PR TITLE
refactor(iota-indexer): support filtered queries on transactions with a fallback to the archival store

### DIFF
--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -39,7 +39,7 @@ strum_macros.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "net"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "net", "signal"] }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 toml.workspace = true

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1559,51 +1559,35 @@ impl IndexerReader {
             .filter(|_| stored_txes.len() != tx_sequence_numbers.len())
         {
             Some(fallback_reader) => {
-                // pre-allocate results with None. Found transactions will replace None with
-                // Some(tx).
-                let mut results: Vec<Option<StoredTransaction>> =
-                    vec![None; tx_sequence_numbers.len()];
+                let found: HashSet<i64> =
+                    stored_txes.iter().map(|tx| tx.tx_sequence_number).collect();
+                let missing_seqs: Vec<i64> = tx_sequence_numbers
+                    .iter()
+                    .copied()
+                    .filter(|s| !found.contains(s))
+                    .collect();
 
-                match is_descending {
-                    Some(true) => tx_sequence_numbers.sort_unstable_by_key(|&s| Reverse(s)),
-                    Some(false) => tx_sequence_numbers.sort_unstable(),
-                    None => {}
-                }
-
-                // each entry is a tuple of (key, original_index) so we can merge fetched data
-                // back into the correct position in the results vector.
-                let mut tx_seq_to_index = tx_sequence_numbers
-                    .into_iter()
-                    .enumerate()
-                    .map(|(idx, seq)| (seq, idx))
-                    .collect::<HashMap<i64, usize>>();
-
-                for tx in stored_txes {
-                    if let Some(i) = tx_seq_to_index.remove(&tx.tx_sequence_number) {
-                        results[i] = Some(tx);
-                    }
-                }
-
-                let missing_tx_digests = self
+                let missing_digests = self
                     .db()
-                    .resolve_tx_sequence_numbers_to_digests(
-                        tx_seq_to_index.keys().copied().collect(),
-                    )
+                    .resolve_tx_sequence_numbers_to_digests(missing_seqs)
                     .await?;
 
-                let historical_transactions = fallback_reader
-                    .transactions(&missing_tx_digests)
+                let historical = fallback_reader
+                    .transactions(&missing_digests)
                     .await?
                     .into_iter()
                     .flatten();
 
-                for tx in historical_transactions {
-                    if let Some(i) = tx_seq_to_index.remove(&tx.tx_sequence_number) {
-                        results[i] = Some(tx);
-                    }
+                let mut merged: Vec<StoredTransaction> =
+                    stored_txes.into_iter().chain(historical).collect();
+
+                match is_descending {
+                    Some(true) => merged.sort_unstable_by_key(|tx| Reverse(tx.tx_sequence_number)),
+                    Some(false) => merged.sort_unstable_by_key(|tx| tx.tx_sequence_number),
+                    None => {}
                 }
 
-                results.into_iter().flatten().collect()
+                merged
             }
             None => stored_txes,
         };

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -4,6 +4,7 @@
 
 //! Types and logic to interact with the db.
 use std::{
+    cmp::Reverse,
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
 };
@@ -1536,7 +1537,7 @@ impl IndexerReader {
 
     async fn multi_get_transaction_block_response_by_sequence_numbers_with_fallback(
         &self,
-        tx_sequence_numbers: Vec<i64>,
+        mut tx_sequence_numbers: Vec<i64>,
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
         // Some(true) for desc, Some(false) for asc, None for undefined order
         is_descending: Option<bool>,
@@ -1562,6 +1563,12 @@ impl IndexerReader {
                 // Some(tx).
                 let mut results: Vec<Option<StoredTransaction>> =
                     vec![None; tx_sequence_numbers.len()];
+
+                match is_descending {
+                    Some(true) => tx_sequence_numbers.sort_unstable_by_key(|&s| Reverse(s)),
+                    Some(false) => tx_sequence_numbers.sort_unstable(),
+                    None => {}
+                }
 
                 // each entry is a tuple of (key, original_index) so we can merge fetched data
                 // back into the correct position in the results vector.

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -902,7 +902,7 @@ impl IndexerReader {
 
     fn multi_get_transactions_with_sequence_numbers(
         &self,
-        tx_sequence_numbers: Vec<i64>,
+        tx_sequence_numbers: &[i64],
         // Some(true) for desc, Some(false) for asc, None for undefined order
         is_descending: Option<bool>,
     ) -> Result<Vec<StoredTransaction>, IndexerError> {
@@ -1483,7 +1483,7 @@ impl IndexerReader {
         .into_iter()
         .map(|tsn| tsn.tx_sequence_number)
         .collect::<Vec<i64>>();
-        self.multi_get_transaction_block_response_by_sequence_numbers_in_blocking_task(
+        self.multi_get_transaction_block_response_by_sequence_numbers_with_fallback(
             tx_sequence_numbers,
             options,
             Some(is_descending),
@@ -1534,7 +1534,7 @@ impl IndexerReader {
         ))
     }
 
-    async fn multi_get_transaction_block_response_by_sequence_numbers_in_blocking_task(
+    async fn multi_get_transaction_block_response_by_sequence_numbers_with_fallback(
         &self,
         tx_sequence_numbers: Vec<i64>,
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
@@ -1542,14 +1542,66 @@ impl IndexerReader {
         is_descending: Option<bool>,
     ) -> Result<Vec<iota_json_rpc_types::IotaTransactionBlockResponse>, IndexerError> {
         let stored_txes: Vec<StoredTransaction> = self
-            .spawn_blocking(move |this| {
-                this.multi_get_transactions_with_sequence_numbers(
-                    tx_sequence_numbers,
-                    is_descending,
-                )
+            .spawn_blocking({
+                let tx_sequence_numbers = tx_sequence_numbers.clone();
+                move |this| {
+                    this.multi_get_transactions_with_sequence_numbers(
+                        &tx_sequence_numbers,
+                        is_descending,
+                    )
+                }
             })
             .await?;
-        self.stored_transaction_to_transaction_block(stored_txes, options)
+
+        let fetched_transactions = match self
+            .fallback_reader()
+            .filter(|_| stored_txes.len() != tx_sequence_numbers.len())
+        {
+            Some(fallback_reader) => {
+                // pre-allocate results with None. Found transactions will replace None with
+                // Some(tx).
+                let mut results: Vec<Option<StoredTransaction>> =
+                    vec![None; tx_sequence_numbers.len()];
+
+                // each entry is a tuple of (key, original_index) so we can merge fetched data
+                // back into the correct position in the results vector.
+                let mut tx_seq_to_index = tx_sequence_numbers
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, seq)| (seq, idx))
+                    .collect::<HashMap<i64, usize>>();
+
+                for tx in stored_txes {
+                    if let Some(i) = tx_seq_to_index.remove(&tx.tx_sequence_number) {
+                        results[i] = Some(tx);
+                    }
+                }
+
+                let missing_tx_digests = self
+                    .db()
+                    .resolve_tx_sequence_numbers_to_digests(
+                        tx_seq_to_index.keys().copied().collect(),
+                    )
+                    .await?;
+
+                let historical_transactions = fallback_reader
+                    .transactions(&missing_tx_digests)
+                    .await?
+                    .into_iter()
+                    .flatten();
+
+                for tx in historical_transactions {
+                    if let Some(i) = tx_seq_to_index.remove(&tx.tx_sequence_number) {
+                        results[i] = Some(tx);
+                    }
+                }
+
+                results.into_iter().flatten().collect()
+            }
+            None => stored_txes,
+        };
+
+        self.stored_transaction_to_transaction_block(fetched_transactions, options)
             .await
     }
 
@@ -3071,6 +3123,31 @@ impl<'a> DBReader<'a> {
                 .optional()
         })
         .map(Option::flatten)
+    }
+
+    /// Resolve transaction sequence numbers to their corresponding digests.
+    async fn resolve_tx_sequence_numbers_to_digests(
+        &self,
+        tx_sequence_numbers: Vec<i64>,
+    ) -> Result<Vec<TransactionDigest>, IndexerError> {
+        let pool = self.main_reader.get_pool();
+
+        let rows = run_query_async!(&pool, |conn| {
+            tx_digests::table
+                .filter(tx_digests::tx_sequence_number.eq_any(tx_sequence_numbers))
+                .select(tx_digests::tx_digest)
+                .load::<Vec<u8>>(conn)
+        })?;
+
+        rows.into_iter()
+            .map(|bytes| {
+                TransactionDigest::from_bytes(&bytes).map_err(|e| {
+                    IndexerError::PersistentStorageDataCorruption(format!(
+                        "unable to convert {bytes:?} as tx_digest: {e}",
+                    ))
+                })
+            })
+            .collect()
     }
 }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1537,7 +1537,7 @@ impl IndexerReader {
 
     async fn multi_get_transaction_block_response_by_sequence_numbers_with_fallback(
         &self,
-        mut tx_sequence_numbers: Vec<i64>,
+        tx_sequence_numbers: Vec<i64>,
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
         // Some(true) for desc, Some(false) for asc, None for undefined order
         is_descending: Option<bool>,


### PR DESCRIPTION
# Description of change

This PR adds support for pruned transactions to be retrieved form the fallback archival store in the `IndexerApi::query_transaction_blocks`.

Included the `signal` feature flag to `tokio` dependency needed for the graceful shutdown.


## Links to any relevant issues

fixes #9498 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

The fix was verified by manually simulating a pruned state and confirming the API successfully fetches missing data from the fallback store.

1. Started a local network using the `iota-localnet` cli tool
```shell
cargo r -- -p iota-localnet -- start --force-regenesis --with-grpc
```
2. Start the kv-store ingestion task to write checkpoints into BigTable (see the README in the `iota-kvstore` crate for details):
```shell
cargo r -p iota-data-ingestion --bin iota-data-ingestion -- bigtable.yaml
```
3. Start the kv-store REST API
```shell
cargo -p iota-rest-kv r -- --config bigtable.yaml
```
4. Start the indexer writer:
```shell
cargo r -p iota-indexer -- --database-url=postgres://postgres:postgrespw@localhost:5432/iota_indexer indexer --remote-store-url=http://localhost:50051 --reset-db
```
5. Start the indexer reader with the fallback KV URL configured:
```shell
 cargo r -p iota-indexer -- --database-url=postgres://postgres:postgrespw@localhost:5432/iota_indexer --metrics-address=0.0.0.0:9185 json-rpc-service --rpc-client-url=http://localhost:50051 --fallback-kv-url=http://localhost:3555 --rpc-address=0.0.0.0:9001
```

Once the database had ingested some transactions, we picked a starting point for the test queries. We listed checkpoints:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iota_getCheckpoints",
  "params": [
    "10",
    4,
    false
  ]
}
```
and used the first transaction digest (`37JSrDLCumYdftCbyXMCupcjCLEw2hmq1SXtwHVSVdz5`) from checkpoint sequence number `11` as the cursor.

We then ran a filtered query and recorded the response:
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "iotax_queryTransactionBlocks",
    "params": [
        {
            "filter": {
                "TransactionKind": "SystemTransaction"
            },
            "options": null
        },
        "37JSrDLCumYdftCbyXMCupcjCLEw2hmq1SXtwHVSVdz5",
        100,
        false
    ]
}
```
From the response we picked several transactions to delete directly from the `transactions` table by their sequence number (we removed `18`–`20` and `23`), simulating pruned rows whose data is still available in the archival store.

We then re-ran the identical query. The response was to the original one, confirming the deleted rows were recovered from the fallback store, and that ordering was preserved.

We repeated the same procedure with `descending_order: true`, deleting transactions from that page and re-querying. The results matched the original and ordering was preserved.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch doe snot affect the normal ingestion operation of the indexer, it only affects the reading part (JSON-RPC), which tests were conducted above.