### PR TITLE
fix(cli): enable MoveAuthenticator signatures with no auth args

### DIFF
--- a/crates/iota/src/signing.rs
+++ b/crates/iota/src/signing.rs
@@ -74,42 +74,54 @@ pub(crate) async fn sign_transaction(
     auth_args: Option<(Vec<CallArg>, Vec<TypeTag>)>,
 ) -> Result<GenericSignature> {
     let iota_client = context.get_client().await?;
-
-    if let Some((auth_call_args, auth_type_args)) = auth_args {
-        let initial_shared_version =
-            get_shared_object_version(&iota_client, signer_address).await?;
-
-        return Ok(GenericSignature::MoveAuthenticator(
-            MoveAuthenticator::new_v1(
-                auth_call_args,
-                auth_type_args,
-                CallArg::Shared(SharedObjectRef::new(
-                    ObjectID::from(*signer_address),
-                    initial_shared_version,
-                    false,
-                )),
-            ),
-        ));
-    }
-
     let key = context.config().keystore().get_key(signer_address)?;
 
     match key {
-        StoredKey::KeyPair(_) => Ok(context
-            .config()
-            .keystore()
-            .sign_secure(signer_address, tx_data, Intent::iota_transaction())?
-            .into()),
+        // An abstract account always signs via `MoveAuthenticator`, regardless of whether
+        // `--auth-call-args` / `--auth-type-args` were supplied. When they were, the resolved
+        // `auth_args` carry the user-facing inputs; when they weren't, the authenticator is
+        // expected to take no user-facing inputs (only the signer account and the framework
+        // contexts), so we forward empty `CallArg` / `TypeTag` vectors and let the validator
+        // reject the transaction at runtime if the on-chain function actually requires more.
         StoredKey::Account(_) => {
-            bail!(
-                "Cannot sign for account address without --auth-call-args (and --auth-type-args if needed)."
-            )
+            let (auth_call_args, auth_type_args) = auth_args.unwrap_or_default();
+            let initial_shared_version =
+                get_shared_object_version(&iota_client, signer_address).await?;
+
+            Ok(GenericSignature::MoveAuthenticator(
+                MoveAuthenticator::new_v1(
+                    auth_call_args,
+                    auth_type_args,
+                    CallArg::Shared(SharedObjectRef::new(
+                        ObjectID::from(*signer_address),
+                        initial_shared_version,
+                        false,
+                    )),
+                ),
+            ))
+        }
+        StoredKey::KeyPair(_) => {
+            if auth_args.is_some() {
+                bail!(
+                    "--auth-call-args / --auth-type-args were supplied for {signer_address}, but it is not an abstract account."
+                );
+            }
+            Ok(context
+                .config()
+                .keystore()
+                .sign_secure(signer_address, tx_data, Intent::iota_transaction())?
+                .into())
         }
         StoredKey::External {
             derivation_path,
             source,
             ..
         } => {
+            if auth_args.is_some() {
+                bail!(
+                    "--auth-call-args / --auth-type-args were supplied for {signer_address}, but it is not an abstract account."
+                );
+            }
             match ExternalKeySource::from(source.as_str()) {
                 ExternalKeySource::Ledger => {
                     let Some(derivation_path) = derivation_path else {
@@ -150,7 +162,7 @@ where
         StoredKey::KeyPair(_) => Ok(keystore.sign_secure(address, &msg, intent)?),
         StoredKey::Account(_) => {
             bail!(
-                "Cannot sign for account address without --auth-call-args (and --auth-type-args if needed)."
+                "Cannot sign an arbitrary message for an abstract account — abstract accounts can only sign transactions via `MoveAuthenticator`."
             )
         }
         StoredKey::External {

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -7111,9 +7111,7 @@ async fn test_move_authenticator_no_user_args() -> Result<(), anyhow::Error> {
     .execute(context)
     .await?;
 
-    // Submit a PTB with NO `--auth-call-args` / `--auth-type-args`. Before
-    // the refactor this would bail at the CLI; now it succeeds with an empty
-    // MoveAuthenticator call-args vector.
+    // Submit a PTB with NO `--auth-call-args` / `--auth-type-args`.
     let ptb_resp = IotaClientCommands::PTB(PTB {
         args: vec![
             "--split-coins".to_string(),

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -7078,3 +7078,145 @@ async fn test_move_authenticator_sender_and_sponsor() -> Result<(), anyhow::Erro
 
     Ok(())
 }
+
+/// Tests that the CLI can sign for an abstract account whose authenticator
+/// function takes no user-facing inputs, without supplying `--auth-call-args`
+/// or `--auth-type-args`.
+#[sim_test]
+async fn test_move_authenticator_no_user_args() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+    let sender_address = test_cluster.get_address_0();
+    let context = &mut test_cluster.wallet;
+
+    // Bind the AA to `account::authenticate_no_args`, which has no
+    // user-facing parameters (only `&Account`, `&AuthContext`, `&TxContext`).
+    let account_address = setup_move_authenticator_account(
+        context,
+        sender_address,
+        "examples/move/account",
+        "account",
+        "authenticate_no_args",
+        2_000_000_000,
+    )
+    .await?;
+
+    // Switch to the AA so subsequent commands treat it as the active address.
+    IotaClientCommands::Switch {
+        address: Some(IotaAddress::from(account_address).into()),
+        env: None,
+    }
+    .execute(context)
+    .await?;
+
+    // Submit a PTB with NO `--auth-call-args` / `--auth-type-args`. Before
+    // the refactor this would bail at the CLI; now it succeeds with an empty
+    // MoveAuthenticator call-args vector.
+    let ptb_resp = IotaClientCommands::PTB(PTB {
+        args: vec![
+            "--split-coins".to_string(),
+            "gas".to_string(),
+            "[1]".to_string(),
+            "--assign".to_string(),
+            "coin".to_string(),
+            "--transfer-objects".to_string(),
+            "[coin]".to_string(),
+            format!("@{account_address}"),
+        ],
+        display: HashSet::new(),
+    })
+    .execute(context)
+    .await?;
+    assert!(matches!(
+        ptb_resp,
+        IotaClientCommandResult::TransactionBlock(ref tx) if tx.effects.as_ref().unwrap().status().is_ok()
+    ));
+
+    Ok(())
+}
+
+/// Tests that the CLI can submit a sponsored transaction where the sender is
+/// an abstract account with a 1-argument authenticator and the sponsor is an
+/// abstract account whose authenticator takes no user-facing inputs: passing
+/// `--auth-call-args` for the sender but omitting `--sponsor-auth-call-args`
+/// entirely.
+#[sim_test]
+async fn test_move_authenticator_sender_and_sponsor_no_sponsor_args() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+    let publisher = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+    let context = &mut test_cluster.wallet;
+
+    // Sender AA: authenticator requires the literal "hello" as its only user arg.
+    let sender_aa = setup_move_authenticator_account(
+        context,
+        publisher,
+        "examples/move/account",
+        "account",
+        "authenticate",
+        2_000_000_000,
+    )
+    .await?;
+
+    // Sponsor AA: authenticator takes no user-facing args.
+    let sponsor_aa = setup_move_authenticator_account(
+        context,
+        publisher,
+        "examples/move/account",
+        "account",
+        "authenticate_no_args",
+        2_000_000_000,
+    )
+    .await?;
+    assert_ne!(sender_aa, sponsor_aa);
+
+    // Sponsored PTB splitting a nano off the sponsor's gas and transferring it
+    // to `recipient`. Sender is authenticated via `--auth-call-args hello`;
+    // sponsor has no user-facing inputs, so `--sponsor-auth-call-args` is
+    // omitted and the CLI must still route the sponsor through the
+    // `MoveAuthenticator` path with an empty call-args vector.
+    let ptb_resp = IotaClientCommands::PTB(PTB {
+        args: vec![
+            "--split-coins".to_string(),
+            "gas".to_string(),
+            "[1]".to_string(),
+            "--assign".to_string(),
+            "coin".to_string(),
+            "--transfer-objects".to_string(),
+            "[coin]".to_string(),
+            format!("@{recipient}"),
+            "--sender".to_string(),
+            format!("@{sender_aa}"),
+            "--gas-sponsor".to_string(),
+            format!("@{sponsor_aa}"),
+            "--auth-call-args".to_string(),
+            "hello".to_string(),
+        ],
+        display: HashSet::new(),
+    })
+    .execute(context)
+    .await?;
+
+    let IotaClientCommandResult::TransactionBlock(tx) = ptb_resp else {
+        panic!("Expected TransactionBlock result, got {ptb_resp:?}");
+    };
+    let effects = tx.effects.as_ref().unwrap();
+    assert!(
+        effects.status().is_ok(),
+        "Sponsored tx with a no-user-args sponsor authenticator should succeed: {:?}",
+        effects.status()
+    );
+    let tx_block = tx.transaction.as_ref().expect("transaction block");
+    assert_eq!(tx_block.data.sender(), &IotaAddress::from(sender_aa));
+    assert_eq!(
+        tx_block.data.gas_data().owner,
+        IotaAddress::from(sponsor_aa)
+    );
+
+    Ok(())
+}

--- a/examples/move/account/sources/account.move
+++ b/examples/move/account/sources/account.move
@@ -44,3 +44,13 @@ public fun authenticate(
 ) {
     assert!(msg == std::ascii::string(b"hello"), 0);
 }
+
+/// An unsecure example authenticator function that takes no user-facing inputs.
+/// Used by the CLI tests that exercise signing an abstract account without
+/// `--auth-call-args` / `--auth-type-args`.
+#[authenticator]
+public fun authenticate_no_args(
+    _account: &Account,
+    _auth_ctx: &iota::auth_context::AuthContext,
+    _ctx: &TxContext,
+) {}


### PR DESCRIPTION
# Description of change

I was not able to run examples where the authenticator function had only an account param and nothing else. This should allow to create move authenticators for accounts where the authenticator function requires no additional args.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Enable the creation of MoveAuthenticators for accounts where the authenticator function requires no additional args.
- [ ] Rust SDK:
- [ ] gRPC:
