### PR TITLE
refactor(iota-rest-kv): remove range query variants from Key and ItemType enums

### DIFF
--- a/crates/iota-rest-kv/src/aws.rs
+++ b/crates/iota-rest-kv/src/aws.rs
@@ -319,9 +319,6 @@ impl KvStoreClient {
         let item_type = key.item_type().to_string();
 
         match key {
-            Key::TransactionDigestsByAddress(_address) => {
-                bail!("unsupported key");
-            }
             Key::Transaction(transaction_digest) => {
                 self.get_from_dynamodb(transaction_digest, item_type).await
             }

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -138,9 +138,6 @@ impl KvStoreClient {
 
         // Use the first key to determine the type - all keys should be of the same type
         match keys.first().expect("emptiness was checked earlier") {
-            Key::TransactionDigestsByAddress(_address) => {
-                return Err(ApiError::BadRequest("unsupported key".into()));
-            }
             Key::Transaction(_) => {
                 let digests = extract_keys(&keys, |k| match k {
                     Key::Transaction(digest) => Some(*digest),

--- a/crates/iota-rest-kv/src/server.rs
+++ b/crates/iota-rest-kv/src/server.rs
@@ -11,7 +11,6 @@ use axum::{
     response::IntoResponse,
     routing::{get, post},
 };
-use iota_storage::http_key_value_store::ItemType;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -50,7 +49,7 @@ impl Server {
             // static and dynamic route segments are allowed to overlap. If they do, static segments
             // will be given higher priority.
             .route(
-                &format!("/{}/{{address}}", ItemType::TransactionDigestsByAddress),
+                "/txa/{address}",
                 get(kv_store::transaction_digests_by_address),
             )
             .with_state(shared_state)

--- a/crates/iota-storage/src/http_key_value_store.rs
+++ b/crates/iota-storage/src/http_key_value_store.rs
@@ -113,9 +113,6 @@ pub enum ItemType {
     #[strum(serialize = "evtx")]
     #[serde(rename = "evtx")]
     EventTransactionDigest,
-    #[strum(serialize = "txa")]
-    #[serde(rename = "txa")]
-    TransactionDigestsByAddress,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -128,7 +125,6 @@ pub enum Key {
     TransactionToCheckpoint(TransactionDigest),
     ObjectKey(ObjectKey),
     EventsByTransactionDigest(TransactionDigest),
-    TransactionDigestsByAddress(IotaAddress),
 }
 
 impl Key {
@@ -202,9 +198,6 @@ impl Key {
             ItemType::EventTransactionDigest => Ok(Key::EventsByTransactionDigest(
                 TransactionDigest::from_bytes(decoded_key.as_slice())?,
             )),
-            ItemType::TransactionDigestsByAddress => Ok(Key::TransactionDigestsByAddress(
-                IotaAddress::from_bytes(decoded_key.as_slice())?,
-            )),
         }
     }
 
@@ -237,7 +230,6 @@ impl Key {
             Key::TransactionToCheckpoint(_) => ItemType::TransactionToCheckpoint,
             Key::ObjectKey(_) => ItemType::Object,
             Key::EventsByTransactionDigest(_) => ItemType::EventTransactionDigest,
-            Key::TransactionDigestsByAddress(_) => ItemType::TransactionDigestsByAddress,
         }
     }
 
@@ -285,9 +277,6 @@ impl Key {
             Key::TransactionToCheckpoint(digest) => encode_digest(digest),
             Key::ObjectKey(object_key) => encode_object_key(object_key),
             Key::EventsByTransactionDigest(digest) => encode_digest(digest),
-            // TODO: `encode_digest` could be renamed to `encode` to fit more use cases.
-            // tracking issue: https://github.com/iotaledger/iota/issues/11754
-            Key::TransactionDigestsByAddress(address) => encode_digest(address),
         };
 
         (self.item_type(), encoded_key_digest)


### PR DESCRIPTION
Resolves #11716

This refactors the internal logic of `iota-rest-kv` to decouple range/paginated queries from the point-lookup `Key` and `ItemType` enums, removing the `TransactionDigestsByAddress` variants and using static routing for `/txa/{address}`.

Static review only. No local tests or builds were run due to resource-safety policy.