### PR TITLE
upstream(core): Rename authority execution methods

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1174,9 +1174,12 @@ impl AuthorityState {
             .inc();
     }
 
-    /// Executes a certificate for its effects.
+    /// Wait for a certificate to be executed.
+    /// For consensus transactions, it needs to be sequenced by the consensus.
+    /// For owned object transactions, this function will enqueue the
+    /// transaction for execution.
     #[instrument(level = "trace", skip_all)]
-    pub async fn execute_certificate(
+    pub async fn wait_for_certificate_execution(
         &self,
         certificate: &VerifiedCertificate,
         epoch_store: &Arc<AuthorityPerEpochStore>,
@@ -1190,7 +1193,7 @@ impl AuthorityState {
                 .execute_certificate_latency_single_writer
                 .start_timer()
         };
-        trace!("execute_certificate");
+        trace!("wait_for_certificate_execution");
 
         self.metrics.total_cert_attempts.inc();
 
@@ -1222,7 +1225,7 @@ impl AuthorityState {
     ///
     /// It is caller's responsibility to ensure input objects are available and
     /// locks are set. If this cannot be satisfied by the caller,
-    /// execute_certificate() should be called instead.
+    /// wait_for_certificate_execution() should be called instead.
     ///
     /// Should only be called within iota-core.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?certificate.digest()))]
@@ -1429,12 +1432,12 @@ impl AuthorityState {
             });
         }
 
-        // Errors originating from prepare_certificate may be transient (failure to read
+        // Errors originating from execute_certificate may be transient (failure to read
         // locks) or non-transient (transaction input is invalid, move vm
         // errors). However, all errors from this function occur before we have
         // written anything to the db, so we commit the tx guard and rely on the
         // client to retry the tx (if it was transient).
-        let (inner_temporary_store, effects, execution_error_opt) = match self.prepare_certificate(
+        let (inner_temporary_store, effects, execution_error_opt) = match self.execute_certificate(
             &execution_guard,
             certificate,
             tx_input_objects,
@@ -1610,19 +1613,19 @@ impl AuthorityState {
         );
     }
 
-    /// prepare_certificate validates the transaction input, and executes the
+    /// execute_certificate validates the transaction input, and executes the
     /// certificate, returning effects, output objects, events, etc.
     ///
     /// It reads state from the db (both owned and shared locks), but it has no
     /// side effects.
     ///
-    /// It can be generally understood that a failure of prepare_certificate
+    /// It can be generally understood that a failure of execute_certificate
     /// indicates a non-transient error, e.g. the transaction input is
     /// somehow invalid, the correct locks are not held, etc. However, this
     /// is not entirely true, as a transient db read error may also cause
     /// this function to fail.
     #[instrument(level = "trace", skip_all)]
-    fn prepare_certificate(
+    fn execute_certificate(
         &self,
         _execution_guard: &ExecutionLockReadGuard<'_>,
         certificate: &VerifiedExecutableTransaction,
@@ -1634,7 +1637,7 @@ impl AuthorityState {
         TransactionEffects,
         Option<ExecutionError>,
     )> {
-        let _scope = monitored_scope("Execution::prepare_certificate");
+        let _scope = monitored_scope("Execution::execute_certificate");
         let _metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
         let prepare_certificate_start_time = tokio::time::Instant::now();
 
@@ -1855,7 +1858,7 @@ impl AuthorityState {
         let lock = RwLock::new(epoch_store.epoch());
         let execution_guard = lock.try_read().unwrap();
 
-        self.prepare_certificate(
+        self.execute_certificate(
             &execution_guard,
             certificate,
             input_objects,
@@ -5284,7 +5287,7 @@ impl AuthorityState {
         let (input_objects, _) =
             self.read_objects_for_execution(&tx_lock, &executable_tx, epoch_store)?;
 
-        let (temporary_store, effects, _execution_error_opt) = self.prepare_certificate(
+        let (temporary_store, effects, _execution_error_opt) = self.execute_certificate(
             &execution_guard,
             &executable_tx,
             input_objects,

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -686,7 +686,7 @@ impl ValidatorService {
             |certificate| async move {
                 let effects = self
                     .state
-                    .execute_certificate(&certificate, epoch_store)
+                    .wait_for_certificate_execution(&certificate, epoch_store)
                     .await?;
                 let events = if include_events {
                     if effects.events_digest().is_some() {

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -2277,7 +2277,7 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
         &authority_state,
     );
     let effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -2312,7 +2312,7 @@ async fn test_handle_confirmation_transaction_ok() {
     let old_account = authority_state.get_object(&object_id).await.unwrap();
 
     let signed_effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction.clone(),
             &authority_state.epoch_store_for_testing(),
         )
@@ -2368,7 +2368,7 @@ async fn test_handle_confirmation_transaction_idempotent() {
     );
 
     let effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -2377,7 +2377,7 @@ async fn test_handle_confirmation_transaction_idempotent() {
     assert_eq!(effects.status(), &ExecutionStatus::Success);
 
     let signed_effects2 = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -2525,7 +2525,7 @@ async fn test_move_call_insufficient_gas() {
         &authority_state,
     );
     let effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -2886,7 +2886,7 @@ async fn test_idempotent_reversed_confirmation() {
         &authority_state,
     );
     let result1 = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -3151,7 +3151,7 @@ async fn test_transfer_iota_no_amount() {
 
     let certificate = init_certified_transaction(transaction.into(), &authority_state);
     let effects = authority_state
-        .execute_certificate(&certificate, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&certificate, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
     // Check that the transaction was successful, and the gas object is the only
@@ -3193,7 +3193,7 @@ async fn test_transfer_iota_with_amount() {
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     let certificate = init_certified_transaction(transaction, &authority_state);
     let effects = authority_state
-        .execute_certificate(&certificate, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&certificate, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
     // Check that the transaction was successful, the gas object remains in the
@@ -3243,7 +3243,7 @@ async fn test_store_revert_transfer_iota() {
     let certificate = init_certified_transaction(transaction, &authority_state);
     let tx_digest = *certificate.digest();
     authority_state
-        .execute_certificate(&certificate, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&certificate, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
 
@@ -3325,7 +3325,7 @@ async fn test_store_revert_wrap_move_call() {
     let wrap_digest = *wrap_cert.digest();
 
     let wrap_effects = authority_state
-        .execute_certificate(&wrap_cert, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&wrap_cert, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
 
@@ -3424,7 +3424,7 @@ async fn test_store_revert_unwrap_move_call() {
     let unwrap_digest = *unwrap_cert.digest();
 
     let unwrap_effects = authority_state
-        .execute_certificate(&unwrap_cert, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&unwrap_cert, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
 
@@ -3704,7 +3704,7 @@ async fn test_store_revert_add_ofield() {
     let add_digest = *add_cert.digest();
 
     let add_effects = authority_state
-        .execute_certificate(&add_cert, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&add_cert, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
 
@@ -3830,7 +3830,7 @@ async fn test_store_revert_remove_ofield() {
     let remove_ofield_digest = *remove_ofield_cert.digest();
 
     let remove_effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &remove_ofield_cert,
             &authority_state.epoch_store_for_testing(),
         )
@@ -3897,7 +3897,7 @@ async fn test_iter_live_object_set() {
         &authority,
     );
     authority
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority.epoch_store_for_testing(),
         )

--- a/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
@@ -240,7 +240,7 @@ impl TestRunner {
         // `execute_certificate_with_execution_error` to make sure we go through TM
         let effects = self
             .authority_state
-            .execute_certificate(&ct, &epoch_store)
+            .wait_for_certificate_execution(&ct, &epoch_store)
             .await
             .unwrap();
 

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -170,7 +170,7 @@ impl SingleValidator {
                         .enqueue_certificates_for_execution(vec![cert.clone()], &self.epoch_store);
                 }
                 self.get_validator()
-                    .execute_certificate(&cert, &self.epoch_store)
+                    .wait_for_certificate_execution(&cert, &self.epoch_store)
                     .await
                     .unwrap()
             }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.49.2, v1.50.1)
- Port commit:
  - [MystenLabs/sui@5357e92b0c](https://github.com/MystenLabs/sui/commit/5357e92b0cde849f67684de41cae695499db61a0)
- Description:

Renames:
* `AuthorityState::execute_certificate` to `wait_for_certificate_execution`
* `prepare_certificate` to `execute_certificate`

**Not ported**: 
* The structural reshape from the upstream commit — The reshape exists upstream to support Mysticeti Fastpath certificates skipping the commit step. This fork has no Mysticeti Fastpath, so the reshape would carry permanent complexity with no consumer.
* The `execute_transaction` → `wait_for_transaction_execution` rename (this fork has no separate `execute_transaction`), and `execution_start_time` / `Vec<ExecutionTiming>` / `record_local_execution_time` plumbing (this fork has none of that infrastructure).

## Links to any relevant issues

Part of #11322

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes