### PR TITLE
chore(move): remove MoveObjectType re-export from iota-types

### DIFF
--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -13,14 +13,14 @@ use iota_sdk_crypto::{
 use iota_sdk_types::{
     Argument, ChangeEpoch, Command, CommandArgumentError, ConsensusCommitPrologueV1,
     ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus, Identifier,
-    MoveLocation, ObjectId, Owner, PackageUpgradeError, SimpleSignature, StructTag,
+    MoveLocation, MoveObjectType, ObjectId, Owner, PackageUpgradeError, SimpleSignature, StructTag,
     TypeArgumentError, TypeTag,
     crypto::{Intent, IntentMessage, PersonalMessage},
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
 };
 use iota_types::{
     base_types::{
-        self, ExecutionData, IotaAddress, MoveObjectType, ObjectDigest, TransactionDigest,
+        self, ExecutionData, IotaAddress, ObjectDigest, TransactionDigest,
         TransactionEffectsDigest,
     },
     crypto::{

--- a/crates/iota-graphql-rpc/src/types/move_type.rs
+++ b/crates/iota-graphql-rpc/src/types/move_type.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use iota_sdk_types::{StructTag, TypeTag};
-use iota_types::base_types::MoveObjectType;
+use iota_sdk_types::{MoveObjectType, StructTag, TypeTag};
 use move_binary_format::file_format::AbilitySet;
 use move_core_types::annotated_value as A;
 use serde::{Deserialize, Serialize};

--- a/crates/iota-grpc-server/tests/list_owned_objects.rs
+++ b/crates/iota-grpc-server/tests/list_owned_objects.rs
@@ -22,9 +22,9 @@ use iota_grpc_types::{
         types::Address as ProtoAddress,
     },
 };
-use iota_sdk_types::{ObjectId, Owner, StructTag};
+use iota_sdk_types::{MoveObjectType, ObjectId, Owner, StructTag};
 use iota_types::{
-    base_types::{IotaAddress, MoveObjectType},
+    base_types::IotaAddress,
     crypto::{AccountKeyPair, get_key_pair},
     digests::TransactionDigest,
     gas_coin::GasCoin,

--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -13,9 +13,9 @@ use anyhow::anyhow;
 use fastcrypto::hash::HashFunction;
 use iota_protocol_config::ProtocolConfig;
 pub use iota_sdk_types::{
-    Address as IotaAddress, MoveObjectType, ObjectReference as ObjectRef, Version as SequenceNumber,
+    Address as IotaAddress, ObjectReference as ObjectRef, Version as SequenceNumber,
 };
-use iota_sdk_types::{Identifier, ObjectId, Owner, StructTag, TypeTag};
+use iota_sdk_types::{Identifier, MoveObjectType, ObjectId, Owner, StructTag, TypeTag};
 use move_binary_format::{CompiledModule, file_format::SignatureToken};
 use move_bytecode_utils::resolve_struct;
 use move_core_types::{

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -11,7 +11,7 @@ use std::{
 
 use iota_protocol_config::ProtocolConfig;
 pub use iota_sdk_types::{MoveStruct as MoveObject, ObjectData as Data};
-use iota_sdk_types::{ObjectId, Owner, StructTag, TypeTag, move_package::MovePackage};
+use iota_sdk_types::{MoveObjectType, ObjectId, Owner, StructTag, TypeTag, move_package::MovePackage};
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::{layout::TypeLayoutBuilder, module_cache::GetModule};
 use move_core_types::annotated_value::{MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue};
@@ -21,7 +21,7 @@ use self::{balance_traversal::BalanceTraversal, bounded_visitor::BoundedVisitor}
 use crate::{
     balance::Balance,
     base_types::{
-        IotaAddress, MoveObjectType, ObjectDigest, ObjectRef, SequenceNumber, TransactionDigest,
+        IotaAddress, ObjectDigest, ObjectRef, SequenceNumber, TransactionDigest,
     },
     coin::{Coin, CoinMetadata, TreasuryCap},
     crypto::{default_hash, deterministic_random_account_key},

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -4,13 +4,13 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{MoveObjectType, ObjectId};
 use serde::{Deserialize, Serialize};
 use typed_store_error::TypedStoreError;
 
 use super::{ObjectStore, error::Result};
 use crate::{
-    base_types::{EpochId, IotaAddress, MoveObjectType, ObjectType, SequenceNumber},
+    base_types::{EpochId, IotaAddress, ObjectType, SequenceNumber},
     committee::Committee,
     digests::{CheckpointContentsDigest, CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEvents},


### PR DESCRIPTION
Static review only. No local tests or builds were run due to resource-safety policy.

Closes #11567

Removes `MoveObjectType` from the public `pub use` re-exports in `iota-types` (`base_types.rs`), and updates consuming files to import it directly from the originating `iota_sdk_types` crate.