### PR TITLE
refactor(agents): fold comment rules into RUST_CONVENTIONS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,79 +130,13 @@ iota/
 
 ### Conventions reference
 
-- [`RUST_CONVENTIONS.md`](RUST_CONVENTIONS.md) — full list of Rust style and safety rules (panics, error handling, naming, module layout, etc.).
+- [`RUST_CONVENTIONS.md`](RUST_CONVENTIONS.md) — full list of Rust style and safety rules (panics, error handling, naming, module layout, comment style, etc.).
 - [`REVIEW.md`](REVIEW.md) — review depth tiers, cross-cutting checks (license headers, breaking changes, dependency hygiene), and language-specific review guidance.
 
-## Comment Style
+### Comment style
 
-These rules apply to every comment you write or modify. They exist because comments authored from chat context tend to be verbose, restate the visible code, and embed conversational history that becomes stale once the PR is merged.
+When writing or modifying comments, follow the **Comments** rules in [`RUST_CONVENTIONS.md`](RUST_CONVENTIONS.md#comments). In short:
 
-### Function- and item-level doc comments (`///`, `//!`, `/** */`)
-
-Write them for the **caller**, not the implementer. The doc should answer "what do I need to know to call this correctly?" — nothing more.
-
-**Include:**
-
-- One short sentence describing what the function or type does, from the caller's point of view.
-- Invariants the caller must uphold (preconditions on arguments or state).
-- Surprising postconditions, side effects, or ordering guarantees.
-- `# Errors`, `# Panics`, `# Safety` sections (Rust) where they apply — see [`RUST_CONVENTIONS.md`](RUST_CONVENTIONS.md).
-
-**Do not include:**
-
-- A step-by-step list of what the function does internally — that's the body.
-- Rationale for design choices, rejected alternatives, or trade-offs considered.
-- References to the change history: "added for X flow", "used by Y", "as discussed", PR or issue numbers.
-- Restatements of what well-named parameters or return types already convey.
-
-### Inline comments inside a function body
-
-Default to **none**. A line of code with a good name does not need a comment explaining what it does.
-
-Add a comment **only** when:
-
-- There is a non-obvious _why_: a workaround for a known bug, a constraint imposed by code elsewhere, a deliberate departure from the obvious approach.
-- An invariant holds at that exact point that a future reader would otherwise have to re-derive.
-- The behavior at that line would surprise a careful reader.
-
-Implementation details belong **next to the implementation**, not in the function header. If a fact only matters at one specific line, comment that line — do not lift the explanation into the docstring.
-
-### Anti-patterns
-
-Never write these, even if asked to "document thoroughly":
-
-- "This function was added to handle the X case discussed with the team."
-- "We chose approach A over B because B would have required ..."
-- "TODO: revisit per the conversation on YYYY-MM-DD."
-- Multi-paragraph rationale blocks attached to a function signature.
-- Section headers (`# Implementation`, `# Notes`, `# Design`) that introduce a content dump rather than a documented contract.
-- A comment immediately before `let x = foo();` that says "Get foo and assign it to x."
-
-If rationale needs to live somewhere, it lives in the PR description, the commit message, or a design doc — never in a doc comment that future readers must scroll past every time they look up the function's contract.
-
-### Worked example
-
-Bad:
-
-```rust
-/// Computes the next epoch's committee.
-///
-/// This function was added as part of the consensus rework discussed in #1234.
-/// It first loads the validator set, then filters out validators that have been
-/// slashed, then sorts them by stake, then picks the top N. We chose to sort
-/// by stake rather than by VRF output because the team agreed that stake-based
-/// selection is more predictable for testing.
-pub fn next_committee(epoch: Epoch) -> Committee { ... }
-```
-
-Good:
-
-```rust
-/// Returns the committee that will be active in `epoch`.
-///
-/// `epoch` must be the current epoch or the immediate next one; older or
-/// further-future epochs return `Err(EpochOutOfRange)`.
-pub fn next_committee(epoch: Epoch) -> Result<Committee, EpochError> { ... }
-```
-
-If the stake-vs-VRF choice matters for a reader of the body, the comment goes inside the function at the sort step — not in the header.
+- Doc comments are for the **caller** — what they need to know to call it correctly, not how it works inside.
+- Inline comments explain a non-obvious **why**, never a **what**; default to none.
+- Never embed conversational or change history ("added for X", "as discussed", PR/issue numbers) — that belongs in the PR description or commit message, not the code.

--- a/RUST_CONVENTIONS.md
+++ b/RUST_CONVENTIONS.md
@@ -40,6 +40,83 @@ It is acceptable to use short, non-descriptive variables in some situations. For
 - Indexes in loops (`i`, `j`, `k`, `idx`, etc)
 - Single-line mapping closures
 
+### Comments
+
+These rules apply to every comment, and matter especially for comments authored from chat context, which tend to be
+verbose, restate the visible code, and embed conversational history that becomes stale once the PR is merged.
+
+#### Doc Comments Are For The Caller
+
+Function- and item-level doc comments (`///`, `//!`, `/** */`) are written for the **caller**, not the implementer. They
+should answer "what do I need to know to call this correctly?" — nothing more.
+
+Include:
+
+- One short sentence describing what the function or type does, from the caller's point of view.
+- Invariants the caller must uphold (preconditions on arguments or state).
+- Surprising postconditions, side effects, or ordering guarantees.
+- `# Errors`, `# Panics`, `# Safety` sections where they apply (see [Justify Panics](#justify-panics) and [Document Potential Panics](#document-potential-panics)).
+
+Do not include:
+
+- A step-by-step list of what the function does internally — that's the body.
+- Rationale for design choices, rejected alternatives, or trade-offs considered.
+- References to change history: "added for X flow", "used by Y", "as discussed", PR or issue numbers.
+- Restatements of what well-named parameters or return types already convey.
+
+#### Inline Comments Explain Why, Not What
+
+Default to **no** inline comments inside a function body. A line of code with a good name does not need a comment
+explaining what it does.
+
+Add an inline comment **only** when:
+
+- There is a non-obvious _why_: a workaround for a known bug, a constraint imposed by code elsewhere, or a deliberate departure from the obvious approach.
+- An invariant holds at that exact point that a future reader would otherwise have to re-derive.
+- The behavior at that line would surprise a careful reader.
+
+Implementation details belong next to the implementation, not in the function header. If a fact only matters at one
+specific line, comment that line — do not lift the explanation into the docstring.
+
+#### Comment Anti-Patterns
+
+Never write these, even when asked to "document thoroughly":
+
+- "This function was added to handle the X case discussed with the team."
+- "We chose approach A over B because B would have required ..."
+- "TODO: revisit per the conversation on YYYY-MM-DD."
+- Multi-paragraph rationale blocks attached to a function signature.
+- Section headers (`# Implementation`, `# Notes`, `# Design`) that introduce a content dump rather than a documented contract.
+- A comment immediately before `let x = foo();` that says "Get foo and assign it to x."
+
+If rationale needs to live somewhere, it lives in the PR description, the commit message, or a design doc — never in a
+doc comment that future readers must scroll past every time they look up the function's contract.
+
+The following doc comment is bad — it records change history, narrates the body, and justifies a design choice:
+
+```rust
+/// Computes the next epoch's committee.
+///
+/// This function was added as part of the consensus rework discussed in #1234.
+/// It first loads the validator set, then filters out validators that have been
+/// slashed, then sorts them by stake, then picks the top N. We chose to sort
+/// by stake rather than by VRF output because the team agreed that stake-based
+/// selection is more predictable for testing.
+pub fn next_committee(epoch: Epoch) -> Committee { ... }
+```
+
+The following is good — it states the contract the caller needs and nothing else:
+
+```rust
+/// Returns the committee that will be active in `epoch`.
+///
+/// `epoch` must be the current epoch or the immediate next one; older or
+/// further-future epochs return `Err(EpochOutOfRange)`.
+pub fn next_committee(epoch: Epoch) -> Result<Committee, EpochError> { ... }
+```
+
+If the stake-vs-VRF choice matters for a reader of the body, the comment goes inside the function at the sort step — not in the header.
+
 ### Organization
 
 #### Absolute Imports


### PR DESCRIPTION
## Description of change

Follow-up to the comment-style guidance added in this branch (#11735).

The comment-style section was ~74 lines, making it roughly a third of `AGENTS.md` — a file that is loaded into context in **full** at the start of every agent session, regardless of the task. This moves the detailed rules to where detail already lives and keeps the always-loaded file lean.

### What changed

- **`AGENTS.md`** — replaced the full `## Comment Style` section with a slim, always-loaded **`### Comment style`** anchor: three imperative musts plus a link to the full rules. The non-negotiable core is still guaranteed in context for every session.
- **`RUST_CONVENTIONS.md`** — added a `### Comments` section under *Requirements* (caller-focused doc comments, why-not-what inline comments, anti-patterns, and the bad/good worked example). Cross-linked to the existing `Justify Panics` / `Document Potential Panics` rules to avoid duplicating the `# Panics` / `# Safety` guidance.

### Why

This matches the convention `AGENTS.md` already uses — linking out to `RUST_CONVENTIONS.md` and `REVIEW.md` for depth rather than inlining everything. Detailed comment/documentation rules now sit alongside the other Rust conventions (panics, errors, naming) instead of in the always-on agent file, while the must-follow summary stays inline so it's never missed.

No content was dropped — the include/exclude lists, anti-patterns, and worked example are all preserved in `RUST_CONVENTIONS.md`.

https://claude.ai/code/session_011Cg6iYQYYnoKUeuwsEDiaL

---
_Generated by [Claude Code](https://claude.ai/code/session_011Cg6iYQYYnoKUeuwsEDiaL)_