### PR TITLE
experiments: transient `tc qdisc show` failure deletes the htb root and silently wipes all applied netem

### DIFF
--- a/dev-tools/iota-private-network/experiments/network-benchmark.sh
+++ b/dev-tools/iota-private-network/experiments/network-benchmark.sh
@@ -138,11 +138,17 @@ apply_and_mark() {
   classid="1:$((100 + mark))"
 
   # Ensure a classful root qdisc exists once per container
-  if ! nsenter -t "$pid" -n tc qdisc show dev eth0 2>/dev/null | grep -q "htb 1:"; then
-    nsenter -t "$pid" -n tc qdisc del dev eth0 root 2>/dev/null || true
-    nsenter -t "$pid" -n tc qdisc add dev eth0 root handle 1: htb default 1 2>/dev/null || \
-      log "Warning: failed to create htb root qdisc for $A"
-    nsenter -t "$pid" -n tc class add dev eth0 parent 1: classid 1:1 htb rate 1000mbit ceil 1000mbit 2>/dev/null || true
+  local show_out status=0
+  show_out=$(nsenter -t "$pid" -n tc qdisc show dev eth0 2>/dev/null) || status=$?
+  if [ $status -eq 0 ]; then
+    if ! echo "$show_out" | grep -q "htb 1:"; then
+      nsenter -t "$pid" -n tc qdisc del dev eth0 root 2>/dev/null || true
+      nsenter -t "$pid" -n tc qdisc add dev eth0 root handle 1: htb default 1 2>/dev/null || \
+        log "Warning: failed to create htb root qdisc for $A"
+      nsenter -t "$pid" -n tc class add dev eth0 parent 1: classid 1:1 htb rate 1000mbit ceil 1000mbit 2>/dev/null || true
+    fi
+  else
+    log "Warning: transient tc qdisc show failure for $A (status $status), skipping root recreation"
   fi
 
   # Mark packets A → B inside the container namespace (idempotent)

--- a/dev-tools/iota-private-network/experiments/network-fuzz.sh
+++ b/dev-tools/iota-private-network/experiments/network-fuzz.sh
@@ -242,10 +242,17 @@ apply_node_qdisc(){
   [[ -z "$pid" || "$pid" = "0" ]] && return 0
 
   # Ensure a classful root qdisc exists once per container
-  if ! sudo nsenter -t "$pid" -n tc qdisc show dev eth0 2>/dev/null | grep -q "htb 1:"; then
-    sudo nsenter -t "$pid" -n tc qdisc del dev eth0 root 2>/dev/null || true
-    sudo nsenter -t "$pid" -n tc qdisc add dev eth0 root handle 1: htb default 1 2>/dev/null || true
-    sudo nsenter -t "$pid" -n tc class add dev eth0 parent 1: classid 1:1 htb rate 1000mbit ceil 1000mbit 2>/dev/null || true
+  local show_out status=0
+  show_out=$(sudo nsenter -t "$pid" -n tc qdisc show dev eth0 2>/dev/null) || status=$?
+  if [ $status -eq 0 ]; then
+    if ! echo "$show_out" | grep -q "htb 1:"; then
+      sudo nsenter -t "$pid" -n tc qdisc del dev eth0 root 2>/dev/null || true
+      sudo nsenter -t "$pid" -n tc qdisc add dev eth0 root handle 1: htb default 1 2>/dev/null || true
+      sudo nsenter -t "$pid" -n tc class add dev eth0 parent 1: classid 1:1 htb rate 1000mbit ceil 1000mbit 2>/dev/null || true
+    fi
+  else
+    log "Warning: transient tc qdisc show failure for $v (status $status), skipping root recreation"
+    return 0
   fi
 
   # Clear existing filters so we can re-attach per-destination ones


### PR DESCRIPTION
Static review only. No local tests or builds were run due to resource-safety policy.

Resolves #11738.

This PR fixes the issue where a transient query failure (e.g. from nsenter during a container restart) on `tc qdisc show dev eth0` evaluates to true inside the `if ! ...` check, causing the script to run `tc qdisc del dev eth0 root`. This silently destroys all applied netem qdiscs on that source.

Changes:
1. Captures the exit code of `tc qdisc show dev eth0` inside `network-benchmark.sh`'s `apply_and_mark` and `network-fuzz.sh`'s `apply_node_qdisc`.
2. Skip root qdisc deletion/recreation if the query command returns a non-zero exit status (transient error).