### PR TITLE
feat(data-ingestion-core): introduce EPOCH_BOUNDARIES

### DIFF
--- a/crates/iota-data-ingestion-core/src/errors.rs
+++ b/crates/iota-data-ingestion-core/src/errors.rs
@@ -55,6 +55,9 @@ pub enum IngestionError {
     #[error("reading historical data failed: `{0}`")]
     HistoryRead(String),
 
+    #[error("invalid epoch boundary update: `{0}`")]
+    EpochBoundary(String),
+
     #[error("max downloaded checkpoints limit reached")]
     MaxCheckpointsCapacityReached,
 

--- a/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
+++ b/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
@@ -6,14 +6,9 @@
 use std::{collections::BTreeMap, ops::RangeBounds};
 
 use bytes::Bytes;
-use fastcrypto::hash::{HashFunction, Sha3_256};
-use iota_storage::{
-    SHA3_BYTES,
-    blob::{Blob, BlobEncoding},
-    object_store::{
-        ObjectStoreGetExt, ObjectStorePutExt,
-        util::{exists, get, put},
-    },
+use iota_storage::object_store::{
+    ObjectStoreGetExt, ObjectStorePutExt,
+    util::{exists, get, put},
 };
 use iota_types::{committee::EpochId, messages_checkpoint::CheckpointSequenceNumber};
 use object_store::path::Path;
@@ -22,7 +17,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     IngestionError,
     errors::IngestionResult as Result,
-    history::{EPOCH_BOUNDARIES_FILE_MAGIC, EPOCH_BOUNDARIES_FILENAME, MAGIC_BYTES},
+    history::{
+        EPOCH_BOUNDARIES_FILE_MAGIC, EPOCH_BOUNDARIES_FILENAME, finalize_magic_blob,
+        read_magic_blob,
+    },
 };
 
 /// Stores the epoch boundaries.
@@ -126,53 +124,13 @@ pub async fn read_epoch_boundaries_or_default<S: ObjectStoreGetExt>(
 ///
 /// Fails if the magic byte or the trailing SHA3-256 checksum does not match.
 pub fn read_epoch_boundaries_from_bytes(vec: Vec<u8>) -> Result<EpochBoundaries> {
-    let file_size = vec.len();
-    let mut reader = Cursor::new(vec);
-
-    // Reads from the beginning of the file and verifies the magic byte.
-    reader.rewind()?;
-    let magic = reader.read_u32::<BigEndian>()?;
-    if magic != EPOCH_BOUNDARIES_FILE_MAGIC {
-        return Err(IngestionError::HistoryRead(format!(
-            "unexpected magic byte in epoch boundaries: {magic}",
-        )));
-    }
-
-    // Reads the SHA3 checksum stored at the end of the file.
-    reader.seek(SeekFrom::End(-(SHA3_BYTES as i64)))?;
-    let mut sha3_digest = [0u8; SHA3_BYTES];
-    reader.read_exact(&mut sha3_digest)?;
-
-    // Reads the content and verifies it against the stored checksum.
-    reader.rewind()?;
-    let mut content_buf = vec![0u8; file_size - SHA3_BYTES];
-    reader.read_exact(&mut content_buf)?;
-    let mut hasher = Sha3_256::default();
-    hasher.update(&content_buf);
-    let computed_digest = hasher.finalize().digest;
-    if computed_digest != sha3_digest {
-        return Err(IngestionError::HistoryRead(format!(
-            "epoch boundaries corrupted, computed checksum: {computed_digest:?}, stored checksum: {sha3_digest:?}"
-        )));
-    }
-    reader.rewind()?;
-    reader.seek(SeekFrom::Start(MAGIC_BYTES as u64))?;
-    Ok(Blob::read(&mut reader)?.decode()?)
+    read_magic_blob(vec, EPOCH_BOUNDARIES_FILE_MAGIC, EPOCH_BOUNDARIES_FILENAME)
 }
 
 /// Encodes the epoch boundaries with its magic byte and a trailing SHA3-256
 /// checksum.
 pub fn finalize_epoch_boundaries(boundaries: &EpochBoundaries) -> Result<Bytes> {
-    let mut buf = BufWriter::new(vec![]);
-    buf.write_u32::<BigEndian>(EPOCH_BOUNDARIES_FILE_MAGIC)?;
-    let blob = Blob::encode(boundaries, BlobEncoding::Bcs)?;
-    blob.write(&mut buf)?;
-    buf.flush()?;
-    let mut hasher = Sha3_256::default();
-    hasher.update(buf.get_ref());
-    let computed_digest = hasher.finalize().digest;
-    buf.write_all(&computed_digest)?;
-    Ok(Bytes::from(buf.into_inner().map_err(|e| e.into_error())?))
+    finalize_magic_blob(boundaries, EPOCH_BOUNDARIES_FILE_MAGIC)
 }
 
 /// Writes the epoch boundaries to the store.
@@ -192,6 +150,7 @@ pub async fn write_epoch_boundaries<S: ObjectStorePutExt>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{IngestionError, history::MAGIC_BYTES};
 
     fn sample() -> EpochBoundaries {
         [(0, 5), (1, 100), (2, 1000)].into_iter().collect()

--- a/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
+++ b/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
@@ -3,7 +3,7 @@
 
 //! Maintain the sequence number of the last checkpoint of each epoch.
 
-use std::{collections::BTreeMap, ops::RangeBounds};
+use std::{collections::BTreeMap, ops::RangeBounds, time::Duration};
 
 use bytes::Bytes;
 use iota_storage::object_store::{
@@ -22,6 +22,8 @@ use crate::{
         read_magic_blob,
     },
 };
+
+const GET_TIMEOUT_SECS: u64 = 5;
 
 /// Stores the epoch boundaries.
 ///
@@ -113,7 +115,12 @@ pub async fn read_epoch_boundaries_or_default<S: ObjectStoreGetExt>(
     if !exists(&remote_store, &EpochBoundaries::file_path()).await {
         return Ok(Default::default());
     }
-    let bytes = get(&remote_store, &EpochBoundaries::file_path()).await?;
+    let bytes = tokio::time::timeout(
+        Duration::from_secs(GET_TIMEOUT_SECS),
+        get(&remote_store, &EpochBoundaries::file_path()),
+    )
+    .await
+    .map_err(|e| IngestionError::EpochBoundary(e.to_string()))??;
     read_epoch_boundaries_from_bytes(bytes.to_vec())
 }
 

--- a/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
+++ b/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Maintain the sequence number of the last checkpoint of each epoch.
+
+use std::{collections::BTreeMap, ops::RangeBounds};
+
+use bytes::Bytes;
+use fastcrypto::hash::{HashFunction, Sha3_256};
+use iota_storage::{
+    SHA3_BYTES,
+    blob::{Blob, BlobEncoding},
+    object_store::{
+        ObjectStoreGetExt, ObjectStorePutExt,
+        util::{exists, get, put},
+    },
+};
+use iota_types::{committee::EpochId, messages_checkpoint::CheckpointSequenceNumber};
+use object_store::path::Path;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    IngestionError,
+    errors::IngestionResult as Result,
+    history::{EPOCH_BOUNDARIES_FILE_MAGIC, EPOCH_BOUNDARIES_FILENAME, MAGIC_BYTES},
+};
+
+/// Stores the epoch boundaries.
+///
+/// The representation stored is a map between the epoch and the sequence number
+/// of the respective last checkpoint.
+///
+/// # Examples
+///
+/// ```
+/// # use iota_data_ingestion_core::history::epoch_boundaries::EpochBoundaries;
+/// let boundaries: EpochBoundaries = [(0, 5), (1, 100), (2, 1000)].into_iter().collect();
+/// assert_eq!(boundaries.get(1), Some(100));
+/// // The last checkpoints of a range of epochs, in epoch order.
+/// assert_eq!(
+///     boundaries.range(..2).collect::<Vec<_>>(),
+///     vec![(0, 5), (1, 100)]
+/// );
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq)]
+pub struct EpochBoundaries(BTreeMap<EpochId, CheckpointSequenceNumber>);
+
+impl FromIterator<(EpochId, CheckpointSequenceNumber)> for EpochBoundaries {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (EpochId, CheckpointSequenceNumber)>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl EpochBoundaries {
+    /// Returns the boundary of the given epoch.
+    pub fn get(&self, epoch: EpochId) -> Option<CheckpointSequenceNumber> {
+        self.0.get(&epoch).copied()
+    }
+
+    /// Returns the recorded `(epoch, last checkpoint)` pairs for the epochs in
+    /// `range`, in epoch order.
+    pub fn range(
+        &self,
+        range: impl RangeBounds<EpochId>,
+    ) -> impl Iterator<Item = (EpochId, CheckpointSequenceNumber)> + '_ {
+        self.0
+            .range(range)
+            .map(|(&epoch, &boundary)| (epoch, boundary))
+    }
+
+    /// Returns whether the given epoch has a recorded boundary.
+    pub fn contains(&self, epoch: EpochId) -> bool {
+        self.0.contains_key(&epoch)
+    }
+
+    /// Inserts a new epoch boundary, keeping the recorded epochs contiguous.
+    /// Any existing boundary for the same epoch is overwritten.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the previous epoch has not been already recorded.
+    pub fn insert_next(
+        &mut self,
+        epoch: EpochId,
+        boundary: CheckpointSequenceNumber,
+    ) -> Result<()> {
+        if epoch > 0 && !self.contains(epoch - 1) {
+            return Err(IngestionError::EpochBoundary(format!(
+                "epoch {epoch} just ended but its predecessor is not recorded"
+            )));
+        }
+        self.0.insert(epoch, boundary);
+        Ok(())
+    }
+
+    /// The relative path of the file with the serialized boundaries.
+    pub fn file_path() -> Path {
+        Path::from(EPOCH_BOUNDARIES_FILENAME)
+    }
+}
+
+/// Reads the epoch boundaries from the store.
+///
+/// If the remote file is not found, this returns an empty collection.
+///
+/// # Errors
+///
+/// Fails if the file fails to decode.
+pub async fn read_epoch_boundaries_or_default<S: ObjectStoreGetExt>(
+    remote_store: S,
+) -> Result<EpochBoundaries> {
+    if !exists(&remote_store, &EpochBoundaries::file_path()).await {
+        return Ok(Default::default());
+    }
+    let bytes = get(&remote_store, &EpochBoundaries::file_path()).await?;
+    read_epoch_boundaries_from_bytes(bytes.to_vec())
+}
+
+/// Decodes epoch boundaries from the given byte vector and verifies their
+/// integrity.
+///
+/// # Errors
+///
+/// Fails if the magic byte or the trailing SHA3-256 checksum does not match.
+pub fn read_epoch_boundaries_from_bytes(vec: Vec<u8>) -> Result<EpochBoundaries> {
+    let file_size = vec.len();
+    let mut reader = Cursor::new(vec);
+
+    // Reads from the beginning of the file and verifies the magic byte.
+    reader.rewind()?;
+    let magic = reader.read_u32::<BigEndian>()?;
+    if magic != EPOCH_BOUNDARIES_FILE_MAGIC {
+        return Err(IngestionError::HistoryRead(format!(
+            "unexpected magic byte in epoch boundaries: {magic}",
+        )));
+    }
+
+    // Reads the SHA3 checksum stored at the end of the file.
+    reader.seek(SeekFrom::End(-(SHA3_BYTES as i64)))?;
+    let mut sha3_digest = [0u8; SHA3_BYTES];
+    reader.read_exact(&mut sha3_digest)?;
+
+    // Reads the content and verifies it against the stored checksum.
+    reader.rewind()?;
+    let mut content_buf = vec![0u8; file_size - SHA3_BYTES];
+    reader.read_exact(&mut content_buf)?;
+    let mut hasher = Sha3_256::default();
+    hasher.update(&content_buf);
+    let computed_digest = hasher.finalize().digest;
+    if computed_digest != sha3_digest {
+        return Err(IngestionError::HistoryRead(format!(
+            "epoch boundaries corrupted, computed checksum: {computed_digest:?}, stored checksum: {sha3_digest:?}"
+        )));
+    }
+    reader.rewind()?;
+    reader.seek(SeekFrom::Start(MAGIC_BYTES as u64))?;
+    Ok(Blob::read(&mut reader)?.decode()?)
+}
+
+/// Encodes the epoch boundaries with its magic byte and a trailing SHA3-256
+/// checksum.
+pub fn finalize_epoch_boundaries(boundaries: &EpochBoundaries) -> Result<Bytes> {
+    let mut buf = BufWriter::new(vec![]);
+    buf.write_u32::<BigEndian>(EPOCH_BOUNDARIES_FILE_MAGIC)?;
+    let blob = Blob::encode(boundaries, BlobEncoding::Bcs)?;
+    blob.write(&mut buf)?;
+    buf.flush()?;
+    let mut hasher = Sha3_256::default();
+    hasher.update(buf.get_ref());
+    let computed_digest = hasher.finalize().digest;
+    buf.write_all(&computed_digest)?;
+    Ok(Bytes::from(buf.into_inner().map_err(|e| e.into_error())?))
+}
+
+/// Writes the epoch boundaries to the store.
+///
+/// # Errors
+///
+/// Fails if encoding or the upload fails.
+pub async fn write_epoch_boundaries<S: ObjectStorePutExt>(
+    boundaries: &EpochBoundaries,
+    remote_store: S,
+) -> Result<()> {
+    let bytes = finalize_epoch_boundaries(boundaries)?;
+    put(&remote_store, &EpochBoundaries::file_path(), bytes).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> EpochBoundaries {
+        [(0, 5), (1, 100), (2, 1000)].into_iter().collect()
+    }
+
+    #[test]
+    fn insert_next_enforces_contiguity() {
+        let mut boundaries = EpochBoundaries::default();
+        // The first recorded epoch must be 0.
+        assert!(matches!(
+            boundaries.insert_next(1, 50),
+            Err(IngestionError::EpochBoundary(_))
+        ));
+        boundaries.insert_next(0, 5).unwrap();
+        boundaries.insert_next(1, 100).unwrap();
+        // A gap is rejected.
+        assert!(boundaries.insert_next(3, 200).is_err());
+    }
+
+    #[test]
+    fn write_read() {
+        for boundaries in [EpochBoundaries::default(), sample()] {
+            let bytes = finalize_epoch_boundaries(&boundaries).unwrap();
+            assert_eq!(
+                read_epoch_boundaries_from_bytes(bytes.to_vec()).unwrap(),
+                boundaries
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_magic() {
+        let mut bytes = finalize_epoch_boundaries(&sample()).unwrap().to_vec();
+        bytes[0] ^= 0xFF;
+        assert!(matches!(
+            read_epoch_boundaries_from_bytes(bytes),
+            Err(IngestionError::HistoryRead(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_corrupted_content() {
+        let mut bytes = finalize_epoch_boundaries(&sample()).unwrap().to_vec();
+        // Flip a byte in the encoded body, past the 4-byte magic.
+        bytes[MAGIC_BYTES + 1] ^= 0xFF;
+        assert!(matches!(
+            read_epoch_boundaries_from_bytes(bytes),
+            Err(IngestionError::HistoryRead(_))
+        ));
+    }
+}

--- a/crates/iota-data-ingestion-core/src/history/manifest.rs
+++ b/crates/iota-data-ingestion-core/src/history/manifest.rs
@@ -13,21 +13,13 @@
 //! │      sha3 <32 bytes>         │
 //! └──────────────────────────────┘
 
-use std::{
-    io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write},
-    num::NonZeroUsize,
-    ops::Range,
-};
+use std::{num::NonZeroUsize, ops::Range};
 
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use bytes::Bytes;
-use fastcrypto::hash::{HashFunction, Sha3_256};
 use iota_config::{
     node::ArchiveReaderConfig as HistoricalReaderConfig, object_storage_config::ObjectStoreConfig,
 };
 use iota_storage::{
-    SHA3_BYTES,
-    blob::{Blob, BlobEncoding},
     compute_sha3_checksum, compute_sha3_checksum_for_bytes,
     object_store::{
         ObjectStoreGetExt, ObjectStorePutExt,
@@ -39,11 +31,10 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::{
-    IngestionError,
     errors::IngestionResult as Result,
     history::{
-        CHECKPOINT_FILE_SUFFIX, MAGIC_BYTES, MANIFEST_FILE_MAGIC, MANIFEST_FILENAME,
-        reader::HistoricalReader,
+        CHECKPOINT_FILE_SUFFIX, MANIFEST_FILE_MAGIC, MANIFEST_FILENAME, finalize_magic_blob,
+        read_magic_blob, reader::HistoricalReader,
     },
 };
 
@@ -171,55 +162,12 @@ pub async fn read_manifest<S: ObjectStoreGetExt>(remote_store: S) -> Result<Mani
 /// Reads the manifest file from the given byte vector and verifies the
 /// integrity of the file.
 pub fn read_manifest_from_bytes(vec: Vec<u8>) -> Result<Manifest> {
-    let manifest_file_size = vec.len();
-    let mut manifest_reader = Cursor::new(vec);
-
-    // Reads from the beginning of the file and verifies the magic byte
-    // is MANIFEST_FILE_MAGIC
-    manifest_reader.rewind()?;
-    let magic = manifest_reader.read_u32::<BigEndian>()?;
-    if magic != MANIFEST_FILE_MAGIC {
-        return Err(IngestionError::HistoryRead(format!(
-            "unexpected magic byte in manifest: {magic}",
-        )));
-    }
-
-    // Reads from the end of the file and gets the SHA3 checksum
-    // of the content.
-    manifest_reader.seek(SeekFrom::End(-(SHA3_BYTES as i64)))?;
-    let mut sha3_digest = [0u8; SHA3_BYTES];
-    manifest_reader.read_exact(&mut sha3_digest)?;
-
-    // Reads the content of the file and verifies the SHA3 checksum
-    // of the content matches the stored checksum.
-    manifest_reader.rewind()?;
-    let mut content_buf = vec![0u8; manifest_file_size - SHA3_BYTES];
-    manifest_reader.read_exact(&mut content_buf)?;
-    let mut hasher = Sha3_256::default();
-    hasher.update(&content_buf);
-    let computed_digest = hasher.finalize().digest;
-    if computed_digest != sha3_digest {
-        return Err(IngestionError::HistoryRead(format!(
-            "manifest corrupted, computed checksum: {computed_digest:?}, stored checksum: {sha3_digest:?}"
-        )));
-    }
-    manifest_reader.rewind()?;
-    manifest_reader.seek(SeekFrom::Start(MAGIC_BYTES as u64))?;
-    Ok(Blob::read(&mut manifest_reader)?.decode()?)
+    read_magic_blob(vec, MANIFEST_FILE_MAGIC, MANIFEST_FILENAME)
 }
 
 /// Computes the SHA3 checksum of the Manifest and writes it to a byte vector.
 pub fn finalize_manifest(manifest: Manifest) -> Result<Bytes> {
-    let mut buf = BufWriter::new(vec![]);
-    buf.write_u32::<BigEndian>(MANIFEST_FILE_MAGIC)?;
-    let blob = Blob::encode(&manifest, BlobEncoding::Bcs)?;
-    blob.write(&mut buf)?;
-    buf.flush()?;
-    let mut hasher = Sha3_256::default();
-    hasher.update(buf.get_ref());
-    let computed_digest = hasher.finalize().digest;
-    buf.write_all(&computed_digest)?;
-    Ok(Bytes::from(buf.into_inner().map_err(|e| e.into_error())?))
+    finalize_magic_blob(&manifest, MANIFEST_FILE_MAGIC)
 }
 
 /// Writes the Manifest to the remote store.

--- a/crates/iota-data-ingestion-core/src/history/mod.rs
+++ b/crates/iota-data-ingestion-core/src/history/mod.rs
@@ -12,11 +12,16 @@
 //! file. MANIFEST is the index and source of truth for all files present in the
 //! ingestion source history.
 //!
+//! EPOCH_BOUNDARIES holds the map between the epochs and the sequence number of
+//! the respective last checkpoint. This allows reading directly the last
+//! checkpoints from the store, which is useful for verification purposes.
+//!
 //! Ingestion Source History Directory Layout
 //! ```text
 //!  - ingestion/
 //!     - historical/
 //!          - MANIFEST
+//!          - EPOCH_BOUNDARIES
 //!          - 0.chk
 //!          - 1000.chk
 //!          - 3000.chk
@@ -44,16 +49,17 @@
 //! │ len <uvarint> │ encoding <1 byte> │ data <bytes> │
 //! └───────────────┴───────────────────┴──────────────┘
 //!
-//! MANIFEST File Disk Format
+//! MANIFEST and EPOCH_BOUNDARIES File Disk Format
 //! ┌──────────────────────────────┐
 //! │        magic<4 byte>         │
 //! ├──────────────────────────────┤
-//! │   serialized manifest        │
+//! │   serialized contents        │
 //! ├──────────────────────────────┤
 //! │      sha3 <32 bytes>         │
 //! └──────────────────────────────┘
 //! ```
 
+pub mod epoch_boundaries;
 pub mod manifest;
 pub mod reader;
 
@@ -62,3 +68,5 @@ pub const CHECKPOINT_FILE_SUFFIX: &str = "chk";
 pub const MAGIC_BYTES: usize = 4;
 pub const MANIFEST_FILE_MAGIC: u32 = 0x0000FACE;
 pub const MANIFEST_FILENAME: &str = "MANIFEST";
+pub const EPOCH_BOUNDARIES_FILE_MAGIC: u32 = 0x0000E90C;
+pub const EPOCH_BOUNDARIES_FILENAME: &str = "EPOCH_BOUNDARIES";

--- a/crates/iota-data-ingestion-core/src/history/mod.rs
+++ b/crates/iota-data-ingestion-core/src/history/mod.rs
@@ -59,6 +59,19 @@
 //! └──────────────────────────────┘
 //! ```
 
+use std::io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write};
+
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use bytes::Bytes;
+use fastcrypto::hash::{HashFunction, Sha3_256};
+use iota_storage::{
+    SHA3_BYTES,
+    blob::{Blob, BlobEncoding},
+};
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::{IngestionError, errors::IngestionResult as Result};
+
 pub mod epoch_boundaries;
 pub mod manifest;
 pub mod reader;
@@ -70,3 +83,67 @@ pub const MANIFEST_FILE_MAGIC: u32 = 0x0000FACE;
 pub const MANIFEST_FILENAME: &str = "MANIFEST";
 pub const EPOCH_BOUNDARIES_FILE_MAGIC: u32 = 0x0000E90C;
 pub const EPOCH_BOUNDARIES_FILENAME: &str = "EPOCH_BOUNDARIES";
+
+/// Encodes `value` as a BCS [`Blob`] framed with a 4-byte `magic` prefix and a
+/// trailing SHA3-256 checksum computed over the magic and the blob.
+///
+/// This is the on-disk format shared by the MANIFEST and EPOCH_BOUNDARIES
+/// files.
+pub(crate) fn finalize_magic_blob<T: Serialize>(value: &T, magic: u32) -> Result<Bytes> {
+    let mut buf = BufWriter::new(vec![]);
+    buf.write_u32::<BigEndian>(magic)?;
+    Blob::encode(value, BlobEncoding::Bcs)?.write(&mut buf)?;
+    buf.flush()?;
+    let mut hasher = Sha3_256::default();
+    hasher.update(buf.get_ref());
+    let computed_digest = hasher.finalize().digest;
+    buf.write_all(&computed_digest)?;
+    Ok(Bytes::from(buf.into_inner().map_err(|e| e.into_error())?))
+}
+
+/// Decodes a value written by [`finalize_magic_blob`] and verifies its
+/// integrity.
+///
+/// `filename` names the file in error messages (e.g. `"manifest"`).
+///
+/// # Errors
+///
+/// Fails if the `magic` prefix or the trailing SHA3-256 checksum does not
+/// match.
+pub(crate) fn read_magic_blob<T: DeserializeOwned>(
+    vec: Vec<u8>,
+    magic: u32,
+    filename: &str,
+) -> Result<T> {
+    let file_size = vec.len();
+    let mut reader = Cursor::new(vec);
+
+    // Reads from the beginning of the file and verifies the magic byte.
+    let found = reader.read_u32::<BigEndian>()?;
+    if found != magic {
+        return Err(IngestionError::HistoryRead(format!(
+            "unexpected magic byte in {filename}: {found}",
+        )));
+    }
+
+    // Reads the SHA3 checksum stored at the end of the file.
+    reader.seek(SeekFrom::End(-(SHA3_BYTES as i64)))?;
+    let mut sha3_digest = [0u8; SHA3_BYTES];
+    reader.read_exact(&mut sha3_digest)?;
+
+    // Reads the content and verifies it against the stored checksum.
+    reader.rewind()?;
+    let mut content_buf = vec![0u8; file_size - SHA3_BYTES];
+    reader.read_exact(&mut content_buf)?;
+    let mut hasher = Sha3_256::default();
+    hasher.update(&content_buf);
+    let computed_digest = hasher.finalize().digest;
+    if computed_digest != sha3_digest {
+        return Err(IngestionError::HistoryRead(format!(
+            "{filename} corrupted, computed checksum: {computed_digest:?}, stored checksum: {sha3_digest:?}"
+        )));
+    }
+
+    reader.seek(SeekFrom::Start(MAGIC_BYTES as u64))?;
+    Ok(Blob::read(&mut reader)?.decode()?)
+}

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -26,6 +26,7 @@ use crate::{
     errors::IngestionResult as Result,
     history::{
         CHECKPOINT_FILE_MAGIC,
+        epoch_boundaries::{EpochBoundaries, read_epoch_boundaries_or_default},
         manifest::{FileMetadata, Manifest, read_manifest},
     },
 };
@@ -224,6 +225,18 @@ impl HistoricalReader {
 
     pub fn remote_store_identifier(&self) -> String {
         self.remote_object_store.to_string()
+    }
+
+    /// Returns the last checkpoint of each epoch, indexed by epoch.
+    ///
+    /// Read from the epoch boundaries file maintained alongside the manifest.
+    /// Callers slice the boundaries by epoch range as needed.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the epoch boundaries file cannot be read.
+    pub async fn epoch_boundaries(&self) -> Result<EpochBoundaries> {
+        read_epoch_boundaries_or_default(self.remote_object_store.clone()).await
     }
 
     /// Syncs the Manifest from remote store.


### PR DESCRIPTION
# Description of change

This patch introduces a new file `EPOCH_BOUNDARIES` in the historical checkpoint store.

The file maintains a map between epochs and the sequence number of the respective last checkpoint sequence number. For the underlying context see https://github.com/iotaledger/iota/issues/11694.

Introducing a new file was preferred to integrating this information into the existing `MANIFEST`  primarily to ease the initialization and make traversal of the boundaries more efficient. Conceptually this is warranted, as epoch boundaries is information that lies on a higher level than checkpoint batches.

## Links to any relevant issues

Fixes #11695 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

