### PR TITLE
[dev-tools]: update historical worker config.yaml with epoch-boundaries seed

### DIFF
--- a/dev-tools/iota-data-ingestion/historical/config.yaml
+++ b/dev-tools/iota-data-ingestion/historical/config.yaml
@@ -74,3 +74,14 @@ tasks:
       # checkpoint production rate.
       #
       commit-duration-seconds: 250
+      # Set the seed to initialize EPOCH_BOUNDARIES in existing instances.
+      #
+      # The seed has an effect only if the remote EPOCH_BOUNDARIES is not present.
+      #
+      # The last epoch in the seed MUST be greater than or equal to the last completed epoch on the network.
+      # Otherwise, when the current epoch changes the ingestion will fail to ensure that EPOCH_BOUNDARIES is contiguous
+      # with respect to epochs.
+      epoch-boundaries:
+        0: 1
+        1: 100
+        2: 20000


### PR DESCRIPTION
Static review only. No local tests or builds were run due to resource-safety policy.

Resolves #11721.

This PR updates the local developer configuration for the data ingestion historical worker (`dev-tools/iota-data-ingestion/historical/config.yaml`) to include the `epoch-boundaries` initialization seed. This prepares the dev-tools configuration for epoch boundary tracking in the historical store.