### PR TITLE
fix(indexer): bump `object_type_package` statistics target on `checkpointed_objects`

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-06-02-121300_checkpointed_objects_type_package_statistics/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-06-02-121300_checkpointed_objects_type_package_statistics/down.sql
@@ -1,0 +1,6 @@
+-- Restore the default per-column statistics target (-1 means
+-- `default_statistics_target`, which is 100 by default).
+ALTER TABLE checkpointed_objects
+    ALTER COLUMN object_type_package SET STATISTICS -1;
+
+ANALYZE checkpointed_objects (object_type_package);

--- a/crates/iota-indexer/migrations/pg/2026-06-02-121300_checkpointed_objects_type_package_statistics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-06-02-121300_checkpointed_objects_type_package_statistics/up.sql
@@ -1,0 +1,10 @@
+-- Bump the per-column statistics target for `object_type_package` so the
+-- planner gets accurate row-count estimates for unpopular packages. This is
+-- required for type-filtered `objects` GraphQL queries to pick the right
+-- index.
+--
+-- See https://github.com/iotaledger/iota/issues/11711
+ALTER TABLE checkpointed_objects
+    ALTER COLUMN object_type_package SET STATISTICS 1000;
+
+ANALYZE checkpointed_objects (object_type_package);


### PR DESCRIPTION
# Description of change

With the default per-column statistics target (100), Postgres estimates ~20k rows for unpopular packages on `checkpointed_objects`, which makes the planner pick `checkpointed_objects_id_type` and stream pre-sorted results, which times out because only a few rows match which is not enough to fill the page. A target of 1000 brings the estimate down to ~1k, at which point the planner picks `checkpointed_objects_type_id`, loads the small matching set, and sorts in memory.

## Links to any relevant issues

fixes #11711

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage) - tested on staging which has indexer synced with testnet

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
