### PR TITLE
fix(json-rpc): allow negative individual epoch APY values in mean_apy_from_exchange_rates

### DIFF
--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -505,8 +505,8 @@ pub fn mean_apy_from_exchange_rates<'er>(
         .map(|(er, er_next)| calculate_apy(er, er_next))
         .collect::<Vec<_>>();
 
-    // Return 0.0 if there is no data OR if any APY is negative
-    if apys.is_empty() || apys.iter().any(|&apy| apy < 0.0) {
+    // Return 0.0 if there is no data
+    if apys.is_empty() {
         return 0.0;
     }
     // If any single epoch has outliers (that is APY > MAX_VALID_APY or exchange
@@ -517,12 +517,13 @@ pub fn mean_apy_from_exchange_rates<'er>(
 
     apys.truncate(SAMPLES);
 
-    if has_outlier {
+    let final_apy = if has_outlier {
         Data::new(apys).median()
     } else {
         let sum: f64 = apys.iter().sum();
         sum / SAMPLES as f64
-    }
+    };
+    final_apy.max(0.0)
 }
 
 /// Calculate the APY by the exchange rate of two consecutive epochs


### PR DESCRIPTION
Avoid setting the entire 7-epoch moving average APY to 0.0 if any single epoch APY in the window was negative. Instead, clamp the final average APY to 0.0.

Closes #11651

**Validation header:**
Static review only. No local tests or builds were run due to resource-safety policy.