### PR TITLE
feat(consensus): StarfishSpeed — optimistic-commit consensus variant

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1315,6 +1315,7 @@
                 "consensus_round_prober": false,
                 "consensus_round_prober_probe_accepted_rounds": false,
                 "consensus_smart_ancestor_selection": false,
+                "consensus_starfish_speed": false,
                 "consensus_zstd_compression": false,
                 "convert_type_argument_error": true,
                 "dependency_linkage_error": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -492,6 +492,10 @@ struct FeatureFlags {
     // If true, only sponsor Move authentication is performed pre-consensus.
     #[serde(skip_serializing_if = "is_false")]
     pre_consensus_sponsor_only_move_authentication: bool,
+
+    // If true, enables the optimistic commit rule (StarfishSpeed) in Starfish consensus.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_starfish_speed: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1731,6 +1735,10 @@ impl ProtocolConfig {
             );
         }
         pre_consensus_sponsor_only_move_authentication
+    }
+
+    pub fn consensus_starfish_speed(&self) -> bool {
+        self.feature_flags.consensus_starfish_speed
     }
 }
 
@@ -3092,6 +3100,10 @@ impl ProtocolConfig {
     pub fn set_pre_consensus_sponsor_only_move_authentication_for_testing(&mut self, val: bool) {
         self.feature_flags
             .pre_consensus_sponsor_only_move_authentication = val;
+    }
+
+    pub fn set_consensus_starfish_speed_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_starfish_speed = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1738,7 +1738,12 @@ impl ProtocolConfig {
     }
 
     pub fn consensus_starfish_speed(&self) -> bool {
-        self.feature_flags.consensus_starfish_speed
+        let res = self.feature_flags.consensus_starfish_speed;
+        assert!(
+            !res || self.consensus_fast_commit_sync(),
+            "consensus_starfish_speed requires consensus_fast_commit_sync to be enabled"
+        );
+        res
     }
 }
 

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -36,6 +36,13 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_min_block_delay")]
     pub min_block_delay: Duration,
 
+    /// Soft counterpart of `leader_timeout`: after this duration we are
+    /// willing to propose a block even without a strong-vote quorum, to avoid
+    /// liveness stalls when leader data is slow to propagate. Fires earlier
+    /// than `leader_timeout` and does not force block creation on its own.
+    #[serde(default = "Parameters::default_soft_leader_timeout")]
+    pub soft_leader_timeout: Duration,
+
     /// Maximum forward time drift (how far in future) allowed for received
     /// blocks.
     #[serde(default = "Parameters::default_max_forward_time_drift")]
@@ -129,7 +136,7 @@ pub struct Parameters {
 
 impl Parameters {
     pub(crate) fn default_leader_timeout() -> Duration {
-        Duration::from_millis(250)
+        Duration::from_millis(200)
     }
 
     pub(crate) fn default_min_block_delay() -> Duration {
@@ -147,6 +154,10 @@ impl Parameters {
             // block rate to 20 blocks/sec
             Duration::from_millis(50)
         }
+    }
+
+    pub(crate) fn default_soft_leader_timeout() -> Duration {
+        Duration::from_millis(100)
     }
 
     pub(crate) fn default_max_forward_time_drift() -> Duration {
@@ -272,6 +283,7 @@ impl Default for Parameters {
             db_path: PathBuf::default(),
             leader_timeout: Parameters::default_leader_timeout(),
             min_block_delay: Parameters::default_min_block_delay(),
+            soft_leader_timeout: Parameters::default_soft_leader_timeout(),
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),
             max_headers_per_commit_sync_fetch:
                 Parameters::default_max_headers_per_commit_sync_fetch(),

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -144,7 +144,7 @@ pub struct Parameters {
 
 impl Parameters {
     pub(crate) fn default_leader_timeout() -> Duration {
-        Duration::from_millis(250)
+        Duration::from_millis(200)
     }
 
     pub(crate) fn default_min_block_delay() -> Duration {

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -132,6 +132,14 @@ pub struct Parameters {
     /// discovered, without affecting protocol-level endpoint availability.
     #[serde(default = "Parameters::default_enable_fast_commit_syncer")]
     pub enable_fast_commit_syncer: bool,
+
+    /// Enable adaptive acknowledgment filtering for StarfishSpeed.
+    /// Local heuristic that drops acks for authorities persistently blamed
+    /// by recent strong-vote masks. Effective only when the protocol-level
+    /// `consensus_starfish_speed` flag is also on. Enabled by default;
+    /// operators can disable it locally without a protocol change.
+    #[serde(default = "Parameters::default_enable_starfish_speed_adaptive_acknowledgments")]
+    pub enable_starfish_speed_adaptive_acknowledgments: bool,
 }
 
 impl Parameters {
@@ -275,6 +283,10 @@ impl Parameters {
         // without waiting for a protocol upgrade.
         true
     }
+
+    pub(crate) fn default_enable_starfish_speed_adaptive_acknowledgments() -> bool {
+        true
+    }
 }
 
 impl Default for Parameters {
@@ -305,6 +317,8 @@ impl Default for Parameters {
             fast_commit_sync_batch_size: Parameters::default_fast_commit_sync_batch_size(),
             commit_sync_gap_threshold: Parameters::default_commit_sync_gap_threshold(),
             enable_fast_commit_syncer: Parameters::default_enable_fast_commit_syncer(),
+            enable_starfish_speed_adaptive_acknowledgments:
+                Parameters::default_enable_starfish_speed_adaptive_acknowledgments(),
         }
     }
 }

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -144,7 +144,7 @@ pub struct Parameters {
 
 impl Parameters {
     pub(crate) fn default_leader_timeout() -> Duration {
-        Duration::from_millis(200)
+        Duration::from_millis(250)
     }
 
     pub(crate) fn default_min_block_delay() -> Duration {

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -4,7 +4,7 @@ expression: parameters
 ---
 leader_timeout:
   secs: 0
-  nanos: 250000000
+  nanos: 200000000
 min_block_delay:
   secs: 0
   nanos: 50000000

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -37,3 +37,4 @@ tonic:
 fast_commit_sync_batch_size: 1000
 commit_sync_gap_threshold: 1000
 enable_fast_commit_syncer: true
+enable_starfish_speed_adaptive_acknowledgments: true

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -4,10 +4,13 @@ expression: parameters
 ---
 leader_timeout:
   secs: 0
-  nanos: 250000000
+  nanos: 200000000
 min_block_delay:
   secs: 0
   nanos: 50000000
+soft_leader_timeout:
+  secs: 0
+  nanos: 100000000
 max_forward_time_drift:
   secs: 0
   nanos: 500000000

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -4,7 +4,7 @@ expression: parameters
 ---
 leader_timeout:
   secs: 0
-  nanos: 200000000
+  nanos: 250000000
 min_block_delay:
   secs: 0
   nanos: 50000000

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -99,6 +99,11 @@ impl ConsensusAuthority {
                 .join(", ")
         );
         info!("Consensus parameters: {:?}", parameters);
+        info!(
+            "Protocol consensus flags: starfish_speed={} fast_commit_sync={}",
+            protocol_config.consensus_starfish_speed(),
+            protocol_config.consensus_fast_commit_sync(),
+        );
         info!("Consensus committee: {:?}", committee);
         let context = Arc::new(Context::new(
             epoch_start_timestamp_ms,

--- a/crates/starfish/core/src/authority_set.rs
+++ b/crates/starfish/core/src/authority_set.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeSet, fmt};
+
+use serde::{Deserialize, Serialize};
+use starfish_config::AuthorityIndex;
+
+/// Compact bitmask representing a subset of authorities.
+/// Supports up to 256 authorities (AuthorityIndex is u8).
+#[derive(Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AuthoritySet([u64; 4]);
+
+impl AuthoritySet {
+    /// Creates an empty authority set.
+    pub fn new() -> Self {
+        Self([0; 4])
+    }
+
+    /// Creates a set with two authorities pre-inserted.
+    pub fn new_with(a: AuthorityIndex, b: AuthorityIndex) -> Self {
+        let mut s = Self::new();
+        s.insert(a);
+        s.insert(b);
+        s
+    }
+
+    /// Inserts an authority into the set. Returns true if the authority was
+    /// not already present.
+    pub fn insert(&mut self, index: AuthorityIndex) -> bool {
+        let i = index.value();
+        let array_index = i / 64;
+        let bit_pos = i % 64;
+        let mask = 1u64 << bit_pos;
+        let already_present = (self.0[array_index] & mask) != 0;
+        self.0[array_index] |= mask;
+        !already_present
+    }
+
+    /// Returns true if the set contains the given authority.
+    pub fn contains(&self, index: AuthorityIndex) -> bool {
+        let i = index.value();
+        let array_index = i / 64;
+        let bit_pos = i % 64;
+        (self.0[array_index] & (1u64 << bit_pos)) != 0
+    }
+
+    /// Returns true if the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.iter().all(|&bits| bits == 0)
+    }
+
+    /// Returns the number of authorities in the set.
+    pub fn len(&self) -> usize {
+        self.0.iter().map(|bits| bits.count_ones() as usize).sum()
+    }
+
+    /// Iterates over the authority indices in the set, in ascending order.
+    pub fn iter(&self) -> impl Iterator<Item = AuthorityIndex> + '_ {
+        self.0.iter().enumerate().flat_map(|(array_index, &bits)| {
+            let base = array_index * 64;
+            BitIter(bits).map(move |bit| AuthorityIndex::from((base + bit) as u8))
+        })
+    }
+
+    /// Converts to a BTreeSet of AuthorityIndex.
+    pub fn to_btreeset(self) -> BTreeSet<AuthorityIndex> {
+        self.iter().collect()
+    }
+}
+
+impl From<&BTreeSet<AuthorityIndex>> for AuthoritySet {
+    fn from(set: &BTreeSet<AuthorityIndex>) -> Self {
+        let mut result = Self::new();
+        for &index in set {
+            result.insert(index);
+        }
+        result
+    }
+}
+
+impl fmt::Debug for AuthoritySet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let indices: Vec<_> = self.iter().collect();
+        write!(f, "AuthoritySet({indices:?})")
+    }
+}
+
+/// Iterator over set bits in a u64.
+struct BitIter(u64);
+
+impl Iterator for BitIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        if self.0 == 0 {
+            return None;
+        }
+        let bit = self.0.trailing_zeros() as usize;
+        self.0 &= self.0 - 1;
+        Some(bit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_set() {
+        let set = AuthoritySet::new();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+        assert_eq!(set.iter().count(), 0);
+    }
+
+    #[test]
+    fn test_insert_and_contains() {
+        let mut set = AuthoritySet::new();
+        let idx = AuthorityIndex::new_for_test(5);
+
+        assert!(!set.contains(idx));
+        assert!(set.insert(idx));
+        assert!(set.contains(idx));
+        assert!(!set.insert(idx)); // duplicate
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn test_across_buckets() {
+        let mut set = AuthoritySet::new();
+        set.insert(AuthorityIndex::new_for_test(0));
+        set.insert(AuthorityIndex::new_for_test(63));
+        set.insert(AuthorityIndex::new_for_test(64));
+        set.insert(AuthorityIndex::new_for_test(127));
+        set.insert(AuthorityIndex::new_for_test(128));
+        set.insert(AuthorityIndex::new_for_test(255));
+
+        assert_eq!(set.len(), 6);
+        assert!(set.contains(AuthorityIndex::new_for_test(0)));
+        assert!(set.contains(AuthorityIndex::new_for_test(255)));
+        assert!(!set.contains(AuthorityIndex::new_for_test(1)));
+    }
+
+    #[test]
+    fn test_iter_order() {
+        let mut set = AuthoritySet::new();
+        set.insert(AuthorityIndex::new_for_test(200));
+        set.insert(AuthorityIndex::new_for_test(3));
+        set.insert(AuthorityIndex::new_for_test(100));
+        set.insert(AuthorityIndex::new_for_test(65));
+
+        let indices: Vec<_> = set.iter().map(|i| i.value()).collect();
+        assert_eq!(indices, vec![3, 65, 100, 200]);
+    }
+
+    #[test]
+    fn test_new_with() {
+        let a = AuthorityIndex::new_for_test(3);
+        let b = AuthorityIndex::new_for_test(7);
+        let set = AuthoritySet::new_with(a, b);
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(a));
+        assert!(set.contains(b));
+    }
+
+    #[test]
+    fn test_btreeset_roundtrip() {
+        let mut btree = BTreeSet::new();
+        btree.insert(AuthorityIndex::new_for_test(10));
+        btree.insert(AuthorityIndex::new_for_test(50));
+        btree.insert(AuthorityIndex::new_for_test(200));
+
+        let authority_set = AuthoritySet::from(&btree);
+        assert_eq!(authority_set.to_btreeset(), btree);
+    }
+}

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -2,7 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, fmt::Display, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+    sync::Arc,
+};
 
 use parking_lot::RwLock;
 use starfish_config::{AuthorityIndex, Stake};
@@ -10,7 +14,7 @@ use tracing::warn;
 
 use crate::{
     block_header::{BlockHeaderAPI, BlockRef, Round, Slot, VerifiedBlockHeader},
-    commit::{LeaderStatus, WAVE_LENGTH, WaveNumber},
+    commit::{CommitMetastate, LeaderStatus, WAVE_LENGTH, WaveNumber},
     context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
@@ -24,6 +28,10 @@ mod base_committer_tests;
 #[cfg(test)]
 #[path = "tests/base_committer_declarative_tests.rs"]
 mod base_committer_declarative_tests;
+
+#[cfg(test)]
+#[path = "tests/base_committer_metastate_tests.rs"]
+mod base_committer_metastate_tests;
 
 #[derive(Default)]
 pub(crate) struct BaseCommitterOptions {
@@ -92,7 +100,10 @@ impl BaseCommitter {
         let mut leaders_with_enough_support: Vec<_> = leader_blocks
             .into_iter()
             .filter(|l| self.enough_leader_support(certifying_round, l))
-            .map(LeaderStatus::Commit)
+            .map(|leader_block| {
+                let metastate = self.determine_metastate_direct(&leader_block);
+                LeaderStatus::Commit(leader_block, metastate)
+            })
             .collect();
 
         // There can be at most one leader with enough support for each round, otherwise
@@ -106,33 +117,27 @@ impl BaseCommitter {
             .unwrap_or(LeaderStatus::Undecided(leader))
     }
 
-    /// Apply the indirect decision rule to the specified leader to see whether
-    /// we can indirect-commit or indirect-skip it.
-    #[tracing::instrument(skip_all, fields(leader = %leader_slot))]
+    /// Apply the indirect rule; return `current` unchanged if no committed
+    /// anchor is reachable.
+    #[tracing::instrument(skip_all, fields(leader = %current))]
     pub fn try_indirect_decide<'a>(
         &self,
-        leader_slot: Slot,
+        current: LeaderStatus,
         leaders: impl Iterator<Item = &'a LeaderStatus>,
     ) -> LeaderStatus {
-        // The anchor is the first committed leader with round higher than the decision
-        // round of the target leader. We must stop the iteration upon
-        // encountering an undecided leader.
-        let anchors = leaders.filter(|x| leader_slot.round + WAVE_LENGTH <= x.round());
-
+        let slot = current.slot();
+        let anchors = leaders.filter(|x| slot.round + WAVE_LENGTH <= x.round());
         for anchor in anchors {
-            tracing::trace!(
-                "[{self}] Trying to indirect-decide {leader_slot} using anchor {anchor}",
-            );
+            tracing::trace!("[{self}] Trying to indirect-decide {slot} using anchor {anchor}",);
             match anchor {
-                LeaderStatus::Commit(anchor) => {
-                    return self.decide_leader_from_anchor(anchor, leader_slot);
+                LeaderStatus::Commit(anchor, _) => {
+                    return self.decide_leader_from_anchor(anchor, slot);
                 }
                 LeaderStatus::Skip(..) => (),
-                LeaderStatus::Undecided(..) => break,
+                LeaderStatus::Undecided(..) => return current,
             }
         }
-
-        LeaderStatus::Undecided(leader_slot)
+        current
     }
 
     pub fn elect_leader(&self, round: Round) -> Option<Slot> {
@@ -255,16 +260,51 @@ impl BaseCommitter {
             .reachable_headers_at_round_above_last_commit(anchor, certifying_round);
 
         // Use those potential certificates to determine which (if any) of the target
-        // leader blocks can be committed.
-        let mut certified_leader_blocks: Vec<_> = leader_blocks
-            .into_iter()
-            .filter(|leader_block| {
+        // leader blocks can be committed, and — when StarfishSpeed is enabled —
+        // classify the metastate in the same walk. When the flag is off we
+        // stick to the cheap regular-certificate-only check.
+        let starfish_speed = self.context.protocol_config.consensus_starfish_speed();
+        let mut certified_leader_blocks: Vec<(VerifiedBlockHeader, Option<CommitMetastate>)> =
+            Vec::new();
+        for leader_block in leader_blocks {
+            let (any_cert, metastate) = if starfish_speed {
+                let (vote_refs, strong_vote_refs) =
+                    self.vote_and_strong_vote_refs_for_leader(&leader_block);
+                let mut any_cert = false;
+                let mut any_strong = false;
+                for potential_certificate in &potential_certificates {
+                    let (is_cert, is_strong) = self.classify_certificate(
+                        potential_certificate,
+                        &vote_refs,
+                        &strong_vote_refs,
+                    );
+                    any_cert |= is_cert;
+                    any_strong |= is_strong;
+                    if any_cert && any_strong {
+                        break;
+                    }
+                }
+                let metastate = if any_cert {
+                    Some(if any_strong {
+                        CommitMetastate::Optimistic
+                    } else {
+                        CommitMetastate::Standard
+                    })
+                } else {
+                    None
+                };
+                (any_cert, metastate)
+            } else {
                 let vote_refs = self.vote_refs_for_leader(leader_block);
-                potential_certificates.iter().any(|potential_certificate| {
-                    self.is_certificate(potential_certificate, &vote_refs)
-                })
-            })
-            .collect();
+                let any_cert = potential_certificates.iter().any(|potential_certificate| {
+                    self.is_certificate(potential_certificate, &leader_block, &mut vote_refs)
+                });
+                (any_cert, None)
+            };
+            if any_cert {
+                certified_leader_blocks.push((leader_block, metastate));
+            }
+        }
 
         // There can be at most one certified leader, otherwise it means the BFT
         // assumption is broken.
@@ -272,10 +312,10 @@ impl BaseCommitter {
             panic!("More than one certified block at wave {wave} from leader {leader_slot}")
         }
 
-        // We commit the target leader if it has a certificate that is an ancestor of
-        // the anchor. Otherwise skip it.
         match certified_leader_blocks.pop() {
-            Some(certified_leader_block) => LeaderStatus::Commit(certified_leader_block),
+            Some((certified_leader_block, metastate)) => {
+                LeaderStatus::Commit(certified_leader_block, metastate)
+            }
             None => LeaderStatus::Skip(leader_slot),
         }
     }
@@ -345,6 +385,162 @@ impl BaseCommitter {
             let authority = decision_block.reference().author;
             if self.is_certificate(decision_block, &vote_refs)
                 && certificate_stake_aggregator.add(authority, &self.context.committee)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Direct-commit metastate: StrongQC quorum → `Optimistic`, strong-blame
+    /// quorum → `Standard`, else `Pending`. `None` when the flag is off.
+    fn determine_metastate_direct(
+        &self,
+        leader_block: &VerifiedBlockHeader,
+    ) -> Option<CommitMetastate> {
+        if !self.context.protocol_config.consensus_starfish_speed() {
+            return None;
+        }
+
+        if self.has_strong_qc_quorum(leader_block) {
+            return Some(CommitMetastate::Optimistic);
+        }
+
+        if self.has_strong_blame_quorum(leader_block) {
+            return Some(CommitMetastate::Standard);
+        }
+
+        Some(CommitMetastate::Pending)
+    }
+
+    /// `(vote_refs, strong_vote_refs)` at r+1 for `leader_block`, built in a
+    /// single pass. Strong votes are a subset of votes; `is_strong_vote()`
+    /// alone is insufficient (a voter may flag itself strong while supporting
+    /// an equivocating leader).
+    fn vote_and_strong_vote_refs_for_leader(
+        &self,
+        leader_block: &VerifiedBlockHeader,
+    ) -> (HashSet<BlockRef>, HashSet<BlockRef>) {
+        let voting_round = leader_block.round() + 1;
+        let voters = self
+            .dag_state
+            .read()
+            .get_uncommitted_block_headers_at_round(voting_round);
+        let mut vote_refs = HashSet::new();
+        let mut strong_vote_refs = HashSet::new();
+        for voter in &voters {
+            if self.is_vote(voter, leader_block) {
+                let r = voter.reference();
+                vote_refs.insert(r);
+                if voter.is_strong_vote() {
+                    strong_vote_refs.insert(r);
+                }
+            }
+        }
+        (vote_refs, strong_vote_refs)
+    }
+
+    /// 2f+1 StrongQCs at `r+2` for `leader_block`.
+    fn has_strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
+        let voting_round = leader_block.round() + 1;
+        let certifying_round = leader_block.round() + 2;
+
+        let (voters, decision_blocks) = {
+            let dag_state = self.dag_state.read();
+            (
+                dag_state.get_uncommitted_block_headers_at_round(voting_round),
+                dag_state.get_uncommitted_block_headers_at_round(certifying_round),
+            )
+        };
+
+        let strong_vote_refs: HashSet<BlockRef> = voters
+            .into_iter()
+            .filter(|b| b.is_strong_vote() && self.is_vote(b, leader_block))
+            .map(|b| b.reference())
+            .collect();
+
+        let mut strong_qc_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        for decision_block in &decision_blocks {
+            let authority = decision_block.reference().author;
+            if self.is_strong_certificate(decision_block, &strong_vote_refs)
+                && strong_qc_stake_aggregator.add(authority, &self.context.committee)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// True if `potential_certificate` carries a StrongQC for the leader
+    /// whose strong votes are pre-filtered in `strong_vote_refs`.
+    fn is_strong_certificate(
+        &self,
+        potential_certificate: &VerifiedBlockHeader,
+        strong_vote_refs: &HashSet<BlockRef>,
+    ) -> bool {
+        let mut strong_votes_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        for reference in potential_certificate.ancestors() {
+            if strong_vote_refs.contains(reference)
+                && strong_votes_stake_aggregator.add(reference.author, &self.context.committee)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Single-walk `(is_certificate, is_strong_certificate)` classifier.
+    /// `vote_refs`/`strong_vote_refs` are the pre-computed voter sets.
+    /// Invariant: `is_strong ⇒ is_certificate`.
+    fn classify_certificate(
+        &self,
+        potential_certificate: &VerifiedBlockHeader,
+        vote_refs: &HashSet<BlockRef>,
+        strong_vote_refs: &HashSet<BlockRef>,
+    ) -> (bool, bool) {
+        let mut vote_agg = StakeAggregator::<QuorumThreshold>::new();
+        let mut strong_agg = StakeAggregator::<QuorumThreshold>::new();
+        let mut is_cert = false;
+        let mut is_strong = false;
+        for reference in potential_certificate.ancestors() {
+            if !is_cert
+                && vote_refs.contains(reference)
+                && vote_agg.add(reference.author, &self.context.committee)
+            {
+                is_cert = true;
+            }
+            if !is_strong
+                && strong_vote_refs.contains(reference)
+                && strong_agg.add(reference.author, &self.context.committee)
+            {
+                is_strong = true;
+            }
+            if is_cert && is_strong {
+                break;
+            }
+        }
+        (is_cert, is_strong)
+    }
+
+    /// Check whether 2f+1 blocks at `r+1` both vote for `leader_block` and
+    /// carry `is_strong_blame() == true`.
+    fn has_strong_blame_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
+        let voting_round = leader_block.round() + 1;
+        let voting_blocks = self
+            .dag_state
+            .read()
+            .get_uncommitted_block_headers_at_round(voting_round);
+
+        let mut strong_blame_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        for voting_block in &voting_blocks {
+            if !voting_block.is_strong_blame() {
+                continue;
+            }
+            if !self.is_vote(voting_block, leader_block) {
+                continue;
+            }
+            if strong_blame_stake_aggregator
+                .add(voting_block.reference().author, &self.context.committee)
             {
                 return true;
             }

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -421,9 +421,11 @@ impl BaseCommitter {
     }
 
     /// `(vote_refs, strong_vote_refs)` at r+1 for `leader_block`, built in a
-    /// single pass. Strong votes are a subset of votes; `is_strong_vote()`
-    /// alone is insufficient (a voter may flag itself strong while supporting
-    /// an equivocating leader).
+    /// single pass. Strong votes are a subset of votes; the strong-vote filter
+    /// also requires the voter's pinned leader (`strong_vote_leader`) to
+    /// match `leader_block.author()` — strong votes computed against a
+    /// different leader (e.g. before a schedule rotation) don't count toward
+    /// this leader's quorum.
     fn vote_and_strong_vote_refs_for_leader(
         &self,
         leader_block: &VerifiedBlockHeader,
@@ -439,7 +441,7 @@ impl BaseCommitter {
             if self.is_vote(voter, leader_block) {
                 let r = voter.reference();
                 vote_refs.insert(r);
-                if voter.is_strong_vote() {
+                if voter.is_strong_vote_for(leader_block.author()) {
                     strong_vote_refs.insert(r);
                 }
             }
@@ -463,7 +465,9 @@ impl BaseCommitter {
 
         let strong_vote_refs: HashSet<BlockRef> = voters
             .into_iter()
-            .filter(|b| b.is_strong_vote() && self.is_vote(b, leader_block))
+            .filter(|b| {
+                b.is_strong_vote_for(leader_block.author()) && self.is_vote(b, leader_block)
+            })
             .map(|b| b.reference())
             .collect();
 
@@ -530,8 +534,10 @@ impl BaseCommitter {
         (is_cert, is_strong)
     }
 
-    /// Check whether 2f+1 blocks at `r+1` both vote for `leader_block` and
-    /// carry `is_strong_blame() == true`.
+    /// Check whether 2f+1 blocks at `r+1` vote for `leader_block`, pin their
+    /// strong-blame to `leader_block.author()`, and carry
+    /// `is_strong_blame() == true`. Strong blames whose pinned leader doesn't
+    /// match are ignored — same misattribution rule as for strong votes.
     fn has_strong_blame_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
         let voting_round = leader_block.round() + 1;
         let voting_blocks = self
@@ -541,7 +547,7 @@ impl BaseCommitter {
 
         let mut strong_blame_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         for voting_block in &voting_blocks {
-            if !voting_block.is_strong_blame() {
+            if !voting_block.is_strong_blame_for(leader_block.author()) {
                 continue;
             }
             if !self.is_vote(voting_block, leader_block) {

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -2,11 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Display,
-    sync::Arc,
-};
+use std::{collections::HashSet, fmt::Display, sync::Arc};
 
 use parking_lot::RwLock;
 use starfish_config::{AuthorityIndex, Stake};
@@ -101,8 +97,8 @@ impl BaseCommitter {
             .into_iter()
             .filter(|l| self.enough_leader_support(certifying_round, l))
             .map(|leader_block| {
-                let metastate = self.determine_metastate_direct(&leader_block);
-                LeaderStatus::Commit(leader_block, metastate)
+                let (metastate, strong_voters) = self.determine_metastate_direct(&leader_block);
+                LeaderStatus::Commit(leader_block, metastate, strong_voters)
             })
             .collect();
 
@@ -130,7 +126,7 @@ impl BaseCommitter {
         for anchor in anchors {
             tracing::trace!("[{self}] Trying to indirect-decide {slot} using anchor {anchor}",);
             match anchor {
-                LeaderStatus::Commit(anchor, _) => {
+                LeaderStatus::Commit(anchor, _, _) => {
                     return self.decide_leader_from_anchor(anchor, slot);
                 }
                 LeaderStatus::Skip(..) => (),
@@ -264,10 +260,13 @@ impl BaseCommitter {
         // classify the metastate in the same walk. When the flag is off we
         // stick to the cheap regular-certificate-only check.
         let starfish_speed = self.context.protocol_config.consensus_starfish_speed();
-        let mut certified_leader_blocks: Vec<(VerifiedBlockHeader, Option<CommitMetastate>)> =
-            Vec::new();
+        let mut certified_leader_blocks: Vec<(
+            VerifiedBlockHeader,
+            Option<CommitMetastate>,
+            Vec<AuthorityIndex>,
+        )> = Vec::new();
         for leader_block in leader_blocks {
-            let (any_cert, metastate) = if starfish_speed {
+            let (any_cert, metastate, strong_voters) = if starfish_speed {
                 let (vote_refs, strong_vote_refs) =
                     self.vote_and_strong_vote_refs_for_leader(&leader_block);
                 let mut any_cert = false;
@@ -293,16 +292,21 @@ impl BaseCommitter {
                 } else {
                     None
                 };
-                (any_cert, metastate)
+                let strong_voters = if any_strong {
+                    strong_vote_refs.iter().map(|r| r.author).collect()
+                } else {
+                    Vec::new()
+                };
+                (any_cert, metastate, strong_voters)
             } else {
-                let vote_refs = self.vote_refs_for_leader(leader_block);
+                let vote_refs = self.vote_refs_for_leader(&leader_block);
                 let any_cert = potential_certificates.iter().any(|potential_certificate| {
-                    self.is_certificate(potential_certificate, &leader_block, &mut vote_refs)
+                    self.is_certificate(potential_certificate, &vote_refs)
                 });
-                (any_cert, None)
+                (any_cert, None, Vec::new())
             };
             if any_cert {
-                certified_leader_blocks.push((leader_block, metastate));
+                certified_leader_blocks.push((leader_block, metastate, strong_voters));
             }
         }
 
@@ -313,8 +317,8 @@ impl BaseCommitter {
         }
 
         match certified_leader_blocks.pop() {
-            Some((certified_leader_block, metastate)) => {
-                LeaderStatus::Commit(certified_leader_block, metastate)
+            Some((certified_leader_block, metastate, strong_voters)) => {
+                LeaderStatus::Commit(certified_leader_block, metastate, strong_voters)
             }
             None => LeaderStatus::Skip(leader_slot),
         }
@@ -394,23 +398,26 @@ impl BaseCommitter {
 
     /// Direct-commit metastate: StrongQC quorum → `Optimistic`, strong-blame
     /// quorum → `Standard`, else `Pending`. `None` when the flag is off.
+    /// The returned `Vec<AuthorityIndex>` carries the leader's strong-voter
+    /// authorities for the Optimistic case (used by the linearizer to seed
+    /// the per-ref ack tracker); empty otherwise.
     fn determine_metastate_direct(
         &self,
         leader_block: &VerifiedBlockHeader,
-    ) -> Option<CommitMetastate> {
+    ) -> (Option<CommitMetastate>, Vec<AuthorityIndex>) {
         if !self.context.protocol_config.consensus_starfish_speed() {
-            return None;
+            return (None, Vec::new());
         }
 
-        if self.has_strong_qc_quorum(leader_block) {
-            return Some(CommitMetastate::Optimistic);
+        if let Some(strong_voters) = self.strong_qc_quorum(leader_block) {
+            return (Some(CommitMetastate::Optimistic), strong_voters);
         }
 
         if self.has_strong_blame_quorum(leader_block) {
-            return Some(CommitMetastate::Standard);
+            return (Some(CommitMetastate::Standard), Vec::new());
         }
 
-        Some(CommitMetastate::Pending)
+        (Some(CommitMetastate::Pending), Vec::new())
     }
 
     /// `(vote_refs, strong_vote_refs)` at r+1 for `leader_block`, built in a
@@ -440,8 +447,9 @@ impl BaseCommitter {
         (vote_refs, strong_vote_refs)
     }
 
-    /// 2f+1 StrongQCs at `r+2` for `leader_block`.
-    fn has_strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> bool {
+    /// `Some(strong-voter authorities)` when 2f+1 StrongQCs exist at `r+2`
+    /// for `leader_block`; `None` otherwise.
+    fn strong_qc_quorum(&self, leader_block: &VerifiedBlockHeader) -> Option<Vec<AuthorityIndex>> {
         let voting_round = leader_block.round() + 1;
         let certifying_round = leader_block.round() + 2;
 
@@ -465,10 +473,10 @@ impl BaseCommitter {
             if self.is_strong_certificate(decision_block, &strong_vote_refs)
                 && strong_qc_stake_aggregator.add(authority, &self.context.committee)
             {
-                return true;
+                return Some(strong_vote_refs.iter().map(|r| r.author).collect());
             }
         }
-        false
+        None
     }
 
     /// True if `potential_certificate` carries a StrongQC for the leader

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -434,7 +434,7 @@ impl BaseCommitter {
         let voters = self
             .dag_state
             .read()
-            .get_uncommitted_block_headers_at_round(voting_round);
+            .get_block_headers_at_round_above_last_commit(voting_round);
         let mut vote_refs = HashSet::new();
         let mut strong_vote_refs = HashSet::new();
         for voter in &voters {
@@ -458,8 +458,8 @@ impl BaseCommitter {
         let (voters, decision_blocks) = {
             let dag_state = self.dag_state.read();
             (
-                dag_state.get_uncommitted_block_headers_at_round(voting_round),
-                dag_state.get_uncommitted_block_headers_at_round(certifying_round),
+                dag_state.get_block_headers_at_round_above_last_commit(voting_round),
+                dag_state.get_block_headers_at_round_above_last_commit(certifying_round),
             )
         };
 
@@ -543,7 +543,7 @@ impl BaseCommitter {
         let voting_blocks = self
             .dag_state
             .read()
-            .get_uncommitted_block_headers_at_round(voting_round);
+            .get_block_headers_at_round_above_last_commit(voting_round);
 
         let mut strong_blame_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         for voting_block in &voting_blocks {

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -245,8 +245,6 @@ pub struct BlockHeaderV2 {
 }
 
 impl BlockHeaderV2 {
-    // Will be used when block construction is gated on consensus_starfish_speed.
-    #[expect(dead_code)]
     pub(crate) fn new(
         epoch: Epoch,
         round: Round,

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1484,6 +1484,7 @@ pub struct TestBlockHeader {
     ancestors: Vec<BlockRef>,
     acknowledgments: Vec<BlockRef>,
     block_header: BlockHeaderV1,
+    strong_vote: Option<StrongVote>,
 }
 
 impl TestBlockHeader {
@@ -1500,6 +1501,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1527,6 +1529,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1558,6 +1561,7 @@ impl TestBlockHeader {
             },
             ancestors: vec![],
             acknowledgments: vec![],
+            strong_vote: None,
         }
     }
 
@@ -1601,7 +1605,27 @@ impl TestBlockHeader {
         self
     }
 
+    /// Sets the V2-only `strong_vote` payload. When `Some`, `build()` emits a
+    /// `BlockHeader::V2`; otherwise a V1.
+    pub fn set_strong_vote(mut self, strong_vote: Option<StrongVote>) -> Self {
+        self.strong_vote = strong_vote;
+        self
+    }
+
     pub fn build(mut self) -> BlockHeader {
+        if let Some(strong_vote) = self.strong_vote {
+            return BlockHeader::V2(BlockHeaderV2::new(
+                self.block_header.epoch,
+                self.block_header.round,
+                self.block_header.author,
+                self.block_header.timestamp_ms,
+                self.ancestors,
+                self.acknowledgments,
+                self.block_header.commit_votes,
+                self.block_header.transactions_commitment,
+                Some(strong_vote),
+            ));
+        }
         let (references, overlap_start_index, overlap_end_index) =
             BlockHeader::compress_references(self.ancestors, self.acknowledgments);
         self.block_header.references = references;
@@ -1620,6 +1644,7 @@ mod tests {
     use std::sync::Arc;
 
     use fastcrypto::error::FastCryptoError;
+    use rstest::rstest;
 
     use crate::{
         BlockHeaderAPI,
@@ -1762,5 +1787,57 @@ mod tests {
         for ack in acknowledgments.iter() {
             assert!(compressed_acknowledgments.contains(ack));
         }
+    }
+
+    #[rstest]
+    #[test]
+    fn test_verify_references_indices(#[values(false, true)] use_v2: bool) {
+        use crate::block_header::{BlockHeader, BlockHeaderV1, BlockHeaderV2, BlockRef};
+        let rng = &mut rand::thread_rng();
+        let refs = vec![
+            BlockRef::new(1, 0.into(), BlockHeaderDigest::random(&mut *rng)),
+            BlockRef::new(1, 1.into(), BlockHeaderDigest::random(&mut *rng)),
+            BlockRef::new(1, 2.into(), BlockHeaderDigest::random(&mut *rng)),
+        ];
+        let build = |overlap_start: u8, overlap_end: u8| -> BlockHeader {
+            if use_v2 {
+                BlockHeader::V2(BlockHeaderV2 {
+                    references: refs.clone(),
+                    overlap_start_index: overlap_start,
+                    overlap_end_index: overlap_end,
+                    ..Default::default()
+                })
+            } else {
+                BlockHeader::V1(BlockHeaderV1 {
+                    references: refs.clone(),
+                    overlap_start_index: overlap_start,
+                    overlap_end_index: overlap_end,
+                    ..Default::default()
+                })
+            }
+        };
+
+        // Valid indices: 0 <= start <= end <= references.len().
+        build(1, 2).verify_references_indices().unwrap(); // overlap region
+        build(2, 2).verify_references_indices().unwrap(); // no overlap, interior split
+        build(3, 3).verify_references_indices().unwrap(); // no overlap, boundary at len
+
+        // overlap_end > references.len().
+        assert!(matches!(
+            build(0, 4).verify_references_indices(),
+            Err(ConsensusError::InvalidOverlapIndices { .. })
+        ));
+
+        // overlap_start > references.len().
+        assert!(matches!(
+            build(4, 3).verify_references_indices(),
+            Err(ConsensusError::InvalidOverlapIndices { .. })
+        ));
+
+        // overlap_start > overlap_end.
+        assert!(matches!(
+            build(2, 1).verify_references_indices(),
+            Err(ConsensusError::InvalidOverlapIndices { .. })
+        ));
     }
 }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -111,9 +111,20 @@ pub trait BlockHeaderAPI {
     fn ancestors(&self) -> &[BlockRef];
     fn commit_votes(&self) -> &[CommitVote];
     fn transactions_commitment(&self) -> TransactionsCommitment;
-    fn strong_vote(&self) -> Option<AuthoritySet>;
+    fn strong_vote(&self) -> Option<StrongVote>;
+    fn strong_vote_leader(&self) -> Option<AuthorityIndex>;
     fn is_strong_vote(&self) -> bool;
     fn is_strong_blame(&self) -> bool;
+
+    /// True if this block is a strong vote pinned to `leader`.
+    fn is_strong_vote_for(&self, leader: AuthorityIndex) -> bool {
+        self.is_strong_vote() && self.strong_vote_leader() == Some(leader)
+    }
+
+    /// True if this block is a strong blame pinned to `leader`.
+    fn is_strong_blame_for(&self, leader: AuthorityIndex) -> bool {
+        self.is_strong_blame() && self.strong_vote_leader() == Some(leader)
+    }
 }
 
 #[derive(Clone, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
@@ -213,7 +224,11 @@ impl BlockHeaderAPI for BlockHeaderV1 {
     }
 
     // V1 blocks do not carry a strong vote; always returns None.
-    fn strong_vote(&self) -> Option<AuthoritySet> {
+    fn strong_vote(&self) -> Option<StrongVote> {
+        None
+    }
+
+    fn strong_vote_leader(&self) -> Option<AuthorityIndex> {
         None
     }
 
@@ -223,6 +238,26 @@ impl BlockHeaderAPI for BlockHeaderV1 {
 
     fn is_strong_blame(&self) -> bool {
         false
+    }
+}
+
+/// Strong-vote payload pinned to a specific leader authority. The producer
+/// records which leader the vote/blame is *for*, so consumers can reject votes
+/// whose pinned leader doesn't match the canonical leader they're evaluating.
+#[derive(Clone, Copy, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq, Debug)]
+pub struct StrongVote {
+    /// Authority of the leader at round - 1, per the producer's swap table at
+    /// block-creation time.
+    pub leader_authority: AuthorityIndex,
+    /// Bitmask of authorities whose data the producer was missing relative to
+    /// the pinned leader's data set. Empty = strong vote; non-empty = strong
+    /// blame.
+    pub missing: AuthoritySet,
+}
+
+impl StrongVote {
+    pub fn is_strong_vote(&self) -> bool {
+        self.missing.is_empty()
     }
 }
 
@@ -237,11 +272,10 @@ pub struct BlockHeaderV2 {
     overlap_end_index: u8,
     transactions_commitment: TransactionsCommitment,
     commit_votes: Vec<CommitVote>,
-    // Bitmask of authorities whose transaction data (announced by the leader)
-    // is not available. None means no vote. Some(empty) means all data is
-    // available (strong vote). Some(nonempty) means some data is missing
-    // (strong blame).
-    strong_vote: Option<AuthoritySet>,
+    // Strong-vote payload pinned to a specific leader. None = no vote;
+    // Some(StrongVote { missing: empty, .. }) = strong vote;
+    // Some(StrongVote { missing: nonempty, .. }) = strong blame.
+    strong_vote: Option<StrongVote>,
 }
 
 impl BlockHeaderV2 {
@@ -254,7 +288,7 @@ impl BlockHeaderV2 {
         acknowledgments: Vec<BlockRef>,
         commit_votes: Vec<CommitVote>,
         transactions_commitment: TransactionsCommitment,
-        strong_vote: Option<AuthoritySet>,
+        strong_vote: Option<StrongVote>,
     ) -> BlockHeaderV2 {
         let (references, overlap_start_index, overlap_end_index) =
             BlockHeader::compress_references(ancestors, acknowledgments);
@@ -328,16 +362,20 @@ impl BlockHeaderAPI for BlockHeaderV2 {
         self.transactions_commitment
     }
 
-    fn strong_vote(&self) -> Option<AuthoritySet> {
+    fn strong_vote(&self) -> Option<StrongVote> {
         self.strong_vote
     }
 
+    fn strong_vote_leader(&self) -> Option<AuthorityIndex> {
+        self.strong_vote.map(|sv| sv.leader_authority)
+    }
+
     fn is_strong_vote(&self) -> bool {
-        self.strong_vote.is_some_and(|s| s.is_empty())
+        self.strong_vote.is_some_and(|sv| sv.is_strong_vote())
     }
 
     fn is_strong_blame(&self) -> bool {
-        self.strong_vote.is_some_and(|s| !s.is_empty())
+        self.strong_vote.is_some_and(|sv| !sv.is_strong_vote())
     }
 }
 
@@ -405,10 +443,17 @@ impl BlockHeaderAPI for BlockHeader {
         }
     }
 
-    fn strong_vote(&self) -> Option<AuthoritySet> {
+    fn strong_vote(&self) -> Option<StrongVote> {
         match self {
             BlockHeader::V1(header) => header.strong_vote(),
             BlockHeader::V2(header) => header.strong_vote(),
+        }
+    }
+
+    fn strong_vote_leader(&self) -> Option<AuthorityIndex> {
+        match self {
+            BlockHeader::V1(header) => header.strong_vote_leader(),
+            BlockHeader::V2(header) => header.strong_vote_leader(),
         }
     }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -22,6 +22,7 @@ use starfish_config::{
 use tracing::instrument;
 
 use crate::{
+    authority_set::AuthoritySet,
     commit::CommitVote,
     context::Context,
     encoder::ShardEncoder,
@@ -97,6 +98,7 @@ impl Transaction {
 #[derive(Clone, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
 pub enum BlockHeader {
     V1(BlockHeaderV1),
+    V2(BlockHeaderV2),
 }
 
 pub trait BlockHeaderAPI {
@@ -109,6 +111,9 @@ pub trait BlockHeaderAPI {
     fn ancestors(&self) -> &[BlockRef];
     fn commit_votes(&self) -> &[CommitVote];
     fn transactions_commitment(&self) -> TransactionsCommitment;
+    fn strong_vote(&self) -> Option<AuthoritySet>;
+    fn is_strong_vote(&self) -> bool;
+    fn is_strong_blame(&self) -> bool;
 }
 
 #[derive(Clone, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
@@ -142,7 +147,7 @@ impl BlockHeaderV1 {
         transactions_commitment: TransactionsCommitment,
     ) -> BlockHeaderV1 {
         let (references, overlap_start_index, overlap_end_index) =
-            Self::compress_references(ancestors, acknowledgments);
+            BlockHeader::compress_references(ancestors, acknowledgments);
         Self {
             epoch,
             round,
@@ -154,55 +159,6 @@ impl BlockHeaderV1 {
             transactions_commitment,
             commit_votes,
         }
-    }
-    /// Compresses ancestors and acknowledgments into a single references
-    /// vector, and returns the overlap indices. The first ancestor is
-    /// always the first reference (ref0). If it is also in acknowledgments,
-    /// it is appended to the end of references.
-    pub(crate) fn compress_references(
-        ancestors: Vec<BlockRef>,
-        acknowledgments: Vec<BlockRef>,
-    ) -> (Vec<BlockRef>, u8, u8) {
-        if ancestors.is_empty() {
-            return (acknowledgments, 0, 0);
-        }
-        // Sets for membership checks
-        let ancestor_set: HashSet<_> = ancestors.iter().cloned().collect();
-        let ack_set: HashSet<_> = acknowledgments.into_iter().collect();
-        // ref0 is the first ancestor, and is also always the first reference
-        let ref0 = ancestors[0];
-        // if it is also in acknowledgments, it is appended to the end of references
-        let append_ref0 = ack_set.contains(&ref0);
-
-        // partition ancestors into overlap and ancestors_only (excluding ref0)
-        let (overlap, mut ancestors_only): (Vec<_>, Vec<_>) = ancestors
-            .into_iter()
-            .skip(1)
-            .partition(|a| ack_set.contains(a));
-        // insert ref0 back to the front of ancestors_only
-        ancestors_only.insert(0, ref0);
-
-        // acknowledgments_only excludes any overlap with ancestors
-        let acknowledgments_only: Vec<_> = ack_set
-            .into_iter()
-            .filter(|a| !ancestor_set.contains(a))
-            .collect();
-
-        let overlap_start_index = ancestors_only.len();
-        let overlap_end_index = overlap_start_index + overlap.len();
-        // combine all parts into references
-        // |ancestors_only|overlap|acknowledgments_only|ref0?|
-        let mut references = ancestors_only;
-        references.extend(overlap);
-        references.extend(acknowledgments_only);
-        if append_ref0 {
-            references.push(ref0);
-        }
-        (
-            references,
-            overlap_start_index as u8,
-            overlap_end_index as u8,
-        )
     }
 
     /// Validates that overlap_start_index and overlap_end_index are within
@@ -274,60 +230,220 @@ impl BlockHeaderAPI for BlockHeaderV1 {
     fn transactions_commitment(&self) -> TransactionsCommitment {
         self.transactions_commitment
     }
+
+    // V1 blocks do not carry a strong vote; always returns None.
+    fn strong_vote(&self) -> Option<AuthoritySet> {
+        None
+    }
+
+    fn is_strong_vote(&self) -> bool {
+        false
+    }
+
+    fn is_strong_blame(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
+pub struct BlockHeaderV2 {
+    epoch: Epoch,
+    round: Round,
+    author: AuthorityIndex,
+    timestamp_ms: BlockTimestampMs,
+    references: Vec<BlockRef>,
+    overlap_start_index: u8,
+    overlap_end_index: u8,
+    transactions_commitment: TransactionsCommitment,
+    commit_votes: Vec<CommitVote>,
+    // Bitmask of authorities whose transaction data (announced by the leader)
+    // is not available. None means no vote. Some(empty) means all data is
+    // available (strong vote). Some(nonempty) means some data is missing
+    // (strong blame).
+    strong_vote: Option<AuthoritySet>,
+}
+
+impl BlockHeaderV2 {
+    // Will be used when block construction is gated on consensus_starfish_speed.
+    #[expect(dead_code)]
+    pub(crate) fn new(
+        epoch: Epoch,
+        round: Round,
+        author: AuthorityIndex,
+        timestamp_ms: BlockTimestampMs,
+        ancestors: Vec<BlockRef>,
+        acknowledgments: Vec<BlockRef>,
+        commit_votes: Vec<CommitVote>,
+        transactions_commitment: TransactionsCommitment,
+        strong_vote: Option<AuthoritySet>,
+    ) -> BlockHeaderV2 {
+        let (references, overlap_start_index, overlap_end_index) =
+            BlockHeader::compress_references(ancestors, acknowledgments);
+        Self {
+            epoch,
+            round,
+            author,
+            timestamp_ms,
+            references,
+            overlap_start_index,
+            overlap_end_index,
+            transactions_commitment,
+            commit_votes,
+            strong_vote,
+        }
+    }
+
+    // Will be used when genesis block construction is gated on
+    // consensus_starfish_speed.
+    #[expect(dead_code)]
+    fn genesis_block_header(context: &Context, author: AuthorityIndex) -> Self {
+        Self {
+            epoch: context.committee.epoch(),
+            round: GENESIS_ROUND,
+            author,
+            timestamp_ms: context.epoch_start_timestamp_ms,
+            references: vec![],
+            overlap_start_index: 0,
+            overlap_end_index: 0,
+            commit_votes: vec![],
+            transactions_commitment: TransactionsCommitment::default(),
+            strong_vote: None,
+        }
+    }
+}
+
+impl BlockHeaderAPI for BlockHeaderV2 {
+    fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    fn round(&self) -> Round {
+        self.round
+    }
+
+    fn author(&self) -> AuthorityIndex {
+        self.author
+    }
+
+    fn slot(&self) -> Slot {
+        Slot::new(self.round, self.author)
+    }
+
+    fn acknowledgments(&self) -> &[BlockRef] {
+        &self.references[self.overlap_start_index as usize..]
+    }
+
+    fn timestamp_ms(&self) -> BlockTimestampMs {
+        self.timestamp_ms
+    }
+
+    fn ancestors(&self) -> &[BlockRef] {
+        &self.references[..self.overlap_end_index as usize]
+    }
+
+    fn commit_votes(&self) -> &[CommitVote] {
+        &self.commit_votes
+    }
+
+    fn transactions_commitment(&self) -> TransactionsCommitment {
+        self.transactions_commitment
+    }
+
+    fn strong_vote(&self) -> Option<AuthoritySet> {
+        self.strong_vote
+    }
+
+    fn is_strong_vote(&self) -> bool {
+        self.strong_vote.is_some_and(|s| s.is_empty())
+    }
+
+    fn is_strong_blame(&self) -> bool {
+        self.strong_vote.is_some_and(|s| !s.is_empty())
+    }
 }
 
 impl BlockHeaderAPI for BlockHeader {
     fn epoch(&self) -> Epoch {
         match self {
             BlockHeader::V1(header) => header.epoch(),
+            BlockHeader::V2(header) => header.epoch(),
         }
     }
 
     fn round(&self) -> Round {
         match self {
             BlockHeader::V1(header) => header.round(),
+            BlockHeader::V2(header) => header.round(),
         }
     }
 
     fn author(&self) -> AuthorityIndex {
         match self {
             BlockHeader::V1(header) => header.author(),
+            BlockHeader::V2(header) => header.author(),
         }
     }
 
     fn slot(&self) -> Slot {
         match self {
             BlockHeader::V1(header) => header.slot(),
+            BlockHeader::V2(header) => header.slot(),
         }
     }
 
     fn acknowledgments(&self) -> &[BlockRef] {
         match self {
             BlockHeader::V1(header) => header.acknowledgments(),
+            BlockHeader::V2(header) => header.acknowledgments(),
         }
     }
 
     fn timestamp_ms(&self) -> BlockTimestampMs {
         match self {
             BlockHeader::V1(header) => header.timestamp_ms(),
+            BlockHeader::V2(header) => header.timestamp_ms(),
         }
     }
 
     fn ancestors(&self) -> &[BlockRef] {
         match self {
             BlockHeader::V1(header) => header.ancestors(),
+            BlockHeader::V2(header) => header.ancestors(),
         }
     }
 
     fn commit_votes(&self) -> &[CommitVote] {
         match self {
             BlockHeader::V1(header) => header.commit_votes(),
+            BlockHeader::V2(header) => header.commit_votes(),
         }
     }
 
     fn transactions_commitment(&self) -> TransactionsCommitment {
         match self {
             BlockHeader::V1(header) => header.transactions_commitment(),
+            BlockHeader::V2(header) => header.transactions_commitment(),
+        }
+    }
+
+    fn strong_vote(&self) -> Option<AuthoritySet> {
+        match self {
+            BlockHeader::V1(header) => header.strong_vote(),
+            BlockHeader::V2(header) => header.strong_vote(),
+        }
+    }
+
+    fn is_strong_vote(&self) -> bool {
+        match self {
+            BlockHeader::V1(header) => header.is_strong_vote(),
+            BlockHeader::V2(header) => header.is_strong_vote(),
+        }
+    }
+
+    fn is_strong_blame(&self) -> bool {
+        match self {
+            BlockHeader::V1(header) => header.is_strong_blame(),
+            BlockHeader::V2(header) => header.is_strong_blame(),
         }
     }
 }
@@ -343,6 +459,64 @@ impl BlockHeader {
 impl From<BlockHeaderV1> for BlockHeader {
     fn from(header: BlockHeaderV1) -> Self {
         BlockHeader::V1(header)
+    }
+}
+
+impl From<BlockHeaderV2> for BlockHeader {
+    fn from(header: BlockHeaderV2) -> Self {
+        BlockHeader::V2(header)
+    }
+}
+
+impl BlockHeader {
+    /// Compresses ancestors and acknowledgments into a single references
+    /// vector, and returns the overlap indices. The first ancestor is
+    /// always the first reference (ref0). If it is also in acknowledgments,
+    /// it is appended to the end of references.
+    pub(crate) fn compress_references(
+        ancestors: Vec<BlockRef>,
+        acknowledgments: Vec<BlockRef>,
+    ) -> (Vec<BlockRef>, u8, u8) {
+        if ancestors.is_empty() {
+            return (acknowledgments, 0, 0);
+        }
+        // Sets for membership checks
+        let ancestor_set: HashSet<_> = ancestors.iter().cloned().collect();
+        let ack_set: HashSet<_> = acknowledgments.into_iter().collect();
+        // ref0 is the first ancestor, and is also always the first reference
+        let ref0 = ancestors[0];
+        // if it is also in acknowledgments, it is appended to the end of references
+        let append_ref0 = ack_set.contains(&ref0);
+
+        // partition ancestors into overlap and ancestors_only (excluding ref0)
+        let (overlap, mut ancestors_only): (Vec<_>, Vec<_>) = ancestors
+            .into_iter()
+            .skip(1)
+            .partition(|a| ack_set.contains(a));
+        // insert ref0 back to the front of ancestors_only
+        ancestors_only.insert(0, ref0);
+
+        // acknowledgments_only excludes any overlap with ancestors
+        let acknowledgments_only: Vec<_> = ack_set
+            .into_iter()
+            .filter(|a| !ancestor_set.contains(a))
+            .collect();
+
+        let overlap_start_index = ancestors_only.len();
+        let overlap_end_index = overlap_start_index + overlap.len();
+        // combine all parts into references
+        // |ancestors_only|overlap|acknowledgments_only|ref0?|
+        let mut references = ancestors_only;
+        references.extend(overlap);
+        references.extend(acknowledgments_only);
+        if append_ref0 {
+            references.push(ref0);
+        }
+        (
+            references,
+            overlap_start_index as u8,
+            overlap_end_index as u8,
+        )
     }
 }
 
@@ -1381,7 +1555,7 @@ impl TestBlockHeader {
 
     pub fn build(mut self) -> BlockHeader {
         let (references, overlap_start_index, overlap_end_index) =
-            BlockHeaderV1::compress_references(self.ancestors, self.acknowledgments);
+            BlockHeader::compress_references(self.ancestors, self.acknowledgments);
         self.block_header.references = references;
         self.block_header.overlap_start_index = overlap_start_index;
         self.block_header.overlap_end_index = overlap_end_index;
@@ -1469,7 +1643,7 @@ mod tests {
         let ancestors = vec![ref_a, ref_b];
         let acknowledgments = vec![ref_c, ref_d];
         let (references, overlap_start_index, overlap_end_index) =
-            crate::block_header::BlockHeaderV1::compress_references(ancestors, acknowledgments);
+            crate::block_header::BlockHeader::compress_references(ancestors, acknowledgments);
         let expected = [ref_a, ref_b, ref_c, ref_d];
         assert_eq!(references.len(), expected.len());
         for r in references.iter() {
@@ -1483,7 +1657,7 @@ mod tests {
         let ancestors = vec![ref_a, ref_b, ref_c];
         let acknowledgments = vec![ref_c, ref_d];
         let (references, overlap_start_index, overlap_end_index) =
-            crate::block_header::BlockHeaderV1::compress_references(ancestors, acknowledgments);
+            crate::block_header::BlockHeader::compress_references(ancestors, acknowledgments);
         let expected = [ref_a, ref_b, ref_c, ref_d];
         assert_eq!(references.len(), expected.len());
         for r in references.iter() {
@@ -1498,7 +1672,7 @@ mod tests {
         let acknowledgments = vec![ref_a, ref_c, ref_d, ref_e];
 
         let (references, overlap_start_index, overlap_end_index) =
-            crate::block_header::BlockHeaderV1::compress_references(ancestors, acknowledgments);
+            crate::block_header::BlockHeader::compress_references(ancestors, acknowledgments);
 
         let expected = [ref_a, ref_b, ref_c, ref_d, ref_e, ref_a];
         assert_eq!(references.len(), expected.len());
@@ -1515,7 +1689,7 @@ mod tests {
         let ancestors = vec![ref_a, ref_b, ref_c];
         let acknowledgments = vec![ref_a, ref_b, ref_c];
         let (references, overlap_start_index, overlap_end_index) =
-            crate::block_header::BlockHeaderV1::compress_references(
+            crate::block_header::BlockHeader::compress_references(
                 ancestors.clone(),
                 acknowledgments.clone(),
             );

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -161,25 +161,6 @@ impl BlockHeaderV1 {
         }
     }
 
-    /// Validates that overlap_start_index and overlap_end_index are within
-    /// bounds of the references vector. Must be called before accessing
-    /// ancestors() or acknowledgments() on deserialized headers to prevent
-    /// panics from adversarial index values.
-    pub(crate) fn verify_references_indices(&self) -> ConsensusResult<()> {
-        let len = self.references.len();
-        if self.overlap_end_index as usize > len
-            || self.overlap_start_index as usize > len
-            || self.overlap_start_index > self.overlap_end_index
-        {
-            return Err(ConsensusError::InvalidOverlapIndices {
-                overlap_start: self.overlap_start_index,
-                overlap_end: self.overlap_end_index,
-                references_len: len,
-            });
-        }
-        Ok(())
-    }
-
     fn genesis_block_header(context: &Context, author: AuthorityIndex) -> Self {
         Self {
             epoch: context.committee.epoch(),
@@ -449,10 +430,34 @@ impl BlockHeaderAPI for BlockHeader {
 }
 
 impl BlockHeader {
+    /// Validates that overlap_start_index and overlap_end_index are within
+    /// bounds of the references vector. Must be called before accessing
+    /// ancestors() or acknowledgments() on deserialized headers to prevent
+    /// panics from adversarial index values.
     pub(crate) fn verify_references_indices(&self) -> ConsensusResult<()> {
-        match self {
-            BlockHeader::V1(header) => header.verify_references_indices(),
+        let (references_len, overlap_start, overlap_end) = match self {
+            BlockHeader::V1(h) => (
+                h.references.len(),
+                h.overlap_start_index,
+                h.overlap_end_index,
+            ),
+            BlockHeader::V2(h) => (
+                h.references.len(),
+                h.overlap_start_index,
+                h.overlap_end_index,
+            ),
+        };
+        if overlap_end as usize > references_len
+            || overlap_start as usize > references_len
+            || overlap_start > overlap_end
+        {
+            return Err(ConsensusError::InvalidOverlapIndices {
+                overlap_start,
+                overlap_end,
+                references_len,
+            });
         }
+        Ok(())
     }
 }
 

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -228,15 +228,37 @@ impl BlockVerifier for SignedBlockVerifier {
         }
 
         // Validate strong_vote field.
-        if let Some(authority_set) = block.strong_vote() {
+        if let Some(strong_vote) = block.strong_vote() {
             if !self.context.protocol_config.consensus_starfish_speed() {
                 return Err(ConsensusError::UnexpectedStrongVote);
             }
-            for authority_index in authority_set.iter() {
+            if !committee.is_valid_index(strong_vote.leader_authority) {
+                return Err(ConsensusError::InvalidStrongVoteAuthority {
+                    index: strong_vote.leader_authority,
+                    max: committee.size(),
+                });
+            }
+            for authority_index in strong_vote.missing.iter() {
                 if !committee.is_valid_index(authority_index) {
                     return Err(ConsensusError::InvalidStrongVoteAuthority {
                         index: authority_index,
                         max: committee.size(),
+                    });
+                }
+            }
+            // Self-consistency: the pinned leader must appear in the block's
+            // ancestors at round-1.
+            let leader_round = block.round().saturating_sub(1);
+            if leader_round != GENESIS_ROUND {
+                let leader_seen = block
+                    .ancestors()
+                    .iter()
+                    .any(|r| r.round == leader_round && r.author == strong_vote.leader_authority);
+                if !leader_seen {
+                    return Err(ConsensusError::StrongVoteLeaderNotInAncestors {
+                        block_round: block.round(),
+                        leader_round,
+                        leader_authority: strong_vote.leader_authority,
                     });
                 }
             }

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -226,6 +226,21 @@ impl BlockVerifier for SignedBlockVerifier {
                 quorum: committee.quorum_threshold(),
             });
         }
+
+        // Validate strong_vote field.
+        if let Some(authority_set) = block.strong_vote() {
+            if !self.context.protocol_config.consensus_starfish_speed() {
+                return Err(ConsensusError::UnexpectedStrongVote);
+            }
+            for authority_index in authority_set.iter() {
+                if !committee.is_valid_index(authority_index) {
+                    return Err(ConsensusError::InvalidStrongVoteAuthority {
+                        index: authority_index,
+                        max: committee.size(),
+                    });
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -259,11 +259,9 @@ impl BlockVerifier for SignedBlockVerifier {
             });
         }
 
-        // Validate strong_vote field.
+        // Validate strong_vote field. Reachable only on V2 headers, which the
+        // version-flag check above already gated on `consensus_starfish_speed`.
         if let Some(strong_vote) = block.strong_vote() {
-            if !self.context.protocol_config.consensus_starfish_speed() {
-                return Err(ConsensusError::UnexpectedStrongVote);
-            }
             if !committee.is_valid_index(strong_vote.leader_authority) {
                 return Err(ConsensusError::InvalidStrongVoteAuthority {
                     index: strong_vote.leader_authority,
@@ -327,7 +325,8 @@ pub(crate) mod test {
 
     use super::*;
     use crate::{
-        block_header::{BlockHeaderDigest, BlockRef, TestBlockHeader},
+        authority_set::AuthoritySet,
+        block_header::{BlockHeaderDigest, BlockRef, StrongVote, TestBlockHeader},
         context::Context,
         transaction::{TransactionVerifier, ValidationError},
     };
@@ -759,6 +758,94 @@ pub(crate) mod test {
                     starfish_speed: false,
                 })
             ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_block_strong_vote() {
+        let (mut context_on, keypairs) = Context::new_for_test(4);
+        context_on
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(true);
+        let context_on = Arc::new(context_on);
+
+        let keypair = &keypairs[2].1;
+        let leader_authority = AuthorityIndex::new_for_test(0);
+        let verifier_on = SignedBlockVerifier::new(context_on, Arc::new(TxnSizeVerifier {}));
+
+        let base = TestBlockHeader::new(10, 2).set_ancestors(vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+            BlockRef::new(9, leader_authority, BlockHeaderDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+            BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+        ]);
+        let well_formed = StrongVote {
+            leader_authority,
+            missing: AuthoritySet::new(),
+        };
+
+        // Flag on + missing contains an index >= committee.size() ->
+        // InvalidStrongVoteAuthority.
+        {
+            let mut missing = AuthoritySet::new();
+            missing.insert(AuthorityIndex::new_for_test(99));
+            let block = base
+                .clone()
+                .set_strong_vote(Some(StrongVote {
+                    leader_authority,
+                    missing,
+                }))
+                .build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            assert!(matches!(
+                verifier_on.verify(&signed_block),
+                Err(ConsensusError::InvalidStrongVoteAuthority { .. })
+            ));
+        }
+
+        // Flag on + leader_authority >= committee.size() ->
+        // InvalidStrongVoteAuthority. Trips the leader_authority bound check
+        // before the leader-in-ancestors check below.
+        {
+            let block = base
+                .clone()
+                .set_strong_vote(Some(StrongVote {
+                    leader_authority: AuthorityIndex::new_for_test(99),
+                    missing: AuthoritySet::new(),
+                }))
+                .build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            assert!(matches!(
+                verifier_on.verify(&signed_block),
+                Err(ConsensusError::InvalidStrongVoteAuthority { .. })
+            ));
+        }
+
+        // Flag on + valid leader_authority but pinned leader not in ancestors
+        // at round-1 -> StrongVoteLeaderNotInAncestors. Authority 3 is in the
+        // base block's ancestors only at round 7, not at round 9
+        // (= leader_round).
+        {
+            let block = base
+                .clone()
+                .set_strong_vote(Some(StrongVote {
+                    leader_authority: AuthorityIndex::new_for_test(3),
+                    missing: AuthoritySet::new(),
+                }))
+                .build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            assert!(matches!(
+                verifier_on.verify(&signed_block),
+                Err(ConsensusError::StrongVoteLeaderNotInAncestors { .. })
+            ));
+        }
+
+        // Flag on + well-formed strong_vote (empty missing, leader at R-1 in
+        // ancestors) -> Ok.
+        {
+            let block = base.set_strong_vote(Some(well_formed)).build();
+            let signed_block = SignedBlockHeader::new(block, keypair).unwrap();
+            verifier_on.verify(&signed_block).unwrap();
         }
     }
 }

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -9,7 +9,8 @@ use tracing::instrument;
 use crate::{
     Transaction,
     block_header::{
-        BlockHeaderAPI, BlockRef, GENESIS_ROUND, SignedBlockHeader, genesis_block_headers,
+        BlockHeader, BlockHeaderAPI, BlockRef, GENESIS_ROUND, SignedBlockHeader,
+        genesis_block_headers,
     },
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -88,6 +89,33 @@ impl SignedBlockVerifier {
     }
 }
 
+/// Rejects a deserialized `BlockHeader` whose variant does not match the local
+/// `consensus_starfish_speed` configuration. The flag is uniform across the
+/// network within an epoch, so any mismatch implies either a malicious peer
+/// or a misconfigured upgrade path. V2 is gated by `consensus_starfish_speed`;
+/// V1 is the only legal variant when the flag is off.
+pub(crate) fn check_block_header_version_matches_flag(
+    header: &BlockHeader,
+    protocol_config: &iota_protocol_config::ProtocolConfig,
+) -> ConsensusResult<()> {
+    let starfish_speed = protocol_config.consensus_starfish_speed();
+    let variant_matches_flag = matches!(
+        (header, starfish_speed),
+        (BlockHeader::V1(_), false) | (BlockHeader::V2(_), true)
+    );
+    if !variant_matches_flag {
+        let actual = match header {
+            BlockHeader::V1(_) => "V1",
+            BlockHeader::V2(_) => "V2",
+        };
+        return Err(ConsensusError::WrongBlockHeaderVersionForFlag {
+            actual,
+            starfish_speed,
+        });
+    }
+    Ok(())
+}
+
 // All block verification logic are implemented below.
 impl BlockVerifier for SignedBlockVerifier {
     #[instrument(level = "trace", skip_all)]
@@ -105,6 +133,10 @@ impl BlockVerifier for SignedBlockVerifier {
             return Err(ConsensusError::UnexpectedGenesisHeader);
         }
         ConsensusError::quick_validation_authority_indices(&[block.author()], committee)?;
+
+        // Reject blocks whose header variant does not match the local
+        // `consensus_starfish_speed` configuration.
+        check_block_header_version_matches_flag(block, &self.context.protocol_config)?;
 
         // Verify the block's signature.
         block.verify_signature(&self.context)?;
@@ -663,6 +695,70 @@ pub(crate) mod test {
                 .build();
             let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
             verifier.verify(&signed_block).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_block_version_flag() {
+        use crate::block_header::BlockHeader;
+
+        let ancestors = vec![
+            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+            BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+        ];
+
+        // V1 block reaching a flag-on receiver -> WrongBlockHeaderVersionForFlag.
+        {
+            let (mut context, keypairs) = Context::new_for_test(4);
+            context
+                .protocol_config
+                .set_consensus_fast_commit_sync_for_testing(true);
+            context
+                .protocol_config
+                .set_consensus_starfish_speed_for_testing(true);
+            let context = Arc::new(context);
+            let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+
+            let block = TestBlockHeader::new(10, 2)
+                .set_ancestors(ancestors.clone())
+                .build();
+            let signed_block = SignedBlockHeader::new(block, &keypairs[2].1).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::WrongBlockHeaderVersionForFlag {
+                    actual: "V1",
+                    starfish_speed: true,
+                })
+            ));
+        }
+
+        // V2 block reaching a flag-off receiver -> WrongBlockHeaderVersionForFlag.
+        {
+            let (context, keypairs) = Context::new_for_test(4);
+            let context = Arc::new(context);
+            let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+
+            let v2 = crate::block_header::BlockHeaderV2::new(
+                0,
+                10,
+                AuthorityIndex::new_for_test(2),
+                0,
+                ancestors,
+                vec![],
+                vec![],
+                crate::block_header::TransactionsCommitment::DEFAULT_FOR_TEST,
+                None,
+            );
+            let signed_block = SignedBlockHeader::new(BlockHeader::V2(v2), &keypairs[2].1).unwrap();
+            assert!(matches!(
+                verifier.verify(&signed_block),
+                Err(ConsensusError::WrongBlockHeaderVersionForFlag {
+                    actual: "V2",
+                    starfish_speed: false,
+                })
+            ));
         }
     }
 }

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -809,14 +809,20 @@ fn format_block_digests(blocks: &[BlockRef]) -> String {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum Decision {
+    /// Direct rule produced the final status.
     Direct,
+    /// Direct rule produced `Commit(Pending)`; indirect rule later examined
+    /// an anchor's path and upgraded the metastate to Optimistic/Standard.
+    Upgraded,
+    /// Direct rule left the slot Undecided; indirect rule produced the
+    /// final status.
     Indirect,
 }
 
 /// The status of a leader slot from the direct and indirect commit rules.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum LeaderStatus {
-    Commit(VerifiedBlockHeader),
+    Commit(VerifiedBlockHeader, Option<CommitMetastate>),
     Skip(Slot),
     Undecided(Slot),
 }
@@ -824,23 +830,33 @@ pub(crate) enum LeaderStatus {
 impl LeaderStatus {
     pub(crate) fn round(&self) -> Round {
         match self {
-            Self::Commit(block) => block.round(),
+            Self::Commit(block, _) => block.round(),
             Self::Skip(leader) => leader.round,
             Self::Undecided(leader) => leader.round,
         }
     }
 
-    pub(crate) fn is_decided(&self) -> bool {
+    /// Slot of the leader this status refers to.
+    pub(crate) fn slot(&self) -> Slot {
         match self {
-            Self::Commit(_) => true,
-            Self::Skip(_) => true,
+            Self::Commit(block, _) => block.reference().into(),
+            Self::Skip(leader) | Self::Undecided(leader) => *leader,
+        }
+    }
+
+    /// True when sequencing can proceed past this leader. `Commit(Pending)`
+    /// and `Undecided` are non-final.
+    pub(crate) fn is_final(&self) -> bool {
+        match self {
+            Self::Commit(_, Some(CommitMetastate::Pending)) => false,
+            Self::Commit(..) | Self::Skip(_) => true,
             Self::Undecided(_) => false,
         }
     }
 
     pub(crate) fn into_decided_leader(self) -> Option<DecidedLeader> {
         match self {
-            Self::Commit(block) => Some(DecidedLeader::Commit(block)),
+            Self::Commit(block, metastate) => Some(DecidedLeader::Commit(block, metastate)),
             Self::Skip(slot) => Some(DecidedLeader::Skip(slot)),
             Self::Undecided(..) => None,
         }
@@ -850,7 +866,10 @@ impl LeaderStatus {
 impl Display for LeaderStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Commit(block) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, None) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, Some(metastate)) => {
+                write!(f, "Commit({},{metastate})", block.reference())
+            }
             Self::Skip(slot) => write!(f, "Skip({slot})"),
             Self::Undecided(slot) => write!(f, "Undecided({slot})"),
         }
@@ -860,7 +879,7 @@ impl Display for LeaderStatus {
 /// Decision of each leader slot.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum DecidedLeader {
-    Commit(VerifiedBlockHeader),
+    Commit(VerifiedBlockHeader, Option<CommitMetastate>),
     Skip(Slot),
 }
 
@@ -868,7 +887,7 @@ impl DecidedLeader {
     // Slot where the leader is decided.
     pub(crate) fn slot(&self) -> Slot {
         match self {
-            Self::Commit(block) => block.reference().into(),
+            Self::Commit(block, _) => block.reference().into(),
             Self::Skip(slot) => *slot,
         }
     }
@@ -877,7 +896,7 @@ impl DecidedLeader {
     // otherwise.
     pub(crate) fn into_committed_block(self) -> Option<VerifiedBlockHeader> {
         match self {
-            Self::Commit(block) => Some(block),
+            Self::Commit(block, _) => Some(block),
             Self::Skip(_) => None,
         }
     }
@@ -885,7 +904,7 @@ impl DecidedLeader {
     #[cfg(test)]
     pub(crate) fn round(&self) -> Round {
         match self {
-            Self::Commit(block) => block.round(),
+            Self::Commit(block, _) => block.round(),
             Self::Skip(leader) => leader.round,
         }
     }
@@ -893,7 +912,7 @@ impl DecidedLeader {
     #[cfg(test)]
     pub(crate) fn authority(&self) -> AuthorityIndex {
         match self {
-            Self::Commit(block) => block.author(),
+            Self::Commit(block, _) => block.author(),
             Self::Skip(leader) => leader.authority,
         }
     }
@@ -902,8 +921,36 @@ impl DecidedLeader {
 impl Display for DecidedLeader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Commit(block) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, None) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, Some(metastate)) => {
+                write!(f, "Commit({},{metastate})", block.reference())
+            }
             Self::Skip(slot) => write!(f, "Skip({slot})"),
+        }
+    }
+}
+
+/// Refined commit state for StarfishSpeed leaders, determined at commit time
+/// from the strong-vote evidence at rounds r+1 (voting) and r+2 (certifying).
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub(crate) enum CommitMetastate {
+    /// Strong-vote quorum at r+1 AND StrongQC quorum at r+2.
+    /// Sequence histDA(L) + leader acknowledgment blocks.
+    Optimistic,
+    /// Strong-blame quorum observed at r+1 (no StrongQC quorum possible).
+    /// Sequence histDA(L) only (same as base Starfish).
+    Standard,
+    /// Neither a strong-vote nor a strong-blame quorum observed.
+    /// Metastate is resolved later (by the indirect rule).
+    Pending,
+}
+
+impl Display for CommitMetastate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Optimistic => write!(f, "optimistic"),
+            Self::Standard => write!(f, "standard"),
+            Self::Pending => write!(f, "pending"),
         }
     }
 }

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -62,11 +62,12 @@ pub(crate) type WaveNumber = u32;
 pub(crate) enum Commit {
     V1(CommitV1),
     V2(CommitV2),
+    V3(CommitV3),
 }
 
 impl Commit {
-    /// Create a new commit. The variant (V1 or V2) is determined by the
-    /// consensus_fast_commit_sync protocol flag.
+    /// Create a new commit. The variant (V1, V2, or V3) is determined by the
+    /// consensus_fast_commit_sync and consensus_starfish_speed protocol flags.
     pub(crate) fn new(
         context: &Arc<Context>,
         index: CommitIndex,
@@ -76,8 +77,33 @@ impl Commit {
         blocks: Vec<BlockRef>,
         committed_transactions: Vec<GenericTransactionRef>,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
+        is_optimistic: bool,
     ) -> Self {
-        if context.protocol_config.consensus_fast_commit_sync() {
+        if context.protocol_config.consensus_starfish_speed() {
+            debug!("Creating CommitV3 as consensus_starfish_speed is enabled");
+            // consensus_starfish_speed implies consensus_fast_commit_sync (asserted in
+            // protocol config), so all committed transactions are TransactionRefs.
+            let transaction_refs: Vec<TransactionRef> = committed_transactions
+                .into_iter()
+                .map(|gen_ref| match gen_ref {
+                    GenericTransactionRef::TransactionRef(tr) => tr,
+                    GenericTransactionRef::BlockRef(_) => {
+                        panic!("Expected TransactionRef when consensus_starfish_speed is enabled")
+                    }
+                })
+                .collect();
+
+            Commit::V3(CommitV3 {
+                index,
+                previous_digest,
+                timestamp_ms,
+                leader,
+                block_headers: blocks,
+                committed_transactions: transaction_refs,
+                reputation_scores_desc,
+                is_optimistic,
+            })
+        } else if context.protocol_config.consensus_fast_commit_sync() {
             debug!("Creating CommitV2 as consensus_fast_commit_sync is enabled");
             // Extract TransactionRefs from GenericTransactionRef
             let transaction_refs: Vec<TransactionRef> = committed_transactions
@@ -139,6 +165,7 @@ pub(crate) trait CommitAPI {
     fn block_headers(&self) -> &[BlockRef];
     fn committed_transactions(&self) -> Vec<GenericTransactionRef>;
     fn reputation_scores(&self) -> &[(AuthorityIndex, u64)];
+    fn is_optimistic(&self) -> bool;
 }
 
 /// Specifies one consensus commit.
@@ -200,6 +227,10 @@ impl CommitAPI for CommitV1 {
     fn reputation_scores(&self) -> &[(AuthorityIndex, u64)] {
         // CommitV1 does not have reputation scores
         &[]
+    }
+
+    fn is_optimistic(&self) -> bool {
+        false
     }
 }
 
@@ -266,6 +297,82 @@ impl CommitAPI for CommitV2 {
     fn reputation_scores(&self) -> &[(AuthorityIndex, u64)] {
         &self.reputation_scores_desc
     }
+
+    fn is_optimistic(&self) -> bool {
+        false
+    }
+}
+
+/// Specifies one consensus commit.
+/// It is stored on disk, so it does not contain blocks which are stored
+/// individually.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub(crate) struct CommitV3 {
+    /// Index of the commit.
+    /// First commit after genesis has an index of 1, then every next commit has
+    /// an index incremented by 1.
+    index: CommitIndex,
+    /// Digest of the previous commit.
+    /// Set to CommitDigest::MIN for the first commit after genesis.
+    previous_digest: CommitDigest,
+    /// Timestamp of the commit, max of the timestamp of the leader block and
+    /// previous Commit timestamp.
+    timestamp_ms: BlockTimestampMs,
+    /// A reference to the commit leader.
+    leader: BlockRef,
+    /// Refs to committed headers, in the commit order.
+    block_headers: Vec<BlockRef>,
+    /// Refs to transactions in blocks for which quorum of acknowledgments has
+    /// been collected in this and past commits.
+    committed_transactions: Vec<TransactionRef>,
+    /// Optional scores that are provided as part of the consensus output to
+    /// IOTA that can then be used by IOTA for future transaction submission to
+    /// consensus.
+    reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
+    /// True if the leader was committed via the StarfishSpeed Optimistic
+    /// metastate.
+    is_optimistic: bool,
+}
+
+impl CommitAPI for CommitV3 {
+    fn round(&self) -> Round {
+        self.leader.round
+    }
+
+    fn index(&self) -> CommitIndex {
+        self.index
+    }
+
+    fn previous_digest(&self) -> CommitDigest {
+        self.previous_digest
+    }
+
+    fn timestamp_ms(&self) -> BlockTimestampMs {
+        self.timestamp_ms
+    }
+
+    fn leader(&self) -> BlockRef {
+        self.leader
+    }
+
+    fn block_headers(&self) -> &[BlockRef] {
+        &self.block_headers
+    }
+
+    fn committed_transactions(&self) -> Vec<GenericTransactionRef> {
+        self.committed_transactions
+            .iter()
+            .map(|t| GenericTransactionRef::TransactionRef(*t))
+            .collect()
+    }
+
+    fn reputation_scores(&self) -> &[(AuthorityIndex, u64)] {
+        &self.reputation_scores_desc
+    }
+
+    fn is_optimistic(&self) -> bool {
+        self.is_optimistic
+    }
 }
 
 /// A commit is trusted when it is produced locally or certified by a quorum of
@@ -311,6 +418,7 @@ impl TrustedCommit {
             blocks,
             committed_transactions,
             vec![],
+            false,
         );
         let serialized = commit.serialize().unwrap();
         Self::new_trusted(commit, serialized)

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -820,9 +820,18 @@ pub(crate) enum Decision {
 }
 
 /// The status of a leader slot from the direct and indirect commit rules.
+///
+/// `Commit(_, Some(Optimistic), strong_voters)` carries the r+1 authorities
+/// whose strong votes attest data availability for the leader and its
+/// acknowledgments; the linearizer feeds them to the per-ref ack tracker.
+/// Empty for every other case.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum LeaderStatus {
-    Commit(VerifiedBlockHeader, Option<CommitMetastate>),
+    Commit(
+        VerifiedBlockHeader,
+        Option<CommitMetastate>,
+        Vec<AuthorityIndex>,
+    ),
     Skip(Slot),
     Undecided(Slot),
 }
@@ -830,7 +839,7 @@ pub(crate) enum LeaderStatus {
 impl LeaderStatus {
     pub(crate) fn round(&self) -> Round {
         match self {
-            Self::Commit(block, _) => block.round(),
+            Self::Commit(block, _, _) => block.round(),
             Self::Skip(leader) => leader.round,
             Self::Undecided(leader) => leader.round,
         }
@@ -839,7 +848,7 @@ impl LeaderStatus {
     /// Slot of the leader this status refers to.
     pub(crate) fn slot(&self) -> Slot {
         match self {
-            Self::Commit(block, _) => block.reference().into(),
+            Self::Commit(block, _, _) => block.reference().into(),
             Self::Skip(leader) | Self::Undecided(leader) => *leader,
         }
     }
@@ -848,7 +857,7 @@ impl LeaderStatus {
     /// and `Undecided` are non-final.
     pub(crate) fn is_final(&self) -> bool {
         match self {
-            Self::Commit(_, Some(CommitMetastate::Pending)) => false,
+            Self::Commit(_, Some(CommitMetastate::Pending), _) => false,
             Self::Commit(..) | Self::Skip(_) => true,
             Self::Undecided(_) => false,
         }
@@ -856,7 +865,9 @@ impl LeaderStatus {
 
     pub(crate) fn into_decided_leader(self) -> Option<DecidedLeader> {
         match self {
-            Self::Commit(block, metastate) => Some(DecidedLeader::Commit(block, metastate)),
+            Self::Commit(block, metastate, strong_voters) => {
+                Some(DecidedLeader::Commit(block, metastate, strong_voters))
+            }
             Self::Skip(slot) => Some(DecidedLeader::Skip(slot)),
             Self::Undecided(..) => None,
         }
@@ -866,8 +877,8 @@ impl LeaderStatus {
 impl Display for LeaderStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Commit(block, None) => write!(f, "Commit({})", block.reference()),
-            Self::Commit(block, Some(metastate)) => {
+            Self::Commit(block, None, _) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, Some(metastate), _) => {
                 write!(f, "Commit({},{metastate})", block.reference())
             }
             Self::Skip(slot) => write!(f, "Skip({slot})"),
@@ -879,7 +890,11 @@ impl Display for LeaderStatus {
 /// Decision of each leader slot.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum DecidedLeader {
-    Commit(VerifiedBlockHeader, Option<CommitMetastate>),
+    Commit(
+        VerifiedBlockHeader,
+        Option<CommitMetastate>,
+        Vec<AuthorityIndex>,
+    ),
     Skip(Slot),
 }
 
@@ -887,16 +902,24 @@ impl DecidedLeader {
     // Slot where the leader is decided.
     pub(crate) fn slot(&self) -> Slot {
         match self {
-            Self::Commit(block, _) => block.reference().into(),
+            Self::Commit(block, _, _) => block.reference().into(),
             Self::Skip(slot) => *slot,
         }
     }
 
-    // Converts to committed block if the decision is to commit. Returns None
-    // otherwise.
-    pub(crate) fn into_committed_block(self) -> Option<VerifiedBlockHeader> {
+    // Converts a Commit decision into the committed block, metastate, and
+    // strong-voter authority set. Returns None for Skip.
+    pub(crate) fn into_committed_block(
+        self,
+    ) -> Option<(
+        VerifiedBlockHeader,
+        Option<CommitMetastate>,
+        Vec<AuthorityIndex>,
+    )> {
         match self {
-            Self::Commit(block, _) => Some(block),
+            Self::Commit(block, metastate, strong_voters) => {
+                Some((block, metastate, strong_voters))
+            }
             Self::Skip(_) => None,
         }
     }
@@ -904,7 +927,7 @@ impl DecidedLeader {
     #[cfg(test)]
     pub(crate) fn round(&self) -> Round {
         match self {
-            Self::Commit(block, _) => block.round(),
+            Self::Commit(block, _, _) => block.round(),
             Self::Skip(leader) => leader.round,
         }
     }
@@ -912,7 +935,7 @@ impl DecidedLeader {
     #[cfg(test)]
     pub(crate) fn authority(&self) -> AuthorityIndex {
         match self {
-            Self::Commit(block, _) => block.author(),
+            Self::Commit(block, _, _) => block.author(),
             Self::Skip(leader) => leader.authority,
         }
     }
@@ -921,8 +944,8 @@ impl DecidedLeader {
 impl Display for DecidedLeader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Commit(block, None) => write!(f, "Commit({})", block.reference()),
-            Self::Commit(block, Some(metastate)) => {
+            Self::Commit(block, None, _) => write!(f, "Commit({})", block.reference()),
+            Self::Commit(block, Some(metastate), _) => {
                 write!(f, "Commit({},{metastate})", block.reference())
             }
             Self::Skip(slot) => write!(f, "Skip({slot})"),
@@ -953,6 +976,19 @@ impl Display for CommitMetastate {
             Self::Pending => write!(f, "pending"),
         }
     }
+}
+
+/// Test helper: pair each leader with `None` metastate and an empty
+/// strong-voter set.
+#[cfg(test)]
+pub(crate) fn with_no_metastate(
+    blocks: Vec<VerifiedBlockHeader>,
+) -> Vec<(
+    VerifiedBlockHeader,
+    Option<CommitMetastate>,
+    Vec<AuthorityIndex>,
+)> {
+    blocks.into_iter().map(|b| (b, None, Vec::new())).collect()
 }
 
 /// Per-commit properties that can be regenerated from past values, and do not

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::{
     CommitConsumer, CommittedSubDag,
-    block_header::{BlockHeaderAPI, VerifiedBlockHeader},
+    block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
     commit::{
         CommitAPI, CommitIndex, CommitMetastate, PendingSubDag, TrustedCommit,
         load_pending_subdag_from_store,
@@ -327,6 +327,7 @@ impl CommitObserver {
         for commit in recovery_commits {
             // Recovery only needs headers/acks, so reputation scores are irrelevant here.
             let commit_index = commit.index();
+            let is_optimistic = commit.is_optimistic();
             let pending_sub_dag =
                 load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
 
@@ -344,6 +345,29 @@ impl CommitObserver {
                         authority_idx,
                         transaction_acknowledgments,
                     );
+                }
+
+                // Repopulate the ack tracker for transactions optimistically committed
+                // pre-restart so post-restart acks don't cross 2f+1 and re-commit them.
+                // The full committee is used as a conservative over-approximation of
+                // the actual acknowledging set.
+                if is_optimistic {
+                    let leader_ref = pending_sub_dag.leader;
+                    let leader_header = pending_sub_dag
+                        .headers
+                        .iter()
+                        .find(|h| h.reference() == leader_ref)
+                        .expect("leader header must be present in pending sub-dag");
+                    let refs: Vec<BlockRef> = std::iter::once(leader_ref)
+                        .chain(leader_header.acknowledgments().iter().copied())
+                        .collect();
+                    for (authority_idx, _) in self.context.committee.authorities() {
+                        let _ = self.linearizer.add_committed_transaction_acks(
+                            leader_header.round() + 1,
+                            authority_idx,
+                            refs.clone(),
+                        );
+                    }
                 }
             }
 
@@ -646,6 +670,7 @@ mod tests {
         dag_state::{DagState, DataSource},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
+        transaction_ref::GenericTransactionRefAPI,
     };
 
     #[tokio::test]
@@ -1328,5 +1353,197 @@ mod tests {
 
         // Verify that txs_after significantly exceeds txs_before
         assert!(txs_after >= txs_before * 4,);
+    }
+
+    /// Run the commit pipeline through a restart. With `starfish_speed` true,
+    /// L5 is committed Optimistically (full-committee strong-voters); with
+    /// false, L5 is committed standardly. Returns L5's ref, L5's acks, the
+    /// refs in L5's commit, and the refs across all post-restart commits.
+    async fn run_recovery_scenario(
+        starfish_speed: bool,
+    ) -> (
+        BlockRef,
+        Vec<BlockRef>,
+        Vec<GenericTransactionRef>,
+        Vec<GenericTransactionRef>,
+    ) {
+        let num_authorities = 4;
+
+        let mut protocol_config =
+            iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE();
+        protocol_config.set_consensus_starfish_speed_for_testing(starfish_speed);
+
+        let (committee, _keypairs) =
+            starfish_config::local_committee_and_keys(0, vec![1; num_authorities]);
+        let metrics = crate::metrics::test_metrics();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let clock = Arc::new(crate::context::Clock::default());
+        let context = Arc::new(Context::new(
+            0,
+            starfish_config::AuthorityIndex::new_for_test(0),
+            committee,
+            starfish_config::Parameters {
+                db_path: temp_dir.keep(),
+                ..Default::default()
+            },
+            protocol_config,
+            metrics,
+            clock,
+        ));
+
+        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            mem_store.clone(),
+        )));
+        let (sender, mut receiver) = unbounded_channel("consensus_output");
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
+            context.clone(),
+            dag_state.clone(),
+        ));
+
+        let mut observer = CommitObserver::new(
+            context.clone(),
+            CommitConsumer::new(sender.clone(), 0),
+            dag_state.clone(),
+            mem_store.clone(),
+            leader_schedule.clone(),
+        );
+
+        let mut builder = DagBuilder::new(context.clone());
+        builder
+            .layers(1..=5)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        let leaders_1_to_4: Vec<_> = builder
+            .leader_blocks(1..=4)
+            .into_iter()
+            .map(Option::unwrap)
+            .collect();
+        let l5 = builder
+            .leader_block(5)
+            .expect("leader at round 5 should exist");
+        let l5_ref = l5.reference();
+        let l5_acks: Vec<BlockRef> = l5.acknowledgments().to_vec();
+
+        observer
+            .handle_committed_leaders(
+                with_no_metastate(leaders_1_to_4),
+                CommittedSubDagSource::Consensus,
+            )
+            .unwrap();
+
+        let l5_meta = if starfish_speed {
+            let strong_voters: Vec<AuthorityIndex> = (0..num_authorities as u8)
+                .map(AuthorityIndex::new_for_test)
+                .collect();
+            vec![(l5, Some(CommitMetastate::Optimistic), strong_voters)]
+        } else {
+            with_no_metastate(vec![l5])
+        };
+        let (pre_commits, _) = observer
+            .handle_committed_leaders(l5_meta, CommittedSubDagSource::Consensus)
+            .unwrap();
+        let pre_refs = pre_commits
+            .last()
+            .expect("at least one commit")
+            .committed_transaction_refs
+            .clone();
+
+        while receiver.try_recv().is_ok() {}
+        drop(observer);
+        let mut observer_after = CommitObserver::new(
+            context,
+            CommitConsumer::new(sender, 0),
+            dag_state.clone(),
+            mem_store,
+            leader_schedule,
+        );
+        while receiver.try_recv().is_ok() {}
+
+        builder.layers(6..=8).build().persist_layers(dag_state);
+        let later_leaders: Vec<_> = builder.leader_blocks(6..=8).into_iter().flatten().collect();
+        let (later_commits, _) = observer_after
+            .handle_committed_leaders(
+                with_no_metastate(later_leaders),
+                CommittedSubDagSource::Consensus,
+            )
+            .unwrap();
+        let post_refs: Vec<GenericTransactionRef> = later_commits
+            .iter()
+            .flat_map(|c| c.committed_transaction_refs.iter().cloned())
+            .collect();
+
+        (l5_ref, l5_acks, pre_refs, post_refs)
+    }
+
+    /// With `consensus_starfish_speed` ON, L5 is committed Optimistically and
+    /// its ref + acks land in commit 5 (early); recovery seeding then
+    /// suppresses re-commit post-restart. With the flag OFF, L5 is
+    /// committed standardly: its ref + acks are NOT in commit 5 and appear
+    /// only later, when natural 2f+1 acks accumulate across post-restart
+    /// commits.
+    #[tokio::test]
+    async fn test_optimistic_vs_standard_recovery_timing() {
+        telemetry_subscribers::init_for_testing();
+
+        let (l5_ref_on, l5_acks_on, pre_on, post_on) = run_recovery_scenario(true).await;
+        let (l5_ref_off, l5_acks_off, pre_off, post_off) = run_recovery_scenario(false).await;
+
+        assert!(!l5_acks_on.is_empty(), "leader should have acks");
+        assert!(!l5_acks_off.is_empty(), "leader should have acks");
+
+        let contains = |refs: &[GenericTransactionRef], target: &BlockRef| -> bool {
+            refs.iter()
+                .any(|r| r.round() == target.round && r.author() == target.author)
+        };
+
+        // Flag ON: L5's ref + every ack land in L5's commit (early), and
+        // recovery seeding suppresses re-commit post-restart.
+        assert!(
+            contains(&pre_on, &l5_ref_on),
+            "ON: L5's commit should include L5_ref"
+        );
+        for ack in &l5_acks_on {
+            assert!(
+                contains(&pre_on, ack),
+                "ON: L5's commit should include L5_ack {ack:?}"
+            );
+        }
+        assert!(
+            !contains(&post_on, &l5_ref_on),
+            "ON: post-restart commits must NOT re-include L5_ref"
+        );
+        for ack in &l5_acks_on {
+            assert!(
+                !contains(&post_on, ack),
+                "ON: post-restart commits must NOT re-include L5_ack {ack:?}"
+            );
+        }
+
+        // Flag OFF: L5's ref + acks are NOT in L5's commit (no Optimistic
+        // pre-credit); they appear only in some later commit when 2f+1 acks
+        // accumulate naturally.
+        assert!(
+            !contains(&pre_off, &l5_ref_off),
+            "OFF: L5's commit must NOT include L5_ref"
+        );
+        for ack in &l5_acks_off {
+            assert!(
+                !contains(&pre_off, ack),
+                "OFF: L5's commit must NOT include L5_ack {ack:?}"
+            );
+        }
+        assert!(
+            contains(&post_off, &l5_ref_off),
+            "OFF: post-restart commits SHOULD include L5_ref once natural acks accumulate"
+        );
+        for ack in &l5_acks_off {
+            assert!(
+                contains(&post_off, ack),
+                "OFF: post-restart commits SHOULD include L5_ack {ack:?} once natural acks accumulate"
+            );
+        }
     }
 }

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -1391,7 +1391,7 @@ mod tests {
             clock,
         ));
 
-        let mem_store = Arc::new(MemStore::new(context.clone()));
+        let mem_store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             mem_store.clone(),

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -18,7 +18,8 @@ use crate::{
     CommitConsumer, CommittedSubDag,
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
     commit::{
-        CommitAPI, CommitIndex, PendingSubDag, TrustedCommit, load_pending_subdag_from_store,
+        CommitAPI, CommitIndex, CommitMetastate, PendingSubDag, TrustedCommit,
+        load_pending_subdag_from_store,
     },
     commit_solidifier::CommitSolidifier,
     context::Context,
@@ -146,7 +147,11 @@ impl CommitObserver {
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn handle_committed_leaders(
         &mut self,
-        committed_leaders: Vec<VerifiedBlockHeader>,
+        committed_leaders: Vec<(
+            VerifiedBlockHeader,
+            Option<CommitMetastate>,
+            Vec<AuthorityIndex>,
+        )>,
         source: CommittedSubDagSource,
     ) -> ConsensusResult<(
         Vec<PendingSubDag>,
@@ -636,6 +641,7 @@ mod tests {
     use super::*;
     use crate::{
         block_header::BlockRef,
+        commit::with_no_metastate,
         context::Context,
         dag_state::{DagState, DataSource},
         storage::mem_store::MemStore,
@@ -683,7 +689,10 @@ mod tests {
             .collect::<Vec<_>>();
 
         let (commits, _missing_transactions_refs) = observer
-            .handle_committed_leaders(leaders.clone(), CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(
+                with_no_metastate(leaders.clone()),
+                CommittedSubDagSource::Consensus,
+            )
             .unwrap();
 
         // Check commits are returned by CommitObserver::handle_commit is accurate
@@ -804,11 +813,13 @@ mod tests {
         let expected_last_processed_index: usize = 2;
         let (mut created_commits, _missing_transactions_refs) = observer
             .handle_committed_leaders(
-                leaders
-                    .clone()
-                    .into_iter()
-                    .take(expected_last_processed_index)
-                    .collect::<Vec<_>>(),
+                with_no_metastate(
+                    leaders
+                        .clone()
+                        .into_iter()
+                        .take(expected_last_processed_index)
+                        .collect::<Vec<_>>(),
+                ),
                 CommittedSubDagSource::Consensus,
             )
             .unwrap();
@@ -841,10 +852,12 @@ mod tests {
         created_commits.append(
             &mut observer
                 .handle_committed_leaders(
-                    leaders
-                        .into_iter()
-                        .skip(expected_last_processed_index)
-                        .collect::<Vec<_>>(),
+                    with_no_metastate(
+                        leaders
+                            .into_iter()
+                            .skip(expected_last_processed_index)
+                            .collect::<Vec<_>>(),
+                    ),
                     CommittedSubDagSource::Consensus,
                 )
                 .unwrap()
@@ -950,7 +963,7 @@ mod tests {
         // the consensus output channel.
         let expected_last_processed_index: usize = 10;
         let (created_commits, _missing_transactions_refs) = observer
-            .handle_committed_leaders(leaders, CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(with_no_metastate(leaders), CommittedSubDagSource::Consensus)
             .unwrap();
 
         // Check commits sent over consensus output channel is accurate
@@ -1045,7 +1058,7 @@ mod tests {
         assert_eq!(leaders.len(), num_rounds as usize);
 
         let _ = observer
-            .handle_committed_leaders(leaders, CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(with_no_metastate(leaders), CommittedSubDagSource::Consensus)
             .unwrap();
 
         // Drain the receiver to simulate consumer processing commits before crash.
@@ -1256,7 +1269,10 @@ mod tests {
         // Commit first 3 leaders (rounds 1-3)
         // Each leader in the first 3 rounds has transactions from previous rounds
         let (_, _) = observer
-            .handle_committed_leaders(all_leaders[0..3].to_vec(), CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(
+                with_no_metastate(all_leaders[0..3].to_vec()),
+                CommittedSubDagSource::Consensus,
+            )
             .unwrap();
 
         // Count transactions: with 4 authorities and standard DAG, each commit includes
@@ -1297,7 +1313,10 @@ mod tests {
         // Process new blocks - they acknowledge transactions from rounds 5-6
         // plus transactions from recovered blocks (rounds 1-3)
         let (_commits_after, _) = observer_after_restart
-            .handle_committed_leaders(new_leaders, CommittedSubDagSource::Consensus)
+            .handle_committed_leaders(
+                with_no_metastate(new_leaders),
+                CommittedSubDagSource::Consensus,
+            )
             .unwrap();
 
         // Count transactions from new commits: new leaders in rounds 7-8 will process

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -223,18 +223,21 @@ pub(crate) fn check_commit_version_matches_flags(
     protocol_config: &iota_protocol_config::ProtocolConfig,
 ) -> ConsensusResult<()> {
     let fast_commit_sync = protocol_config.consensus_fast_commit_sync();
+    let starfish_speed = protocol_config.consensus_starfish_speed();
     let variant_matches_flags = matches!(
-        (commit, fast_commit_sync),
-        (Commit::V1(_), false) | (Commit::V2(_), true)
+        (commit, fast_commit_sync, starfish_speed),
+        (Commit::V1(_), false, false) | (Commit::V2(_), true, false) | (Commit::V3(_), true, true)
     );
     if !variant_matches_flags {
         let actual = match commit {
             Commit::V1(_) => "V1",
             Commit::V2(_) => "V2",
+            Commit::V3(_) => "V3",
         };
         return Err(ConsensusError::WrongCommitVersionForFlags {
             actual,
             fast_commit_sync,
+            starfish_speed,
         });
     }
     Ok(())
@@ -809,18 +812,25 @@ mod tests {
     use super::*;
     use crate::{
         block_verifier::NoopBlockVerifier,
-        commit::{CommitV1, CommitV2},
+        commit::{CommitV1, CommitV2, CommitV3},
     };
 
     /// Builds a single-commit byte stream from `commit` and runs it through
-    /// `verify_commits` with `consensus_fast_commit_sync` set to
-    /// `fast_commit_sync_on`. The version check fires before the index
-    /// check, so the default commit index of 0 is fine here.
-    fn run_verify(commit: Commit, fast_commit_sync_on: bool) -> ConsensusResult<()> {
+    /// `verify_commits` with the two protocol flags set as specified. The
+    /// version check fires before the index check, so the default commit
+    /// index of 0 is fine here.
+    fn run_verify(
+        commit: Commit,
+        fast_commit_sync_on: bool,
+        starfish_speed_on: bool,
+    ) -> ConsensusResult<()> {
         let (mut context, _) = Context::new_for_test(4);
         context
             .protocol_config
             .set_consensus_fast_commit_sync_for_testing(fast_commit_sync_on);
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(starfish_speed_on);
         let context = Arc::new(context);
         let misbehavior_store = MisbehaviorStore::new(&context);
         let serialized = commit.serialize().unwrap();
@@ -837,27 +847,31 @@ mod tests {
         .map(|_| ())
     }
 
+    #[rstest::rstest]
+    #[case::v1_with_fast_on(Commit::V1(CommitV1::default()), true, false, "V1")]
+    #[case::v1_with_starfish_on(Commit::V1(CommitV1::default()), true, true, "V1")]
+    #[case::v2_with_fast_off(Commit::V2(CommitV2::default()), false, false, "V2")]
+    #[case::v2_with_starfish_on(Commit::V2(CommitV2::default()), true, true, "V2")]
+    #[case::v3_with_fast_off(Commit::V3(CommitV3::default()), false, false, "V3")]
+    #[case::v3_with_starfish_off(Commit::V3(CommitV3::default()), true, false, "V3")]
     #[tokio::test]
-    async fn verify_commits_rejects_v2_commit_when_fast_commit_sync_disabled() {
-        let result = run_verify(Commit::V2(CommitV2::default()), false);
-        assert!(matches!(
-            result,
-            Err(ConsensusError::WrongCommitVersionForFlags {
-                actual: "V2",
-                fast_commit_sync: false,
-            })
-        ));
-    }
-
-    #[tokio::test]
-    async fn verify_commits_rejects_v1_commit_when_fast_commit_sync_enabled() {
-        let result = run_verify(Commit::V1(CommitV1::default()), true);
-        assert!(matches!(
-            result,
-            Err(ConsensusError::WrongCommitVersionForFlags {
-                actual: "V1",
-                fast_commit_sync: true,
-            })
-        ));
+    async fn verify_commits_rejects_wrong_version(
+        #[case] commit: Commit,
+        #[case] fast_commit_sync_on: bool,
+        #[case] starfish_speed_on: bool,
+        #[case] expected_variant: &'static str,
+    ) {
+        let result = run_verify(commit, fast_commit_sync_on, starfish_speed_on);
+        let Err(ConsensusError::WrongCommitVersionForFlags {
+            actual,
+            fast_commit_sync,
+            starfish_speed,
+        }) = result
+        else {
+            panic!("expected WrongCommitVersionForFlags, got {result:?}");
+        };
+        assert_eq!(actual, expected_variant);
+        assert_eq!(fast_commit_sync, fast_commit_sync_on);
+        assert_eq!(starfish_speed, starfish_speed_on);
     }
 }

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -20,6 +20,7 @@ use tracing::{debug, warn};
 
 use crate::{
     BlockHeaderAPI, BlockRef, Round, VerifiedBlockHeader,
+    authority_set::AuthoritySet,
     block_header::{BlockHeaderDigest, TransactionsCommitment, VerifiedBlock},
     context::Context,
     dag_state::DagState,
@@ -43,43 +44,7 @@ const CORDIAL_KNOWLEDGE_CHANNEL_CAPACITY: usize = 10_000;
 /// skip evictions for too long either.
 const EVICTION_CHECK_INTERVAL: usize = 10_000;
 
-/// Represents a subset of authorities using a bitmask.
-/// Each bit in the `low` and `high` fields corresponds to an authority index.
-/// The maximum number of authorities supported is 256 (0-255).
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct SubsetAuthorities {
-    low: u128,
-    high: u128,
-}
-
 pub type Ancestors = Arc<[BlockRef]>;
-impl SubsetAuthorities {
-    #[inline]
-    pub fn new_with(author: usize, own: usize) -> Self {
-        let mut s = Self { low: 0, high: 0 };
-        s.insert(author);
-        s.insert(own);
-        s
-    }
-
-    /// Insert an authority into the subset. Returns true if the authority was
-    /// not already present.
-    #[inline]
-    pub fn insert(&mut self, i: usize) -> bool {
-        if i < 128 {
-            let mask = 1u128 << i;
-            let already_present = (self.low & mask) != 0;
-            self.low |= mask;
-            !already_present
-        } else {
-            let bit = i - 128;
-            let mask = 1u128 << bit;
-            let already_present = (self.high & mask) != 0;
-            self.high |= mask;
-            !already_present
-        }
-    }
-}
 
 /// Manages the global cordial knowledge state.
 /// Receives high-level updates from DagState and AuthorityService and
@@ -105,8 +70,7 @@ pub(crate) struct CordialKnowledge {
     /// shall retrieve it from `cordial_knowledge[block_ref.
     /// author][block_ref.round][block_ref.digest]`. The provided value is a
     /// tuple of (ancestors, who knows the block header).
-    cordial_knowledge:
-        Vec<BTreeMap<Round, AHashMap<BlockHeaderDigest, (Ancestors, SubsetAuthorities)>>>,
+    cordial_knowledge: Vec<BTreeMap<Round, AHashMap<BlockHeaderDigest, (Ancestors, AuthoritySet)>>>,
     /// Each Connection Knowledge corresponds to one peer. Upon reception of a
     /// message from CordialKnowledge, we propagate the respected
     /// information for each connection.
@@ -623,7 +587,7 @@ impl CordialKnowledge {
 
         // Insert block into cordial knowledge
         let ancestors: Ancestors = Arc::from(header.ancestors());
-        let who_knows_this_block = SubsetAuthorities::new_with(block_author, own_index);
+        let who_knows_this_block = AuthoritySet::new_with(block_ref.author, self.context.own_index);
         round_map.insert(block_digest, (ancestors, who_knows_this_block));
 
         // 2) Notify all *other* authorities (except self and block_author) about new
@@ -693,7 +657,7 @@ impl CordialKnowledge {
                 if let Some(parent_round_map) = parent_author_map.get_mut(&parent_round) {
                     if let Some((_, who_knows_parent)) = parent_round_map.get_mut(&parent_digest) {
                         // Mark that block_author now knows this parent
-                        if who_knows_parent.insert(block_author) {
+                        if who_knows_parent.insert(block_ref.author) {
                             vec_knowledge_msgs[block_author].push(
                                 ConnectionKnowledgeMessage::RemoveHeader {
                                     block_ref: *parent_ref,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -111,6 +111,10 @@ pub(crate) struct Core {
     /// Encoder is used to encode transactions into a longer vector of shards
     encoder: Box<dyn ShardEncoder + Send + Sync>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
+    /// Clock round for which the wait for a strong-vote quorum has timed out.
+    /// Any subsequent block-creation attempt at that same round skips the
+    /// strong-vote quorum check, regardless of the reason that triggered it.
+    strong_vote_timed_out_round: Option<Round>,
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
@@ -118,6 +122,7 @@ pub(crate) enum ReasonToCreateBlock {
     MinBlockDelayTimeout,
     AddBlock,
     AddBlockHeader,
+    SoftTimeout,
     MaxLeaderTimeout,
     Recover,
     QuorumSubscribersExist,
@@ -133,6 +138,7 @@ impl ReasonToCreateBlock {
             ReasonToCreateBlock::AddBlock => "AddBlock",
             ReasonToCreateBlock::MaxLeaderTimeout => "MaxLeaderTimeout",
             ReasonToCreateBlock::AddBlockHeader => "AddBlockHeader",
+            ReasonToCreateBlock::SoftTimeout => "SoftTimeout",
             ReasonToCreateBlock::Recover => "Recover",
             ReasonToCreateBlock::QuorumSubscribersExist => "QuorumSubscribersExist",
             ReasonToCreateBlock::KnownLastBlock => "KnownLastBlock",
@@ -148,6 +154,7 @@ impl ReasonToCreateBlock {
             ReasonToCreateBlock::AddBlock => false,
             ReasonToCreateBlock::MaxLeaderTimeout => true,
             ReasonToCreateBlock::AddBlockHeader => false,
+            ReasonToCreateBlock::SoftTimeout => false,
             ReasonToCreateBlock::Recover => true,
             ReasonToCreateBlock::QuorumSubscribersExist => true,
             ReasonToCreateBlock::KnownLastBlock => true,
@@ -253,6 +260,7 @@ impl Core {
             last_known_proposed_round: min_propose_round,
             encoder,
             commit_vote_monitor,
+            strong_vote_timed_out_round: None,
         }
         .recover()
     }
@@ -792,14 +800,37 @@ impl Core {
         // upstream in `should_propose`.
         let clock_round = self.dag_state.read().threshold_clock_round();
 
+        // Record when the wait for a strong-vote quorum has timed out for
+        // this clock round. Every subsequent attempt at the same round then
+        // skips the strong-vote check regardless of reason. A stale value
+        // from an earlier round is inert because only an exact match with
+        // the current clock_round below triggers the skip.
+        if matches!(reason, ReasonToCreateBlock::SoftTimeout) {
+            self.strong_vote_timed_out_round = Some(clock_round);
+        }
+        let strong_vote_timed_out = self.strong_vote_timed_out_round == Some(clock_round);
+
         // There must be a quorum of blocks from the previous round.
         let quorum_round = clock_round.saturating_sub(1);
+
+        // Fetch the leader block header at quorum_round once; reused for the
+        // leader-existence check, the strong-vote readiness check, and the
+        // block header's strong_vote field.
+        let leader_header = self.leader_header(quorum_round);
 
         // Create a new block either because we want to "forcefully" propose a block due
         // to a leader timeout, or because we are actually ready to produce the
         // block (leader exists and min delay has passed).
         if !reason.is_forced() {
-            if !self.leaders_exist(quorum_round) {
+            leader_header.as_ref()?;
+
+            // Strong-vote readiness check 1 (StarfishSpeed only, bypassed on
+            // soft-timeout): 2f+1 strong votes at clock_round-1 for the leader
+            // at clock_round-2.
+            if !strong_vote_timed_out
+                && self.context.protocol_config.consensus_starfish_speed()
+                && !self.has_strong_vote_quorum(quorum_round)
+            {
                 return None;
             }
 
@@ -812,6 +843,27 @@ impl Core {
             {
                 return None;
             }
+        }
+
+        // Compute the strong_vote once; reused for readiness check 2 and
+        // the block header below.
+        let strong_vote = if self.context.protocol_config.consensus_starfish_speed() {
+            leader_header.as_ref().map(|h| self.compute_strong_vote(h))
+        } else {
+            None
+        };
+
+        // Strong-vote readiness check 2 (StarfishSpeed only, bypassed on
+        // soft-timeout): our block would itself be a strong vote for the
+        // leader at clock_round-1 (strong_vote is Some(empty)).
+        if !reason.is_forced()
+            && !strong_vote_timed_out
+            && self.context.protocol_config.consensus_starfish_speed()
+            && !strong_vote
+                .as_ref()
+                .is_some_and(|missing| missing.is_empty())
+        {
+            return None;
         }
 
         // Determine the ancestors to be included in proposal. A quorum of ancestor must
@@ -937,7 +989,6 @@ impl Core {
         // Create the block and insert to storage.
         let ancestor_refs = ancestors.iter().map(|b| b.reference()).collect();
         let block_header = if self.context.protocol_config.consensus_starfish_speed() {
-            let strong_vote = self.compute_strong_vote(clock_round, &ancestors);
             BlockHeader::V2(BlockHeaderV2::new(
                 self.context.committee.epoch(),
                 clock_round,
@@ -1400,25 +1451,15 @@ impl Core {
         included_ancestors
     }
 
-    /// Computes the strong_vote bitmask for a block being proposed at
-    /// `clock_round`. Checks data availability for the previous round's
-    /// leader block and its acknowledgments.
-    fn compute_strong_vote(
-        &self,
-        clock_round: Round,
-        ancestors: &[VerifiedBlockHeader],
-    ) -> Option<AuthoritySet> {
+    /// Given a leader block header, computes the `strong_vote` bitmask for
+    /// a block voting on that leader: the set of authorities (the leader
+    /// itself and those it acknowledges) whose transaction data is not
+    /// locally available. An empty set means a strong vote; a non-empty set
+    /// means strong blame.
+    fn compute_strong_vote(&self, leader_header: &VerifiedBlockHeader) -> AuthoritySet {
         if !self.context.protocol_config.consensus_starfish_speed() {
             error!("compute_strong_vote called while consensus_starfish_speed is disabled");
-            return None;
         }
-
-        let leader_round = clock_round.saturating_sub(1);
-        let leaders = self.leaders(leader_round);
-
-        let leader_header = ancestors.iter().find(|a| {
-            a.round() == leader_round && leaders.iter().any(|s| s.authority == a.author())
-        })?;
 
         let dag_state = self.dag_state.read();
         let mut missing = AuthoritySet::new();
@@ -1434,23 +1475,33 @@ impl Core {
             }
         }
 
-        Some(missing)
+        missing
     }
 
-    /// Checks whether the leaders of the round exist.
-    fn leaders_exist(&self, round: Round) -> bool {
+    /// Returns true when 2f+1 stake of blocks at `voting_round` have
+    /// `is_strong_vote() == true`. A block at round R with `is_strong_vote`
+    /// certifies the leader at R-1, so a quorum at `voting_round` certifies
+    /// the leader at `voting_round - 1`.
+    fn has_strong_vote_quorum(&self, voting_round: Round) -> bool {
         let dag_state = self.dag_state.read();
-        for leader in self.leaders(round) {
-            // Search for all the leaders. If at least one is not found, then return false.
-            // A linear search should be fine here as the set of elements is not expected to
-            // be small enough and more sophisticated data structures might not
-            // give us much here.
-            if !dag_state.contains_cached_block_header_at_slot(leader) {
-                return false;
+        let blocks = dag_state.get_last_cached_block_header_per_authority(voting_round + 1);
+        let mut strong_votes = StakeAggregator::<QuorumThreshold>::new();
+        for (block, _equivocating) in &blocks {
+            if block.round() == voting_round && block.is_strong_vote() {
+                strong_votes.add(block.author(), &self.context.committee);
             }
         }
+        strong_votes.reached_threshold(&self.context.committee)
+    }
 
-        true
+    /// Returns the leader block header for `round` if it is present in the
+    /// DAG. Starfish has exactly one leader per round, so this is either
+    /// `Some(leader_block)` or `None`.
+    fn leader_header(&self, round: Round) -> Option<VerifiedBlockHeader> {
+        let leader = self.leaders(round).into_iter().next()?;
+        self.dag_state
+            .read()
+            .get_cached_block_header_at_slot(Slot::new(round, leader.authority))
     }
 
     /// Returns the leaders of the provided round.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3647,4 +3647,146 @@ mod test {
             "Expected {expected_notifications} notifications but only received {received_notifications}"
         );
     }
+
+    #[tokio::test]
+    async fn test_compute_strong_vote() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(true);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context, store)));
+
+        // Round-1 ack targets at authorities 2 and 3.
+        let r1_a2 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build());
+        let r1_a3 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 3).build());
+
+        // Leader at round=2, author=1, acknowledging the two round-1 blocks.
+        let leader = VerifiedBlock::new_for_test(
+            TestBlockHeader::new(2, 1)
+                .set_acknowledgments(vec![r1_a2.reference(), r1_a3.reference()])
+                .build(),
+        );
+
+        let add_data_for = |block: &VerifiedBlock| {
+            let mut s = dag_state.write();
+            s.accept_block_header(block.verified_block_header.clone(), DataSource::Test);
+            s.add_transactions(block.verified_transactions.clone(), DataSource::Test);
+        };
+
+        let a1 = AuthorityIndex::new_for_test(1);
+        let a2 = AuthorityIndex::new_for_test(2);
+        let a3 = AuthorityIndex::new_for_test(3);
+
+        // Empty DagState: leader and both acks are missing.
+        {
+            let sv = Core::compute_strong_vote(&dag_state.read(), &leader.verified_block_header);
+            assert_eq!(sv.leader_authority, a1);
+            assert!(sv.missing.contains(a1));
+            assert!(sv.missing.contains(a2));
+            assert!(sv.missing.contains(a3));
+            assert_eq!(sv.missing.len(), 3);
+            assert!(!sv.is_strong_vote());
+        }
+
+        // Leader and ack at author 2 present; ack at author 3 still missing.
+        add_data_for(&leader);
+        add_data_for(&r1_a2);
+        {
+            let sv = Core::compute_strong_vote(&dag_state.read(), &leader.verified_block_header);
+            assert_eq!(sv.leader_authority, a1);
+            assert!(!sv.missing.contains(a1));
+            assert!(!sv.missing.contains(a2));
+            assert!(sv.missing.contains(a3));
+            assert_eq!(sv.missing.len(), 1);
+            assert!(!sv.is_strong_vote());
+        }
+
+        // All data present: empty missing, strong vote.
+        add_data_for(&r1_a3);
+        {
+            let sv = Core::compute_strong_vote(&dag_state.read(), &leader.verified_block_header);
+            assert_eq!(sv.leader_authority, a1);
+            assert!(sv.missing.is_empty());
+            assert!(sv.is_strong_vote());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_has_strong_vote_quorum() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(true);
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(true);
+        let fixture = CoreTextFixture::new(
+            context,
+            vec![1; 4],
+            AuthorityIndex::new_for_test(0),
+            false,
+            false,
+        );
+
+        let leader = AuthorityIndex::new_for_test(1);
+        let strong_vote = StrongVote {
+            leader_authority: leader,
+            missing: AuthoritySet::new(),
+        };
+        let mut blame_missing = AuthoritySet::new();
+        blame_missing.insert(AuthorityIndex::new_for_test(3));
+        let strong_blame = StrongVote {
+            leader_authority: leader,
+            missing: blame_missing,
+        };
+
+        let add_block = |round: Round, author: u8, sv: StrongVote| {
+            let header = VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(round, author)
+                    .set_strong_vote(Some(sv))
+                    .build(),
+            );
+            fixture
+                .core
+                .dag_state
+                .write()
+                .accept_block_header(header, DataSource::Test);
+        };
+
+        // Empty DagState at round 5 -> no quorum.
+        assert!(!fixture.core.has_strong_vote_quorum(5, leader));
+
+        // 3 strong votes for `leader` at round 5 -> quorum.
+        for author in [0u8, 1, 2] {
+            add_block(5, author, strong_vote);
+        }
+        assert!(fixture.core.has_strong_vote_quorum(5, leader));
+
+        // 2 strong votes for `leader` at round 6 -> below quorum.
+        for author in [0u8, 1] {
+            add_block(6, author, strong_vote);
+        }
+        assert!(!fixture.core.has_strong_vote_quorum(6, leader));
+
+        // 2 strong votes + 1 strong blame for `leader` at round 7 -> below
+        // quorum (blame does not count as vote).
+        add_block(7, 0, strong_vote);
+        add_block(7, 1, strong_vote);
+        add_block(7, 2, strong_blame);
+        assert!(!fixture.core.has_strong_vote_quorum(7, leader));
+
+        // 3 strong votes at round 8 pinned to a different leader -> the
+        // pinning filter rejects them and the quorum check returns false.
+        let other = AuthorityIndex::new_for_test(2);
+        let strong_vote_other = StrongVote {
+            leader_authority: other,
+            missing: AuthoritySet::new(),
+        };
+        for author in [0u8, 1, 2] {
+            add_block(8, author, strong_vote_other);
+        }
+        assert!(!fixture.core.has_strong_vote_quorum(8, leader));
+    }
 }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1187,7 +1187,7 @@ impl Core {
                 sequenced_leaders.len(),
                 sequenced_leaders
                     .iter()
-                    .map(|b| b.reference().to_string())
+                    .map(|(b, _, _)| b.reference().to_string())
                     .join(",")
             );
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1460,8 +1460,15 @@ impl Core {
         if !self.context.protocol_config.consensus_starfish_speed() {
             error!("compute_strong_vote called while consensus_starfish_speed is disabled");
         }
+        Self::compute_strong_vote_for(&self.dag_state.read(), leader_header)
+    }
 
-        let dag_state = self.dag_state.read();
+    /// Static form of [`Self::compute_strong_vote`]: derives the missing-data
+    /// mask from a borrowed `DagState`, no `Core` instance required.
+    pub(crate) fn compute_strong_vote_for(
+        dag_state: &DagState,
+        leader_header: &VerifiedBlockHeader,
+    ) -> AuthoritySet {
         let mut missing = AuthoritySet::new();
 
         let leader_ref = leader_header.reference();

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -23,7 +23,7 @@ use tokio::{
     sync::{broadcast, watch},
     time::Instant,
 };
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, info, instrument, trace, warn};
 
 #[cfg(test)]
 use crate::storage::Store;
@@ -36,8 +36,8 @@ use crate::{
     authority_set::AuthoritySet,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockHeaderV2, BlockRef, BlockTimestampMs,
-        GENESIS_ROUND, Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
-        VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
+        GENESIS_ROUND, Round, SignedBlockHeader, Slot, StrongVote, TransactionsCommitment,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, CommitAPI, PendingSubDag},
@@ -825,13 +825,17 @@ impl Core {
             leader_header.as_ref()?;
 
             // Strong-vote readiness check 1 (StarfishSpeed only, bypassed on
-            // soft-timeout): 2f+1 strong votes at clock_round-1 for the leader
-            // at clock_round-2.
+            // soft-timeout): 2f+1 strong votes at quorum_round pinned to the
+            // leader at quorum_round - 1.
             if !strong_vote_timed_out
                 && self.context.protocol_config.consensus_starfish_speed()
-                && !self.has_strong_vote_quorum(quorum_round)
+                && quorum_round > GENESIS_ROUND
             {
-                return None;
+                if let Some(prev_leader) = self.leader_header(quorum_round - 1) {
+                    if !self.has_strong_vote_quorum(quorum_round, prev_leader.author()) {
+                        return None;
+                    }
+                }
             }
 
             if Duration::from_millis(
@@ -848,20 +852,20 @@ impl Core {
         // Compute the strong_vote once; reused for readiness check 2 and
         // the block header below.
         let strong_vote = if self.context.protocol_config.consensus_starfish_speed() {
-            leader_header.as_ref().map(|h| self.compute_strong_vote(h))
+            leader_header
+                .as_ref()
+                .map(|h| Self::compute_strong_vote(&self.dag_state.read(), h))
         } else {
             None
         };
 
         // Strong-vote readiness check 2 (StarfishSpeed only, bypassed on
         // soft-timeout): our block would itself be a strong vote for the
-        // leader at clock_round-1 (strong_vote is Some(empty)).
+        // leader at clock_round-1.
         if !reason.is_forced()
             && !strong_vote_timed_out
             && self.context.protocol_config.consensus_starfish_speed()
-            && !strong_vote
-                .as_ref()
-                .is_some_and(|missing| missing.is_empty())
+            && !strong_vote.as_ref().is_some_and(|sv| sv.is_strong_vote())
         {
             return None;
         }
@@ -1451,24 +1455,15 @@ impl Core {
         included_ancestors
     }
 
-    /// Given a leader block header, computes the `strong_vote` bitmask for
-    /// a block voting on that leader: the set of authorities (the leader
-    /// itself and those it acknowledges) whose transaction data is not
-    /// locally available. An empty set means a strong vote; a non-empty set
-    /// means strong blame.
-    fn compute_strong_vote(&self, leader_header: &VerifiedBlockHeader) -> AuthoritySet {
-        if !self.context.protocol_config.consensus_starfish_speed() {
-            error!("compute_strong_vote called while consensus_starfish_speed is disabled");
-        }
-        Self::compute_strong_vote_for(&self.dag_state.read(), leader_header)
-    }
-
-    /// Static form of [`Self::compute_strong_vote`]: derives the missing-data
-    /// mask from a borrowed `DagState`, no `Core` instance required.
-    pub(crate) fn compute_strong_vote_for(
+    /// Builds the `StrongVote` payload for a block voting on `leader_header`:
+    /// pins the leader's authority and records the set of authorities (the
+    /// leader itself and those it acknowledges) whose transaction data is not
+    /// locally available. An empty `missing` set means a strong vote; a
+    /// non-empty set means strong blame.
+    pub(crate) fn compute_strong_vote(
         dag_state: &DagState,
         leader_header: &VerifiedBlockHeader,
-    ) -> AuthoritySet {
+    ) -> StrongVote {
         let mut missing = AuthoritySet::new();
 
         let leader_ref = leader_header.reference();
@@ -1482,19 +1477,23 @@ impl Core {
             }
         }
 
-        missing
+        StrongVote {
+            leader_authority: leader_header.author(),
+            missing,
+        }
     }
 
-    /// Returns true when 2f+1 stake of blocks at `voting_round` have
-    /// `is_strong_vote() == true`. A block at round R with `is_strong_vote`
-    /// certifies the leader at R-1, so a quorum at `voting_round` certifies
-    /// the leader at `voting_round - 1`.
-    fn has_strong_vote_quorum(&self, voting_round: Round) -> bool {
+    /// Returns true when 2f+1 stake of blocks at `voting_round` carry a strong
+    /// vote pinned to `expected_leader`. A block at round R with
+    /// `is_strong_vote` certifies the leader at R-1, so a quorum at
+    /// `voting_round` certifies `expected_leader` at `voting_round - 1`.
+    /// Strong votes whose pinned leader doesn't match are ignored.
+    fn has_strong_vote_quorum(&self, voting_round: Round, expected_leader: AuthorityIndex) -> bool {
         let dag_state = self.dag_state.read();
         let blocks = dag_state.get_last_cached_block_header_per_authority(voting_round + 1);
         let mut strong_votes = StakeAggregator::<QuorumThreshold>::new();
         for (block, _equivocating) in &blocks {
-            if block.round() == voting_round && block.is_strong_vote() {
+            if block.round() == voting_round && block.is_strong_vote_for(expected_leader) {
                 strong_votes.add(block.author(), &self.context.committee);
             }
         }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -23,7 +23,7 @@ use tokio::{
     sync::{broadcast, watch},
     time::Instant,
 };
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 #[cfg(test)]
 use crate::storage::Store;
@@ -33,10 +33,11 @@ use crate::storage::rocksdb_store::RocksDBStore;
 use crate::{CommitConsumer, CommittedSubDag, TransactionClient, storage::mem_store::MemStore};
 use crate::{
     Transaction,
+    authority_set::AuthoritySet,
     block_header::{
-        BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
-        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedOwnShard, VerifiedTransactions,
+        BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockHeaderV2, BlockRef, BlockTimestampMs,
+        GENESIS_ROUND, Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock,
+        VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
     commit::{CertifiedCommits, CommitAPI, PendingSubDag},
@@ -934,16 +935,32 @@ impl Core {
         });
 
         // Create the block and insert to storage.
-        let block_header = BlockHeader::V1(BlockHeaderV1::new(
-            self.context.committee.epoch(),
-            clock_round,
-            self.context.own_index,
-            now,
-            ancestors.iter().map(|b| b.reference()).collect(),
-            acknowledgments,
-            commit_votes,
-            transactions_commitment,
-        ));
+        let ancestor_refs = ancestors.iter().map(|b| b.reference()).collect();
+        let block_header = if self.context.protocol_config.consensus_starfish_speed() {
+            let strong_vote = self.compute_strong_vote(clock_round, &ancestors);
+            BlockHeader::V2(BlockHeaderV2::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestor_refs,
+                acknowledgments,
+                commit_votes,
+                transactions_commitment,
+                strong_vote,
+            ))
+        } else {
+            BlockHeader::V1(BlockHeaderV1::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestor_refs,
+                acknowledgments,
+                commit_votes,
+                transactions_commitment,
+            ))
+        };
 
         let signed_block_header = SignedBlockHeader::new(block_header, &self.block_signer)
             .expect("Block signing failed.");
@@ -1381,6 +1398,43 @@ impl Core {
         );
 
         included_ancestors
+    }
+
+    /// Computes the strong_vote bitmask for a block being proposed at
+    /// `clock_round`. Checks data availability for the previous round's
+    /// leader block and its acknowledgments.
+    fn compute_strong_vote(
+        &self,
+        clock_round: Round,
+        ancestors: &[VerifiedBlockHeader],
+    ) -> Option<AuthoritySet> {
+        if !self.context.protocol_config.consensus_starfish_speed() {
+            error!("compute_strong_vote called while consensus_starfish_speed is disabled");
+            return None;
+        }
+
+        let leader_round = clock_round.saturating_sub(1);
+        let leaders = self.leaders(leader_round);
+
+        let leader_header = ancestors.iter().find(|a| {
+            a.round() == leader_round && leaders.iter().any(|s| s.authority == a.author())
+        })?;
+
+        let dag_state = self.dag_state.read();
+        let mut missing = AuthoritySet::new();
+
+        let leader_ref = leader_header.reference();
+        if !dag_state.is_data_available(&leader_ref) {
+            missing.insert(leader_ref.author);
+        }
+
+        for ack_ref in leader_header.acknowledgments() {
+            if !dag_state.is_data_available(ack_ref) {
+                missing.insert(ack_ref.author);
+            }
+        }
+
+        Some(missing)
     }
 
     /// Checks whether the leaders of the round exist.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -426,7 +426,9 @@ impl Core {
             .block_manager
             .try_accept_block_headers(block_headers, source);
 
-        if !accepted_block_headers.is_empty() {
+        if !accepted_block_headers.is_empty()
+            && self.context.protocol_config.consensus_starfish_speed()
+        {
             self.record_strong_vote_complaints(
                 &mut self.dag_state.write(),
                 &accepted_block_headers,
@@ -830,6 +832,20 @@ impl Core {
         // block header's strong_vote field.
         let leader_header = self.leader_header(quorum_round);
 
+        // If an ordinary-ready moment was recorded for an earlier clock round
+        // but we never proposed in it (the round advanced first), the
+        // strong-vote wait still counts toward the extra-wait metric.
+        if let Some((recorded_round, start)) = self.ordinary_propose_ready_at {
+            if recorded_round != clock_round {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .strong_vote_extra_wait_seconds
+                    .observe(start.elapsed().as_secs_f64());
+                self.ordinary_propose_ready_at = None;
+            }
+        }
+
         // Record the first moment in this clock round at which the ordinary
         // (base Starfish) propose condition was satisfied. Used to observe the
         // extra wait imposed by the StarfishSpeed strong-vote condition.
@@ -932,17 +948,20 @@ impl Core {
             .with_label_values(&[leader_authority])
             .inc();
 
-        // Extra wait between ordinary-condition readiness and actual proposal,
-        // attributable to the StarfishSpeed strong-vote condition.
-        if !reason.is_forced() && self.context.protocol_config.consensus_starfish_speed() {
-            if let Some((r, start)) = self.ordinary_propose_ready_at {
-                if r == clock_round {
+        // The strong-vote wait for this clock round ends with this proposal.
+        // Observe it for non-forced proposals; forced proposals (e.g. max
+        // leader timeout) are excluded. Clear it either way so the wait is not
+        // re-counted as an abandoned round on a later call.
+        if let Some((r, start)) = self.ordinary_propose_ready_at {
+            if r == clock_round {
+                if !reason.is_forced() && self.context.protocol_config.consensus_starfish_speed() {
                     self.context
                         .metrics
                         .node_metrics
                         .strong_vote_extra_wait_seconds
                         .observe(start.elapsed().as_secs_f64());
                 }
+                self.ordinary_propose_ready_at = None;
             }
         }
 
@@ -1573,15 +1592,12 @@ impl Core {
 
     /// Records strong-vote complaints from each freshly-accepted block into
     /// DagState's per-leader-round hint tables. Caller passes a write-locked
-    /// DagState. No-op when the StarfishSpeed flag is off.
+    /// DagState. Called only when Starfish-Speed flag is on.
     fn record_strong_vote_complaints(
         &self,
         dag_state: &mut DagState,
         blocks: &[VerifiedBlockHeader],
     ) {
-        if !self.context.protocol_config.consensus_starfish_speed() {
-            return;
-        }
         let own_index = self.context.own_index;
         for block in blocks {
             // Use the producer's pinned leader (in the strong-vote payload),
@@ -3723,7 +3739,7 @@ mod test {
             .protocol_config
             .set_consensus_fast_commit_sync_for_testing(true);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context, store)));
 
         // Round-1 ack targets at authorities 2 and 3.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -115,6 +115,10 @@ pub(crate) struct Core {
     /// Any subsequent block-creation attempt at that same round skips the
     /// strong-vote quorum check, regardless of the reason that triggered it.
     strong_vote_timed_out_round: Option<Round>,
+    /// First moment in the current clock round at which the ordinary (base
+    /// Starfish) propose condition was satisfied. Used to measure the extra
+    /// wait imposed by StarfishSpeed's strong-vote condition.
+    ordinary_propose_ready_at: Option<(Round, Instant)>,
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
@@ -261,6 +265,7 @@ impl Core {
             encoder,
             commit_vote_monitor,
             strong_vote_timed_out_round: None,
+            ordinary_propose_ready_at: None,
         }
         .recover()
     }
@@ -825,6 +830,25 @@ impl Core {
         // block header's strong_vote field.
         let leader_header = self.leader_header(quorum_round);
 
+        // Record the first moment in this clock round at which the ordinary
+        // (base Starfish) propose condition was satisfied. Used to observe the
+        // extra wait imposed by the StarfishSpeed strong-vote condition.
+        if self.context.protocol_config.consensus_starfish_speed()
+            && !reason.is_forced()
+            && leader_header.is_some()
+            && Duration::from_millis(
+                self.context
+                    .clock
+                    .timestamp_utc_ms()
+                    .saturating_sub(self.last_proposed_timestamp_ms()),
+            ) >= self.context.parameters.min_block_delay
+            && self
+                .ordinary_propose_ready_at
+                .is_none_or(|(r, _)| r != clock_round)
+        {
+            self.ordinary_propose_ready_at = Some((clock_round, Instant::now()));
+        }
+
         // Create a new block either because we want to "forcefully" propose a block due
         // to a leader timeout, or because we are actually ready to produce the
         // block (leader exists and min delay has passed).
@@ -907,6 +931,40 @@ impl Core {
             .block_proposal_leader_wait_count
             .with_label_values(&[leader_authority])
             .inc();
+
+        // Extra wait between ordinary-condition readiness and actual proposal,
+        // attributable to the StarfishSpeed strong-vote condition.
+        if !reason.is_forced() && self.context.protocol_config.consensus_starfish_speed() {
+            if let Some((r, start)) = self.ordinary_propose_ready_at {
+                if r == clock_round {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .strong_vote_extra_wait_seconds
+                        .observe(start.elapsed().as_secs_f64());
+                }
+            }
+        }
+
+        // Strong-vote payload metrics: distribution of the `missing` set size,
+        // and per-leader counter when the payload is a blame (non-empty).
+        if let Some(sv) = strong_vote.as_ref() {
+            let node_metrics = &self.context.metrics.node_metrics;
+            node_metrics
+                .strong_vote_missing_authorities
+                .observe(sv.missing.len() as f64);
+            if !sv.missing.is_empty() {
+                let leader = &self
+                    .context
+                    .committee
+                    .authority(sv.leader_authority)
+                    .hostname;
+                node_metrics
+                    .strong_blames_emitted_for_leader
+                    .with_label_values(&[leader])
+                    .inc();
+            }
+        }
 
         self.context
             .metrics
@@ -1218,7 +1276,10 @@ impl Core {
                 sequenced_leaders.len(),
                 sequenced_leaders
                     .iter()
-                    .map(|(b, _, _)| b.reference().to_string())
+                    .map(|(b, m, _)| match m {
+                        Some(state) => format!("{}({state})", b.reference()),
+                        None => b.reference().to_string(),
+                    })
                     .join(",")
             );
 
@@ -1484,7 +1545,7 @@ impl Core {
 
     /// Builds the `StrongVote` payload for a block voting on `leader_header`:
     /// pins the leader's authority and records the set of authorities (the
-    /// leader itself and those it acknowledges) whose transaction data is not
+    /// leader itself and those it acknowledges) whose transactions are not
     /// locally available. An empty `missing` set means a strong vote; a
     /// non-empty set means strong blame.
     pub(crate) fn compute_strong_vote(
@@ -1494,12 +1555,12 @@ impl Core {
         let mut missing = AuthoritySet::new();
 
         let leader_ref = leader_header.reference();
-        if !dag_state.is_data_available(&leader_ref) {
+        if !dag_state.are_transactions_available(&leader_ref) {
             missing.insert(leader_ref.author);
         }
 
         for ack_ref in leader_header.acknowledgments() {
-            if !dag_state.is_data_available(ack_ref) {
+            if !dag_state.are_transactions_available(ack_ref) {
                 missing.insert(ack_ref.author);
             }
         }
@@ -1537,6 +1598,13 @@ impl Core {
             let Some(strong_vote) = block.strong_vote() else {
                 continue;
             };
+            let voter = &self.context.committee.authority(block.author()).hostname;
+            self.context
+                .metrics
+                .node_metrics
+                .strong_blames_received_from_voter
+                .with_label_values(&[voter])
+                .inc();
             dag_state.record_strong_vote_complaint(
                 block.author(),
                 leader_round,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -421,6 +421,13 @@ impl Core {
             .block_manager
             .try_accept_block_headers(block_headers, source);
 
+        if !accepted_block_headers.is_empty() {
+            self.record_strong_vote_complaints(
+                &mut self.dag_state.write(),
+                &accepted_block_headers,
+            );
+        }
+
         let missing_committed_txns = if !accepted_block_headers.is_empty() {
             debug!(
                 "Accepted block headers: {}",
@@ -937,6 +944,26 @@ impl Core {
             .proposed_block_transactions
             .observe(transactions.len() as f64);
 
+        // Adaptive acknowledgment filtering: only applied to leader blocks,
+        // where included refs feed the optimistic-commit path.
+        let am_leader_at_clock_round = self
+            .leaders(clock_round)
+            .iter()
+            .any(|slot| slot.authority == self.context.own_index);
+        let exclude = if am_leader_at_clock_round
+            && self.context.protocol_config.consensus_starfish_speed()
+            && self
+                .context
+                .parameters
+                .enable_starfish_speed_adaptive_acknowledgments
+        {
+            self.dag_state
+                .read()
+                .starfish_speed_excluded_ack_authorities()
+        } else {
+            AuthoritySet::new()
+        };
+
         // Consume the acknowledgments about transaction data availability for past
         // blocks to be included.
         let max_acknowledgments = self
@@ -946,7 +973,7 @@ impl Core {
         let acknowledgments = self
             .dag_state
             .write()
-            .take_acknowledgments(max_acknowledgments);
+            .take_acknowledgments(max_acknowledgments, exclude);
 
         self.context
             .metrics
@@ -1480,6 +1507,41 @@ impl Core {
         StrongVote {
             leader_authority: leader_header.author(),
             missing,
+        }
+    }
+
+    /// Records strong-vote complaints from each freshly-accepted block into
+    /// DagState's per-leader-round hint tables. Caller passes a write-locked
+    /// DagState. No-op when the StarfishSpeed flag is off.
+    fn record_strong_vote_complaints(
+        &self,
+        dag_state: &mut DagState,
+        blocks: &[VerifiedBlockHeader],
+    ) {
+        if !self.context.protocol_config.consensus_starfish_speed() {
+            return;
+        }
+        let own_index = self.context.own_index;
+        for block in blocks {
+            // Use the producer's pinned leader (in the strong-vote payload),
+            // not the local canonical leader. The local view can disagree
+            // across schedule rotations — same misattribution surface fixed
+            // for the commit path in StarfishSpeed.
+            if !block.is_strong_blame_for(own_index) {
+                continue;
+            }
+            let leader_round = block.round().saturating_sub(1);
+            if leader_round == GENESIS_ROUND {
+                continue;
+            }
+            let Some(strong_vote) = block.strong_vote() else {
+                continue;
+            };
+            dag_state.record_strong_vote_complaint(
+                block.author(),
+                leader_round,
+                strong_vote.missing,
+            );
         }
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2021,8 +2021,8 @@ impl DagState {
         taken.into_iter().collect()
     }
 
-    /// Check if a block's transaction data is locally available.
-    pub(crate) fn is_data_available(&self, block_ref: &BlockRef) -> bool {
+    /// Check if a block's transactions are locally available.
+    pub(crate) fn are_transactions_available(&self, block_ref: &BlockRef) -> bool {
         let transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
             let Some(header) = self.recent_block_headers.get(block_ref) else {
                 return false;
@@ -2248,14 +2248,23 @@ impl DagState {
                 self.pending_acknowledgments.remove(&last_ack);
             }
         } else {
+            let mut dropped: u64 = 0;
             for ack in self.pending_acknowledgments.iter() {
                 if taken.len() >= limit || ack.round >= clock_round {
                     break;
                 }
                 if exclude.contains(ack.author) {
+                    dropped += 1;
                     continue;
                 }
                 taken.push(*ack);
+            }
+            if dropped > 0 {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .adaptive_ack_acks_dropped
+                    .inc_by(dropped);
             }
             for ack in &taken {
                 self.pending_acknowledgments.remove(ack);
@@ -2736,6 +2745,11 @@ impl DagState {
                 mask.insert(AuthorityIndex::from(auth as u8));
             }
         }
+        self.context
+            .metrics
+            .node_metrics
+            .adaptive_ack_excluded_authorities
+            .set(mask.len() as i64);
         mask
     }
 }
@@ -3970,7 +3984,9 @@ mod test {
 
     #[rstest]
     #[tokio::test]
-    async fn test_is_data_available(#[values(true, false)] consensus_fast_commit_sync: bool) {
+    async fn test_are_transactions_available(
+        #[values(true, false)] consensus_fast_commit_sync: bool,
+    ) {
         let (mut context, _) = Context::new_for_test(4);
         context
             .protocol_config
@@ -3983,15 +3999,15 @@ mod test {
         let block_ref = block.reference();
 
         // Empty DagState.
-        assert!(!dag_state.is_data_available(&block_ref));
+        assert!(!dag_state.are_transactions_available(&block_ref));
 
         // Header without transactions.
         dag_state.accept_block_header(block.verified_block_header.clone(), DataSource::Test);
-        assert!(!dag_state.is_data_available(&block_ref));
+        assert!(!dag_state.are_transactions_available(&block_ref));
 
         // Header and transactions both present.
         dag_state.add_transactions(block.verified_transactions, DataSource::Test);
-        assert!(dag_state.is_data_available(&block_ref));
+        assert!(dag_state.are_transactions_available(&block_ref));
 
         // Transactions without a header: flag-off ignores the header check;
         // flag-on requires it.
@@ -3999,7 +4015,7 @@ mod test {
         let other_ref = other.reference();
         dag_state.add_transactions(other.verified_transactions, DataSource::Test);
         assert_eq!(
-            dag_state.is_data_available(&other_ref),
+            dag_state.are_transactions_available(&other_ref),
             !consensus_fast_commit_sync,
         );
     }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3992,7 +3992,7 @@ mod test {
             .protocol_config
             .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         let context = Arc::new(context);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
 
         let block = VerifiedBlock::new_for_test(TestBlockHeader::new(5, 1).build());
@@ -4644,7 +4644,7 @@ mod test {
             2,
             "this test assumes f+1 = 2 (n=4)"
         );
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
 
         let target = AuthorityIndex::from(2u8);
@@ -4675,7 +4675,7 @@ mod test {
     #[tokio::test]
     async fn adaptive_ack_same_voter_counts_once_per_leader_round() {
         let context = adaptive_ack_test_context(true);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
 
         let target_x = AuthorityIndex::from(2u8);
@@ -4710,7 +4710,7 @@ mod test {
     #[tokio::test]
     async fn adaptive_ack_prunes_complaints_outside_window() {
         let context = adaptive_ack_test_context(true);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
 
         let target = AuthorityIndex::from(2u8);
@@ -4761,7 +4761,7 @@ mod test {
             ctx.parameters
                 .enable_starfish_speed_adaptive_acknowledgments = adaptive_acks;
             let context = Arc::new(ctx);
-            let store = Arc::new(MemStore::new(context.clone()));
+            let store = Arc::new(MemStore::new());
             let mut dag_state = DagState::new(context, store);
 
             let target = AuthorityIndex::from(2u8);
@@ -4797,7 +4797,7 @@ mod test {
     #[tokio::test]
     async fn adaptive_ack_filter_drops_blamed_authority_refs() {
         let context = adaptive_ack_test_context(true);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
 
         // Pending acknowledgments: one ref per authority.
@@ -4839,7 +4839,7 @@ mod test {
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config.set_gc_depth_for_testing(20);
         let context = Arc::new(ctx);
-        let store = Arc::new(MemStore::new(context.clone()));
+        let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
 
         // Advance threshold_clock to round 5 — quorum (3 of 4) at round 4.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -15,7 +15,7 @@ use std::{
 use bytes::Bytes;
 use iota_metrics::monitored_mpsc::Sender;
 use itertools::Itertools as _;
-use starfish_config::AuthorityIndex;
+use starfish_config::{AuthorityIndex, Stake};
 use tokio::{
     sync::{mpsc::error::TrySendError, watch},
     time::Instant,
@@ -23,6 +23,7 @@ use tokio::{
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
+    authority_set::AuthoritySet,
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
         TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard,
@@ -114,6 +115,45 @@ impl DataSource {
 impl std::fmt::Display for DataSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+/// Number of recent leader rounds whose strong-vote complaints contribute to
+/// the adaptive-acknowledgment exclusion score for StarfishSpeed.
+const STARFISH_SPEED_HINT_WINDOW_LEADER_ROUNDS: usize = 10;
+
+/// Per-leader-round complaint history derived from the strong-vote masks of
+/// blocks that voted for that leader. The first mask we observe from each
+/// voter is folded into `complaint_stakes` (which authorities the voter blamed,
+/// weighted by the voter's stake) and the voter is recorded in
+/// `voters_counted`; subsequent masks from the same voter — i.e. equivocations
+/// — are ignored, capping each voter's contribution at its own stake per
+/// blamed authority.
+#[derive(Default)]
+struct StarfishSpeedLeaderRoundHints {
+    voters_counted: AuthoritySet,
+    complaint_stakes: Vec<Stake>,
+}
+
+impl StarfishSpeedLeaderRoundHints {
+    fn new(committee_size: usize) -> Self {
+        Self {
+            voters_counted: AuthoritySet::new(),
+            complaint_stakes: vec![0; committee_size],
+        }
+    }
+
+    /// Records `voter`'s blame mask, accumulating `voter_stake` against each
+    /// authority in the mask. No-op if `voter` has already contributed to
+    /// this round (equivocations are ignored).
+    fn add_vote(&mut self, voter: AuthorityIndex, voter_stake: Stake, mask: AuthoritySet) {
+        if !self.voters_counted.insert(voter) {
+            return;
+        }
+        for authority in mask.iter() {
+            let stake = &mut self.complaint_stakes[authority.value()];
+            *stake = stake.saturating_add(voter_stake);
+        }
     }
 }
 
@@ -237,6 +277,10 @@ pub(crate) struct DagState {
 
     /// Cordial Knowledge senders (main updates, eviction rounds).
     cordial_knowledge_senders: Option<(Sender<CordialKnowledgeMessage>, watch::Sender<Vec<Round>>)>,
+
+    /// History of strong-vote complaint masks against this node's own
+    /// leader rounds, keyed by leader round.
+    starfish_speed_leader_hints: BTreeMap<Round, StarfishSpeedLeaderRoundHints>,
 }
 
 impl DagState {
@@ -354,6 +398,7 @@ impl DagState {
             cached_rounds,
             evicted_rounds: vec![0; num_authorities],
             cordial_knowledge_senders: None,
+            starfish_speed_leader_hints: BTreeMap::new(),
         };
 
         // Load cached data for each authority from storage
@@ -375,6 +420,7 @@ impl DagState {
             &state.context,
         );
 
+        state.replay_strong_vote_complaints_from_recovered_headers();
         state
     }
 
@@ -450,6 +496,7 @@ impl DagState {
         self.pending_commit_votes.clear();
         self.pending_acknowledgments.clear();
         self.misbehavior_store.reset();
+        self.starfish_speed_leader_hints.clear();
 
         // 2. Reinitialize threshold_clock with current round
         let current_round = self.threshold_clock.get_round();
@@ -481,6 +528,8 @@ impl DagState {
         // Rebuild scoring_subdag from stored commits so leader schedule state
         // matches peers after fast sync reinitialization.
         self.rebuild_scoring_subdag_from_store();
+
+        self.replay_strong_vote_complaints_from_recovered_headers();
 
         info!("DagState reinitialized successfully");
     }
@@ -2175,28 +2224,42 @@ impl DagState {
         self.pending_acknowledgments.insert(block_ref);
     }
 
-    /// Takes at most `limit` acknowledgments from `pending_acknowledgments`,
-    /// ensuring they are from rounds below `clock_round`.
-    pub(crate) fn take_acknowledgments(&mut self, limit: usize) -> Vec<BlockRef> {
+    /// Takes at most `limit` acknowledgments from `pending_acknowledgments`
+    /// from rounds below `clock_round`. Refs whose author is in `exclude` are
+    /// skipped over and stay pending so they can be acked later.
+    pub(crate) fn take_acknowledgments(
+        &mut self,
+        limit: usize,
+        exclude: AuthoritySet,
+    ) -> Vec<BlockRef> {
         self.evict_pending_acknowledgments();
         let clock_round = self.threshold_clock_round();
         let mut taken = Vec::with_capacity(limit);
-        let mut last_ack = None;
 
-        for ack in self.pending_acknowledgments.iter() {
-            if taken.len() >= limit || ack.round >= clock_round {
-                break;
+        if exclude.is_empty() {
+            for ack in self.pending_acknowledgments.iter() {
+                if taken.len() >= limit || ack.round >= clock_round {
+                    break;
+                }
+                taken.push(*ack);
             }
-            taken.push(*ack);
-        }
-
-        if let Some(last) = taken.last() {
-            last_ack = Some(*last);
-        }
-
-        if let Some(last_ack) = last_ack {
-            self.pending_acknowledgments = self.pending_acknowledgments.split_off(&last_ack);
-            self.pending_acknowledgments.remove(&last_ack);
+            if let Some(&last_ack) = taken.last() {
+                self.pending_acknowledgments = self.pending_acknowledgments.split_off(&last_ack);
+                self.pending_acknowledgments.remove(&last_ack);
+            }
+        } else {
+            for ack in self.pending_acknowledgments.iter() {
+                if taken.len() >= limit || ack.round >= clock_round {
+                    break;
+                }
+                if exclude.contains(ack.author) {
+                    continue;
+                }
+                taken.push(*ack);
+            }
+            for ack in &taken {
+                self.pending_acknowledgments.remove(ack);
+            }
         }
 
         taken
@@ -2570,6 +2633,110 @@ impl DagState {
 
     pub(crate) fn misbehavior_store(&self) -> &MisbehaviorStore {
         &self.misbehavior_store
+    }
+
+    /// Seeds adaptive-ack hints from strong-blame masks already present in
+    /// `recent_block_headers` so the heuristic survives a restart.
+    fn replay_strong_vote_complaints_from_recovered_headers(&mut self) {
+        if !self.context.protocol_config.consensus_starfish_speed()
+            || !self
+                .context
+                .parameters
+                .enable_starfish_speed_adaptive_acknowledgments
+        {
+            return;
+        }
+        let own_index = self.context.own_index;
+        // Snapshot before mutating self via record_strong_vote_complaint.
+        let to_replay: Vec<(AuthorityIndex, Round, AuthoritySet)> = self
+            .recent_block_headers
+            .values()
+            .filter_map(|h| {
+                if !h.is_strong_blame_for(own_index) {
+                    return None;
+                }
+                let leader_round = h.round().saturating_sub(1);
+                if leader_round == GENESIS_ROUND {
+                    return None;
+                }
+                Some((h.author(), leader_round, h.strong_vote()?.missing))
+            })
+            .collect();
+        for (voter, leader_round, mask) in to_replay {
+            self.record_strong_vote_complaint(voter, leader_round, mask);
+        }
+    }
+
+    /// Records a strong-vote complaint from `voter` against this node when
+    /// it was the leader at `leader_round`. Caller is responsible for
+    /// confirming `leader_round`'s leader was the local authority. No-op
+    /// when the feature is off.
+    pub(crate) fn record_strong_vote_complaint(
+        &mut self,
+        voter: AuthorityIndex,
+        leader_round: Round,
+        mask: AuthoritySet,
+    ) {
+        if !self.context.protocol_config.consensus_starfish_speed()
+            || !self
+                .context
+                .parameters
+                .enable_starfish_speed_adaptive_acknowledgments
+        {
+            return;
+        }
+        let committee_size = self.context.committee.size();
+        let voter_stake = self.context.committee.stake(voter);
+        let entry = self
+            .starfish_speed_leader_hints
+            .entry(leader_round)
+            .or_insert_with(|| StarfishSpeedLeaderRoundHints::new(committee_size));
+        entry.add_vote(voter, voter_stake, mask);
+
+        while self.starfish_speed_leader_hints.len() > STARFISH_SPEED_HINT_WINDOW_LEADER_ROUNDS {
+            let Some(&oldest) = self.starfish_speed_leader_hints.keys().next() else {
+                break;
+            };
+            self.starfish_speed_leader_hints.remove(&oldest);
+        }
+    }
+
+    /// Returns the set of authorities the local node should drop from the
+    /// `acknowledgments` field of new blocks: those whose aggregated
+    /// complaint stake over the last `STARFISH_SPEED_HINT_WINDOW_LEADER_ROUNDS`
+    /// of the local node's leader rounds reaches
+    /// `Committee::validity_threshold` (= f+1 in stake). Returns an empty set
+    /// when the feature is off.
+    pub(crate) fn starfish_speed_excluded_ack_authorities(&self) -> AuthoritySet {
+        if !self.context.protocol_config.consensus_starfish_speed()
+            || !self
+                .context
+                .parameters
+                .enable_starfish_speed_adaptive_acknowledgments
+        {
+            return AuthoritySet::new();
+        }
+        let committee_size = self.context.committee.size();
+        let mut scores: Vec<Stake> = vec![0; committee_size];
+        for hints in self
+            .starfish_speed_leader_hints
+            .iter()
+            .rev()
+            .take(STARFISH_SPEED_HINT_WINDOW_LEADER_ROUNDS)
+            .map(|(_, h)| h)
+        {
+            for (auth, score) in scores.iter_mut().enumerate() {
+                *score = score.saturating_add(hints.complaint_stakes[auth]);
+            }
+        }
+        let threshold = self.context.committee.validity_threshold();
+        let mut mask = AuthoritySet::new();
+        for (auth, score) in scores.into_iter().enumerate() {
+            if score >= threshold {
+                mask.insert(AuthorityIndex::from(auth as u8));
+            }
+        }
+        mask
     }
 }
 #[cfg(test)]
@@ -4392,5 +4559,297 @@ mod test {
         dag_state_off.update_pending_commit_votes(votes);
         dag_state_off.evict_pending_commit_votes();
         assert_eq!(dag_state_off.pending_commit_votes.len(), 10);
+    }
+
+    /// Builds a 4-authority context with `consensus_starfish_speed` toggled
+    /// per the argument and the local adaptive-ack parameter unchanged from
+    /// its default (`true`).
+    fn adaptive_ack_test_context(starfish_speed: bool) -> Arc<Context> {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
+        Arc::new(ctx)
+    }
+
+    /// Single-authority `AuthoritySet` mask blaming `target`.
+    fn blame_mask(target: AuthorityIndex) -> AuthoritySet {
+        let mut mask = AuthoritySet::new();
+        mask.insert(target);
+        mask
+    }
+
+    /// Round-1 placeholder ref for an authority — only `(round, author)`
+    /// matters for the adaptive-ack filter; the digest is incidental.
+    fn ref_for(author: AuthorityIndex) -> BlockRef {
+        BlockRef::new(1, author, BlockHeaderDigest::MIN)
+    }
+
+    #[tokio::test]
+    async fn adaptive_ack_excludes_authority_at_validity_threshold() {
+        let context = adaptive_ack_test_context(true);
+        assert_eq!(
+            context.committee.validity_threshold(),
+            2,
+            "this test assumes f+1 = 2 (n=4)"
+        );
+        let store = Arc::new(MemStore::new(context.clone()));
+        let mut dag_state = DagState::new(context, store);
+
+        let target = AuthorityIndex::from(2u8);
+        let voter_0 = AuthorityIndex::from(0u8);
+        let voter_1 = AuthorityIndex::from(1u8);
+        let leader_round = 5;
+        let mask = blame_mask(target);
+
+        // First voter: count = 1, below f+1 = 2.
+        dag_state.record_strong_vote_complaint(voter_0, leader_round, mask);
+        assert!(
+            !dag_state
+                .starfish_speed_excluded_ack_authorities()
+                .contains(target),
+            "single voter must not exclude — below validity threshold"
+        );
+
+        // Second distinct voter: count = 2 = f+1 → exclude.
+        dag_state.record_strong_vote_complaint(voter_1, leader_round, mask);
+        assert!(
+            dag_state
+                .starfish_speed_excluded_ack_authorities()
+                .contains(target),
+            "two distinct voters reached validity threshold, target should be excluded"
+        );
+    }
+
+    #[tokio::test]
+    async fn adaptive_ack_same_voter_counts_once_per_leader_round() {
+        let context = adaptive_ack_test_context(true);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let mut dag_state = DagState::new(context, store);
+
+        let target_x = AuthorityIndex::from(2u8);
+        let target_y = AuthorityIndex::from(3u8);
+        let voter_0 = AuthorityIndex::from(0u8);
+        let voter_1 = AuthorityIndex::from(1u8);
+        let leader_round = 5;
+
+        // Voter 0 records `{X}`.
+        dag_state.record_strong_vote_complaint(voter_0, leader_round, blame_mask(target_x));
+        // Same voter 0 records a second, different mask `{X, Y}` for the same
+        // leader round — first-vote-wins, the second mask is dropped entirely
+        // (Y stays at 0; X stays at 1).
+        let mut second_mask = AuthoritySet::new();
+        second_mask.insert(target_x);
+        second_mask.insert(target_y);
+        dag_state.record_strong_vote_complaint(voter_0, leader_round, second_mask);
+
+        // Add one more distinct voter blaming X. X reaches f+1 = 2 → excluded;
+        // Y is still at 0 → not excluded. If equivocations were counted, Y's
+        // count would be 1 here.
+        dag_state.record_strong_vote_complaint(voter_1, leader_round, blame_mask(target_x));
+
+        let excluded = dag_state.starfish_speed_excluded_ack_authorities();
+        assert!(excluded.contains(target_x), "X must be excluded");
+        assert!(
+            !excluded.contains(target_y),
+            "Y must not be excluded — voter_0's second mask was dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn adaptive_ack_prunes_complaints_outside_window() {
+        let context = adaptive_ack_test_context(true);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let mut dag_state = DagState::new(context, store);
+
+        let target = AuthorityIndex::from(2u8);
+        let voter_0 = AuthorityIndex::from(0u8);
+        let voter_1 = AuthorityIndex::from(1u8);
+        let initial_leader_round = 5;
+
+        // Two voters blame target at the initial leader round → would exclude.
+        dag_state.record_strong_vote_complaint(voter_0, initial_leader_round, blame_mask(target));
+        dag_state.record_strong_vote_complaint(voter_1, initial_leader_round, blame_mask(target));
+        assert!(
+            dag_state
+                .starfish_speed_excluded_ack_authorities()
+                .contains(target),
+            "target excluded before window slides"
+        );
+
+        // Record complaints at 10 later leader rounds with unrelated masks
+        // (blame voter_0 instead of target). The window keeps the most recent
+        // 10 entries — `initial_leader_round` is pruned.
+        for r in 1..=(STARFISH_SPEED_HINT_WINDOW_LEADER_ROUNDS as Round) {
+            dag_state.record_strong_vote_complaint(
+                voter_0,
+                initial_leader_round + r,
+                blame_mask(voter_0),
+            );
+        }
+        assert!(
+            !dag_state
+                .starfish_speed_excluded_ack_authorities()
+                .contains(target),
+            "initial leader round was pruned out of the window — target no longer excluded"
+        );
+    }
+
+    #[tokio::test]
+    async fn adaptive_ack_feature_gating() {
+        // Sweep all 4 (protocol_flag, local_param) combinations. Feature is
+        // active iff both are true; in every other combination both
+        // `record_strong_vote_complaint` and
+        // `starfish_speed_excluded_ack_authorities` short-circuit.
+        for (starfish_speed, adaptive_acks) in
+            [(false, false), (false, true), (true, false), (true, true)]
+        {
+            let (mut ctx, _) = Context::new_for_test(4);
+            ctx.protocol_config
+                .set_consensus_starfish_speed_for_testing(starfish_speed);
+            ctx.parameters
+                .enable_starfish_speed_adaptive_acknowledgments = adaptive_acks;
+            let context = Arc::new(ctx);
+            let store = Arc::new(MemStore::new(context.clone()));
+            let mut dag_state = DagState::new(context, store);
+
+            let target = AuthorityIndex::from(2u8);
+            let leader_round = 5;
+            dag_state.record_strong_vote_complaint(
+                AuthorityIndex::from(0u8),
+                leader_round,
+                blame_mask(target),
+            );
+            dag_state.record_strong_vote_complaint(
+                AuthorityIndex::from(1u8),
+                leader_round,
+                blame_mask(target),
+            );
+
+            let feature_active = starfish_speed && adaptive_acks;
+            let case = format!("(starfish_speed={starfish_speed}, adaptive_acks={adaptive_acks})");
+            assert_eq!(
+                dag_state
+                    .starfish_speed_excluded_ack_authorities()
+                    .contains(target),
+                feature_active,
+                "{case}: target excluded iff feature active",
+            );
+            assert_eq!(
+                !dag_state.starfish_speed_leader_hints.is_empty(),
+                feature_active,
+                "{case}: hints recorded iff feature active",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn adaptive_ack_filter_drops_blamed_authority_refs() {
+        let context = adaptive_ack_test_context(true);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let mut dag_state = DagState::new(context, store);
+
+        // Pending acknowledgments: one ref per authority.
+        let auth = |i: u8| AuthorityIndex::from(i);
+        let raw_acks = vec![
+            ref_for(auth(0)),
+            ref_for(auth(1)),
+            ref_for(auth(2)),
+            ref_for(auth(3)),
+        ];
+
+        // Two distinct voters blame authority 2 → exclude.
+        let target = auth(2);
+        let leader_round = 5;
+        dag_state.record_strong_vote_complaint(auth(0), leader_round, blame_mask(target));
+        dag_state.record_strong_vote_complaint(auth(1), leader_round, blame_mask(target));
+
+        let excluded = dag_state.starfish_speed_excluded_ack_authorities();
+        let filtered: Vec<BlockRef> = raw_acks
+            .into_iter()
+            .filter(|r| !excluded.contains(r.author))
+            .collect();
+
+        assert_eq!(filtered.len(), 3, "blamed authority's ref dropped");
+        assert!(
+            filtered.iter().all(|r| r.author != target),
+            "filtered acks must not contain target"
+        );
+        for kept in [auth(0), auth(1), auth(3)] {
+            assert!(
+                filtered.iter().any(|r| r.author == kept),
+                "non-blamed authority {kept} kept in acks"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn adaptive_ack_take_acknowledgments_skips_masked_authors() {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config.set_gc_depth_for_testing(20);
+        let context = Arc::new(ctx);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let mut dag_state = DagState::new(context, store);
+
+        // Advance threshold_clock to round 5 — quorum (3 of 4) at round 4.
+        for author in 0..3u8 {
+            dag_state.threshold_clock.add_block_header(BlockRef::new(
+                4,
+                author.into(),
+                BlockHeaderDigest::MIN,
+            ));
+        }
+        assert_eq!(dag_state.threshold_clock_round(), 5);
+
+        let r =
+            |round: Round, author: u8| BlockRef::new(round, author.into(), BlockHeaderDigest::MIN);
+
+        // Eligible: rounds 1..=4 × 4 authors (16). Above clock: round 6 × 4 authors.
+        let mut seeded = Vec::new();
+        for round in 1..=4u32 {
+            for author in 0..4u8 {
+                seeded.push(r(round, author));
+            }
+        }
+        for author in 0..4u8 {
+            seeded.push(r(6, author));
+        }
+        dag_state.set_pending_acknowledgments(seeded);
+
+        // First call: mask authors 1 and 3.
+        let mut mask = AuthoritySet::new();
+        mask.insert(AuthorityIndex::from(1u8));
+        mask.insert(AuthorityIndex::from(3u8));
+        let taken = dag_state.take_acknowledgments(1024, mask);
+        assert_eq!(taken.len(), 8, "2 unmasked authors × 4 eligible rounds");
+        assert!(taken.iter().all(
+            |x| x.author == AuthorityIndex::from(0u8) || x.author == AuthorityIndex::from(2u8)
+        ));
+        assert!(taken.iter().all(|x| x.round < 5));
+
+        // Masked refs and round-6 refs stay pending.
+        for round in 1..=4u32 {
+            for author in [1u8, 3u8] {
+                assert!(
+                    dag_state
+                        .pending_acknowledgments
+                        .contains(&r(round, author))
+                );
+            }
+        }
+        for author in 0..4u8 {
+            assert!(dag_state.pending_acknowledgments.contains(&r(6, author)));
+        }
+
+        // Empty mask + capped limit: exactly `limit` returned.
+        let taken_limited = dag_state.take_acknowledgments(3, AuthoritySet::new());
+        assert_eq!(taken_limited.len(), 3);
+
+        // Empty mask + no cap: drains the remaining 5 previously-skipped refs;
+        // round-6 refs stay pending (above clock_round).
+        let taken_rest = dag_state.take_acknowledgments(1024, AuthoritySet::new());
+        assert_eq!(taken_rest.len(), 5);
+        for author in 0..4u8 {
+            assert!(dag_state.pending_acknowledgments.contains(&r(6, author)));
+        }
     }
 }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1968,8 +1968,6 @@ impl DagState {
     }
 
     /// Check if a block's transaction data is locally available.
-    // Will be used by strong-vote computation in a later StarfishSpeed step.
-    #[expect(dead_code)]
     pub(crate) fn is_data_available(&self, block_ref: &BlockRef) -> bool {
         let transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
             let Some(header) = self.recent_block_headers.get(block_ref) else {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1690,38 +1690,43 @@ impl DagState {
         block_headers.into_iter().zip(equivocating_blocks).collect()
     }
 
-    /// Checks whether a block header exists in the slot. The method checks only
-    /// against the cached data. If the user asks for a slot that is not
-    /// within the cached data then a panic is thrown.
-    pub(crate) fn contains_cached_block_header_at_slot(&self, slot: Slot) -> bool {
-        // Always return true for genesis slots.
+    /// Returns the cached block header at the given slot, or `None` if no
+    /// such block is cached (including when the slot is older than the
+    /// authority's last evicted round). If multiple equivocating blocks
+    /// exist at the same slot, returns the one with the largest
+    /// `BlockHeaderDigest` — matching the selection rule used by
+    /// `get_last_cached_block_header_per_authority`.
+    pub(crate) fn get_cached_block_header_at_slot(
+        &self,
+        slot: Slot,
+    ) -> Option<VerifiedBlockHeader> {
         if slot.round == GENESIS_ROUND {
-            return true;
+            return self
+                .genesis
+                .iter()
+                .find(|(k, _)| k.author == slot.authority)
+                .map(|(_, b)| (**b).clone());
         }
 
-        let eviction_round = self.evicted_rounds[slot.authority];
-        if slot.round <= eviction_round {
-            panic!(
-                "{}",
-                format!(
-                    "Attempted to check for slot {slot} that is <= the last evicted round {eviction_round}"
-                )
-            );
+        if slot.round <= self.evicted_rounds[slot.authority] {
+            return None;
         }
 
-        let mut result = self.recent_headers_refs_by_authority[slot.authority].range((
-            Included(BlockRef::new(
-                slot.round,
-                slot.authority,
-                BlockHeaderDigest::MIN,
-            )),
-            Included(BlockRef::new(
-                slot.round,
-                slot.authority,
-                BlockHeaderDigest::MAX,
-            )),
-        ));
-        result.next().is_some()
+        self.recent_headers_refs_by_authority[slot.authority]
+            .range((
+                Included(BlockRef::new(
+                    slot.round,
+                    slot.authority,
+                    BlockHeaderDigest::MIN,
+                )),
+                Included(BlockRef::new(
+                    slot.round,
+                    slot.authority,
+                    BlockHeaderDigest::MAX,
+                )),
+            ))
+            .next_back()
+            .and_then(|block_ref| self.recent_block_headers.get(block_ref).cloned())
     }
 
     /// Checks whether the required block headers are in cache; if not, then
@@ -2930,124 +2935,6 @@ mod test {
         // Then all should be found apart from the last one
         expected.insert(3, false);
         assert_eq!(result, expected.clone());
-    }
-
-    #[tokio::test]
-    async fn test_contains_cached_block_header_at_slot() {
-        /// Only keep elements up to 2 rounds before the last committed round
-        const CACHED_ROUNDS: Round = 2;
-
-        let num_authorities: u8 = 4;
-        let (mut context, _) = Context::new_for_test(num_authorities as usize);
-        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store);
-
-        // Create test block headers for round 1 ~ 10
-        let num_rounds: u32 = 10;
-        let mut block_headers = Vec::new();
-
-        for round in 1..=num_rounds {
-            for author in 0..num_authorities {
-                let block_header =
-                    VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
-                block_headers.push(block_header.clone());
-                dag_state.accept_block_header(block_header, DataSource::Test);
-            }
-        }
-
-        // Query for genesis round 0, genesis block headers should be returned
-        for (author, _) in context.committee.authorities() {
-            assert!(
-                dag_state.contains_cached_block_header_at_slot(Slot::new(GENESIS_ROUND, author)),
-                "Genesis should always be found"
-            );
-        }
-
-        // Now when trying to query whether we have all the block headers, we should
-        // receive a positive answer for all headers
-        let mut block_refs = block_headers
-            .iter()
-            .map(|block_header| block_header.reference())
-            .collect::<Vec<_>>();
-
-        for block_ref in block_refs.clone() {
-            let slot = block_ref.into();
-            let found = dag_state.contains_cached_block_header_at_slot(slot);
-            assert!(found, "A block should be found at slot {slot}");
-        }
-
-        // Now try to ask also for one block ref that is not in the cache
-        // Then all should be found apart from the last one
-        block_refs.insert(
-            3,
-            BlockRef::new(
-                11,
-                AuthorityIndex::new_for_test(3),
-                BlockHeaderDigest::default(),
-            ),
-        );
-        let mut expected = vec![true; (num_rounds * num_authorities as u32) as usize];
-        expected.insert(3, false);
-
-        // Attempt to check the same for via the contains slot method
-        for block_ref in block_refs {
-            let slot = block_ref.into();
-            let found = dag_state.contains_cached_block_header_at_slot(slot);
-
-            assert_eq!(expected.remove(0), found);
-        }
-    }
-
-    #[tokio::test]
-    #[should_panic(
-        expected = "Attempted to check for slot S8[0] that is <= the last evicted round 8"
-    )]
-    async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range() {
-        const CACHED_ROUNDS: Round = 2;
-        const GC_DEPTH: Round = 3;
-        // With 14 rounds: gc_round = 14 - 6 = 8, eviction = min(8, 14 - 2) = 8
-        const NUM_ROUNDS: Round = 2 * GC_DEPTH + CACHED_ROUNDS + 6;
-
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context.protocol_config.set_gc_depth_for_testing(GC_DEPTH);
-
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store);
-
-        // Create test block headers for authority 0
-        let mut block_headers = Vec::new();
-        for round in 1..=NUM_ROUNDS {
-            let block_header =
-                VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build());
-            block_headers.push(block_header.clone());
-            dag_state.accept_block_header(block_header, DataSource::Test);
-        }
-
-        // Now add a commit and flush to trigger an eviction
-        dag_state.add_commit(TrustedCommit::new_for_test(
-            &context,
-            1 as CommitIndex,
-            CommitDigest::MIN,
-            0,
-            block_headers.last().unwrap().reference(),
-            block_headers
-                .into_iter()
-                .map(|block_header| block_header.reference())
-                .collect::<Vec<_>>(),
-            vec![],
-        ));
-
-        dag_state.flush();
-
-        // Eviction round = min(gc_round, last_round - cached_rounds) = min(8, 12) = 8.
-        // Querying at round 8 should panic since it is <= evicted round.
-        let _ = dag_state
-            .contains_cached_block_header_at_slot(Slot::new(8, AuthorityIndex::new_for_test(0)));
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3968,6 +3968,42 @@ mod test {
         assert_eq!(result, expected);
     }
 
+    #[rstest]
+    #[tokio::test]
+    async fn test_is_data_available(#[values(true, false)] consensus_fast_commit_sync: bool) {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new(context.clone()));
+        let mut dag_state = DagState::new(context, store);
+
+        let block = VerifiedBlock::new_for_test(TestBlockHeader::new(5, 1).build());
+        let block_ref = block.reference();
+
+        // Empty DagState.
+        assert!(!dag_state.is_data_available(&block_ref));
+
+        // Header without transactions.
+        dag_state.accept_block_header(block.verified_block_header.clone(), DataSource::Test);
+        assert!(!dag_state.is_data_available(&block_ref));
+
+        // Header and transactions both present.
+        dag_state.add_transactions(block.verified_transactions, DataSource::Test);
+        assert!(dag_state.is_data_available(&block_ref));
+
+        // Transactions without a header: flag-off ignores the header check;
+        // flag-on requires it.
+        let other = VerifiedBlock::new_for_test(TestBlockHeader::new(6, 2).build());
+        let other_ref = other.reference();
+        dag_state.add_transactions(other.verified_transactions, DataSource::Test);
+        assert_eq!(
+            dag_state.is_data_available(&other_ref),
+            !consensus_fast_commit_sync,
+        );
+    }
+
     #[tokio::test]
     async fn test_no_panic_on_future_timestamp() {
         // GIVEN

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -782,8 +782,10 @@ impl DagState {
 
         // Handle pending acknowledgments for recent blocks
         let has_transactions = transactions.has_transactions();
+        let block_digest = transactions.block_ref().map(|br| br.digest);
         let clock_round = self.threshold_clock_round();
         let min_round: Round = clock_round.saturating_sub(self.context.protocol_config.gc_depth());
+
         let hostname = self
             .context
             .committee
@@ -811,11 +813,7 @@ impl DagState {
                 && source != DataSource::CommitSyncer
                 && source != DataSource::Recover
             {
-                self.add_pending_acknowledgment(
-                    transaction_ref,
-                    transactions.block_ref().map(|br| br.digest),
-                    source,
-                );
+                self.add_pending_acknowledgment(transaction_ref, block_digest, source);
             }
         } else {
             self.context
@@ -1967,6 +1965,25 @@ impl DagState {
         let kept = self.pending_commit_votes.split_off(&pivot);
         let taken = std::mem::replace(&mut self.pending_commit_votes, kept);
         taken.into_iter().collect()
+    }
+
+    /// Check if a block's transaction data is locally available.
+    // Will be used by strong-vote computation in a later StarfishSpeed step.
+    #[expect(dead_code)]
+    pub(crate) fn is_data_available(&self, block_ref: &BlockRef) -> bool {
+        let transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
+            let Some(header) = self.recent_block_headers.get(block_ref) else {
+                return false;
+            };
+            GenericTransactionRef::from(TransactionRef {
+                round: block_ref.round,
+                author: block_ref.author,
+                transactions_commitment: header.transactions_commitment(),
+            })
+        } else {
+            GenericTransactionRef::from(*block_ref)
+        };
+        self.recent_transactions_by_authority[block_ref.author].contains_key(&transaction_ref)
     }
 
     /// Clean up old cached data for each authority, all cached blocks

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -362,6 +362,12 @@ pub(crate) enum ConsensusError {
         actual: &'static str,
         fast_commit_sync: bool,
     },
+
+    #[error("Block has strong_vote field but consensus_starfish_speed is disabled")]
+    UnexpectedStrongVote,
+
+    #[error("Block strong_vote contains invalid authority index {index}, committee size is {max}")]
+    InvalidStrongVoteAuthority { index: AuthorityIndex, max: usize },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -368,6 +368,16 @@ pub(crate) enum ConsensusError {
 
     #[error("Block strong_vote contains invalid authority index {index}, committee size is {max}")]
     InvalidStrongVoteAuthority { index: AuthorityIndex, max: usize },
+
+    #[error(
+        "Block at round {block_round} carries strong_vote pinned to leader \
+         authority {leader_authority} but does not reference that leader at round {leader_round}"
+    )]
+    StrongVoteLeaderNotInAncestors {
+        block_round: Round,
+        leader_round: Round,
+        leader_authority: AuthorityIndex,
+    },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -356,11 +356,12 @@ pub(crate) enum ConsensusError {
     },
 
     #[error(
-        "Commit variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync})"
+        "Commit variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync}, consensus_starfish_speed={starfish_speed})"
     )]
     WrongCommitVersionForFlags {
         actual: &'static str,
         fast_commit_sync: bool,
+        starfish_speed: bool,
     },
 
     #[error("Block has strong_vote field but consensus_starfish_speed is disabled")]
@@ -377,6 +378,14 @@ pub(crate) enum ConsensusError {
         block_round: Round,
         leader_round: Round,
         leader_authority: AuthorityIndex,
+    },
+
+    #[error(
+        "BlockHeader variant {actual} does not match protocol flag (consensus_starfish_speed={starfish_speed})"
+    )]
+    WrongBlockHeaderVersionForFlag {
+        actual: &'static str,
+        starfish_speed: bool,
     },
 }
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -364,9 +364,6 @@ pub(crate) enum ConsensusError {
         starfish_speed: bool,
     },
 
-    #[error("Block has strong_vote field but consensus_starfish_speed is disabled")]
-    UnexpectedStrongVote,
-
     #[error("Block strong_vote contains invalid authority index {index}, committee size is {max}")]
     InvalidStrongVoteAuthority { index: AuthorityIndex, max: usize },
 

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -64,11 +64,7 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
             stop,
             new_block_receiver: signals_receivers.block_broadcast_receiver(),
             new_round_receiver: signals_receivers.new_round_receiver(),
-            leader_timeout: if context.protocol_config.consensus_starfish_speed() {
-                Duration::from_millis(200)
-            } else {
-                context.parameters.leader_timeout
-            },
+            leader_timeout: context.parameters.leader_timeout,
             min_block_delay: context.parameters.min_block_delay,
             soft_leader_timeout: context.parameters.soft_leader_timeout,
             starfish_speed_enabled: context.protocol_config.consensus_starfish_speed(),

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -43,6 +43,8 @@ pub(crate) struct LeaderTimeoutTask<D: CoreThreadDispatcher> {
     new_block_receiver: broadcast::Receiver<VerifiedBlock>,
     leader_timeout: Duration,
     min_block_delay: Duration,
+    soft_leader_timeout: Duration,
+    starfish_speed_enabled: bool,
     stop: Receiver<()>,
 }
 
@@ -64,6 +66,8 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
             new_round_receiver: signals_receivers.new_round_receiver(),
             leader_timeout: context.parameters.leader_timeout,
             min_block_delay: context.parameters.min_block_delay,
+            soft_leader_timeout: context.parameters.soft_leader_timeout,
+            starfish_speed_enabled: context.protocol_config.consensus_starfish_speed(),
         };
         let handle = tokio::spawn(async move { me.run().await });
 
@@ -88,12 +92,15 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
         let mut clock_round: Round = *new_clock_round.borrow_and_update();
         let mut last_own_block_round: Option<Round> = None;
         let mut min_block_delay_timed_out = false;
+        let mut soft_timed_out = false;
         let mut max_leader_round_timed_out = false;
         let timer_start = Instant::now();
         let min_block_delay_timeout = sleep_until(timer_start + self.min_block_delay);
+        let soft_timeout = sleep_until(timer_start + self.soft_leader_timeout);
         let max_leader_timeout = sleep_until(timer_start + self.leader_timeout);
 
         tokio::pin!(min_block_delay_timeout);
+        tokio::pin!(soft_timeout);
         tokio::pin!(max_leader_timeout);
 
         loop {
@@ -104,55 +111,25 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
 
                 () = &mut min_block_delay_timeout, if !min_block_delay_timed_out && last_own_block_round.is_some() => {
                     let next_round: Round = last_own_block_round.expect("We should expect some last own round") + 1;
-                    match self.dispatcher.new_block(next_round, ReasonToCreateBlock::MinBlockDelayTimeout).await {
-                        Ok(missing_committed_txns) => {
-                            if !missing_committed_txns.is_empty() {
-                                debug!(
-                                    "Missing committed transactions after creating new block: {:?}",
-                                    missing_committed_txns
-                                );
-                                if let Err(err) = self.transactions_synchronizer
-                                    .fetch_transactions(missing_committed_txns)
-                                    .await
-                                {
-                                    warn!(
-                                        "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
-                                    );
-                                }
-                            }
-                        },
-                        Err(err) => {
-                            warn!("Error received while calling dispatcher, probably dispatcher is shutting down, will now exit: {err:?}");
-                            return;
-                        }
+                    if Self::dispatch_new_block(&self.dispatcher, &self.transactions_synchronizer, next_round, ReasonToCreateBlock::MinBlockDelayTimeout).await {
+                        return;
                     }
                     min_block_delay_timed_out = true;
+                },
+                // When the soft leader timeout expires, attempt block creation without requiring
+                // a strong-vote quorum. Only active when starfish speed is enabled.
+                () = &mut soft_timeout, if !soft_timed_out && self.starfish_speed_enabled => {
+                    if Self::dispatch_new_block(&self.dispatcher, &self.transactions_synchronizer, clock_round, ReasonToCreateBlock::SoftTimeout).await {
+                        return;
+                    }
+                    soft_timed_out = true;
                 },
                 // When the max leader timer expires then we attempt to trigger the creation of a new block. This
                 // call is made with reason MaxLeaderTimeout to bypass any checks that allow to propose immediately if block
                 // not already produced.
                 () = &mut max_leader_timeout, if !max_leader_round_timed_out => {
-                    match self.dispatcher.new_block(clock_round, ReasonToCreateBlock::MaxLeaderTimeout).await {
-                        Ok(missing_committed_txns) => {
-                            if !missing_committed_txns.is_empty() {
-                                debug!(
-                                    "Missing committed transactions after creating new block: {:?}",
-                                    missing_committed_txns
-                                );
-                                if let Err(err) = self.transactions_synchronizer
-                                    .fetch_transactions(missing_committed_txns)
-                                    .await
-                                {
-                                    warn!(
-                                        "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
-                                    );
-                                }
-                            }
-                        }
-                        Err(err) =>  {
-                            warn!("Error received while calling dispatcher, probably dispatcher is shutting down, will now exit: {err:?}");
-                            return;
-                        }
+                    if Self::dispatch_new_block(&self.dispatcher, &self.transactions_synchronizer, clock_round, ReasonToCreateBlock::MaxLeaderTimeout).await {
+                        return;
                     }
                     max_leader_round_timed_out = true;
                 }
@@ -164,12 +141,16 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                     let _span = tracing::trace_span!("new_consensus_round_received", round = ?clock_round).entered();
 
                     max_leader_round_timed_out = false;
+                    soft_timed_out = false;
 
                     let now = Instant::now();
 
                     max_leader_timeout
                     .as_mut()
                     .reset(now + self.leader_timeout);
+                    soft_timeout
+                    .as_mut()
+                    .reset(now + self.soft_leader_timeout);
                 },
                  // A new block was created. Set a timer in min_block_delay
                 Ok(block) = new_block.recv() => {
@@ -177,14 +158,50 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                     last_own_block_round = Some(block.round());
 
                     min_block_delay_timed_out = false;
+                    soft_timed_out = false;
 
                     let now = Instant::now();
                     min_block_delay_timeout.as_mut().reset(now + self.min_block_delay);
+                    soft_timeout.as_mut().reset(now + self.soft_leader_timeout);
                 },
                 _ = &mut self.stop => {
                     debug!("Stop signal has been received, now shutting down");
                     return;
                 }
+            }
+        }
+    }
+
+    /// Request a new block and fetch any missing committed transactions.
+    /// Returns `true` if the dispatcher is shutting down.
+    async fn dispatch_new_block(
+        dispatcher: &D,
+        transactions_synchronizer: &TransactionsSynchronizerHandle,
+        round: Round,
+        reason: ReasonToCreateBlock,
+    ) -> bool {
+        match dispatcher.new_block(round, reason).await {
+            Ok(missing_committed_txns) => {
+                if !missing_committed_txns.is_empty() {
+                    debug!(
+                        "Missing committed transactions after creating new block: {missing_committed_txns:?}"
+                    );
+                    if let Err(err) = transactions_synchronizer
+                        .fetch_transactions(missing_committed_txns)
+                        .await
+                    {
+                        warn!(
+                            "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
+                        );
+                    }
+                }
+                false
+            }
+            Err(err) => {
+                warn!(
+                    "Error received while calling dispatcher, probably dispatcher is shutting down, will now exit: {err:?}"
+                );
+                true
             }
         }
     }

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -64,7 +64,11 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
             stop,
             new_block_receiver: signals_receivers.block_broadcast_receiver(),
             new_round_receiver: signals_receivers.new_round_receiver(),
-            leader_timeout: context.parameters.leader_timeout,
+            leader_timeout: if context.protocol_config.consensus_starfish_speed() {
+                Duration::from_millis(200)
+            } else {
+                context.parameters.leader_timeout
+            },
             min_block_delay: context.parameters.min_block_delay,
             soft_leader_timeout: context.parameters.soft_leader_timeout,
             starfish_speed_enabled: context.protocol_config.consensus_starfish_speed(),

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod authority_node;
 mod authority_service;
+mod authority_set;
 mod base_committer;
 mod block_header;
 mod block_manager;

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -207,6 +207,7 @@ impl Linearizer {
                 .collect::<Vec<BlockRef>>(),
             committed_transactions_refs,
             reputation_scores_desc.clone(),
+            metastate == Some(CommitMetastate::Optimistic),
         );
         let serialized = commit
             .serialize()

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -1204,7 +1204,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),
@@ -1273,7 +1273,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),
@@ -1347,7 +1347,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),
@@ -1396,7 +1396,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),
@@ -1469,7 +1469,7 @@ mod tests {
 
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
-            Arc::new(MemStore::new(context.clone())),
+            Arc::new(MemStore::new()),
         )));
         let leader_schedule = Arc::new(LeaderSchedule::new(
             context.clone(),

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -156,6 +156,10 @@ impl Linearizer {
                     refs.clone(),
                 ));
             }
+            // The order in which transactions are added to the committed_transactions
+            // in above loop is not deterministic and depends on local state of validator,
+            // so we need to sort them.
+            committed_transactions.sort();
         }
 
         // Check that there are no duplicates in the committed transactions

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -16,7 +16,9 @@ use crate::{
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, VerifiedBlockHeader,
     },
-    commit::{Commit, CommitAPI, PendingSubDag, TrustedCommit, sort_sub_dag_blocks},
+    commit::{
+        Commit, CommitAPI, CommitMetastate, PendingSubDag, TrustedCommit, sort_sub_dag_blocks,
+    },
     context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
@@ -77,6 +79,8 @@ impl Linearizer {
     fn collect_sub_dag_and_commit(
         &mut self,
         leader_block: VerifiedBlockHeader,
+        metastate: Option<CommitMetastate>,
+        strong_voters: Vec<AuthorityIndex>,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
     ) -> (PendingSubDag, TrustedCommit) {
         let _s = self
@@ -123,7 +127,7 @@ impl Linearizer {
 
         // Collect all block references for transactions that reached quorum after
         // adding acknowledgments
-        let committed_transactions = to_commit
+        let mut committed_transactions = to_commit
             .iter()
             // Add the acknowledgments to the tracker and collect the ones that reached quorum.
             // This will return a vector of block references that reached the quorum threshold, so
@@ -136,6 +140,24 @@ impl Linearizer {
                 )
             })
             .collect::<Vec<BlockRef>>();
+
+        // Optimistic: record the leader's r+1 strong-voters as acks for the
+        // leader's ref and each of its acknowledgments. Crossing 2f+1 commits
+        // the ref through the standard quorum path.
+        if metastate == Some(CommitMetastate::Optimistic) {
+            let leader_ref = leader_block.reference();
+            let refs: Vec<BlockRef> = std::iter::once(leader_ref)
+                .chain(leader_block.acknowledgments().iter().copied())
+                .collect();
+            for strong_voter in &strong_voters {
+                committed_transactions.extend(self.add_committed_transaction_acks(
+                    leader_block.round() + 1,
+                    *strong_voter,
+                    refs.clone(),
+                ));
+            }
+        }
+
         // Check that there are no duplicates in the committed transactions
         assert_eq!(
             committed_transactions.len(),
@@ -265,7 +287,11 @@ impl Linearizer {
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn get_pending_sub_dags(
         &mut self,
-        committed_leaders: Vec<VerifiedBlockHeader>,
+        committed_leaders: Vec<(
+            VerifiedBlockHeader,
+            Option<CommitMetastate>,
+            Vec<AuthorityIndex>,
+        )>,
     ) -> Vec<PendingSubDag> {
         if committed_leaders.is_empty() {
             return vec![];
@@ -279,7 +305,9 @@ impl Linearizer {
 
         let mut pending_sub_dags = vec![];
 
-        for (i, leader_block) in committed_leaders.into_iter().enumerate() {
+        for (i, (leader_block, metastate, strong_voters)) in
+            committed_leaders.into_iter().enumerate()
+        {
             let reputation_scores_desc = if schedule_updated && i == 0 {
                 self.leader_schedule
                     .leader_swap_table
@@ -290,8 +318,12 @@ impl Linearizer {
                 vec![]
             };
 
-            let (sub_dag, commit) =
-                self.collect_sub_dag_and_commit(leader_block, reputation_scores_desc);
+            let (sub_dag, commit) = self.collect_sub_dag_and_commit(
+                leader_block,
+                metastate,
+                strong_voters,
+                reputation_scores_desc,
+            );
 
             // Buffer commit in dag state for persistence later.
             // This also updates the last committed rounds.
@@ -510,7 +542,7 @@ mod tests {
     use super::*;
     use crate::{
         CommitIndex, TestBlockHeader,
-        commit::{CommitDigest, WAVE_LENGTH},
+        commit::{CommitDigest, WAVE_LENGTH, with_no_metastate},
         context::Context,
         dag_state::DataSource,
         leader_schedule::{LeaderSchedule, LeaderSwapTable},
@@ -549,7 +581,7 @@ mod tests {
             .map(Option::unwrap)
             .collect::<Vec<_>>();
 
-        let commits = linearizer.get_pending_sub_dags(leaders.clone());
+        let commits = linearizer.get_pending_sub_dags(with_no_metastate(leaders.clone()));
         for (idx, subdag) in commits.into_iter().enumerate() {
             tracing::info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
@@ -631,7 +663,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Create some commits
-        let commits = linearizer.get_pending_sub_dags(leaders);
+        let commits = linearizer.get_pending_sub_dags(with_no_metastate(leaders));
         {
             // Write them in DagState
             let mut write = dag_state.write();
@@ -653,7 +685,7 @@ mod tests {
 
         // Now on the commits only the first one should contain the updated scores, the
         // other should be empty
-        let commits = linearizer.get_pending_sub_dags(leaders);
+        let commits = linearizer.get_pending_sub_dags(with_no_metastate(leaders));
         assert_eq!(commits.len(), 10);
         let scores = vec![
             (AuthorityIndex::new_for_test(1), 29),
@@ -766,7 +798,7 @@ mod tests {
             vec![],
         );
 
-        let commit = linearizer.get_pending_sub_dags(vec![leader.clone()]);
+        let commit = linearizer.get_pending_sub_dags(with_no_metastate(vec![leader.clone()]));
         assert_eq!(commit.len(), 1);
 
         let subdag = &commit[0];
@@ -860,7 +892,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         for (idx, leader) in leaders.iter().enumerate() {
-            let subdags = linearizer.get_pending_sub_dags(vec![leader.clone()]);
+            let subdags = linearizer.get_pending_sub_dags(with_no_metastate(vec![leader.clone()]));
             assert_eq!(subdags.len(), 1);
             let subdag = &subdags[0];
 
@@ -979,7 +1011,7 @@ mod tests {
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
-        linearizer.get_pending_sub_dags(leaders);
+        linearizer.get_pending_sub_dags(with_no_metastate(leaders));
         // Check that before eviction acknowledgements for all rounds up to num_rounds-2
         // are stored
         for round in 1..=num_rounds - 2 {
@@ -1158,5 +1190,356 @@ mod tests {
         let block = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
         let err = median_timestamp_by_stake(&context, vec![block].into_iter()).unwrap_err();
         assert_eq!(err, "Total stake 1 < quorum threshold 3");
+    }
+
+    #[tokio::test]
+    async fn test_optimistic_commits_leader_ref_and_acknowledgments() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=5).build().persist_layers(dag_state);
+
+        let leader = dag_builder
+            .leader_block(5)
+            .expect("Leader at round 5 should exist");
+        let leader_ref = leader.reference();
+        let leader_ack_refs: Vec<BlockRef> = leader.acknowledgments().to_vec();
+        assert!(
+            !leader_ack_refs.is_empty(),
+            "fully-linked round-5 leader should have acknowledgments"
+        );
+
+        // Synthetic strong-voter set: every authority. Carries 2f+1 stake so
+        // the per-ref tracker reaches quorum once these votes are added.
+        let strong_voters: Vec<AuthorityIndex> = (0..num_authorities as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect();
+        let commits = linearizer.get_pending_sub_dags(vec![(
+            leader,
+            Some(CommitMetastate::Optimistic),
+            strong_voters,
+        )]);
+        assert_eq!(commits.len(), 1);
+        let optimistic_refs = &commits[0].committed_transaction_refs;
+        let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
+            refs.iter()
+                .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
+        };
+
+        // Optimistic commits the leader's own ref.
+        assert!(
+            contains_block(optimistic_refs, &leader_ref),
+            "Optimistic should include leader's own ref {leader_ref:?}"
+        );
+
+        // Optimistic commits every ack of the leader.
+        for ack_ref in &leader_ack_refs {
+            assert!(
+                contains_block(optimistic_refs, ack_ref),
+                "Optimistic should include leader's ack ref {ack_ref:?}"
+            );
+        }
+
+        // Optimistic is additive over the standard flow.
+        assert!(
+            optimistic_refs.len() > 1 + leader_ack_refs.len(),
+            "Optimistic should additively include standard-flow refs; \
+             got {} refs, optimistic-only would give {}",
+            optimistic_refs.len(),
+            1 + leader_ack_refs.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimistic_does_not_double_commit_across_sub_dags() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=7).build().persist_layers(dag_state);
+
+        // First commit: L_a at round 4 with Optimistic metastate.
+        let leader_a = dag_builder
+            .leader_block(4)
+            .expect("Leader at round 4 should exist");
+        let optimistic_set: Vec<BlockRef> = std::iter::once(leader_a.reference())
+            .chain(leader_a.acknowledgments().iter().copied())
+            .collect();
+        let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
+            refs.iter()
+                .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
+        };
+
+        let strong_voters: Vec<AuthorityIndex> = (0..num_authorities as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect();
+        let commits_a = linearizer.get_pending_sub_dags(vec![(
+            leader_a,
+            Some(CommitMetastate::Optimistic),
+            strong_voters,
+        )]);
+        assert_eq!(commits_a.len(), 1);
+        for block_ref in &optimistic_set {
+            assert!(
+                contains_block(&commits_a[0].committed_transaction_refs, block_ref),
+                "Optimistic commit of L_a should include {block_ref:?}"
+            );
+        }
+
+        // Second commit: L_b at round 7 standardly. Its causal history
+        // accumulates 2f+1 acks for L_a's optimistically-committed refs, but
+        // the votes already recorded for L_a's commit must keep the per-ref
+        // tracker at threshold so the standard path skips re-commit.
+        let leader_b = dag_builder
+            .leader_block(7)
+            .expect("Leader at round 7 should exist");
+        let commits_b = linearizer.get_pending_sub_dags(vec![(leader_b, None, vec![])]);
+        assert_eq!(commits_b.len(), 1);
+        for block_ref in &optimistic_set {
+            assert!(
+                !contains_block(&commits_b[0].committed_transaction_refs, block_ref),
+                "Standard commit of L_b should NOT re-include {block_ref:?} \
+                 already committed by L_a's Optimistic commit"
+            );
+        }
+
+        // Sanity: the standard flow still commits refs L_a never touched.
+        let has_round_5_ref = commits_b[0]
+            .committed_transaction_refs
+            .iter()
+            .any(|r| r.round() == 5);
+        assert!(
+            has_round_5_ref,
+            "Standard commit of L_b should still include round-5 refs"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_standard_metastate_does_not_commit_leader_ref_or_acks() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=5).build().persist_layers(dag_state);
+
+        let leader = dag_builder
+            .leader_block(5)
+            .expect("Leader at round 5 should exist");
+        let leader_ref = leader.reference();
+        let leader_ack_refs: Vec<BlockRef> = leader.acknowledgments().to_vec();
+
+        let commits = linearizer.get_pending_sub_dags(vec![(
+            leader,
+            Some(CommitMetastate::Standard),
+            vec![],
+        )]);
+        assert_eq!(commits.len(), 1);
+        let standard_refs = &commits[0].committed_transaction_refs;
+        let contains_block = |refs: &[GenericTransactionRef], block_ref: &BlockRef| -> bool {
+            refs.iter()
+                .any(|r| r.round() == block_ref.round && r.author() == block_ref.author)
+        };
+
+        // Standard metastate must not trigger the Optimistic shortcut.
+        assert!(
+            !contains_block(standard_refs, &leader_ref),
+            "Standard should not include leader's own ref {leader_ref:?}"
+        );
+        for ack_ref in &leader_ack_refs {
+            assert!(
+                !contains_block(standard_refs, ack_ref),
+                "Standard should not include leader's ack ref {ack_ref:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_optimistic_records_strong_voters_in_ack_tracker() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=5).build().persist_layers(dag_state);
+
+        let leader = dag_builder
+            .leader_block(5)
+            .expect("Leader at round 5 should exist");
+        let leader_ref = leader.reference();
+        let leader_ack_refs: Vec<BlockRef> = leader.acknowledgments().to_vec();
+
+        // Synthetic strong-voter set: exactly 2f+1 (= 3) authorities. These
+        // should land in the tracker as actual votes for the leader's ref and
+        // for every block the leader acknowledges, so that
+        // `get_transaction_ack_authors` returns them as fetch sources.
+        let strong_voters: BTreeSet<AuthorityIndex> =
+            (0..3u8).map(AuthorityIndex::new_for_test).collect();
+        let commits = linearizer.get_pending_sub_dags(vec![(
+            leader,
+            Some(CommitMetastate::Optimistic),
+            strong_voters.iter().copied().collect(),
+        )]);
+        assert_eq!(commits.len(), 1);
+
+        let ack_authors =
+            linearizer.get_transaction_ack_authors(commits[0].committed_transaction_refs.clone());
+
+        let leader_generic = ack_authors
+            .iter()
+            .find(|(r, _)| r.round() == leader_ref.round && r.author() == leader_ref.author)
+            .map(|(_, authors)| authors)
+            .expect("leader ref must be present in ack tracker");
+        assert!(
+            strong_voters.is_subset(leader_generic),
+            "leader ref tracker should record the strong-voter authorities; \
+             got {leader_generic:?}, expected superset of {strong_voters:?}"
+        );
+
+        for ack_ref in &leader_ack_refs {
+            let recorded = ack_authors
+                .iter()
+                .find(|(r, _)| r.round() == ack_ref.round && r.author() == ack_ref.author)
+                .map(|(_, authors)| authors)
+                .unwrap_or_else(|| panic!("ack ref {ack_ref:?} must be in tracker"));
+            assert!(
+                strong_voters.is_subset(recorded),
+                "ack ref {ack_ref:?} tracker should record the strong-voter authorities; \
+                 got {recorded:?}, expected superset of {strong_voters:?}"
+            );
+        }
+    }
+
+    /// A leader-ack that is not among the leader's ancestors never enters
+    /// the traversed-headers tracker, so the Optimistic path must not commit
+    /// it when `consensus_commit_transactions_only_for_traversed_headers` is
+    /// on.
+    #[tokio::test]
+    async fn test_optimistic_path_respects_traversed_headers_gate() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+        let (mut ctx, _) = Context::new_for_test(num_authorities);
+        ctx.protocol_config
+            .set_consensus_commit_transactions_only_for_traversed_headers_for_testing(true);
+        let context = Arc::new(ctx);
+
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new(context.clone())),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        let all_authorities: Vec<AuthorityIndex> = (0..num_authorities as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect();
+        // Pick an authority that is neither the local node (own_index = 0) nor
+        // the round-5 leader. Their round-3 block will be the orphaned ref.
+        let orphan_author = AuthorityIndex::new_for_test(2);
+
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder
+            .layers(1..=3)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        // Round 4: every authority builds, but no round-4 block references the
+        // orphan author's round-3 block as either ancestor or ack. The orphan's
+        // round-3 block stays in dag_state but is not in the transitive
+        // ancestry of any round-5 block.
+        dag_builder
+            .layers(4..=4)
+            .authorities(all_authorities.clone())
+            .skip_ancestor_links(vec![orphan_author])
+            .skip_acknowledgements(vec![orphan_author])
+            .build()
+            .persist_layers(dag_state.clone());
+
+        dag_builder
+            .layers(5..=5)
+            .build()
+            .persist_layers(dag_state.clone());
+
+        let orphan_block = dag_builder
+            .block_headers(3..=3)
+            .into_iter()
+            .find(|b| b.author() == orphan_author)
+            .expect("orphan round-3 block should exist");
+        let orphan_ref = orphan_block.reference();
+
+        let leader_orig = dag_builder
+            .leader_block(5)
+            .expect("leader at round 5 should exist");
+        let leader_author = leader_orig.author();
+        let leader_ancestors: Vec<BlockRef> = leader_orig.ancestors().to_vec();
+        let mut modified_acks = leader_orig.acknowledgments().to_vec();
+        modified_acks.push(orphan_ref);
+        let leader_modified = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(5, leader_author.value() as u8)
+                .set_ancestors(leader_ancestors)
+                .set_acknowledgments(modified_acks)
+                .build(),
+        );
+        dag_state
+            .write()
+            .accept_block_header(leader_modified.clone(), DataSource::Test);
+
+        let subdags = linearizer.get_pending_sub_dags(vec![(
+            leader_modified,
+            Some(CommitMetastate::Optimistic),
+            all_authorities,
+        )]);
+        assert_eq!(subdags.len(), 1);
+
+        let contains_orphan = subdags[0]
+            .committed_transaction_refs
+            .iter()
+            .any(|r| r.round() == orphan_ref.round && r.author() == orphan_ref.author);
+        assert!(
+            !contains_orphan,
+            "Optimistic path must not commit a ref whose header is not traversed"
+        );
     }
 }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -49,6 +49,19 @@ const NUM_BUCKETS: &[f64] = &[
     1_000_000.0,
 ];
 
+/// Integer-aligned buckets for committee-size-bounded counts (e.g. the size
+/// of a strong-blame set). Each cumulative bucket `le=N.5` captures exactly
+/// the integer value N — so 0 and 1 land in different buckets, which is what
+/// `histogram_quantile` / heatmap visualisations need to distinguish a clean
+/// strong vote (`missing.len() == 0`) from a single-authority blame
+/// (`missing.len() == 1`). Boundaries cover the full `AuthorityIndex: u8`
+/// range; fine-grained at the low end where the common case lives, coarser
+/// for outliers.
+const COMMITTEE_COUNT_BUCKETS: &[f64] = &[
+    0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 12.5, 15.5, 20.5, 30.5, 50.5, 100.5,
+    256.5,
+];
+
 const LATENCY_SEC_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9,
     1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5,
@@ -255,6 +268,12 @@ pub(crate) struct NodeMetrics {
     pub(crate) faulty_blocks_unprovable_by_peer: IntGaugeVec,
     pub(crate) equivocations_by_authority: IntGaugeVec,
     pub(crate) missing_proposals_by_authority: IntGaugeVec,
+    pub(crate) strong_vote_extra_wait_seconds: Histogram,
+    pub(crate) strong_vote_missing_authorities: Histogram,
+    pub(crate) strong_blames_emitted_for_leader: IntCounterVec,
+    pub(crate) strong_blames_received_from_voter: IntCounterVec,
+    pub(crate) adaptive_ack_excluded_authorities: IntGauge,
+    pub(crate) adaptive_ack_acks_dropped: IntCounter,
 }
 
 impl NodeMetrics {
@@ -1162,6 +1181,40 @@ impl NodeMetrics {
                 "missing_proposals_by_authority",
                 "Missing proposals per authority (source: persisted or in_memory)",
                 &["authority", "source"],
+                registry,
+            ).unwrap(),
+            strong_vote_extra_wait_seconds: register_histogram_with_registry!(
+                "strong_vote_extra_wait_seconds",
+                "Extra wait at block proposal time imposed by the StarfishSpeed strong-vote condition: time between when the ordinary (base Starfish) propose condition first became satisfiable for the current clock round and when the proposal actually happened. Observed only when consensus_starfish_speed is enabled.",
+                FINE_GRAINED_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            strong_vote_missing_authorities: register_histogram_with_registry!(
+                "strong_vote_missing_authorities",
+                "Size of the `missing` set in the strong-vote payload of each proposed block: authorities whose transactions are not locally available among the leader and its acknowledgments. 0 means a clean strong vote; >0 means strong blame. Observed only when consensus_starfish_speed is enabled.",
+                COMMITTEE_COUNT_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            strong_blames_emitted_for_leader: register_int_counter_vec_with_registry!(
+                "strong_blames_emitted_for_leader",
+                "Number of proposed blocks that strong-blame the leader (non-empty `missing` set), labeled by leader authority.",
+                &["leader"],
+                registry,
+            ).unwrap(),
+            strong_blames_received_from_voter: register_int_counter_vec_with_registry!(
+                "strong_blames_received_from_voter",
+                "Number of strong blames received against this node (when acting as leader), labeled by the voter authority that emitted the blame.",
+                &["voter"],
+                registry,
+            ).unwrap(),
+            adaptive_ack_excluded_authorities: register_int_gauge_with_registry!(
+                "adaptive_ack_excluded_authorities",
+                "Number of authorities currently in the adaptive-ack exclusion set, as observed at the most recent leader block proposal. Empty when consensus_starfish_speed or enable_starfish_speed_adaptive_acknowledgments is off.",
+                registry,
+            ).unwrap(),
+            adaptive_ack_acks_dropped: register_int_counter_with_registry!(
+                "adaptive_ack_acks_dropped",
+                "Total pending acknowledgments skipped because their author was in the adaptive-ack exclusion set at proposal time. Skipped refs remain pending and may be included later if the author leaves the exclusion set.",
                 registry,
             ).unwrap(),
         }

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -298,20 +298,13 @@ pub(crate) struct SerializedBlockBundleParts {
     pub(crate) useful_shards_authors_bitmask: AuthoritySet,
 }
 
-fn validate_authority_bitmask(bitmask: [u64; 4], committee: &Committee) -> ConsensusResult<()> {
-    for (array_index, &bits) in bitmask.iter().enumerate() {
-        let mut bits = bits;
-        let base = array_index * 64;
-        while bits != 0 {
-            let bit = bits.trailing_zeros() as usize;
-            let index = base + bit;
-            if index >= committee.size() {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: AuthorityIndex::from(index as u8),
-                    max: committee.size(),
-                });
-            }
-            bits &= bits - 1;
+fn validate_authority_set(set: &AuthoritySet, committee: &Committee) -> ConsensusResult<()> {
+    for index in set.iter() {
+        if !committee.is_valid_index(index) {
+            return Err(ConsensusError::InvalidAuthorityIndex {
+                index,
+                max: committee.size(),
+            });
         }
     }
     Ok(())
@@ -319,8 +312,8 @@ fn validate_authority_bitmask(bitmask: [u64; 4], committee: &Committee) -> Conse
 
 impl SerializedBlockBundleParts {
     pub(crate) fn validate_useful_authorities(&self, committee: &Committee) -> ConsensusResult<()> {
-        validate_authority_bitmask(self.useful_headers_authors_bitmask, committee)?;
-        validate_authority_bitmask(self.useful_shards_authors_bitmask, committee)?;
+        validate_authority_set(&self.useful_headers_authors_bitmask, committee)?;
+        validate_authority_set(&self.useful_shards_authors_bitmask, committee)?;
         Ok(())
     }
 

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -32,6 +32,7 @@ use starfish_config::{AuthorityIndex, Committee};
 
 use crate::{
     Round, VerifiedBlockHeader,
+    authority_set::AuthoritySet,
     block_header::{BlockRef, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
@@ -293,33 +294,8 @@ pub(crate) struct SerializedBlockBundleParts {
     pub(crate) serialized_block: Bytes,
     pub(crate) serialized_headers: Vec<Bytes>,
     pub(crate) serialized_shards: Vec<Bytes>,
-    pub(crate) useful_headers_authors_bitmask: [u64; 4],
-    pub(crate) useful_shards_authors_bitmask: [u64; 4],
-}
-
-fn authority_set_to_bitmask(authorities: &BTreeSet<AuthorityIndex>) -> [u64; 4] {
-    let mut bitmask = [0u64; 4];
-    for authority_index in authorities {
-        let index = authority_index.value();
-        let array_index = index / 64;
-        let bit_pos = index % 64;
-        bitmask[array_index] |= 1u64 << bit_pos;
-    }
-    bitmask
-}
-
-fn bitmask_to_authority_set(bitmask: [u64; 4]) -> BTreeSet<AuthorityIndex> {
-    let mut set = BTreeSet::new();
-    for (array_index, &bits) in bitmask.iter().enumerate() {
-        let mut bits = bits;
-        let base = array_index * 64;
-        while bits != 0 {
-            let bit = bits.trailing_zeros() as usize;
-            set.insert(AuthorityIndex::from((base + bit) as u8));
-            bits &= bits - 1;
-        }
-    }
-    set
+    pub(crate) useful_headers_authors_bitmask: AuthoritySet,
+    pub(crate) useful_shards_authors_bitmask: AuthoritySet,
 }
 
 fn validate_authority_bitmask(bitmask: [u64; 4], committee: &Committee) -> ConsensusResult<()> {
@@ -349,10 +325,10 @@ impl SerializedBlockBundleParts {
     }
 
     pub(crate) fn useful_headers_authors(&self) -> BTreeSet<AuthorityIndex> {
-        bitmask_to_authority_set(self.useful_headers_authors_bitmask)
+        self.useful_headers_authors_bitmask.to_btreeset()
     }
     pub(crate) fn useful_shards_authors(&self) -> BTreeSet<AuthorityIndex> {
-        bitmask_to_authority_set(self.useful_shards_authors_bitmask)
+        self.useful_shards_authors_bitmask.to_btreeset()
     }
 }
 
@@ -375,8 +351,8 @@ impl TryFrom<VerifiedBlock> for SerializedBlockBundleParts {
             serialized_block: Bytes::from(bytes),
             serialized_headers: vec![],
             serialized_shards: vec![],
-            useful_headers_authors_bitmask: [0u64; 4],
-            useful_shards_authors_bitmask: [0u64; 4],
+            useful_headers_authors_bitmask: AuthoritySet::new(),
+            useful_shards_authors_bitmask: AuthoritySet::new(),
         })
     }
 }
@@ -400,12 +376,10 @@ impl TryFrom<BlockBundle> for SerializedBlockBundleParts {
             serialized_block: Bytes::from(bytes),
             serialized_headers: serialized_block_headers,
             serialized_shards: block_bundle.serialized_shards,
-            useful_headers_authors_bitmask: authority_set_to_bitmask(
+            useful_headers_authors_bitmask: AuthoritySet::from(
                 &block_bundle.useful_headers_authors,
             ),
-            useful_shards_authors_bitmask: authority_set_to_bitmask(
-                &block_bundle.useful_shards_authors,
-            ),
+            useful_shards_authors_bitmask: AuthoritySet::from(&block_bundle.useful_shards_authors),
         })
     }
 }

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -237,7 +237,7 @@ async fn indirect_commit() {
     tracing::info!("Leader index wave 2: {leader_index_wave2}");
 
     let leader_status_wave_2 = committer.try_direct_decide(leader_wave2);
-    if let LeaderStatus::Commit(committed, _) = leader_status_wave_2.clone() {
+    if let LeaderStatus::Commit(committed, _, _) = leader_status_wave_2.clone() {
         tracing::info!("Direct committed leader at wave 2: {committed}");
     } else {
         panic!(
@@ -250,7 +250,7 @@ async fn indirect_commit() {
         [leader_status_wave_2].iter(),
     );
 
-    if let LeaderStatus::Commit(committed, _) = leader_status_wave1_indirect {
+    if let LeaderStatus::Commit(committed, _, _) = leader_status_wave1_indirect {
         tracing::info!("Indirect committed leader at wave 1: {committed}");
     } else {
         panic!(
@@ -304,7 +304,7 @@ async fn indirect_skip() {
     tracing::info!("Leader index wave 1: {leader_index}");
 
     let leader_status_wave1 = committer.try_direct_decide(leader);
-    if let LeaderStatus::Commit(committed, _) = leader_status_wave1 {
+    if let LeaderStatus::Commit(committed, _, _) = leader_status_wave1 {
         tracing::info!("Direct undecided leader at wave 1: {committed}");
     } else {
         panic!(
@@ -341,7 +341,7 @@ async fn indirect_skip() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_3.authority);
         decided_leaders.push(leader_status);
     } else {

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -55,7 +55,7 @@ async fn direct_commit() {
         .elect_leader(leader_round)
         .expect("there should be a leader at wave 1");
     let leader_status = committer.try_direct_decide(leader);
-    if let LeaderStatus::Commit(_) = leader_status {
+    if let LeaderStatus::Commit(..) = leader_status {
         tracing::info!("Committed: {leader_status}");
     } else {
         panic!("Expected a committed leader, got {leader_status}");
@@ -237,7 +237,7 @@ async fn indirect_commit() {
     tracing::info!("Leader index wave 2: {leader_index_wave2}");
 
     let leader_status_wave_2 = committer.try_direct_decide(leader_wave2);
-    if let LeaderStatus::Commit(committed) = leader_status_wave_2.clone() {
+    if let LeaderStatus::Commit(committed, _) = leader_status_wave_2.clone() {
         tracing::info!("Direct committed leader at wave 2: {committed}");
     } else {
         panic!(
@@ -245,10 +245,12 @@ async fn indirect_commit() {
         );
     };
 
-    let leader_status_wave1_indirect =
-        committer.try_indirect_decide(leader, [leader_status_wave_2].iter());
+    let leader_status_wave1_indirect = committer.try_indirect_decide(
+        LeaderStatus::Undecided(leader),
+        [leader_status_wave_2].iter(),
+    );
 
-    if let LeaderStatus::Commit(committed) = leader_status_wave1_indirect {
+    if let LeaderStatus::Commit(committed, _) = leader_status_wave1_indirect {
         tracing::info!("Indirect committed leader at wave 1: {committed}");
     } else {
         panic!(
@@ -302,7 +304,7 @@ async fn indirect_skip() {
     tracing::info!("Leader index wave 1: {leader_index}");
 
     let leader_status_wave1 = committer.try_direct_decide(leader);
-    if let LeaderStatus::Commit(committed) = leader_status_wave1 {
+    if let LeaderStatus::Commit(committed, _) = leader_status_wave1 {
         tracing::info!("Direct undecided leader at wave 1: {committed}");
     } else {
         panic!(
@@ -339,7 +341,7 @@ async fn indirect_skip() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_3.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -362,7 +364,10 @@ async fn indirect_skip() {
 
     // 3. Ensure we skip leader of wave 2 indirectly.
     tracing::info!("Try indirect commit for leader {leader_wave_2}",);
-    let leader_status = committer.try_indirect_decide(leader_wave_2, decided_leaders.iter());
+    let leader_status = committer.try_indirect_decide(
+        LeaderStatus::Undecided(leader_wave_2),
+        decided_leaders.iter(),
+    );
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Skip(skipped_slot) = leader_status {

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -8,16 +8,21 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     authority_set::AuthoritySet,
-    base_committer::base_committer_builder::BaseCommitterBuilder,
+    base_committer::{
+        BaseCommitter, BaseCommitterOptions, base_committer_builder::BaseCommitterBuilder,
+    },
     block_header::{
         BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        TransactionsCommitment, VerifiedBlockHeader, genesis_block_headers,
+        TransactionsCommitment, VerifiedBlockHeader, VerifiedTransactions, genesis_block_headers,
     },
     commit::{CommitMetastate, DecidedLeader, LeaderStatus},
     context::Context,
+    core::Core,
     dag_state::{DagState, DataSource},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
+    linearizer::Linearizer,
     storage::mem_store::MemStore,
+    transaction_ref::GenericTransactionRef,
     universal_committer::universal_committer_builder::UniversalCommitterBuilder,
 };
 
@@ -42,6 +47,38 @@ fn v2_block(
         strong_vote,
     );
     VerifiedBlockHeader::new_for_test(BlockHeader::V2(header))
+}
+
+/// `v2_block` variant that takes a non-empty `acks` list.
+fn v2_block_with_acks(
+    round: Round,
+    author: u8,
+    ancestors: Vec<BlockRef>,
+    acks: Vec<BlockRef>,
+    strong_vote: Option<AuthoritySet>,
+    timestamp_ms: BlockTimestampMs,
+) -> VerifiedBlockHeader {
+    let header = BlockHeaderV2::new(
+        0,
+        round,
+        AuthorityIndex::from(author),
+        timestamp_ms,
+        ancestors,
+        acks,
+        vec![],
+        TransactionsCommitment::DEFAULT_FOR_TEST,
+        strong_vote,
+    );
+    VerifiedBlockHeader::new_for_test(BlockHeader::V2(header))
+}
+
+/// Marks `header`'s transaction data as locally available, so
+/// `DagState::is_data_available` returns true for that ref.
+fn add_transactions_for(dag_state: &Arc<RwLock<DagState>>, header: &VerifiedBlockHeader) {
+    let verified = VerifiedTransactions::new_for_test(header, vec![]);
+    dag_state
+        .write()
+        .add_transactions(verified, DataSource::Test);
 }
 
 /// Default timestamp for single-block-per-slot callers.
@@ -690,5 +727,219 @@ async fn pending_leader_resolves_to_standard() {
     assert_eq!(
         round_3_metastate(&universal, &decided),
         Some(CommitMetastate::Standard),
+    );
+}
+
+/// Optimistic-commit injects phantom acks: when the canonical leader at commit
+/// time differs from the leader the producers were "voting for" (e.g. block
+/// built before a schedule rotation, committed after), the strong-vote bytes
+/// — which carry no leader identity — get credited as acks for the canonical
+/// leader's `acknowledgments` set. The test sets up a single-validator view
+/// where:
+///   - The canonical leader of round 3 (per the post-rotation table) is
+///     authority 1, whose round-3 block has acks=[round-2 block from authority
+///     3].
+///   - That round-2 block's transaction data is *not* locally available.
+///   - Round-4 voters carry `strong_vote = Some(empty)`, consistent with the
+///     pre-rotation leader (different acks, all available).
+/// Optimistic linearization injects phantom acks for the canonical leader's
+/// ack set, committing the round-2 block via fictional 2f+1 evidence — even
+/// though no validator has its data. Asserts the system invariant
+/// "Z committed via Optimistic ⇒ ≥1 stake has Z's data" — fails by design.
+#[tokio::test]
+async fn optimistic_commits_ref_without_actual_data_backing() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let auth_1 = AuthorityIndex::from(1u8);
+    let auth_3 = AuthorityIndex::from(3u8);
+
+    // Round 1.
+    let mut r1_blocks = Vec::new();
+    let mut r1_refs = Vec::new();
+    for author in 0..4u8 {
+        let block = v2_block(
+            1,
+            author,
+            genesis_block_headers(&context)
+                .iter()
+                .map(|b| b.reference())
+                .collect(),
+            None,
+            default_ts(1, author),
+        );
+        r1_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block.clone(), DataSource::Test);
+        r1_blocks.push(block);
+    }
+
+    // Round 2.
+    let mut r2_blocks = Vec::new();
+    let mut r2_refs = Vec::new();
+    for author in 0..4u8 {
+        let block = v2_block(2, author, r1_refs.clone(), None, default_ts(2, author));
+        r2_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block.clone(), DataSource::Test);
+        r2_blocks.push(block);
+    }
+
+    // Round 3: A (auth 0) has no acks. B (auth 1) has acks=[round-2 block from
+    // auth 3]. Other authorities have no acks.
+    let mut r3_blocks = Vec::new();
+    let mut r3_refs = Vec::new();
+    for author in 0..4u8 {
+        let acks = if author == 1 {
+            vec![r2_refs[3]]
+        } else {
+            vec![]
+        };
+        let block = v2_block_with_acks(
+            3,
+            author,
+            r2_refs.clone(),
+            acks,
+            None,
+            default_ts(3, author),
+        );
+        r3_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block.clone(), DataSource::Test);
+        r3_blocks.push(block);
+    }
+
+    // Mark transaction data as locally available for everything *except*
+    //   - r2[3] (the block in B's acks)
+    //   - r3[1..=3] (B, C, D themselves)
+    // The producer's data state covers A's set ({A, A.acks=∅}) cleanly, so
+    // `Core::compute_strong_vote_for(A_block)` returns `Some(empty)` — a
+    // legitimate strong vote for A.
+    for block in &r1_blocks {
+        add_transactions_for(&dag_state, block);
+    }
+    for (i, block) in r2_blocks.iter().enumerate() {
+        if i != 3 {
+            add_transactions_for(&dag_state, block);
+        }
+    }
+    add_transactions_for(&dag_state, &r3_blocks[0]);
+
+    // Sanity: with this data state, A is a legitimate strong-vote target; B
+    // is *not* (data for B itself and for `r2[3]` is missing).
+    let a_block = &r3_blocks[0];
+    let b_block = &r3_blocks[1];
+    {
+        let dag = dag_state.read();
+        assert!(
+            Core::compute_strong_vote_for(&dag, a_block).is_empty(),
+            "producer should be able to legitimately strong-vote for A"
+        );
+        assert!(
+            !Core::compute_strong_vote_for(&dag, b_block).is_empty(),
+            "producer should NOT be able to legitimately strong-vote for B"
+        );
+    }
+
+    // Build round-4 voters using the production strong-vote computation
+    // against A — this is what an honest validator on the pre-rotation table
+    // would produce.
+    let voter_strong_vote = {
+        let dag = dag_state.read();
+        Core::compute_strong_vote_for(&dag, a_block)
+    };
+    let r4_refs: Vec<BlockRef> = (0..4u8)
+        .map(|author| {
+            let block = v2_block(
+                4,
+                author,
+                r3_refs.clone(),
+                Some(voter_strong_vote),
+                default_ts(4, author),
+            );
+            let r = block.reference();
+            dag_state
+                .write()
+                .accept_block_header(block, DataSource::Test);
+            r
+        })
+        .collect();
+
+    // Round 5 certifiers.
+    for author in 0..4u8 {
+        let block = v2_block(5, author, r4_refs.clone(), None, default_ts(5, author));
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    // Force canonical leader of round 3 to authority 1 (B).
+    // Test mode: `elect_leader(3, 0)` returns `(3 + 0) % 4 = 3`. The swap
+    // table flags auth 3 as bad and remaps to auth 1.
+    let alt_table = LeaderSwapTable {
+        good_nodes: vec![(
+            auth_1,
+            context.committee.authority(auth_1).hostname.clone(),
+            context.committee.authority(auth_1).stake,
+        )],
+        bad_nodes: std::iter::once((
+            auth_3,
+            (
+                context.committee.authority(auth_3).hostname.clone(),
+                context.committee.authority(auth_3).stake,
+            ),
+        ))
+        .collect(),
+        ..LeaderSwapTable::default()
+    };
+    let alt_schedule = Arc::new(LeaderSchedule::new(context.clone(), alt_table));
+    let committer = BaseCommitter::new(
+        context.clone(),
+        alt_schedule.clone(),
+        dag_state.clone(),
+        BaseCommitterOptions::default(),
+    );
+
+    let leader_b_slot = committer.elect_leader(3).expect("leader at round 3");
+    assert_eq!(leader_b_slot.authority, auth_1);
+
+    let (block_b, strong_voters) = match committer.try_direct_decide(leader_b_slot) {
+        LeaderStatus::Commit(b, Some(CommitMetastate::Optimistic), sv) => (b, sv),
+        other => panic!("expected Optimistic Commit, got {other}"),
+    };
+
+    let mut linearizer = Linearizer::new(context, dag_state.clone(), alt_schedule);
+    let pending = linearizer.get_pending_sub_dags(vec![(
+        block_b,
+        Some(CommitMetastate::Optimistic),
+        strong_voters,
+    )]);
+    assert_eq!(pending.len(), 1);
+
+    // The Optimistic injection records each strong voter as acking
+    // {leader_ref, leader.acks}. With B.acks = [r2[3]], r2[3] crosses the
+    // 2f+1 threshold via these phantom acks and lands in committed_refs.
+    let p_committed = pending[0]
+        .committed_transaction_refs
+        .iter()
+        .any(|r| match r {
+            GenericTransactionRef::BlockRef(br) => br.round == 2 && br.author == auth_3,
+            GenericTransactionRef::TransactionRef(tr) => tr.round == 2 && tr.author == auth_3,
+        });
+    assert!(
+        p_committed,
+        "round-2 block from auth 3 (B's ack target) should be committed via the \
+         Optimistic injection"
+    );
+
+    let p_data_available = dag_state.read().is_data_available(&r2_refs[3]);
+
+    assert!(
+        !p_committed || p_data_available,
+        "Optimistic committed round-2 block from auth 3 via phantom acks: \
+         strong-vote bytes were leader-agnostic, got credited as acks for B's \
+         ack set, despite no validator having that block's transaction data"
     );
 }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -1,0 +1,661 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use starfish_config::AuthorityIndex;
+
+use crate::{
+    authority_set::AuthoritySet,
+    base_committer::base_committer_builder::BaseCommitterBuilder,
+    block_header::{
+        BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
+        TransactionsCommitment, VerifiedBlockHeader, genesis_block_headers,
+    },
+    commit::{CommitMetastate, DecidedLeader, LeaderStatus},
+    context::Context,
+    dag_state::{DagState, DataSource},
+    leader_schedule::{LeaderSchedule, LeaderSwapTable},
+    storage::mem_store::MemStore,
+    universal_committer::universal_committer_builder::UniversalCommitterBuilder,
+};
+
+/// Verified V2 header for tests. `timestamp_ms` distinguishes equivocating
+/// blocks at the same `(round, author)`.
+fn v2_block(
+    round: Round,
+    author: u8,
+    ancestors: Vec<BlockRef>,
+    strong_vote: Option<AuthoritySet>,
+    timestamp_ms: BlockTimestampMs,
+) -> VerifiedBlockHeader {
+    let header = BlockHeaderV2::new(
+        0,
+        round,
+        AuthorityIndex::from(author),
+        timestamp_ms,
+        ancestors,
+        vec![],
+        vec![],
+        TransactionsCommitment::DEFAULT_FOR_TEST,
+        strong_vote,
+    );
+    VerifiedBlockHeader::new_for_test(BlockHeader::V2(header))
+}
+
+/// Default timestamp for single-block-per-slot callers.
+fn default_ts(round: Round, author: u8) -> BlockTimestampMs {
+    round as BlockTimestampMs * 1000 + author as BlockTimestampMs
+}
+
+/// Empty `AuthoritySet` — flags the carrier as a strong vote.
+fn strong_vote() -> Option<AuthoritySet> {
+    Some(AuthoritySet::new())
+}
+
+/// Non-empty `AuthoritySet` — flags the carrier as a strong blame. The
+/// specific authority is immaterial; only emptiness matters.
+fn strong_blame() -> Option<AuthoritySet> {
+    let mut s = AuthoritySet::new();
+    s.insert(AuthorityIndex::from(0u8));
+    Some(s)
+}
+
+/// Assert that direct-committing `slot` yields `Commit(_, expected)`.
+fn assert_direct_commit_metastate(
+    committer: &crate::base_committer::BaseCommitter,
+    slot: Slot,
+    expected: Option<CommitMetastate>,
+) {
+    match committer.try_direct_decide(slot) {
+        LeaderStatus::Commit(_, metastate) => assert_eq!(metastate, expected),
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+/// Fully-connected V2 layers from `start` (or genesis) through `stop`. V2
+/// mirror of `test_dag::build_dag`, matching the DAG shape used when
+/// `consensus_starfish_speed` is enabled.
+fn build_v2_layers(
+    context: &Context,
+    dag_state: &Arc<RwLock<DagState>>,
+    start: Option<Vec<BlockRef>>,
+    stop: Round,
+) -> Vec<BlockRef> {
+    let mut ancestors: Vec<BlockRef> = match start {
+        Some(refs) => refs,
+        None => genesis_block_headers(context)
+            .iter()
+            .map(|b| b.reference())
+            .collect(),
+    };
+    let starting_round = ancestors.first().map(|r| r.round).unwrap_or(0) + 1;
+    for round in starting_round..=stop {
+        let mut refs = Vec::new();
+        for author in 0..context.committee.size() {
+            let author = author as u8;
+            let block = v2_block(
+                round,
+                author,
+                ancestors.clone(),
+                None,
+                default_ts(round, author),
+            );
+            refs.push(block.reference());
+            dag_state
+                .write()
+                .accept_block_header(block, DataSource::Test);
+        }
+        ancestors = refs;
+    }
+    ancestors
+}
+
+/// Test context with the starfish-speed flag set, plus an empty DAG state.
+fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwLock<DagState>>) {
+    let (mut ctx, _) = Context::new_for_test(4);
+    ctx.protocol_config
+        .set_consensus_starfish_speed_for_testing(enable_starfish_speed);
+    let ctx = Arc::new(ctx);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        ctx.clone(),
+        Arc::new(MemStore::new(ctx.clone())),
+    )));
+    (ctx, dag_state)
+}
+
+/// Populate `dag_state` through round 5; round-4 voters carry the given
+/// `strong_vote` values. Returns the leader slot at round 3.
+fn build_metastate_dag(
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+    committer: &crate::base_committer::BaseCommitter,
+    voter_strong_votes: [Option<AuthoritySet>; 4],
+) -> crate::block_header::Slot {
+    let round_3_refs = build_v2_layers(&context, &dag_state, None, committer.leader_round(1));
+
+    // Round 4 (voting): each voter links to all round-3 blocks and carries the
+    // configured strong_vote.
+    let mut round_4_refs = Vec::new();
+    let voting_round = committer.leader_round(1) + 1;
+    for (author, strong_vote) in voter_strong_votes.into_iter().enumerate() {
+        let author = author as u8;
+        let block = v2_block(
+            voting_round,
+            author,
+            round_3_refs.clone(),
+            strong_vote,
+            default_ts(voting_round, author),
+        );
+        round_4_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    // Round 5 (certifying): each certifier links to all round-4 blocks.
+    let certifying_round = committer.certifying_round(1);
+    for author in 0..context.committee.size() {
+        let author = author as u8;
+        let block = v2_block(
+            certifying_round,
+            author,
+            round_4_refs.clone(),
+            None,
+            default_ts(certifying_round, author),
+        );
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    committer
+        .elect_leader(committer.leader_round(1))
+        .expect("should elect a leader")
+}
+
+#[tokio::test]
+async fn determine_metastate_disabled_returns_none() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(false);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let leader = build_metastate_dag(context, dag_state, &committer, [strong_vote(); 4]);
+    assert_direct_commit_metastate(&committer, leader, None);
+}
+
+#[tokio::test]
+async fn determine_metastate_optimistic_when_strong_qc_quorum() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Four strong votes at r+1 → every r+2 certifier observes a StrongQC →
+    // 2f+1 StrongQC quorum → Optimistic.
+    let leader = build_metastate_dag(context, dag_state, &committer, [strong_vote(); 4]);
+    assert_direct_commit_metastate(&committer, leader, Some(CommitMetastate::Optimistic));
+}
+
+#[tokio::test]
+async fn determine_metastate_standard_when_strong_blame_quorum() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // 3 strong blames + 1 strong vote → no StrongQC quorum, 2f+1 strong-blame
+    // quorum → Standard.
+    let blame = strong_blame();
+    let leader = build_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [strong_vote(), blame, blame, blame],
+    );
+    assert_direct_commit_metastate(&committer, leader, Some(CommitMetastate::Standard));
+}
+
+#[tokio::test]
+async fn determine_metastate_pending_when_neither_quorum() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // 2 strong votes + 2 strong blames → neither side reaches 2f+1 = 3 → Pending.
+    let blame = strong_blame();
+    let leader = build_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [strong_vote(), strong_vote(), blame, blame],
+    );
+    assert_direct_commit_metastate(&committer, leader, Some(CommitMetastate::Pending));
+}
+
+/// Which equivocating leader a voter supports.
+#[derive(Clone, Copy)]
+enum LeaderChoice {
+    A,
+    B,
+}
+
+/// Same as `build_metastate_dag`, but the leader author produces two
+/// equivocating blocks `L_A`/`L_B` at round 3 and voters split per
+/// `voter_config`. Returns `(leader_slot, L_A, L_B)`.
+fn build_equivocating_metastate_dag(
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+    committer: &crate::base_committer::BaseCommitter,
+    voter_config: [(LeaderChoice, Option<AuthoritySet>); 4],
+) -> (crate::block_header::Slot, BlockRef, BlockRef) {
+    let leader_round = committer.leader_round(1);
+    let voting_round = leader_round + 1;
+    let certifying_round = committer.certifying_round(1);
+
+    let prev_refs = build_v2_layers(&context, &dag_state, None, leader_round - 1);
+
+    let leader_slot = committer
+        .elect_leader(leader_round)
+        .expect("should elect a leader");
+    let leader_author: u8 = leader_slot.authority.value() as u8;
+
+    // Round `leader_round`: one block per non-leader authority, plus TWO
+    // equivocating leader blocks (different timestamps → distinct refs).
+    let mut non_leader_refs = Vec::new();
+    for author in 0..context.committee.size() {
+        let author = author as u8;
+        if author == leader_author {
+            continue;
+        }
+        let block = v2_block(
+            leader_round,
+            author,
+            prev_refs.clone(),
+            None,
+            default_ts(leader_round, author),
+        );
+        non_leader_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    let leader_a = v2_block(
+        leader_round,
+        leader_author,
+        prev_refs.clone(),
+        None,
+        default_ts(leader_round, leader_author),
+    );
+    let leader_b = v2_block(
+        leader_round,
+        leader_author,
+        prev_refs,
+        None,
+        default_ts(leader_round, leader_author) + 1,
+    );
+    let leader_a_ref = leader_a.reference();
+    let leader_b_ref = leader_b.reference();
+    dag_state
+        .write()
+        .accept_block_header(leader_a, DataSource::Test);
+    dag_state
+        .write()
+        .accept_block_header(leader_b, DataSource::Test);
+
+    // Round `voting_round`: each voter includes all non-leader round-3 blocks
+    // plus the chosen leader block, and carries the configured strong_vote.
+    let mut round_4_refs = Vec::new();
+    for (author, (leader_choice, strong_vote)) in voter_config.into_iter().enumerate() {
+        let author = author as u8;
+        let chosen_leader = match leader_choice {
+            LeaderChoice::A => leader_a_ref,
+            LeaderChoice::B => leader_b_ref,
+        };
+        let mut ancestors = non_leader_refs.clone();
+        ancestors.push(chosen_leader);
+        let block = v2_block(
+            voting_round,
+            author,
+            ancestors,
+            strong_vote,
+            default_ts(voting_round, author),
+        );
+        round_4_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    // Round `certifying_round`: each certifier links to all voters.
+    for author in 0..context.committee.size() {
+        let author = author as u8;
+        let block = v2_block(
+            certifying_round,
+            author,
+            round_4_refs.clone(),
+            None,
+            default_ts(certifying_round, author),
+        );
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    (leader_slot, leader_a_ref, leader_b_ref)
+}
+
+#[tokio::test]
+async fn determine_metastate_pending_when_equivocating_strong_vote_is_filtered() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Discriminator for the `is_vote()` filter in `has_strong_qc_quorum`:
+    // - 2 voters are strong votes for `L_A`
+    // - 1 voter votes for `L_A` with no strong_vote
+    // - 1 voter is a strong vote for the equivocating `L_B`
+    //
+    // `L_A` has 3 regular votes → committable. Strong votes *attributable*
+    // to `L_A` are only 2 → below the 2f+1 = 3 threshold → not `Optimistic`
+    // and not `Standard` (no blames) → `Pending`. If the `is_vote()` filter
+    // were missing, the `L_B`-directed strong vote would be miscounted for
+    // `L_A`, reaching the threshold and yielding a wrong `Optimistic`.
+    let strong = strong_vote();
+    let (leader_slot, leader_a_ref, _leader_b_ref) = build_equivocating_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [
+            (LeaderChoice::A, strong),
+            (LeaderChoice::A, strong),
+            (LeaderChoice::A, None),
+            (LeaderChoice::B, strong),
+        ],
+    );
+
+    match committer.try_direct_decide(leader_slot) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference(), leader_a_ref);
+            assert_eq!(metastate, Some(CommitMetastate::Pending));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn determine_metastate_pending_when_equivocating_strong_blame_is_filtered() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Discriminator for the `is_vote()` filter in `has_strong_blame_quorum`:
+    // - 2 voters blame `L_A`
+    // - 1 voter votes for `L_A` with no strong_vote
+    // - 1 voter blames the equivocating `L_B`
+    //
+    // `L_A` has 3 regular votes → committable. Strong blames *attributable*
+    // to `L_A` are only 2 → below the 2f+1 = 3 threshold → `Pending`. If
+    // the `is_vote()` filter were missing, the `L_B`-directed strong blame
+    // would be miscounted for `L_A`, reaching the threshold and yielding a
+    // wrong `Standard`.
+    let blame = strong_blame();
+    let (leader_slot, leader_a_ref, _leader_b_ref) = build_equivocating_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [
+            (LeaderChoice::A, blame),
+            (LeaderChoice::A, blame),
+            (LeaderChoice::A, None),
+            (LeaderChoice::B, blame),
+        ],
+    );
+
+    match committer.try_direct_decide(leader_slot) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference(), leader_a_ref);
+            assert_eq!(metastate, Some(CommitMetastate::Pending));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+/// Populate `dag_state` through round 4 (voters link to all round-3 blocks).
+/// Returns the leader slot and voter refs indexed by author.
+fn build_through_voting_round(
+    context: &Context,
+    dag_state: &Arc<RwLock<DagState>>,
+    committer: &crate::base_committer::BaseCommitter,
+    voter_strong_votes: [Option<AuthoritySet>; 4],
+) -> (crate::block_header::Slot, Vec<BlockRef>) {
+    let leader_round = committer.leader_round(1);
+    let voting_round = leader_round + 1;
+    let round_3_refs = build_v2_layers(context, dag_state, None, leader_round);
+
+    let mut voter_refs = Vec::with_capacity(4);
+    for (author, strong_vote) in voter_strong_votes.into_iter().enumerate() {
+        let author = author as u8;
+        let block = v2_block(
+            voting_round,
+            author,
+            round_3_refs.clone(),
+            strong_vote,
+            default_ts(voting_round, author),
+        );
+        voter_refs.push(block.reference());
+        dag_state
+            .write()
+            .accept_block_header(block, DataSource::Test);
+    }
+
+    let leader_slot = committer
+        .elect_leader(leader_round)
+        .expect("should elect a leader");
+    (leader_slot, voter_refs)
+}
+
+/// Build one round-5 certifier from the specified round-4 voter refs.
+fn certifier(
+    committer: &crate::base_committer::BaseCommitter,
+    author: u8,
+    voter_refs: Vec<BlockRef>,
+) -> VerifiedBlockHeader {
+    let round = committer.certifying_round(1);
+    v2_block(round, author, voter_refs, None, default_ts(round, author))
+}
+
+/// Wave-1 DAG with a single StrongQC at r+2 (the others are regular QCs).
+/// The direct rule classifies the round-3 leader as Pending under this
+/// setup. Returns `(leader_slot, [c0, c1, c2, c3])` where `c0` is the
+/// StrongQC and `c1..c3` are regular QCs.
+fn build_wave_one_with_single_strong_qc(
+    context: &Context,
+    dag_state: &Arc<RwLock<DagState>>,
+    committer: &crate::base_committer::BaseCommitter,
+) -> (Slot, [BlockRef; 4]) {
+    let (leader_slot, voters) = build_through_voting_round(
+        context,
+        dag_state,
+        committer,
+        [strong_vote(), strong_vote(), strong_vote(), None],
+    );
+    let c0 = certifier(committer, 0, vec![voters[0], voters[1], voters[2]]);
+    let c1 = certifier(committer, 1, vec![voters[0], voters[1], voters[3]]);
+    let c2 = certifier(committer, 2, vec![voters[0], voters[2], voters[3]]);
+    let c3 = certifier(committer, 3, vec![voters[1], voters[2], voters[3]]);
+    let refs = [
+        c0.reference(),
+        c1.reference(),
+        c2.reference(),
+        c3.reference(),
+    ];
+    for b in [c0, c1, c2, c3] {
+        dag_state.write().accept_block_header(b, DataSource::Test);
+    }
+    (leader_slot, refs)
+}
+
+#[tokio::test]
+async fn indirect_metastate_optimistic_when_anchor_path_contains_strong_qc() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let (leader_slot, [c0, c1, c2, _c3]) =
+        build_wave_one_with_single_strong_qc(&context, &dag_state, &committer);
+
+    // Anchor at round 6 includes the StrongQC c0 in its round-5 ancestors.
+    let anchor_round = committer.certifying_round(1) + 1;
+    let anchor = v2_block(
+        anchor_round,
+        0,
+        vec![c0, c1, c2],
+        None,
+        default_ts(anchor_round, 0),
+    );
+    dag_state
+        .write()
+        .accept_block_header(anchor.clone(), DataSource::Test);
+
+    let anchor_status = LeaderStatus::Commit(anchor, None);
+    let current = LeaderStatus::Undecided(leader_slot);
+    match committer.try_indirect_decide(current, std::iter::once(&anchor_status)) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference().round, leader_slot.round);
+            assert_eq!(block.reference().author, leader_slot.authority);
+            assert_eq!(metastate, Some(CommitMetastate::Optimistic));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let (leader_slot, [_c0, c1, c2, c3]) =
+        build_wave_one_with_single_strong_qc(&context, &dag_state, &committer);
+
+    // Anchor excludes the StrongQC c0. Indirect must still resolve from the
+    // restricted r+2 path and pick Standard, not Optimistic.
+    let anchor_round = committer.certifying_round(1) + 1;
+    let anchor = v2_block(
+        anchor_round,
+        1,
+        vec![c1, c2, c3],
+        None,
+        default_ts(anchor_round, 1),
+    );
+    dag_state
+        .write()
+        .accept_block_header(anchor.clone(), DataSource::Test);
+
+    let anchor_status = LeaderStatus::Commit(anchor, None);
+    let current = LeaderStatus::Undecided(leader_slot);
+    match committer.try_indirect_decide(current, std::iter::once(&anchor_status)) {
+        LeaderStatus::Commit(block, metastate) => {
+            assert_eq!(block.reference().round, leader_slot.round);
+            assert_eq!(block.reference().author, leader_slot.authority);
+            assert_eq!(metastate, Some(CommitMetastate::Standard));
+        }
+        status => panic!("expected Commit, got {status}"),
+    }
+}
+
+#[tokio::test]
+async fn leader_status_is_final_classification() {
+    let (context, dag_state) = test_context_with_flag(true);
+    let refs = build_v2_layers(&context, &dag_state, None, 1);
+    let block = dag_state
+        .read()
+        .get_verified_block_header(&refs[0])
+        .expect("round-1 block exists");
+
+    let slot = Slot::new(3, AuthorityIndex::from(0u8));
+    assert!(!LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending)).is_final());
+    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic)).is_final());
+    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard)).is_final());
+    assert!(LeaderStatus::Commit(block, None).is_final());
+    assert!(LeaderStatus::Skip(slot).is_final());
+    assert!(!LeaderStatus::Undecided(slot).is_final());
+}
+
+fn build_universal_committer(
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+) -> crate::universal_committer::UniversalCommitter {
+    let leader_schedule = Arc::new(LeaderSchedule::new(
+        context.clone(),
+        LeaderSwapTable::default(),
+    ));
+    UniversalCommitterBuilder::new(context, leader_schedule, dag_state).build()
+}
+
+/// Round-3 leader's metastate in `decided`. Panics if not a Commit.
+fn round_3_metastate(
+    universal: &crate::universal_committer::UniversalCommitter,
+    decided: &[DecidedLeader],
+) -> Option<CommitMetastate> {
+    let leader_authority = universal
+        .get_leaders(3)
+        .into_iter()
+        .next()
+        .expect("round-3 has a leader");
+    let slot = Slot::new(3, leader_authority);
+    let decided = decided
+        .iter()
+        .find(|d| d.slot() == slot)
+        .expect("round-3 leader should be decided");
+    match decided {
+        DecidedLeader::Commit(_, m) => *m,
+        other => panic!("expected round-3 Commit, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn pending_leader_resolves_to_optimistic() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let universal = build_universal_committer(context.clone(), dag_state.clone());
+    let base = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let (round_3_slot, round_5_refs) =
+        build_wave_one_with_single_strong_qc(&context, &dag_state, &base);
+
+    // No wave-2 anchor yet — direct says Pending and can't upgrade.
+    assert_direct_commit_metastate(&base, round_3_slot, Some(CommitMetastate::Pending));
+
+    // Wave 2 pulls the StrongQC (c0) into the round-6 anchor's r+2 path.
+    build_v2_layers(&context, &dag_state, Some(round_5_refs.to_vec()), 8);
+
+    let decided = universal.try_decide(Slot::new(GENESIS_ROUND, 0u8));
+    assert_eq!(
+        round_3_metastate(&universal, &decided),
+        Some(CommitMetastate::Optimistic),
+    );
+}
+
+#[tokio::test]
+async fn pending_leader_resolves_to_standard() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let universal = build_universal_committer(context.clone(), dag_state.clone());
+    let base = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Wave 1 only — strong_vote = None everywhere → direct says Pending.
+    let round_5_refs = build_v2_layers(&context, &dag_state, None, 5);
+    let round_3_slot = base.elect_leader(3).expect("round 3 has a leader");
+    assert_direct_commit_metastate(&base, round_3_slot, Some(CommitMetastate::Pending));
+
+    // Wave 2 arrives. The round-6 anchor's r+2 path has only regular QCs.
+    build_v2_layers(&context, &dag_state, Some(round_5_refs), 8);
+
+    let decided = universal.try_decide(Slot::new(GENESIS_ROUND, 0u8));
+    assert_eq!(
+        round_3_metastate(&universal, &decided),
+        Some(CommitMetastate::Standard),
+    );
+}

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -85,8 +85,8 @@ fn pin_strong_vote(
     })
 }
 
-/// Marks `header`'s transaction data as locally available, so
-/// `DagState::is_data_available` returns true for that ref.
+/// Marks `header`'s transactions as locally available, so
+/// `DagState::are_transactions_available` returns true for that ref.
 fn add_transactions_for(dag_state: &Arc<RwLock<DagState>>, header: &VerifiedBlockHeader) {
     let verified = VerifiedTransactions::new_for_test(header, vec![]);
     dag_state
@@ -758,14 +758,14 @@ async fn pending_leader_resolves_to_standard() {
 /// A strong vote computed against one leader must not be counted as evidence
 /// for a different canonical leader (e.g. across a leader-schedule swap).
 /// Asserts the StarfishSpeed safety invariant: every ref in
-/// `committed_transaction_refs` has locally-available transaction data.
+/// `committed_transaction_refs` has locally-available transactions.
 ///
 /// Setup: round-3 leaders have asymmetric ack lists — A (auth 0) acks
 /// nothing; B (auth 1) acks `r2[3]`. Local data state covers everything
 /// except `r2[3]`. Round-4 voters cast strong votes computed against A.
 /// The committer's swap table designates B as canonical leader of round 3.
 #[tokio::test]
-async fn optimistic_commits_ref_without_actual_data_backing() {
+async fn optimistic_commits_ref_without_actual_transactions() {
     telemetry_subscribers::init_for_testing();
     let (context, dag_state) = test_context_with_flag(true);
     let auth_1 = AuthorityIndex::from(1u8);
@@ -829,7 +829,7 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
         r3_blocks.push(block);
     }
 
-    // Mark transaction data available for everything except `r2[3]` and
+    // Mark transactions available for everything except `r2[3]` and
     // round-3 blocks other than A.
     for block in &r1_blocks {
         add_transactions_for(&dag_state, block);
@@ -922,11 +922,11 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
             GenericTransactionRef::BlockRef(br) => br.round == 2 && br.author == auth_3,
             GenericTransactionRef::TransactionRef(tr) => tr.round == 2 && tr.author == auth_3,
         });
-    let p_data_available = dag_state.read().is_data_available(&r2_refs[3]);
+    let p_transactions_available = dag_state.read().are_transactions_available(&r2_refs[3]);
 
     assert!(
-        !p_committed || p_data_available,
-        "ref {:?} committed without locally-available transaction data",
+        !p_committed || p_transactions_available,
+        "ref {:?} committed without locally-available transactions",
         r2_refs[3]
     );
 }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -13,7 +13,8 @@ use crate::{
     },
     block_header::{
         BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        TransactionsCommitment, VerifiedBlockHeader, VerifiedTransactions, genesis_block_headers,
+        StrongVote, TransactionsCommitment, VerifiedBlockHeader, VerifiedTransactions,
+        genesis_block_headers,
     },
     commit::{CommitMetastate, DecidedLeader, LeaderStatus},
     context::Context,
@@ -32,7 +33,7 @@ fn v2_block(
     round: Round,
     author: u8,
     ancestors: Vec<BlockRef>,
-    strong_vote: Option<AuthoritySet>,
+    strong_vote: Option<StrongVote>,
     timestamp_ms: BlockTimestampMs,
 ) -> VerifiedBlockHeader {
     let header = BlockHeaderV2::new(
@@ -55,7 +56,7 @@ fn v2_block_with_acks(
     author: u8,
     ancestors: Vec<BlockRef>,
     acks: Vec<BlockRef>,
-    strong_vote: Option<AuthoritySet>,
+    strong_vote: Option<StrongVote>,
     timestamp_ms: BlockTimestampMs,
 ) -> VerifiedBlockHeader {
     let header = BlockHeaderV2::new(
@@ -70,6 +71,18 @@ fn v2_block_with_acks(
         strong_vote,
     );
     VerifiedBlockHeader::new_for_test(BlockHeader::V2(header))
+}
+
+/// Wraps a "missing" mask into a `StrongVote` pinned to `leader_authority`.
+/// `None` passes through (no vote).
+fn pin_strong_vote(
+    leader_authority: AuthorityIndex,
+    missing: Option<AuthoritySet>,
+) -> Option<StrongVote> {
+    missing.map(|missing| StrongVote {
+        leader_authority,
+        missing,
+    })
 }
 
 /// Marks `header`'s transaction data as locally available, so
@@ -162,27 +175,33 @@ fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwL
     (ctx, dag_state)
 }
 
-/// Populate `dag_state` through round 5; round-4 voters carry the given
-/// `strong_vote` values. Returns the leader slot at round 3.
+/// Populate `dag_state` through round 5; round-4 voters carry strong-vote
+/// payloads pinned to the canonical round-3 leader. Returns the leader slot at
+/// round 3.
 fn build_metastate_dag(
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     committer: &crate::base_committer::BaseCommitter,
     voter_strong_votes: [Option<AuthoritySet>; 4],
 ) -> crate::block_header::Slot {
-    let round_3_refs = build_v2_layers(&context, &dag_state, None, committer.leader_round(1));
+    let leader_round = committer.leader_round(1);
+    let round_3_refs = build_v2_layers(&context, &dag_state, None, leader_round);
+    let leader_authority = committer
+        .elect_leader(leader_round)
+        .expect("should elect a leader")
+        .authority;
 
     // Round 4 (voting): each voter links to all round-3 blocks and carries the
-    // configured strong_vote.
+    // configured missing-mask, pinned to the canonical leader.
     let mut round_4_refs = Vec::new();
-    let voting_round = committer.leader_round(1) + 1;
-    for (author, strong_vote) in voter_strong_votes.into_iter().enumerate() {
+    let voting_round = leader_round + 1;
+    for (author, missing) in voter_strong_votes.into_iter().enumerate() {
         let author = author as u8;
         let block = v2_block(
             voting_round,
             author,
             round_3_refs.clone(),
-            strong_vote,
+            pin_strong_vote(leader_authority, missing),
             default_ts(voting_round, author),
         );
         round_4_refs.push(block.reference());
@@ -368,9 +387,11 @@ fn build_equivocating_metastate_dag(
         .accept_block_header(leader_b, DataSource::Test);
 
     // Round `voting_round`: each voter includes all non-leader round-3 blocks
-    // plus the chosen leader block, and carries the configured strong_vote.
+    // plus the chosen leader block, and carries the configured missing-mask
+    // pinned to the (shared) leader authority — the equivocating L_A and L_B
+    // share the same author.
     let mut round_4_refs = Vec::new();
-    for (author, (leader_choice, strong_vote)) in voter_config.into_iter().enumerate() {
+    for (author, (leader_choice, missing)) in voter_config.into_iter().enumerate() {
         let author = author as u8;
         let chosen_leader = match leader_choice {
             LeaderChoice::A => leader_a_ref,
@@ -382,7 +403,7 @@ fn build_equivocating_metastate_dag(
             voting_round,
             author,
             ancestors,
-            strong_vote,
+            pin_strong_vote(leader_slot.authority, missing),
             default_ts(voting_round, author),
         );
         round_4_refs.push(block.reference());
@@ -496,15 +517,19 @@ fn build_through_voting_round(
     let leader_round = committer.leader_round(1);
     let voting_round = leader_round + 1;
     let round_3_refs = build_v2_layers(context, dag_state, None, leader_round);
+    let leader_authority = committer
+        .elect_leader(leader_round)
+        .expect("should elect a leader")
+        .authority;
 
     let mut voter_refs = Vec::with_capacity(4);
-    for (author, strong_vote) in voter_strong_votes.into_iter().enumerate() {
+    for (author, missing) in voter_strong_votes.into_iter().enumerate() {
         let author = author as u8;
         let block = v2_block(
             voting_round,
             author,
             round_3_refs.clone(),
-            strong_vote,
+            pin_strong_vote(leader_authority, missing),
             default_ts(voting_round, author),
         );
         voter_refs.push(block.reference());
@@ -730,22 +755,15 @@ async fn pending_leader_resolves_to_standard() {
     );
 }
 
-/// Optimistic-commit injects phantom acks: when the canonical leader at commit
-/// time differs from the leader the producers were "voting for" (e.g. block
-/// built before a schedule rotation, committed after), the strong-vote bytes
-/// — which carry no leader identity — get credited as acks for the canonical
-/// leader's `acknowledgments` set. The test sets up a single-validator view
-/// where:
-///   - The canonical leader of round 3 (per the post-rotation table) is
-///     authority 1, whose round-3 block has acks=[round-2 block from authority
-///     3].
-///   - That round-2 block's transaction data is *not* locally available.
-///   - Round-4 voters carry `strong_vote = Some(empty)`, consistent with the
-///     pre-rotation leader (different acks, all available).
-/// Optimistic linearization injects phantom acks for the canonical leader's
-/// ack set, committing the round-2 block via fictional 2f+1 evidence — even
-/// though no validator has its data. Asserts the system invariant
-/// "Z committed via Optimistic ⇒ ≥1 stake has Z's data" — fails by design.
+/// A strong vote computed against one leader must not be counted as evidence
+/// for a different canonical leader (e.g. across a leader-schedule swap).
+/// Asserts the StarfishSpeed safety invariant: every ref in
+/// `committed_transaction_refs` has locally-available transaction data.
+///
+/// Setup: round-3 leaders have asymmetric ack lists — A (auth 0) acks
+/// nothing; B (auth 1) acks `r2[3]`. Local data state covers everything
+/// except `r2[3]`. Round-4 voters cast strong votes computed against A.
+/// The committer's swap table designates B as canonical leader of round 3.
 #[tokio::test]
 async fn optimistic_commits_ref_without_actual_data_backing() {
     telemetry_subscribers::init_for_testing();
@@ -811,12 +829,8 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
         r3_blocks.push(block);
     }
 
-    // Mark transaction data as locally available for everything *except*
-    //   - r2[3] (the block in B's acks)
-    //   - r3[1..=3] (B, C, D themselves)
-    // The producer's data state covers A's set ({A, A.acks=∅}) cleanly, so
-    // `Core::compute_strong_vote_for(A_block)` returns `Some(empty)` — a
-    // legitimate strong vote for A.
+    // Mark transaction data available for everything except `r2[3]` and
+    // round-3 blocks other than A.
     for block in &r1_blocks {
         add_transactions_for(&dag_state, block);
     }
@@ -827,28 +841,17 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
     }
     add_transactions_for(&dag_state, &r3_blocks[0]);
 
-    // Sanity: with this data state, A is a legitimate strong-vote target; B
-    // is *not* (data for B itself and for `r2[3]` is missing).
     let a_block = &r3_blocks[0];
     let b_block = &r3_blocks[1];
     {
         let dag = dag_state.read();
-        assert!(
-            Core::compute_strong_vote_for(&dag, a_block).is_empty(),
-            "producer should be able to legitimately strong-vote for A"
-        );
-        assert!(
-            !Core::compute_strong_vote_for(&dag, b_block).is_empty(),
-            "producer should NOT be able to legitimately strong-vote for B"
-        );
+        assert!(Core::compute_strong_vote(&dag, a_block).is_strong_vote());
+        assert!(!Core::compute_strong_vote(&dag, b_block).is_strong_vote());
     }
 
-    // Build round-4 voters using the production strong-vote computation
-    // against A — this is what an honest validator on the pre-rotation table
-    // would produce.
     let voter_strong_vote = {
         let dag = dag_state.read();
-        Core::compute_strong_vote_for(&dag, a_block)
+        Core::compute_strong_vote(&dag, a_block)
     };
     let r4_refs: Vec<BlockRef> = (0..4u8)
         .map(|author| {
@@ -875,9 +878,7 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
             .accept_block_header(block, DataSource::Test);
     }
 
-    // Force canonical leader of round 3 to authority 1 (B).
-    // Test mode: `elect_leader(3, 0)` returns `(3 + 0) % 4 = 3`. The swap
-    // table flags auth 3 as bad and remaps to auth 1.
+    // Swap table forcing canonical leader of round 3 to authority 1.
     let alt_table = LeaderSwapTable {
         good_nodes: vec![(
             auth_1,
@@ -905,22 +906,15 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
     let leader_b_slot = committer.elect_leader(3).expect("leader at round 3");
     assert_eq!(leader_b_slot.authority, auth_1);
 
-    let (block_b, strong_voters) = match committer.try_direct_decide(leader_b_slot) {
-        LeaderStatus::Commit(b, Some(CommitMetastate::Optimistic), sv) => (b, sv),
-        other => panic!("expected Optimistic Commit, got {other}"),
+    let (block_b, metastate, strong_voters) = match committer.try_direct_decide(leader_b_slot) {
+        LeaderStatus::Commit(b, m, sv) => (b, m, sv),
+        other => panic!("expected Commit at any metastate, got {other}"),
     };
 
     let mut linearizer = Linearizer::new(context, dag_state.clone(), alt_schedule);
-    let pending = linearizer.get_pending_sub_dags(vec![(
-        block_b,
-        Some(CommitMetastate::Optimistic),
-        strong_voters,
-    )]);
+    let pending = linearizer.get_pending_sub_dags(vec![(block_b, metastate, strong_voters)]);
     assert_eq!(pending.len(), 1);
 
-    // The Optimistic injection records each strong voter as acking
-    // {leader_ref, leader.acks}. With B.acks = [r2[3]], r2[3] crosses the
-    // 2f+1 threshold via these phantom acks and lands in committed_refs.
     let p_committed = pending[0]
         .committed_transaction_refs
         .iter()
@@ -928,18 +922,11 @@ async fn optimistic_commits_ref_without_actual_data_backing() {
             GenericTransactionRef::BlockRef(br) => br.round == 2 && br.author == auth_3,
             GenericTransactionRef::TransactionRef(tr) => tr.round == 2 && tr.author == auth_3,
         });
-    assert!(
-        p_committed,
-        "round-2 block from auth 3 (B's ack target) should be committed via the \
-         Optimistic injection"
-    );
-
     let p_data_available = dag_state.read().is_data_available(&r2_refs[3]);
 
     assert!(
         !p_committed || p_data_available,
-        "Optimistic committed round-2 block from auth 3 via phantom acks: \
-         strong-vote bytes were leader-agnostic, got credited as acks for B's \
-         ack set, despite no validator having that block's transaction data"
+        "ref {:?} committed without locally-available transaction data",
+        r2_refs[3]
     );
 }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
@@ -69,7 +69,7 @@ fn assert_direct_commit_metastate(
     expected: Option<CommitMetastate>,
 ) {
     match committer.try_direct_decide(slot) {
-        LeaderStatus::Commit(_, metastate) => assert_eq!(metastate, expected),
+        LeaderStatus::Commit(_, metastate, _) => assert_eq!(metastate, expected),
         status => panic!("expected Commit, got {status}"),
     }
 }
@@ -195,6 +195,33 @@ async fn determine_metastate_optimistic_when_strong_qc_quorum() {
     // 2f+1 StrongQC quorum → Optimistic.
     let leader = build_metastate_dag(context, dag_state, &committer, [strong_vote(); 4]);
     assert_direct_commit_metastate(&committer, leader, Some(CommitMetastate::Optimistic));
+}
+
+#[tokio::test]
+async fn strong_qc_quorum_collects_strong_voter_authorities_from_dag() {
+    telemetry_subscribers::init_for_testing();
+    let (context, dag_state) = test_context_with_flag(true);
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // 3 strong votes + 1 strong blame: every r+2 certifier still observes a
+    // 2f+1 strong-vote quorum at r+1 (Optimistic), but the strong-voter list
+    // returned by `strong_qc_quorum` must contain exactly authors {0, 1, 2}
+    // and exclude the strong-blamer at author 3.
+    let blame = strong_blame();
+    let leader = build_metastate_dag(
+        context,
+        dag_state,
+        &committer,
+        [strong_vote(), strong_vote(), strong_vote(), blame],
+    );
+
+    let strong_voters = match committer.try_direct_decide(leader) {
+        LeaderStatus::Commit(_, Some(CommitMetastate::Optimistic), strong_voters) => strong_voters,
+        other => panic!("expected Commit(Optimistic), got {other}"),
+    };
+    let collected: BTreeSet<AuthorityIndex> = strong_voters.into_iter().collect();
+    let expected: BTreeSet<AuthorityIndex> = (0..3u8).map(AuthorityIndex::from).collect();
+    assert_eq!(collected, expected);
 }
 
 #[tokio::test]
@@ -375,7 +402,7 @@ async fn determine_metastate_pending_when_equivocating_strong_vote_is_filtered()
     );
 
     match committer.try_direct_decide(leader_slot) {
-        LeaderStatus::Commit(block, metastate) => {
+        LeaderStatus::Commit(block, metastate, _) => {
             assert_eq!(block.reference(), leader_a_ref);
             assert_eq!(metastate, Some(CommitMetastate::Pending));
         }
@@ -413,7 +440,7 @@ async fn determine_metastate_pending_when_equivocating_strong_blame_is_filtered(
     );
 
     match committer.try_direct_decide(leader_slot) {
-        LeaderStatus::Commit(block, metastate) => {
+        LeaderStatus::Commit(block, metastate, _) => {
             assert_eq!(block.reference(), leader_a_ref);
             assert_eq!(metastate, Some(CommitMetastate::Pending));
         }
@@ -518,10 +545,10 @@ async fn indirect_metastate_optimistic_when_anchor_path_contains_strong_qc() {
         .write()
         .accept_block_header(anchor.clone(), DataSource::Test);
 
-    let anchor_status = LeaderStatus::Commit(anchor, None);
+    let anchor_status = LeaderStatus::Commit(anchor, None, vec![]);
     let current = LeaderStatus::Undecided(leader_slot);
     match committer.try_indirect_decide(current, std::iter::once(&anchor_status)) {
-        LeaderStatus::Commit(block, metastate) => {
+        LeaderStatus::Commit(block, metastate, _) => {
             assert_eq!(block.reference().round, leader_slot.round);
             assert_eq!(block.reference().author, leader_slot.authority);
             assert_eq!(metastate, Some(CommitMetastate::Optimistic));
@@ -553,10 +580,10 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
         .write()
         .accept_block_header(anchor.clone(), DataSource::Test);
 
-    let anchor_status = LeaderStatus::Commit(anchor, None);
+    let anchor_status = LeaderStatus::Commit(anchor, None, vec![]);
     let current = LeaderStatus::Undecided(leader_slot);
     match committer.try_indirect_decide(current, std::iter::once(&anchor_status)) {
-        LeaderStatus::Commit(block, metastate) => {
+        LeaderStatus::Commit(block, metastate, _) => {
             assert_eq!(block.reference().round, leader_slot.round);
             assert_eq!(block.reference().author, leader_slot.authority);
             assert_eq!(metastate, Some(CommitMetastate::Standard));
@@ -575,10 +602,16 @@ async fn leader_status_is_final_classification() {
         .expect("round-1 block exists");
 
     let slot = Slot::new(3, AuthorityIndex::from(0u8));
-    assert!(!LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending)).is_final());
-    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic)).is_final());
-    assert!(LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard)).is_final());
-    assert!(LeaderStatus::Commit(block, None).is_final());
+    assert!(
+        !LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending), vec![]).is_final()
+    );
+    assert!(
+        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic), vec![]).is_final()
+    );
+    assert!(
+        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard), vec![]).is_final()
+    );
+    assert!(LeaderStatus::Commit(block, None, vec![]).is_final());
     assert!(LeaderStatus::Skip(slot).is_final());
     assert!(!LeaderStatus::Undecided(slot).is_final());
 }
@@ -610,7 +643,7 @@ fn round_3_metastate(
         .find(|d| d.slot() == slot)
         .expect("round-3 leader should be decided");
     match decided {
-        DecidedLeader::Commit(_, m) => *m,
+        DecidedLeader::Commit(_, m, _) => *m,
         other => panic!("expected round-3 Commit, got {other:?}"),
     }
 }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -170,7 +170,7 @@ fn test_context_with_flag(enable_starfish_speed: bool) -> (Arc<Context>, Arc<RwL
     let ctx = Arc::new(ctx);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         ctx.clone(),
-        Arc::new(MemStore::new(ctx.clone())),
+        Arc::new(MemStore::new()),
     )));
     (ctx, dag_state)
 }

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -55,7 +55,7 @@ async fn try_direct_commit() {
         tracing::info!("Leader commit status: {leader_status}");
 
         if round < incomplete_wave_leader_round {
-            if let LeaderStatus::Commit(ref committed_block) = leader_status {
+            if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
                 assert_eq!(committed_block.author(), leader.authority)
             } else {
                 panic!("Expected a committed leader at round {round}")
@@ -99,7 +99,7 @@ async fn idempotence() {
     let leader_status = committer.try_direct_decide(leader);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref block) = leader_status {
+    if let LeaderStatus::Commit(ref block, _) = leader_status {
         assert_eq!(block.author(), leader.authority)
     } else {
         panic!("Expected a committed leader")
@@ -110,7 +110,7 @@ async fn idempotence() {
     let leader_status = committer.try_direct_decide(leader);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader.authority)
     } else {
         panic!("Expected a committed leader")
@@ -150,7 +150,7 @@ async fn multiple_direct_commit() {
         let leader_status = committer.try_direct_decide(leader);
         tracing::info!("Leader commit status: {leader_status}");
 
-        if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
             assert_eq!(committed_block.author(), leader.authority)
         } else {
             panic!("Expected a committed leader")
@@ -314,7 +314,7 @@ async fn indirect_commit() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_2.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -344,10 +344,13 @@ async fn indirect_commit() {
     // Ensure we commit the leader of wave 1 indirectly with the committed leader
     // of wave 2 as the anchor.
     tracing::info!("Try indirect commit for leader {leader_wave_1}",);
-    let leader_status = committer.try_indirect_decide(leader_wave_1, decided_leaders.iter());
+    let leader_status = committer.try_indirect_decide(
+        LeaderStatus::Undecided(leader_wave_1),
+        decided_leaders.iter(),
+    );
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority)
     } else {
         panic!("Expected a committed leader")
@@ -433,7 +436,7 @@ async fn indirect_skip() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_3.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -459,7 +462,10 @@ async fn indirect_skip() {
 
     // 3. Ensure we skip leader of wave 2 indirectly.
     tracing::info!("Try indirect commit for leader {leader_wave_2}",);
-    let leader_status = committer.try_indirect_decide(leader_wave_2, decided_leaders.iter());
+    let leader_status = committer.try_indirect_decide(
+        LeaderStatus::Undecided(leader_wave_2),
+        decided_leaders.iter(),
+    );
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Skip(skipped_slot) = leader_status {
@@ -477,7 +483,7 @@ async fn indirect_skip() {
     let leader_status = committer.try_direct_decide(leader_wave_1);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority);
     } else {
         panic!("Expected a committed leader")
@@ -560,7 +566,8 @@ async fn undecided() {
     // Ensure we indirectly mark leader of wave 1 undecided as there is no anchor
     // to make an indirect decision.
     tracing::info!("Try indirect commit for leader {leader_wave_1}");
-    let leader_status = committer.try_indirect_decide(leader_wave_1, [].iter());
+    let leader_status =
+        committer.try_indirect_decide(LeaderStatus::Undecided(leader_wave_1), [].iter());
     tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Undecided(undecided_slot) = leader_status {
@@ -729,7 +736,7 @@ async fn test_byzantine_direct_commit() {
     let leader_status = committer.try_direct_decide(leader_wave_4);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_4.authority);
     } else {
         panic!("Expected a committed leader")

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -55,7 +55,7 @@ async fn try_direct_commit() {
         tracing::info!("Leader commit status: {leader_status}");
 
         if round < incomplete_wave_leader_round {
-            if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+            if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
                 assert_eq!(committed_block.author(), leader.authority)
             } else {
                 panic!("Expected a committed leader at round {round}")
@@ -99,7 +99,7 @@ async fn idempotence() {
     let leader_status = committer.try_direct_decide(leader);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref block, _) = leader_status {
+    if let LeaderStatus::Commit(ref block, _, _) = leader_status {
         assert_eq!(block.author(), leader.authority)
     } else {
         panic!("Expected a committed leader")
@@ -110,7 +110,7 @@ async fn idempotence() {
     let leader_status = committer.try_direct_decide(leader);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader.authority)
     } else {
         panic!("Expected a committed leader")
@@ -150,7 +150,7 @@ async fn multiple_direct_commit() {
         let leader_status = committer.try_direct_decide(leader);
         tracing::info!("Leader commit status: {leader_status}");
 
-        if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+        if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
             assert_eq!(committed_block.author(), leader.authority)
         } else {
             panic!("Expected a committed leader")
@@ -314,7 +314,7 @@ async fn indirect_commit() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_2.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -350,7 +350,7 @@ async fn indirect_commit() {
     );
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority)
     } else {
         panic!("Expected a committed leader")
@@ -436,7 +436,7 @@ async fn indirect_skip() {
     tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_3.authority);
         decided_leaders.push(leader_status);
     } else {
@@ -483,7 +483,7 @@ async fn indirect_skip() {
     let leader_status = committer.try_direct_decide(leader_wave_1);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority);
     } else {
         panic!("Expected a committed leader")
@@ -736,7 +736,7 @@ async fn test_byzantine_direct_commit() {
     let leader_status = committer.try_direct_decide(leader_wave_4);
     tracing::info!("Leader commit status: {leader_status}");
 
-    if let LeaderStatus::Commit(ref committed_block, _) = leader_status {
+    if let LeaderStatus::Commit(ref committed_block, _, _) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_4.authority);
     } else {
         panic!("Expected a committed leader")

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -33,7 +33,7 @@ async fn direct_commit() {
     assert_eq!(sequence.len(), 1);
 
     let leader_round_wave_0_pipeline_1 = committer.committers[1].leader_round(0);
-    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[0] {
         assert_eq!(block.round(), leader_round_wave_0_pipeline_1);
         assert_eq!(
             block.author(),
@@ -61,7 +61,7 @@ async fn idempotence() {
     assert_eq!(first_sequence.len(), 1);
     tracing::info!("Commit sequence: {first_sequence:#?}");
 
-    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
         assert_eq!(block.round(), leader_round_pipeline_1_wave_0);
         assert_eq!(
             block.author(),
@@ -76,7 +76,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
         assert_eq!(block.round(), leader_round_pipeline_1_wave_0);
         assert_eq!(
             block.author(),
@@ -122,7 +122,7 @@ async fn multiple_direct_commit() {
         tracing::info!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), 1);
-        if let DecidedLeader::Commit(ref block, _) = sequence[0] {
+        if let DecidedLeader::Commit(ref block, _, _) = sequence[0] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(
                 block.author(),
@@ -161,7 +161,7 @@ async fn direct_commit_late_call() {
     for (i, leader_block) in sequence.iter().enumerate() {
         // First sequenced leader should be in round 1.
         let leader_round = i as u32 + 1;
-        if let DecidedLeader::Commit(ref block, _) = leader_block {
+        if let DecidedLeader::Commit(ref block, _, _) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -415,7 +415,7 @@ async fn indirect_commit() {
 
     let committed_leader_round = 1;
     let leader = committer.get_leaders(committed_leader_round)[0];
-    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[0] {
         assert_eq!(block.round(), committed_leader_round);
         assert_eq!(block.author(), leader);
     } else {
@@ -499,7 +499,7 @@ async fn indirect_skip() {
         // First sequenced leader should be in round 1.
         let leader_round = i + 1;
         let leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block, _) = sequence[i as usize] {
+        if let DecidedLeader::Commit(ref block, _, _) = sequence[i as usize] {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -518,7 +518,7 @@ async fn indirect_skip() {
     for i in 4..=6 {
         let leader_round = i + 1;
         let leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block, _) = sequence[i as usize] {
+        if let DecidedLeader::Commit(ref block, _, _) = sequence[i as usize] {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -730,7 +730,7 @@ async fn test_byzantine_validator() {
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
-    if let DecidedLeader::Commit(ref block, _) = sequence[11] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[11] {
         assert_eq!(block.round(), leader_round_12);
         assert_eq!(block.author(), committer.get_leaders(leader_round_12)[0])
     } else {

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -33,7 +33,7 @@ async fn direct_commit() {
     assert_eq!(sequence.len(), 1);
 
     let leader_round_wave_0_pipeline_1 = committer.committers[1].leader_round(0);
-    if let DecidedLeader::Commit(ref block) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
         assert_eq!(block.round(), leader_round_wave_0_pipeline_1);
         assert_eq!(
             block.author(),
@@ -61,7 +61,7 @@ async fn idempotence() {
     assert_eq!(first_sequence.len(), 1);
     tracing::info!("Commit sequence: {first_sequence:#?}");
 
-    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
         assert_eq!(block.round(), leader_round_pipeline_1_wave_0);
         assert_eq!(
             block.author(),
@@ -76,7 +76,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
         assert_eq!(block.round(), leader_round_pipeline_1_wave_0);
         assert_eq!(
             block.author(),
@@ -122,7 +122,7 @@ async fn multiple_direct_commit() {
         tracing::info!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), 1);
-        if let DecidedLeader::Commit(ref block) = sequence[0] {
+        if let DecidedLeader::Commit(ref block, _) = sequence[0] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(
                 block.author(),
@@ -161,7 +161,7 @@ async fn direct_commit_late_call() {
     for (i, leader_block) in sequence.iter().enumerate() {
         // First sequenced leader should be in round 1.
         let leader_round = i as u32 + 1;
-        if let DecidedLeader::Commit(ref block) = leader_block {
+        if let DecidedLeader::Commit(ref block, _) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -415,7 +415,7 @@ async fn indirect_commit() {
 
     let committed_leader_round = 1;
     let leader = committer.get_leaders(committed_leader_round)[0];
-    if let DecidedLeader::Commit(ref block) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
         assert_eq!(block.round(), committed_leader_round);
         assert_eq!(block.author(), leader);
     } else {
@@ -499,7 +499,7 @@ async fn indirect_skip() {
         // First sequenced leader should be in round 1.
         let leader_round = i + 1;
         let leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block) = sequence[i as usize] {
+        if let DecidedLeader::Commit(ref block, _) = sequence[i as usize] {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -518,7 +518,7 @@ async fn indirect_skip() {
     for i in 4..=6 {
         let leader_round = i + 1;
         let leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block) = sequence[i as usize] {
+        if let DecidedLeader::Commit(ref block, _) = sequence[i as usize] {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -730,7 +730,7 @@ async fn test_byzantine_validator() {
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
-    if let DecidedLeader::Commit(ref block) = sequence[11] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[11] {
         assert_eq!(block.round(), leader_round_12);
         assert_eq!(block.author(), committer.get_leaders(leader_round_12)[0])
     } else {

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -61,7 +61,7 @@ async fn test_randomized_dag_all_direct_commit() {
         for (i, leader_block) in sequence.iter().enumerate() {
             // First sequenced leader should be in round 1.
             let leader_round = i as u32 + 1;
-            if let DecidedLeader::Commit(ref block) = leader_block {
+            if let DecidedLeader::Commit(ref block, _) = leader_block {
                 assert_eq!(block.round(), leader_round);
                 assert_eq!(
                     block.author(),

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -61,7 +61,7 @@ async fn test_randomized_dag_all_direct_commit() {
         for (i, leader_block) in sequence.iter().enumerate() {
             // First sequenced leader should be in round 1.
             let leader_round = i as u32 + 1;
-            if let DecidedLeader::Commit(ref block, _) = leader_block {
+            if let DecidedLeader::Commit(ref block, _, _) = leader_block {
                 assert_eq!(block.round(), leader_round);
                 assert_eq!(
                     block.author(),

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -52,7 +52,7 @@ async fn direct_commit() {
     tracing::info!("Commit sequence: {sequence:#?}");
     // The decided leaders should be all from round 1 to round 5
     assert_eq!(sequence.len(), 5);
-    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[0] {
         assert_eq!(
             block.author(),
             test_setup
@@ -84,7 +84,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
     assert_eq!(first_sequence.len(), 1);
 
-    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), first_non_genesis_leader_round);
         assert_eq!(
             block.author(),
@@ -99,7 +99,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), first_non_genesis_leader_round);
         assert_eq!(
             block.author(),
@@ -132,7 +132,7 @@ async fn idempotence() {
     // Expect that all leaders between round 2 and round 5 are committed.
     // The last one is a block of leader from round 5
     assert_eq!(second_sequence.len(), 4);
-    if let DecidedLeader::Commit(ref block, _) = second_sequence[3] {
+    if let DecidedLeader::Commit(ref block, _, _) = second_sequence[3] {
         assert_eq!(block.round(), round_5);
         assert_eq!(block.author(), committer.get_leaders(round_5)[0]);
     } else {
@@ -164,7 +164,7 @@ async fn multiple_direct_commit() {
         let sequence = committer.try_decide(last_decided);
         tracing::info!("Commit sequence: {sequence:#?}");
         assert_eq!(sequence.len(), 3);
-        if let DecidedLeader::Commit(ref block, _) = sequence[2] {
+        if let DecidedLeader::Commit(ref block, _, _) = sequence[2] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -198,7 +198,7 @@ async fn direct_commit_late_call() {
     assert_eq!(sequence.len(), 3 * (num_waves - 1_usize));
     for (i, leader_block) in sequence.iter().enumerate() {
         let leader_round = committer.committers[(i + 1) % 3].leader_round((i as u32 + 1) / 3);
-        if let DecidedLeader::Commit(ref block, _) = leader_block {
+        if let DecidedLeader::Commit(ref block, _, _) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -394,7 +394,7 @@ async fn indirect_commit() {
         let leader_round =
             committer.committers[(idx + 1) % 3].leader_round(((idx + 1) / 3) as WaveNumber);
         let expected_leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block, _) = decided_leader {
+        if let DecidedLeader::Commit(ref block, _, _) = decided_leader {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), expected_leader);
         } else {
@@ -469,7 +469,7 @@ async fn indirect_skip() {
     assert_eq!(sequence.len(), 7);
 
     for (idx, decided_leader) in sequence.iter().enumerate() {
-        if let DecidedLeader::Commit(ref block, _) = decided_leader {
+        if let DecidedLeader::Commit(ref block, _, _) = decided_leader {
             assert_eq!(block.round(), (idx + 1) as Round);
             assert_eq!(
                 block.author(),
@@ -699,7 +699,7 @@ async fn test_byzantine_direct_commit() {
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
-    if let DecidedLeader::Commit(ref block, _) = sequence[11] {
+    if let DecidedLeader::Commit(ref block, _, _) = sequence[11] {
         assert_eq!(block.author(), committer.get_leaders(round_12)[0])
     } else {
         panic!("Expected a committed leader")

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -52,7 +52,7 @@ async fn direct_commit() {
     tracing::info!("Commit sequence: {sequence:#?}");
     // The decided leaders should be all from round 1 to round 5
     assert_eq!(sequence.len(), 5);
-    if let DecidedLeader::Commit(ref block) = sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[0] {
         assert_eq!(
             block.author(),
             test_setup
@@ -84,7 +84,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
     assert_eq!(first_sequence.len(), 1);
 
-    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), first_non_genesis_leader_round);
         assert_eq!(
             block.author(),
@@ -99,7 +99,7 @@ async fn idempotence() {
     let first_sequence = committer.try_decide(last_decided);
 
     assert_eq!(first_sequence.len(), 1);
-    if let DecidedLeader::Commit(ref block) = first_sequence[0] {
+    if let DecidedLeader::Commit(ref block, _) = first_sequence[0] {
         assert_eq!(first_sequence[0].round(), first_non_genesis_leader_round);
         assert_eq!(
             block.author(),
@@ -132,7 +132,7 @@ async fn idempotence() {
     // Expect that all leaders between round 2 and round 5 are committed.
     // The last one is a block of leader from round 5
     assert_eq!(second_sequence.len(), 4);
-    if let DecidedLeader::Commit(ref block) = second_sequence[3] {
+    if let DecidedLeader::Commit(ref block, _) = second_sequence[3] {
         assert_eq!(block.round(), round_5);
         assert_eq!(block.author(), committer.get_leaders(round_5)[0]);
     } else {
@@ -164,7 +164,7 @@ async fn multiple_direct_commit() {
         let sequence = committer.try_decide(last_decided);
         tracing::info!("Commit sequence: {sequence:#?}");
         assert_eq!(sequence.len(), 3);
-        if let DecidedLeader::Commit(ref block) = sequence[2] {
+        if let DecidedLeader::Commit(ref block, _) = sequence[2] {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -198,7 +198,7 @@ async fn direct_commit_late_call() {
     assert_eq!(sequence.len(), 3 * (num_waves - 1_usize));
     for (i, leader_block) in sequence.iter().enumerate() {
         let leader_round = committer.committers[(i + 1) % 3].leader_round((i as u32 + 1) / 3);
-        if let DecidedLeader::Commit(ref block) = leader_block {
+        if let DecidedLeader::Commit(ref block, _) = leader_block {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), committer.get_leaders(leader_round)[0]);
         } else {
@@ -394,7 +394,7 @@ async fn indirect_commit() {
         let leader_round =
             committer.committers[(idx + 1) % 3].leader_round(((idx + 1) / 3) as WaveNumber);
         let expected_leader = committer.get_leaders(leader_round)[0];
-        if let DecidedLeader::Commit(ref block) = decided_leader {
+        if let DecidedLeader::Commit(ref block, _) = decided_leader {
             assert_eq!(block.round(), leader_round);
             assert_eq!(block.author(), expected_leader);
         } else {
@@ -469,7 +469,7 @@ async fn indirect_skip() {
     assert_eq!(sequence.len(), 7);
 
     for (idx, decided_leader) in sequence.iter().enumerate() {
-        if let DecidedLeader::Commit(ref block) = decided_leader {
+        if let DecidedLeader::Commit(ref block, _) = decided_leader {
             assert_eq!(block.round(), (idx + 1) as Round);
             assert_eq!(
                 block.author(),
@@ -699,7 +699,7 @@ async fn test_byzantine_direct_commit() {
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
-    if let DecidedLeader::Commit(ref block) = sequence[11] {
+    if let DecidedLeader::Commit(ref block, _) = sequence[11] {
         assert_eq!(block.author(), committer.get_leaders(round_12)[0])
     } else {
         panic!("Expected a committed leader")

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -86,8 +86,8 @@ impl UniversalCommitter {
                         tracing::debug!("Outcome of indirect rule: {indirect}");
                         decision = match (&status, &indirect) {
                             (
-                                LeaderStatus::Commit(_, Some(CommitMetastate::Pending)),
-                                LeaderStatus::Commit(_, Some(m)),
+                                LeaderStatus::Commit(_, Some(CommitMetastate::Pending), _),
+                                LeaderStatus::Commit(_, Some(m), _),
                             ) if *m != CommitMetastate::Pending => Decision::Upgraded,
                             _ => Decision::Indirect,
                         };
@@ -141,8 +141,8 @@ impl UniversalCommitter {
             Decision::Indirect => "indirect",
         };
         let status = match decided_leader {
-            DecidedLeader::Commit(_, None) => format!("{decision_str}-commit"),
-            DecidedLeader::Commit(_, Some(metastate)) => {
+            DecidedLeader::Commit(_, None, _) => format!("{decision_str}-commit"),
+            DecidedLeader::Commit(_, Some(metastate), _) => {
                 format!("{decision_str}-commit-{metastate}")
             }
             DecidedLeader::Skip(..) => format!("{decision_str}-skip"),

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -10,7 +10,7 @@ use starfish_config::AuthorityIndex;
 use crate::{
     base_committer::BaseCommitter,
     block_header::{GENESIS_ROUND, Round, Slot},
-    commit::{DecidedLeader, Decision},
+    commit::{CommitMetastate, DecidedLeader, Decision, LeaderStatus},
     context::Context,
     dag_state::DagState,
 };
@@ -47,7 +47,7 @@ impl UniversalCommitter {
         let highest_accepted_round = self.dag_state.read().highest_accepted_round();
 
         // Try to decide as many leaders as possible, starting with the highest round.
-        let mut leaders = VecDeque::new();
+        let mut leaders: VecDeque<(LeaderStatus, Decision)> = VecDeque::new();
 
         let last_round = last_decided.round + 1;
 
@@ -71,30 +71,47 @@ impl UniversalCommitter {
 
                 tracing::debug!("Trying to decide {slot} with {committer}",);
 
-                // Try to directly decide the leader.
                 let mut status = committer.try_direct_decide(slot);
+                let mut decision = Decision::Direct;
                 tracing::debug!("Outcome of direct rule: {status}");
 
-                // If we can't directly decide the leader, try to indirectly decide it.
-                if status.is_decided() {
-                    leaders.push_front((status, Decision::Direct));
-                } else {
-                    status = committer.try_indirect_decide(slot, leaders.iter().map(|(x, _)| x));
-                    tracing::debug!("Outcome of indirect rule: {status}");
-                    leaders.push_front((status, Decision::Indirect));
+                // If the direct result is not final (Commit(Pending) or
+                // Undecided), run the indirect rule. For Pending, a
+                // committed anchor's path can upgrade the metastate; for
+                // Undecided, indirect may resolve the slot entirely.
+                if !status.is_final() {
+                    let indirect = committer
+                        .try_indirect_decide(status.clone(), leaders.iter().map(|(x, _)| x));
+                    if indirect != status {
+                        tracing::debug!("Outcome of indirect rule: {indirect}");
+                        decision = match (&status, &indirect) {
+                            (
+                                LeaderStatus::Commit(_, Some(CommitMetastate::Pending)),
+                                LeaderStatus::Commit(_, Some(m)),
+                            ) if *m != CommitMetastate::Pending => Decision::Upgraded,
+                            _ => Decision::Indirect,
+                        };
+                        status = indirect;
+                    }
                 }
+                leaders.push_front((status, decision));
             }
         }
 
-        // The decided sequence is the longest prefix of decided leaders.
+        // The decided sequence is the longest prefix of final decisions.
+        // Commit(Pending) is decided but non-final — sequencing stops until
+        // the metastate is upgraded on a subsequent commit pass.
         let mut decided_leaders = Vec::new();
         for (leader, decision) in leaders {
             if leader.round() == GENESIS_ROUND {
                 continue;
             }
-            let Some(decided_leader) = leader.into_decided_leader() else {
+            if !leader.is_final() {
                 break;
-            };
+            }
+            let decided_leader = leader
+                .into_decided_leader()
+                .expect("is_final implies decided");
             Self::update_metrics(&self.context, &decided_leader, decision);
             decided_leaders.push(decided_leader);
         }
@@ -120,10 +137,14 @@ impl UniversalCommitter {
     ) {
         let decision_str = match decision {
             Decision::Direct => "direct",
+            Decision::Upgraded => "upgraded",
             Decision::Indirect => "indirect",
         };
         let status = match decided_leader {
-            DecidedLeader::Commit(..) => format!("{decision_str}-commit"),
+            DecidedLeader::Commit(_, None) => format!("{decision_str}-commit"),
+            DecidedLeader::Commit(_, Some(metastate)) => {
+                format!("{decision_str}-commit-{metastate}")
+            }
             DecidedLeader::Skip(..) => format!("{decision_str}-skip"),
         };
         let leader_host = &context

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -19378,6 +19378,578 @@
       ],
       "title": "Inbound / Outbound Network Metrics",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 820
+      },
+      "id": 400,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Extra wait at block proposal time imposed by the StarfishSpeed strong-vote condition: time between when the ordinary (base Starfish) propose condition first became satisfiable and when the proposal actually happened. Observed only when consensus_starfish_speed is enabled.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 821
+          },
+          "id": 401,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.5, sum by(le) (rate(consensus_strong_vote_extra_wait_seconds_bucket[5m])))",
+              "legendFormat": "p50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(consensus_strong_vote_extra_wait_seconds_bucket[5m])))",
+              "legendFormat": "p95",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by(le) (rate(consensus_strong_vote_extra_wait_seconds_bucket[5m])))",
+              "legendFormat": "p99",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Strong-vote extra wait",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Distribution of the `missing` set size in the strong-vote payload of each proposed block. Each cell shows the rate of proposals whose `missing.len()` fell in the bucket on the Y axis. Bucket `le=0.5` = clean strong vote (no blame); `le=1.5` = single-authority blame; etc. Buckets are integer-aligned (boundaries at N.5) so 0 and 1 are separable. Observed only when consensus_starfish_speed is enabled.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 821
+          },
+          "id": 402,
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 64
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-09
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false
+            }
+          },
+          "pluginVersion": "11.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by(le) (rate(consensus_strong_vote_missing_authorities_bucket[5m]))",
+              "format": "heatmap",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Missing authorities in strong vote",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of proposed blocks that strong-blame the leader (non-empty `missing` set), by leader authority.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 829
+          },
+          "id": 403,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by(leader) (rate(consensus_strong_blames_emitted_for_leader[5m]))",
+              "legendFormat": "{{leader}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Strong blames emitted (by leader)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of strong blames received against this node (when acting as leader), by voter authority.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 829
+          },
+          "id": 404,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by(voter) (rate(consensus_strong_blames_received_from_voter[5m]))",
+              "legendFormat": "{{voter}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Strong blames received (by voter)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Number of authorities currently in the adaptive-ack exclusion set, as observed at the most recent leader block proposal.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "stepBefore",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 837
+          },
+          "id": 405,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "consensus_adaptive_ack_excluded_authorities",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Adaptive-ack excluded authorities",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of pending acknowledgments skipped because their author was in the adaptive-ack exclusion set at leader proposal time.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 837
+          },
+          "id": 406,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(consensus_adaptive_ack_acks_dropped[5m])",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Adaptive-ack acks dropped",
+          "type": "timeseries"
+        }
+      ],
+      "title": "StarfishSpeed",
+      "type": "row"
     }
   ],
   "refresh": "5s",


### PR DESCRIPTION
# Description of change

Adds **StarfishSpeed**, a new variant of the Starfish DAG consensus
protocol gated behind the `consensus_starfish_speed` protocol flag.
When the flag is active, validators classify each committed leader by
a metastate (optimistic / standard / pending) and, in the optimistic
case, additionally sequence the leader's acknowledgments alongside
its historical sub-DAG — shortening the path from transaction
submission to commit at the cost of a stricter block-creation rule (a
strong-vote quorum requirement). A soft-timeout fallback lets the
validator propose under the base Starfish rule when the strong-vote
quorum cannot be reached in time, preserving liveness.

## What the branch introduces

In dependency order:

- **Protocol & versioned types.** A new protocol flag
  `consensus_starfish_speed`; a `BlockHeaderV2` carrying a
  `strong_vote` payload (the pinned leader authority plus the set of
  authorities whose transactions are not locally available); a
  `CommitV3` carrying an `is_optimistic` flag and the transactions
  sequenced alongside the leader in the optimistic case. Both
  versioned types are activated together via a version-flag check.
- **Data-availability tracking.** `DagState` tracks which transactions
  are locally available per past block, so the `missing` set in the
  strong vote can be computed accurately during proposal.
- **Block proposal.** Strong-vote computation; a strong-vote quorum
  requirement for non-forced block creation; the soft-timeout fallback
  described above.
- **Commit path.** Leader-metastate classification at commit time, and
  Optimistic-metastate ack commit in the linearizer. Strong votes and
  blames are pinned to the leader's authority so a leader-schedule
  rotation does not misattribute them.
- **Recovery & operator controls.** Recovery seeding of the ack
  tracker from stored block headers; adaptive acknowledgment filtering
  that drops acks for authorities persistently blamed by recent
  strong-vote masks (with a local-only enable switch so operators can
  disable it without a protocol change).
- **Observability.** Metrics for strong-vote extra wait,
  missing-authorities distribution, outbound and inbound blames by
  authority, adaptive-ack exclusion size, and dropped acks. A new
  Grafana dashboard (`dev-tools/grafana-local/dashboards/starfish-overview.json`)
  visualizes these metrics alongside the existing Starfish ones.

## Backward compatibility

The `consensus_starfish_speed` protocol flag is not enabled on any
network yet, so this PR is a no-op everywhere.

## Reviewing

Every commit in this branch is a previously-merged, already-reviewed PR (linked from the commit subject); this PR rolls those sub-PRs back into `develop` with no new code on top.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Coverage added on top of the existing Starfish test suite:

- `base_committer_metastate_tests.rs` — a new ~930-line suite exercising
  the optimistic / standard / pending metastate classification across
  DAG shapes (strong-vote quorum reached, missing-authority blames,
  rotated leader schedules, recovery boundaries).
- Phantom-ack regression test guarding the invariant that acks
  committed in the optimistic path cannot reference transactions
  outside the leader's sub-DAG.
- Extensions to the existing `base_committer_tests`,
  `pipelined_committer_tests`, and `universal_committer_tests` to
  cover StarfishSpeed-specific commit shapes.
- Multi-node behaviour is covered by the consensus simtests
  (`#[sim_test]`) that run under `cargo simtest`.
