### PR TITLE
chore(graphql): Remove WRAPPED_OR_DELETED ObjectStatus variant

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -507,8 +507,6 @@ type Coin implements IMoveObject & IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -683,8 +681,6 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -1533,8 +1529,6 @@ interface IObject {
 	            contents of a genesis or system package upgrade transaction.
 	            - INDEXED: The object is retrieved from the off-chain index and
 	            represents the most recent or historical state of the object.
-	            - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	            information can be loaded.
 	        
 	"""
 	status: ObjectKind!
@@ -2108,8 +2102,6 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2314,8 +2306,6 @@ type MovePackage implements IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2766,8 +2756,6 @@ type NameRegistration implements IMoveObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2952,8 +2940,6 @@ type Object implements IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -3184,11 +3170,6 @@ enum ObjectKind {
 	The object is fetched from the index.
 	"""
 	INDEXED
-	"""
-	The object is deleted or wrapped and only partial information can be
-	loaded from the indexer.
-	"""
-	WRAPPED_OR_DELETED @deprecated(reason: "will be removed with v1.26, as such objects can be considered non-existent")
 }
 
 """
@@ -4077,8 +4058,6 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -173,8 +173,6 @@ impl Coin {
     ///   contents of a genesis or system package upgrade transaction.
     /// - INDEXED: The object is retrieved from the off-chain index and
     ///   represents the most recent or historical state of the object.
-    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/iota-graphql-rpc/src/types/coin_metadata.rs
@@ -159,8 +159,6 @@ impl CoinMetadata {
     ///   contents of a genesis or system package upgrade transaction.
     /// - INDEXED: The object is retrieved from the off-chain index and
     ///   represents the most recent or historical state of the object.
-    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -213,8 +213,6 @@ impl NameRegistration {
     ///   contents of a genesis or system package upgrade transaction.
     /// - INDEXED: The object is retrieved from the off-chain index and
     ///   represents the most recent or historical state of the object.
-    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -230,8 +230,6 @@ impl MoveObject {
     ///   contents of a genesis or system package upgrade transaction.
     /// - INDEXED: The object is retrieved from the off-chain index and
     ///   represents the most recent or historical state of the object.
-    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -319,8 +319,6 @@ impl MovePackage {
     ///   contents of a genesis or system package upgrade transaction.
     /// - INDEXED: The object is retrieved from the off-chain index and
     ///   represents the most recent or historical state of the object.
-    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_).status().await
     }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -106,12 +106,6 @@ pub enum ObjectStatus {
     NotIndexed,
     /// The object is fetched from the index.
     Indexed,
-    /// The object is deleted or wrapped and only partial information can be
-    /// loaded from the indexer.
-    #[graphql(
-        deprecation = "will be removed with v1.26, as such objects can be considered non-existent"
-    )]
-    WrappedOrDeleted,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, InputObject)]
@@ -264,8 +258,6 @@ pub(crate) struct HistoricalObjectCursor {
             contents of a genesis or system package upgrade transaction.
             - INDEXED: The object is retrieved from the off-chain index and
             represents the most recent or historical state of the object.
-            - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-            information can be loaded.
         "#
     ),
     field(
@@ -469,8 +461,6 @@ impl Object {
     ///   contents of a genesis or system package upgrade transaction.
     /// - INDEXED: The object is retrieved from the off-chain index and
     ///   represents the most recent or historical state of the object.
-    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(self).status().await
     }
@@ -946,7 +936,7 @@ impl Object {
     ) -> Result<Option<Self>, Error> {
         let DataLoader(loader) = &ctx.data_unchecked();
 
-        match key {
+        let object = match key {
             ObjectLookup::VersionAt {
                 version,
                 checkpoint_viewed_at,
@@ -987,7 +977,15 @@ impl Object {
                     })
                     .await
             }
+        }?;
+
+        if let Some(object) = &object {
+            if matches!(object.kind, ObjectKind::WrappedOrDeleted(_)) {
+                return Ok(None);
+            }
         }
+
+        Ok(object)
     }
 
     /// Query for a singleton object identified by its type. Note: the object is
@@ -1961,7 +1959,7 @@ impl From<&ObjectKind> for ObjectStatus {
         match kind {
             ObjectKind::NotIndexed(_) => ObjectStatus::NotIndexed,
             ObjectKind::Indexed(_, _) => ObjectStatus::Indexed,
-            ObjectKind::WrappedOrDeleted(_) => ObjectStatus::WrappedOrDeleted,
+            ObjectKind::WrappedOrDeleted(_) => ObjectStatus::Indexed,
         }
     }
 }

--- a/crates/iota-graphql-rpc/src/types/stake.rs
+++ b/crates/iota-graphql-rpc/src/types/stake.rs
@@ -179,8 +179,6 @@ impl StakedIota {
     ///   contents of a genesis or system package upgrade transaction.
     /// - INDEXED: The object is retrieved from the off-chain index and
     ///   represents the most recent or historical state of the object.
-    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-    ///   information can be loaded.
     pub(crate) async fn status(&self) -> ObjectStatus {
         ObjectImpl(&self.super_.super_).status().await
     }

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -511,8 +511,6 @@ type Coin implements IMoveObject & IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -687,8 +685,6 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -1537,8 +1533,6 @@ interface IObject {
 	            contents of a genesis or system package upgrade transaction.
 	            - INDEXED: The object is retrieved from the off-chain index and
 	            represents the most recent or historical state of the object.
-	            - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	            information can be loaded.
 	        
 	"""
 	status: ObjectKind!
@@ -2112,8 +2106,6 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2318,8 +2310,6 @@ type MovePackage implements IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2770,8 +2760,6 @@ type NameRegistration implements IMoveObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -2956,8 +2944,6 @@ type Object implements IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""
@@ -3188,11 +3174,6 @@ enum ObjectKind {
 	The object is fetched from the index.
 	"""
 	INDEXED
-	"""
-	The object is deleted or wrapped and only partial information can be
-	loaded from the indexer.
-	"""
-	WRAPPED_OR_DELETED @deprecated(reason: "will be removed with v1.26, as such objects can be considered non-existent")
 }
 
 """
@@ -4081,8 +4062,6 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	contents of a genesis or system package upgrade transaction.
 	- INDEXED: The object is retrieved from the off-chain index and
 	represents the most recent or historical state of the object.
-	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-	information can be loaded.
 	"""
 	status: ObjectKind!
 	"""


### PR DESCRIPTION
Static review only. No local tests or builds were run due to resource-safety policy.

Resolves #11619. This removes the deprecated WRAPPED_OR_DELETED ObjectStatus variant from the GraphQL API, filters out wrapped/deleted objects in point queries, and cleans up the schema and schema snapshots.