### PR TITLE
upstream(core): Ensure cargo-simtest reliably cleans up Cargo.toml/lock changes on exit

### DIFF
--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -102,7 +102,7 @@ root_dir=$(git rev-parse --show-toplevel)
 export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"
 
 # we need to use "target.'cfg(all())'.rustflags" instead of "build.rustflags" because the latter are ignored if any "target" flags are set
-exec cargo "${cargo_command[@]}" \
+cargo "${cargo_command[@]}" \
   --config "target.'cfg(all())'.rustflags = [$(IFS=, ; echo "${rust_flags[*]}")]" \
   "${cargo_patch_args[@]}" \
   "$@"

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -3,9 +3,13 @@
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
-if [ "$1" != "simtest" ]; then
-  echo "expected to be invoked via \`cargo simtest\`"
+die() {
+  echo "$0: $*" >&2
   exit 1
+}
+
+if [[ "$1" != "simtest" ]]; then
+  die "expected to be invoked via \`cargo simtest\`"
 fi
 
 # consume simtest arg
@@ -15,10 +19,7 @@ shift
 # ourselves.
 STARTING_DIR=$(pwd)
 MANIFEST_DIR="$STARTING_DIR"
-while true; do
-  if grep -q '^\[workspace\]$' Cargo.toml 2> /dev/null; then
-    break
-  fi
+until grep -q '^\[workspace\]$' Cargo.toml 2> /dev/null; do
   cd ..
   MANIFEST_DIR=$(pwd)
 done
@@ -28,25 +29,24 @@ done
 #   echo "Please commit or revert your changes to Cargo.lock before running cargo simtest"
 #   exit 1
 # fi
-cd "$STARTING_DIR" || exit 1
+cd "$STARTING_DIR" || die "failed to cd to '$STARTING_DIR'"
 
-cleanup () {
-  cd "$MANIFEST_DIR" || exit 1
-  git checkout Cargo.lock > /dev/null
-  cd "$STARTING_DIR" || exit 1
-}
+cleanup () (
+  cd "$MANIFEST_DIR" || die "failed to cd to '$MANIFEST_DIR'"
+  git checkout -- Cargo.lock > /dev/null
+)
 
-trap cleanup SIGINT
+trap cleanup EXIT
 
-if [ -z "$MSIM_TEST_SEED" ]; then
+if [[ -z "$MSIM_TEST_SEED" ]]; then
   export MSIM_TEST_SEED=1
 else
   echo "Using MSIM_TEST_SEED=$MSIM_TEST_SEED from the environment"
 fi
 
-RUST_FLAGS=('"--cfg"' '"msim"')
+rust_flags=( '"--cfg"' '"msim"' )
 
-if [ -n "$LOCAL_MSIM_PATH" ]; then
+if [[ -n "$LOCAL_MSIM_PATH" ]]; then
   cargo_patch_args=(
     --config "patch.crates-io.tokio.path = \"$LOCAL_MSIM_PATH/msim-tokio\""
     --config "patch.'https://github.com/iotaledger/iota-sim'.msim.path = \"$LOCAL_MSIM_PATH/msim\""
@@ -64,9 +64,9 @@ fi
 # Mock out the blst crate to massively speed up the simulation.
 # You should not assume that test runs will be repeatable with and without blst mocking,
 # as blst samples from the PRNG when not mocked.
-if [ -n "$USE_MOCK_CRYPTO" ]; then
+if [[ -n "$USE_MOCK_CRYPTO" ]]; then
   echo "Using mocked crypto crates - no cryptographic verification will occur"
-  RUST_FLAGS+=(
+  rust_flags+=(
     '"--cfg"'
     '"use_mock_crypto"'
   )
@@ -75,8 +75,6 @@ if [ -n "$USE_MOCK_CRYPTO" ]; then
     --config 'patch.crates-io.blst.rev = "630ca4d55de8e199e62c5b6a695c702d95fe6498"'
   )
 fi
-
-rust_flags_str=$(IFS=, ; echo "${RUST_FLAGS[*]}")
 
 if ! cargo nextest --help > /dev/null 2>&1; then
   echo "nextest (https://nexte.st) does not appear to be installed. Please install before proceeding."
@@ -88,10 +86,10 @@ if ! cargo nextest --help > /dev/null 2>&1; then
   exit 1
 fi
 
-CARGO_COMMAND=(nextest run --cargo-profile simulator)
-if [ "$1" = "build" ]; then
+cargo_command=( nextest run --cargo-profile simulator )
+if [[ "$1" = "build" ]]; then
   shift
-  CARGO_COMMAND=(build --profile simulator)
+  cargo_command=( build --profile simulator )
 fi
 
 # Must supply a new temp dir - the test is deterministic and can't choose one randomly itself.
@@ -104,13 +102,7 @@ root_dir=$(git rev-parse --show-toplevel)
 export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"
 
 # we need to use "target.'cfg(all())'.rustflags" instead of "build.rustflags" because the latter are ignored if any "target" flags are set
-cargo "${CARGO_COMMAND[@]}" \
-  --config "target.'cfg(all())'.rustflags = [$rust_flags_str]" \
+exec cargo "${cargo_command[@]}" \
+  --config "target.'cfg(all())'.rustflags = [$(IFS=, ; echo "${rust_flags[*]}")]" \
   "${cargo_patch_args[@]}" \
   "$@"
-
-STATUS=$?
-
-cleanup
-
-exit $STATUS


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.49.2, v1.50.1)
- Port commit:
  - [MystenLabs/sui@c24480fc](https://github.com/MystenLabs/sui/commit/c24480fc3dae41adad57cfe5756201238e2856b7)
  - [MystenLabs/sui@b71124b6](https://github.com/MystenLabs/sui/commit/b71124b68d2425fac1b80877542efa50439580dd)
- Description:
  * Hardens `scripts/simtest/cargo-simtest`'s cleanup logic so the mutated `Cargo.lock` is restored even when the script is killed. 
  * Drops the `exec` before `cargo`, since `exec` replaces the shell process and would prevent the `EXIT` trap from ever running.

## Links to any relevant issues

Part of #11322

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes