### PR TITLE
chore(consensus): small StarfishSpeed corrections

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -144,7 +144,7 @@ pub struct Parameters {
 
 impl Parameters {
     pub(crate) fn default_leader_timeout() -> Duration {
-        Duration::from_millis(200)
+        Duration::from_millis(250)
     }
 
     pub(crate) fn default_min_block_delay() -> Duration {

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -4,7 +4,7 @@ expression: parameters
 ---
 leader_timeout:
   secs: 0
-  nanos: 200000000
+  nanos: 250000000
 min_block_delay:
   secs: 0
   nanos: 50000000

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -426,7 +426,9 @@ impl Core {
             .block_manager
             .try_accept_block_headers(block_headers, source);
 
-        if !accepted_block_headers.is_empty() {
+        if !accepted_block_headers.is_empty()
+            && self.context.protocol_config.consensus_starfish_speed()
+        {
             self.record_strong_vote_complaints(
                 &mut self.dag_state.write(),
                 &accepted_block_headers,
@@ -1573,15 +1575,12 @@ impl Core {
 
     /// Records strong-vote complaints from each freshly-accepted block into
     /// DagState's per-leader-round hint tables. Caller passes a write-locked
-    /// DagState. No-op when the StarfishSpeed flag is off.
+    /// DagState. Called only when Starfish-Speed flag is on.
     fn record_strong_vote_complaints(
         &self,
         dag_state: &mut DagState,
         blocks: &[VerifiedBlockHeader],
     ) {
-        if !self.context.protocol_config.consensus_starfish_speed() {
-            return;
-        }
         let own_index = self.context.own_index;
         for block in blocks {
             // Use the producer's pinned leader (in the strong-vote payload),

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -832,6 +832,20 @@ impl Core {
         // block header's strong_vote field.
         let leader_header = self.leader_header(quorum_round);
 
+        // If an ordinary-ready moment was recorded for an earlier clock round
+        // but we never proposed in it (the round advanced first), the
+        // strong-vote wait still counts toward the extra-wait metric.
+        if let Some((recorded_round, start)) = self.ordinary_propose_ready_at {
+            if recorded_round != clock_round {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .strong_vote_extra_wait_seconds
+                    .observe(start.elapsed().as_secs_f64());
+                self.ordinary_propose_ready_at = None;
+            }
+        }
+
         // Record the first moment in this clock round at which the ordinary
         // (base Starfish) propose condition was satisfied. Used to observe the
         // extra wait imposed by the StarfishSpeed strong-vote condition.
@@ -934,17 +948,20 @@ impl Core {
             .with_label_values(&[leader_authority])
             .inc();
 
-        // Extra wait between ordinary-condition readiness and actual proposal,
-        // attributable to the StarfishSpeed strong-vote condition.
-        if !reason.is_forced() && self.context.protocol_config.consensus_starfish_speed() {
-            if let Some((r, start)) = self.ordinary_propose_ready_at {
-                if r == clock_round {
+        // The strong-vote wait for this clock round ends with this proposal.
+        // Observe it for non-forced proposals; forced proposals (e.g. max
+        // leader timeout) are excluded. Clear it either way so the wait is not
+        // re-counted as an abandoned round on a later call.
+        if let Some((r, start)) = self.ordinary_propose_ready_at {
+            if r == clock_round {
+                if !reason.is_forced() && self.context.protocol_config.consensus_starfish_speed() {
                     self.context
                         .metrics
                         .node_metrics
                         .strong_vote_extra_wait_seconds
                         .observe(start.elapsed().as_secs_f64());
                 }
+                self.ordinary_propose_ready_at = None;
             }
         }
 

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -64,7 +64,11 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
             stop,
             new_block_receiver: signals_receivers.block_broadcast_receiver(),
             new_round_receiver: signals_receivers.new_round_receiver(),
-            leader_timeout: context.parameters.leader_timeout,
+            leader_timeout: if context.protocol_config.consensus_starfish_speed() {
+                Duration::from_millis(200)
+            } else {
+                context.parameters.leader_timeout
+            },
             min_block_delay: context.parameters.min_block_delay,
             soft_leader_timeout: context.parameters.soft_leader_timeout,
             starfish_speed_enabled: context.protocol_config.consensus_starfish_speed(),


### PR DESCRIPTION
# Description of change

A bundle of small corrections on the StarfishSpeed branch:

- `record_strong_vote_complaints` no longer acquires `dag_state.write()`
  when the protocol flag is off; the gate moves from inside the helper
  to the call site, matching the convention used by `compute_strong_vote`.
- Restore the default `leader_timeout` to 250ms (develop's value) on the
  SS-off path; the SS-on path keeps the calibrated 200ms.
- Refresh the starfish-config parameters snapshot for the timeout
  default change.
- Count the strong-vote wait against the `strong_vote_extra_wait_seconds`
  histogram when a clock round advances before any proposal happens
  (previously lost).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
