### PR TITLE
experiments: run-all-benchmark.sh / run-all-fuzz.sh check Grafana network connection

### DIFF
--- a/dev-tools/iota-private-network/experiments/run-all-benchmark.sh
+++ b/dev-tools/iota-private-network/experiments/run-all-benchmark.sh
@@ -296,11 +296,16 @@ sleep 5
 GRAFANA_DIR="../../grafana-local"
 cd "$GRAFANA_DIR" || { log "Grafana folder not found"; exit 1; }
 
-# Check if any Grafana container is already running
+# Check if any Grafana container is already running on the correct network
+current_net=""
 if docker compose ps --services --filter "status=running" | grep -q grafana; then
-  log "Grafana already running, skipping start"
+  current_net=$(docker inspect -f '{{range $net, $val := .NetworkSettings.Networks}}{{$net}}{{end}}' "$(docker compose ps -q grafana)" 2>/dev/null || true)
+fi
+
+if [ "$current_net" = "iota-private-network_iota-network" ]; then
+  log "Grafana already running on correct network, skipping start"
 else
-  log "Starting Grafana dashboard..."
+  log "Starting/recreating Grafana dashboard on correct network..."
   docker compose up -d
 fi
 log "Grafana URL: http://localhost:3000/dashboards"

--- a/dev-tools/iota-private-network/experiments/run-all-fuzz.sh
+++ b/dev-tools/iota-private-network/experiments/run-all-fuzz.sh
@@ -354,10 +354,16 @@ sleep 5
 GRAFANA_DIR="../../grafana-local"
 cd "$GRAFANA_DIR" || { log "Grafana folder not found"; exit 1; }
 
+# Check if any Grafana container is already running on the correct network
+current_net=""
 if docker compose ps --services --filter "status=running" | grep -q grafana; then
-  log "Grafana already running, skipping start"
+  current_net=$(docker inspect -f '{{range $net, $val := .NetworkSettings.Networks}}{{$net}}{{end}}' "$(docker compose ps -q grafana)" 2>/dev/null || true)
+fi
+
+if [ "$current_net" = "iota-private-network_iota-network" ]; then
+  log "Grafana already running on correct network, skipping start"
 else
-  log "Starting Grafana dashboard..."
+  log "Starting/recreating Grafana dashboard on correct network..."
   docker compose up -d
 fi
 log "Grafana URL: http://localhost:3000/dashboards"


### PR DESCRIPTION
Static review only. No local tests or builds were run due to resource-safety policy.

Resolves #11739.

This PR fixes the issue where `run-all-benchmark.sh` and `run-all-fuzz.sh` check if the Grafana container is already running and, if so, skip running `docker compose up -d`. This skips recreating the stack when it is connected to a stale network (e.g. from `run-migration-test.py` on `migration-network`), leaving Prometheus unable to scrape the benchmark/fuzz validators on `iota-network`.

Changes:
1. Inspects the network configuration of the running `grafana` container using `docker inspect`.
2. Only skips stack startup if the container is running and connected specifically to the expected network (`iota-private-network_iota-network`).
3. Otherwise, runs `docker compose up -d` to recreate/re-attach the containers to the correct network.