### PR TITLE
feat(iota-rest-kv): add address-transaction query

### DIFF
--- a/crates/iota-rest-kv/src/aws.rs
+++ b/crates/iota-rest-kv/src/aws.rs
@@ -8,7 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use aws_config::{BehaviorVersion, Region, timeout::TimeoutConfig};
 use aws_sdk_dynamodb::{Client, config::Credentials, primitives::Blob, types::AttributeValue};
 use bytes::Bytes;
@@ -319,6 +319,9 @@ impl KvStoreClient {
         let item_type = key.item_type().to_string();
 
         match key {
+            Key::TransactionDigestsByAddress(_address) => {
+                bail!("unsupported key");
+            }
             Key::Transaction(transaction_digest) => {
                 self.get_from_dynamodb(transaction_digest, item_type).await
             }

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -12,13 +12,13 @@ use anyhow::Result;
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt, stream};
 use iota_kvstore::{
-    BigTableClient, Cell,
+    BigTableClient, Cell, KeyValueStoreReader,
     client::{
         CHECKPOINT_CONTENTS_COLUMN_QUALIFIER, CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
         CHECKPOINTS_BY_DIGEST_TABLE, CHECKPOINTS_TABLE, DEFAULT_COLUMN_QUALIFIER,
         EFFECTS_COLUMN_QUALIFIER, EVENTS_COLUMN_QUALIFIER, OBJECTS_TABLE,
         TRANSACTION_COLUMN_QUALIFIER, TRANSACTION_TO_CHECKPOINT, TRANSACTIONS_TABLE,
-        raw_object_key,
+        TransactionSequenceNumber, TransactionsOrder, raw_object_key,
     },
     proto::bigtable::v2::{
         RowFilter,
@@ -27,7 +27,10 @@ use iota_kvstore::{
     },
 };
 use iota_storage::http_key_value_store::{ItemType, Key};
-use iota_types::{effects::TransactionEvents, storage::ObjectKey};
+use iota_types::{
+    base_types::IotaAddress, digests::TransactionDigest, effects::TransactionEvents,
+    storage::ObjectKey,
+};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -135,6 +138,9 @@ impl KvStoreClient {
 
         // Use the first key to determine the type - all keys should be of the same type
         match keys.first().expect("emptiness was checked earlier") {
+            Key::TransactionDigestsByAddress(_address) => {
+                return Err(ApiError::BadRequest("unsupported key".into()));
+            }
             Key::Transaction(_) => {
                 let digests = extract_keys(&keys, |k| match k {
                     Key::Transaction(digest) => Some(*digest),
@@ -411,6 +417,37 @@ impl KvStoreClient {
             .map(|range| self.object_before_version(range))
             .buffered(max_buffered_concurrent_futures)
             .try_collect::<Vec<Option<Bytes>>>()
+            .await
+    }
+
+    /// Fetches a list `(sequence number, digest)` pairs for transactions
+    /// affecting the given address, ordered by `oldest_first` and capped
+    /// at `limit`.
+    ///
+    /// # Pagination
+    /// `cursor` is **exclusive**.
+    ///
+    /// - oldest_first = `false`: returns entries with `tx_seq < cursor`.
+    /// - oldest_first = `true`: returns entries with `tx_seq > cursor`.
+    ///
+    /// When `None`, the scan starts from the beginning of the requested
+    /// `oldest_first` order.
+    pub async fn transactions_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionSequenceNumber>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> Result<Vec<(TransactionSequenceNumber, TransactionDigest)>, anyhow::Error> {
+        let mut client = self.bigtable_client.clone();
+
+        let order = match oldest_first {
+            true => TransactionsOrder::OldestFirst,
+            false => TransactionsOrder::NewestFirst,
+        };
+
+        client
+            .get_transaction_digests_by_address(address, cursor, limit, order)
             .await
     }
 }

--- a/crates/iota-rest-kv/src/routes/kv_store.rs
+++ b/crates/iota-rest-kv/src/routes/kv_store.rs
@@ -1,5 +1,8 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
+use std::num::NonZeroUsize;
+
 use axum::{
     Json,
     body::Body,
@@ -7,7 +10,9 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use iota_kvstore::client::TransactionSequenceNumber;
 use iota_storage::http_key_value_store::{ItemType, Key};
+use iota_types::base_types::IotaAddress;
 use serde::Deserialize;
 
 use crate::{
@@ -161,5 +166,76 @@ pub async fn multi_get_data(
     };
 
     let bcs_data = bcs::to_bytes(&results).map_err(|_| ApiError::InternalServerError)?;
+    Ok(bcs_data.into_response())
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct TransactionDigestsByAddressQuery {
+    pub(crate) cursor: Option<TransactionSequenceNumber>,
+    pub(crate) limit: Option<NonZeroUsize>,
+    #[serde(default)]
+    pub(crate) oldest_first: bool,
+}
+
+/// Retrieves a paginated list of transactions that affect a given address.
+///
+/// An address is considered "affected" by a transaction if it appears as the
+/// sender, a recipient, or the gas payer.
+///
+/// # Path Parameters
+///
+/// * `address`: Base64-url-encoded [`IotaAddress`].
+///
+/// # Query Parameters
+///
+/// * `cursor` (optional): The [`TransactionSequenceNumber`] used as an
+///   exclusive pagination boundary. Omit for the first request.
+/// * `limit` (optional): The maximum number of results to return. Defaults to
+///   the server's configured `multiget_max_items` when omitted.
+/// * `oldest_first` (optional, default `false`):
+///   - `true`: Ascending sequence order (oldest first).
+///   - `false`: Descending sequence order (newest first).
+///
+/// # Responses
+///
+/// * `200 OK`: A BCS-encoded `Vec<(TransactionSequenceNumber,
+///   TransactionDigest)>`. Returns an empty list when no transaction digests
+///   are found in the range scan.
+/// * `400 Bad Request`: Returned if the provided `address` is malformed or
+///   invalid.
+/// * `500 Internal Server Error`: Returned if an error occurs interacting with
+///   the KV store.
+pub async fn transaction_digests_by_address(
+    State(app_state): State<SharedRestServerAppState>,
+    Path(address): Path<String>,
+    Query(query): Query<TransactionDigestsByAddressQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let address = base64_url::decode(&address)
+        .map_err(|_| ApiError::BadRequest("address is not valid base64-url".into()))?;
+
+    let address = IotaAddress::from_bytes(&address)
+        .map_err(|_| ApiError::BadRequest("invalid address".into()))?;
+
+    let TransactionDigestsByAddressQuery {
+        cursor,
+        limit,
+        oldest_first,
+    } = query;
+
+    let max_limit = app_state.multiget_max_items.get();
+    let limit = limit.map_or(max_limit, |l| l.get());
+
+    if limit > max_limit {
+        return Err(ApiError::BadRequest(format!(
+            "limit too large: maximum allowed is {max_limit}",
+        )));
+    }
+
+    let transactions = app_state
+        .kv_store_client
+        .transactions_by_address(address, cursor, limit, oldest_first)
+        .await?;
+
+    let bcs_data = bcs::to_bytes(&transactions).map_err(|_| ApiError::InternalServerError)?;
     Ok(bcs_data.into_response())
 }

--- a/crates/iota-rest-kv/src/server.rs
+++ b/crates/iota-rest-kv/src/server.rs
@@ -11,6 +11,7 @@ use axum::{
     response::IntoResponse,
     routing::{get, post},
 };
+use iota_storage::http_key_value_store::ItemType;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -46,6 +47,12 @@ impl Server {
             .route("/health", get(health::health))
             .route("/{item_type}", post(kv_store::multi_get_data))
             .route("/{item_type}/{key}", get(kv_store::data_as_bytes))
+            // static and dynamic route segments are allowed to overlap. If they do, static segments
+            // will be given higher priority.
+            .route(
+                &format!("/{}/{{address}}", ItemType::TransactionDigestsByAddress),
+                get(kv_store::transaction_digests_by_address),
+            )
             .with_state(shared_state)
             .fallback(fallback);
 

--- a/crates/iota-storage/src/http_key_value_store.rs
+++ b/crates/iota-storage/src/http_key_value_store.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, StreamExt};
 use iota_types::{
-    base_types::{ObjectID, SequenceNumber},
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
     digests::{CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{IotaError, IotaResult},
@@ -113,6 +113,9 @@ pub enum ItemType {
     #[strum(serialize = "evtx")]
     #[serde(rename = "evtx")]
     EventTransactionDigest,
+    #[strum(serialize = "txa")]
+    #[serde(rename = "txa")]
+    TransactionDigestsByAddress,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -125,6 +128,7 @@ pub enum Key {
     TransactionToCheckpoint(TransactionDigest),
     ObjectKey(ObjectKey),
     EventsByTransactionDigest(TransactionDigest),
+    TransactionDigestsByAddress(IotaAddress),
 }
 
 impl Key {
@@ -198,6 +202,9 @@ impl Key {
             ItemType::EventTransactionDigest => Ok(Key::EventsByTransactionDigest(
                 TransactionDigest::from_bytes(decoded_key.as_slice())?,
             )),
+            ItemType::TransactionDigestsByAddress => Ok(Key::TransactionDigestsByAddress(
+                IotaAddress::from_bytes(decoded_key.as_slice())?,
+            )),
         }
     }
 
@@ -230,6 +237,7 @@ impl Key {
             Key::TransactionToCheckpoint(_) => ItemType::TransactionToCheckpoint,
             Key::ObjectKey(_) => ItemType::Object,
             Key::EventsByTransactionDigest(_) => ItemType::EventTransactionDigest,
+            Key::TransactionDigestsByAddress(_) => ItemType::TransactionDigestsByAddress,
         }
     }
 
@@ -277,6 +285,9 @@ impl Key {
             Key::TransactionToCheckpoint(digest) => encode_digest(digest),
             Key::ObjectKey(object_key) => encode_object_key(object_key),
             Key::EventsByTransactionDigest(digest) => encode_digest(digest),
+            // TODO: `encode_digest` could be renamed to `encode` to fit more use cases.
+            // tracking issue: https://github.com/iotaledger/iota/issues/11754
+            Key::TransactionDigestsByAddress(address) => encode_digest(address),
         };
 
         (self.item_type(), encoded_key_digest)


### PR DESCRIPTION
# Description of change

This PR adds support for address-to-transaction relation queries via a new REST endpoint, `GET /txa/{address}`.

## Why a separate route

The existing `GET` and `POST` routes follow the following contract: the caller provides a key (`GET`) or a list of keys (`POST`) and gets back a value (or a list of values), one-to-one. 

The new endpoint is fundamentally different: a single address resolves to many transaction digests, the response is an ordered list, and pagination is required because an address can have a long history.

Forcing this into the existing routes would mean stretching their contract to carry list responses and pagination semantics that the other item types don't need. A dedicated route keeps the existing endpoints' shape intact and puts the range-query semantics in their own clearly-named handler.

We created a dedicated issue to refactor the rest api accordingly to accommodate more ergonomically paginated queries.
- https://github.com/iotaledger/iota/issues/11716

## Links to any relevant issues

fixes #11676 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Verified end-to-end with the BigTable emulator and a running `iota-rest-kv` server (`cargo r -p iota-rest-kv -- --config ../dev-tools/iota-rest-kv/config/bigtable.yaml`). See the test cases below for the queries exercised; BigTable setup is documented in `iota-kvstore/README.md`.

<details>
<summary>TEST CASES</summary>

```rust
#[cfg(test)]
mod tests {

    use std::str::FromStr;

    use iota_storage::http_key_value_store::encode_digest;
    use iota_types::base_types::IotaAddress;
    use url::Url;

    use super::*;

    #[tokio::test]
    async fn default_query_params() {
        let address = IotaAddress::from_hex(
            "0x30cc1fd7d8fb786af29eb1cfe14a69ef5fb2bdb25bafe1a9aa745853c2e8a859",
        )
        .unwrap();
        let base_address = encode_digest(&address);
        println!("{}", base_address);

        let client = reqwest::Client::new();

        let base_url = Url::from_str("http://localhost:3555").unwrap();
        let url = base_url.join(&format!("txa/{base_address}")).unwrap();

        let resp = client.get(url.clone()).send().await.unwrap();

        let bytes = resp.bytes().await.unwrap();
        let result = bcs::from_bytes::<Vec<(u64, TransactionDigest)>>(&bytes).unwrap();
        assert_eq!(
            result
                .into_iter()
                .map(|(seq, _digest)| seq)
                .collect::<Vec<_>>(),
            vec![50, 30, 20, 10]
        )
    }
    #[tokio::test]
    async fn default_with_limit() {
        let address = IotaAddress::from_hex(
            "0x30cc1fd7d8fb786af29eb1cfe14a69ef5fb2bdb25bafe1a9aa745853c2e8a859",
        )
        .unwrap();
        let base_address = encode_digest(&address);

        let client = reqwest::Client::new();

        let base_url = Url::from_str("http://localhost:3555").unwrap();
        let mut url = base_url.join(&format!("txa/{base_address}")).unwrap();
        url.query_pairs_mut().append_pair("limit", "1");

        let resp = client.get(url.clone()).send().await.unwrap();

        let bytes = resp.bytes().await.unwrap();
        let result = bcs::from_bytes::<Vec<(u64, TransactionDigest)>>(&bytes).unwrap();
        assert_eq!(
            result
                .into_iter()
                .map(|(seq, _digest)| seq)
                .collect::<Vec<_>>(),
            vec![50]
        )
    }
    #[tokio::test]
    async fn default_with_cursor() {
        let address = IotaAddress::from_hex(
            "0x30cc1fd7d8fb786af29eb1cfe14a69ef5fb2bdb25bafe1a9aa745853c2e8a859",
        )
        .unwrap();
        let base_address = encode_digest(&address);

        let client = reqwest::Client::new();

        let base_url = Url::from_str("http://localhost:3555").unwrap();
        let mut url = base_url.join(&format!("txa/{base_address}")).unwrap();
        url.query_pairs_mut().append_pair("cursor", "30");

        let resp = client.get(url.clone()).send().await.unwrap();

        let bytes = resp.bytes().await.unwrap();
        let result = bcs::from_bytes::<Vec<(u64, TransactionDigest)>>(&bytes).unwrap();
        assert_eq!(
            result
                .into_iter()
                .map(|(seq, _digest)| seq)
                .collect::<Vec<_>>(),
            vec![20, 10]
        )
    }
    #[tokio::test]
    async fn default_with_cursor_oldest_first() {
        let address = IotaAddress::from_hex(
            "0x30cc1fd7d8fb786af29eb1cfe14a69ef5fb2bdb25bafe1a9aa745853c2e8a859",
        )
        .unwrap();
        let base_address = encode_digest(&address);

        let client = reqwest::Client::new();

        let base_url = Url::from_str("http://localhost:3555").unwrap();
        let mut url = base_url.join(&format!("txa/{base_address}")).unwrap();
        url.query_pairs_mut()
            .append_pair("cursor", "30")
            .append_pair("oldest_first", "true");

        let resp = client.get(url.clone()).send().await.unwrap();

        let bytes = resp.bytes().await.unwrap();
        let result = bcs::from_bytes::<Vec<(u64, TransactionDigest)>>(&bytes).unwrap();
        assert_eq!(
            result
                .into_iter()
                .map(|(seq, _digest)| seq)
                .collect::<Vec<_>>(),
            vec![50]
        )
    }
    #[tokio::test]
    async fn default_with_past_cursor() {
        let address = IotaAddress::from_hex(
            "0x30cc1fd7d8fb786af29eb1cfe14a69ef5fb2bdb25bafe1a9aa745853c2e8a859",
        )
        .unwrap();
        let base_address = encode_digest(&address);

        let client = reqwest::Client::new();

        let base_url = Url::from_str("http://localhost:3555").unwrap();
        let mut url = base_url.join(&format!("txa/{base_address}")).unwrap();
        url.query_pairs_mut().append_pair("cursor", "10");

        let resp = client.get(url.clone()).send().await.unwrap();

        let bytes = resp.bytes().await.unwrap();
        let result = bcs::from_bytes::<Vec<(u64, TransactionDigest)>>(&bytes).unwrap();
        assert!(result.is_empty())
    }
}
```

</details>


### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal operation of the indexer, thus no further tests were conducted.
