### PR TITLE
chore: remove package re-exports

### DIFF
--- a/crates/iota-core/src/authority/authority_store_types.rs
+++ b/crates/iota-core/src/authority/authority_store_types.rs
@@ -2,12 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::{Owner, StructTag};
+use iota_sdk_types::{Owner, StructTag, move_package::MovePackage};
 use iota_types::{
     base_types::TransactionDigest,
     coin::Coin,
     error::IotaError,
-    move_package::MovePackage,
     object::{Data, MoveObject, MoveObjectExt, Object, ObjectInner},
     storage::ObjectKey,
 };

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2695,7 +2695,7 @@ mod tests {
     use futures::{FutureExt as _, future::BoxFuture};
     use iota_macros::sim_test;
     use iota_protocol_config::{Chain, ProtocolConfig};
-    use iota_sdk_types::{Identifier, ObjectId, Owner};
+    use iota_sdk_types::{Identifier, ObjectId, Owner, move_package::MovePackage};
     use iota_types::{
         base_types::{SequenceNumber, TransactionEffectsDigest},
         crypto::Signature,
@@ -2704,7 +2704,6 @@ mod tests {
             TransactionEvents,
         },
         messages_checkpoint::SignedCheckpointSummary,
-        move_package::MovePackage,
         object,
         transaction::{GenesisObject, VerifiedTransaction},
     };

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -15,6 +15,7 @@ use iota_sdk_types::{
     ConsensusDeterminedVersionAssignments, Identifier, ObjectId, Owner, SimpleSignature, StructTag,
     TypeTag,
     crypto::{Intent, IntentMessage, PersonalMessage},
+    move_package::{MovePackage, TypeOrigin, UpgradeInfo},
 };
 use iota_types::{
     base_types::{
@@ -42,7 +43,6 @@ use iota_types::{
         CheckpointContentsDigest, CheckpointDigest, CheckpointSummary, FullCheckpointContents,
     },
     messages_grpc::ObjectInfoRequestKind,
-    move_package::{MovePackage, TypeOrigin},
     multisig::{MultiSig, MultiSigPublicKey, MultisigMember},
     object::{Data, MoveObject, MoveObjectExt, ObjectInner},
     signature::GenericSignature,
@@ -275,7 +275,7 @@ fn get_registry() -> Result<Registry> {
     tracer
         .trace_value(&mut samples, &Data::Struct(sample_move_obj))
         .unwrap();
-    let sample_upgrade_info = iota_types::move_package::UpgradeInfo {
+    let sample_upgrade_info = UpgradeInfo {
         upgraded_id: ObjectId::ZERO,
         upgraded_version: 1u64.into(),
     };

--- a/crates/iota-core/src/unit_tests/move_package_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_tests.rs
@@ -6,12 +6,15 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use iota_move_build::{BuildConfig, CompiledPackage};
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Identifier, ObjectId};
+use iota_sdk_types::{
+    Identifier, ObjectId,
+    move_package::{MovePackage, TypeOrigin, UpgradeInfo},
+};
 use iota_types::{
     digests::TransactionDigest,
     error::ExecutionErrorKind,
     execution_status::PackageUpgradeError,
-    move_package::{MovePackage, MovePackageExt, TypeOrigin, UpgradeInfo},
+    move_package::MovePackageExt,
     object::{Data, OBJECT_START_VERSION, Object},
 };
 use move_binary_format::file_format::CompiledModule;

--- a/crates/iota-framework/src/lib.rs
+++ b/crates/iota-framework/src/lib.rs
@@ -4,11 +4,11 @@
 
 use std::{fmt::Formatter, sync::LazyLock};
 
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, move_package::MovePackage};
 use iota_types::{
     base_types::ObjectRef,
     digests::TransactionDigest,
-    move_package::{MovePackage, MovePackageExt},
+    move_package::MovePackageExt,
     object::{OBJECT_START_VERSION, Object},
     storage::ObjectStore,
 };

--- a/crates/iota-genesis-builder/src/stardust/migration/executor.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/executor.rs
@@ -17,7 +17,10 @@ use iota_framework::BuiltInFramework;
 use iota_move_build::CompiledPackage;
 use iota_move_natives_latest::all_natives;
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
-use iota_sdk_types::{Command, Identifier, ObjectId};
+use iota_sdk_types::{
+    Command, Identifier, ObjectId,
+    move_package::{MovePackage, TypeOrigin},
+};
 use iota_stardust_types::block::output::{
     AliasOutput as StardustAliasOutput, BasicOutput as StardustBasicOutput, FoundryOutput,
     NativeTokens, NftOutput as StardustNftOutput, OutputId, TokenId,
@@ -32,7 +35,6 @@ use iota_types::{
     in_memory_storage::InMemoryStorage,
     inner_temporary_store::InnerTemporaryStore,
     metrics::LimitsMetrics,
-    move_package::{MovePackage, TypeOrigin},
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     stardust::{

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -15,8 +15,8 @@ use diesel::{
 };
 use iota_indexer::{models::objects::StoredHistoryObject, schema::packages};
 use iota_package_resolver::{Package as ParsedMovePackage, error::Error as PackageCacheError};
-use iota_sdk_types::Identifier;
-use iota_types::{move_package::MovePackage as NativeMovePackage, object::Data};
+use iota_sdk_types::{Identifier, move_package::MovePackage as NativeMovePackage};
+use iota_types::object::Data;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -6,7 +6,7 @@ use iota_json_rpc_types::{
     BalanceChange, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
     IotaTransactionKind, ObjectChange,
 };
-use iota_sdk_types::{ObjectId, Owner, StructTag, TypeTag};
+use iota_sdk_types::{ObjectId, Owner, StructTag, TypeTag, move_package::MovePackage};
 use iota_types::{
     base_types::{IotaAddress, ObjectDigest, SequenceNumber},
     crypto::AggregateAuthoritySignature,
@@ -18,7 +18,6 @@ use iota_types::{
     messages_checkpoint::{
         CheckpointCommitment, CheckpointDigest, CheckpointSequenceNumber, EndOfEpochData,
     },
-    move_package::MovePackage,
     object::Object,
     transaction::SenderSignedData,
 };

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -13,7 +13,10 @@ use anyhow::{anyhow, bail};
 use colored::Colorize;
 use fastcrypto::encoding::Base64;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Identifier, ObjectId, Owner, StructTag};
+use iota_sdk_types::{
+    Identifier, ObjectId, Owner, StructTag,
+    move_package::{MovePackage, TypeOrigin, UpgradeInfo},
+};
 use iota_types::{
     base_types::{
         IotaAddress, ObjectDigest, ObjectInfo, ObjectRef, ObjectType, SequenceNumber,
@@ -22,7 +25,6 @@ use iota_types::{
     error::{ExecutionError, IotaError, IotaResult, UserInputError, UserInputResult},
     gas_coin::GasCoin,
     messages_checkpoint::CheckpointSequenceNumber,
-    move_package::{MovePackage, TypeOrigin, UpgradeInfo},
     object::{Data, MoveObject, MoveObjectExt, Object, ObjectInner, ObjectRead},
 };
 use move_bytecode_utils::module_cache::GetModule;

--- a/crates/iota-json/src/lib.rs
+++ b/crates/iota-json/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::{anyhow, bail};
 use fastcrypto::encoding::{Encoding, Hex};
-use iota_sdk_types::{Identifier, ObjectId, StructTag, TypeTag};
+use iota_sdk_types::{Identifier, ObjectId, StructTag, TypeTag, move_package::MovePackage};
 use iota_types::{
     base_types::{
         IotaAddress, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TxContext,
@@ -18,7 +18,7 @@ use iota_types::{
     },
     id::{self, RESOLVED_IOTA_ID},
     iota_sdk_types_conversions::struct_tag_core_to_sdk,
-    move_package::{MovePackage, MovePackageExt},
+    move_package::MovePackageExt,
     object::bounded_visitor::BoundedVisitor,
     transfer::RESOLVED_RECEIVING_STRUCT,
 };

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -17,12 +17,12 @@ use iota_package_management::{
     PublishedAtError, resolve_published_id,
     system_package_versions::{SYSTEM_GIT_REPO, SystemPackagesVersion},
 };
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, move_package::MovePackage};
 use iota_types::{
     base_types::IotaAddress,
     error::{IotaError, IotaResult},
     move_package::{
-        FnInfo, FnInfoKey, FnInfoMap, IotaAttribute, MovePackage, RuntimeModuleMetadata,
+        FnInfo, FnInfoKey, FnInfoMap, IotaAttribute, RuntimeModuleMetadata,
         RuntimeModuleMetadataWrapper, get_authenticator_version_from_fun,
     },
 };

--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -10,11 +10,13 @@ use std::{
 };
 
 use async_trait::async_trait;
-use iota_sdk_types::{Argument, Command, Identifier, MakeMoveVector, StructTag, TypeTag};
+use iota_sdk_types::{
+    Argument, Command, Identifier, MakeMoveVector, StructTag, TypeTag,
+    move_package::{MovePackage, TypeOrigin},
+};
 use iota_types::{
     base_types::{IotaAddress, SequenceNumber, is_primitive_type_tag},
     iota_sdk_types_conversions::{struct_tag_sdk_to_core, type_tag_core_to_sdk},
-    move_package::{MovePackage, TypeOrigin},
     object::Object,
     transaction::{CallArg, ProgrammableTransaction},
 };

--- a/crates/iota-tool/src/genesis_inspector.rs
+++ b/crates/iota-tool/src/genesis_inspector.rs
@@ -6,14 +6,13 @@ use std::collections::BTreeMap;
 
 use inquire::Select;
 use iota_config::genesis::UnsignedGenesis;
-use iota_sdk_types::{ObjectId, Owner};
+use iota_sdk_types::{ObjectId, Owner, move_package::MovePackage};
 use iota_types::{
     balance::Balance,
     coin::CoinMetadata,
     gas_coin::{GasCoin, IotaTreasuryCap, NANOS_PER_IOTA},
     governance::StakedIota,
     iota_system_state::IotaValidatorGenesis,
-    move_package::MovePackage,
     object::{MoveObject, Object},
     stardust::output::{AliasOutput, BasicOutput, NftOutput},
     timelock::{

--- a/crates/iota-transaction-builder/src/package.rs
+++ b/crates/iota-transaction-builder/src/package.rs
@@ -6,10 +6,9 @@ use std::result::Result;
 
 use anyhow::{Ok, anyhow, bail};
 use iota_json_rpc_types::IotaObjectDataOptions;
-use iota_sdk_types::{Argument, Identifier, ObjectId, Owner};
+use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, move_package::MovePackage};
 use iota_types::{
     base_types::IotaAddress,
-    move_package::MovePackage,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{CallArg, SharedObjectRef, TransactionData, TransactionDataAPI, TransactionKind},
 };

--- a/crates/iota-transaction-builder/src/utils.rs
+++ b/crates/iota-transaction-builder/src/utils.rs
@@ -12,13 +12,15 @@ use iota_json::{
 };
 use iota_json_rpc_types::{IotaArgument, IotaData, IotaObjectDataOptions, IotaRawData, PtbInput};
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, StructTag, TypeTag};
+use iota_sdk_types::{
+    Argument, Identifier, ObjectId, Owner, StructTag, TypeTag, move_package::MovePackage,
+};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef, ObjectType, TxContext, TxContextKind},
     error::UserInputError,
     fp_ensure,
     gas_coin::GasCoin,
-    move_package::{MovePackage, MovePackageExt},
+    move_package::MovePackageExt,
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{CallArg, SharedObjectRef},

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -32,7 +32,7 @@ use iota_json_rpc_types::{
 };
 use iota_node_storage::GrpcStateReader;
 use iota_protocol_config::{Chain, ProtocolConfig};
-use iota_sdk_types::{Argument, Command, Identifier, ObjectId, TypeTag};
+use iota_sdk_types::{Argument, Command, Identifier, ObjectId, TypeTag, move_package::MovePackage};
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
 };
@@ -51,9 +51,7 @@ use iota_types::{
         CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, VerifiedCheckpoint,
     },
     move_authenticator::MoveAuthenticator,
-    move_package::{
-        IotaAttribute, MovePackage, RuntimeModuleMetadata, RuntimeModuleMetadataWrapper,
-    },
+    move_package::{IotaAttribute, RuntimeModuleMetadata, RuntimeModuleMetadataWrapper},
     object::{self, GAS_VALUE_FOR_TESTING, MoveObjectExt, Object, bounded_visitor::BoundedVisitor},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     signature::GenericSignature,

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -41,8 +41,10 @@ use std::{
 
 use derive_more::Display;
 use iota_protocol_config::ProtocolConfig;
-pub use iota_sdk_types::move_package::{MovePackage, TypeOrigin, UpgradeInfo};
-use iota_sdk_types::{Identifier, ObjectId, StructTag, TypeTag, Version};
+use iota_sdk_types::{
+    Identifier, ObjectId, StructTag, TypeTag, Version,
+    move_package::{MovePackage, TypeOrigin, UpgradeInfo},
+};
 use move_binary_format::{
     binary_config::BinaryConfig, file_format::CompiledModule, file_format_common::VERSION_6,
     normalized,

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -11,7 +11,7 @@ use std::{
 
 use iota_protocol_config::ProtocolConfig;
 pub use iota_sdk_types::{MoveStruct as MoveObject, ObjectData as Data};
-use iota_sdk_types::{ObjectId, Owner, StructTag, TypeTag};
+use iota_sdk_types::{ObjectId, Owner, StructTag, TypeTag, move_package::MovePackage};
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::{layout::TypeLayoutBuilder, module_cache::GetModule};
 use move_core_types::annotated_value::{MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue};
@@ -31,7 +31,7 @@ use crate::{
     gas_coin::{GAS, GasCoin},
     iota_sdk_types_conversions::type_tag_sdk_to_core,
     layout_resolver::LayoutResolver,
-    move_package::{MovePackage, MovePackageExt},
+    move_package::MovePackageExt,
     timelock::timelock::TimeLock,
 };
 

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -16,7 +16,7 @@ use std::{
     sync::Arc,
 };
 
-use iota_sdk_types::{Identifier, ObjectId};
+use iota_sdk_types::{Identifier, ObjectId, move_package::MovePackage};
 use itertools::Itertools;
 use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
@@ -38,7 +38,6 @@ use crate::{
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
     error::{ExecutionError, IotaError, IotaResult},
     execution::{DynamicallyLoadedObjectMetadata, ExecutionResults},
-    move_package::MovePackage,
     object::Object,
     storage::error::Error as StorageError,
     transaction::{SenderSignedData, TransactionDataAPI},

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -53,6 +53,7 @@ use iota_sdk::{
 use iota_sdk_types::{
     Identifier, ObjectId, Owner, TypeTag,
     crypto::{Intent, IntentMessage},
+    move_package::MovePackage,
 };
 use iota_source_validation::{BytecodeSourceVerifier, ValidationMode};
 use iota_types::{
@@ -70,7 +71,7 @@ use iota_types::{
     message_envelope::Envelope,
     metrics::BytecodeVerifierMetrics,
     move_authenticator::MoveAuthenticator,
-    move_package::{MovePackage, UpgradeCap},
+    move_package::UpgradeCap,
     parse_iota_type_tag,
     quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -14,11 +14,12 @@ use iota_move_build::CompiledPackage;
 use iota_sdk::apis::ReadApi;
 use iota_sdk_types::{
     Argument, Command, Identifier, ObjectId, Owner, ProgrammableTransaction, TypeTag,
+    move_package::MovePackage,
 };
 use iota_types::{
     base_types::{IotaAddress, TxContext, TxContextKind, is_primitive_type_tag},
     iota_sdk_types_conversions::type_tag_core_to_sdk,
-    move_package::{MovePackage, MovePackageExt},
+    move_package::MovePackageExt,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     resolve_address,
     transaction::{CallArg, SharedObjectRef},

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -40,7 +40,10 @@ use iota_keys::keystore::AccountKeystore;
 use iota_macros::sim_test;
 use iota_move_build::{BuildConfig, IotaPackageHooks};
 use iota_sdk::{IotaClient, PagedFn, wallet_context::WalletContext};
-use iota_sdk_types::{ObjectId, Owner, StructTag};
+use iota_sdk_types::{
+    ObjectId, Owner, StructTag,
+    move_package::{MovePackage, UpgradeInfo},
+};
 use iota_swarm_config::genesis_config::{AccountConfig, GenesisConfig};
 use iota_test_transaction_builder::batch_make_transfer_transactions;
 use iota_types::{
@@ -50,7 +53,6 @@ use iota_types::{
         Secp256k1IotaSignature, SignatureScheme, get_key_pair,
     },
     gas_coin::GasCoin,
-    move_package::{MovePackage, UpgradeInfo},
     transaction::{
         TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
         TEST_ONLY_GAS_UNIT_FOR_PUBLISH, TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -18,7 +18,9 @@ mod checked {
         self, LoadedRuntimeObject, ObjectRuntime, RuntimeResults, get_all_uids, max_event_error,
     };
     use iota_protocol_config::ProtocolConfig;
-    use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, StructTag, TypeTag};
+    use iota_sdk_types::{
+        Argument, Identifier, ObjectId, Owner, StructTag, TypeTag, move_package::MovePackage,
+    };
     use iota_types::{
         balance::Balance,
         base_types::{IotaAddress, TxContext},
@@ -29,7 +31,7 @@ mod checked {
         execution_status::CommandArgumentError,
         iota_sdk_types_conversions::{struct_tag_core_to_sdk, type_tag_core_to_sdk},
         metrics::LimitsMetrics,
-        move_package::{MovePackage, MovePackageExt, derive_package_metadata_id},
+        move_package::{MovePackageExt, derive_package_metadata_id},
         object::{Data, MoveObject, MoveObjectExt, Object, ObjectInner},
         storage::{BackingPackageStore, DenyListResult, PackageObject},
         transaction::{CallArg, SharedObjectRef},

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -16,7 +16,9 @@ mod checked {
 
     use iota_move_natives::object_runtime::ObjectRuntime;
     use iota_protocol_config::ProtocolConfig;
-    use iota_sdk_types::{Command, Identifier, ObjectId, StructTag, TypeTag};
+    use iota_sdk_types::{
+        Command, Identifier, ObjectId, StructTag, TypeTag, move_package::MovePackage,
+    };
     use iota_types::{
         auth_context,
         base_types::{
@@ -31,7 +33,7 @@ mod checked {
         iota_sdk_types_conversions::type_tag_core_to_sdk,
         metrics::LimitsMetrics,
         move_package::{
-            IotaAttribute, MovePackage, MovePackageExt, PackageMetadata, RuntimeModuleMetadata,
+            IotaAttribute, MovePackageExt, PackageMetadata, RuntimeModuleMetadata,
             RuntimeModuleMetadataWrapper, UpgradeCap, UpgradePolicy, UpgradeReceipt, UpgradeTicket,
             normalize_deserialized_modules,
         },

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/linkage_view.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/linkage_view.rs
@@ -8,10 +8,13 @@ use std::{
     str::FromStr,
 };
 
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{
+    ObjectId,
+    move_package::{MovePackage, TypeOrigin, UpgradeInfo},
+};
 use iota_types::{
     error::{ExecutionError, IotaError, IotaResult},
-    move_package::{MovePackage, MovePackageExt, TypeOrigin, UpgradeInfo},
+    move_package::MovePackageExt,
     storage::{BackingPackageStore, PackageObject, get_module},
 };
 use move_core_types::{


### PR DESCRIPTION
# Description of change

`iota-types::move_package` re-exported `MovePackage`, `TypeOrigin`, and `UpgradeInfo` from `iota_sdk_types::move_package` via a `pub use`. This continues the ongoing effort to drop those re-exports so that `iota-rust-sdk` is the single canonical source for client-visible types, rather than having them reachable through `iota-types` (see the recent `Owner`, `Argument`, and consensus-message re-export removals).

The `pub use` is removed and every consumer now imports `MovePackage` / `TypeOrigin` / `UpgradeInfo` directly from `iota_sdk_types::move_package`. Purely a change of import paths — no functional or API change.

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/11567

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes