### PR TITLE
chore(starfish): include starfish-config in update_all_snapshots.sh

### DIFF
--- a/scripts/update_all_snapshots.sh
+++ b/scripts/update_all_snapshots.sh
@@ -16,5 +16,6 @@ UPDATE=1 cargo test -p iota-framework --test build-system-packages
 cd "$ROOT/crates/iota-protocol-config" && cargo insta test --review
 cd "$ROOT/crates/iota-cost" && cargo insta test --review
 cd "$ROOT/crates/iota-swarm-config" && cargo insta test --review
+cd "$ROOT/crates/starfish/config" && cargo insta test --review
 cd "$ROOT/crates/iota-open-rpc" && cargo run --example generate-json-rpc-spec -- record
 cd "$ROOT/crates/iota-core" && cargo -q run --example generate-format -- print > tests/staged/iota.yaml


### PR DESCRIPTION
# Description of change

Add `crates/starfish/config` to `update_all_snapshots.sh` so its
parameters/committee snapshots refresh alongside the other
snapshot-bearing crates. Previously the script skipped starfish, so a
parameter change there (e.g. a `leader_timeout` default) left the
snapshot stale until someone ran `cargo insta` by hand.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
