### PR TITLE
feat(iota-config): compile iota-config to wasm32

### DIFF
--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -214,7 +214,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Check Move VM crates compile to wasm32
-        run: cargo check -p iota-types -p iota-common --target wasm32-unknown-unknown
+        run: cargo check -p iota-types -p iota-common -p iota-config --target wasm32-unknown-unknown
 
   check-wasm32-cancel:
     needs: [check-wasm32]

--- a/crates/iota-config/Cargo.toml
+++ b/crates/iota-config/Cargo.toml
@@ -21,8 +21,8 @@ tracing.workspace = true
 iota-types.workspace = true
 move-vm-config.workspace = true
 
-# Heavy node-side deps (network, file IO, key management). Gated so wasm32
-# only sees `transaction_deny_config` and `verifier_signing_config`.
+# Heavy node-side deps (network, file IO, key management). Gated so they're
+# excluded from the wasm32 build.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external dependencies
 anemo.workspace = true

--- a/crates/iota-config/Cargo.toml
+++ b/crates/iota-config/Cargo.toml
@@ -11,26 +11,33 @@ workspace = true
 
 [dependencies]
 # external dependencies
-anemo.workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
+once_cell.workspace = true
+rand.workspace = true
+serde.workspace = true
+tracing.workspace = true
+
+# internal dependencies
+iota-types.workspace = true
+move-vm-config.workspace = true
+
+# Heavy node-side deps (network, file IO, key management). Gated so wasm32
+# only sees `transaction_deny_config` and `verifier_signing_config`.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# external dependencies
+anemo.workspace = true
 bcs.workspace = true
 clap.workspace = true
 csv.workspace = true
 dirs.workspace = true
 fastcrypto.workspace = true
 object_store.workspace = true
-once_cell.workspace = true
 prometheus.workspace = true
-rand.workspace = true
 reqwest.workspace = true
-serde.workspace = true
 serde_yaml.workspace = true
-tracing.workspace = true
 
 # internal dependencies
 iota-genesis-common.workspace = true
 iota-keys.workspace = true
 iota-names.workspace = true
-iota-types.workspace = true
-move-vm-config.workspace = true
 starfish-config.workspace = true

--- a/crates/iota-config/src/lib.rs
+++ b/crates/iota-config/src/lib.rs
@@ -2,30 +2,48 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::{
     fs,
     io::BufWriter,
     path::{Path, PathBuf},
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 use anyhow::{Context, Result};
+#[cfg(not(target_arch = "wasm32"))]
 use serde::{Serialize, de::DeserializeOwned};
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::trace;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod certificate_deny_config;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod genesis;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod local_ip_utils;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod migration_tx_data;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod node;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod node_config_metrics;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod object_storage_config;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod p2p;
+// `transaction_deny_config` + `verifier_signing_config` are the two modules
+// the execution path needs at sign-time. Everything else pulls in network /
+// filesystem / config-file machinery and is gated.
 pub mod transaction_deny_config;
 pub mod verifier_signing_config;
 
+#[cfg(not(target_arch = "wasm32"))]
 use iota_types::multiaddr::Multiaddr;
+#[cfg(not(target_arch = "wasm32"))]
 pub use node::{ConsensusConfig, ExecutionCacheConfig, NodeConfig, WritebackCacheConfig};
 
+#[cfg(not(target_arch = "wasm32"))]
 const IOTA_DIR: &str = ".iota";
 pub const IOTA_CONFIG_DIR: &str = "iota_config";
 pub const IOTA_NETWORK_CONFIG: &str = "network.yaml";
@@ -41,6 +59,7 @@ pub const AUTHORITIES_DB_NAME: &str = "authorities_db";
 pub const CONSENSUS_DB_NAME: &str = "consensus_db";
 pub const FULL_NODE_DB_PATH: &str = "full_node_db";
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn iota_config_dir() -> Result<PathBuf, anyhow::Error> {
     match std::env::var_os("IOTA_CONFIG_DIR") {
         Some(config_env) => Ok(config_env.into()),
@@ -59,6 +78,7 @@ pub fn iota_config_dir() -> Result<PathBuf, anyhow::Error> {
 
 /// Check if the genesis blob exists in the given directory or the default
 /// directory.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn genesis_blob_exists(config_dir: Option<PathBuf>) -> bool {
     if let Some(dir) = config_dir {
         dir.join(IOTA_GENESIS_FILENAME).exists()
@@ -74,14 +94,17 @@ pub fn genesis_blob_exists(config_dir: Option<PathBuf>) -> bool {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn validator_config_file(address: Multiaddr, i: usize) -> String {
     multiaddr_to_filename(address).unwrap_or(format!("validator-config-{i}.yaml"))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn ssfn_config_file(address: Multiaddr, i: usize) -> String {
     multiaddr_to_filename(address).unwrap_or(format!("ssfn-config-{i}.yaml"))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn multiaddr_to_filename(address: Multiaddr) -> Option<String> {
     if let Some(hostname) = address.hostname() {
         if let Some(port) = address.port() {
@@ -91,6 +114,7 @@ fn multiaddr_to_filename(address: Multiaddr) -> Option<String> {
     None
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub trait Config
 where
     Self: DeserializeOwned + Serialize,
@@ -120,11 +144,13 @@ where
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub struct PersistedConfig<C> {
     inner: C,
     path: PathBuf,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<C> PersistedConfig<C>
 where
     C: Config,
@@ -146,6 +172,7 @@ where
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<C> std::ops::Deref for PersistedConfig<C> {
     type Target = C;
 
@@ -154,6 +181,7 @@ impl<C> std::ops::Deref for PersistedConfig<C> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<C> std::ops::DerefMut for PersistedConfig<C> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner

--- a/crates/iota-config/src/lib.rs
+++ b/crates/iota-config/src/lib.rs
@@ -3,20 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(not(target_arch = "wasm32"))]
-use std::{
-    fs,
-    io::BufWriter,
-    path::{Path, PathBuf},
-};
-
-#[cfg(not(target_arch = "wasm32"))]
-use anyhow::{Context, Result};
-#[cfg(not(target_arch = "wasm32"))]
-use serde::{Serialize, de::DeserializeOwned};
-#[cfg(not(target_arch = "wasm32"))]
-use tracing::trace;
-
-#[cfg(not(target_arch = "wasm32"))]
 pub mod certificate_deny_config;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod genesis;
@@ -32,6 +18,10 @@ pub mod node_config_metrics;
 pub mod object_storage_config;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod p2p;
+// Filesystem-backed config helpers (the `Config` / `PersistedConfig` traits and
+// path utilities). Node-only, so the whole module is gated out on wasm.
+#[cfg(not(target_arch = "wasm32"))]
+mod persisted_config;
 // `transaction_deny_config` + `verifier_signing_config` are the two modules
 // the execution path needs at sign-time. Everything else pulls in network /
 // filesystem / config-file machinery and is gated.
@@ -39,12 +29,13 @@ pub mod transaction_deny_config;
 pub mod verifier_signing_config;
 
 #[cfg(not(target_arch = "wasm32"))]
-use iota_types::multiaddr::Multiaddr;
-#[cfg(not(target_arch = "wasm32"))]
 pub use node::{ConsensusConfig, ExecutionCacheConfig, NodeConfig, WritebackCacheConfig};
-
 #[cfg(not(target_arch = "wasm32"))]
-const IOTA_DIR: &str = ".iota";
+pub use persisted_config::{
+    Config, PersistedConfig, genesis_blob_exists, iota_config_dir, ssfn_config_file,
+    validator_config_file,
+};
+
 pub const IOTA_CONFIG_DIR: &str = "iota_config";
 pub const IOTA_NETWORK_CONFIG: &str = "network.yaml";
 pub const IOTA_FULLNODE_CONFIG: &str = "fullnode.yaml";
@@ -58,132 +49,3 @@ pub const IOTA_DEV_NET_URL: &str = "https://api.devnet.iota.cafe:443";
 pub const AUTHORITIES_DB_NAME: &str = "authorities_db";
 pub const CONSENSUS_DB_NAME: &str = "consensus_db";
 pub const FULL_NODE_DB_PATH: &str = "full_node_db";
-
-#[cfg(not(target_arch = "wasm32"))]
-pub fn iota_config_dir() -> Result<PathBuf, anyhow::Error> {
-    match std::env::var_os("IOTA_CONFIG_DIR") {
-        Some(config_env) => Ok(config_env.into()),
-        None => match dirs::home_dir() {
-            Some(v) => Ok(v.join(IOTA_DIR).join(IOTA_CONFIG_DIR)),
-            None => anyhow::bail!("cannot obtain home directory path"),
-        },
-    }
-    .and_then(|dir| {
-        if !dir.exists() {
-            fs::create_dir_all(dir.clone())?;
-        }
-        Ok(dir)
-    })
-}
-
-/// Check if the genesis blob exists in the given directory or the default
-/// directory.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn genesis_blob_exists(config_dir: Option<PathBuf>) -> bool {
-    if let Some(dir) = config_dir {
-        dir.join(IOTA_GENESIS_FILENAME).exists()
-    } else if let Some(config_env) = std::env::var_os("IOTA_CONFIG_DIR") {
-        Path::new(&config_env).join(IOTA_GENESIS_FILENAME).exists()
-    } else if let Some(home) = dirs::home_dir() {
-        let mut config = PathBuf::new();
-        config.push(&home);
-        config.extend([IOTA_DIR, IOTA_CONFIG_DIR, IOTA_GENESIS_FILENAME]);
-        config.exists()
-    } else {
-        false
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub fn validator_config_file(address: Multiaddr, i: usize) -> String {
-    multiaddr_to_filename(address).unwrap_or(format!("validator-config-{i}.yaml"))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub fn ssfn_config_file(address: Multiaddr, i: usize) -> String {
-    multiaddr_to_filename(address).unwrap_or(format!("ssfn-config-{i}.yaml"))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn multiaddr_to_filename(address: Multiaddr) -> Option<String> {
-    if let Some(hostname) = address.hostname() {
-        if let Some(port) = address.port() {
-            return Some(format!("{hostname}-{port}.yaml"));
-        }
-    }
-    None
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub trait Config
-where
-    Self: DeserializeOwned + Serialize,
-{
-    fn persisted(self, path: &Path) -> PersistedConfig<Self> {
-        PersistedConfig {
-            inner: self,
-            path: path.to_path_buf(),
-        }
-    }
-
-    fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
-        let path = path.as_ref();
-        trace!("Reading config from {}", path.display());
-        let reader = fs::File::open(path)
-            .with_context(|| format!("unable to load config from {}", path.display()))?;
-        Ok(serde_yaml::from_reader(reader)?)
-    }
-
-    fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), anyhow::Error> {
-        let path = path.as_ref();
-        trace!("Writing config to {}", path.display());
-        let mut write = BufWriter::new(fs::File::create(path)?);
-        serde_yaml::to_writer(&mut write, &self)
-            .with_context(|| format!("unable to save config to {}", path.display()))?;
-        Ok(())
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub struct PersistedConfig<C> {
-    inner: C,
-    path: PathBuf,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<C> PersistedConfig<C>
-where
-    C: Config,
-{
-    pub fn read(path: &Path) -> Result<C, anyhow::Error> {
-        Config::load(path)
-    }
-
-    pub fn save(&self) -> Result<(), anyhow::Error> {
-        self.inner.save(&self.path)
-    }
-
-    pub fn into_inner(self) -> C {
-        self.inner
-    }
-
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<C> std::ops::Deref for PersistedConfig<C> {
-    type Target = C;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<C> std::ops::DerefMut for PersistedConfig<C> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
-    }
-}

--- a/crates/iota-config/src/persisted_config.rs
+++ b/crates/iota-config/src/persisted_config.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Filesystem-backed configuration helpers.
+//!
+//! Everything in this module reaches into the filesystem / config-file
+//! machinery (and the network `Multiaddr` type), so the whole module is gated
+//! out on wasm32 with a single `#[cfg]` on its declaration in `lib.rs`.
+
+use std::{
+    fs,
+    io::BufWriter,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use iota_types::multiaddr::Multiaddr;
+use serde::{Serialize, de::DeserializeOwned};
+use tracing::trace;
+
+use crate::{IOTA_CONFIG_DIR, IOTA_GENESIS_FILENAME};
+
+const IOTA_DIR: &str = ".iota";
+
+pub fn iota_config_dir() -> Result<PathBuf, anyhow::Error> {
+    match std::env::var_os("IOTA_CONFIG_DIR") {
+        Some(config_env) => Ok(config_env.into()),
+        None => match dirs::home_dir() {
+            Some(v) => Ok(v.join(IOTA_DIR).join(IOTA_CONFIG_DIR)),
+            None => anyhow::bail!("cannot obtain home directory path"),
+        },
+    }
+    .and_then(|dir| {
+        if !dir.exists() {
+            fs::create_dir_all(dir.clone())?;
+        }
+        Ok(dir)
+    })
+}
+
+/// Check if the genesis blob exists in the given directory or the default
+/// directory.
+pub fn genesis_blob_exists(config_dir: Option<PathBuf>) -> bool {
+    if let Some(dir) = config_dir {
+        dir.join(IOTA_GENESIS_FILENAME).exists()
+    } else if let Some(config_env) = std::env::var_os("IOTA_CONFIG_DIR") {
+        Path::new(&config_env).join(IOTA_GENESIS_FILENAME).exists()
+    } else if let Some(home) = dirs::home_dir() {
+        let mut config = PathBuf::new();
+        config.push(&home);
+        config.extend([IOTA_DIR, IOTA_CONFIG_DIR, IOTA_GENESIS_FILENAME]);
+        config.exists()
+    } else {
+        false
+    }
+}
+
+pub fn validator_config_file(address: Multiaddr, i: usize) -> String {
+    multiaddr_to_filename(address).unwrap_or(format!("validator-config-{i}.yaml"))
+}
+
+pub fn ssfn_config_file(address: Multiaddr, i: usize) -> String {
+    multiaddr_to_filename(address).unwrap_or(format!("ssfn-config-{i}.yaml"))
+}
+
+fn multiaddr_to_filename(address: Multiaddr) -> Option<String> {
+    if let Some(hostname) = address.hostname() {
+        if let Some(port) = address.port() {
+            return Some(format!("{hostname}-{port}.yaml"));
+        }
+    }
+    None
+}
+
+pub trait Config
+where
+    Self: DeserializeOwned + Serialize,
+{
+    fn persisted(self, path: &Path) -> PersistedConfig<Self> {
+        PersistedConfig {
+            inner: self,
+            path: path.to_path_buf(),
+        }
+    }
+
+    fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
+        let path = path.as_ref();
+        trace!("Reading config from {}", path.display());
+        let reader = fs::File::open(path)
+            .with_context(|| format!("unable to load config from {}", path.display()))?;
+        Ok(serde_yaml::from_reader(reader)?)
+    }
+
+    fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), anyhow::Error> {
+        let path = path.as_ref();
+        trace!("Writing config to {}", path.display());
+        let mut write = BufWriter::new(fs::File::create(path)?);
+        serde_yaml::to_writer(&mut write, &self)
+            .with_context(|| format!("unable to save config to {}", path.display()))?;
+        Ok(())
+    }
+}
+
+pub struct PersistedConfig<C> {
+    inner: C,
+    path: PathBuf,
+}
+
+impl<C> PersistedConfig<C>
+where
+    C: Config,
+{
+    pub fn read(path: &Path) -> Result<C, anyhow::Error> {
+        Config::load(path)
+    }
+
+    pub fn save(&self) -> Result<(), anyhow::Error> {
+        self.inner.save(&self.path)
+    }
+
+    pub fn into_inner(self) -> C {
+        self.inner
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl<C> std::ops::Deref for PersistedConfig<C> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<C> std::ops::DerefMut for PersistedConfig<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/crates/iota-config/src/persisted_config.rs
+++ b/crates/iota-config/src/persisted_config.rs
@@ -6,7 +6,7 @@
 //!
 //! Everything in this module reaches into the filesystem / config-file
 //! machinery (and the network `Multiaddr` type), so the whole module is gated
-//! out on wasm32 with a single `#[cfg]` on its declaration in `lib.rs`.
+//! out on wasm32.
 
 use std::{
     fs,

--- a/crates/iota-config/src/persisted_config.rs
+++ b/crates/iota-config/src/persisted_config.rs
@@ -23,6 +23,7 @@ use crate::{IOTA_CONFIG_DIR, IOTA_GENESIS_FILENAME};
 
 const IOTA_DIR: &str = ".iota";
 
+/// Return the IOTA config directory, creating it if it doesn't exist.
 pub fn iota_config_dir() -> Result<PathBuf, anyhow::Error> {
     match std::env::var_os("IOTA_CONFIG_DIR") {
         Some(config_env) => Ok(config_env.into()),
@@ -56,14 +57,17 @@ pub fn genesis_blob_exists(config_dir: Option<PathBuf>) -> bool {
     }
 }
 
+/// Config file name for the validator at the given address (or index).
 pub fn validator_config_file(address: Multiaddr, i: usize) -> String {
     multiaddr_to_filename(address).unwrap_or(format!("validator-config-{i}.yaml"))
 }
 
+/// Config file name for the SSFN at the given address (or index).
 pub fn ssfn_config_file(address: Multiaddr, i: usize) -> String {
     multiaddr_to_filename(address).unwrap_or(format!("ssfn-config-{i}.yaml"))
 }
 
+/// Derive a `<hostname>-<port>.yaml` file name from a multiaddr, if possible.
 fn multiaddr_to_filename(address: Multiaddr) -> Option<String> {
     if let Some(hostname) = address.hostname() {
         if let Some(port) = address.port() {
@@ -73,6 +77,7 @@ fn multiaddr_to_filename(address: Multiaddr) -> Option<String> {
     None
 }
 
+/// A config type that can be loaded from and saved to a YAML file on disk.
 pub trait Config
 where
     Self: DeserializeOwned + Serialize,
@@ -102,6 +107,7 @@ where
     }
 }
 
+/// A [`Config`] paired with the on-disk path it is persisted to.
 pub struct PersistedConfig<C> {
     inner: C,
     path: PathBuf,

--- a/crates/iota-config/src/persisted_config.rs
+++ b/crates/iota-config/src/persisted_config.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
+// Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! Filesystem-backed configuration helpers.

--- a/crates/iota-config/src/persisted_config.rs
+++ b/crates/iota-config/src/persisted_config.rs
@@ -3,10 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Filesystem-backed configuration helpers.
-//!
-//! Everything in this module reaches into the filesystem / config-file
-//! machinery (and the network `Multiaddr` type), so the whole module is gated
-//! out on wasm32.
 
 use std::{
     fs,
@@ -62,7 +58,8 @@ pub fn validator_config_file(address: Multiaddr, i: usize) -> String {
     multiaddr_to_filename(address).unwrap_or(format!("validator-config-{i}.yaml"))
 }
 
-/// Config file name for the SSFN at the given address (or index).
+/// Config file name for the State Sync Full Node at the given address (or
+/// index).
 pub fn ssfn_config_file(address: Multiaddr, i: usize) -> String {
     multiaddr_to_filename(address).unwrap_or(format!("ssfn-config-{i}.yaml"))
 }


### PR DESCRIPTION
## Summary

Makes the `iota-config` crate compile to `wasm32-unknown-unknown` while keeping the node build byte-identical. Part of the **IOTA Move VM WASM** epic, following the same approach as #11660 (`iota-types`) and #11683 (`iota-common`).

Fixes #11548

The guiding rule: on wasm only `transaction_deny_config` and `verifier_signing_config` are exposed — these are what `iota-transaction-checks` needs at sign / execution time. Everything else (networking, key management, on-disk genesis / node config, P2P) stays node-only and is gated out entirely.

### Changes

**`Cargo.toml`** — Moved the heavy node-side dependencies into a `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` table:
- external: `anemo`, `bcs`, `clap`, `csv`, `dirs`, `fastcrypto`, `object_store`, `prometheus`, `reqwest`, `serde_yaml`
- internal: `iota-genesis-common`, `iota-keys`, `iota-names`, `starfish-config`
- Stays enabled for wasm: `anyhow`, `once_cell`, `rand`, `serde`, `tracing`, `iota-types`, `move-vm-config`.

**`lib.rs`** — Gated everything node-only behind `#[cfg(not(target_arch = "wasm32"))]`:
- Modules: `certificate_deny_config`, `genesis`, `local_ip_utils`, `migration_tx_data`, `node`, `node_config_metrics`, `object_storage_config`, `p2p`.
- The `Config` / `PersistedConfig` trait and impls (filesystem-based), `iota_config_dir`, `genesis_blob_exists`, `validator_config_file`, `ssfn_config_file`, `multiaddr_to_filename`, the `IOTA_DIR` constant, the `iota_types::multiaddr::Multiaddr` import, and the `node::*` re-export.
- Kept `transaction_deny_config`, `verifier_signing_config`, and all `&str` path constants (`IOTA_CONFIG_DIR`, `IOTA_NETWORK_CONFIG`, …) available on wasm.

**CI** — Extended the existing `check-wasm32` job to also check `iota-config`.

## Test plan

- [x] `cargo check -p iota-config --target wasm32-unknown-unknown`
- [x] `cargo check -p iota-config` (native, incl. downstream deps)

https://claude.ai/code/session_01CJY7adUTrwcFiTvL2dPXMj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJY7adUTrwcFiTvL2dPXMj)_