### PR TITLE
upstream(core): Move RocksDBStore to use DBMapUtils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13068,6 +13068,7 @@ dependencies = [
  "cfg-if",
  "dashmap",
  "enum_dispatch",
+ "eyre",
  "fastcrypto",
  "futures",
  "http 1.4.0",

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     io,
     io::{BufReader, Read, Write},
     ops::Range,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -298,89 +298,4 @@ pub async fn verify_checkpoint_range<S>(
     store
         .try_update_highest_verified_checkpoint(&final_checkpoint)
         .expect("Failed to update highest verified checkpoint");
-}
-
-fn hard_link(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    fs::create_dir_all(&dst)?;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            hard_link(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        } else {
-            fs::hard_link(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use tempfile::TempDir;
-    use typed_store::{
-        Map, reopen,
-        rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options, open_cf_opts},
-    };
-
-    use crate::hard_link;
-
-    #[tokio::test]
-    pub async fn test_db_hard_link() -> anyhow::Result<()> {
-        let input = TempDir::new()?;
-        let input_path = input.path();
-
-        let output = TempDir::new()?;
-        let output_path = output.path();
-
-        const FIRST_CF: &str = "First_CF";
-        const SECOND_CF: &str = "Second_CF";
-
-        let db_a = open_cf_opts(
-            input_path,
-            None,
-            MetricConf::new("test_db_hard_link_1"),
-            &[
-                (FIRST_CF, default_db_options().options),
-                (SECOND_CF, default_db_options().options),
-            ],
-        )
-        .unwrap();
-
-        let (db_map_1, db_map_2) = reopen!(&db_a, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-
-        let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
-        let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
-
-        assert!(db_map_1.multi_insert(keys_vals_cf1).is_ok());
-        assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
-
-        // set up db hard link
-        hard_link(input_path, output_path)?;
-        let db_b = open_cf_opts(
-            output_path,
-            None,
-            MetricConf::new("test_db_hard_link_2"),
-            &[
-                (FIRST_CF, default_db_options().options),
-                (SECOND_CF, default_db_options().options),
-            ],
-        )
-        .unwrap();
-
-        let (db_map_1, db_map_2) = reopen!(&db_b, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-        for i in 1..100 {
-            assert!(
-                db_map_1
-                    .contains_key(&i)
-                    .expect("Failed to call contains key")
-            );
-            assert!(
-                db_map_2
-                    .contains_key(&i)
-                    .expect("Failed to call contains key")
-            );
-        }
-
-        Ok(())
-    }
 }

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -19,6 +19,7 @@ bytes.workspace = true
 cfg-if = "1.0.0"
 dashmap.workspace = true
 enum_dispatch.workspace = true
+eyre.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
 http.workspace = true
@@ -34,6 +35,7 @@ rs_merkle.workspace = true
 serde.workspace = true
 strum_macros.workspace = true
 tap.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net"] }
 tokio-stream.workspace = true
@@ -61,7 +63,6 @@ typed-store.workspace = true
 # external dependencies
 rstest.workspace = true
 serial_test.workspace = true
-tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 
 # internal dependencies

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -2,17 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{ops::Bound::Included, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, ops::Bound::Included, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use iota_macros::fail_point;
 use starfish_config::AuthorityIndex;
 use tracing::debug;
 use typed_store::{
-    Map as _,
+    DBMapUtils, Map as _,
     metrics::SamplingInterval,
-    reopen,
-    rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options, open_cf_opts},
+    rocks::{DBMap, DBMapTableConfigMap, MetricConf, default_db_options},
 };
 
 use super::{CommitInfo, Store, WriteBatch};
@@ -29,6 +28,7 @@ use crate::{
 };
 
 /// Persistent storage with RocksDB.
+#[derive(DBMapUtils)]
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlockHeader by refs.
     block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
@@ -37,6 +37,7 @@ pub(crate) struct RocksDBStore {
     /// Stores Transactions by transaction refs
     transactions_by_tx_refs: DBMap<(Round, AuthorityIndex, TransactionsCommitment), Bytes>,
     /// A secondary index that orders refs first by authors.
+    #[rename = "digests"]
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
     /// A secondary index that orders transaction commitments first by authors.
     transaction_commitments_by_authorities:
@@ -76,89 +77,54 @@ impl RocksDBStore {
         let db_options = default_db_options().optimize_db_for_write_throughput(2);
         let mut metrics_conf = MetricConf::new("consensus");
         metrics_conf.read_sample_interval = SamplingInterval::new(Duration::from_secs(60), 0);
-        let cf_options = default_db_options().optimize_for_write_throughput().options;
-        let column_family_options = vec![
+        let cf_options = default_db_options().optimize_for_write_throughput();
+        let column_family_options = DBMapTableConfigMap::new(BTreeMap::from([
             (
-                Self::TRANSACTIONS_CF,
+                Self::TRANSACTIONS_CF.to_string(),
                 default_db_options()
                     .optimize_for_write_throughput_no_deletion()
                     // Using larger block is ok since there is not much point reads on the cf.
-                    .set_block_options(512, 128 << 10)
-                    .options,
+                    .set_block_options(512, 128 << 10),
             ),
             (
-                Self::TRANSACTIONS_BY_TX_REF_CF,
+                Self::TRANSACTIONS_BY_TX_REF_CF.to_string(),
                 default_db_options()
                     .optimize_for_write_throughput_no_deletion()
                     // Using larger block is ok since there is not much point reads on the cf.
-                    .set_block_options(512, 128 << 10)
-                    .options,
+                    .set_block_options(512, 128 << 10),
             ),
             (
-                Self::BLOCK_HEADERS_CF,
+                Self::BLOCK_HEADERS_CF.to_string(),
                 default_db_options()
                     .optimize_for_write_throughput_no_deletion()
                     // TODO:think about these constants, for now it is a copy from blocks
-                    .set_block_options(512, 128 << 10)
-                    .options,
+                    .set_block_options(512, 128 << 10),
             ),
-            (Self::DIGESTS_BY_AUTHORITIES_CF, cf_options.clone()),
             (
-                Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF,
+                Self::DIGESTS_BY_AUTHORITIES_CF.to_string(),
                 cf_options.clone(),
             ),
-            (Self::COMMITS_CF, cf_options.clone()),
-            (Self::COMMIT_VOTES_CF, cf_options.clone()),
-            (Self::COMMIT_INFO_CF, cf_options.clone()),
+            (
+                Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF.to_string(),
+                cf_options.clone(),
+            ),
+            (Self::COMMITS_CF.to_string(), cf_options.clone()),
+            (Self::COMMIT_VOTES_CF.to_string(), cf_options.clone()),
+            (Self::COMMIT_INFO_CF.to_string(), cf_options.clone()),
             // Voting block headers are much fewer than regular block headers,
             // so using standard options is sufficient.
-            (Self::VOTING_BLOCK_HEADERS_CF, cf_options.clone()),
-            (Self::FAST_COMMIT_SYNC_FLAG_CF, cf_options),
-        ];
-        let rocksdb = open_cf_opts(
-            path,
-            Some(db_options.options),
+            (
+                Self::VOTING_BLOCK_HEADERS_CF.to_string(),
+                cf_options.clone(),
+            ),
+            (Self::FAST_COMMIT_SYNC_FLAG_CF.to_string(), cf_options),
+        ]));
+        Self::open_tables_read_write(
+            path.into(),
             metrics_conf,
-            &column_family_options,
+            Some(db_options.options),
+            Some(column_family_options),
         )
-        .expect("Cannot open database");
-
-        let (
-            block_headers,
-            transactions,
-            transactions_by_tx_refs,
-            digests_by_authorities,
-            transaction_commitments_by_authorities,
-            commits,
-            commit_votes,
-            commit_info,
-            voting_block_headers,
-            fast_commit_sync_flag,
-        ) = reopen!(&rocksdb,
-            Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-            Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-            Self::TRANSACTIONS_BY_TX_REF_CF;<(Round, AuthorityIndex, TransactionsCommitment), Bytes>,
-            Self::DIGESTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
-            Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, TransactionsCommitment), ()>,
-            Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
-            Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
-            Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
-            Self::VOTING_BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-            Self::FAST_COMMIT_SYNC_FLAG_CF;<(), ()>
-        );
-
-        Self {
-            block_headers,
-            transactions,
-            transactions_by_tx_refs,
-            digests_by_authorities,
-            transaction_commitments_by_authorities,
-            commits,
-            commit_votes,
-            commit_info,
-            voting_block_headers,
-            fast_commit_sync_flag,
-        }
     }
 }
 
@@ -843,18 +809,6 @@ impl RocksDBStore {
 
         let metrics = initialise_metrics(Registry::new());
         let clock = Arc::new(Clock::default());
-        let context = Arc::new(Context::new(
-            0,
-            authority_index,
-            committee,
-            Parameters {
-                db_path: db_path.to_path_buf(),
-                ..Default::default()
-            },
-            protocol_config,
-            metrics,
-            clock,
-        ));
 
         let store = RocksDBStore::new(
             db_path

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -49,18 +49,6 @@ const DB_CORRUPTED_KEY: &[u8] = b"db_corrupted";
 #[cfg(test)]
 mod tests;
 
-// TODO: deprecate macros use
-#[macro_export]
-macro_rules! reopen {
-    ( $db:expr, $($cf:expr;<$K:ty, $V:ty>),*) => {
-        (
-            $(
-                DBMap::<$K, $V>::reopen($db, Some($cf), &ReadWriteOptions::default(), false).expect(&format!("Cannot open {} CF.", $cf)[..])
-            ),*
-        )
-    };
-}
-
 #[derive(Debug)]
 pub(crate) struct RocksDB {
     pub(crate) underlying: rocksdb::DBWithThreadMode<MultiThreaded>,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::*;
-use crate::{reopen, traits::Map};
+use crate::traits::Map;
 
 fn get_iter<K, V>(db: &DBMap<K, V>) -> impl Iterator<Item = (K, V)> + use<'_, K, V>
 where
@@ -76,35 +76,6 @@ async fn test_reopen() {
         db.contains_key(&123456789)
             .expect("Failed to retrieve item in storage")
     );
-}
-
-#[tokio::test]
-async fn test_reopen_macro() {
-    const FIRST_CF: &str = "First_CF";
-    const SECOND_CF: &str = "Second_CF";
-
-    let tmp_dir = iota_common::tempdir();
-    let rocks = open_cf_opts(
-        tmp_dir.path(),
-        None,
-        MetricConf::default(),
-        &[
-            (FIRST_CF, rocksdb::Options::default()),
-            (SECOND_CF, rocksdb::Options::default()),
-        ],
-    )
-    .unwrap();
-
-    let (db_map_1, db_map_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-
-    let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
-    let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
-
-    assert_eq!(db_map_1.cf_name(), FIRST_CF);
-    assert_eq!(db_map_2.cf_name(), SECOND_CF);
-
-    assert!(db_map_1.multi_insert(keys_vals_cf1).is_ok());
-    assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.49.2, v1.50.1)
- Port commit:
  - [MystenLabs/sui@e0ff9c2](https://github.com/MystenLabs/sui/commit/e0ff9c28f2843b0eae62eb982302328c3537d377)
- Description:
  * switches consensus::RocksDBStore to DBMapUtils (as used in the rest of
the codebase) as a preparation step for experiments with TideHunter
  * deprecates the `typed_store::reopen!` macro and its remaining call
sites.

TideHunter-related changes are skipped, as this fork does not include TideHunter.

## Links to any relevant issues

Part of #11322

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes