### PR TITLE
chore: remove `TransactionKind` and `TransactionExpiration` re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5918,6 +5918,7 @@ dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "iota-verifier-latest",
  "move-binary-format",
@@ -6115,6 +6116,7 @@ version = "1.26.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "prometheus",
 ]

--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -7,11 +7,11 @@ use std::{collections::BTreeSet, sync::Arc};
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
 use iota_data_ingestion_core::Worker;
-use iota_sdk_types::Command;
+use iota_sdk_types::{Command, TransactionKind};
 use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
-    transaction::{TransactionDataAPI, TransactionKind, TransactionKindExt},
+    transaction::{TransactionDataAPI, TransactionKindExt},
 };
 use tokio::sync::Mutex;
 use tracing::error;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -45,7 +45,7 @@ use iota_metrics::{
     TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX, monitored_scope, spawn_monitored_task,
 };
 use iota_sdk_types::{
-    ExecutionStatus, ObjectId, Owner, StructTag, TypeTag,
+    ExecutionStatus, ObjectId, Owner, StructTag, TransactionKind, TypeTag,
     crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
 };
 use iota_storage::{

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -45,7 +45,7 @@ use iota_metrics::{
     TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX, monitored_scope, spawn_monitored_task,
 };
 use iota_sdk_types::{
-    ExecutionStatus, ObjectId, Owner, StructTag, TransactionKind, TypeTag,
+    ExecutionStatus, ObjectId, Owner, StructTag, TransactionExpiration, TransactionKind, TypeTag,
     crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
 };
 use iota_storage::{

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -30,7 +30,9 @@ use iota_metrics::monitored_scope;
 use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
-use iota_sdk_types::{CancelledTransaction, CheckpointTimestamp, ObjectId, VersionAssignment};
+use iota_sdk_types::{
+    CancelledTransaction, CheckpointTimestamp, ObjectId, TransactionKind, VersionAssignment,
+};
 use iota_storage::mutex_table::{MutexGuard, MutexTable};
 use iota_types::{
     base_types::{
@@ -60,8 +62,7 @@ use iota_types::{
     storage::{BackingPackageStore, InputKey},
     transaction::{
         CertifiedTransaction, InputObjectKind, SenderSignedData, Transaction, TransactionDataAPI,
-        TransactionKey, TransactionKind, VerifiedCertificate, VerifiedSignedTransaction,
-        VerifiedTransaction,
+        TransactionKey, VerifiedCertificate, VerifiedSignedTransaction, VerifiedTransaction,
     },
 };
 use itertools::izip;

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -27,6 +27,7 @@ use futures::StreamExt;
 use iota_common::{debug_fatal, fatal};
 use iota_config::node::{CheckpointExecutorConfig, RunWithRange};
 use iota_macros::fail_point;
+use iota_sdk_types::TransactionKind;
 use iota_types::{
     base_types::{TransactionDigest, TransactionEffectsDigest},
     crypto::RandomnessRound,
@@ -35,7 +36,7 @@ use iota_types::{
     full_checkpoint_content::CheckpointData,
     global_state_hash::GlobalStateHash,
     messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber, VerifiedCheckpoint},
-    transaction::{TransactionDataAPI, TransactionKey, TransactionKind, VerifiedTransaction},
+    transaction::{TransactionDataAPI, TransactionKey, VerifiedTransaction},
 };
 use parking_lot::Mutex;
 use tap::{TapFallible, TapOptional};

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -22,7 +22,7 @@ use iota_macros::fail_point;
 use iota_metrics::{MonitoredFutureExt, monitored_future, monitored_scope};
 use iota_network::default_iota_network_config;
 use iota_protocol_config::ProtocolVersion;
-use iota_sdk_types::GasCostSummary;
+use iota_sdk_types::{GasCostSummary, TransactionKind};
 use iota_types::{
     base_types::{AuthorityName, ConciseableName, EpochId, TransactionDigest},
     committee::StakeUnit,
@@ -45,7 +45,7 @@ use iota_types::{
     },
     messages_consensus::ConsensusTransactionKey,
     signature::GenericSignature,
-    transaction::{TransactionDataAPI, TransactionKey, TransactionKind},
+    transaction::{TransactionDataAPI, TransactionKey},
 };
 use itertools::Itertools;
 use nonempty::NonEmpty;

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -14,7 +14,7 @@ use iota_sdk_types::{
     Argument, ChangeEpoch, Command, CommandArgumentError, ConsensusCommitPrologueV1,
     ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus, Identifier,
     MoveLocation, ObjectId, Owner, PackageUpgradeError, SimpleSignature, StructTag,
-    TransactionKind, TypeArgumentError, TypeTag,
+    TransactionExpiration, TransactionKind, TypeArgumentError, TypeTag,
     crypto::{Intent, IntentMessage, PersonalMessage},
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
 };
@@ -47,7 +47,7 @@ use iota_types::{
     transaction::{
         CallArg, EndOfEpochTransactionKind, GenesisObject, GenesisTransaction,
         ProgrammableTransaction, RandomnessStateUpdate, SenderSignedData, SharedObjectRef,
-        Transaction, TransactionData, TransactionDataAPI, TransactionExpiration,
+        Transaction, TransactionData, TransactionDataAPI,
     },
 };
 use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -14,7 +14,7 @@ use iota_sdk_types::{
     Argument, ChangeEpoch, Command, CommandArgumentError, ConsensusCommitPrologueV1,
     ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus, Identifier,
     MoveLocation, ObjectId, Owner, PackageUpgradeError, SimpleSignature, StructTag,
-    TypeArgumentError, TypeTag,
+    TransactionKind, TypeArgumentError, TypeTag,
     crypto::{Intent, IntentMessage, PersonalMessage},
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
 };
@@ -47,7 +47,7 @@ use iota_types::{
     transaction::{
         CallArg, EndOfEpochTransactionKind, GenesisObject, GenesisTransaction,
         ProgrammableTransaction, RandomnessStateUpdate, SenderSignedData, SharedObjectRef,
-        Transaction, TransactionData, TransactionDataAPI, TransactionExpiration, TransactionKind,
+        Transaction, TransactionData, TransactionDataAPI, TransactionExpiration,
     },
 };
 use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -9,7 +9,7 @@ use iota_protocol_config::{
 };
 use iota_sdk_types::{
     CancelledTransaction, ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus,
-    ObjectId, VersionAssignment,
+    ObjectId, TransactionKind, VersionAssignment,
 };
 use iota_types::{
     base_types::{IotaAddress, ObjectRef, SequenceNumber},
@@ -20,7 +20,7 @@ use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
         CallArg, ProgrammableTransaction, SharedObjectRef, Transaction, TransactionData,
-        TransactionDataAPI, TransactionKind, VerifiedCertificate,
+        TransactionDataAPI, VerifiedCertificate,
     },
     utils::to_sender_signed_transaction,
 };

--- a/crates/iota-core/src/unit_tests/gas_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Command, ExecutionError, ExecutionStatus, Identifier};
+use iota_sdk_types::{Command, ExecutionError, ExecutionStatus, Identifier, TransactionKind};
 use iota_types::{
     base_types::dbg_addr,
     crypto::{AccountKeyPair, get_key_pair},

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -11,7 +11,7 @@ use fastcrypto::traits::KeyPair;
 use iota_macros::sim_test;
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
-    ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, Identifier,
+    ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, Identifier, TransactionKind,
     crypto::{Intent, IntentScope},
 };
 use iota_types::{
@@ -19,7 +19,7 @@ use iota_types::{
     crypto::{AccountKeyPair, Signature, get_key_pair},
     error::{IotaError, UserInputError},
     messages_grpc::HandleSoftBundleCertificatesRequestV1,
-    transaction::{GenesisTransaction, TransactionDataAPI, TransactionKind},
+    transaction::{GenesisTransaction, TransactionDataAPI},
     utils::to_sender_signed_transaction,
 };
 use starfish_core::{BlockRef, BlockStatus};

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -13,7 +13,7 @@ use std::{
 
 use async_trait::async_trait;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, TransactionKind};
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef, SequenceNumber},
@@ -27,9 +27,7 @@ use iota_types::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
         CheckpointSummary, SignedCheckpointSummary,
     },
-    transaction::{
-        RandomnessStateUpdate, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
-    },
+    transaction::{RandomnessStateUpdate, Transaction, TransactionData, TransactionDataAPI},
     utils::make_committee_key,
 };
 use prometheus::Registry;

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -14,7 +14,7 @@ use iota_keys::keystore::AccountKeystore;
 use iota_macros::*;
 use iota_node::IotaNodeHandle;
 use iota_sdk::wallet_context::WalletContext;
-use iota_sdk_types::{Identifier, ObjectId, Owner};
+use iota_sdk_types::{Identifier, ObjectId, Owner, TransactionKind};
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
 };
@@ -37,7 +37,7 @@ use iota_types::{
     storage::ObjectStore,
     transaction::{
         CallArg, GasData, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
-        TransactionData, TransactionDataAPI, TransactionKind,
+        TransactionData, TransactionDataAPI,
     },
     utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
 };

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -66,7 +66,7 @@ mod sim_only_tests {
     use iota_macros::*;
     use iota_move_build::{BuildConfig, CompiledPackage};
     use iota_protocol_config::Chain;
-    use iota_sdk_types::{Command, Identifier, MoveCall, ObjectId, Owner};
+    use iota_sdk_types::{Command, Identifier, MoveCall, ObjectId, Owner, TransactionKind};
     use iota_types::{
         base_types::{ConciseableName, IotaAddress, ObjectRef, SequenceNumber},
         digests::TransactionDigest,
@@ -82,7 +82,7 @@ mod sim_only_tests {
         supported_protocol_versions::SupportedProtocolVersions,
         transaction::{
             CallArg, ProgrammableTransaction, TEST_ONLY_GAS_UNIT_FOR_GENERIC, TransactionData,
-            TransactionDataAPI, TransactionKind,
+            TransactionDataAPI,
         },
     };
     use move_binary_format::CompiledModule;

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -18,7 +18,10 @@ use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
 use iota_macros::sim_test;
 use iota_node::IotaNodeHandle;
 use iota_protocol_config::{Chain, ProtocolConfig};
-use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
+use iota_sdk_types::{
+    TransactionExpiration,
+    crypto::{Intent, IntentMessage, IntentScope},
+};
 use iota_swarm_config::genesis_config::{ValidatorGenesisConfig, ValidatorGenesisConfigBuilder};
 use iota_test_transaction_builder::{TestTransactionBuilder, make_transfer_iota_transaction};
 use iota_types::{
@@ -36,7 +39,7 @@ use iota_types::{
     messages_consensus::{AuthorityCapabilitiesV1, SignedAuthorityCapabilitiesV1},
     messages_grpc::{HandleCapabilityNotificationRequestV1, HandleCertificateRequestV1},
     supported_protocol_versions::SupportedProtocolVersions,
-    transaction::{TransactionDataAPI, TransactionExpiration, VerifiedTransaction},
+    transaction::{TransactionDataAPI, VerifiedTransaction},
 };
 use rand::{
     SeedableRng,

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -8,6 +8,7 @@ use iota_core::{
     authority_client::NetworkAuthorityClient, transaction_orchestrator::TransactionOrchestrator,
 };
 use iota_macros::sim_test;
+use iota_sdk_types::TransactionExpiration;
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
 };
@@ -23,7 +24,7 @@ use iota_types::{
         ExecuteTransactionRequestType, ExecuteTransactionRequestV1, ExecuteTransactionResponseV1,
         FinalizedEffects, IsTransactionExecutedLocally, QuorumDriverError,
     },
-    transaction::{Transaction, TransactionDataAPI, TransactionExpiration},
+    transaction::{Transaction, TransactionDataAPI},
 };
 use test_cluster::TestClusterBuilder;
 use tokio::time::timeout;

--- a/crates/iota-e2e-tests/tests/tx_bytes_validity_check.rs
+++ b/crates/iota-e2e-tests/tests/tx_bytes_validity_check.rs
@@ -6,8 +6,8 @@ use iota_json_rpc_api::WriteApiClient;
 use iota_json_rpc_types::{IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolVersion;
-use iota_sdk_types::{Command, Identifier, ObjectId};
-use iota_types::transaction::{CallArg, ProgrammableTransaction, TransactionKind};
+use iota_sdk_types::{Command, Identifier, ObjectId, TransactionKind};
+use iota_types::transaction::{CallArg, ProgrammableTransaction};
 use jsonrpsee::{core::ClientError, types::ErrorCode};
 use test_cluster::TestClusterBuilder;
 

--- a/crates/iota-genesis-common/Cargo.toml
+++ b/crates/iota-genesis-common/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 # external dependencies
+iota-sdk-types.workspace = true
 prometheus.workspace = true
 
 # internal dependencies

--- a/crates/iota-genesis-common/Cargo.toml
+++ b/crates/iota-genesis-common/Cargo.toml
@@ -11,10 +11,10 @@ workspace = true
 
 [dependencies]
 # external dependencies
-iota-sdk-types.workspace = true
 prometheus.workspace = true
 
 # internal dependencies
 iota-execution.workspace = true
 iota-protocol-config.workspace = true
+iota-sdk-types.workspace = true
 iota-types.workspace = true

--- a/crates/iota-genesis-common/src/lib.rs
+++ b/crates/iota-genesis-common/src/lib.rs
@@ -5,6 +5,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use iota_execution::executor;
 use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
+use iota_sdk_types::TransactionKind;
 use iota_types::{
     digests::ChainIdentifier,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
@@ -14,7 +15,7 @@ use iota_types::{
     messages_checkpoint::CheckpointTimestamp,
     metrics::LimitsMetrics,
     object::Object,
-    transaction::{CheckedInputObjects, Transaction, TransactionDataAPI, TransactionKind},
+    transaction::{CheckedInputObjects, Transaction, TransactionDataAPI},
 };
 use prometheus::Registry;
 

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -10,12 +10,12 @@ use iota_indexer::apis::ReadApi;
 use iota_json::IotaJsonValue;
 use iota_json_rpc_api::{ReadApiServer, WriteApiServer};
 use iota_json_rpc_types::{DevInspectArgs, IotaTypeTag};
-use iota_sdk_types::TypeTag;
+use iota_sdk_types::{TransactionKind, TypeTag};
 use iota_types::{
     base_types::ObjectRef,
     gas_coin::GAS,
     supported_protocol_versions::Chain,
-    transaction::{TransactionData, TransactionDataAPI, TransactionKind},
+    transaction::{TransactionData, TransactionDataAPI},
 };
 use move_core_types::account_address::AccountAddress;
 use serde::de::DeserializeOwned;

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -15,6 +15,7 @@ use iota_indexer::{
     schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
 };
 use iota_json_rpc_api::ReadApiServer;
+use iota_sdk_types::TransactionExpiration;
 use iota_types::{
     base_types::IotaAddress as NativeIotaAddress,
     effects::TransactionEffects as NativeTransactionEffects,
@@ -22,7 +23,7 @@ use iota_types::{
     message_envelope::Message,
     transaction::{
         SenderSignedData as NativeSenderSignedData, TransactionData as NativeTransactionData,
-        TransactionDataAPI, TransactionExpiration,
+        TransactionDataAPI,
     },
 };
 use serde::{Deserialize, Serialize};

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use iota_types::transaction::TransactionKind as NativeTransactionKind;
+use iota_sdk_types::TransactionKind as NativeTransactionKind;
 
 use self::{
     consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,

--- a/crates/iota-grpc-server/src/transaction_filter.rs
+++ b/crates/iota-grpc-server/src/transaction_filter.rs
@@ -30,22 +30,20 @@ pub enum TransactionKind {
     RandomnessStateUpdate = 6,
 }
 
-impl From<&iota_types::transaction::TransactionKind> for TransactionKind {
-    fn from(kind: &iota_types::transaction::TransactionKind) -> Self {
+impl From<&iota_sdk_types::TransactionKind> for TransactionKind {
+    fn from(kind: &iota_sdk_types::TransactionKind) -> Self {
         match kind {
-            iota_types::transaction::TransactionKind::Programmable(_) => {
-                TransactionKind::Programmable
-            }
-            iota_types::transaction::TransactionKind::Genesis(_) => TransactionKind::Genesis,
-            iota_types::transaction::TransactionKind::ConsensusCommitPrologueV1(_) => {
+            iota_sdk_types::TransactionKind::Programmable(_) => TransactionKind::Programmable,
+            iota_sdk_types::TransactionKind::Genesis(_) => TransactionKind::Genesis,
+            iota_sdk_types::TransactionKind::ConsensusCommitPrologueV1(_) => {
                 TransactionKind::ConsensusCommitPrologueV1
             }
             #[allow(deprecated)]
-            iota_types::transaction::TransactionKind::AuthenticatorStateUpdateV1Deprecated => {
+            iota_sdk_types::TransactionKind::AuthenticatorStateUpdateV1Deprecated => {
                 TransactionKind::System
             }
-            iota_types::transaction::TransactionKind::EndOfEpoch(_) => TransactionKind::EndOfEpoch,
-            iota_types::transaction::TransactionKind::RandomnessStateUpdate(_) => {
+            iota_sdk_types::TransactionKind::EndOfEpoch(_) => TransactionKind::EndOfEpoch,
+            iota_sdk_types::TransactionKind::RandomnessStateUpdate(_) => {
                 TransactionKind::RandomnessStateUpdate
             }
             _ => unimplemented!(
@@ -365,7 +363,7 @@ impl TransactionFilter {
                 .any(|obj_ref| &obj_ref.object_id == o),
 
             TransactionFilter::Command(cmd_filter) => match tx_data.kind() {
-                iota_types::transaction::TransactionKind::Programmable(pt) => {
+                iota_sdk_types::TransactionKind::Programmable(pt) => {
                     cmd_filter.matches_commands(&pt.commands)
                 }
                 _ => false,

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -25,7 +25,7 @@ use iota_json_rpc_types::{
 use iota_open_rpc::Module;
 use iota_package_resolver::{PackageStore, Resolver};
 use iota_protocol_config::Chain;
-use iota_sdk_types::{ObjectId, TransactionKind};
+use iota_sdk_types::{ObjectId, TransactionExpiration, TransactionKind};
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     base_types::{IotaAddress, SequenceNumber},
@@ -37,7 +37,6 @@ use iota_types::{
     signature::GenericSignature,
     transaction::{
         GasData, SenderSignedData, TransactionData, TransactionDataAPI, TransactionDataV1,
-        TransactionExpiration,
     },
 };
 use jsonrpsee::{RpcModule, core::RpcResult};

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -25,7 +25,7 @@ use iota_json_rpc_types::{
 use iota_open_rpc::Module;
 use iota_package_resolver::{PackageStore, Resolver};
 use iota_protocol_config::Chain;
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, TransactionKind};
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     base_types::{IotaAddress, SequenceNumber},
@@ -37,7 +37,7 @@ use iota_types::{
     signature::GenericSignature,
     transaction::{
         GasData, SenderSignedData, TransactionData, TransactionDataAPI, TransactionDataV1,
-        TransactionExpiration, TransactionKind,
+        TransactionExpiration,
     },
 };
 use jsonrpsee::{RpcModule, core::RpcResult};

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -21,7 +21,7 @@ use iota_json_rpc_types::{
     IotaTransactionBlockResponseOptions, ObjectChange, TransactionBlockBytes,
 };
 use iota_move_build::BuildConfig;
-use iota_sdk_types::{Identifier, ObjectId, Owner, StructTag, TypeTag};
+use iota_sdk_types::{Identifier, ObjectId, Owner, StructTag, TransactionKind, TypeTag};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
@@ -29,7 +29,6 @@ use iota_types::{
     gas_coin::NANOS_PER_IOTA,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     quorum_driver_types::ExecuteTransactionRequestType,
-    transaction::TransactionKind,
     utils::to_sender_signed_transaction,
 };
 use itertools::Itertools;

--- a/crates/iota-json-rpc-tests/tests/balance_changes_tests.rs
+++ b/crates/iota-json-rpc-tests/tests/balance_changes_tests.rs
@@ -6,9 +6,10 @@ use std::path::PathBuf;
 
 use iota_move_build::{BuildConfig, IotaPackageHooks};
 use iota_sdk::IotaClient;
+use iota_sdk_types::TransactionKind;
 use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{TransactionData, TransactionDataAPI, TransactionKind},
+    transaction::{TransactionData, TransactionDataAPI},
 };
 use test_cluster::TestClusterBuilder;
 

--- a/crates/iota-json-rpc-tests/tests/write_api.rs
+++ b/crates/iota-json-rpc-tests/tests/write_api.rs
@@ -7,11 +7,9 @@ use iota_json_rpc_types::{
     IotaTransactionBlockEffectsAPI,
 };
 use iota_macros::sim_test;
-use iota_sdk_types::Owner;
+use iota_sdk_types::{Owner, TransactionKind};
 use iota_simulator::fastcrypto::encoding::Base64;
-use iota_types::{
-    programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::TransactionKind,
-};
+use iota_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use test_cluster::TestClusterBuilder;
 
 #[sim_test]

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -13,8 +13,8 @@ use iota_package_resolver::{CleverError, ErrorConstants, PackageStore, Resolver}
 use iota_sdk_types::{
     Argument, CancelledTransaction, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,
     Command, ConsensusDeterminedVersionAssignments, ExecutionError as ExecutionFailureStatus,
-    ExecutionStatus, Identifier, MoveCall, ObjectId, Owner, TransferObjects, TypeTag,
-    VersionAssignment,
+    ExecutionStatus, Identifier, MoveCall, ObjectId, Owner, TransactionKind, TransferObjects,
+    TypeTag, VersionAssignment,
 };
 use iota_types::{
     base_types::{EpochId, IotaAddress, ObjectRef, SequenceNumber, TransactionDigest},
@@ -36,7 +36,7 @@ use iota_types::{
     transaction::{
         CallArg, EndOfEpochTransactionKind, GenesisObject, InputObjectKind,
         ProgrammableTransaction, SenderSignedData, SharedObjectRef, TransactionData,
-        TransactionDataAPI, TransactionKind,
+        TransactionDataAPI,
     },
 };
 use move_binary_format::CompiledModule;

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -19,7 +19,7 @@ use iota_json_rpc_types::{
     Coin as IotaCoin, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, IotaEvent,
     IotaObjectDataFilter, TransactionFilter,
 };
-use iota_sdk_types::{ObjectId, StructTag, TypeTag};
+use iota_sdk_types::{ObjectId, StructTag, TransactionKind, TypeTag};
 use iota_storage::key_value_store::{
     KVStoreTransactionData, TransactionKeyValueStore, TransactionKeyValueStoreTrait,
 };
@@ -41,7 +41,7 @@ use iota_types::{
     object::{Object, ObjectRead, PastObjectRead},
     storage::{BackingPackageStore, ObjectStore, WriteKind},
     timelock::timelocked_staked_iota::TimelockedStakedIota,
-    transaction::{Transaction, TransactionData, TransactionKind},
+    transaction::{Transaction, TransactionData},
 };
 #[cfg(test)]
 use mockall::automock;

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -26,7 +26,7 @@ use iota_package_resolver::{
 };
 use iota_protocol_config::Chain;
 use iota_sdk_types::{
-    ObjectId,
+    ObjectId, TransactionKind,
     crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
 };
 use iota_transaction_builder::TransactionBuilder;
@@ -40,9 +40,7 @@ use iota_types::{
     },
     signature::GenericSignature,
     storage::PostExecutionPackageResolver,
-    transaction::{
-        InputObjectKind, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
-    },
+    transaction::{InputObjectKind, Transaction, TransactionData, TransactionDataAPI},
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
 use tracing::{Instrument, instrument};

--- a/crates/iota-replay/src/data_fetcher.rs
+++ b/crates/iota-replay/src/data_fetcher.rs
@@ -15,14 +15,12 @@ use iota_json_rpc_types::{
 };
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_sdk::IotaClient;
-use iota_sdk_types::{ObjectId, StructTag};
+use iota_sdk_types::{ObjectId, StructTag, TransactionKind};
 use iota_types::{
     base_types::{SequenceNumber, VersionNumber},
     digests::{ChainIdentifier, TransactionDigest},
     object::Object,
-    transaction::{
-        EndOfEpochTransactionKind, SenderSignedData, TransactionDataAPI, TransactionKind,
-    },
+    transaction::{EndOfEpochTransactionKind, SenderSignedData, TransactionDataAPI},
 };
 use lru::LruCache;
 use parking_lot::RwLock;

--- a/crates/iota-replay/src/fuzz.rs
+++ b/crates/iota-replay/src/fuzz.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_config::node::ExpensiveSafetyCheckConfig;
-use iota_sdk_types::ExecutionError;
-use iota_types::{digests::TransactionDigest, transaction::TransactionKind};
+use iota_sdk_types::{ExecutionError, TransactionKind};
+use iota_types::digests::TransactionDigest;
 use thiserror::Error;
 use tracing::{error, info};
 

--- a/crates/iota-replay/src/fuzz_mutations.rs
+++ b/crates/iota-replay/src/fuzz_mutations.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::transaction::TransactionKind;
+use iota_sdk_types::TransactionKind;
 use rand::{SeedableRng, seq::SliceRandom};
 
 use crate::fuzz::TransactionKindMutator;

--- a/crates/iota-replay/src/fuzz_mutations/drop_random_command_suffix.rs
+++ b/crates/iota-replay/src/fuzz_mutations/drop_random_command_suffix.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::transaction::TransactionKind;
+use iota_sdk_types::TransactionKind;
 use rand::Rng;
 use tracing::info;
 

--- a/crates/iota-replay/src/fuzz_mutations/drop_random_commands.rs
+++ b/crates/iota-replay/src/fuzz_mutations/drop_random_commands.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::transaction::TransactionKind;
+use iota_sdk_types::TransactionKind;
 use rand::seq::SliceRandom;
 use tracing::info;
 

--- a/crates/iota-replay/src/fuzz_mutations/shuffle_command_inputs.rs
+++ b/crates/iota-replay/src/fuzz_mutations/shuffle_command_inputs.rs
@@ -2,8 +2,9 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::{Command, MakeMoveVector, MergeCoins, MoveCall, SplitCoins, TransferObjects};
-use iota_types::transaction::TransactionKind;
+use iota_sdk_types::{
+    Command, MakeMoveVector, MergeCoins, MoveCall, SplitCoins, TransactionKind, TransferObjects,
+};
 use rand::seq::SliceRandom;
 use tracing::info;
 

--- a/crates/iota-replay/src/fuzz_mutations/shuffle_commands.rs
+++ b/crates/iota-replay/src/fuzz_mutations/shuffle_commands.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::transaction::TransactionKind;
+use iota_sdk_types::TransactionKind;
 use rand::seq::SliceRandom;
 use tracing::info;
 

--- a/crates/iota-replay/src/fuzz_mutations/shuffle_transaction_inputs.rs
+++ b/crates/iota-replay/src/fuzz_mutations/shuffle_transaction_inputs.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::transaction::TransactionKind;
+use iota_sdk_types::TransactionKind;
 use rand::seq::SliceRandom;
 use tracing::info;
 

--- a/crates/iota-replay/src/fuzz_mutations/shuffle_types.rs
+++ b/crates/iota-replay/src/fuzz_mutations/shuffle_types.rs
@@ -2,8 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::Command;
-use iota_types::transaction::TransactionKind;
+use iota_sdk_types::{Command, TransactionKind};
 use rand::seq::SliceRandom;
 use tracing::info;
 

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -18,7 +18,7 @@ use iota_json_rpc_types::{
 };
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk::{IotaClient, IotaClientBuilder};
-use iota_sdk_types::{ObjectId, Owner, StructTag};
+use iota_sdk_types::{ObjectId, Owner, StructTag, TransactionKind};
 use iota_types::{
     IOTA_DENY_LIST_OBJECT_ID,
     account_abstraction::{
@@ -49,7 +49,7 @@ use iota_types::{
     },
     transaction::{
         CheckedInputObjects, GasData, InputObjectKind, InputObjects, ObjectReadResult,
-        ObjectReadResultKind, SenderSignedData, Transaction, TransactionDataAPI, TransactionKind,
+        ObjectReadResultKind, SenderSignedData, Transaction, TransactionDataAPI,
         VerifiedTransaction,
     },
 };

--- a/crates/iota-replay/src/types.rs
+++ b/crates/iota-replay/src/types.rs
@@ -7,13 +7,13 @@ use std::fmt::Debug;
 use iota_json_rpc_types::{IotaEvent, IotaObjectResponseError, IotaTransactionBlockEffects};
 use iota_protocol_config::{Chain, ProtocolVersion};
 use iota_sdk::error::Error as IotaRpcError;
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, TransactionKind};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef, SequenceNumber, VersionNumber},
     digests::{ObjectDigest, TransactionDigest},
     error::{IotaError, IotaResult, UserInputError},
     object::Object,
-    transaction::{InputObjectKind, SenderSignedData, TransactionKind},
+    transaction::{InputObjectKind, SenderSignedData},
 };
 use jsonrpsee::core::ClientError as JsonRpseeError;
 use move_binary_format::CompiledModule;

--- a/crates/iota-sdk/examples/read_api/simulate_transaction.rs
+++ b/crates/iota-sdk/examples/read_api/simulate_transaction.rs
@@ -11,8 +11,9 @@ mod utils;
 
 use iota_sdk::types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{TransactionData, TransactionDataAPI, TransactionKind},
+    transaction::{TransactionData, TransactionDataAPI},
 };
+use iota_sdk_types::TransactionKind;
 use utils::setup_for_write;
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/transaction_builder/consolidate.rs
+++ b/crates/iota-sdk/examples/transaction_builder/consolidate.rs
@@ -15,10 +15,10 @@ use iota_sdk::{
     types::{
         base_types::ObjectRef,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::{CallArg, TransactionData, TransactionDataAPI, TransactionKind},
+        transaction::{CallArg, TransactionData, TransactionDataAPI},
     },
 };
-use iota_sdk_types::{Argument, Command};
+use iota_sdk_types::{Argument, Command, TransactionKind};
 use utils::{setup_for_write, sign_and_execute_transaction};
 
 #[tokio::main]

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -21,13 +21,13 @@ use iota_json_rpc_types::{
     IotaTransactionBlockResponseQueryV2, ObjectsPage, ProtocolConfigResponse,
     TransactionBlocksPage, TransactionFilter,
 };
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, TransactionKind};
 use iota_types::{
     base_types::{IotaAddress, SequenceNumber, TransactionDigest},
     dynamic_field::DynamicFieldName,
     iota_serde::BigInt,
     messages_checkpoint::CheckpointSequenceNumber,
-    transaction::{TransactionData, TransactionKind},
+    transaction::TransactionData,
 };
 use jsonrpsee::core::client::Subscription;
 

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -14,7 +14,7 @@ use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
     IotaObjectDataOptions, IotaObjectResponse, IotaTypeTag, PtbInput, RPCTransactionRequestParams,
 };
-use iota_sdk_types::{Command, Identifier, ObjectId, StructTag};
+use iota_sdk_types::{Command, Identifier, ObjectId, StructTag, TransactionKind};
 use iota_types::{
     base_types::IotaAddress,
     coin,
@@ -24,7 +24,7 @@ use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
         CallArg, InputObjectKind, ProgrammableTransactionExt, TransactionData, TransactionDataAPI,
-        TransactionKind, TransactionKindExt,
+        TransactionKindExt,
     },
 };
 

--- a/crates/iota-transaction-builder/src/package.rs
+++ b/crates/iota-transaction-builder/src/package.rs
@@ -6,11 +6,13 @@ use std::result::Result;
 
 use anyhow::{Ok, anyhow, bail};
 use iota_json_rpc_types::IotaObjectDataOptions;
-use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, move_package::MovePackage};
+use iota_sdk_types::{
+    Argument, Identifier, ObjectId, Owner, TransactionKind, move_package::MovePackage,
+};
 use iota_types::{
     base_types::IotaAddress,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{CallArg, SharedObjectRef, TransactionData, TransactionDataAPI, TransactionKind},
+    transaction::{CallArg, SharedObjectRef, TransactionData, TransactionDataAPI},
 };
 
 use crate::TransactionBuilder;

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -15,7 +15,7 @@ mod checked {
 
     use iota_config::verifier_signing_config::VerifierSigningConfig;
     use iota_protocol_config::ProtocolConfig;
-    use iota_sdk_types::{ObjectId, Owner};
+    use iota_sdk_types::{ObjectId, Owner, TransactionKind};
     use iota_types::{
         IOTA_AUTHENTICATOR_STATE_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION,
         base_types::{IotaAddress, ObjectRef, SequenceNumber},
@@ -28,8 +28,7 @@ mod checked {
         transaction::{
             CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult,
             ObjectReadResultKind, ProgrammableTransactionExt, ReceivingObjectReadResult,
-            ReceivingObjects, TransactionData, TransactionDataAPI, TransactionKind,
-            TransactionKindExt,
+            ReceivingObjects, TransactionData, TransactionDataAPI, TransactionKindExt,
         },
     };
     use tracing::{error, instrument};

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -19,7 +19,7 @@ use iota_core::authority::{
 };
 use iota_json_rpc::authority_state::StateRead;
 use iota_json_rpc_types::{DevInspectResults, DryRunTransactionBlockResponse, EventFilter};
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, TransactionKind};
 use iota_storage::key_value_store::TransactionKeyValueStore;
 use iota_types::{
     base_types::{IotaAddress, VersionNumber},
@@ -36,7 +36,7 @@ use iota_types::{
     messages_checkpoint::{CheckpointContentsDigest, VerifiedCheckpoint},
     object::Object,
     storage::{ObjectStore, ReadStore},
-    transaction::{InputObjects, Transaction, TransactionData, TransactionKind},
+    transaction::{InputObjects, Transaction, TransactionData},
 };
 pub use move_transactional_test_runner::framework::{
     create_adapter, run_tasks_with_adapter, run_test_impl,

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -33,7 +33,8 @@ use iota_json_rpc_types::{
 use iota_node_storage::GrpcStateReader;
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::{
-    Argument, Command, ExecutionStatus, Identifier, ObjectId, TypeTag, move_package::MovePackage,
+    Argument, Command, ExecutionStatus, Identifier, ObjectId, TransactionKind, TypeTag,
+    move_package::MovePackage,
 };
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
@@ -59,7 +60,7 @@ use iota_types::{
     storage::{ObjectStore, ReadStore},
     transaction::{
         CallArg, ProgrammableTransaction, Transaction, TransactionData, TransactionDataAPI,
-        TransactionKind, VerifiedTransaction,
+        VerifiedTransaction,
     },
     utils::{
         to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -4,7 +4,7 @@
 
 use std::collections::BTreeMap;
 
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, TransactionKind};
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
@@ -17,9 +17,8 @@ use crate::{
     messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents},
     object::Object,
     storage::{BackingPackageStore, EpochInfo, error::Error as StorageError},
-    transaction::{Transaction, TransactionDataAPI, TransactionKind},
+    transaction::{Transaction, TransactionDataAPI},
 };
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointData {
     pub checkpoint_summary: CertifiedCheckpointSummary,

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -19,6 +19,7 @@ use crate::{
     storage::{BackingPackageStore, EpochInfo, error::Error as StorageError},
     transaction::{Transaction, TransactionDataAPI},
 };
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointData {
     pub checkpoint_summary: CertifiedCheckpointSummary,

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -5,7 +5,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Identifier, ObjectId, Owner, StructTag, TypeTag};
+use iota_sdk_types::{Identifier, ObjectId, Owner, StructTag, TransactionKind, TypeTag};
 use tap::Pipe;
 
 use crate::{
@@ -28,7 +28,7 @@ use crate::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
         CallArg, EndOfEpochTransactionKind, SenderSignedData, SharedObjectRef, Transaction,
-        TransactionData, TransactionDataAPI, TransactionKind,
+        TransactionData, TransactionDataAPI,
     },
 };
 

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -19,15 +19,14 @@ use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Argument, CancelledTransaction, Command, ConsensusCommitPrologueV1,
     ConsensusDeterminedVersionAssignments, Digest, Identifier, Input, MakeMoveVector, MergeCoins,
-    MoveCall, ObjectId, Owner, Publish, SplitCoins, TransactionKind, TransferObjects, TypeTag,
-    Upgrade,
+    MoveCall, ObjectId, Owner, Publish, SplitCoins, TransactionExpiration, TransactionKind,
+    TransferObjects, TypeTag, Upgrade,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 pub use iota_sdk_types::{
     EndOfEpochTransactionKind, GasPayment as GasData, GenesisObject, GenesisTransaction,
     ProgrammableTransaction, RandomnessStateUpdate, SharedObjectReference as SharedObjectRef,
-    SystemPackage, Transaction as TransactionData, TransactionExpiration,
-    TransactionV1 as TransactionDataV1,
+    SystemPackage, Transaction as TransactionData, TransactionV1 as TransactionDataV1,
 };
 use itertools::Either;
 use nonempty::{NonEmpty, nonempty};

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -19,13 +19,14 @@ use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Argument, CancelledTransaction, Command, ConsensusCommitPrologueV1,
     ConsensusDeterminedVersionAssignments, Digest, Identifier, Input, MakeMoveVector, MergeCoins,
-    MoveCall, ObjectId, Owner, Publish, SplitCoins, TransferObjects, TypeTag, Upgrade,
+    MoveCall, ObjectId, Owner, Publish, SplitCoins, TransactionKind, TransferObjects, TypeTag,
+    Upgrade,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 pub use iota_sdk_types::{
     EndOfEpochTransactionKind, GasPayment as GasData, GenesisObject, GenesisTransaction,
     ProgrammableTransaction, RandomnessStateUpdate, SharedObjectReference as SharedObjectRef,
-    SystemPackage, Transaction as TransactionData, TransactionExpiration, TransactionKind,
+    SystemPackage, Transaction as TransactionData, TransactionExpiration,
     TransactionV1 as TransactionDataV1,
 };
 use itertools::Either;

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -10,7 +10,7 @@ use iota_sdk_crypto::{
     secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair,
 };
 use iota_sdk_types::{
-    ObjectId, SimpleSignature,
+    ObjectId, SimpleSignature, TransactionKind,
     crypto::{Intent, IntentMessage},
 };
 use rand::{SeedableRng, rngs::StdRng};
@@ -29,7 +29,7 @@ use crate::{
     signature::GenericSignature,
     transaction::{
         SenderSignedData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER, Transaction, TransactionData,
-        TransactionDataAPI, TransactionKind,
+        TransactionDataAPI,
     },
 };
 

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -51,7 +51,7 @@ use iota_sdk::{
     wallet_context::WalletContext,
 };
 use iota_sdk_types::{
-    Identifier, ObjectId, Owner, TypeTag,
+    Identifier, ObjectId, Owner, TransactionKind, TypeTag,
     crypto::{Intent, IntentMessage},
     move_package::MovePackage,
 };
@@ -77,7 +77,7 @@ use iota_types::{
     signature::GenericSignature,
     transaction::{
         CallArg, InputObjectKind, SenderSignedData, SharedObjectRef, Transaction, TransactionData,
-        TransactionDataAPI, TransactionKind, TransactionKindExt,
+        TransactionDataAPI, TransactionKindExt,
     },
 };
 use json_to_table::json_to_table;

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -9,11 +9,9 @@ use clap::{Args, ValueHint, arg, builder::StyledStr};
 use iota_json_rpc_types::{DevInspectResults, IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
 use iota_keys::keystore::AccountKeystore;
 use iota_sdk::{IotaClient, wallet_context::WalletContext};
-use iota_sdk_types::Address;
+use iota_sdk_types::{Address, TransactionKind};
 use iota_types::{
-    digests::TransactionDigest,
-    gas::GasCostSummary,
-    transaction::{ProgrammableTransaction, TransactionKind},
+    digests::TransactionDigest, gas::GasCostSummary, transaction::ProgrammableTransaction,
 };
 use move_core_types::account_address::AccountAddress;
 use serde::Serialize;

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -31,7 +31,7 @@ use iota_config::{
 };
 use iota_node_storage::{GrpcIndexes, GrpcStateReader};
 use iota_protocol_config::ProtocolVersion;
-use iota_sdk_types::{ObjectId, StructTag};
+use iota_sdk_types::{ObjectId, StructTag, TransactionKind};
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_swarm_config::{
     genesis_config::AccountConfig, network_config::NetworkConfig,
@@ -59,7 +59,7 @@ use iota_types::{
     storage::{EpochInfo, ObjectStore, ReadStore, TransactionInfo},
     transaction::{
         EndOfEpochTransactionKind, GasData, Transaction, TransactionData, TransactionDataAPI,
-        TransactionKind, VerifiedTransaction,
+        VerifiedTransaction,
     },
 };
 use rand::rngs::OsRng;
@@ -463,7 +463,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             builder.finish()
         };
 
-        let kind = iota_types::transaction::TransactionKind::Programmable(pt);
+        let kind = TransactionKind::Programmable(pt);
         let tx_data =
             iota_types::transaction::TransactionData::new_with_gas_data(kind, sender, gas_data);
         let tx = Transaction::from_data_and_signer(tx_data, vec![&key]);

--- a/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
+++ b/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
@@ -6,13 +6,13 @@
 use std::sync::Arc;
 
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{ExecutionError, ExecutionStatus};
+use iota_sdk_types::{ExecutionError, ExecutionStatus, TransactionKind};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     error::{IotaError, UserInputError},
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{GasData, Transaction, TransactionData, TransactionDataAPI, TransactionKind},
+    transaction::{GasData, Transaction, TransactionData, TransactionDataAPI},
     utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
 };
 use once_cell::sync::Lazy;

--- a/crates/transaction-fuzzer/src/transaction_data_gen.rs
+++ b/crates/transaction-fuzzer/src/transaction_data_gen.rs
@@ -2,13 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::ObjectId;
+use iota_sdk_types::{ObjectId, TransactionKind};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef, SequenceNumber},
     digests::ObjectDigest,
-    transaction::{
-        GasData, TransactionData, TransactionDataV1, TransactionExpiration, TransactionKind,
-    },
+    transaction::{GasData, TransactionData, TransactionDataV1, TransactionExpiration},
 };
 use move_core_types::account_address::AccountAddress;
 use proptest::{arbitrary::*, collection::vec, prelude::*};

--- a/crates/transaction-fuzzer/src/transaction_data_gen.rs
+++ b/crates/transaction-fuzzer/src/transaction_data_gen.rs
@@ -2,11 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::{ObjectId, TransactionKind};
+use iota_sdk_types::{ObjectId, TransactionExpiration, TransactionKind};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef, SequenceNumber},
     digests::ObjectDigest,
-    transaction::{GasData, TransactionData, TransactionDataV1, TransactionExpiration},
+    transaction::{GasData, TransactionData, TransactionDataV1},
 };
 use move_core_types::account_address::AccountAddress;
 use proptest::{arbitrary::*, collection::vec, prelude::*};

--- a/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_core::test_utils::send_and_confirm_transaction;
-use iota_sdk_types::{Identifier, ObjectId, StructTag, TypeTag};
+use iota_sdk_types::{Identifier, ObjectId, StructTag, TransactionKind, TypeTag};
 use iota_types::{
     base_types::IotaAddress,
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::IotaError,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{ProgrammableTransaction, TransactionData, TransactionDataAPI, TransactionKind},
+    transaction::{ProgrammableTransaction, TransactionData, TransactionDataAPI},
     utils::to_sender_signed_transaction,
 };
 use proptest::{arbitrary::*, prelude::*};

--- a/crates/transaction-fuzzer/tests/gas_data_tests.rs
+++ b/crates/transaction-fuzzer/tests/gas_data_tests.rs
@@ -2,11 +2,12 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use iota_sdk_types::TransactionKind;
 use iota_types::{
     base_types::{address_from_iota_pub_key, dbg_addr},
     crypto::KeypairTraits,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{TransactionData, TransactionDataAPI, TransactionKind},
+    transaction::{TransactionData, TransactionDataAPI},
     utils::to_sender_signed_transaction,
 };
 use proptest::{arbitrary::*, test_runner::TestCaseError};

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
@@ -3134,6 +3134,7 @@ dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "iota-verifier-latest",
  "move-binary-format",
@@ -3146,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3159,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3175,17 +3176,18 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "prometheus",
 ]
 
 [[package]]
 name = "iota-http"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "bytes",
  "http",
@@ -3205,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3222,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3242,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3278,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3298,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3308,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3333,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3379,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3391,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -3420,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3430,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3442,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -3458,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3473,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3483,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3497,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3506,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3580,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3601,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3617,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5565,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7686,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.25.0-alpha"
+version = "1.26.0-alpha"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
@@ -15,12 +15,12 @@ use iota_keys::keystore::{AccountKeystore, InMemKeystore};
 use iota_sdk::{
     IotaClient, IotaClientBuilder, rpc_types::ObjectChange, types::crypto::SignatureScheme::ED25519,
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, TypeTag};
+use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, TransactionKind, TypeTag};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     signature::GenericSignature,
-    transaction::{CallArg, SharedObjectRef, Transaction, TransactionData, TransactionKind},
+    transaction::{CallArg, SharedObjectRef, Transaction, TransactionData},
     utils::MoveAuthenticator,
 };
 

--- a/examples/tic-tac-toe/cli/src/client.rs
+++ b/examples/tic-tac-toe/cli/src/client.rs
@@ -18,7 +18,7 @@ use iota_sdk::{
     wallet_context::WalletContext,
 };
 use iota_sdk_types::{
-    Identifier, ObjectId, Owner, StructTag,
+    Identifier, ObjectId, Owner, StructTag, TransactionKind,
     crypto::{Intent, UserSignature},
 };
 use iota_types::{
@@ -29,7 +29,7 @@ use iota_types::{
     signature::GenericSignature,
     transaction::{
         CallArg, InputObjectKind, ProgrammableTransaction, SharedObjectRef, Transaction,
-        TransactionData, TransactionDataAPI, TransactionKind, TransactionKindExt,
+        TransactionData, TransactionDataAPI, TransactionKindExt,
     },
 };
 

--- a/iota-execution/Cargo.toml
+++ b/iota-execution/Cargo.toml
@@ -12,7 +12,6 @@ iota-adapter-latest = { path = "latest/iota-adapter" }
 # iota-adapter-$CUT = { path = "$CUT/iota-adapter" }
 iota-move-natives-latest = { path = "latest/iota-move-natives" }
 iota-protocol-config.workspace = true
-# move-vm-types-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-types" }
 iota-sdk-types.workspace = true
 iota-types.workspace = true
 # iota-move-natives-$CUT = { path = "$CUT/iota-move-natives" }
@@ -26,6 +25,7 @@ move-vm-config.workspace = true
 move-vm-runtime-latest = { path = "../external-crates/move/crates/move-vm-runtime", package = "move-vm-runtime" }
 # move-vm-runtime-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-runtime" }
 move-vm-types-latest = { path = "../external-crates/move/crates/move-vm-types", package = "move-vm-types" }
+# move-vm-types-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-types" }
 
 [dev-dependencies]
 cargo_metadata = "0.15"

--- a/iota-execution/Cargo.toml
+++ b/iota-execution/Cargo.toml
@@ -12,6 +12,8 @@ iota-adapter-latest = { path = "latest/iota-adapter" }
 # iota-adapter-$CUT = { path = "$CUT/iota-adapter" }
 iota-move-natives-latest = { path = "latest/iota-move-natives" }
 iota-protocol-config.workspace = true
+# move-vm-types-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-types" }
+iota-sdk-types.workspace = true
 iota-types.workspace = true
 # iota-move-natives-$CUT = { path = "$CUT/iota-move-natives" }
 iota-verifier-latest = { path = "latest/iota-verifier" }
@@ -24,7 +26,6 @@ move-vm-config.workspace = true
 move-vm-runtime-latest = { path = "../external-crates/move/crates/move-vm-runtime", package = "move-vm-runtime" }
 # move-vm-runtime-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-runtime" }
 move-vm-types-latest = { path = "../external-crates/move/crates/move-vm-types", package = "move-vm-types" }
-# move-vm-types-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-types" }
 
 [dev-dependencies]
 cargo_metadata = "0.15"

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -18,7 +18,7 @@ mod checked {
     use iota_protocol_config::{LimitThresholdCrossed, ProtocolConfig, check_limit_by_meter};
     use iota_sdk_types::{
         Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command,
-        ExecutionStatus, Identifier, ObjectId,
+        ExecutionStatus, Identifier, ObjectId, TransactionKind,
     };
     #[cfg(msim)]
     use iota_types::iota_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -50,7 +50,7 @@ mod checked {
         transaction::{
             CallArg, CheckedInputObjects, EndOfEpochTransactionKind, GasData, GenesisTransaction,
             InputObjects, ProgrammableTransaction, RandomnessStateUpdate, SharedObjectRef,
-            SystemPackage, TransactionKind, TransactionKindExt,
+            SystemPackage, TransactionKindExt,
         },
     };
     use move_binary_format::CompiledModule;

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -5,6 +5,7 @@
 use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
 
 use iota_protocol_config::ProtocolConfig;
+use iota_sdk_types::TransactionKind;
 use iota_types::{
     account_abstraction::authenticator_function::{
         AuthenticatorFunctionRef, AuthenticatorFunctionRefForExecution,
@@ -22,7 +23,7 @@ use iota_types::{
     metrics::LimitsMetrics,
     move_authenticator::MoveAuthenticator,
     storage::BackingStore,
-    transaction::{CheckedInputObjects, GasData, ProgrammableTransaction, TransactionKind},
+    transaction::{CheckedInputObjects, GasData, ProgrammableTransaction},
 };
 use move_trace_format::format::MoveTraceBuilder;
 

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -15,6 +15,7 @@ use iota_adapter_latest::{
 };
 use iota_move_natives_latest::all_natives;
 use iota_protocol_config::ProtocolConfig;
+use iota_sdk_types::TransactionKind;
 use iota_types::{
     account_abstraction::authenticator_function::{
         AuthenticatorFunctionRef, AuthenticatorFunctionRefForExecution,
@@ -32,7 +33,7 @@ use iota_types::{
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
     move_authenticator::MoveAuthenticator,
     storage::BackingStore,
-    transaction::{CheckedInputObjects, GasData, ProgrammableTransaction, TransactionKind},
+    transaction::{CheckedInputObjects, GasData, ProgrammableTransaction},
 };
 use iota_verifier_latest::meter::IotaVerifierMeter;
 use move_binary_format::CompiledModule;

--- a/iota-execution/src/tests.rs
+++ b/iota-execution/src/tests.rs
@@ -34,6 +34,7 @@ fn test_encapsulation() {
     // exclusively via `iota-execution`.
     exec_crates.remove("iota-protocol-config");
     exec_crates.remove("iota-types");
+    exec_crates.remove("iota-sdk-types");
     exec_crates.remove("move-binary-format");
     exec_crates.remove("move-bytecode-utils");
     exec_crates.remove("move-core-types");


### PR DESCRIPTION
# Description of change

`iota-types`' `transaction` module re-exported `TransactionKind` and `TransactionExpiration` from `iota-sdk-types`. This removes those re-exports and points every consumer at the canonical source in `iota-sdk-types` directly.

This continues the direction of travel called out in `AGENTS.md`: client-visible types live in `iota-rust-sdk` and should be imported from there, not laundered through a re-export in `iota-types`. The change is mechanical — only import paths move; no behavior changes.

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/11567

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

No new tests — this is a pure import-path refactor with no behavioral change.