### PR TITLE
chore(iota-indexer): schedule --epochs-to-keep removal for v1.28.0

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -117,7 +117,7 @@ tx_senders = 3
 > [!NOTE]
 > All retention values must be greater than 0.
 
-The legacy `--epochs-to-keep` CLI argument is still supported but deprecated. If both `--pruning-config-path` and `--epochs-to-keep` are provided, the config file takes precedence.
+The legacy `--epochs-to-keep` CLI argument is still supported but deprecated, and will be removed in v1.28.0. If both `--pruning-config-path` and `--epochs-to-keep` are provided, the config file takes precedence.
 
 #### Default behavior
 

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -305,8 +305,8 @@ pub enum Command {
 
 #[derive(Args, Default, Debug, Clone)]
 pub struct PruningOptions {
-    /// Argument left for backward compatibility, users are encouraged to use
-    /// pruning_config_path
+    /// DEPRECATED: will be removed in v1.28.0. Use `--pruning-config-path`
+    /// pointing at a TOML retention config instead.
     #[arg(long, env = "EPOCHS_TO_KEEP")]
     pub epochs_to_keep: Option<u64>,
     /// Path to TOML file containing configuration for retention policies.
@@ -340,6 +340,7 @@ impl PruningOptions {
             };
             warn!(
                 "using the deprecated --epochs-to-keep argument for pruning configuration. \
+                 This argument will be removed in v1.28.0. \
                  Please use --pruning-config-path to specify a TOML configuration file instead."
             );
             return Ok(Some(RetentionConfig::new(
@@ -350,7 +351,8 @@ impl PruningOptions {
 
         if self.epochs_to_keep.is_some() {
             warn!(
-                "the --epochs-to-keep argument will be ignored since --pruning-config-path is also provided."
+                "the --epochs-to-keep argument will be ignored since --pruning-config-path is also provided. \
+                 Note that --epochs-to-keep is deprecated and will be removed in v1.28.0."
             );
         };
 


### PR DESCRIPTION
# Description of change

`--epochs-to-keep` scheduled for removal in v1.28, please migrate to `--pruning-config-path`

removal will be done in scope of https://github.com/iotaledger/iota/issues/11693

## Links to any relevant issues

fixes #11571 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: `--epochs-to-keep` scheduled for removal in v1.28, please migrate to `--pruning-config-path`
