### PR TITLE
fix(experiments): unconditionally start grafana in run-all scripts

### DIFF
--- a/dev-tools/iota-private-network/experiments/run-all-benchmark.sh
+++ b/dev-tools/iota-private-network/experiments/run-all-benchmark.sh
@@ -296,13 +296,8 @@ sleep 5
 GRAFANA_DIR="../../grafana-local"
 cd "$GRAFANA_DIR" || { log "Grafana folder not found"; exit 1; }
 
-# Check if any Grafana container is already running
-if docker compose ps --services --filter "status=running" | grep -q grafana; then
-  log "Grafana already running, skipping start"
-else
-  log "Starting Grafana dashboard..."
-  docker compose up -d
-fi
+log "Starting Grafana dashboard..."
+docker compose up -d
 log "Grafana URL: http://localhost:3000/dashboards"
 cd - >/dev/null
 

--- a/dev-tools/iota-private-network/experiments/run-all-fuzz.sh
+++ b/dev-tools/iota-private-network/experiments/run-all-fuzz.sh
@@ -354,12 +354,8 @@ sleep 5
 GRAFANA_DIR="../../grafana-local"
 cd "$GRAFANA_DIR" || { log "Grafana folder not found"; exit 1; }
 
-if docker compose ps --services --filter "status=running" | grep -q grafana; then
-  log "Grafana already running, skipping start"
-else
-  log "Starting Grafana dashboard..."
-  docker compose up -d
-fi
+log "Starting Grafana dashboard..."
+docker compose up -d
 log "Grafana URL: http://localhost:3000/dashboards"
 cd - >/dev/null
 


### PR DESCRIPTION
Fixes #11739

This PR resolves the issue where `run-all-benchmark.sh` and `run-all-fuzz.sh` left Prometheus and Grafana on the stale `migration-network` if they were run after `migration-test`. By unconditionally running `docker compose up -d`, we let docker compose automatically resolve differences in network configuration and recreate containers properly on the default `iota-network`.

**Validation header:**
Static review only. No local tests or builds were run due to resource-safety policy.