### PR TITLE
upstream(core): Wait for replaying consensus commits before checkpoint builder starts

### DIFF
--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -80,6 +80,7 @@ use crate::{
         checkpoint_output::{CertifiedCheckpointOutput, CheckpointOutput},
     },
     consensus_handler::SequencedConsensusTransactionKey,
+    consensus_manager::ReplayWaiter,
     execution_cache::TransactionCacheRead,
     global_state_hasher::GlobalStateHasher,
     stake_aggregator::{InsertResult, MultiStakeAggregator},
@@ -1003,9 +1004,20 @@ impl CheckpointBuilder {
         }
     }
 
-    /// Runs the `CheckpointBuilder` in an asynchronous loop, managing the
-    /// creation of checkpoints.
-    async fn run(mut self) {
+    /// This function first waits for ConsensusCommitHandler to finish
+    /// reprocessing commits that have been processed before the last
+    /// restart, if consensus_replay_waiter is supplied. Then it starts
+    /// building checkpoints in a loop.
+    ///
+    /// It is optional to pass in consensus_replay_waiter, to make it easier to
+    /// attribute if slow recovery of previously built checkpoints is due to
+    /// consensus replay or checkpoint building.
+    async fn run(mut self, consensus_replay_waiter: Option<ReplayWaiter>) {
+        if let Some(replay_waiter) = consensus_replay_waiter {
+            info!("Waiting for consensus commits to replay ...");
+            replay_waiter.wait_for_replay().await;
+            info!("Consensus commits finished replaying");
+        }
         info!("Starting CheckpointBuilder");
         loop {
             self.maybe_build_checkpoints().await;
@@ -2512,11 +2524,11 @@ impl CheckpointService {
     /// have a number of consensus commits and resulting checkpoints that
     /// were built but not committed to disk. We want to reprocess the
     /// commits and rebuild the checkpoints before starting normal operation.
-    pub async fn spawn(&self) -> JoinSet<()> {
+    pub async fn spawn(&self, consensus_replay_waiter: Option<ReplayWaiter>) -> JoinSet<()> {
         let mut tasks = JoinSet::new();
 
         let (builder, aggregator, state_hasher) = self.state.lock().take_unstarted();
-        tasks.spawn(monitored_future!(builder.run()));
+        tasks.spawn(monitored_future!(builder.run(consensus_replay_waiter)));
         tasks.spawn(monitored_future!(aggregator.run()));
         tasks.spawn(monitored_future!(state_hasher.run()));
 
@@ -2844,7 +2856,7 @@ mod tests {
             3,
             100_000,
         );
-        let _tasks = checkpoint_service.spawn().await;
+        let _tasks = checkpoint_service.spawn(None).await;
 
         checkpoint_service
             .write_and_notify_checkpoint_for_testing(&epoch_store, p(0, vec![4], 0))

--- a/crates/iota-core/src/consensus_manager/mod.rs
+++ b/crates/iota-core/src/consensus_manager/mod.rs
@@ -12,10 +12,11 @@ use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use fastcrypto::traits::KeyPair as _;
 use iota_config::{ConsensusConfig, NodeConfig};
-use iota_metrics::RegistryService;
+use iota_metrics::{RegistryID, RegistryService};
 use iota_protocol_config::ProtocolVersion;
 use iota_types::{committee::EpochId, error::IotaResult, messages_consensus::ConsensusTransaction};
 use prometheus::{IntGauge, Registry, register_int_gauge_with_registry};
+use starfish_core::ConsensusAuthority;
 use tokio::{
     sync::{Mutex, MutexGuard},
     time::{sleep, timeout},
@@ -52,6 +53,8 @@ pub trait ConsensusManagerTrait {
     async fn shutdown(&self);
 
     async fn is_running(&self) -> bool;
+
+    fn replay_waiter(&self) -> Option<ReplayWaiter>;
 }
 
 /// Used by IOTA validator to start consensus protocol for each epoch.
@@ -118,6 +121,10 @@ impl ConsensusManagerTrait for ConsensusManager {
     async fn is_running(&self) -> bool {
         self.starfish_manager.is_running().await
     }
+
+    fn replay_waiter(&self) -> Option<ReplayWaiter> {
+        self.starfish_manager.replay_waiter()
+    }
 }
 
 /// A ConsensusClient that can be updated internally at any time. This usually
@@ -174,6 +181,21 @@ impl ConsensusClient for UpdatableConsensusClient {
     ) -> IotaResult<BlockStatusReceiver> {
         let client = self.get().await;
         client.submit(transactions, epoch_store).await
+    }
+}
+
+#[derive(Clone)]
+pub struct ReplayWaiter {
+    authority: Arc<(ConsensusAuthority, RegistryID)>,
+}
+
+impl ReplayWaiter {
+    pub(crate) fn new(authority: Arc<(ConsensusAuthority, RegistryID)>) -> Self {
+        Self { authority }
+    }
+
+    pub(crate) async fn wait_for_replay(&self) {
+        self.authority.0.replay_complete().await;
     }
 }
 

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -25,7 +25,7 @@ use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
     consensus_handler::{ConsensusHandlerInitializer, StarfishConsensusHandler},
     consensus_manager::{
-        ConsensusManagerMetrics, ConsensusManagerTrait, Running, RunningLockGuard,
+        ConsensusManagerMetrics, ConsensusManagerTrait, ReplayWaiter, Running, RunningLockGuard,
     },
     consensus_validator::IotaTxValidator,
     starfish_adapter::LazyStarfishClient,
@@ -204,11 +204,6 @@ impl ConsensusManagerTrait for StarfishManager {
 
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);
-
-        // Wait until all locally available commits have been processed
-        info!("replaying commits at startup");
-        registered_authority.0.replay_complete().await;
-        info!("Startup commit replay complete");
     }
 
     async fn shutdown(&self) {
@@ -242,5 +237,10 @@ impl ConsensusManagerTrait for StarfishManager {
 
     async fn is_running(&self) -> bool {
         Running::False != *self.running.lock().await
+    }
+
+    fn replay_waiter(&self) -> Option<ReplayWaiter> {
+        let authority = self.authority.load_full()?;
+        Some(ReplayWaiter::new(authority))
     }
 }

--- a/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
@@ -54,7 +54,7 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
         3,
         100_000,
     );
-    checkpoint_service.spawn().now_or_never().unwrap();
+    checkpoint_service.spawn(None).now_or_never().unwrap();
     checkpoint_service
 }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1304,9 +1304,10 @@ impl IotaNode {
                 ),
             )
             .await;
+        let consensus_replay_waiter = consensus_manager.replay_waiter();
 
         info!("Spawning checkpoint service");
-        let checkpoint_service_tasks = checkpoint_service.spawn().await;
+        let checkpoint_service_tasks = checkpoint_service.spawn(consensus_replay_waiter).await;
 
         Ok(ValidatorComponents {
             validator_server_handle,


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.49.2, v1.50.1)
- Port commit:
  - [MystenLabs/sui@e714b19](https://github.com/MystenLabs/sui/commit/e714b19fada0c88dd18e564c6937c5f03c7e9f25)
- Description:

Checkpoint builder is the only component that needs to wait for consensus to finish replay. It seems better to wait in checkpoint builder instead of during consensus startup.

This also improves the parallelism between starting consensus and other components. Currently, starting up other components are blocked on consensus starting, without a timeout.
Note: The change applies to `StarfishManager` (upstream `MysticetiManager`) and `ConsensusAuthority` from `starfish_core`.

## Links to any relevant issues

Part of #11322

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes