### PR TITLE
feat(grpc,core): Apply shared traffic controller to gRPC API and refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6242,6 +6242,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "iota-config",
+ "iota-core",
  "iota-metrics",
  "iota-node-storage",
  "iota-protocol-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5658,6 +5658,7 @@ dependencies = [
  "fastcrypto-tbls",
  "fs_extra",
  "futures",
+ "http 1.4.0",
  "iota-archival",
  "iota-authority-aggregation",
  "iota-common",

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -28,6 +28,7 @@ eyre.workspace = true
 fastcrypto.workspace = true
 fastcrypto-tbls.workspace = true
 futures.workspace = true
+http.workspace = true
 itertools.workspace = true
 lru.workspace = true
 mockall.workspace = true

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -46,10 +46,7 @@ use prometheus::{
     register_int_counter_with_registry,
 };
 use tap::TapFallible;
-use tonic::{
-    metadata::{Ascii, MetadataValue},
-    transport::server::TcpConnectInfo,
-};
+use tonic::transport::server::TcpConnectInfo;
 use tracing::{Instrument, debug, error, error_span, info, trace_span, warn};
 
 use crate::{
@@ -59,7 +56,9 @@ use crate::{
         ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
     },
     starfish_adapter::LazyStarfishClient,
-    traffic_controller::{TrafficController, parse_ip, policies::TrafficTally},
+    traffic_controller::{
+        ClientIpStatus, TrafficController, get_client_ip, policies::TrafficTally,
+    },
 };
 
 #[cfg(test)]
@@ -1019,101 +1018,68 @@ impl ValidatorService {
         request: &tonic::Request<T>,
         source: &ClientIdSource,
     ) -> Option<IpAddr> {
-        let forwarded_header = request.metadata().get_all("x-forwarded-for").iter().next();
-
-        if let Some(header) = forwarded_header {
+        // Observability gauge: track the hop depth even when we're not using
+        // x-forwarded-for as the source, to detect misconfigured proxies.
+        if let Some(header) = request.metadata().get_all("x-forwarded-for").iter().next() {
             let num_hops = header
                 .to_str()
                 .map(|h| h.split(',').count().saturating_sub(1))
                 .unwrap_or(0);
-
             self.metrics.x_forwarded_for_num_hops.set(num_hops as f64);
         }
 
-        match source {
-            ClientIdSource::SocketAddr => {
-                let socket_addr: Option<SocketAddr> = request.remote_addr();
-
+        match get_client_ip(request.metadata().as_ref(), request.remote_addr(), source) {
+            ClientIpStatus::Ok(ip) => Some(ip),
+            ClientIpStatus::SocketAddrMissing => {
                 // We will hit this case if the IO type used does not
                 // implement Connected or when using a unix domain socket.
                 // TODO: once we have confirmed that no legitimate traffic
                 // is hitting this case, we should reject such requests that
                 // hit this case.
-                if let Some(socket_addr) = socket_addr {
-                    Some(socket_addr.ip())
+                if cfg!(msim) {
+                    // Ignore the error from simtests.
+                } else if cfg!(test) {
+                    panic!("Failed to get remote address from request");
                 } else {
-                    if cfg!(msim) {
-                        // Ignore the error from simtests.
-                    } else if cfg!(test) {
-                        panic!("Failed to get remote address from request");
-                    } else {
-                        self.metrics.connection_ip_not_found.inc();
-                        error!("Failed to get remote address from request");
-                    }
-                    None
+                    self.metrics.connection_ip_not_found.inc();
+                    error!("Failed to get remote address from request");
                 }
+                None
             }
-            ClientIdSource::XForwardedFor(num_hops) => {
-                let do_header_parse = |op: &MetadataValue<Ascii>| {
-                    match op.to_str() {
-                        Ok(header_val) => {
-                            let header_contents =
-                                header_val.split(',').map(str::trim).collect::<Vec<_>>();
-                            if *num_hops == 0 {
-                                error!(
-                                    "x-forwarded-for: 0 specified. x-forwarded-for contents: {:?}. Please assign nonzero value for \
-                                    number of hops here, or use `socket-addr` client-id-source type if requests are not being proxied \
-                                    to this node. Skipping traffic controller request handling.",
-                                    header_contents,
-                                );
-                                return None;
-                            }
-                            let contents_len = header_contents.len();
-                            if contents_len < *num_hops {
-                                error!(
-                                    "x-forwarded-for header value of {:?} contains {} values, but {} hops were specified. \
-                                    Expected at least {} values. Please correctly set the `x-forwarded-for` value under \
-                                    `client-id-source` in the node config.",
-                                    header_contents, contents_len, num_hops, contents_len,
-                                );
-                                self.metrics.client_id_source_config_mismatch.inc();
-                                return None;
-                            }
-                            let Some(client_ip) = header_contents.get(contents_len - num_hops)
-                            else {
-                                error!(
-                                    "x-forwarded-for header value of {:?} contains {} values, but {} hops were specified. \
-                                    Expected at least {} values. Skipping traffic controller request handling.",
-                                    header_contents, contents_len, num_hops, contents_len,
-                                );
-                                return None;
-                            };
-                            parse_ip(client_ip).or_else(|| {
-                                self.metrics.forwarded_header_parse_error.inc();
-                                None
-                            })
-                        }
-                        Err(e) => {
-                            // TODO: once we have confirmed that no legitimate traffic
-                            // is hitting this case, we should reject such requests that
-                            // hit this case.
-                            self.metrics.forwarded_header_invalid.inc();
-                            error!("Invalid UTF-8 in x-forwarded-for header: {:?}", e);
-                            None
-                        }
-                    }
-                };
-                if let Some(op) = request.metadata().get("x-forwarded-for") {
-                    do_header_parse(op)
-                } else if let Some(op) = request.metadata().get("X-Forwarded-For") {
-                    do_header_parse(op)
-                } else {
-                    self.metrics.forwarded_header_not_included.inc();
-                    error!(
-                        "x-forwarded-for header not present for request despite node configuring x-forwarded-for tracking type"
-                    );
-                    None
-                }
+            ClientIpStatus::XForwardedForHeaderMissing => {
+                self.metrics.forwarded_header_not_included.inc();
+                error!(
+                    "x-forwarded-for header not present for request despite node configuring x-forwarded-for tracking type"
+                );
+                None
+            }
+            ClientIpStatus::XForwardedForInvalidUtf8 => {
+                // TODO: once we have confirmed that no legitimate traffic
+                // is hitting this case, we should reject such requests that
+                // hit this case.
+                self.metrics.forwarded_header_invalid.inc();
+                error!("Invalid UTF-8 in x-forwarded-for header");
+                None
+            }
+            ClientIpStatus::XForwardedForZeroHops => {
+                error!(
+                    "x-forwarded-for: 0 specified. Please assign nonzero value for number of hops here, or use \
+                    `socket-addr` client-id-source type if requests are not being proxied to this node. \
+                    Skipping traffic controller request handling."
+                );
+                None
+            }
+            ClientIpStatus::XForwardedForConfigMismatch { expected, actual } => {
+                error!(
+                    "x-forwarded-for header contains {actual} values, but {expected} hops were specified. \
+                    Please correctly set the `x-forwarded-for` value under `client-id-source` in the node config."
+                );
+                self.metrics.client_id_source_config_mismatch.inc();
+                None
+            }
+            ClientIpStatus::XForwardedForUnparsable => {
+                self.metrics.forwarded_header_parse_error.inc();
+                None
             }
         }
     }

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1036,6 +1036,7 @@ impl ValidatorService {
                 // TODO: once we have confirmed that no legitimate traffic
                 // is hitting this case, we should reject such requests that
                 // hit this case.
+                // issue: https://github.com/iotaledger/iota/issues/11756
                 if cfg!(msim) {
                     // Ignore the error from simtests.
                 } else if cfg!(test) {
@@ -1057,6 +1058,7 @@ impl ValidatorService {
                 // TODO: once we have confirmed that no legitimate traffic
                 // is hitting this case, we should reject such requests that
                 // hit this case.
+                // issue: https://github.com/iotaledger/iota/issues/11756
                 self.metrics.forwarded_header_invalid.inc();
                 error!("Invalid UTF-8 in x-forwarded-for header");
                 None

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -47,13 +47,13 @@ pub const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 300;
 type Blocklist = Arc<DashMap<IpAddr, SystemTime>>;
 
 #[derive(Clone)]
-pub struct Blocklists {
+struct Blocklists {
     clients: Blocklist,
     proxied_clients: Blocklist,
 }
 
 #[derive(Clone)]
-pub enum Acl {
+enum Acl {
     Blocklists(Blocklists),
     /// If this variant is set, then we do no tallying or running
     /// of background tasks, and instead simply block all IPs not
@@ -234,26 +234,26 @@ impl TrafficController {
             dry_run,
         } = params;
         if let Some(error_threshold) = error_threshold {
+            let policy = self.error_policy.as_ref().ok_or_else(|| {
+                IotaError::InvalidAdminRequest(
+                    "Cannot reconfigure error policy threshold in allowlist mode".to_string(),
+                )
+            })?;
             self.metrics
                 .error_client_threshold
                 .set(error_threshold as i64);
-            Self::update_policy_threshold(
-                self.error_policy.as_ref().unwrap(),
-                error_threshold,
-                dry_run,
-            )
-            .await?;
+            Self::update_policy_threshold(policy, error_threshold, dry_run).await?;
         }
         if let Some(spam_threshold) = spam_threshold {
+            let policy = self.spam_policy.as_ref().ok_or_else(|| {
+                IotaError::InvalidAdminRequest(
+                    "Cannot reconfigure spam policy threshold in allowlist mode".to_string(),
+                )
+            })?;
             self.metrics
                 .spam_client_threshold
                 .set(spam_threshold as i64);
-            Self::update_policy_threshold(
-                self.spam_policy.as_ref().unwrap(),
-                spam_threshold,
-                dry_run,
-            )
-            .await?;
+            Self::update_policy_threshold(policy, spam_threshold, dry_run).await?;
         }
         if let Some(dry_run) = dry_run {
             self.metrics.dry_run_enabled.set(dry_run as i64);

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -1020,12 +1020,8 @@ pub fn parse_ip(ip: &str) -> Option<IpAddr> {
 }
 
 /// Outcome of resolving the client IP for an incoming request.
-///
-/// The non-`Ok` variants are diagnostic — callers map them to logs/metrics
-/// that match their surface (validator service vs. fullnode gRPC server).
 #[derive(Debug)]
 pub enum ClientIpStatus {
-    /// Successfully resolved the client IP.
     Ok(IpAddr),
     /// `SocketAddr` source but the IO type did not expose a remote address
     /// (e.g. Unix sockets, custom transports). In tests this is usually a
@@ -1040,18 +1036,16 @@ pub enum ClientIpStatus {
     XForwardedForZeroHops,
     /// `XForwardedFor` configured with `expected` hops but the header
     /// only had `actual` entries.
-    XForwardedForConfigMismatch { expected: usize, actual: usize },
+    XForwardedForConfigMismatch {
+        expected: usize,
+        actual: usize,
+    },
     /// `XForwardedFor` header was present and well-formed but the chosen hop
     /// position did not parse as an IP address.
     XForwardedForUnparsable,
 }
 
 /// Resolve the client IP for an incoming request.
-///
-/// Shared between the validator service and the fullnode gRPC server so the
-/// two surfaces agree on which IP gets fed into the traffic controller.
-/// Returns a [`ClientIpStatus`] so callers can attach their own metric
-/// counters and log messages.
 pub fn get_client_ip(
     headers: &http::HeaderMap,
     remote_addr: Option<SocketAddr>,

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -12,7 +12,10 @@ use std::{
     fs,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     ops::Add,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant, SystemTime},
 };
 
@@ -70,6 +73,10 @@ pub struct TrafficController {
     spam_policy: Option<Arc<Mutex<TrafficControlPolicy>>>,
     error_policy: Option<Arc<Mutex<TrafficControlPolicy>>>,
     policy_config: Arc<RwLock<PolicyConfig>>,
+    // Lifted out of `policy_config` so the request hot path in `check`
+    // can read it with a relaxed atomic load instead of acquiring the
+    // RwLock and cloning the entire config.
+    dry_run: Arc<AtomicBool>,
     fw_config: Option<RemoteFirewallConfig>,
 }
 
@@ -100,6 +107,7 @@ impl TrafficController {
         fw_config: Option<RemoteFirewallConfig>,
     ) -> Self {
         metrics.dry_run_enabled.set(policy_config.dry_run as i64);
+        let dry_run = Arc::new(AtomicBool::new(policy_config.dry_run));
         match policy_config.allow_list.clone() {
             Some(allow_list) => {
                 let allowlist = allow_list
@@ -115,6 +123,7 @@ impl TrafficController {
                     acl: Acl::Allowlist(allowlist),
                     metrics,
                     policy_config: Arc::new(RwLock::new(policy_config)),
+                    dry_run,
                     fw_config,
                     spam_policy: None,
                     error_policy: None,
@@ -135,6 +144,7 @@ impl TrafficController {
                     }),
                     metrics,
                     policy_config: Arc::new(RwLock::new(policy_config)),
+                    dry_run,
                     fw_config,
                     spam_policy: Some(spam_policy),
                     error_policy: Some(error_policy),
@@ -220,7 +230,7 @@ impl TrafficController {
             }
         }
 
-        result.dry_run = Some(self.policy_config.read().await.dry_run);
+        result.dry_run = Some(self.dry_run.load(Ordering::Relaxed));
         result
     }
 
@@ -257,7 +267,7 @@ impl TrafficController {
         }
         if let Some(dry_run) = dry_run {
             self.metrics.dry_run_enabled.set(dry_run as i64);
-            self.policy_config.write().await.dry_run = dry_run;
+            self.dry_run.store(dry_run, Ordering::Relaxed);
         }
 
         Ok(self.get_current_state().await)
@@ -343,9 +353,9 @@ impl TrafficController {
 
     /// Handle check with dry-run mode considered
     pub async fn check(&self, client: &Option<IpAddr>, proxied_client: &Option<IpAddr>) -> bool {
-        let policy_config = { self.policy_config.read().await.clone() };
+        let dry_run = self.dry_run.load(Ordering::Relaxed);
         let check_with_dry_run_maybe = |allowed| -> bool {
-            match (allowed, policy_config.dry_run) {
+            match (allowed, dry_run) {
                 // request allowed
                 (true, _) => true,
                 // request blocked while in dry-run mode

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -26,7 +26,8 @@ use iota_metrics::spawn_monitored_task;
 use iota_types::{
     error::IotaError,
     traffic_control::{
-        PolicyConfig, PolicyType, RemoteFirewallConfig, TrafficControlReconfigParams, Weight,
+        ClientIdSource, PolicyConfig, PolicyType, RemoteFirewallConfig,
+        TrafficControlReconfigParams, Weight,
     },
 };
 use parking_lot::Mutex as ParkingLotMutex;
@@ -1016,4 +1017,77 @@ pub fn parse_ip(ip: &str) -> Option<IpAddr> {
                 None
             })
     })
+}
+
+/// Outcome of resolving the client IP for an incoming request.
+///
+/// The non-`Ok` variants are diagnostic — callers map them to logs/metrics
+/// that match their surface (validator service vs. fullnode gRPC server).
+#[derive(Debug)]
+pub enum ClientIpStatus {
+    /// Successfully resolved the client IP.
+    Ok(IpAddr),
+    /// `SocketAddr` source but the IO type did not expose a remote address
+    /// (e.g. Unix sockets, custom transports). In tests this is usually a
+    /// programming error; in production it usually means a misconfigured
+    /// transport.
+    SocketAddrMissing,
+    /// `XForwardedFor` source but no `x-forwarded-for` header on the request.
+    XForwardedForHeaderMissing,
+    /// `XForwardedFor` source but the header value was not valid UTF-8.
+    XForwardedForInvalidUtf8,
+    /// `XForwardedFor` configured with `num_hops == 0` (operator misconfig).
+    XForwardedForZeroHops,
+    /// `XForwardedFor` configured with `expected` hops but the header
+    /// only had `actual` entries.
+    XForwardedForConfigMismatch { expected: usize, actual: usize },
+    /// `XForwardedFor` header was present and well-formed but the chosen hop
+    /// position did not parse as an IP address.
+    XForwardedForUnparsable,
+}
+
+/// Resolve the client IP for an incoming request.
+///
+/// Shared between the validator service and the fullnode gRPC server so the
+/// two surfaces agree on which IP gets fed into the traffic controller.
+/// Returns a [`ClientIpStatus`] so callers can attach their own metric
+/// counters and log messages.
+pub fn get_client_ip(
+    headers: &http::HeaderMap,
+    remote_addr: Option<SocketAddr>,
+    source: &ClientIdSource,
+) -> ClientIpStatus {
+    match source {
+        ClientIdSource::SocketAddr => match remote_addr {
+            Some(addr) => ClientIpStatus::Ok(addr.ip()),
+            None => ClientIpStatus::SocketAddrMissing,
+        },
+        ClientIdSource::XForwardedFor(num_hops) => {
+            let header = match headers
+                .get("x-forwarded-for")
+                .or_else(|| headers.get("X-Forwarded-For"))
+            {
+                Some(h) => h,
+                None => return ClientIpStatus::XForwardedForHeaderMissing,
+            };
+            let value = match header.to_str() {
+                Ok(v) => v,
+                Err(_) => return ClientIpStatus::XForwardedForInvalidUtf8,
+            };
+            if *num_hops == 0 {
+                return ClientIpStatus::XForwardedForZeroHops;
+            }
+            let contents: Vec<&str> = value.split(',').map(str::trim).collect();
+            if contents.len() < *num_hops {
+                return ClientIpStatus::XForwardedForConfigMismatch {
+                    expected: *num_hops,
+                    actual: contents.len(),
+                };
+            }
+            match parse_ip(contents[contents.len() - num_hops]) {
+                Some(ip) => ClientIpStatus::Ok(ip),
+                None => ClientIpStatus::XForwardedForUnparsable,
+            }
+        }
+    }
 }

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -32,6 +32,7 @@ tracing.workspace = true
 
 # internal dependencies
 iota-config.workspace = true
+iota-core.workspace = true
 iota-grpc-types.workspace = true
 iota-metrics.workspace = true
 iota-node-storage.workspace = true

--- a/crates/iota-grpc-server/src/lib.rs
+++ b/crates/iota-grpc-server/src/lib.rs
@@ -15,6 +15,7 @@ pub mod move_package_service;
 pub mod response;
 pub mod server;
 pub mod state_service;
+pub mod traffic_control;
 pub mod transaction_execution_service;
 pub mod transaction_filter;
 pub mod types;
@@ -29,6 +30,7 @@ pub use move_package_service::MovePackageGrpcService;
 pub use response::append_info_headers;
 pub use server::{GrpcServerHandle, start_grpc_server};
 pub use state_service::StateGrpcService;
+pub use traffic_control::TrafficControlLayer;
 pub use transaction_execution_service::TransactionExecutionGrpcService;
 pub use types::{
     DynamicFieldIterItem, GrpcCheckpointDataBroadcaster, GrpcReader, OwnedObjectCursor,

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -6,12 +6,13 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
+use iota_core::traffic_controller::TrafficController;
 use iota_grpc_types::v1::{
     ledger_service as grpc_ledger_service, move_package_service as grpc_move_package_service,
     service_methods, state_service as grpc_state_service,
     transaction_execution_service as grpc_tx_service,
 };
-use iota_types::transaction_executor::TransactionExecutor;
+use iota_types::{traffic_control::ClientIdSource, transaction_executor::TransactionExecutor};
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::TcpListenerStream;
 use tokio_util::sync::CancellationToken;
@@ -20,7 +21,7 @@ use tonic::transport::{Identity, Server, ServerTlsConfig};
 use crate::{
     GrpcCheckpointDataBroadcaster, GrpcReader, GrpcServerMetrics, LedgerGrpcService,
     MovePackageGrpcService, StateGrpcService, TransactionExecutionGrpcService,
-    metrics::GrpcMetricsLayer,
+    metrics::GrpcMetricsLayer, traffic_control::TrafficControlLayer,
 };
 
 /// Handle to control a running gRPC server
@@ -130,6 +131,8 @@ pub async fn start_grpc_server(
     shutdown_token: CancellationToken,
     chain_id: iota_types::digests::ChainIdentifier,
     metrics: Option<GrpcServerMetrics>,
+    traffic_controller: Option<Arc<TrafficController>>,
+    client_id_source: Option<ClientIdSource>,
 ) -> Result<GrpcServerHandle> {
     // Create broadcast channels
     let (checkpoint_data_tx, _) = broadcast::channel(config.broadcast_buffer_size as usize);
@@ -207,40 +210,31 @@ pub async fn start_grpc_server(
             .map_err(|e| anyhow::anyhow!("failed to configure TLS: {}", e))?;
     }
 
-    // Add services and spawn the server, optionally wrapping with metrics layer
-    let server_handle = if let Some(metrics) = metrics {
-        // Use the auto-generated exact method path whitelist so the metrics
-        // layer can label unrecognized/non-gRPC traffic under a single "SPAM"
-        // bucket instead of creating unbounded cardinality from arbitrary HTTP
-        // paths.
-        let mut layered_builder = server_builder.layer(GrpcMetricsLayer::new(
-            Arc::new(metrics),
-            &service_methods::ALL_METHOD_PATHS,
-        ));
-        build_and_spawn!(
-            layered_builder,
-            ledger_service,
-            tx_service,
-            state_service,
-            move_package_service,
-            config,
-            listener,
-            actual_addr,
-            shutdown_token
-        )
-    } else {
-        build_and_spawn!(
-            server_builder,
-            ledger_service,
-            tx_service,
-            state_service,
-            move_package_service,
-            config,
-            listener,
-            actual_addr,
-            shutdown_token
-        )
-    };
+    // Order matters: the metrics layer is outermost so it observes blocked requests
+    // too.
+    let mut layered_builder = server_builder.layer(
+        tower::ServiceBuilder::new()
+            .option_layer(
+                metrics.map(|m| {
+                    GrpcMetricsLayer::new(Arc::new(m), &service_methods::ALL_METHOD_PATHS)
+                }),
+            )
+            .option_layer(
+                traffic_controller
+                    .map(|tc| TrafficControlLayer::new(tc, client_id_source.unwrap_or_default())),
+            ),
+    );
+    let server_handle = build_and_spawn!(
+        layered_builder,
+        ledger_service,
+        tx_service,
+        state_service,
+        move_package_service,
+        config,
+        listener,
+        actual_addr,
+        shutdown_token
+    );
 
     Ok(GrpcServerHandle {
         server_handle,

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -9,33 +9,30 @@
 //! one controller across both surfaces so the same blocklist and tally apply
 //! to a given client IP regardless of which API it hits.
 //!
-//! The layer extracts the client IP from `TcpConnectInfo` (added to request
-//! extensions by tonic per connection) or from the `x-forwarded-for` header,
-//! depending on [`ClientIdSource`], calls
-//! [`TrafficController::check`][check] before dispatching, then calls
-//! [`tally`][tally] with a weight derived from the response's gRPC status
-//! code.
+//! The layer extracts the client IP via [`get_client_ip`] (shared with the
+//! validator), calls [`TrafficController::check`][check] before dispatching,
+//! then calls [`tally`][tally] with a weight derived from the response's
+//! gRPC status code.
 //!
 //! [check]: iota_core::traffic_controller::TrafficController::check
 //! [tally]: iota_core::traffic_controller::TrafficController::tally
 
 use std::{
     future::Future,
-    net::{IpAddr, SocketAddr},
+    net::IpAddr,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
     time::SystemTime,
 };
 
-use iota_core::traffic_controller::{TrafficController, parse_ip, policies::TrafficTally};
+use iota_core::traffic_controller::{
+    ClientIpStatus, TrafficController, get_client_ip, policies::TrafficTally,
+};
 use iota_types::traffic_control::{ClientIdSource, Weight};
 use tonic::{Code, Status, transport::server::TcpConnectInfo};
 use tower::{Layer, Service};
-use tracing::error;
-
-/// Header name used for forwarded client identification.
-const X_FORWARDED_FOR: &str = "x-forwarded-for";
+use tracing::warn;
 
 /// Tower [`Layer`] that integrates the shared traffic controller.
 #[derive(Clone)]
@@ -94,7 +91,19 @@ where
 
     fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
         let traffic_controller = self.traffic_controller.clone();
-        let client = extract_client_ip(&req, &self.client_id_source);
+        let remote_addr = req
+            .extensions()
+            .get::<TcpConnectInfo>()
+            .and_then(|info| info.remote_addr());
+        let client = match get_client_ip(req.headers(), remote_addr, &self.client_id_source) {
+            ClientIpStatus::Ok(ip) => Some(ip),
+            other => {
+                warn!(
+                    "Skipping traffic controller request handling for client {remote_addr:?}: {other:?}"
+                );
+                None
+            }
+        };
 
         // Tower contract: the cloned service is the one ready to call, so swap
         // the clone in and keep the previously-ready inner for this request.
@@ -129,9 +138,6 @@ fn tally(traffic_controller: &TrafficController, client: Option<IpAddr>, code: C
         direct: client,
         through_fullnode: None,
         error_info,
-        // Match the JSON-RPC layer: count every request equally as spam.
-        // A future refinement could weight transaction-execution paths more
-        // heavily than reads.
         spam_weight: Weight::one(),
         timestamp: SystemTime::now(),
     });
@@ -151,42 +157,5 @@ fn normalize(code: Code) -> Weight {
         | Code::Unauthenticated
         | Code::PermissionDenied => Weight::one(),
         _ => Weight::zero(),
-    }
-}
-
-fn extract_client_ip<B>(req: &http::Request<B>, source: &ClientIdSource) -> Option<IpAddr> {
-    match source {
-        ClientIdSource::SocketAddr => req
-            .extensions()
-            .get::<TcpConnectInfo>()
-            .and_then(|info| info.remote_addr())
-            .map(|addr: SocketAddr| addr.ip()),
-        ClientIdSource::XForwardedFor(num_hops) => {
-            let header = req
-                .headers()
-                .get(X_FORWARDED_FOR)
-                .or_else(|| req.headers().get("X-Forwarded-For"))?;
-            let value = header
-                .to_str()
-                .map_err(|e| error!("Invalid UTF-8 in x-forwarded-for header: {e:?}"))
-                .ok()?;
-            let contents: Vec<&str> = value.split(',').map(str::trim).collect();
-            if *num_hops == 0 {
-                error!(
-                    "x-forwarded-for: 0 hops specified. Contents: {contents:?}. Set a nonzero hop count or use socket-addr."
-                );
-                return None;
-            }
-            if contents.len() < *num_hops {
-                error!(
-                    "x-forwarded-for header value of {contents:?} contains {} values but {num_hops} hops were specified.",
-                    contents.len()
-                );
-                return None;
-            }
-            contents
-                .get(contents.len() - num_hops)
-                .and_then(|ip| parse_ip(ip))
-        }
     }
 }

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tower [`Layer`] that wires the shared [`TrafficController`] into the
+//! gRPC server.
+//!
+//! The fullnode-facing gRPC API exposes the same class of traffic that the
+//! JSON-RPC API protects, including transaction execution endpoints. We share
+//! one controller across both surfaces so the same blocklist and tally apply
+//! to a given client IP regardless of which API it hits.
+//!
+//! The layer extracts the client IP from `TcpConnectInfo` (added to request
+//! extensions by tonic per connection) or from the `x-forwarded-for` header,
+//! depending on [`ClientIdSource`], calls
+//! [`TrafficController::check`][check] before dispatching, then calls
+//! [`tally`][tally] with a weight derived from the response's gRPC status
+//! code.
+//!
+//! [check]: iota_core::traffic_controller::TrafficController::check
+//! [tally]: iota_core::traffic_controller::TrafficController::tally
+
+use std::{
+    future::Future,
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::SystemTime,
+};
+
+use iota_core::traffic_controller::{TrafficController, parse_ip, policies::TrafficTally};
+use iota_types::traffic_control::{ClientIdSource, Weight};
+use tonic::{Code, Status, transport::server::TcpConnectInfo};
+use tower::{Layer, Service};
+use tracing::error;
+
+/// Header name used for forwarded client identification.
+const X_FORWARDED_FOR: &str = "x-forwarded-for";
+
+/// Tower [`Layer`] that integrates the shared traffic controller.
+#[derive(Clone)]
+pub struct TrafficControlLayer {
+    traffic_controller: Arc<TrafficController>,
+    client_id_source: ClientIdSource,
+}
+
+impl TrafficControlLayer {
+    pub fn new(
+        traffic_controller: Arc<TrafficController>,
+        client_id_source: ClientIdSource,
+    ) -> Self {
+        Self {
+            traffic_controller,
+            client_id_source,
+        }
+    }
+}
+
+impl<S> Layer<S> for TrafficControlLayer {
+    type Service = TrafficControlService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TrafficControlService {
+            inner,
+            traffic_controller: self.traffic_controller.clone(),
+            client_id_source: self.client_id_source.clone(),
+        }
+    }
+}
+
+/// Tower [`Service`] wrapper that gates requests through the traffic
+/// controller.
+#[derive(Clone)]
+pub struct TrafficControlService<S> {
+    inner: S,
+    traffic_controller: Arc<TrafficController>,
+    client_id_source: ClientIdSource,
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for TrafficControlService<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response, S::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        let traffic_controller = self.traffic_controller.clone();
+        let client = extract_client_ip(&req, &self.client_id_source);
+
+        // Tower contract: the cloned service is the one ready to call, so swap
+        // the clone in and keep the previously-ready inner for this request.
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+
+        Box::pin(async move {
+            if !traffic_controller.check(&client, &None).await {
+                let response = Status::resource_exhausted("Too many requests").into_http();
+                tally(&traffic_controller, client, Code::ResourceExhausted);
+                return Ok(response);
+            }
+
+            let result = inner.call(req).await;
+            if let Ok(response) = &result {
+                let code =
+                    Status::from_header_map(response.headers()).map_or(Code::Ok, |s| s.code());
+                tally(&traffic_controller, client, code);
+            }
+            result
+        })
+    }
+}
+
+fn tally(traffic_controller: &TrafficController, client: Option<IpAddr>, code: Code) {
+    let error_info = if matches!(code, Code::Ok) {
+        None
+    } else {
+        Some((normalize(code), format!("{code:?}")))
+    };
+    traffic_controller.tally(TrafficTally {
+        direct: client,
+        through_fullnode: None,
+        error_info,
+        // Match the JSON-RPC layer: count every request equally as spam.
+        // A future refinement could weight transaction-execution paths more
+        // heavily than reads.
+        spam_weight: Weight::one(),
+        timestamp: SystemTime::now(),
+    });
+}
+
+/// Map a gRPC status code to a tally weight.
+///
+/// Mirrors the conservative shape of the JSON-RPC `normalize`: only obvious
+/// client-side mistakes contribute to the error-policy budget. Server-side
+/// failures (`Internal`, `Unavailable`, `DataLoss`) must not count, or a
+/// flaky backend would auto-block legitimate clients.
+fn normalize(code: Code) -> Weight {
+    match code {
+        Code::InvalidArgument
+        | Code::FailedPrecondition
+        | Code::OutOfRange
+        | Code::Unauthenticated
+        | Code::PermissionDenied => Weight::one(),
+        _ => Weight::zero(),
+    }
+}
+
+fn extract_client_ip<B>(req: &http::Request<B>, source: &ClientIdSource) -> Option<IpAddr> {
+    match source {
+        ClientIdSource::SocketAddr => req
+            .extensions()
+            .get::<TcpConnectInfo>()
+            .and_then(|info| info.remote_addr())
+            .map(|addr: SocketAddr| addr.ip()),
+        ClientIdSource::XForwardedFor(num_hops) => {
+            let header = req
+                .headers()
+                .get(X_FORWARDED_FOR)
+                .or_else(|| req.headers().get("X-Forwarded-For"))?;
+            let value = header
+                .to_str()
+                .map_err(|e| error!("Invalid UTF-8 in x-forwarded-for header: {e:?}"))
+                .ok()?;
+            let contents: Vec<&str> = value.split(',').map(str::trim).collect();
+            if *num_hops == 0 {
+                error!(
+                    "x-forwarded-for: 0 hops specified. Contents: {contents:?}. Set a nonzero hop count or use socket-addr."
+                );
+                return None;
+            }
+            if contents.len() < *num_hops {
+                error!(
+                    "x-forwarded-for header value of {contents:?} contains {} values but {num_hops} hops were specified.",
+                    contents.len()
+                );
+                return None;
+            }
+            contents
+                .get(contents.len() - num_hops)
+                .and_then(|ip| parse_ip(ip))
+        }
+    }
+}

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -4,15 +4,8 @@
 //! Tower [`Layer`] that wires the shared [`TrafficController`] into the
 //! gRPC server.
 //!
-//! The fullnode-facing gRPC API exposes the same class of traffic that the
-//! JSON-RPC API protects, including transaction execution endpoints. We share
-//! one controller across both surfaces so the same blocklist and tally apply
-//! to a given client IP regardless of which API it hits.
-//!
-//! The layer extracts the client IP via [`get_client_ip`] (shared with the
-//! validator), calls [`TrafficController::check`][check] before dispatching,
-//! then calls [`tally`][tally] with a weight derived from the response's
-//! gRPC status code.
+//! The layer extracts the client IP via and calls the traffic controller
+//! with a weight derived from the response's gRPC status code.
 //!
 //! [check]: iota_core::traffic_controller::TrafficController::check
 //! [tally]: iota_core::traffic_controller::TrafficController::tally

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -105,16 +105,14 @@ where
             }
         };
 
-        // Tower contract: the cloned service is the one ready to call, so swap
-        // the clone in and keep the previously-ready inner for this request.
+        // Tower contract: `self.inner` is the ready one (poll_ready set it up),
+        // so call it and leave the clone for the next request.
         let cloned = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, cloned);
 
         Box::pin(async move {
             if !traffic_controller.check(&client, &None).await {
-                let response = Status::resource_exhausted("Too many requests").into_http();
-                tally(&traffic_controller, client, Code::ResourceExhausted);
-                return Ok(response);
+                return Ok(Status::resource_exhausted("Too many requests").into_http());
             }
 
             let result = inner.call(req).await;

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -504,6 +504,8 @@ pub async fn start_test_server(
         cancellation_token,
         iota_types::digests::ChainIdentifier::default(),
         None,
+        None,
+        None,
     )
     .await
     .expect("Failed to start gRPC server");

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2295,10 +2295,6 @@ async fn build_grpc_server(
 
     // Create gRPC server metrics
     let grpc_server_metrics = iota_grpc_server::GrpcServerMetrics::new(prometheus_registry);
-
-    // Share the traffic controller and client-id source with the JSON-RPC
-    // server so a single blocklist and policy applies to both surfaces.
-    let traffic_controller = state.traffic_controller.clone();
     let client_id_source = config
         .policy_config
         .as_ref()
@@ -2311,7 +2307,7 @@ async fn build_grpc_server(
         shutdown_token,
         chain_id,
         Some(grpc_server_metrics),
-        traffic_controller,
+        state.traffic_controller.clone(),
         client_id_source,
     )
     .await?;

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2296,6 +2296,14 @@ async fn build_grpc_server(
     // Create gRPC server metrics
     let grpc_server_metrics = iota_grpc_server::GrpcServerMetrics::new(prometheus_registry);
 
+    // Share the traffic controller and client-id source with the JSON-RPC
+    // server so a single blocklist and policy applies to both surfaces.
+    let traffic_controller = state.traffic_controller.clone();
+    let client_id_source = config
+        .policy_config
+        .as_ref()
+        .map(|p| p.client_id_source.clone());
+
     let handle = start_grpc_server(
         grpc_reader,
         executor,
@@ -2303,6 +2311,8 @@ async fn build_grpc_server(
         shutdown_token,
         chain_id,
         Some(grpc_server_metrics),
+        traffic_controller,
+        client_id_source,
     )
     .await?;
 

--- a/crates/iota-types/src/traffic_control.rs
+++ b/crates/iota-types/src/traffic_control.rs
@@ -317,7 +317,7 @@ impl PolicyConfig {
             channel_capacity: 6000,
             spam_sample_rate: Weight::new(1.0).unwrap(),
             dry_run: true,
-            ..PolicyConfig::default()
+            ..Self::default()
         }
     }
 }

--- a/crates/simulacrum-server/src/grpc_server.rs
+++ b/crates/simulacrum-server/src/grpc_server.rs
@@ -46,6 +46,8 @@ pub async fn start_simulacrum_grpc_server(
         shutdown_token,
         chain_id,
         None,
+        None,
+        None,
     )
     .await
 }


### PR DESCRIPTION
# Description of change

* Wires the shared `TrafficController` into the gRPC server as a tower
`Layer`, so the same blocklist and tally apply to a given client IP
regardless of whether it hits the JSON-RPC or gRPC surface.
* Client-IP extraction is factored out of `authority_server.rs` and reused by the
new layer.
* Includes follow-up cleanup on the recent traffic-controller port: https://github.com/iotaledger/iota/pull/11598

## Links to any relevant issues

Closes #11668

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes