### PR TITLE
[dev-tools] update historical worker config.yaml

### DIFF
--- a/dev-tools/iota-data-ingestion/historical/config.yaml
+++ b/dev-tools/iota-data-ingestion/historical/config.yaml
@@ -74,3 +74,14 @@ tasks:
       # checkpoint production rate.
       #
       commit-duration-seconds: 250
+      # Set the seed to initialize EPOCH_BOUNDARIES in existing instances.
+      #
+      # The seed has an effect only if the remote EPOCH_BOUNDARIES is not present.
+      #
+      # The last epoch in the seed MUST be greater than or equal to the last completed epoch on the network.
+      # Otherwise, when the current epoch changes the ingestion will fail to ensure that EPOCH_BOUNDARIES is contiguous
+      # with respect to epochs.
+      epoch-boundaries:
+        0: 1
+        1: 100
+        2: 20000


### PR DESCRIPTION
Updates the historical worker config.yaml template to include the seeding configuration for the new epoch-boundaries file.

PR is generated automatically.

Static review only. No local tests or builds were run due to resource-safety policy.