### PR TITLE
feat(iota-adapter): compile latest execution layer to wasm32

### DIFF
--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -214,7 +214,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Check Move VM crates compile to wasm32
-        run: cargo check -p iota-types -p iota-common -p iota-config --target wasm32-unknown-unknown
+        run: cargo check -p iota-types -p iota-common -p iota-config -p iota-adapter-latest --target wasm32-unknown-unknown
 
   check-wasm32-cancel:
     needs: [check-wasm32]

--- a/crates/iota-common/src/logging.rs
+++ b/crates/iota-common/src/logging.rs
@@ -40,6 +40,20 @@ macro_rules! debug_fatal {
     }};
 }
 
+// On wasm32 the `iota-metrics` dep is excluded. Keep the macro available with
+// the same surface but without the metrics callout.
+#[cfg(target_arch = "wasm32")]
+#[macro_export]
+macro_rules! debug_fatal {
+    ($($arg:tt)*) => {{
+        if $crate::logging::crash_on_debug() {
+            $crate::fatal!($($arg)*);
+        } else {
+            tracing::error!(debug_fatal = true, $($arg)*);
+        }
+    }};
+}
+
 mod tests {
     #[test]
     #[should_panic]

--- a/crates/iota-common/src/logging.rs
+++ b/crates/iota-common/src/logging.rs
@@ -40,8 +40,8 @@ macro_rules! debug_fatal {
     }};
 }
 
-// On wasm32 the `iota-metrics` dep is excluded. Keep the macro available with
-// the same surface but without the metrics callout.
+// `iota-metrics` isn't available on wasm32; same macro without the metrics
+// callout.
 #[cfg(target_arch = "wasm32")]
 #[macro_export]
 macro_rules! debug_fatal {

--- a/crates/iota-types/src/metrics.rs
+++ b/crates/iota-types/src/metrics.rs
@@ -142,3 +142,96 @@ impl BytecodeVerifierMetrics {
         }
     }
 }
+
+// wasm32 doesn't link `prometheus`, but the execution path still references
+// `LimitsMetrics` / `BytecodeVerifierMetrics`. Provide no-op stubs with a
+// matching API: counters and histograms become zero-cost no-ops. There's no
+// registry to register against, so the constructors are `new_stub()`.
+#[cfg(target_arch = "wasm32")]
+mod wasm_stubs {
+    #[derive(Default, Clone)]
+    pub struct StubCounter;
+    impl StubCounter {
+        pub fn inc(&self) {}
+        pub fn inc_by(&self, _v: u64) {}
+    }
+
+    #[derive(Default, Clone)]
+    pub struct StubCounterVec;
+    impl StubCounterVec {
+        pub fn with_label_values(&self, _labels: &[&str]) -> StubCounter {
+            StubCounter
+        }
+    }
+
+    pub struct StubTimer;
+    impl StubTimer {
+        pub fn observe_duration(self) {}
+        pub fn stop_and_record(self) -> f64 {
+            0.0
+        }
+        pub fn stop_and_discard(self) -> f64 {
+            0.0
+        }
+    }
+
+    #[derive(Default, Clone)]
+    pub struct StubHistogram;
+    impl StubHistogram {
+        pub fn observe(&self, _v: f64) {}
+        pub fn start_timer(&self) -> StubTimer {
+            StubTimer
+        }
+    }
+
+    pub struct LimitsMetrics {
+        pub excessive_estimated_effects_size: StubCounterVec,
+        pub excessive_written_objects_size: StubCounterVec,
+        pub excessive_new_move_object_ids: StubCounterVec,
+        pub excessive_deleted_move_object_ids: StubCounterVec,
+        pub excessive_transferred_move_object_ids: StubCounterVec,
+        pub excessive_object_runtime_cached_objects: StubCounterVec,
+        pub excessive_object_runtime_store_entries: StubCounterVec,
+    }
+
+    impl LimitsMetrics {
+        pub fn new_stub() -> Self {
+            Self {
+                excessive_estimated_effects_size: StubCounterVec,
+                excessive_written_objects_size: StubCounterVec,
+                excessive_new_move_object_ids: StubCounterVec,
+                excessive_deleted_move_object_ids: StubCounterVec,
+                excessive_transferred_move_object_ids: StubCounterVec,
+                excessive_object_runtime_cached_objects: StubCounterVec,
+                excessive_object_runtime_store_entries: StubCounterVec,
+            }
+        }
+    }
+
+    pub struct BytecodeVerifierMetrics {
+        pub verifier_timeout_metrics: StubCounterVec,
+        pub verifier_runtime_per_module_success_latency: StubHistogram,
+        pub verifier_runtime_per_ptb_success_latency: StubHistogram,
+        pub verifier_runtime_per_module_timeout_latency: StubHistogram,
+        pub verifier_runtime_per_ptb_timeout_latency: StubHistogram,
+    }
+
+    impl BytecodeVerifierMetrics {
+        pub const OVERALL_TAG: &'static str = "overall";
+        pub const SUCCESS_TAG: &'static str = "success";
+        pub const TIMEOUT_TAG: &'static str = "failed";
+
+        pub fn new_stub() -> Self {
+            Self {
+                verifier_timeout_metrics: StubCounterVec,
+                verifier_runtime_per_module_success_latency: StubHistogram,
+                verifier_runtime_per_ptb_success_latency: StubHistogram,
+                verifier_runtime_per_module_timeout_latency: StubHistogram,
+                verifier_runtime_per_ptb_timeout_latency: StubHistogram,
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm_stubs::*;

--- a/crates/iota-types/src/metrics.rs
+++ b/crates/iota-types/src/metrics.rs
@@ -143,10 +143,8 @@ impl BytecodeVerifierMetrics {
     }
 }
 
-// wasm32 doesn't link `prometheus`, but the execution path still references
-// `LimitsMetrics` / `BytecodeVerifierMetrics`. Provide no-op stubs with a
-// matching API: counters and histograms become zero-cost no-ops. There's no
-// registry to register against, so the constructors are `new_stub()`.
+// `prometheus` isn't available on wasm32; provide no-op stubs with a matching
+// API for the execution path. Constructed via `new_stub()` (no registry).
 #[cfg(target_arch = "wasm32")]
 mod wasm_stubs {
     #[derive(Default, Clone)]

--- a/iota-execution/latest/iota-adapter/Cargo.toml
+++ b/iota-execution/latest/iota-adapter/Cargo.toml
@@ -38,8 +38,6 @@ move-vm-runtime = { path = "../../../external-crates/move/crates/move-vm-runtime
 move-vm-types = { path = "../../../external-crates/move/crates/move-vm-types" }
 
 # `iota-metrics` pulls in axum/anemo/tokio-net and can't compile to wasm32.
-# We only use it for a single `monitored_scope` call wrapped in a cfg gate
-# below in `temporary_store.rs`.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iota-metrics.workspace = true
 

--- a/iota-execution/latest/iota-adapter/Cargo.toml
+++ b/iota-execution/latest/iota-adapter/Cargo.toml
@@ -22,7 +22,6 @@ tracing.workspace = true
 # internal dependencies
 iota-common.workspace = true
 iota-macros.workspace = true
-iota-metrics.workspace = true
 iota-move-natives = { path = "../iota-move-natives", package = "iota-move-natives-latest" }
 iota-protocol-config.workspace = true
 iota-sdk-types.workspace = true
@@ -37,6 +36,12 @@ move-vm-config.workspace = true
 move-vm-profiler = { path = "../../../external-crates/move/crates/move-vm-profiler" }
 move-vm-runtime = { path = "../../../external-crates/move/crates/move-vm-runtime" }
 move-vm-types = { path = "../../../external-crates/move/crates/move-vm-types" }
+
+# `iota-metrics` pulls in axum/anemo/tokio-net and can't compile to wasm32.
+# We only use it for a single `monitored_scope` call wrapped in a cfg gate
+# below in `temporary_store.rs`.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+iota-metrics.workspace = true
 
 [features]
 tracing = [

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -10,13 +10,6 @@ use std::{
 
 #[cfg(not(target_arch = "wasm32"))]
 use iota_metrics::monitored_scope;
-// wasm32 doesn't link `iota-metrics` (it pulls in axum/anemo). Stub the helper
-// so the single call site below still compiles — it just no-ops a metrics
-// scope guard, which is fine for offline simulation.
-#[cfg(target_arch = "wasm32")]
-fn monitored_scope(_name: &'static str) -> Option<()> {
-    None
-}
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     auth_context::AuthContext,
@@ -52,6 +45,14 @@ use move_core_types::{account_address::AccountAddress, resolver::ResourceResolve
 use parking_lot::RwLock;
 
 use crate::gas_charger::GasCharger;
+
+// wasm32 doesn't link `iota-metrics` (it pulls in axum/anemo). Stub the helper
+// so the single call site below still compiles — it just no-ops a metrics
+// scope guard, which is fine for offline simulation.
+#[cfg(target_arch = "wasm32")]
+fn monitored_scope(_name: &'static str) -> Option<()> {
+    None
+}
 
 pub struct TemporaryStore<'backing> {
     // The backing store for retrieving Move packages onchain.

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -46,9 +46,7 @@ use parking_lot::RwLock;
 
 use crate::gas_charger::GasCharger;
 
-// wasm32 doesn't link `iota-metrics` (it pulls in axum/anemo). Stub the helper
-// so the single call site below still compiles — it just no-ops a metrics
-// scope guard, which is fine for offline simulation.
+// `iota-metrics` isn't available on wasm32; no-op the scope guard.
 #[cfg(target_arch = "wasm32")]
 fn monitored_scope(_name: &'static str) -> Option<()> {
     None

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -8,7 +8,15 @@ use std::{
     rc::Rc,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 use iota_metrics::monitored_scope;
+// wasm32 doesn't link `iota-metrics` (it pulls in axum/anemo). Stub the helper
+// so the single call site below still compiles — it just no-ops a metrics
+// scope guard, which is fine for offline simulation.
+#[cfg(target_arch = "wasm32")]
+fn monitored_scope(_name: &'static str) -> Option<()> {
+    None
+}
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     auth_context::AuthContext,


### PR DESCRIPTION
## Summary

Makes the latest execution layer crate `iota-adapter-latest` (`iota-execution/latest/iota-adapter/`) compile to `wasm32-unknown-unknown` — the last upstream piece the Move VM wasm wrapper needs. Part of the **IOTA Move VM WASM** epic (#11545).

Fixes #11549

### Changes

**`iota-adapter` (`Cargo.toml`, `src/temporary_store.rs`)**
- Move `iota-metrics` to `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` (it pulls in axum/anemo/tokio-net).
- Provide a wasm-only no-op `monitored_scope` shim; the single call site stays unchanged.

**`iota-types` (`src/metrics.rs`)**
- Append wasm-only no-op stubs for `LimitsMetrics` / `BytecodeVerifierMetrics` (referenced by `iota-move-natives` and `iota-adapter`), with a matching API. Native definitions left byte-identical.

**`iota-common` (`src/logging.rs`)**
- Add a wasm variant of the `debug_fatal!` macro (used by the adapter) that drops the `iota-metrics` callout.

**CI**
- Extend the `check-wasm32` job to also run `cargo check -p iota-adapter-latest --target wasm32-unknown-unknown`.

### Why stubs instead of more feature gates

The metrics are pure observability (Prometheus counters/histograms) and don't affect execution, so they *could* be gated out. But they're threaded through shared code — the `check_limit_by_meter!` macro in `iota-protocol-config`, `ObjectRuntime`/`ChildObjectStore` fields and constructors, the adapter's verifier-timeout signature — so gating would scatter `#[cfg]` across a macro and call sites in three crates for no runtime benefit. Stubs keep one code path, leave native byte-identical, and the no-ops inline away on wasm. Same reasoning for the `debug_fatal!` variant and `monitored_scope` shim.

### Note on scope

Beyond the literal issue scope, the `iota-types` and `iota-common` stubs are needed because those gaps remained in the adapter's dependency tree. All additions sit behind `#[cfg(target_arch = "wasm32")]`, so native builds stay byte-identical.

## Test plan

- [x] `cargo check -p iota-adapter-latest --target wasm32-unknown-unknown`
- [x] `cargo check -p iota-types -p iota-common -p iota-adapter-latest` (native)
- [x] `cargo +nightly fmt --check` on the touched crates, `dprint check`

https://claude.ai/code/session_01CJY7adUTrwcFiTvL2dPXMj