### PR TITLE
fix(iota-indexer): use lamport-1 for NotYetCreated backward-history rows

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_recreate_across_checkpoints.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_recreate_across_checkpoints.move
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test checks if object versions are assigned correctly for an
+// object create -> delete -> recreate lifecycle. Assigning the version
+// incorrectly (e.g. constant -1 for both NotYetCreated rows) may result
+// in the wrong object version being returned by consistent views:
+// consistent-view logic selects MIN(version) and so assumes object
+// versions are monotonic throughout the lifetime of the object.
+
+
+//# init --protocol-version 4 --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use iota::dynamic_object_field as ofield;
+
+    public struct Parent has key, store {
+        id: UID,
+    }
+
+    public struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(Parent { id: object::new(ctx) }, recipient)
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(Child { id: object::new(ctx), count: 0 }, recipient)
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun reclaim_and_transfer_child(parent: &mut Parent, name: u64, recipient: address) {
+        let c: Child = ofield::remove(&mut parent.id, name);
+        transfer::public_transfer(c, recipient)
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: Test::M1::child(Input(0));
+//> 1: Test::M1::child(Input(0));
+//> 2: Test::M1::parent(Input(0));
+
+//# run Test::M1::add_child --sender A --args object(2,2) object(2,1) 41
+
+//# create-checkpoint
+
+//# run Test::M1::add_child --sender A --args object(2,2) object(2,0) 42
+
+//# create-checkpoint
+
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,2) 42 @A
+
+//# create-checkpoint
+
+//# run Test::M1::add_child --sender A --args object(2,2) object(2,0) 42
+
+//# create-checkpoint
+
+//# run-graphql --cursors bcs(@{obj_3_0},1)
+{
+  cv1_after: owner(address: "@{obj_2_2}") {
+    dynamicFields(after: "@{cursor_0}") {
+      edges {
+        node {
+          name { bcs }
+          value { ... on MoveObject { contents { json } } }
+        }
+      }
+    }
+  }
+  cv1_before: owner(address: "@{obj_2_2}") {
+    dynamicFields(before: "@{cursor_0}") {
+      edges {
+        node {
+          name { bcs }
+          value { ... on MoveObject { contents { json } } }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors bcs(@{obj_3_0},2)
+{
+  cv2_after: owner(address: "@{obj_2_2}") {
+    dynamicFields(after: "@{cursor_0}") {
+      edges {
+        node {
+          name { bcs }
+          value { ... on MoveObject { contents { json } } }
+        }
+      }
+    }
+  }
+  cv2_before: owner(address: "@{obj_2_2}") {
+    dynamicFields(before: "@{cursor_0}") {
+      edges {
+        node {
+          name { bcs }
+          value { ... on MoveObject { contents { json } } }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors bcs(@{obj_3_0},3)
+{
+  cv3_after: owner(address: "@{obj_2_2}") {
+    dynamicFields(after: "@{cursor_0}") {
+      edges {
+        node {
+          name { bcs }
+          value { ... on MoveObject { contents { json } } }
+        }
+      }
+    }
+  }
+  cv3_before: owner(address: "@{obj_2_2}") {
+    dynamicFields(before: "@{cursor_0}") {
+      edges {
+        node {
+          name { bcs }
+          value { ... on MoveObject { contents { json } } }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors bcs(@{obj_3_0},4)
+{
+  cv4_after: owner(address: "@{obj_2_2}") {
+    dynamicFields(after: "@{cursor_0}") {
+      edges {
+        node {
+          name { bcs }
+          value { ... on MoveObject { contents { json } } }
+        }
+      }
+    }
+  }
+  cv4_before: owner(address: "@{obj_2_2}") {
+    dynamicFields(before: "@{cursor_0}") {
+      edges {
+        node {
+          name { bcs }
+          value { ... on MoveObject { contents { json } } }
+        }
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_recreate_across_checkpoints.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_recreate_across_checkpoints.snap
@@ -1,0 +1,163 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
+---
+processed 15 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 14-43:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 7227600, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 45-48:
+//# programmable --sender A --inputs @A
+//> 0: Test::M1::child(Input(0));
+//> 1: Test::M1::child(Input(0));
+//> 2: Test::M1::parent(Input(0));
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4826000, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 50:
+//# run Test::M1::add_child --sender A --args object(2,2) object(2,1) 41
+created: object(3,0)
+mutated: object(0,0), object(2,1), object(2,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5973600, storage_rebate: 3526400, non_refundable_storage_fee: 0
+
+task 4, line 52:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, line 54:
+//# run Test::M1::add_child --sender A --args object(2,2) object(2,0) 42
+created: object(5,0)
+mutated: object(0,0), object(2,0), object(2,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5973600, storage_rebate: 3526400, non_refundable_storage_fee: 0
+
+task 6, line 56:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, line 58:
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,2) 42 @A
+mutated: object(0,0), object(2,0), object(2,2)
+deleted: object(5,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3526400, storage_rebate: 5973600, non_refundable_storage_fee: 0
+
+task 8, line 60:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 9, line 62:
+//# run Test::M1::add_child --sender A --args object(2,2) object(2,0) 42
+created: object(5,0)
+mutated: object(0,0), object(2,0), object(2,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5973600, storage_rebate: 3526400, non_refundable_storage_fee: 0
+
+task 10, line 64:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 11, lines 66-88:
+//# run-graphql --cursors bcs(@{obj_3_0},1)
+Response: {
+  "data": {
+    "cv1_after": {
+      "dynamicFields": {
+        "edges": []
+      }
+    },
+    "cv1_before": {
+      "dynamicFields": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 12, lines 90-112:
+//# run-graphql --cursors bcs(@{obj_3_0},2)
+Response: {
+  "data": {
+    "cv2_after": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "count": "0",
+                    "id": "0x2ce6099adb778c4162a90f9e88e7bc2bc9cfee970340ef4ad3b2b1af9c00ac00"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cv2_before": {
+      "dynamicFields": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 13, lines 114-136:
+//# run-graphql --cursors bcs(@{obj_3_0},3)
+Response: {
+  "data": {
+    "cv3_after": {
+      "dynamicFields": {
+        "edges": []
+      }
+    },
+    "cv3_before": {
+      "dynamicFields": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 14, lines 138-160:
+//# run-graphql --cursors bcs(@{obj_3_0},4)
+Response: {
+  "data": {
+    "cv4_after": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "count": "0",
+                    "id": "0x2ce6099adb778c4162a90f9e88e7bc2bc9cfee970340ef4ad3b2b1af9c00ac00"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cv4_before": {
+      "dynamicFields": {
+        "edges": []
+      }
+    }
+  }
+}

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -676,11 +676,13 @@ impl PrimaryWorker {
                 }
             }
 
-            // 2. Created objects did not exist before this transaction.
+            // 2. Created objects did not exist before this transaction. Use lamport version
+            //    - 1 so the version is monotonic with other backward-history rows for the
+            //    same object.
             for (r, _) in effects.created() {
                 result.push(StoredBackwardHistoryObject::from_empty(
                     r.object_id,
-                    -1,
+                    r.version.as_u64() as i64 - 1,
                     BackwardHistoryObjectStatus::NotYetCreated,
                     checkpoint_seq,
                 ));

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -701,7 +701,7 @@ mod ingestion_tests {
     ///
     /// `transfer_txn` splits a coin from the gas object and transfers it.
     /// Each such transaction produces:
-    ///   - a CREATED coin  → NOT_YET_CREATED backward entry (version=-1)
+    ///   - a CREATED coin  → NOT_YET_CREATED backward entry (version=lamport-1)
     ///   - a MUTATED gas   → ACTIVE backward entry with previous version/data
     #[tokio::test]
     pub async fn backward_history_ingestion() -> Result<(), IndexerError> {
@@ -723,14 +723,14 @@ mod ingestion_tests {
         let created1: Vec<_> = effects1
             .created()
             .into_iter()
-            .map(|(r, _)| r.object_id)
+            .map(|(r, _)| (r.object_id, r.version))
             .collect();
         assert_eq!(
             created1.len(),
             1,
             "transfer_txn should create exactly 1 coin"
         );
-        let created_coin_1 = created1[0];
+        let (created_coin_1, created_coin_1_version) = created1[0];
 
         // Second transfer in the same checkpoint — uses the same gas object
         // (now at an updated version).
@@ -746,10 +746,10 @@ mod ingestion_tests {
         let created2: Vec<_> = effects2
             .created()
             .into_iter()
-            .map(|(r, _)| r.object_id)
+            .map(|(r, _)| (r.object_id, r.version))
             .collect();
         assert_eq!(created2.len(), 1);
-        let created_coin_2 = created2[0];
+        let (created_coin_2, created_coin_2_version) = created2[0];
 
         // Both transactions land in checkpoint 1.
         sim.create_checkpoint();
@@ -763,10 +763,10 @@ mod ingestion_tests {
         let created3: Vec<_> = effects3
             .created()
             .into_iter()
-            .map(|(r, _)| r.object_id)
+            .map(|(r, _)| (r.object_id, r.version))
             .collect();
         assert_eq!(created3.len(), 1);
-        let created_coin_3 = created3[0];
+        let (created_coin_3, created_coin_3_version) = created3[0];
         sim.create_checkpoint();
 
         let (_, pg_store, _) = start_simulacrum_grpc_with_write_indexer(
@@ -782,14 +782,19 @@ mod ingestion_tests {
 
         // === checkpoint 1 assertions (two transactions) ===
 
-        // Both created coins should have NOT_YET_CREATED entries.
+        // Both created coins should have NOT_YET_CREATED entries, with
+        // object_version = lamport - 1 (the version assigned by the create tx,
+        // minus one).
         let entry = find_backward_entry(&pg_store, created_coin_1.as_bytes(), 1)?
             .expect("created coin 1 must have a backward history entry at cp 1");
         assert_eq!(
             entry.object_status,
             BackwardHistoryObjectStatus::NotYetCreated as i16
         );
-        assert_eq!(entry.object_version, -1);
+        assert_eq!(
+            entry.object_version,
+            created_coin_1_version.as_u64() as i64 - 1
+        );
         assert!(entry.serialized_object.is_none());
         assert!(entry.object_digest.is_none());
 
@@ -799,7 +804,10 @@ mod ingestion_tests {
             entry.object_status,
             BackwardHistoryObjectStatus::NotYetCreated as i16
         );
-        assert_eq!(entry.object_version, -1);
+        assert_eq!(
+            entry.object_version,
+            created_coin_2_version.as_u64() as i64 - 1
+        );
 
         // The gas object was mutated twice in checkpoint 1 — there should be
         // two ACTIVE entries with different previous versions.
@@ -839,7 +847,10 @@ mod ingestion_tests {
             entry.object_status,
             BackwardHistoryObjectStatus::NotYetCreated as i16
         );
-        assert_eq!(entry.object_version, -1);
+        assert_eq!(
+            entry.object_version,
+            created_coin_3_version.as_u64() as i64 - 1
+        );
 
         let entry = find_backward_entry(&pg_store, gas_object_id.as_bytes(), 2)?
             .expect("gas object must have a backward history entry at cp 2");

--- a/crates/iota-indexer/tests/rpc-tests/backward_history.rs
+++ b/crates/iota-indexer/tests/rpc-tests/backward_history.rs
@@ -76,14 +76,19 @@ pub async fn call_test_fn(
         .unwrap()
 }
 
-/// Extract the first created object ID from a transaction response.
-pub fn first_created_id(resp: &iota_json_rpc_types::IotaTransactionBlockResponse) -> ObjectID {
+/// Extract the id and version of the first created object from a transaction
+/// response.
+pub fn first_created(
+    resp: &iota_json_rpc_types::IotaTransactionBlockResponse,
+) -> (ObjectID, SequenceNumber) {
     resp.object_changes
         .as_ref()
         .unwrap()
         .iter()
         .find_map(|c| match c {
-            ObjectChange::Created { object_id, .. } => Some(*object_id),
+            ObjectChange::Created {
+                object_id, version, ..
+            } => Some((*object_id, *version)),
             _ => None,
         })
         .expect("expected a created object")
@@ -167,7 +172,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
             Some(gas_id),
         )
         .await;
-        let item_id = first_created_id(&resp);
+        let (item_id, item_create_version) = first_created(&resp);
         let create_cp = resp.checkpoint.unwrap() as i64;
 
         let entry = find_backward_entry(store, item_id.as_bytes(), create_cp)?
@@ -176,7 +181,12 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
             entry.object_status,
             BackwardHistoryObjectStatus::NotYetCreated as i16
         );
-        assert_eq!(entry.object_version, -1);
+        // NotYetCreated rows carry lamport - 1 so MIN(object_version) stays
+        // monotonic across the object's lifecycle.
+        assert_eq!(
+            entry.object_version,
+            item_create_version.as_u64() as i64 - 1
+        );
         assert!(entry.serialized_object.is_none());
         assert!(entry.object_digest.is_none());
 
@@ -225,7 +235,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         )
         .await;
         let wrap_cp = resp.checkpoint.unwrap() as i64;
-        let box_id = first_created_id(&resp);
+        let (box_id, box_create_version) = first_created(&resp);
 
         // Item was wrapped → ACTIVE backward entry with previous data.
         let entry = find_backward_entry(store, item_id.as_bytes(), wrap_cp)?
@@ -243,7 +253,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
             entry.object_status,
             BackwardHistoryObjectStatus::NotYetCreated as i16
         );
-        assert_eq!(entry.object_version, -1);
+        assert_eq!(entry.object_version, box_create_version.as_u64() as i64 - 1);
 
         // ================================================================
         // Step 4: UNWRAP — unwrap the item from the Box
@@ -328,7 +338,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
             Some(gas_id),
         )
         .await;
-        let item2_id = first_created_id(&resp);
+        let (item2_id, _) = first_created(&resp);
 
         // 6b. Wrap it.
         let resp = call_test_fn(
@@ -342,7 +352,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
             Some(gas_id),
         )
         .await;
-        let box2_id = first_created_id(&resp);
+        let (box2_id, _) = first_created(&resp);
 
         // 6c. Unwrap-then-delete.
         let resp = call_test_fn(

--- a/crates/iota-indexer/tests/rpc-tests/checkpointed_objects.rs
+++ b/crates/iota-indexer/tests/rpc-tests/checkpointed_objects.rs
@@ -15,7 +15,7 @@ use iota_json::call_args;
 use iota_types::crypto::{AccountKeyPair, IotaKeyPair, get_key_pair};
 
 use crate::{
-    backward_history::{call_test_fn, first_created_id},
+    backward_history::{call_test_fn, first_created},
     common::{
         ApiTestSetup, indexer_wait_for_object, indexer_wait_for_transaction,
         publish_test_move_package,
@@ -74,7 +74,7 @@ fn checkpointed_objects_wrap_delete_unwrap_lifecycle() -> Result<(), anyhow::Err
             Some(gas_id),
         )
         .await;
-        let item_id = first_created_id(&resp);
+        let (item_id, _) = first_created(&resp);
 
         let entry = find_checkpointed_object(store, item_id.as_bytes())?
             .expect("item should exist in checkpointed_objects after creation");
@@ -99,7 +99,7 @@ fn checkpointed_objects_wrap_delete_unwrap_lifecycle() -> Result<(), anyhow::Err
             Some(gas_id),
         )
         .await;
-        let box_id = first_created_id(&resp);
+        let (box_id, _) = first_created(&resp);
 
         let entry = find_checkpointed_object(store, item_id.as_bytes())?
             .expect("wrapped item should still exist in checkpointed_objects as tombstone");


### PR DESCRIPTION
# Description of change

Switch the not yet created version to `lamport - 1`, matching the unwrap path and the original design proposal. Each create now results in a distinct version keeping versions of each object monotonic, so MIN(version) works properly in the consistent view query.

Add an e2e test exercising create -> delete -> recreate of a DOF across four checkpoints. The test fails on the old `-1` ingestion (`cv2_after` returns no edges) and passes with the fix.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11686

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
