### PR TITLE
feat(starfish): allow burst block proposals within a rate window instead of fixed min delay

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -28,7 +28,8 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_leader_timeout")]
     pub leader_timeout: Duration,
 
-    /// Minimum delay between own blocks. This avoids generating too many rounds
+    /// Sustained spacing between own blocks: long-run production never exceeds
+    /// one block per `min_block_delay`. This avoids generating too many rounds
     /// when latency is low. This is especially necessary for tests running
     /// locally. If setting a non-default value, it should be set low enough
     /// to avoid reducing round rate and increasing latency in realistic and
@@ -42,6 +43,14 @@ pub struct Parameters {
     /// than `leader_timeout` and does not force block creation on its own.
     #[serde(default = "Parameters::default_soft_leader_timeout")]
     pub soft_leader_timeout: Duration,
+
+    /// Window bounding own block production together with `min_block_delay`:
+    /// idle time accrues budget for bursts of up to `block_rate_window /
+    /// min_block_delay` back-to-back blocks, letting a validator that fell
+    /// behind catch up on rounds instead of skipping them. Set at or below
+    /// `min_block_delay` to disable bursting (fixed spacing between blocks).
+    #[serde(default = "Parameters::default_block_rate_window")]
+    pub block_rate_window: Duration,
 
     /// Number of block headers to fetch per commit sync request.
     #[serde(default = "Parameters::default_max_headers_per_commit_sync_fetch")]
@@ -161,6 +170,17 @@ impl Parameters {
 
     pub(crate) fn default_soft_leader_timeout() -> Duration {
         Duration::from_millis(100)
+    }
+
+    pub(crate) fn default_block_rate_window() -> Duration {
+        Duration::from_secs(2)
+    }
+
+    /// Burst capacity: maximum number of own blocks within `block_rate_window`
+    /// (40 in production, 5 in msim, 8 in tests with the default window).
+    pub fn block_rate_burst(&self) -> u64 {
+        let interval_ms = self.min_block_delay.as_millis().max(1) as u64;
+        (self.block_rate_window.as_millis() as u64 / interval_ms).max(1)
     }
 
     // Maximum number of block headers to fetch per commit sync request.
@@ -287,6 +307,7 @@ impl Default for Parameters {
             leader_timeout: Parameters::default_leader_timeout(),
             min_block_delay: Parameters::default_min_block_delay(),
             soft_leader_timeout: Parameters::default_soft_leader_timeout(),
+            block_rate_window: Parameters::default_block_rate_window(),
             max_headers_per_commit_sync_fetch:
                 Parameters::default_max_headers_per_commit_sync_fetch(),
             max_transactions_per_commit_sync_fetch:

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -11,6 +11,9 @@ min_block_delay:
 soft_leader_timeout:
   secs: 0
   nanos: 100000000
+block_rate_window:
+  secs: 2
+  nanos: 0
 max_headers_per_commit_sync_fetch: 1000
 max_transactions_per_commit_sync_fetch: 1000
 max_headers_per_regular_sync_fetch: 100

--- a/crates/starfish/core/src/block_rate_limiter.rs
+++ b/crates/starfish/core/src/block_rate_limiter.rs
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+/// Rate limiter for own block proposals (GCRA / token-bucket): sustained
+/// production of at most one block per `min_block_delay`, with bursts of up to
+/// `block_rate_window / min_block_delay` back-to-back blocks after idle
+/// periods. A burst capacity of 1 degenerates to a fixed minimum delay
+/// between consecutive blocks.
+///
+/// State is a single instant: the time at which an ideal schedule emitting
+/// exactly one block per interval would emit the next block. Idle time lets it
+/// fall back toward `now` (accruing budget); each proposal advances it by one
+/// interval.
+pub(crate) struct BlockRateLimiter {
+    /// UTC ms at which the next block would be emitted under an ideal schedule
+    /// of one block per `interval_ms` (the GCRA theoretical arrival time). It
+    /// runs ahead of `now` after recent proposals and falls back toward `now`
+    /// while idle; the gap below `now` is the unspent burst budget.
+    next_block_ms: u64,
+    /// Sustained spacing between blocks (`min_block_delay`), in ms.
+    interval_ms: u64,
+    /// Maximum number of back-to-back blocks allowed after an idle period.
+    burst: u64,
+}
+
+impl BlockRateLimiter {
+    pub(crate) fn new(min_block_delay: Duration, burst: u64) -> Self {
+        Self {
+            next_block_ms: 0,
+            interval_ms: min_block_delay.as_millis().max(1) as u64,
+            burst: burst.max(1),
+        }
+    }
+
+    /// Whether a proposal at `now_ms` fits the rate envelope.
+    pub(crate) fn is_conforming(&self, now_ms: u64) -> bool {
+        self.next_block_ms.saturating_sub(now_ms) <= (self.burst - 1) * self.interval_ms
+    }
+
+    /// Records a proposal at `now_ms`. Called for every own block, including
+    /// forced proposals that bypass the conformance check; the cap bounds
+    /// their overdraft so the next non-forced proposal waits at most one
+    /// interval after the last block.
+    pub(crate) fn record(&mut self, now_ms: u64) {
+        self.next_block_ms = (self.next_block_ms.max(now_ms) + self.interval_ms)
+            .min(now_ms + self.burst * self.interval_ms);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use starfish_config::Parameters;
+
+    use crate::block_rate_limiter::BlockRateLimiter;
+
+    /// Drive the tests from the default consensus parameters rather than magic
+    /// numbers, so they track the production config (interval and burst).
+    fn interval_ms_and_burst() -> (u64, u64) {
+        let params = Parameters::default();
+        (
+            params.min_block_delay.as_millis() as u64,
+            params.block_rate_burst(),
+        )
+    }
+
+    fn limiter() -> BlockRateLimiter {
+        let params = Parameters::default();
+        BlockRateLimiter::new(params.min_block_delay, params.block_rate_burst())
+    }
+
+    #[test]
+    fn burst_after_idle_then_reject() {
+        let (interval_ms, burst) = interval_ms_and_burst();
+        let mut l = limiter();
+        let now = 1_000_000;
+        // Exactly `burst` back-to-back proposals conform, the next does not.
+        for _ in 0..burst {
+            assert!(l.is_conforming(now));
+            l.record(now);
+        }
+        assert!(!l.is_conforming(now));
+        // Budget for one more block regenerates after one interval.
+        assert!(!l.is_conforming(now + interval_ms - 1));
+        assert!(l.is_conforming(now + interval_ms));
+    }
+
+    #[test]
+    fn sustained_rate_is_one_per_interval() {
+        let (interval_ms, burst) = interval_ms_and_burst();
+        let mut l = limiter();
+        let start = 1_000_000;
+        // Drain the burst budget.
+        for _ in 0..burst {
+            l.record(start);
+        }
+        // Under continuous attempts, conforming instants are spaced exactly
+        // one interval apart.
+        let mut now = start;
+        for _ in 0..10 {
+            assert!(!l.is_conforming(now + interval_ms - 1));
+            now += interval_ms;
+            assert!(l.is_conforming(now));
+            l.record(now);
+        }
+    }
+
+    #[test]
+    fn burst_one_degenerates_to_fixed_delay() {
+        let (interval_ms, _) = interval_ms_and_burst();
+        let mut l = BlockRateLimiter::new(Duration::from_millis(interval_ms), 1);
+        let now = 1_000_000;
+        assert!(l.is_conforming(now));
+        l.record(now);
+        // Identical to the old rule: blocked until exactly one interval elapses.
+        assert!(!l.is_conforming(now));
+        assert!(!l.is_conforming(now + interval_ms - 1));
+        assert!(l.is_conforming(now + interval_ms));
+    }
+
+    #[test]
+    fn forced_overdraft_is_capped() {
+        let (interval_ms, burst) = interval_ms_and_burst();
+        let mut l = limiter();
+        let now = 1_000_000;
+        // Forced proposals record without a conformance check; the cap keeps
+        // the next non-forced eligibility within one interval of the last.
+        for _ in 0..(3 * burst) {
+            l.record(now);
+        }
+        assert!(!l.is_conforming(now));
+        assert!(l.is_conforming(now + interval_ms));
+    }
+
+    #[test]
+    fn seeding_by_replay_restores_budget_spent() {
+        let (interval_ms, burst) = interval_ms_and_burst();
+        let mut l = limiter();
+        let now = 1_000_000;
+        // Replaying k recent block timestamps leaves budget for `burst - k`
+        // more (no time elapses here, so no budget regenerates in between).
+        let k = burst / 2;
+        for _ in 0..k {
+            l.record(now);
+        }
+        for _ in 0..(burst - k) {
+            assert!(l.is_conforming(now));
+            l.record(now);
+        }
+        assert!(!l.is_conforming(now));
+        // Timestamps older than the whole window leave the budget full.
+        let mut l = limiter();
+        l.record(now - burst * interval_ms);
+        for _ in 0..burst {
+            assert!(l.is_conforming(now));
+            l.record(now);
+        }
+        assert!(!l.is_conforming(now));
+    }
+}

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -40,6 +40,7 @@ use crate::{
         VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
     },
     block_manager::BlockManager,
+    block_rate_limiter::BlockRateLimiter,
     commit::{CertifiedCommits, CommitAPI, PendingSubDag},
     commit_observer::{CommitObserver, CommittedSubDagSource},
     commit_syncer::fast::FastSyncOutput,
@@ -119,6 +120,11 @@ pub(crate) struct Core {
     /// Starfish) propose condition was satisfied. Used to measure the extra
     /// wait imposed by StarfishSpeed's strong-vote condition.
     ordinary_propose_ready_at: Option<(Round, Instant)>,
+    /// Rate limiter for own proposals: sustained rate of one block per
+    /// `min_block_delay`, with burst budget accrued while waiting on the
+    /// network, so a validator that fell behind catches up on rounds instead
+    /// of skipping them.
+    proposal_rate_limiter: BlockRateLimiter,
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
@@ -167,10 +173,11 @@ impl ReasonToCreateBlock {
     }
 }
 
-/// Reason a `Core::should_propose` call returned `false`. Used as the `reason`
-/// label on the `core_skipped_proposals` metric. Keeping the variants in one
-/// enum makes the label space disjoint and centrally visible. Variant data is
-/// the per-reason context interpolated into the corresponding `debug!` line.
+/// Reason a proposal attempt was skipped, either in `Core::should_propose` or
+/// by the rate limiter in `Core::try_new_block`. Used as the `reason` label on
+/// the `core_skipped_proposals` metric. Keeping the variants in one enum makes
+/// the label space disjoint and centrally visible. Variant data is the
+/// per-reason context interpolated into the corresponding `debug!` line.
 ///
 /// The "already proposed at this round" branch is intentionally not modeled
 /// here: it fires on every block accepted in a round we have already proposed
@@ -182,6 +189,7 @@ pub(crate) enum SkipProposalReason {
     NoLastKnownProposedRound,
     HigherLastKnownProposedRound { last_known: Round },
     BehindQuorumCommitRound { approx_quorum: Round },
+    BlockRateLimited,
 }
 
 impl SkipProposalReason {
@@ -191,6 +199,7 @@ impl SkipProposalReason {
             Self::NoLastKnownProposedRound => "no_last_known_proposed_round",
             Self::HigherLastKnownProposedRound { .. } => "higher_last_known_proposed_round",
             Self::BehindQuorumCommitRound { .. } => "behind_quorum_commit_round",
+            Self::BlockRateLimited => "block_rate_limited",
         }
     }
 }
@@ -247,6 +256,21 @@ impl Core {
 
         let encoder = create_encoder(&context);
 
+        // Seed the rate limiter from own recent blocks so a quick restart does
+        // not grant a fresh burst budget. Looking back `burst` rounds captures
+        // the recent own blocks that still affect the state; replaying blocks
+        // older than the window is harmless (the limiter absorbs them).
+        let burst = context.parameters.block_rate_burst();
+        let mut proposal_rate_limiter =
+            BlockRateLimiter::new(context.parameters.min_block_delay, burst);
+        let lookback_start = last_signaled_round.saturating_sub(burst as Round);
+        for header in dag_state
+            .read()
+            .get_cached_block_headers_since_round(context.own_index, lookback_start)
+        {
+            proposal_rate_limiter.record(header.timestamp_ms());
+        }
+
         Self {
             context,
             last_signaled_round,
@@ -266,6 +290,7 @@ impl Core {
             commit_vote_monitor,
             strong_vote_timed_out_round: None,
             ordinary_propose_ready_at: None,
+            proposal_rate_limiter,
         }
         .recover()
     }
@@ -852,12 +877,9 @@ impl Core {
         if self.context.protocol_config.consensus_starfish_speed()
             && !reason.is_forced()
             && leader_header.is_some()
-            && Duration::from_millis(
-                self.context
-                    .clock
-                    .timestamp_utc_ms()
-                    .saturating_sub(self.last_proposed_timestamp_ms()),
-            ) >= self.context.parameters.min_block_delay
+            && self
+                .proposal_rate_limiter
+                .is_conforming(self.context.clock.timestamp_utc_ms())
             && self
                 .ordinary_propose_ready_at
                 .is_none_or(|(r, _)| r != clock_round)
@@ -867,7 +889,7 @@ impl Core {
 
         // Create a new block either because we want to "forcefully" propose a block due
         // to a leader timeout, or because we are actually ready to produce the
-        // block (leader exists and min delay has passed).
+        // block (leader exists and the block rate budget allows it).
         if !reason.is_forced() {
             leader_header.as_ref()?;
 
@@ -885,13 +907,11 @@ impl Core {
                 }
             }
 
-            if Duration::from_millis(
-                self.context
-                    .clock
-                    .timestamp_utc_ms()
-                    .saturating_sub(self.last_proposed_timestamp_ms()),
-            ) < self.context.parameters.min_block_delay
+            if !self
+                .proposal_rate_limiter
+                .is_conforming(self.context.clock.timestamp_utc_ms())
             {
+                self.skip_proposal(clock_round, SkipProposalReason::BlockRateLimited);
                 return None;
             }
         }
@@ -1198,6 +1218,9 @@ impl Core {
             .with_label_values(&[&reason.label()])
             .inc();
 
+        // Every proposal spends rate budget, including forced ones.
+        self.proposal_rate_limiter.record(now);
+
         Some(verified_block)
     }
 
@@ -1485,6 +1508,9 @@ impl Core {
                     "Skip proposing for round {clock_round}, behind approximate quorum commit round {approx_quorum}"
                 );
             }
+            SkipProposalReason::BlockRateLimited => {
+                debug!("Skip proposing for round {clock_round}, block rate budget exhausted");
+            }
         }
         self.context
             .metrics
@@ -1706,12 +1732,15 @@ pub(crate) struct CoreSignals {
 
 impl CoreSignals {
     pub fn new(context: Arc<Context>) -> (Self, CoreSignalsReceivers) {
-        // Blocks buffered in broadcast channel should be roughly equal to thosed cached
+        // Blocks buffered in broadcast channel should be roughly equal to those cached
         // in dag state, since the underlying blocks are ref counted so a lower
-        // buffer here will not reduce memory usage significantly.
-        let (tx_block_broadcast, rx_block_broadcast) = broadcast::channel::<VerifiedBlock>(
-            context.parameters.dag_state_cached_rounds as usize,
-        );
+        // buffer here will not reduce memory usage significantly. The floor holds
+        // one full burst of `burst` back-to-back blocks so a freshly drained burst
+        // is not dropped before subscribers consume it.
+        let capacity = (context.parameters.dag_state_cached_rounds as usize)
+            .max(context.parameters.block_rate_burst() as usize);
+        let (tx_block_broadcast, rx_block_broadcast) =
+            broadcast::channel::<VerifiedBlock>(capacity);
         let (new_round_sender, new_round_receiver) = watch::channel(0);
 
         let me = Self {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1576,7 +1576,6 @@ impl DagState {
     /// Block headers returned are limited to round >= `start`, and cached.
     /// NOTE: caller should not assume returned block headers are always
     /// chained.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn get_cached_block_headers_since_round(
         &self,
         authority: AuthorityIndex,

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -8,6 +8,7 @@ mod authority_set;
 mod base_committer;
 mod block_header;
 mod block_manager;
+mod block_rate_limiter;
 mod block_verifier;
 mod commit;
 mod commit_consumer;


### PR DESCRIPTION
# Description of change

Replaces the fixed `min_block_delay` gate between consecutive own blocks with a GCRA (token-bucket) rate limiter: sustained production stays at one block per `min_block_delay`, while time spent waiting on the network accrues budget for bursts of up to `block_rate_window / min_block_delay` back-to-back blocks (40 in production, 5 in msim, 8 in tests). A validator that fell behind — e.g. bursty block arrival on a high-latency link — can then propose on every threshold-clock advance instead of skipping rounds, mitigating the block-rate spread between fast and slow validators observed on mainnet/testnet.

Design notes:
- GCRA state is a single theoretical-arrival timestamp; burst capacity 1 degenerates to the previous fixed-delay rule, and under saturation conforming instants are spaced exactly `min_block_delay` apart (no burst/dead-zone oscillation).
- Forced proposals (leader timeout etc.) still bypass the check but consume budget, with an overdraft cap reproducing today's "forced block delays the next non-forced one by one interval".
- The leader timeout task is unchanged: with the cap, the retry timer armed at `last_own_block + min_block_delay` remains the latest instant at which a proposal can still be rate-blocked, so it fires exactly when conformance is guaranteed.
- The limiter is seeded on startup by replaying own cached block-header timestamps from DagState, so a quick restart does not grant a fresh burst budget; after a long downtime the bucket is full, which is the desired catch-up behavior.
- Purely local node configuration — no protocol change, safe in mixed fleets (no receive-side validation depends on inter-block spacing). `block-rate-window <= min-block-delay` is a config-only rollback to the previous behavior.
- Rate-limited declines, previously silent, are now counted via `core_skipped_proposals{reason="block_rate_limited"}`.
- The block broadcast channel keeps headroom for a full burst (msim capacity equaled the burst size).


Tested on a local network that has the same artefacts as Mainnet/Testnet, where slow validators receive blocks in bursts from relay nodes and produce a noticeably smaller number of blocks. With this change, there is no difference between the block rate of slow and fast validators. As a side effect, it could improve the e2e latency for transactions handled by slow validators

## Links to any relevant issues

Fixes #11789

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
