### PR TITLE
chore(indexer): clean up deprecated SnapshotLagConfig and flags

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/tests.rs
+++ b/crates/iota-graphql-e2e-tests/tests/tests.rs
@@ -101,7 +101,7 @@ async fn run_test(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
             ),
             internal_data_port,
             adapter.read_replica.as_ref().unwrap().clone(),
-            Some(offchain_config.snapshot_config.clone()),
+
             offchain_config.epochs_to_keep,
             offchain_config.data_ingestion_path.clone(),
         )

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -5,7 +5,6 @@
 use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use iota_graphql_rpc_client::simple_client::SimpleClient;
-pub use iota_indexer::config::SnapshotLagConfig;
 use iota_indexer::{
     config::PruningOptions,
     errors::IndexerError,
@@ -38,7 +37,6 @@ pub struct ExecutorCluster {
     pub indexer_join_handle: JoinHandle<Result<(), IndexerError>>,
     pub graphql_server_join_handle: JoinHandle<()>,
     pub graphql_client: SimpleClient,
-    pub snapshot_config: SnapshotLagConfig,
     pub graphql_connection_config: ConnectionConfig,
     pub cancellation_token: CancellationToken,
 }
@@ -74,7 +72,7 @@ pub async fn start_cluster(
         true,
         None,
         grpc_url.clone(),
-        IndexerTypeConfig::writer_mode(None, None),
+        IndexerTypeConfig::writer_mode(None),
         Some(data_ingestion_path),
         cancellation_token.clone(),
     )
@@ -118,7 +116,6 @@ pub async fn serve_executor(
     graphql_connection_config: ConnectionConfig,
     internal_data_source_rpc_port: u16,
     _executor: Arc<dyn GrpcStateReader + Send + Sync>,
-    snapshot_config: Option<SnapshotLagConfig>,
     epochs_to_keep: Option<u64>,
     data_ingestion_path: PathBuf,
 ) -> ExecutorCluster {
@@ -140,13 +137,10 @@ pub async fn serve_executor(
         true,
         None,
         format!("http://{executor_server_url}"),
-        IndexerTypeConfig::writer_mode(
-            snapshot_config.clone(),
-            Some(PruningOptions {
-                epochs_to_keep,
-                ..Default::default()
-            }),
-        ),
+        IndexerTypeConfig::writer_mode(Some(PruningOptions {
+            epochs_to_keep,
+            ..Default::default()
+        })),
         Some(data_ingestion_path),
         cancellation_token.clone(),
     )
@@ -176,7 +170,6 @@ pub async fn serve_executor(
         indexer_join_handle: pg_handle,
         graphql_server_join_handle: graphql_server_handle,
         graphql_client: client,
-        snapshot_config: snapshot_config.unwrap_or_default(),
         graphql_connection_config,
         cancellation_token,
     }

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -276,8 +276,6 @@ pub enum Command {
         #[command(flatten)]
         ingestion_config: IngestionConfig,
         #[command(flatten)]
-        snapshot_config: SnapshotLagConfig,
-        #[command(flatten)]
         pruning_options: PruningOptions,
         #[arg(long)]
         reset_db: bool,
@@ -430,35 +428,7 @@ impl RetentionConfig {
     }
 }
 
-#[derive(Args, Debug, Clone)]
-pub struct SnapshotLagConfig {
-    #[arg(
-        long = "objects-snapshot-min-checkpoint-lag",
-        default_value_t = Self::DEFAULT_MIN_LAG,
-        env = "OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG",
-    )]
-    pub snapshot_min_lag: usize,
 
-    #[arg(
-        long = "objects-snapshot-sleep-duration",
-        default_value_t = Self::DEFAULT_SLEEP_DURATION_SEC,
-    )]
-    pub sleep_duration: u64,
-}
-
-impl SnapshotLagConfig {
-    pub const DEFAULT_MIN_LAG: usize = 300;
-    pub const DEFAULT_SLEEP_DURATION_SEC: u64 = 5;
-}
-
-impl Default for SnapshotLagConfig {
-    fn default() -> Self {
-        SnapshotLagConfig {
-            snapshot_min_lag: Self::DEFAULT_MIN_LAG,
-            sleep_duration: Self::DEFAULT_SLEEP_DURATION_SEC,
-        }
-    }
-}
 
 #[cfg(test)]
 mod test {

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -14,7 +14,7 @@ use tracing::{info, warn};
 use crate::{
     build_json_rpc_server,
     config::{
-        HistoricFallbackOptions, IngestionConfig, JsonRpcConfig, RetentionConfig, SnapshotLagConfig,
+        HistoricFallbackOptions, IngestionConfig, JsonRpcConfig, RetentionConfig,
     },
     db::ConnectionPool,
     errors::IndexerError,
@@ -44,7 +44,6 @@ impl Indexer {
         config: &IngestionConfig,
         store: PgIndexerStore,
         metrics: IndexerMetrics,
-        snapshot_config: SnapshotLagConfig,
         retention_config: Option<RetentionConfig>,
         cancel: CancellationToken,
     ) -> Result<(), IndexerError> {
@@ -89,7 +88,6 @@ impl Indexer {
         let snapshot_pipeline_builder = SnapshotPipelineBuilder::new(
             store.clone(),
             metrics.clone(),
-            snapshot_config,
             config.checkpoint_download_queue_size,
             cancel.clone(),
         )

--- a/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/orchestration.rs
@@ -17,7 +17,6 @@ use tracing::info;
 
 use crate::{
     CancellationToken, PgIndexerStore,
-    config::SnapshotLagConfig,
     ingestion::{
         common::{
             orchestration::{ShimIndexerProgressStore, new_executor},
@@ -46,11 +45,10 @@ impl SnapshotPipelineBuilder {
     pub async fn new(
         state: PgIndexerStore,
         metrics: IndexerMetrics,
-        lag_config: SnapshotLagConfig,
         checkpoint_download_queue_size: usize,
         cancel: CancellationToken,
     ) -> IndexerResult<SnapshotPipelineBuilder> {
-        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone(), lag_config);
+        let writer = ObjectSnapshotWriter::new(state.clone(), metrics.clone());
         let watermark = writer.get_watermark_hi().await?.unwrap_or_default();
         Ok(SnapshotPipelineBuilder {
             writer,

--- a/crates/iota-indexer/src/ingestion/snapshot/persist.rs
+++ b/crates/iota-indexer/src/ingestion/snapshot/persist.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::{
-    config::SnapshotLagConfig,
     ingestion::{
         common::persist::{CommitterWatermark, ObjectsSnapshotHandlerTables, Writer},
         primary::persist::TransactionObjectChangesToCommit,
@@ -19,7 +18,6 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct ObjectSnapshotWriter {
     pub store: PgIndexerStore,
-    pub(crate) snapshot_config: SnapshotLagConfig,
     pub(crate) metrics: IndexerMetrics,
 }
 
@@ -27,12 +25,10 @@ impl ObjectSnapshotWriter {
     pub fn new(
         store: PgIndexerStore,
         metrics: IndexerMetrics,
-        snapshot_config: SnapshotLagConfig,
     ) -> ObjectSnapshotWriter {
         Self {
             store,
             metrics,
-            snapshot_config,
         }
     }
 }
@@ -71,8 +67,6 @@ impl Writer<TransactionObjectChangesToCommit> for ObjectSnapshotWriter {
 
     async fn get_max_committable_checkpoint(&self) -> IndexerResult<u64> {
         let latest_checkpoint = self.store.get_latest_checkpoint_sequence_number().await?;
-        Ok(latest_checkpoint
-            .map(|seq| seq.saturating_sub(self.snapshot_config.snapshot_min_lag as u64))
-            .unwrap_or_default()) // hold snapshot handler until at least one checkpoint is in DB
+        Ok(latest_checkpoint.unwrap_or_default())
     }
 }

--- a/crates/iota-indexer/src/main.rs
+++ b/crates/iota-indexer/src/main.rs
@@ -56,7 +56,6 @@ async fn main() -> Result<(), IndexerError> {
     match opts.command {
         Command::Indexer {
             ingestion_config,
-            snapshot_config,
             pruning_options,
             reset_db,
         } => {
@@ -87,7 +86,6 @@ async fn main() -> Result<(), IndexerError> {
                 &ingestion_config,
                 store,
                 indexer_metrics,
-                snapshot_config,
                 retention_config,
                 cancel.clone(),
             )

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -14,7 +14,7 @@ use url::Url;
 use crate::{
     IndexerMetrics,
     config::{
-        IngestionConfig, IotaNamesOptions, PruningOptions, RetentionConfig, SnapshotLagConfig,
+        IngestionConfig, IotaNamesOptions, PruningOptions, RetentionConfig,
     },
     db::{ConnectionPool, ConnectionPoolConfig, PoolConnection, new_connection_pool},
     errors::IndexerError,
@@ -65,7 +65,6 @@ pub enum IndexerTypeConfig {
         reader_mode_rpc_url: String,
     },
     Writer {
-        snapshot_config: SnapshotLagConfig,
         retention_config: Option<RetentionConfig>,
     },
     AnalyticalWorker,
@@ -79,11 +78,9 @@ impl IndexerTypeConfig {
     }
 
     pub fn writer_mode(
-        snapshot_config: Option<SnapshotLagConfig>,
         pruning_options: Option<PruningOptions>,
     ) -> Self {
         Self::Writer {
-            snapshot_config: snapshot_config.unwrap_or_default(),
             retention_config: pruning_options.as_ref().and_then(|pruning_options| {
                 pruning_options
                     .epochs_to_keep
@@ -174,7 +171,6 @@ pub async fn start_test_indexer_impl(
             })
         }
         IndexerTypeConfig::Writer {
-            snapshot_config,
             retention_config,
         } => {
             let fullnode_rpc_url = rpc_url.parse::<Url>().unwrap();
@@ -189,7 +185,6 @@ pub async fn start_test_indexer_impl(
                     &ingestion_config,
                     store_clone,
                     indexer_metrics,
-                    snapshot_config,
                     retention_config,
                     cancel,
                 )

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 
 use anyhow::{bail, ensure};
 use clap::{self, Args, Parser};
-use iota_graphql_rpc::test_infra::cluster::SnapshotLagConfig;
 use iota_types::{
     base_types::{IotaAddress, SequenceNumber},
     move_package::UpgradePolicy,
@@ -72,8 +71,6 @@ pub struct IotaInitArgs {
     pub default_gas_price: Option<u64>,
     #[clap(long = "move-auth")]
     pub move_auth: Option<bool>,
-    #[command(flatten)]
-    pub snapshot_config: SnapshotLagConfig,
     #[arg(long)]
     pub flavor: Option<Flavor>,
     /// The number of epochs to keep in the database. Epochs outside of this

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -25,7 +25,7 @@ use fastcrypto::{
 };
 use iota_core::authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder};
 use iota_framework::DEFAULT_FRAMEWORK_PATH;
-use iota_graphql_rpc::test_infra::cluster::SnapshotLagConfig;
+
 use iota_json_rpc_api::QUERY_MAX_RESULT_LIMIT;
 use iota_json_rpc_types::{
     DevInspectResults, DryRunTransactionBlockResponse, IotaExecutionStatus,
@@ -136,7 +136,6 @@ const DEFAULT_CHAIN_START_TIMESTAMP: u64 = 0;
 // TODO: the configs are still tied to the indexer crate, eventually we'd like a
 // new command that is more agnostic
 pub struct OffChainConfig {
-    pub snapshot_config: SnapshotLagConfig,
     pub epochs_to_keep: Option<u64>,
     /// Dir for simulacrum to write checkpoint files to. To be passed to the
     /// offchain indexer if it uses file-based ingestion.
@@ -210,7 +209,6 @@ impl AdapterInitConfig {
             reference_gas_price,
             default_gas_price,
             move_auth,
-            snapshot_config,
             flavor,
             epochs_to_keep,
             data_ingestion_path,
@@ -250,7 +248,6 @@ impl AdapterInitConfig {
 
         let offchain_config = if simulator {
             Some(OffChainConfig {
-                snapshot_config,
                 epochs_to_keep,
                 data_ingestion_path: data_ingestion_path.unwrap_or(tempdir().unwrap().keep()),
                 grpc_api_url,

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -300,7 +300,7 @@ acc1: object(0,0), acc2: object(0,1)
 --custom-validator-account: creates a custom validator account. This is only allowed in simulator mode.
 --reference-gas-price <REFERENCE_GAS_PRICE>: Defines a reference gas price for transactions. Only valid in simulator mode.
 --default-gas-price <DEFAULT_GAS_PRICE>: sSets the default gas price for transactions. If not specified, the default is `1_000`.
---objects-snapshot-min-checkpoint-lag <OBJECT_SNAPSHOT_MIN_CHECKPOINT_LAG>: defines the minimum checkpoint lag for object snapshots. This affects when state snapshots are taken during execution
+
 --flavor <FLAVOR>: Specifies the Move compiler flavor (e.g., Iota).
 The --flavor option in the init command specifies the Move language flavor that will be used in the environment. This option determines the syntax and semantics applied to Move programs and packages in the test adapter(Core or Iota).
 --addresses <NAMED_ADDRESSES>: Maps custom named addresses to specific numerical addresses for the Move environment.


### PR DESCRIPTION
Resolves #11713

Removes the deprecated `--objects-snapshot-min-checkpoint-lag` and `--objects-snapshot-sleep-duration` CLI flags as well as the `SnapshotLagConfig` structure that is no longer needed since it was used to control snapshot lag during ingestion. Also removes references to these from `syntax.md` and other usages across `iota-indexer` and `iota-transactional-test-runner`.

Static review only. No local tests or builds were run due to resource-safety policy.