### PR TITLE
fix(examples): remove-re-exports

### DIFF
--- a/docs/examples/rust/abstract_account/authenticator-inputs-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-inputs-cryptographic-protection.rs
@@ -23,15 +23,13 @@ use iota_sdk::{
     rpc_types::{IotaTransactionBlockEffectsAPI, ObjectChange},
     types::{
         crypto::SignatureScheme::ED25519,
-        programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::{Argument, Transaction},
+        programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::Transaction,
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, TypeTag};
+use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, TypeTag};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     crypto::PublicKey,
-    object::Owner,
     signature::GenericSignature,
     transaction::{CallArg, SharedObjectRef},
     utils::MoveAuthenticator,

--- a/docs/examples/rust/abstract_account/authenticator-shared-object-swap.rs
+++ b/docs/examples/rust/abstract_account/authenticator-shared-object-swap.rs
@@ -22,15 +22,13 @@ use iota_sdk::{
     rpc_types::{IotaTransactionBlockEffectsAPI, ObjectChange},
     types::{
         crypto::SignatureScheme::ED25519,
-        programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::{Argument, Transaction},
+        programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::Transaction,
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, TypeTag};
+use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, TypeTag};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     crypto::PublicKey,
-    object::Owner,
     signature::GenericSignature,
     transaction::{CallArg, SharedObjectRef},
     utils::MoveAuthenticator,

--- a/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
@@ -15,15 +15,12 @@ use iota_keys::keystore::{AccountKeystore, InMemKeystore};
 use iota_sdk::{
     IotaClient, IotaClientBuilder, rpc_types::ObjectChange, types::crypto::SignatureScheme::ED25519,
 };
-use iota_sdk_types::{Identifier, ObjectId, TypeTag};
+use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, TypeTag};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
-    object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     signature::GenericSignature,
-    transaction::{
-        Argument, CallArg, SharedObjectRef, Transaction, TransactionData, TransactionKind,
-    },
+    transaction::{CallArg, SharedObjectRef, Transaction, TransactionData, TransactionKind},
     utils::MoveAuthenticator,
 };
 

--- a/docs/examples/rust/stardust/address-unlock-condition.rs
+++ b/docs/examples/rust/stardust/address-unlock-condition.rs
@@ -24,10 +24,10 @@ use iota_sdk::{
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
         stardust::output::NftOutput,
-        transaction::{Argument, CallArg, Transaction, TransactionData},
+        transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs

--- a/docs/examples/rust/stardust/alias-migration.rs
+++ b/docs/examples/rust/stardust/alias-migration.rs
@@ -20,10 +20,10 @@ use iota_sdk::{
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
         stardust::output::AliasOutput,
-        transaction::{Argument, CallArg, Transaction, TransactionData},
+        transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/alias-output-claim.rs
+++ b/docs/examples/rust/stardust/alias-output-claim.rs
@@ -19,10 +19,10 @@ use iota_sdk::{
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
         stardust::output::AliasOutput,
-        transaction::{Argument, CallArg, Transaction, TransactionData},
+        transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/basic-output-claim.rs
+++ b/docs/examples/rust/stardust/basic-output-claim.rs
@@ -19,10 +19,10 @@ use iota_sdk::{
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
         stardust::output::BasicOutput,
-        transaction::{Argument, CallArg, Transaction, TransactionData},
+        transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/foundry-output-claim.rs
+++ b/docs/examples/rust/stardust/foundry-output-claim.rs
@@ -20,10 +20,10 @@ use iota_sdk::{
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
-        transaction::{Argument, CallArg, Transaction, TransactionData},
+        transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, StructTag, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, StructTag, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs

--- a/docs/examples/rust/stardust/iota-self-sponsor.rs
+++ b/docs/examples/rust/stardust/iota-self-sponsor.rs
@@ -19,10 +19,10 @@ use iota_sdk::{
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
-        transaction::{Argument, CallArg, Transaction, TransactionData},
+        transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 pub const IOTA_COIN_TYPE: u32 = 4218;

--- a/docs/examples/rust/stardust/nft-migration.rs
+++ b/docs/examples/rust/stardust/nft-migration.rs
@@ -16,10 +16,10 @@ use iota_sdk::{
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
-        transaction::{Argument, CallArg, Transaction, TransactionData},
+        transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/nft-output-claim.rs
+++ b/docs/examples/rust/stardust/nft-output-claim.rs
@@ -19,10 +19,10 @@ use iota_sdk::{
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
         stardust::output::NftOutput,
-        transaction::{Argument, CallArg, Transaction, TransactionData},
+        transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/examples/tic-tac-toe/cli/src/client.rs
+++ b/examples/tic-tac-toe/cli/src/client.rs
@@ -18,14 +18,13 @@ use iota_sdk::{
     wallet_context::WalletContext,
 };
 use iota_sdk_types::{
-    Identifier, ObjectId, StructTag,
+    Identifier, ObjectId, Owner, StructTag,
     crypto::{Intent, UserSignature},
 };
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     crypto::PublicKey,
     multisig::{MultiSig, MultiSigPublicKey},
-    object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     signature::GenericSignature,
     transaction::{

--- a/examples/tic-tac-toe/cli/src/game.rs
+++ b/examples/tic-tac-toe/cli/src/game.rs
@@ -5,10 +5,10 @@
 use std::fmt;
 
 use fastcrypto::encoding::{Base64, Encoding};
+use iota_sdk_types::Owner;
 use iota_types::{
     base_types::{ObjectRef, SequenceNumber},
     digests::ObjectDigest,
-    object::Owner,
 };
 use serde::Deserialize;
 


### PR DESCRIPTION
# Description of change

Recent cleanup PRs (#11782, #11730) removed package re-exports, which broke compilation of the Rust documentation examples and the `tic-tac-toe` CLI example. Those files still imported `Owner` and `Argument` from the now-removed re-export paths (`iota_types::object::Owner`, `iota_types::transaction::Argument`, `iota_sdk::types::transaction::Argument`).

This updates the affected imports to pull `Owner` and `Argument` from their canonical location in `iota_sdk_types`, so the examples compile again.

## Links to any relevant issues

N/A

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

These are example files; the fix is verified by their compilation succeeding.