### PR TITLE
feat(data-ingestion): write epoch boundaries with historical worker

### DIFF
--- a/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
+++ b/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
@@ -7,11 +7,11 @@ use std::{collections::BTreeMap, ops::RangeBounds, time::Duration};
 
 use bytes::Bytes;
 use iota_storage::object_store::{
-    ObjectStoreGetExt, ObjectStorePutExt,
-    util::{exists, get, put},
+    ObjectStoreGetExt,
+    util::{exists, get},
 };
 use iota_types::{committee::EpochId, messages_checkpoint::CheckpointSequenceNumber};
-use object_store::path::Path;
+use object_store::{ObjectStore, PutMode, path::Path};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -140,17 +140,24 @@ pub fn finalize_epoch_boundaries(boundaries: &EpochBoundaries) -> Result<Bytes> 
     finalize_magic_blob(boundaries, EPOCH_BOUNDARIES_FILE_MAGIC)
 }
 
-/// Writes the epoch boundaries to the store.
+/// Writes the epoch boundaries to the store atomically.
 ///
 /// # Errors
 ///
-/// Fails if encoding or the upload fails.
-pub async fn write_epoch_boundaries<S: ObjectStorePutExt>(
+/// Fails if the encoding fails, if the remote file already exists or
+/// if the uploading operation fails for other reasons.
+pub async fn write_epoch_boundaries<S: ObjectStore>(
     boundaries: &EpochBoundaries,
     remote_store: S,
 ) -> Result<()> {
     let bytes = finalize_epoch_boundaries(boundaries)?;
-    put(&remote_store, &EpochBoundaries::file_path(), bytes).await?;
+    remote_store
+        .put_opts(
+            &EpochBoundaries::file_path(),
+            bytes.into(),
+            PutMode::Create.into(),
+        )
+        .await?;
     Ok(())
 }
 

--- a/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
+++ b/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
@@ -142,21 +142,20 @@ pub fn finalize_epoch_boundaries(boundaries: &EpochBoundaries) -> Result<Bytes> 
 
 /// Writes the epoch boundaries to the store atomically.
 ///
+///
+///
 /// # Errors
 ///
-/// Fails if the encoding fails, if the remote file already exists or
-/// if the uploading operation fails for other reasons.
+/// Fails if the encoding fails, if the [`PutMode`] invariants are not upheld,
+/// or for any other reason the upload might fail.
 pub async fn write_epoch_boundaries<S: ObjectStore>(
     boundaries: &EpochBoundaries,
     remote_store: S,
+    put_mode: PutMode,
 ) -> Result<()> {
     let bytes = finalize_epoch_boundaries(boundaries)?;
     remote_store
-        .put_opts(
-            &EpochBoundaries::file_path(),
-            bytes.into(),
-            PutMode::Create.into(),
-        )
+        .put_opts(&EpochBoundaries::file_path(), bytes.into(), put_mode.into())
         .await?;
     Ok(())
 }

--- a/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
+++ b/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
@@ -6,10 +6,7 @@
 use std::{collections::BTreeMap, ops::RangeBounds, time::Duration};
 
 use bytes::Bytes;
-use iota_storage::object_store::{
-    ObjectStoreGetExt,
-    util::{exists, get},
-};
+use iota_storage::object_store::{ObjectStoreGetExt, util::get};
 use iota_types::{committee::EpochId, messages_checkpoint::CheckpointSequenceNumber};
 use object_store::{ObjectStore, PutMode, path::Path};
 use serde::{Deserialize, Serialize};
@@ -104,17 +101,12 @@ impl EpochBoundaries {
 
 /// Reads the epoch boundaries from the store.
 ///
-/// If the remote file is not found, this returns an empty collection.
-///
 /// # Errors
 ///
-/// Fails if the file fails to decode.
-pub async fn read_epoch_boundaries_or_default<S: ObjectStoreGetExt>(
+/// Fails if the file cannot be fetched, of if it fails to decode.
+pub async fn read_epoch_boundaries<S: ObjectStoreGetExt>(
     remote_store: S,
 ) -> Result<EpochBoundaries> {
-    if !exists(&remote_store, &EpochBoundaries::file_path()).await {
-        return Ok(Default::default());
-    }
     let bytes = tokio::time::timeout(
         Duration::from_secs(GET_TIMEOUT_SECS),
         get(&remote_store, &EpochBoundaries::file_path()),

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -26,7 +26,7 @@ use crate::{
     errors::IngestionResult as Result,
     history::{
         CHECKPOINT_FILE_MAGIC,
-        epoch_boundaries::{EpochBoundaries, read_epoch_boundaries_or_default},
+        epoch_boundaries::{EpochBoundaries, read_epoch_boundaries},
         manifest::{FileMetadata, Manifest, read_manifest},
     },
 };
@@ -234,9 +234,10 @@ impl HistoricalReader {
     ///
     /// # Errors
     ///
-    /// Fails if the epoch boundaries file cannot be read.
+    /// Fails if the epoch boundaries file cannot be read or if it fails to
+    /// decode.
     pub async fn epoch_boundaries(&self) -> Result<EpochBoundaries> {
-        read_epoch_boundaries_or_default(self.remote_object_store.clone()).await
+        read_epoch_boundaries(self.remote_object_store.clone()).await
     }
 
     /// Syncs the Manifest from remote store.

--- a/crates/iota-data-ingestion/src/workers/historical.rs
+++ b/crates/iota-data-ingestion/src/workers/historical.rs
@@ -24,7 +24,6 @@ use iota_storage::{
     FileCompression, StorageFormat,
     blob::{Blob, BlobEncoding},
     compress,
-    object_store::util::exists,
 };
 use iota_types::{
     committee::EpochId, full_checkpoint_content::CheckpointData,
@@ -115,10 +114,8 @@ impl HistoricalReducer {
     /// Initializes the epoch boundaries from the provided seed if not already
     /// initialized.
     async fn seed_epoch_boundaries(&self, epoch_boundaries: EpochBoundaries) -> anyhow::Result<()> {
-        if !exists(&self.remote_store, &EpochBoundaries::file_path()).await {
-            write_epoch_boundaries(&epoch_boundaries, self.remote_store.clone()).await?;
-            tracing::info!("Initialized epoch boundaries");
-        }
+        write_epoch_boundaries(&epoch_boundaries, self.remote_store.clone()).await?;
+        tracing::info!("Initialized epoch boundaries");
         Ok(())
     }
 

--- a/crates/iota-data-ingestion/src/workers/historical.rs
+++ b/crates/iota-data-ingestion/src/workers/historical.rs
@@ -12,6 +12,9 @@ use iota_data_ingestion_core::{
     Reducer,
     history::{
         CHECKPOINT_FILE_MAGIC, MAGIC_BYTES,
+        epoch_boundaries::{
+            EpochBoundaries, read_epoch_boundaries_or_default, write_epoch_boundaries,
+        },
         manifest::{
             Manifest, create_file_metadata_from_bytes, finalize_manifest, read_manifest_from_bytes,
         },
@@ -21,9 +24,11 @@ use iota_storage::{
     FileCompression, StorageFormat,
     blob::{Blob, BlobEncoding},
     compress,
+    object_store::util::exists,
 };
 use iota_types::{
-    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
+    committee::EpochId, full_checkpoint_content::CheckpointData,
+    messages_checkpoint::CheckpointSequenceNumber,
 };
 use object_store::{DynObjectStore, Error as ObjectStoreError, ObjectStore, ObjectStoreExt};
 use serde::{Deserialize, Serialize};
@@ -35,6 +40,10 @@ use crate::RelayWorker;
 pub struct HistoricalWriterConfig {
     pub object_store_config: ObjectStoreConfig,
     pub commit_duration_seconds: u64,
+    /// Optional seed for the epoch boundaries. When set, it initializes the
+    /// epoch boundaries if not already initialized.
+    #[serde(default)]
+    pub epoch_boundaries: Option<EpochBoundaries>,
 }
 
 pub struct HistoricalReducer {
@@ -46,10 +55,16 @@ impl HistoricalReducer {
     pub async fn new(config: HistoricalWriterConfig) -> anyhow::Result<Self> {
         let remote_store = config.object_store_config.make()?;
 
-        Ok(Self {
+        let reducer = Self {
             remote_store,
             commit_duration_ms: config.commit_duration_seconds * 1000,
-        })
+        };
+
+        if let Some(epoch_boundaries) = config.epoch_boundaries {
+            reducer.seed_epoch_boundaries(epoch_boundaries).await?;
+        }
+
+        Ok(reducer)
     }
 
     async fn upload(
@@ -96,6 +111,34 @@ impl HistoricalReducer {
             Err(err) => Err(err)?,
         })
     }
+
+    /// Initializes the epoch boundaries from the provided seed if not already
+    /// initialized.
+    async fn seed_epoch_boundaries(&self, epoch_boundaries: EpochBoundaries) -> anyhow::Result<()> {
+        if !exists(&self.remote_store, &EpochBoundaries::file_path()).await {
+            write_epoch_boundaries(&epoch_boundaries, self.remote_store.clone()).await?;
+            tracing::info!("Initialized epoch boundaries");
+        }
+        Ok(())
+    }
+
+    /// Adds a new entry in the epoch boundaries maintained in the remote store.
+    ///
+    /// # Errors
+    ///
+    /// Fails if there is a gap between the epochs already recorded and the
+    /// current one.
+    async fn record_epoch_boundary(
+        &self,
+        epoch_id: EpochId,
+        checkpoint_sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<()> {
+        let mut epoch_boundaries =
+            read_epoch_boundaries_or_default(self.remote_store.clone()).await?;
+        epoch_boundaries.insert_next(epoch_id, checkpoint_sequence_number)?;
+        write_epoch_boundaries(&epoch_boundaries, self.remote_store.clone()).await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -111,9 +154,17 @@ impl Reducer<RelayWorker> for HistoricalReducer {
         for checkpoint in batch {
             let data = Blob::encode(&checkpoint, BlobEncoding::Bcs)?;
             data.write(&mut buffer)?;
+            if checkpoint.checkpoint_summary.is_last_checkpoint_of_epoch() {
+                self.record_epoch_boundary(
+                    checkpoint.checkpoint_summary.epoch,
+                    checkpoint.checkpoint_summary.sequence_number,
+                )
+                .await?;
+            }
         }
         self.upload(uploaded_range, self.prepare_data_to_upload(buffer)?)
-            .await
+            .await?;
+        Ok(())
     }
 
     fn should_close_batch(

--- a/crates/iota-data-ingestion/src/workers/historical.rs
+++ b/crates/iota-data-ingestion/src/workers/historical.rs
@@ -13,9 +13,7 @@ use iota_data_ingestion_core::{
     Reducer,
     history::{
         CHECKPOINT_FILE_MAGIC, MAGIC_BYTES,
-        epoch_boundaries::{
-            EpochBoundaries, read_epoch_boundaries_or_default, write_epoch_boundaries,
-        },
+        epoch_boundaries::{EpochBoundaries, read_epoch_boundaries, write_epoch_boundaries},
         manifest::{
             Manifest, create_file_metadata_from_bytes, finalize_manifest, read_manifest_from_bytes,
         },
@@ -141,8 +139,9 @@ impl HistoricalReducer {
         epoch_id: EpochId,
         checkpoint_sequence_number: CheckpointSequenceNumber,
     ) -> anyhow::Result<()> {
-        let mut epoch_boundaries =
-            read_epoch_boundaries_or_default(self.remote_store.clone()).await?;
+        let mut epoch_boundaries = read_epoch_boundaries(self.remote_store.clone())
+            .await
+            .unwrap_or_default();
         epoch_boundaries.insert_next(epoch_id, checkpoint_sequence_number)?;
 
         let backoff = ExponentialBackoffBuilder::<SystemClock>::new()

--- a/crates/iota-data-ingestion/src/workers/historical.rs
+++ b/crates/iota-data-ingestion/src/workers/historical.rs
@@ -29,7 +29,9 @@ use iota_types::{
     committee::EpochId, full_checkpoint_content::CheckpointData,
     messages_checkpoint::CheckpointSequenceNumber,
 };
-use object_store::{DynObjectStore, Error as ObjectStoreError, ObjectStore, ObjectStoreExt};
+use object_store::{
+    DynObjectStore, Error as ObjectStoreError, ObjectStore, ObjectStoreExt, PutMode,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::RelayWorker;
@@ -114,7 +116,12 @@ impl HistoricalReducer {
     /// Initializes the epoch boundaries from the provided seed if not already
     /// initialized.
     async fn seed_epoch_boundaries(&self, epoch_boundaries: EpochBoundaries) -> anyhow::Result<()> {
-        write_epoch_boundaries(&epoch_boundaries, self.remote_store.clone()).await?;
+        write_epoch_boundaries(
+            &epoch_boundaries,
+            self.remote_store.clone(),
+            PutMode::Create,
+        )
+        .await?;
         tracing::info!("Initialized epoch boundaries");
         Ok(())
     }
@@ -133,7 +140,12 @@ impl HistoricalReducer {
         let mut epoch_boundaries =
             read_epoch_boundaries_or_default(self.remote_store.clone()).await?;
         epoch_boundaries.insert_next(epoch_id, checkpoint_sequence_number)?;
-        write_epoch_boundaries(&epoch_boundaries, self.remote_store.clone()).await?;
+        write_epoch_boundaries(
+            &epoch_boundaries,
+            self.remote_store.clone(),
+            PutMode::Overwrite,
+        )
+        .await?;
         Ok(())
     }
 }

--- a/crates/iota-data-ingestion/src/workers/historical.rs
+++ b/crates/iota-data-ingestion/src/workers/historical.rs
@@ -2,9 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{io::Cursor, ops::Range, sync::Arc};
+use std::{io::Cursor, ops::Range, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use backoff::{SystemClock, exponential::ExponentialBackoffBuilder, future::retry};
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
 use iota_config::object_storage_config::ObjectStoreConfig;
@@ -33,8 +34,11 @@ use object_store::{
     DynObjectStore, Error as ObjectStoreError, ObjectStore, ObjectStoreExt, PutMode,
 };
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use crate::RelayWorker;
+
+const RECORD_EPOCH_BOUNDARY_TIMEOUT_SECS: u64 = 5;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
@@ -140,11 +144,22 @@ impl HistoricalReducer {
         let mut epoch_boundaries =
             read_epoch_boundaries_or_default(self.remote_store.clone()).await?;
         epoch_boundaries.insert_next(epoch_id, checkpoint_sequence_number)?;
-        write_epoch_boundaries(
-            &epoch_boundaries,
-            self.remote_store.clone(),
-            PutMode::Overwrite,
-        )
+
+        let backoff = ExponentialBackoffBuilder::<SystemClock>::new()
+            .with_max_interval(Duration::from_secs(RECORD_EPOCH_BOUNDARY_TIMEOUT_SECS))
+            .build();
+        retry(backoff, || async {
+            write_epoch_boundaries(
+                &epoch_boundaries,
+                self.remote_store.clone(),
+                PutMode::Overwrite,
+            )
+            .await
+            .map_err(|e| {
+                error!("failed to write epoch boundaries to the store: {:?}", &e);
+                backoff::Error::transient(e)
+            })
+        })
         .await?;
         Ok(())
     }


### PR DESCRIPTION
# Description of change

This patch follows #11719 to implement the writing logic for the new `EPOCH_BOUNDARIES` file.

To ease the initialization in existing instances, the historical worker accepts a new optional configuration option in the form of an `epoch: checkpoint_sequence_number`. If the remote `EPOCH_BOUNDARIES` file is not present it is initialized from this seed. 

Exampl

```yaml
tasks:
  - name: "local-historical-storage"
    concurrency: 1
    historical:
      object-store-config:
        ...
      commit-duration-seconds: 250
      epoch-boundaries:
        0: 1
        1: 100
        2: 2000
```

## Links to any relevant issues
Fixes #11696 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Tested locally with `localstack` configuration as described in https://github.com/iotaledger/iota/blob/develop/dev-tools/iota-data-ingestion/README.md for the following cases:

- Seeding the file on an existing instance
- Seeding the file from genesis 
- Starting from genesis without seed

