### PR TITLE
chore(dev-tools): update historical config with EPOCH_BOUNDARIES seed

### DIFF
--- a/dev-tools/iota-data-ingestion/historical/config.yaml
+++ b/dev-tools/iota-data-ingestion/historical/config.yaml
@@ -78,7 +78,7 @@ tasks:
       #
       # The seed has an effect only if the remote EPOCH_BOUNDARIES is not present.
       #
-      # The last epoch in the seed MUST match be greater than or equal to the last completed epoch on the network.
+      # The last epoch in the seed MUST be greater than or equal to the last completed epoch on the network.
       # Otherwise, when the current epoch changes the ingestion will fail to ensure that EPOCH_BOUNDARIES is contiguous
       # with respect to epochs.
       epoch-boundaries:

--- a/dev-tools/iota-data-ingestion/historical/config.yaml
+++ b/dev-tools/iota-data-ingestion/historical/config.yaml
@@ -74,3 +74,14 @@ tasks:
       # checkpoint production rate.
       #
       commit-duration-seconds: 250
+      # Set the seed to initialize EPOCH_BOUNDARIES in existing instances.
+      #
+      # The seed has an effect only if the remote EPOCH_BOUNDARIES is not present.
+      #
+      # The last epoch in the seed MUST match be greater than or equal to the last completed epoch on the network.
+      # Otherwise, when the current epoch changes the ingestion will fail to ensure that EPOCH_BOUNDARIES is contiguous
+      # with respect to epochs.
+      epoch-boundaries:
+        0: 1
+        1: 100
+        2: 20000


### PR DESCRIPTION
# Description of change

This patch updates the sample `config.yaml` file for historical workers in `dev-tools/iota-data-ingestion`.

## Links to any relevant issues

Fixes #11721

## How the change has been tested

Ran the config locally as part of #11722