### PR TITLE
feat: enable AA in mainnet and Move-based sponsor authentication in testnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -151,7 +151,7 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 // Version 28: Move authenticator contracts can now inspect which authenticator
 //             function the sender and sponsor used during transaction execution
 //             via new AuthContext accessors.
-//             Enable Move-based account authentication in all networks.
+//             Enable Move-based account authentication in mainnet.
 //             Enable Move-based sponsor account authentication in testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2833,12 +2833,12 @@ impl ProtocolConfig {
                     cfg.auth_context_authenticator_function_info_v1_cost_base = Some(270);
 
                     // Enable storing metadata in module bytes and then
-                    // publishing package metadata in all networks.
+                    // publishing package metadata in mainnet.
                     cfg.feature_flags.metadata_in_module_bytes = true;
                     cfg.feature_flags.publish_package_metadata = true;
-                    // Enable Move authentication in all networks.
+                    // Enable Move authentication in mainnet.
                     cfg.feature_flags.enable_move_authentication = true;
-                    // Increase the base cost for transfer receive object in all networks, since the
+                    // Increase the base cost for transfer receive object in mainnet, since the
                     // implementation now does check if parent is not an account.
                     cfg.transfer_receive_object_cost_base = Some(100);
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -151,6 +151,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 // Version 28: Move authenticator contracts can now inspect which authenticator
 //             function the sender and sponsor used during transaction execution
 //             via new AuthContext accessors.
+//             Enable Move-based account authentication in all networks.
+//             Enable Move-based sponsor account authentication in testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2829,6 +2831,29 @@ impl ProtocolConfig {
                     // digest. auth_context_digest_cost_base = 30 for 32 bytes →
                     // 9 × 30 = 270.
                     cfg.auth_context_authenticator_function_info_v1_cost_base = Some(270);
+
+                    // Enable storing metadata in module bytes and then
+                    // publishing package metadata in all networks.
+                    cfg.feature_flags.metadata_in_module_bytes = true;
+                    cfg.feature_flags.publish_package_metadata = true;
+                    // Enable Move authentication in all networks.
+                    cfg.feature_flags.enable_move_authentication = true;
+                    // Increase the base cost for transfer receive object in all networks, since the
+                    // implementation now does check if parent is not an account.
+                    cfg.transfer_receive_object_cost_base = Some(100);
+
+                    if chain != Chain::Unknown {
+                        // max_auth_gas is 0.00002 IOTA in testnet and mainnet.
+                        cfg.max_auth_gas = Some(20_000);
+                    }
+
+                    if chain != Chain::Mainnet {
+                        // Enable Move-based sponsor account authentication in testnet.
+                        cfg.feature_flags.enable_move_authentication_for_sponsor = true;
+                        // Only sponsor Move authentication is performed pre-consensus in testnet.
+                        cfg.feature_flags
+                            .pre_consensus_sponsor_only_move_authentication = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_28.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_28.snap
@@ -33,6 +33,9 @@ feature_flags:
   consensus_commit_transactions_only_for_traversed_headers: true
   congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
   separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
   pass_validator_scores_to_advance_epoch: true
   move_native_tx_context: true
   additional_borrow_checks: true
@@ -70,6 +73,7 @@ max_move_object_size: 256000
 max_move_package_size: 102400
 max_publish_or_upgrade_per_ptb: 5
 max_tx_gas: 50000000000
+max_auth_gas: 20000
 max_gas_price: 100000
 max_gas_computation_bucket: 5000000
 gas_rounding_step: 1000
@@ -159,7 +163,7 @@ object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
-transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_base: 100
 tx_context_derive_id_cost_base: 52
 tx_context_fresh_id_cost_base: 52
 tx_context_sender_cost_base: 30

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_28.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_28.snap
@@ -37,12 +37,14 @@ feature_flags:
   metadata_in_module_bytes: true
   publish_package_metadata: true
   enable_move_authentication: true
+  enable_move_authentication_for_sponsor: true
   pass_validator_scores_to_advance_epoch: true
   calculate_validator_scores: true
   consensus_fast_commit_sync: true
   consensus_block_restrictions: true
   move_native_tx_context: true
   additional_borrow_checks: true
+  pre_consensus_sponsor_only_move_authentication: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -77,7 +79,7 @@ max_move_object_size: 256000
 max_move_package_size: 102400
 max_publish_or_upgrade_per_ptb: 5
 max_tx_gas: 50000000000
-max_auth_gas: 250000
+max_auth_gas: 20000
 max_gas_price: 100000
 max_gas_computation_bucket: 5000000
 gas_rounding_step: 1000


### PR DESCRIPTION
# Description of change

Enable Move-based account authentication in all networks.
Enable Move-based sponsor account authentication in testnet.
`max_auth_gas` is set to 0.00002 IOTA in testnet and mainnet.


### Release Notes

- [x] Protocol: Enable Move-based account authentication in mainnet Enable Move-based sponsor account authentication in testnet. The max_auth_gas  parameter is set to 0.00002 IOTA in testnet and mainnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
