### PR TITLE
feat(move): Add local_implicit_deps for system packages

### DIFF
--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -15,7 +15,7 @@ use anyhow::bail;
 use fastcrypto::encoding::Base64;
 use iota_package_management::{
     PublishedAtError, resolve_published_id,
-    system_package_versions::{SYSTEM_GIT_REPO, SystemPackagesVersion},
+    system_package_versions::{SYSTEM_GIT_REPO, SystemPackagesVersion, latest_system_packages},
 };
 use iota_sdk_types::ObjectId;
 use iota_types::{
@@ -1004,4 +1004,40 @@ pub fn check_conflicting_addresses(
     };
 
     Err(err)
+}
+
+/// Create a set of [Dependencies] from a [SystemPackagesVersion] that resolve
+/// to the system package sources on the local filesystem, relative to this
+/// crate's location in the iota source tree.
+pub fn local_implicit_deps(packages: &SystemPackagesVersion) -> Dependencies {
+    // This relies on the compile-time `CARGO_MANIFEST_DIR` still existing on disk
+    // at runtime, which holds when the binary is built and run on the same host.
+    // `CARGO_MANIFEST_DIR` is `<repo>/crates/iota-move-build`, so the repo root is
+    // two levels up and each system package lives at `<repo>/<repo_path>`.
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("iota-move-build manifest dir should have a grandparent");
+    packages
+        .packages
+        .iter()
+        .map(|package| {
+            (
+                package.package_name.clone().into(),
+                Dependency::Internal(InternalDependency {
+                    kind: DependencyKind::Local(repo_root.join(&package.repo_path)),
+                    subst: None,
+                    digest: None,
+                    dep_override: true,
+                }),
+            )
+        })
+        .collect()
+}
+
+/// Useful for callers (e.g. the `#[sim_test]` static initializer) that don't
+/// have a [SystemPackagesVersion] on hand and just want the framework resolved
+/// from the local checkout.
+pub fn local_implicit_deps_latest() -> Dependencies {
+    local_implicit_deps(latest_system_packages())
 }

--- a/crates/iota-proc-macros/src/lib.rs
+++ b/crates/iota-proc-macros/src/lib.rs
@@ -61,6 +61,12 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
                     let mut path = PathBuf::from(env!("SIMTEST_STATIC_INIT_MOVE"));
                     let mut build_config = BuildConfig::new_for_testing();
 
+                    // Resolve the system packages (Iota framework, MoveStdlib, …) from the local
+                    // iota checkout rather than fetching them over the network. This lets the
+                    // static-init package omit an explicit `Iota` dependency; for packages that do
+                    // declare one, this injection is skipped and has no effect.
+                    build_config.config.implicit_dependencies =
+                        iota_simulator::iota_move_build::local_implicit_deps_latest();
                     build_config.config.install_dir = Some(TempDir::new().unwrap().keep());
                     let _all_module_bytes = build_config
                         .build(&path)


### PR DESCRIPTION
# Description of change

Fix simtest nightly CI errors: https://github.com/iotaledger/network-benchmark/actions/runs/26795993550/job/78992341956
Simtests depends on iota as a git dependency need to build their Move packages against the framework of the **commit under test**, not the moving `develop` branch. Resolving the framework over the network is both non-deterministic and fails in CI. This helper lets those consumers build offline, against the correct sources.

Adds `local_implicit_deps`, a helper that builds the implicit Move dependencies for the system packages (`Iota` framework, `MoveStdlib`, …) as **local-path** dependencies, rooted at this crate's location in the iota source tree (derived from the compile-time `CARGO_MANIFEST_DIR`).

Unlike the existing `implicit_deps`, which produces **git** dependencies pinned to a published framework revision, `local_implicit_deps` points at the framework sources of the *exact checkout this crate was compiled from*.

Also injects these implicit deps into the `#[sim_test]` macro's static-init build (`iota-proc-macros`), so a static-init package without an explicit `Iota` dependency still resolves the framework. For packages that declare one, injection is skipped (no-op).


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
