### PR TITLE
chore(indexer): Remove --epochs-to-keep CLI argument in v1.28.0

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -7,7 +7,7 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use iota_graphql_rpc_client::simple_client::SimpleClient;
 pub use iota_indexer::config::SnapshotLagConfig;
 use iota_indexer::{
-    config::PruningOptions,
+    config::RetentionConfig,
     errors::IndexerError,
     store::PgIndexerStore,
     test_utils::{IndexerTypeConfig, force_delete_database, start_test_indexer_impl},
@@ -142,10 +142,7 @@ pub async fn serve_executor(
         format!("http://{executor_server_url}"),
         IndexerTypeConfig::writer_mode(
             snapshot_config.clone(),
-            Some(PruningOptions {
-                epochs_to_keep,
-                ..Default::default()
-            }),
+            epochs_to_keep.map(RetentionConfig::new_with_default_retention_only_for_testing),
         ),
         Some(data_ingestion_path),
         cancellation_token.clone(),

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -306,10 +306,6 @@ pub enum Command {
 
 #[derive(Args, Default, Debug, Clone)]
 pub struct PruningOptions {
-    /// DEPRECATED: will be removed in v1.28.0. Use `--pruning-config-path`
-    /// pointing at a TOML retention config instead.
-    #[arg(long, env = "EPOCHS_TO_KEEP")]
-    pub epochs_to_keep: Option<u64>,
     /// Path to TOML file containing configuration for retention policies.
     #[arg(long)]
     pub pruning_config_path: Option<PathBuf>,
@@ -336,25 +332,7 @@ impl PruningOptions {
     /// Loads default retention policy and overrides from file.
     pub fn load_from_file(&self) -> IndexerResult<Option<RetentionConfig>> {
         let Some(config_path) = self.pruning_config_path.as_ref() else {
-            let Some(epochs_to_keep) = self.epochs_to_keep else {
-                return Ok(None);
-            };
-            warn!(
-                "using the deprecated --epochs-to-keep argument for pruning configuration. \
-                 This argument will be removed in v1.28.0. \
-                 Please use --pruning-config-path to specify a TOML configuration file instead."
-            );
-            return Ok(Some(RetentionConfig::new(
-                epochs_to_keep,
-                Default::default(),
-            )));
-        };
-
-        if self.epochs_to_keep.is_some() {
-            warn!(
-                "the --epochs-to-keep argument will be ignored since --pruning-config-path is also provided. \
-                 Note that --epochs-to-keep is deprecated and will be removed in v1.28.0."
-            );
+            return Ok(None);
         };
 
         let contents = std::fs::read_to_string(config_path)
@@ -556,7 +534,6 @@ mod test {
         temp_file.write_all(toml_content.as_bytes()).unwrap();
         let temp_path: PathBuf = temp_file.path().to_path_buf();
         let pruning_options = PruningOptions {
-            epochs_to_keep: None,
             pruning_config_path: Some(temp_path),
             optimistic_pruner_batch_size: None,
         };
@@ -607,7 +584,6 @@ mod test {
         temp_file.write_all(toml_content.as_bytes()).unwrap();
         let temp_path: PathBuf = temp_file.path().to_path_buf();
         let pruning_options = PruningOptions {
-            epochs_to_keep: None,
             pruning_config_path: Some(temp_path),
             optimistic_pruner_batch_size: None,
         };

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -80,15 +80,11 @@ impl IndexerTypeConfig {
 
     pub fn writer_mode(
         snapshot_config: Option<SnapshotLagConfig>,
-        pruning_options: Option<PruningOptions>,
+        retention_config: Option<RetentionConfig>,
     ) -> Self {
         Self::Writer {
             snapshot_config: snapshot_config.unwrap_or_default(),
-            retention_config: pruning_options.as_ref().and_then(|pruning_options| {
-                pruning_options
-                    .epochs_to_keep
-                    .map(RetentionConfig::new_with_default_retention_only_for_testing)
-            }),
+            retention_config,
         }
     }
 }

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -19,7 +19,7 @@ use fastcrypto::traits::Signer;
 use iota_config::local_ip_utils::{get_available_port, new_local_tcp_socket_for_testing};
 use iota_grpc_server::GrpcServerHandle;
 use iota_indexer::{
-    config::{IotaNamesOptions, JsonRpcConfig, PruningOptions, SnapshotLagConfig},
+    config::{IotaNamesOptions, JsonRpcConfig, RetentionConfig, SnapshotLagConfig},
     db::{ConnectionPoolConfig, new_connection_pool},
     errors::IndexerError,
     indexer::Indexer,
@@ -143,7 +143,7 @@ impl SimulacrumTestSetup {
 pub async fn start_test_cluster_with_read_write_indexer(
     database_name: impl Into<Option<&str>>,
     builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
-    pruning_options: Option<PruningOptions>,
+    retention_config: Option<RetentionConfig>,
 ) -> (TestCluster, PgIndexerStore, HttpClient) {
     let database_name = database_name.into();
     let mut builder = TestClusterBuilder::new().with_fullnode_enable_grpc_api(true);
@@ -161,7 +161,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
         true,
         None,
         cluster.grpc_url(),
-        IndexerTypeConfig::writer_mode(None, pruning_options),
+        IndexerTypeConfig::writer_mode(None, retention_config),
         None,
     )
     .await;

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -5,7 +5,7 @@ use std::{fs::File, path::Path, str::FromStr, sync::Arc};
 
 use hex::FromHex;
 use iota_indexer::{
-    config::PruningOptions,
+    config::RetentionConfig,
     models::transactions::StoredTransaction,
     store::{PgIndexerStore, package_resolver::IndexerStorePackageResolver},
     test_utils::{TestDatabase, db_url},
@@ -1970,10 +1970,7 @@ fn get_chain_identifier_with_pruning_enabled() {
         let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
             Some("test_get_chain_identifier_with_pruning_enabled"),
             None,
-            Some(PruningOptions {
-                epochs_to_keep: Some(1),
-                ..Default::default()
-            }),
+            Some(RetentionConfig::new_with_default_retention_only_for_testing(1)),
         )
         .await;
 

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -7,7 +7,7 @@ use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl};
 use fastcrypto::encoding::Base64;
 use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
 use iota_indexer::{
-    config::PruningOptions, errors::IndexerError, read_only_blocking, schema::objects,
+    config::RetentionConfig, errors::IndexerError, read_only_blocking, schema::objects,
     store::indexer_store::IndexerStore, types::IndexerResult,
 };
 use iota_json::{call_arg, call_args, type_args};
@@ -1000,11 +1000,7 @@ async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
     let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
         Some("test_optimistic_tables_pruning"),
         None,
-        Some(PruningOptions {
-            epochs_to_keep: Some(1),
-            pruning_config_path: None,
-            optimistic_pruner_batch_size: None,
-        }),
+        Some(RetentionConfig::new_with_default_retention_only_for_testing(1)),
     )
     .await;
     indexer_wait_for_checkpoint(store, 1).await;


### PR DESCRIPTION
Resolve Issue #11693.

This PR removes the deprecated `--epochs-to-keep` CLI argument and the matching `EPOCHS_TO_KEEP` environment variable from `PruningOptions` inside `iota-indexer`, along with all associated code and test usages.

Validation:
Static review only. No local tests or builds were run due to resource-safety policy.