### PR TITLE
chore: remove `ChangeEpoch` re-exports

### DIFF
--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -6,17 +6,16 @@ use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
 };
+use iota_sdk_types::{
+    ChangeEpoch as NativeChangeEpochTransaction, ChangeEpochV2 as NativeChangeEpochTransactionV2,
+    ChangeEpochV3 as NativeChangeEpochTransactionV3,
+    ChangeEpochV4 as NativeChangeEpochTransactionV4,
+};
 use iota_types::{
     committee::{EpochId, ProtocolVersion},
     digests::TransactionDigest,
     object::Object as NativeObject,
-    transaction::{
-        ChangeEpoch as NativeChangeEpochTransaction,
-        ChangeEpochV2 as NativeChangeEpochTransactionV2,
-        ChangeEpochV3 as NativeChangeEpochTransactionV3,
-        ChangeEpochV4 as NativeChangeEpochTransactionV4,
-        EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind, SystemPackage,
-    },
+    transaction::{EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind, SystemPackage},
 };
 use move_binary_format::{CompiledModule, errors::PartialVMResult};
 

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -10,7 +10,10 @@ use futures::{Stream, StreamExt, stream::FuturesOrdered};
 use iota_json::{IotaJsonValue, primitive_type};
 use iota_metrics::monitored_scope;
 use iota_package_resolver::{CleverError, ErrorConstants, PackageStore, Resolver};
-use iota_sdk_types::{Command, Identifier, MoveCall, ObjectId, TransferObjects, TypeTag};
+use iota_sdk_types::{
+    ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command, Identifier, MoveCall,
+    ObjectId, TransferObjects, TypeTag,
+};
 use iota_types::{
     base_types::{EpochId, IotaAddress, ObjectRef, SequenceNumber, TransactionDigest},
     crypto::IotaSignature,
@@ -33,9 +36,9 @@ use iota_types::{
     signature::GenericSignature,
     storage::{DeleteKind, WriteKind},
     transaction::{
-        Argument, CallArg, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,
-        EndOfEpochTransactionKind, GenesisObject, InputObjectKind, ProgrammableTransaction,
-        SenderSignedData, SharedObjectRef, TransactionData, TransactionDataAPI, TransactionKind,
+        Argument, CallArg, EndOfEpochTransactionKind, GenesisObject, InputObjectKind,
+        ProgrammableTransaction, SenderSignedData, SharedObjectRef, TransactionData,
+        TransactionDataAPI, TransactionKind,
     },
 };
 use move_binary_format::CompiledModule;

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -17,10 +17,9 @@ use anyhow::bail;
 use fastcrypto::{encoding::Base64, hash::HashFunction};
 use iota_protocol_config::ProtocolConfig;
 pub use iota_sdk_types::{
-    Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, EndOfEpochTransactionKind,
-    GasPayment as GasData, GenesisObject, GenesisTransaction, ProgrammableTransaction,
-    RandomnessStateUpdate, SharedObjectReference as SharedObjectRef, SystemPackage,
-    Transaction as TransactionData, TransactionExpiration, TransactionKind,
+    Argument, EndOfEpochTransactionKind, GasPayment as GasData, GenesisObject, GenesisTransaction,
+    ProgrammableTransaction, RandomnessStateUpdate, SharedObjectReference as SharedObjectRef,
+    SystemPackage, Transaction as TransactionData, TransactionExpiration, TransactionKind,
     TransactionV1 as TransactionDataV1,
 };
 use iota_sdk_types::{

--- a/external-crates/move/crates/move-docgen/src/docgen.rs
+++ b/external-crates/move/crates/move-docgen/src/docgen.rs
@@ -975,8 +975,7 @@ impl<'env> Docgen<'env> {
     /// also starts with `E` is fine to flag as the convention is consistent.
     fn is_error_constant(name: &str) -> bool {
         let mut chars = name.chars();
-        chars.next() == Some('E')
-            && matches!(chars.next(), Some(c) if c.is_ascii_uppercase())
+        chars.next() == Some('E') && matches!(chars.next(), Some(c) if c.is_ascii_uppercase())
     }
 
     /// Generates documentation for a struct. `methods` are functions whose

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -16,7 +16,9 @@ mod checked {
 
     use iota_move_natives::all_natives;
     use iota_protocol_config::{LimitThresholdCrossed, ProtocolConfig, check_limit_by_meter};
-    use iota_sdk_types::{Command, Identifier, ObjectId};
+    use iota_sdk_types::{
+        ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command, Identifier, ObjectId,
+    };
     #[cfg(msim)]
     use iota_types::iota_system_state::advance_epoch_result_injection::maybe_modify_result;
     use iota_types::{
@@ -46,10 +48,9 @@ mod checked {
         randomness_state::RANDOMNESS_STATE_UPDATE_FUNCTION_NAME,
         storage::{BackingStore, Storage},
         transaction::{
-            Argument, CallArg, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,
-            CheckedInputObjects, EndOfEpochTransactionKind, GasData, GenesisTransaction,
-            InputObjects, ProgrammableTransaction, RandomnessStateUpdate, SharedObjectRef,
-            SystemPackage, TransactionKind, TransactionKindExt,
+            Argument, CallArg, CheckedInputObjects, EndOfEpochTransactionKind, GasData,
+            GenesisTransaction, InputObjects, ProgrammableTransaction, RandomnessStateUpdate,
+            SharedObjectRef, SystemPackage, TransactionKind, TransactionKindExt,
         },
     };
     use move_binary_format::CompiledModule;


### PR DESCRIPTION
# Description of change

`ChangeEpoch`, `ChangeEpochV2`, `ChangeEpochV3` and `ChangeEpochV4` are defined in `iota-sdk-types` and were being re-exported through `iota_types::transaction`. Per the repo convention of keeping client-visible types sourced from the SDK rather than laundering them through `iota-types`, this drops those re-exports and updates the three consumers (`iota-graphql-rpc`, `iota-json-rpc-types`, `iota-adapter`) to import the types directly from `iota_sdk_types`.

Pure refactor — no behavior change. Continues the same cleanup as the preceding `ObjectID` re-export removal.

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/11567

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage) — N/A, mechanical re-export removal
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, no behavior change
- [x] I have checked that new and existing unit tests pass locally with my changes