### PR TITLE
feat(ci): enforce linked issue workflow

### DIFF
--- a/.github/workflows/enforce_linked_issue.yml
+++ b/.github/workflows/enforce_linked_issue.yml
@@ -1,0 +1,152 @@
+name: Enforce Linked Issue
+
+# Closes pull requests from external contributors that either do not reference an
+# issue the PR closes, or whose linked issue is not assigned to the PR author.
+# Members of the iotaledger/iota-foundation team and bots are exempt.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - ready_for_review
+
+concurrency:
+  group: enforce-linked-issue-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  issues: read
+
+jobs:
+  enforce:
+    name: Require linked & assigned issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check iota-foundation team membership
+        id: membership
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.TEAM_LABELER_TOKEN }}
+          script: |
+            const org = 'iotaledger';
+            const team = 'iota-foundation';
+            const author = context.payload.pull_request.user;
+
+            if (author.type === 'Bot' || author.login.endsWith('[bot]')) {
+              core.info(`Author ${author.login} is a bot; exempt.`);
+              core.setOutput('exempt', 'true');
+              return;
+            }
+
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org,
+                team_slug: team,
+                username: author.login,
+              });
+              core.info(`${author.login} is a member of ${org}/${team}; exempt.`);
+              core.setOutput('exempt', 'true');
+            } catch (err) {
+              if (err.status === 404) {
+                core.info(`${author.login} is not a member of ${org}/${team}; enforcing.`);
+                core.setOutput('exempt', 'false');
+              } else {
+                throw err;
+              }
+            }
+
+      - name: Enforce linked & assigned issue
+        if: steps.membership.outputs.exempt == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Only act on open PRs; an `edited` event can fire on an already
+            // closed PR, and we must not re-comment / re-close it.
+            if (pr.state !== 'open') {
+              core.info(`PR #${pr.number} is ${pr.state}; nothing to do.`);
+              return;
+            }
+
+            const author = pr.user.login;
+
+            // closingIssuesReferences covers both closing keywords in the PR
+            // body (e.g. "Closes #123") and issues linked via the development
+            // sidebar.
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 50) {
+                      nodes {
+                        number
+                        assignees(first: 50) { nodes { login } }
+                      }
+                    }
+                  }
+                }
+              }`;
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: pr.number,
+            });
+            const issues = result.repository.pullRequest.closingIssuesReferences.nodes;
+
+            const eq = (a, b) => a.toLowerCase() === b.toLowerCase();
+
+            let reason = null;
+            if (issues.length === 0) {
+              reason = 'this PR does not reference an issue it closes. Please link an '
+                + 'issue with a closing keyword (e.g. `Closes #123`) in the PR description.';
+            } else {
+              const assignedToAuthor = issues.some(issue =>
+                // We could replace some with every if we required all linked issues to be assigned to the author
+                issue.assignees.nodes.some(a => eq(a.login, author))
+              );
+              if (!assignedToAuthor) {
+                const list = issues.map(i => `#${i.number}`).join(', ');
+                reason = `the linked issue(s) (${list}) are not assigned to you (@${author}). `
+                  + 'Please have the issue assigned to you before opening a PR.';
+              }
+            }
+
+            if (!reason) {
+              core.info(`PR #${pr.number} satisfies the linked-issue requirements.`);
+              return;
+            }
+
+            const body = [
+              `Hi @${author}, thanks for your contribution!`,
+              '',
+              `This PR has been closed automatically because ${reason}`,
+              '',
+              'We require external contributions to be tied to an issue assigned to '
+                + 'the author so that work is coordinated. To proceed:',
+              '',
+              '1. Open or find an issue describing the change.',
+              '2. Ask a maintainer to assign that issue to you.',
+              '3. Reference it from your PR description with a closing keyword (e.g. `Closes #123`).',
+              '',
+              'Once that is done, feel free to reopen this PR. See our '
+                + '[contribution guidelines](../../CONTRIBUTING.md) for more details.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });
+            core.notice(`Closed PR #${pr.number}: ${reason}`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,15 @@ For larger documentation issues, you can [create an issue](https://github.com/io
 
 Want to contribute to the IOTA framework? See [CONTRIBUTING.md](https://github.com/iotaledger/iota/blob/develop/crates/iota-framework/CONTRIBUTING.md) for information related to `iota-framework` crate contributions.
 
+## Link an assigned issue to your pull request
+
+To keep work coordinated and avoid duplicated effort, every pull request from an external contributor must reference an issue **assigned to its author**, using a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) (for example, `Closes #123`) in the description. So, before opening a pull request:
+
+- If no issue covers what you want to work on, [open one](https://github.com/iotaledger/iota/issues/new/choose) describing the change.
+- Ask a maintainer to assign that issue to you (this signals the work isn't already being handled by someone else).
+
+Pull requests that reference no issue, or whose linked issue is not assigned to their author, are **closed automatically** by the [Enforce Linked Issue](./.github/workflows/enforce_linked_issue.yml) workflow. Once you have linked an assigned issue, you are welcome to reopen the pull request.
+
 ## License
 
 By contributing to this project, you agree that your contribution is governed by and licensed under the terms of the project’s current license (as set out in the LICENSE file). You confirm that you have the right to grant this license and that your contribution does not infringe the rights of any third party.


### PR DESCRIPTION
# Description of change

Adds a GitHub Actions workflow that enforces our contribution policy for external pull requests: a PR must reference an issue it closes, and that issue must be assigned to the PR author. This keeps work coordinated and avoids duplicated or drive-by contributions landing without a tracked, owned issue behind them.

The workflow (`.github/workflows/enforce_linked_issue.yml`) runs on `pull_request_target` and:

- Looks up whether the PR author belongs to the `iotaledger/iota-foundation` team (using `TEAM_LABELER_TOKEN`, since the default `GITHUB_TOKEN` cannot read org team membership). Members of that team — and bots — are exempt.
- For everyone else, queries the PR's `closingIssuesReferences` via GraphQL (which covers both closing keywords like `Closes #123` and issues linked through the development sidebar) and checks that at least one linked issue is assigned to the author.
- When no issue is linked, or none is assigned to the author, it posts an explanatory comment and closes the PR. It only acts on open PRs and re-runs on edits/reopen, so a contributor who links an assigned issue and reopens passes the check.

Also documents the policy in `CONTRIBUTING.md` so contributors know to open and get an issue assigned before opening a PR.

## Links to any relevant issues

<!-- Internal contribution; link the tracking issue here if one exists. -->

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests) — workflow YAML validated.
- [ ] Patch-specific tests (correctness, functionality coverage) — N/A for a CI workflow.
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A; `pull_request_target` workflows can't be exercised locally.
- [ ] I have checked that new and existing unit tests pass locally with my changes — N/A.

Additionally verified the `GET /orgs/{org}/teams/{team_slug}/memberships/{username}` behavior against the live `iotaledger/iota-foundation` team: `200` for a member, `404` for a non-member (the branch the workflow relies on). End-to-end behavior should be confirmed on a real external fork PR, since `pull_request_target` can't be triggered locally.