### PR TITLE
chore(move): set package authors to IOTA Foundation

### DIFF
--- a/crates/iota-framework/packages/iota-framework/Move.toml
+++ b/crates/iota-framework/packages/iota-framework/Move.toml
@@ -3,6 +3,7 @@ name = "Iota"
 version = "0.0.1"
 published-at = "0x2"
 edition = "2024"
+authors = ["IOTA Foundation <info@iota.org>"]
 
 [dependencies]
 MoveStdlib = { local = "../move-stdlib" }

--- a/crates/iota-framework/packages/iota-system/Move.toml
+++ b/crates/iota-framework/packages/iota-system/Move.toml
@@ -3,6 +3,7 @@ name = "IotaSystem"
 version = "0.0.1"
 published-at = "0x3"
 edition = "2024"
+authors = ["IOTA Foundation <info@iota.org>"]
 
 [dependencies]
 MoveStdlib = { local = "../move-stdlib" }

--- a/crates/iota-framework/packages/move-stdlib/Move.toml
+++ b/crates/iota-framework/packages/move-stdlib/Move.toml
@@ -3,6 +3,7 @@ name = "MoveStdlib"
 version = "1.6.0"
 published-at = "0x1"
 edition = "2024"
+authors = ["IOTA Foundation <info@iota.org>"]
 
 [addresses]
 std = "0x1"

--- a/crates/iota-framework/packages/stardust/Move.toml
+++ b/crates/iota-framework/packages/stardust/Move.toml
@@ -3,6 +3,7 @@ name = "Stardust"
 version = "0.0.1"
 published-at = "0x107a"
 edition = "2024"
+authors = ["IOTA Foundation <info@iota.org>"]
 
 [dependencies]
 MoveStdlib = { local = "../move-stdlib" }

--- a/external-crates/move/crates/move-stdlib/Move.toml
+++ b/external-crates/move/crates/move-stdlib/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "MoveStdlib"
 edition = "2024"
+authors = ["IOTA Foundation <info@iota.org>"]
 
 [addresses]
 std = "_"

--- a/kiosk/Move.toml
+++ b/kiosk/Move.toml
@@ -2,6 +2,7 @@
 name = "Kiosk"
 version = "0.0.2"
 edition = "2024"
+authors = ["IOTA Foundation <info@iota.org>"]
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/mainnet" }


### PR DESCRIPTION
Static review only. No local tests or builds were run due to resource-safety policy.

Closes #11230

Adds `authors = ["IOTA Foundation <info@iota.org>"]` under `[package]` in the Move package manifests (`Move.toml`) in the repository.