### PR TITLE
fix: clear stale latency lockfiles to avoid silent failures

### DIFF
--- a/dev-tools/iota-private-network/experiments/network-benchmark.sh
+++ b/dev-tools/iota-private-network/experiments/network-benchmark.sh
@@ -408,6 +408,9 @@ reapply_latencies_and_fuzz_loop() {
 log "Starting fuzz manager"
 RANDOM=$SEED
 
+# Clean up any stale latency lockfiles
+rm -f /var/lock/apply_and_mark_*.lock 2>/dev/null || true
+
 # Initially set latencies
 initially_apply_latency
 

--- a/dev-tools/iota-private-network/experiments/run-all-benchmark.sh
+++ b/dev-tools/iota-private-network/experiments/run-all-benchmark.sh
@@ -144,6 +144,11 @@ kill_spammer_processes() {
     # also remove per-user and global lock files
     rm -f /tmp/spammer-*.lock 2>/dev/null || true
     rm -f /tmp/spammer.lock 2>/dev/null || true
+    if command -v sudo >/dev/null 2>&1; then
+      sudo rm -f /var/lock/apply_and_mark_*.lock 2>/dev/null || true
+    else
+      rm -f /var/lock/apply_and_mark_*.lock 2>/dev/null || true
+    fi
 }
 
 trap cleanup_and_kill SIGINT SIGTERM EXIT
@@ -307,6 +312,12 @@ log "Grafana URL: http://localhost:3000/dashboards"
 cd - >/dev/null
 
 # --- 5) Launch combined latency + fuzz watcher in background ---
+if command -v sudo >/dev/null 2>&1; then
+  sudo rm -f /var/lock/apply_and_mark_*.lock 2>/dev/null || true
+else
+  rm -f /var/lock/apply_and_mark_*.lock 2>/dev/null || true
+fi
+
 ./network-benchmark.sh \
     -n "$NUM_VALIDATORS" \
     -s "$SEED" \

--- a/dev-tools/iota-private-network/experiments/run-migration-test.py
+++ b/dev-tools/iota-private-network/experiments/run-migration-test.py
@@ -1021,6 +1021,7 @@ def cleanup() -> None:
 
     lock_dir = cfg.script_dir / "logs" / "network-benchmark-locks"
     shutil.rmtree(lock_dir, ignore_errors=True)
+    subprocess.run(["sudo", "rm", "-f", "/var/lock/apply_and_mark_*.lock"], check=False)
     shutil.rmtree(cfg.log_dir / "load-generator-keystore", ignore_errors=True)
 
     log("Cleanup complete.")
@@ -1365,6 +1366,7 @@ def phase6_apply_latency(cfg: Config) -> subprocess.Popen[str]:
 
     # Kill stale network-benchmark.sh from a previous run (may be owned by root)
     run(["sudo", "pkill", "-f", r"network-benchmark\.sh"], check=False, quiet=True)
+    run(["sudo", "rm", "-f", "/var/lock/apply_and_mark_*.lock"], check=False, quiet=True)
 
     # Avoid confusion from a stale default benchmark log; this migration run writes
     # all latency-script output into the main migration log instead.


### PR DESCRIPTION
Summary
- Clears stale `apply_and_mark_*.lock` files from `/var/lock` before executing the benchmark and during teardown/cleanup in `network-benchmark.sh`, `run-all-benchmark.sh`, and `run-migration-test.py`.
- Prevents silent latency injection failures when lockfiles left over from a previous `sudo` run are owned by `root` (preventing `exec 200>$lockfile` from succeeding due to `EACCES` under `set -euo pipefail`).

Closes #11664

Validation
- Static code review only.
- No local tests, builds, Docker, package installs, benchmarks, or repo scripts were run because this environment shares resources with other local processes.

Risk
- Low risk. The changes only affect shell/Python experiment runner scripts by adding simple `rm -f` commands for targeted lock files.
