### PR TITLE
fix(iota-core): keep already-executed transactions in white-flag checkpoint roots

### DIFF
--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -20,7 +20,8 @@
 //!
 //! 1. Non-`UserTransactionV1` — pass through unchanged.
 //! 2. Dedup by `ConsensusTransactionKey` — silent drop.
-//! 3. Already executed — silent drop.
+//! 3. Already executed — **retained** as a committee-agreed winner (registers
+//!    its locks, skips re-validation); not dropped. See issue #11649.
 //! 4. `validity_check()` — drop with error.
 //! 5. Three-tier lock conflict check (local HashMap → quarantine → DB) — drop
 //!    with error. Cheap; performed before expensive checks.
@@ -35,6 +36,7 @@ use std::{
     sync::Arc,
 };
 
+use iota_common::fatal;
 use iota_types::{
     base_types::{ObjectRef, TransactionDigest},
     error::{IotaError, IotaResult},
@@ -58,11 +60,12 @@ use crate::{
 /// conflicts in a single pass.
 ///
 /// For each `UserTransactionV1` in consensus order:
-/// - Runs deduplication, already-executed check, structural validity, lock
-///   conflict check, and deny checks (deny list, gas, ownership, coin deny
-///   list, Move authenticator).
+/// - Runs deduplication, structural validity, lock conflict check, and deny
+///   checks (deny list, gas, ownership, coin deny list, Move authenticator).
 /// - If all checks pass, acquires owned-object locks in a local tracking map.
 /// - Drops the transaction (with an error) on any failure.
+/// - An already-executed transaction is **retained** (not dropped): it registers
+///   its owned-object locks and skips re-validation. See issue #11649.
 ///
 /// Non-`UserTransactionV1` transactions pass through unchanged.
 ///
@@ -77,8 +80,8 @@ use crate::{
 ///
 /// `Ok((dropped, locks))` where:
 /// - `dropped` — `(digest, error)` for every semantically-invalid or
-///   lock-conflicting transaction. Silent drops (duplicates, already-executed)
-///   are **not** included.
+///   lock-conflicting transaction. Silent drops (duplicates) are **not**
+///   included.
 /// - `locks` — Owned-object locks acquired in this commit, to be stored in the
 ///   consensus quarantine so subsequent commits can see them.
 pub async fn validate_and_resolve_conflicts(
@@ -119,12 +122,48 @@ pub async fn validate_and_resolve_conflicts(
 
         let digest = *transaction.digest();
 
-        // Check #1: Already executed — silent dedup.
+        // Check #1: Already executed (typically by state-sync before this node's
+        // consensus handler reached the commit). It is a committee-agreed winner, so
+        // keep it in the sequence to flow into checkpoint roots like on every other
+        // validator (dropping it forks — issue #11649). Register its owned-object
+        // locks so double-spend siblings still lose, then skip re-validation (#2/#5);
+        // `TransactionManager::enqueue` suppresses the re-execution.
         if authority_state
             .get_transaction_cache_reader()
             .try_is_tx_already_executed(&digest)?
         {
-            keep[i] = false;
+            // Byte-based, so safe even though the inputs are already consumed.
+            let owned_inputs = extract_owned_input_objects(tx)?;
+            for obj_ref in &owned_inputs {
+                // A winner cannot be out-locked: an executed tx owns its inputs. A lock
+                // held by a different tx is a consistency violation, not a conflict.
+                let existing_lock = match current_commit_locks
+                    .get(obj_ref)
+                    .copied()
+                    .or_else(|| epoch_store.get_quarantined_owned_object_lock(obj_ref))
+                {
+                    Some(lock) => Some(lock),
+                    None => epoch_store.tables()?.get_locked_transaction(obj_ref)?,
+                };
+                if let Some(other) = existing_lock {
+                    if other != digest {
+                        fatal!(
+                            "already-executed transaction {:?} has owned input {:?} \
+                             locked by a different transaction {:?}",
+                            digest,
+                            obj_ref,
+                            other,
+                        );
+                    }
+                }
+                current_commit_locks.insert(*obj_ref, digest);
+            }
+            debug!(
+                ?digest,
+                num_owned_inputs = owned_inputs.len(),
+                "Transaction already executed; retained as checkpoint root, skipping re-validation"
+            );
+            // keep[i] stays true so the transaction remains in the sequence.
             continue;
         }
 

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -64,8 +64,9 @@ use crate::{
 ///   checks (deny list, gas, ownership, coin deny list, Move authenticator).
 /// - If all checks pass, acquires owned-object locks in a local tracking map.
 /// - Drops the transaction (with an error) on any failure.
-/// - An already-executed transaction is **retained** (not dropped): it registers
-///   its owned-object locks and skips re-validation. See issue #11649.
+/// - An already-executed transaction is **retained** (not dropped): it
+///   registers its owned-object locks and skips re-validation. See issue
+///   #11649.
 ///
 /// Non-`UserTransactionV1` transactions pass through unchanged.
 ///
@@ -137,15 +138,9 @@ pub async fn validate_and_resolve_conflicts(
             for obj_ref in &owned_inputs {
                 // A winner cannot be out-locked: an executed tx owns its inputs. A lock
                 // held by a different tx is a consistency violation, not a conflict.
-                let existing_lock = match current_commit_locks
-                    .get(obj_ref)
-                    .copied()
-                    .or_else(|| epoch_store.get_quarantined_owned_object_lock(obj_ref))
+                if let Some(other) =
+                    find_existing_lock(obj_ref, &current_commit_locks, epoch_store)?
                 {
-                    Some(lock) => Some(lock),
-                    None => epoch_store.tables()?.get_locked_transaction(obj_ref)?,
-                };
-                if let Some(other) = existing_lock {
                     if other != digest {
                         fatal!(
                             "already-executed transaction {:?} has owned input {:?} \
@@ -210,52 +205,21 @@ pub async fn validate_and_resolve_conflicts(
         // Tier 2: Consensus quarantine (previous uncommitted commits).
         // Tier 3: Persistent DB (committed data).
         let mut conflict: Option<IotaError> = None;
-        'conflict_check: for obj_ref in &owned_inputs {
-            if let Some(&pending_transaction) = current_commit_locks.get(obj_ref) {
-                debug!(
-                    ?digest,
-                    ?obj_ref,
-                    "Transaction conflicts with earlier tx in same commit, dropping"
-                );
-                conflict = Some(IotaError::ObjectLockConflict {
-                    obj_ref: *obj_ref,
-                    pending_transaction,
-                });
-                break 'conflict_check;
-            }
-
-            if let Some(locked_by) = epoch_store.get_quarantined_owned_object_lock(obj_ref) {
+        for obj_ref in &owned_inputs {
+            if let Some(locked_by) =
+                find_existing_lock(obj_ref, &current_commit_locks, epoch_store)?
+            {
                 debug!(
                     ?digest,
                     ?obj_ref,
                     ?locked_by,
-                    "Transaction conflicts with quarantined lock, dropping"
+                    "Transaction conflicts with existing owned-object lock, dropping"
                 );
                 conflict = Some(IotaError::ObjectLockConflict {
                     obj_ref: *obj_ref,
                     pending_transaction: locked_by,
                 });
-                break 'conflict_check;
-            }
-
-            match epoch_store.tables()?.get_locked_transaction(obj_ref)? {
-                Some(locked_by) => {
-                    debug!(
-                        ?digest,
-                        ?obj_ref,
-                        ?locked_by,
-                        "Transaction conflicts with persistent lock, dropping"
-                    );
-                    conflict = Some(IotaError::ObjectLockConflict {
-                        obj_ref: *obj_ref,
-                        pending_transaction: locked_by,
-                    });
-                    break 'conflict_check;
-                }
-                None => {
-                    // No lock in DB — this input is free to be locked by
-                    // the current transaction.
-                }
+                break;
             }
         }
         if let Some(e) = conflict {
@@ -325,6 +289,30 @@ pub async fn validate_and_resolve_conflicts(
     transactions.retain(|_| iter.next().unwrap_or(true));
 
     Ok((dropped, current_commit_locks))
+}
+
+/// Finds an existing owned-object lock on `obj_ref`, walking three tiers in
+/// order:
+/// 1. `current_commit_locks` — locks acquired earlier in the same commit.
+/// 2. Consensus quarantine — locks from previous uncommitted commits.
+/// 3. Persistent DB — committed locks.
+///
+/// Returns `Ok(Some(locker))` if any tier holds a lock, `Ok(None)` if the
+/// input is free. The caller decides what to do with the result (drop with
+/// `ObjectLockConflict` for a contender, or `fatal!` if a winner is
+/// out-locked).
+fn find_existing_lock(
+    obj_ref: &ObjectRef,
+    current_commit_locks: &HashMap<ObjectRef, LockDetails>,
+    epoch_store: &Arc<AuthorityPerEpochStore>,
+) -> IotaResult<Option<LockDetails>> {
+    if let Some(&locker) = current_commit_locks.get(obj_ref) {
+        return Ok(Some(locker));
+    }
+    if let Some(locker) = epoch_store.get_quarantined_owned_object_lock(obj_ref) {
+        return Ok(Some(locker));
+    }
+    epoch_store.tables()?.get_locked_transaction(obj_ref)
 }
 
 /// Extracts owned input object references from a `UserTransactionV1`

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use iota_macros::sim_test;
-use iota_protocol_config::ProtocolConfig;
+use iota_protocol_config::{OverrideGuard, ProtocolConfig};
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
     crypto::{AccountKeyPair, get_key_pair},
@@ -20,7 +20,10 @@ use iota_types::{
 };
 
 use crate::{
-    authority::authority_tests::init_state_with_objects_and_object_basics,
+    authority::{
+        authority_per_epoch_store::{LockDetails, consensus_quarantine::ConsensusCommitOutput},
+        authority_tests::init_state_with_objects_and_object_basics,
+    },
     checkpoints::CheckpointServiceNoop,
     consensus_handler::{SequencedConsensusTransaction, VerifiedSequencedConsensusTransaction},
     post_consensus_validation,
@@ -1240,4 +1243,306 @@ async fn double_spend_loser_excluded_from_checkpoint_roots() {
         !all_roots.contains(&TransactionKey::Digest(loser_digest)),
         "double-spend loser {loser_digest:?} must NOT be a checkpoint root; roots = {all_roots:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 (quarantine) and Tier 3 (persistent DB) lock-tier coverage
+// ---------------------------------------------------------------------------
+//
+// `validate_and_resolve_conflicts` performs the same 3-tier lock lookup in
+// two places (via `find_existing_lock`):
+//   * Check #1 (already-executed branch): same digest = OK; different digest =
+//     `fatal!`.
+//   * Check #4 (conflict drop): any hit = drop with `ObjectLockConflict`.
+//
+// The earlier tests cover Tier 1 (`current_commit_locks` HashMap within the
+// same commit). The tests below close the matrix by seeding Tier 2 (consensus
+// quarantine) and Tier 3 (persistent DB).
+
+/// Which of the two non-local tiers to seed an existing lock into.
+#[derive(Clone, Copy)]
+enum LockTier {
+    Quarantine,
+    Persistent,
+}
+
+/// Shared setup: one owned object + one gas object, both owned by `sender`.
+/// `_config_guard` keeps the white-flag protocol-config override active for
+/// the duration of the test; on drop it clears the thread-local override so a
+/// later test on the same OS thread can install its own.
+struct LockTierSetup {
+    authority: Arc<crate::authority::AuthorityState>,
+    epoch_store: Arc<crate::authority::authority_per_epoch_store::AuthorityPerEpochStore>,
+    sender: IotaAddress,
+    sender_key: AccountKeyPair,
+    recipient: IotaAddress,
+    object_ref: iota_types::base_types::ObjectRef,
+    gas_ref: iota_types::base_types::ObjectRef,
+    rgp: u64,
+    _config_guard: OverrideGuard,
+}
+
+async fn setup_lock_tier() -> LockTierSetup {
+    let _config_guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+
+    let epoch_store = (*authority.epoch_store_for_testing()).clone();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    let object_ref = authority
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let gas_ref = authority
+        .get_object(&gas_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+
+    LockTierSetup {
+        authority,
+        epoch_store,
+        sender,
+        sender_key,
+        recipient,
+        object_ref,
+        gas_ref,
+        rgp,
+        _config_guard: _config_guard,
+    }
+}
+
+impl LockTierSetup {
+    /// Builds and verifies a transfer-object transaction spending
+    /// `self.object_ref` paid by `self.gas_ref`.
+    fn make_tx(&self) -> VerifiedTransaction {
+        let tx = make_transfer_object_transaction(
+            self.object_ref,
+            self.gas_ref,
+            self.sender,
+            &self.sender_key,
+            self.recipient,
+            self.rgp,
+        );
+        self.epoch_store.verify_transaction(tx).unwrap()
+    }
+
+    /// Marks `verified_tx` as executed via the checkpoint-executor path
+    /// (simulates state-sync winning the race against this node's consensus
+    /// handler).
+    fn execute_via_state_sync(&self, verified_tx: &VerifiedTransaction) {
+        let executable = VerifiedExecutableTransaction::new_from_checkpoint(
+            verified_tx.clone(),
+            self.epoch_store.epoch(),
+            1,
+        );
+        self.authority
+            .try_execute_immediately(&executable, None, &self.epoch_store)
+            .unwrap();
+    }
+
+    /// Seeds `(self.object_ref, self.gas_ref) -> locker` into the requested
+    /// tier. For `Persistent`, a signed-transaction row backing the lock is
+    /// also written.
+    fn seed_lock(&self, tier: LockTier, locker_tx: &VerifiedTransaction) {
+        let digest = *locker_tx.digest();
+        match tier {
+            LockTier::Quarantine => {
+                seed_quarantined_lock(&self.epoch_store, self.object_ref, digest);
+                seed_quarantined_lock(&self.epoch_store, self.gas_ref, digest);
+            }
+            LockTier::Persistent => {
+                seed_persistent_lock(
+                    &self.authority,
+                    &self.epoch_store,
+                    locker_tx.clone(),
+                    &[self.object_ref, self.gas_ref],
+                );
+            }
+        }
+    }
+}
+
+/// Seeds a single lock into the consensus quarantine.
+fn seed_quarantined_lock(
+    epoch_store: &crate::authority::authority_per_epoch_store::AuthorityPerEpochStore,
+    obj_ref: iota_types::base_types::ObjectRef,
+    locker: LockDetails,
+) {
+    let mut output = ConsensusCommitOutput::default();
+    output.set_owned_object_locks(std::collections::HashMap::from([(obj_ref, locker)]));
+    output.set_default_commit_stats_for_testing();
+    epoch_store.push_consensus_output_for_tests(output);
+}
+
+/// Seeds locks directly into the persistent DB via the cache writer's
+/// `try_acquire_transaction_locks`.
+fn seed_persistent_lock(
+    authority: &crate::authority::AuthorityState,
+    epoch_store: &crate::authority::authority_per_epoch_store::AuthorityPerEpochStore,
+    verified_tx: VerifiedTransaction,
+    owned_inputs: &[iota_types::base_types::ObjectRef],
+) {
+    use iota_types::transaction::VerifiedSignedTransaction;
+    let signed = VerifiedSignedTransaction::new(
+        epoch_store.epoch(),
+        verified_tx,
+        authority.name,
+        &*authority.secret,
+    );
+    authority
+        .get_cache_writer()
+        .try_acquire_transaction_locks(epoch_store, owned_inputs, signed)
+        .expect("seed_persistent_lock: try_acquire_transaction_locks failed");
+}
+
+/// Body for the Check #4 drop case: a lock held by a DIFFERENT tx in the given
+/// tier causes the new contender to be dropped with `ObjectLockConflict`.
+async fn run_different_digest_lock_drops_contender(tier: LockTier) {
+    let s = setup_lock_tier().await;
+
+    // A first tx owns the lock in `tier`.
+    let other = s.make_tx();
+    s.seed_lock(tier, &other);
+
+    // A different tx contending for the same owned input arrives via consensus.
+    // For Quarantine we can build a contender with the same inputs because
+    // make_tx is hashed by recipient/sender_key which are stable; produce a
+    // different digest by swapping recipient.
+    let alt_recipient = get_key_pair::<AccountKeyPair>().0;
+    let new_tx_raw = make_transfer_object_transaction(
+        s.object_ref,
+        s.gas_ref,
+        s.sender,
+        &s.sender_key,
+        alt_recipient,
+        s.rgp,
+    );
+    let new_verified = s.epoch_store.verify_transaction(new_tx_raw).unwrap();
+    let new_digest = *new_verified.digest();
+    assert_ne!(new_digest, *other.digest());
+
+    let mut transactions = vec![make_user_tx_v1_verified(new_verified)];
+    let (dropped, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &s.authority,
+        &s.epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(transactions.len(), 0, "contender must be removed");
+    assert_eq!(dropped.len(), 1);
+    assert_eq!(dropped[0].0, new_digest);
+    assert!(
+        matches!(dropped[0].1, IotaError::ObjectLockConflict { .. }),
+        "expected ObjectLockConflict, got {:?}",
+        dropped[0].1
+    );
+}
+
+/// Body for the Check #1 retain case: an already-executed tx finding its OWN
+/// digest as the lock holder in the given tier must NOT be dropped and must
+/// NOT trigger `fatal!`.
+async fn run_same_digest_lock_retains_already_executed(tier: LockTier) {
+    let s = setup_lock_tier().await;
+
+    let tx = s.make_tx();
+    let tx_digest = *tx.digest();
+
+    // Order matters for the Persistent tier: the lock must be acquired *before*
+    // we mark the tx as executed (otherwise the perpetual
+    // `live_owned_object_markers` for its inputs are already consumed).
+    s.seed_lock(tier, &tx);
+    s.execute_via_state_sync(&tx);
+
+    let mut transactions = vec![make_user_tx_v1_verified(tx)];
+    let (dropped, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &s.authority,
+        &s.epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        dropped.is_empty(),
+        "already-executed tx must not be dropped"
+    );
+    assert_eq!(
+        transactions.len(),
+        1,
+        "already-executed tx must be retained"
+    );
+    assert!(
+        s.authority
+            .get_transaction_cache_reader()
+            .try_is_tx_already_executed(&tx_digest)
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn tier2_quarantine_different_digest_lock_drops_contender() {
+    run_different_digest_lock_drops_contender(LockTier::Quarantine).await;
+}
+
+#[tokio::test]
+async fn tier2_quarantine_same_digest_lock_retains_already_executed() {
+    run_same_digest_lock_retains_already_executed(LockTier::Quarantine).await;
+}
+
+#[tokio::test]
+async fn tier3_persistent_different_digest_lock_drops_contender() {
+    run_different_digest_lock_drops_contender(LockTier::Persistent).await;
+}
+
+#[tokio::test]
+async fn tier3_persistent_same_digest_lock_retains_already_executed() {
+    run_same_digest_lock_retains_already_executed(LockTier::Persistent).await;
+}
+
+/// Check #1 / `fatal!` invariant: when an already-executed transaction's owned
+/// input is locked by a DIFFERENT transaction digest,
+/// `validate_and_resolve_conflicts` must panic — the executed-but-out-locked
+/// state is a real consistency violation, not a recoverable conflict.
+///
+/// Uses the Tier 2 (quarantine) seeding path; the helper is tier-agnostic, so a
+/// single test covers both quarantine and persistent-DB code paths.
+#[tokio::test]
+#[should_panic(expected = "locked by a different transaction")]
+async fn already_executed_tx_locked_by_different_digest_is_fatal() {
+    let s = setup_lock_tier().await;
+
+    // The tx the committee actually executed (via state-sync on this node).
+    let tx = s.make_tx();
+    s.execute_via_state_sync(&tx);
+
+    // Seed the quarantine with a lock on `tx`'s inputs held by a DIFFERENT
+    // digest — simulates the consistency violation the `fatal!` guards against.
+    let other_digest = TransactionDigest::random();
+    assert_ne!(other_digest, *tx.digest());
+    seed_quarantined_lock(&s.epoch_store, s.object_ref, other_digest);
+
+    let mut transactions = vec![make_user_tx_v1_verified(tx)];
+    // Expected to panic via `fatal!` before returning.
+    let _ = post_consensus_validation::validate_and_resolve_conflicts(
+        &s.authority,
+        &s.epoch_store,
+        &mut transactions,
+    )
+    .await;
 }

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -1321,7 +1321,7 @@ async fn setup_lock_tier() -> LockTierSetup {
         object_ref,
         gas_ref,
         rgp,
-        _config_guard: _config_guard,
+        _config_guard,
     }
 }
 

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -4,6 +4,8 @@
 //! Unit tests for post-consensus transaction validation and owned-object
 //! conflict resolution.
 
+use std::sync::Arc;
+
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
@@ -11,14 +13,17 @@ use iota_types::{
     crypto::{AccountKeyPair, get_key_pair},
     digests::TransactionDigest,
     error::IotaError,
+    executable_transaction::VerifiedExecutableTransaction,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     object::Object,
-    transaction::VerifiedTransaction,
+    transaction::{TransactionKey, VerifiedTransaction},
 };
 
 use crate::{
     authority::authority_tests::init_state_with_objects_and_object_basics,
-    consensus_handler::VerifiedSequencedConsensusTransaction, post_consensus_validation,
+    checkpoints::CheckpointServiceNoop,
+    consensus_handler::{SequencedConsensusTransaction, VerifiedSequencedConsensusTransaction},
+    post_consensus_validation,
     test_utils::make_transfer_object_transaction,
 };
 
@@ -994,5 +999,125 @@ async fn test_dropped_tx_does_not_acquire_locks() {
     assert!(
         !locks.contains_key(&gas1.compute_object_reference()),
         "gas1 should not be locked since tx2 was dropped"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint-root regression test (issue #11649)
+// ---------------------------------------------------------------------------
+
+/// Regression test for the white-flag checkpoint fork observed in the
+/// double-spend stress test (#11649).
+///
+/// A validator that lags through an epoch boundary executes a transaction via
+/// state-sync (from an already-certified checkpoint) *before* its own consensus
+/// handler processes the commit that sequenced that transaction. When the
+/// commit is finally processed, the post-consensus "already-executed" check
+/// (Check #1) silently drops the transaction, so it is excluded from the
+/// locally-built checkpoint `roots`. The rest of the committee included it, so
+/// the local checkpoint forks and the node panics with
+/// "Local checkpoint fork detected".
+///
+/// Invariant under test: a committee-sequenced transaction that this node has
+/// executed must still appear in the pending checkpoint roots, regardless of
+/// whether it was executed via its own consensus or via state-sync.
+///
+/// This test FAILS on the buggy code (the tx is missing from roots) and passes
+/// once the already-executed transaction is kept in the checkpoint roots.
+///
+/// Single-process and fully deterministic, so it uses `#[tokio::test]` rather
+/// than `#[sim_test]` — it does not need the deterministic simulator.
+#[tokio::test]
+async fn already_executed_tx_must_remain_in_checkpoint_roots() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+
+    let object_id = ObjectID::random();
+    let gas_id = ObjectID::random();
+
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+
+    let epoch_store = authority.epoch_store_for_testing();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+
+    let object_ref = authority
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let gas_ref = authority
+        .get_object(&gas_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+
+    let tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let verified_tx = epoch_store.verify_transaction(tx).unwrap();
+    let tx_digest = *verified_tx.digest();
+
+    // Simulate state-sync winning the race: execute the transaction locally via
+    // the checkpoint execution path (as a lagging node catching up would),
+    // *before* the consensus handler processes the commit that sequenced it.
+    let executable = VerifiedExecutableTransaction::new_from_checkpoint(
+        verified_tx.clone(),
+        epoch_store.epoch(),
+        /* checkpoint */ 1,
+    );
+    authority
+        .try_execute_immediately(&executable, None, &epoch_store)
+        .unwrap();
+    assert!(
+        authority
+            .get_transaction_cache_reader()
+            .try_is_tx_already_executed(&tx_digest)
+            .unwrap(),
+        "precondition: transaction should be marked executed after state-sync execution"
+    );
+
+    // Now the committee's consensus delivers the same transaction. Process the
+    // commit exactly as the consensus handler would, which builds the pending
+    // checkpoint for this commit.
+    let seq_tx = SequencedConsensusTransaction::new_test(ConsensusTransaction {
+        kind: ConsensusTransactionKind::UserTransactionV1(Box::new(verified_tx.into())),
+        tracking_id: Default::default(),
+    });
+    authority
+        .epoch_store_for_testing()
+        .process_consensus_transactions_for_tests(
+            vec![seq_tx],
+            &Arc::new(CheckpointServiceNoop {}),
+            authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
+            &authority.metrics,
+            /* skip_consensus_commit_prologue_in_test */ true,
+            &authority,
+        )
+        .await
+        .unwrap();
+
+    // The transaction must still be a checkpoint root on this node, otherwise
+    // its locally-built checkpoint diverges from the committee's certified one.
+    let all_roots: Vec<TransactionKey> = authority
+        .epoch_store_for_testing()
+        .get_pending_checkpoints(None)
+        .unwrap()
+        .into_iter()
+        .flat_map(|(_, cp)| cp.roots().clone())
+        .collect();
+
+    assert!(
+        all_roots.contains(&TransactionKey::Digest(tx_digest)),
+        "already-executed transaction {tx_digest:?} was dropped from checkpoint roots \
+         (fork bug #11649); roots = {all_roots:?}"
     );
 }

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -1071,7 +1071,8 @@ async fn already_executed_tx_must_remain_in_checkpoint_roots() {
     let executable = VerifiedExecutableTransaction::new_from_checkpoint(
         verified_tx.clone(),
         epoch_store.epoch(),
-        /* checkpoint */ 1,
+        // checkpoint
+        1,
     );
     authority
         .try_execute_immediately(&executable, None, &epoch_store)
@@ -1099,7 +1100,8 @@ async fn already_executed_tx_must_remain_in_checkpoint_roots() {
             authority.get_object_cache_reader().as_ref(),
             authority.get_transaction_cache_reader().as_ref(),
             &authority.metrics,
-            /* skip_consensus_commit_prologue_in_test */ true,
+            // skip_consensus_commit_prologue_in_test
+            true,
             &authority,
         )
         .await
@@ -1119,5 +1121,123 @@ async fn already_executed_tx_must_remain_in_checkpoint_roots() {
         all_roots.contains(&TransactionKey::Digest(tx_digest)),
         "already-executed transaction {tx_digest:?} was dropped from checkpoint roots \
          (fork bug #11649); roots = {all_roots:?}"
+    );
+}
+
+/// Companion to the test above: a double-spend *loser* (dropped by the lock
+/// conflict check) must be **excluded** from checkpoint roots.
+///
+/// This guards against an over-broad fix that simply seeds roots from the full
+/// sequenced set: such a fix would include the never-executed loser as a root,
+/// and the checkpoint builder would then block forever waiting for its effects.
+/// Only the winner of the owned-object conflict may appear in the roots.
+#[tokio::test]
+async fn double_spend_loser_excluded_from_checkpoint_roots() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_white_flag_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+
+    // One owned object spent by both transactions, plus a distinct gas object each
+    // so the only conflict is on `object_id`.
+    let object_id = ObjectID::random();
+    let gas_a = ObjectID::random();
+    let gas_b = ObjectID::random();
+
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_a, sender),
+        Object::with_id_owner_for_testing(gas_b, sender),
+    ])
+    .await;
+
+    let epoch_store = authority.epoch_store_for_testing();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+
+    let object_ref = authority
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let gas_a_ref = authority
+        .get_object(&gas_a)
+        .await
+        .unwrap()
+        .compute_object_reference();
+    let gas_b_ref = authority
+        .get_object(&gas_b)
+        .await
+        .unwrap()
+        .compute_object_reference();
+
+    // Two transactions spending the same owned object — a double spend.
+    let tx_winner = make_transfer_object_transaction(
+        object_ref,
+        gas_a_ref,
+        sender,
+        &sender_key,
+        recipient,
+        rgp,
+    );
+    let tx_loser = make_transfer_object_transaction(
+        object_ref,
+        gas_b_ref,
+        sender,
+        &sender_key,
+        recipient,
+        rgp,
+    );
+    let winner_digest = *epoch_store
+        .verify_transaction(tx_winner.clone())
+        .unwrap()
+        .digest();
+    let loser_digest = *epoch_store
+        .verify_transaction(tx_loser.clone())
+        .unwrap()
+        .digest();
+    assert_ne!(winner_digest, loser_digest);
+
+    // The first occurrence in the commit wins the lock; the second conflicts.
+    let seq = |tx: iota_types::transaction::Transaction| {
+        SequencedConsensusTransaction::new_test(ConsensusTransaction {
+            kind: ConsensusTransactionKind::UserTransactionV1(Box::new(
+                epoch_store.verify_transaction(tx).unwrap().into(),
+            )),
+            tracking_id: Default::default(),
+        })
+    };
+    authority
+        .epoch_store_for_testing()
+        .process_consensus_transactions_for_tests(
+            vec![seq(tx_winner), seq(tx_loser)],
+            &Arc::new(CheckpointServiceNoop {}),
+            authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
+            &authority.metrics,
+            // skip_consensus_commit_prologue_in_test
+            true,
+            &authority,
+        )
+        .await
+        .unwrap();
+
+    let all_roots: Vec<TransactionKey> = authority
+        .epoch_store_for_testing()
+        .get_pending_checkpoints(None)
+        .unwrap()
+        .into_iter()
+        .flat_map(|(_, cp)| cp.roots().clone())
+        .collect();
+
+    assert!(
+        all_roots.contains(&TransactionKey::Digest(winner_digest)),
+        "conflict winner {winner_digest:?} should be a checkpoint root; roots = {all_roots:?}"
+    );
+    assert!(
+        !all_roots.contains(&TransactionKey::Digest(loser_digest)),
+        "double-spend loser {loser_digest:?} must NOT be a checkpoint root; roots = {all_roots:?}"
     );
 }


### PR DESCRIPTION
# Description of change

In the white-flag (certificate-less) flow, a transaction that this node had already executed via **state-sync** — before its consensus handler processed the commit that sequenced it — was silently dropped from the locally-built checkpoint by the post-consensus *already-executed* check (`validate_and_resolve_conflicts`, Check #1). Because that pass runs **before** checkpoint `roots` are computed, the transaction was excluded from the local checkpoint while the rest of the committee included it, so the lagging node hit a fatal `Local checkpoint fork detected` and crash-looped.

**Root cause:** an *execution-state* check sat on the *checkpoint-membership* path. Membership must be decided by **consensus processing** (committee-deterministic), not by local execution progress (which depends on state-sync lag). The legacy certificate flow never had this problem — its already-executed filter lives only at the execution layer (`TransactionManager::enqueue`), never on the roots path. Note: the double-spend workload only *created the lag* that triggered this; it is not the cause.

**Fix:** treat an already-executed transaction as a committee-agreed winner that **stays in the sequence** — so it flows through scheduling/deferral into `roots` exactly as on every other validator. It registers its owned-object locks (so double-spend siblings still lose) and skips re-validation; `TransactionManager::enqueue` continues to suppress the actual re-execution. A `fatal!` guards the invariant that such a winner can never be out-locked by a different transaction.

Verified safe for both owned- and shared-object transactions: shared-object version assignment is idempotent (`get_or_init_next_object_versions` is first-touch-wins and guarded across the consensus/executor paths), so consensus assigns the same versions the committee did; owned-object txs run no version assignment at all.

## Links to any relevant issues

fixes #11649

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests) — `cargo clippy -p iota-core --tests` clean, `cargo +nightly fmt` applied
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Two unit tests in `post_consensus_validation_tests.rs`:

- `already_executed_tx_must_remain_in_checkpoint_roots` — reproduces the bug (**red before this fix, green after**): a transaction executed via the state-sync path must still appear in checkpoint roots when its consensus commit is later processed.
- `double_spend_loser_excluded_from_checkpoint_roots` — guards against an over-broad fix: the conflict loser must stay **out** of roots, otherwise the checkpoint builder would block forever waiting for effects that never arrive.

> Note: `test_consensus_handler*` and `test_consensus_commit_prologue_generation` exhibit pre-existing parallel-execution flakiness (they fail intermittently on the unmodified base and pass single-threaded; unrelated to this change).