### PR TITLE
chore: bump rust-sdk version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7350,7 +7350,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=a6e168bb6b5d68de7555d056a44cc9387a17c25c#a6e168bb6b5d68de7555d056a44cc9387a17c25c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=058f623870be7c8fb47d3d52564107eabc2c2f96#058f623870be7c8fb47d3d52564107eabc2c2f96"
 dependencies = [
  "bip32",
  "bip39",
@@ -7365,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=a6e168bb6b5d68de7555d056a44cc9387a17c25c#a6e168bb6b5d68de7555d056a44cc9387a17c25c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=058f623870be7c8fb47d3d52564107eabc2c2f96#058f623870be7c8fb47d3d52564107eabc2c2f96"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=a6e168bb6b5d68de7555d056a44cc9387a17c25c#a6e168bb6b5d68de7555d056a44cc9387a17c25c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=058f623870be7c8fb47d3d52564107eabc2c2f96#058f623870be7c8fb47d3d52564107eabc2c2f96"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=a6e168bb6b5d68de7555d056a44cc9387a17c25c#a6e168bb6b5d68de7555d056a44cc9387a17c25c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=058f623870be7c8fb47d3d52564107eabc2c2f96#058f623870be7c8fb47d3d52564107eabc2c2f96"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,9 +395,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "a6e168bb6b5d68de7555d056a44cc9387a17c25c" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "058f623870be7c8fb47d3d52564107eabc2c2f96" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "a6e168bb6b5d68de7555d056a44cc9387a17c25c" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "058f623870be7c8fb47d3d52564107eabc2c2f96" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -436,7 +436,7 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "a6e168bb6b5d68de7555d056a44cc9387a17c25c", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "058f623870be7c8fb47d3d52564107eabc2c2f96", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -77,7 +77,7 @@ test-outputs = ["dep:iota-sdk-crypto"]
 
 [target.'cfg(not(msim))'.dependencies]
 # iota-sdk-crypto is only used when compiling test-outputs feature
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "a6e168bb6b5d68de7555d056a44cc9387a17c25c", optional = true, features = ["ed25519", "mnemonic"] }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "058f623870be7c8fb47d3d52564107eabc2c2f96", optional = true, features = ["ed25519", "mnemonic"] }
 
 [[example]]
 name = "snapshot_add_test_outputs"

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "a6e168bb6b5d68de7555d056a44cc9387a17c25c" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "058f623870be7c8fb47d3d52564107eabc2c2f96" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -17,5 +17,5 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "a6e168bb6b5d68de7555d056a44cc9387a17c25c" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "058f623870be7c8fb47d3d52564107eabc2c2f96" }
 iota-types = { path = "../../../crates/iota-types" }


### PR DESCRIPTION
# Description of change

Bumps the rust-sdk version to align with the GraphQL changes. 

## Links to any relevant issues

Part of #9255 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)



