### PR TITLE
fix(docker): restore cargo build caching for the iota-tools image

### DIFF
--- a/docker/utils/build-script.sh
+++ b/docker/utils/build-script.sh
@@ -75,15 +75,23 @@ if [ "${DOCKER_BUILDKIT:-0}" = "1" ]; then
 	print_step "Cache mounts enabled - creating temporary Dockerfile with cache support"
 	DOCKERFILE_TMP="${DOCKERFILE}.cache"
 
-	# Add BuildKit syntax and inject cache mounts before cargo build
+	# Add BuildKit syntax and inject cache mounts into the RUN instruction
+	# that builds the binaries (either `RUN cargo build ...` or the
+	# `RUN BINARIES=...` loop form used by multi-binary images).
 	{
 		echo "# syntax=docker/dockerfile:1"
-		sed 's/^RUN cargo build --profile \${PROFILE}/RUN --mount=type=cache,target=\/usr\/local\/cargo\/registry \\\
+		sed -E 's/^RUN (cargo build --profile \$\{PROFILE\}|BINARIES=)/RUN --mount=type=cache,target=\/usr\/local\/cargo\/registry \\\
     --mount=type=cache,target=\/usr\/local\/cargo\/git \\\
     --mount=type=cache,target=\/iota\/target,sharing=locked \\\
-    cargo build --profile ${PROFILE}/' "$DOCKERFILE"
+    \1/' "$DOCKERFILE"
 	} > "$DOCKERFILE_TMP"
 	
+	# A pattern mismatch must fail loudly: a silent no-op here means every
+	# source change triggers a full cold rebuild of all binaries.
+	if ! grep -q -- '--mount=type=cache' "$DOCKERFILE_TMP"; then
+		print_error "Failed to inject cargo cache mounts into $DOCKERFILE: no build instruction matched"
+		exit 1
+	fi
 	DOCKERFILE="$DOCKERFILE_TMP"
 	
 	# Ensure cleanup on exit


### PR DESCRIPTION
# Description of change

The BuildKit cache-mount injection in `docker/utils/build-script.sh` rewrites the Dockerfile with a `sed` matching `RUN cargo build --profile ${PROFILE}` at line start. #11100 refactored the `iota-tools` Dockerfile to a `RUN BINARIES=...` loop, so the injection silently stopped matching — every `iota-tools` build since has been a full cold rebuild of all its binaries. (`iota-node` and `iota-indexer` still use the plain `RUN cargo build` form and were unaffected.)

This PR is entirely contained in `build-script.sh` — no Dockerfile changes are needed:
- extends the pattern to match both the plain `RUN cargo build` form and the `RUN BINARIES=` loop form,
- makes the build fail loudly when no build instruction matches, so a future Dockerfile refactor cannot silently disable caching again.

## Links to any relevant issues

Fixes #11787

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Verified the injection dry-run against all three Dockerfiles on `develop`: 3 cache-mount lines are injected into each, attached to the correct `RUN` instruction (including the `iota-tools` `RUN BINARIES=` loop).