### PR TITLE
refactor(iota-indexer): add fallback support for `TransactionFilter{V2}::FromOrToAddress` transaction query

### DIFF
--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -383,7 +383,7 @@ impl HttpRestKVClient {
 
         let bytes = resp.bytes().await?;
         bcs::from_bytes::<Vec<T>>(&bytes).map_err(|e| {
-            IndexerError::Serde(format!("failed to deserialize multi_get response: {e:?}"))
+            IndexerError::Serde(format!("failed to deserialize paginated response: {e:?}"))
         })
     }
 

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -3,7 +3,7 @@
 
 //! Module containing the client for interacting with the REST API KV server.
 
-use std::time::Duration;
+use std::{fmt::Display, num::NonZeroUsize, time::Duration};
 
 use bytes::Bytes;
 use futures::{
@@ -12,7 +12,7 @@ use futures::{
 };
 use iota_storage::http_key_value_store::{ItemType, Key};
 use iota_types::{
-    base_types::{ObjectID, SequenceNumber},
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
     digests::{CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     messages_checkpoint::{
@@ -36,7 +36,11 @@ use crate::{
     historical_fallback::metrics::HistoricalFallbackClientMetrics,
 };
 
-const CACHE_TIME_TO_IDLE: Duration = Duration::from_secs(600);
+pub(crate) const CACHE_TIME_TO_IDLE: Duration = Duration::from_secs(600);
+
+/// Represents the sequence number of a transaction.
+pub type TransactionSequenceNumber = u64;
+
 /// Request payload for multi_get containing list of keys.
 #[derive(Serialize, Debug)]
 struct MultiGetRequest {
@@ -126,6 +130,41 @@ pub(crate) trait KeyValueStoreClient {
         object_refs: &[(ObjectID, SequenceNumber)],
         before_version: bool,
     ) -> IndexerResult<Vec<Option<Object>>>;
+}
+
+/// Paginated reads against the historical KV store.
+///
+/// Provides an interface for retrieving ordered subsets of values associated
+/// with a single primary key. Distinct from [`KeyValueStoreClient`], which
+/// is designed for point lookups.
+#[async_trait::async_trait]
+pub(crate) trait PaginatedKeyValueStoreClient {
+    /// Fetches a paginated list of transaction digests that affect a given
+    /// address.
+    ///
+    /// An address is considered "affected" by a transaction if it appears
+    /// as the sender, a recipient, or the gas payer.
+    ///
+    /// # Pagination
+    ///
+    /// * **Cursor:** The `cursor` is an *exclusive* boundary. Pass `None` to
+    ///   fetch the first page. For subsequent pages, provide the
+    ///   [`TransactionSequenceNumber`] from the last item of the previous
+    ///   result.
+    /// * **Limit:** The `limit` is the maximum number of items per page. The
+    ///   actual result may contain fewer items than requested.
+    /// * **Ordering:**
+    ///   - `oldest_first = false` (default): newest to oldest.
+    ///   - `oldest_first = true`: oldest to newest.
+    ///
+    /// The `cursor` semantics remain exclusive regardless of scan direction.
+    async fn transaction_digests_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionSequenceNumber>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> IndexerResult<Vec<(TransactionSequenceNumber, TransactionDigest)>>;
 }
 
 #[derive(Clone)]
@@ -275,6 +314,75 @@ impl HttpRestKVClient {
 
         let bytes = resp.bytes().await?;
         bcs::from_bytes::<Vec<Option<Bytes>>>(&bytes).map_err(|e| {
+            IndexerError::Serde(format!("failed to deserialize multi_get response: {e:?}"))
+        })
+    }
+
+    /// Fetches a paginated list of items from a range-query endpoint.
+    ///
+    /// This method performs a one-to-many lookup, retrieving a paginated list
+    /// of records associated with the given `key`.
+    ///
+    /// # Pagination Logic
+    ///
+    /// * **Cursor-based:** The `cursor` is an *exclusive* boundary. When
+    ///   requesting the first page, pass `None`. For subsequent pages, use the
+    ///   cursor identifier from the last item of the previous result set.
+    /// * **Limits:** The `limit` enforces an upper bound on items returned.
+    /// * **Reversed:** The `reversed` flag determines the scan direction.
+    ///   - `false` (default): Follows the natural storage order of the `Key`.
+    ///   - `true`: Attempts to reverse the scan direction.
+    async fn paginate<C, T>(
+        &self,
+        key: Key,
+        cursor: Option<C>,
+        limit: impl TryInto<NonZeroUsize>,
+        reversed: bool,
+    ) -> IndexerResult<Vec<T>>
+    where
+        C: Display,
+        T: for<'de> Deserialize<'de>,
+    {
+        let limit = limit.try_into().map_err(|_| {
+            IndexerError::HistoricalFallbackInput("limit must be greater than 0".into())
+        })?;
+
+        let (item_type, encoded_key) = key.to_path_elements();
+        let mut url = self.base_url.join(&format!("{item_type}/{encoded_key}"))?;
+
+        url.query_pairs_mut()
+            .append_pair("limit", &limit.get().to_string());
+
+        if let Some(cursor) = cursor {
+            url.query_pairs_mut()
+                .append_pair("cursor", &cursor.to_string());
+        }
+
+        if reversed {
+            url.query_pairs_mut().append_pair("oldest_first", "true");
+        }
+
+        trace!("fetching from url: {url}");
+
+        let resp = self.client.get(url.clone()).send().await?;
+
+        trace!(
+            "got response {} for url: {url}, len: {:?}",
+            resp.status(),
+            resp.headers()
+                .get(CONTENT_LENGTH)
+                .unwrap_or(&HeaderValue::from_static("0"))
+        );
+
+        if !resp.status().is_success() {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "multi_fetch request failed with status: {}",
+                resp.status()
+            )));
+        }
+
+        let bytes = resp.bytes().await?;
+        bcs::from_bytes::<Vec<T>>(&bytes).map_err(|e| {
             IndexerError::Serde(format!("failed to deserialize multi_get response: {e:?}"))
         })
     }
@@ -614,5 +722,25 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .collect();
 
         Ok(objects)
+    }
+}
+
+#[async_trait::async_trait]
+impl PaginatedKeyValueStoreClient for HttpRestKVClient {
+    #[instrument(level = "trace", skip_all)]
+    async fn transaction_digests_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionSequenceNumber>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> IndexerResult<Vec<(TransactionSequenceNumber, TransactionDigest)>> {
+        self.paginate(
+            Key::TransactionDigestsByAddress(address),
+            cursor,
+            limit,
+            oldest_first,
+        )
+        .await
     }
 }

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -65,7 +65,7 @@ pub(crate) struct HistoricalFallbackReader {
     /// storage through REST API interface.
     client: HttpRestKVClient,
     package_resolver: PackageResolver,
-    cache_cursor: MokaCache<TransactionDigest, TransactionSequenceNumber>,
+    cursor_cache: MokaCache<TransactionDigest, TransactionSequenceNumber>,
 }
 
 impl HistoricalFallbackReader {
@@ -85,14 +85,14 @@ impl HistoricalFallbackReader {
             HistoricalFallbackClientMetrics::new(registry),
         )?;
 
-        let cache_cursor = MokaCacheBuilder::new(cache_size)
+        let cursor_cache = MokaCacheBuilder::new(cache_size)
             .time_to_idle(CACHE_TIME_TO_IDLE)
             .build();
 
         Ok(Self {
             client,
             package_resolver,
-            cache_cursor,
+            cursor_cache,
         })
     }
 
@@ -545,7 +545,7 @@ impl HistoricalFallbackReader {
         oldest_first: bool,
     ) -> IndexerResult<Vec<TransactionDigest>> {
         let cursor = match cursor {
-            Some(digest) => match self.cache_cursor.get(&digest) {
+            Some(digest) => match self.cursor_cache.get(&digest) {
                 Some(tx_sequence_number) => Some(tx_sequence_number),
                 None => self.resolve_transaction_sequence_number(digest).await?,
             },
@@ -560,7 +560,7 @@ impl HistoricalFallbackReader {
         Ok(pairs
             .into_iter()
             .map(|(seq, digest)| {
-                self.cache_cursor.insert(digest, seq);
+                self.cursor_cache.insert(digest, seq);
                 digest
             })
             .collect())

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use futures::future;
 use iota_json_rpc_types::{CheckpointId, IotaEvent};
 use iota_types::{
-    base_types::{ObjectID, SequenceNumber},
+    base_types::{IotaAddress, ObjectID, SequenceNumber},
     digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
     event::EventID,
@@ -25,12 +25,16 @@ use iota_types::{
     object::Object,
 };
 use itertools::{Either, Itertools, izip};
+use moka::sync::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
 use prometheus::Registry;
 
 use crate::{
     errors::{IndexerError, IndexerResult},
     historical_fallback::{
-        client::{HttpRestKVClient, KeyValueStoreClient},
+        client::{
+            CACHE_TIME_TO_IDLE, HttpRestKVClient, KeyValueStoreClient,
+            PaginatedKeyValueStoreClient, TransactionSequenceNumber,
+        },
         convert::{
             HistoricalFallbackCheckpoint, HistoricalFallbackEvents, HistoricalFallbackTransaction,
         },
@@ -61,6 +65,7 @@ pub(crate) struct HistoricalFallbackReader {
     /// storage through REST API interface.
     client: HttpRestKVClient,
     package_resolver: PackageResolver,
+    cache_cursor: MokaCache<TransactionDigest, TransactionSequenceNumber>,
 }
 
 impl HistoricalFallbackReader {
@@ -79,9 +84,15 @@ impl HistoricalFallbackReader {
             fallback_kv_concurrent_fetches,
             HistoricalFallbackClientMetrics::new(registry),
         )?;
+
+        let cache_cursor = MokaCacheBuilder::new(cache_size)
+            .time_to_idle(CACHE_TIME_TO_IDLE)
+            .build();
+
         Ok(Self {
             client,
             package_resolver,
+            cache_cursor,
         })
     }
 
@@ -496,5 +507,77 @@ impl HistoricalFallbackReader {
         };
 
         Ok(events)
+    }
+
+    /// Resolves the [`TransactionSequenceNumber`] for a given transaction
+    /// digest.
+    async fn resolve_transaction_sequence_number(
+        &self,
+        digest: TransactionDigest,
+    ) -> IndexerResult<Option<TransactionSequenceNumber>> {
+        let checkpoints = self.resolve_checkpoints(&[digest]).await?;
+        let (summary, contents) = checkpoints
+            .get(&digest)
+            .cloned()
+            // if transaction exists but summary is not found this indicates a bug in data
+            // consistency in the KV Store.
+            .ok_or_else(|| {
+                IndexerError::HistoricalFallbackStorageError(format!(
+                    "checkpoint summary and contents linked to transaction: {digest} not found",
+                ))
+            })?;
+
+        let result = contents
+            .enumerate_transactions(&summary)
+            .find(|(_seq, execution_digest)| execution_digest.transaction == digest)
+            .map(|(seq, _execution_digest)| seq);
+
+        Ok(result)
+    }
+
+    /// Fetches a paginated list of transaction digests that affect a given
+    /// address.
+    pub(crate) async fn paginate_transaction_digests_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> IndexerResult<Vec<TransactionDigest>> {
+        let cursor = match cursor {
+            Some(digest) => match self.cache_cursor.get(&digest) {
+                Some(tx_sequence_number) => Some(tx_sequence_number),
+                None => self.resolve_transaction_sequence_number(digest).await?,
+            },
+            None => None,
+        };
+
+        let pairs = self
+            .client
+            .transaction_digests_by_address(address, cursor, limit, oldest_first)
+            .await?;
+
+        Ok(pairs
+            .into_iter()
+            .map(|(seq, digest)| {
+                self.cache_cursor.insert(digest, seq);
+                digest
+            })
+            .collect())
+    }
+
+    /// Fetches a paginated list of transactions that affect a given address.
+    pub(crate) async fn transactions_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> IndexerResult<Vec<Option<StoredTransaction>>> {
+        let digests = self
+            .paginate_transaction_digests_by_address(address, cursor, limit, oldest_first)
+            .await?;
+
+        self.transactions(&digests).await
     }
 }

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -96,6 +96,14 @@ impl HistoricalFallbackReader {
         })
     }
 
+    /// Returns the cached sequence number for a transaction digest.
+    pub(crate) fn cached_cursor(
+        &self,
+        cursor: &TransactionDigest,
+    ) -> Option<TransactionSequenceNumber> {
+        self.cursor_cache.get(cursor)
+    }
+
     /// Resolves the input and output objects from a given transaction effects.
     pub(crate) async fn resolve_transaction_input_output_objects(
         &self,
@@ -509,30 +517,35 @@ impl HistoricalFallbackReader {
         Ok(events)
     }
 
-    /// Resolves the [`TransactionSequenceNumber`] for a given transaction
-    /// digest.
+    /// Resolves the sequence number for a given [`TransactionDigest`] by
+    /// retrieving its corresponding checkpoint data from the fallback storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns `IndexerError::HistoricalFallbackInput` if:
+    /// * The checkpoint data associated with the digest cannot be retrieved
+    ///   from the fallback store.
+    /// * The transaction digest is not found within the retrieved checkpoint.
     async fn resolve_transaction_sequence_number(
         &self,
         digest: TransactionDigest,
-    ) -> IndexerResult<Option<TransactionSequenceNumber>> {
+    ) -> IndexerResult<TransactionSequenceNumber> {
         let checkpoints = self.resolve_checkpoints(&[digest]).await?;
-        let (summary, contents) = checkpoints
-            .get(&digest)
-            .cloned()
-            // if transaction exists but summary is not found this indicates a bug in data
-            // consistency in the KV Store.
-            .ok_or_else(|| {
-                IndexerError::HistoricalFallbackStorageError(format!(
-                    "checkpoint summary and contents linked to transaction: {digest} not found",
-                ))
-            })?;
+        let (summary, contents) = checkpoints.get(&digest).cloned().ok_or_else(|| {
+            IndexerError::HistoricalFallbackInput(format!(
+                "checkpoint summary and contents linked to transaction: {digest} not found",
+            ))
+        })?;
 
-        let result = contents
+        let transaction_sequence_number = contents
             .enumerate_transactions(&summary)
-            .find(|(_seq, execution_digest)| execution_digest.transaction == digest)
-            .map(|(seq, _execution_digest)| seq);
+            .find_map(|(seq, ed)| (ed.transaction == digest).then_some(seq));
 
-        Ok(result)
+        transaction_sequence_number.ok_or_else(|| {
+            IndexerError::HistoricalFallbackInput(format!(
+                "transaction digest {digest} not found in fallback storage",
+            ))
+        })
     }
 
     /// Fetches a paginated list of transaction digests that affect a given
@@ -547,7 +560,7 @@ impl HistoricalFallbackReader {
         let cursor = match cursor {
             Some(digest) => match self.cursor_cache.get(&digest) {
                 Some(tx_sequence_number) => Some(tx_sequence_number),
-                None => self.resolve_transaction_sequence_number(digest).await?,
+                None => Some(self.resolve_transaction_sequence_number(digest).await?),
             },
             None => None,
         };

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -65,7 +65,9 @@ pub(crate) struct HistoricalFallbackReader {
     /// storage through REST API interface.
     client: HttpRestKVClient,
     package_resolver: PackageResolver,
-    cursor_cache: MokaCache<TransactionDigest, TransactionSequenceNumber>,
+    /// Caches transaction sequence numbers to enable efficient pagination
+    /// cursors for "transactions by address" queries.
+    pub(crate) cursor_cache: MokaCache<TransactionDigest, TransactionSequenceNumber>,
 }
 
 impl HistoricalFallbackReader {
@@ -94,14 +96,6 @@ impl HistoricalFallbackReader {
             package_resolver,
             cursor_cache,
         })
-    }
-
-    /// Returns the cached sequence number for a transaction digest.
-    pub(crate) fn cached_cursor(
-        &self,
-        cursor: &TransactionDigest,
-    ) -> Option<TransactionSequenceNumber> {
-        self.cursor_cache.get(cursor)
     }
 
     /// Resolves the input and output objects from a given transaction effects.
@@ -522,10 +516,15 @@ impl HistoricalFallbackReader {
     ///
     /// # Errors
     ///
-    /// Returns `IndexerError::HistoricalFallbackInput` if:
-    /// * The checkpoint data associated with the digest cannot be retrieved
-    ///   from the fallback store.
-    /// * The transaction digest is not found within the retrieved checkpoint.
+    /// Returns [`IndexerError::HistoricalFallbackInput`] when the checkpoint
+    /// data associated with the digest is not found in the historical fallback
+    /// store.
+    ///
+    /// # Panics
+    ///
+    /// If the resolved checkpoint's contents do not contain the digest,
+    /// which would indicate inconsistency between the historical store's index
+    /// and its checkpoint contents.
     async fn resolve_transaction_sequence_number(
         &self,
         digest: TransactionDigest,
@@ -539,13 +538,12 @@ impl HistoricalFallbackReader {
 
         let transaction_sequence_number = contents
             .enumerate_transactions(&summary)
-            .find_map(|(seq, ed)| (ed.transaction == digest).then_some(seq));
+            .find_map(|(seq, ed)| (ed.transaction == digest).then_some(seq))
+            .expect(
+                "historical fallback store inconsistency: checkpoint resolved via transaction digest does not contain the transaction digest in its contents",
+            );
 
-        transaction_sequence_number.ok_or_else(|| {
-            IndexerError::HistoricalFallbackInput(format!(
-                "transaction digest {digest} not found in fallback storage",
-            ))
-        })
+        Ok(transaction_sequence_number)
     }
 
     /// Fetches a paginated list of transaction digests that affect a given

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -902,27 +902,6 @@ impl IndexerReader {
         Ok(tx_blocks)
     }
 
-    fn multi_get_transactions_with_sequence_numbers(
-        &self,
-        tx_sequence_numbers: &[i64],
-        // Some(true) for desc, Some(false) for asc, None for undefined order
-        is_descending: Option<bool>,
-    ) -> Result<Vec<StoredTransaction>, IndexerError> {
-        let mut query = transactions::table
-            .filter(transactions::tx_sequence_number.eq_any(tx_sequence_numbers))
-            .into_boxed();
-        match is_descending {
-            Some(true) => {
-                query = query.order(transactions::dsl::tx_sequence_number.desc());
-            }
-            Some(false) => {
-                query = query.order(transactions::dsl::tx_sequence_number.asc());
-            }
-            None => (),
-        }
-        run_query!(&self.pool, |conn| query.load::<StoredTransaction>(conn))
-    }
-
     pub fn multi_get_transactions_by_sequence_numbers_range(
         &self,
         min_seq: i64,
@@ -1201,6 +1180,50 @@ impl IndexerReader {
             .await
     }
 
+    /// Fetches a paginated list of transactions that affect a given address,
+    /// using the fallback storage if the database is pruned.
+    async fn query_transactions_either_sender_or_recipient_address_with_fallback(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let db_res = self
+            .db()
+            .query_transactions_either_sender_or_recipient_address(
+                address,
+                cursor,
+                limit,
+                is_descending,
+            )
+            .await;
+
+        // when cursor is provided we know if data was pruned.
+        let is_data_pruned = matches!(&db_res, Err(IndexerError::DataPruned(_)));
+        // an empty result is ambiguous, the address may genuinely have no
+        // transactions, or all of its transactions may have been pruned. Probe the
+        // historical fallback to disambiguate.
+        let is_db_response_empty = matches!(&db_res, Ok(v) if v.is_empty());
+
+        let stored_txs = if let Some(kv_reader) = self
+            .fallback_reader()
+            .filter(|_| is_data_pruned || is_db_response_empty)
+        {
+            kv_reader
+                .transactions_by_address(address, cursor, limit, !is_descending)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect()
+        } else {
+            db_res?
+        };
+        self.stored_transaction_to_transaction_block(stored_txs, options)
+            .await
+    }
+
     async fn query_transaction_blocks_impl_with_checkpointed_data_only(
         &self,
         filter: Option<TransactionFilterKind>,
@@ -1215,6 +1238,20 @@ impl IndexerReader {
             return self
                 .query_transactions_by_checkpoint_seq_with_fallback(
                     seq,
+                    cursor,
+                    limit,
+                    is_descending,
+                    options,
+                )
+                .await;
+        };
+
+        if let Some(TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { addr }))
+        | Some(TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { addr })) = filter
+        {
+            return self
+                .query_transactions_either_sender_or_recipient_address_with_fallback(
+                    addr,
                     cursor,
                     limit,
                     is_descending,
@@ -1265,7 +1302,9 @@ impl IndexerReader {
         let (table_name, main_where_clause) = match filter {
             // Processed above
             Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(_)))
-            | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(_))) => {
+            | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(_)))
+            | Some(TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { .. }))
+            | Some(TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { .. })) => {
                 unreachable!("handled in earlier match statement")
             }
             // FIXME: sanitize module & function
@@ -1369,28 +1408,6 @@ impl IndexerReader {
                     ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
                     LIMIT {limit}) AS inner_query
                     ",
-                );
-                (inner_query, "1 = 1".into())
-            }
-            Some(TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { addr }))
-            | Some(TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { addr })) => {
-                let address = Hex::encode(addr.as_bytes());
-                let inner_query = format!(
-                    "( \
-                        ( \
-                            SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_senders \
-                            WHERE sender = '\\x{address}'::BYTEA {cursor_clause} \
-                            ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
-                            LIMIT {limit} \
-                        ) \
-                        UNION \
-                        ( \
-                            SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_recipients \
-                            WHERE recipient = '\\x{address}'::BYTEA {cursor_clause} \
-                            ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
-                            LIMIT {limit} \
-                        ) \
-                    ) AS combined",
                 );
                 (inner_query, "1 = 1".into())
             }
@@ -1544,15 +1561,8 @@ impl IndexerReader {
         is_descending: Option<bool>,
     ) -> Result<Vec<iota_json_rpc_types::IotaTransactionBlockResponse>, IndexerError> {
         let stored_txes: Vec<StoredTransaction> = self
-            .spawn_blocking({
-                let tx_sequence_numbers = tx_sequence_numbers.clone();
-                move |this| {
-                    this.multi_get_transactions_with_sequence_numbers(
-                        &tx_sequence_numbers,
-                        is_descending,
-                    )
-                }
-            })
+            .db()
+            .get_transactions_by_sequence_numbers(tx_sequence_numbers.clone(), is_descending)
             .await?;
 
         let fetched_transactions = match self
@@ -3140,6 +3150,121 @@ impl<'a> DBReader<'a> {
                 })
             })
             .collect()
+    }
+
+    /// Returns a list of [`StoredTransaction`]s by their corresponding sequence
+    /// numbers.
+    ///
+    /// - `true` or `Some(true)` for DESC.
+    /// - `false` or `Some(false)` for ASC.
+    /// - `None` for undefined order.
+    async fn get_transactions_by_sequence_numbers<I>(
+        &self,
+        tx_sequence_numbers: I,
+        is_descending: impl Into<Option<bool>>,
+    ) -> IndexerResult<Vec<StoredTransaction>>
+    where
+        I: IntoIterator<Item = i64> + Send,
+        I::IntoIter: Send,
+    {
+        let mut query = transactions::table
+            .filter(transactions::tx_sequence_number.eq_any(tx_sequence_numbers.into_iter()))
+            .into_boxed();
+        match is_descending.into() {
+            Some(true) => {
+                query = query.order(transactions::dsl::tx_sequence_number.desc());
+            }
+            Some(false) => {
+                query = query.order(transactions::dsl::tx_sequence_number.asc());
+            }
+            None => (),
+        }
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, |conn| query.load::<StoredTransaction>(conn))
+    }
+
+    /// Returns a list of [`StoredTransaction`]s that have a given address as
+    /// sender or recipient.
+    async fn query_transactions_either_sender_or_recipient_address(
+        &self,
+        addr: IotaAddress,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let tx_tables = [
+            CommitterTables::TxSenders,
+            CommitterTables::TxRecipients,
+            CommitterTables::Transactions,
+        ];
+
+        let cursor_tx_seq = if let Some(cursor) = cursor {
+            let tx_seq = self.resolve_cursor_tx_digest_to_seq_num(cursor).await?;
+            self.main_reader
+                .ensure_data_not_pruned_for_tx(tx_seq, &tx_tables)?;
+            Some(tx_seq)
+        } else {
+            None
+        };
+
+        let min_available_tx = self
+            .main_reader
+            .watermark_cache()
+            .get_lowest_available_tx_for_tables(&tx_tables)
+            .unwrap_or(0);
+
+        let address_hex = Hex::encode(addr.as_bytes());
+        let order = if is_descending { "DESC" } else { "ASC" };
+        let cursor_clause = if let Some(cursor_tx_seq) = cursor_tx_seq {
+            if is_descending {
+                format!("AND {TX_SEQUENCE_NUMBER_STR} < {cursor_tx_seq}")
+            } else {
+                format!("AND {TX_SEQUENCE_NUMBER_STR} > {cursor_tx_seq}")
+            }
+        } else {
+            "".into()
+        };
+
+        let query = format!(
+            "SELECT {TX_SEQUENCE_NUMBER_STR} FROM ( \
+                   ( \
+                       SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_senders \
+                       WHERE sender = '\\x{address_hex}'::BYTEA
+                       AND {TX_SEQUENCE_NUMBER_STR} >= {min_available_tx} {cursor_clause} \
+                       ORDER BY {TX_SEQUENCE_NUMBER_STR} {order} \
+                       LIMIT {limit} \
+                   ) \
+                   UNION \
+                   ( \
+                       SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_recipients \
+                       WHERE recipient = '\\x{address_hex}'::BYTEA \
+                       AND {TX_SEQUENCE_NUMBER_STR} >= {min_available_tx} {cursor_clause} \
+                       ORDER BY {TX_SEQUENCE_NUMBER_STR} {order} \
+                       LIMIT {limit} \
+                   ) \
+                ) AS combined \
+                ORDER BY {TX_SEQUENCE_NUMBER_STR} {order} \
+                LIMIT {limit}"
+        );
+
+        // using two-step query to allow partition pruning during execution for
+        // transactions table.
+        let pool = self.main_reader.get_pool();
+        let tx_sequence_numbers = run_query_async!(&pool, move |conn| {
+            diesel::sql_query(query).load::<TxSequenceNumber>(conn)
+        })?;
+
+        if tx_sequence_numbers.is_empty() {
+            return Ok(vec![]);
+        }
+
+        self.get_transactions_by_sequence_numbers(
+            tx_sequence_numbers
+                .into_iter()
+                .map(|tsn| tsn.tx_sequence_number),
+            is_descending,
+        )
+        .await
     }
 }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1192,12 +1192,7 @@ impl IndexerReader {
     ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
         let db_res = self
             .db()
-            .query_transactions_either_sender_or_recipient_address(
-                address,
-                cursor,
-                limit,
-                is_descending,
-            )
+            .query_transactions_by_affected_addresses(address, cursor, limit, is_descending)
             .await;
 
         // when cursor is provided we know if data was pruned.
@@ -1250,7 +1245,7 @@ impl IndexerReader {
         | Some(TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { addr })) = filter
         {
             return self
-                .query_transactions_either_sender_or_recipient_address_with_fallback(
+                .query_transactions_by_affected_addresses_with_fallback(
                     addr,
                     cursor,
                     limit,
@@ -3185,7 +3180,7 @@ impl<'a> DBReader<'a> {
 
     /// Returns a list of [`StoredTransaction`]s that have a given address as
     /// sender or recipient.
-    async fn query_transactions_either_sender_or_recipient_address(
+    async fn query_transactions_by_affected_addresses(
         &self,
         addr: IotaAddress,
         cursor: Option<TransactionDigest>,

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -3267,7 +3267,7 @@ impl<'a> DBReader<'a> {
     ///
     /// * [`IndexerError::DataPruned`] — signals the caller to fall back to the
     ///   historical store. Two triggers:
-    ///   * `cursor` resolves to a sequence number at or below the pruning
+    ///   * `cursor` resolves to a sequence number below the pruning
     ///     min_available_tx.
     ///   * `cursor = None && is_descending = false && min_available_tx > 0`:
     ///     the DB cannot tell whether the address has pre-watermark history.

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1217,10 +1217,11 @@ impl IndexerReader {
         // fast path: cursor is known to KV (cached) and in pruned territory
         // (below watermark). Serve directly from KV until pagination crosses
         // into the unpruned DB range.
-        if let Some((cursor, kv_reader)) = cursor
-            .zip(self.fallback_reader())
-            .filter(|(c, kv)| kv.cached_cursor(&c).is_some_and(|s| (s as i64) < watermark))
-        {
+        if let Some((cursor, kv_reader)) = cursor.zip(self.fallback_reader()).filter(|(c, kv)| {
+            kv.cursor_cache
+                .get(c)
+                .is_some_and(|s| (s as i64) < watermark)
+        }) {
             let stored_txs = kv_reader
                 .transactions_by_address(address, Some(cursor), limit, !is_descending)
                 .await?
@@ -1238,59 +1239,55 @@ impl IndexerReader {
             .query_transactions_by_affected_addresses(address, cursor, limit, is_descending)
             .await;
 
-        let stored_txs = match db_res {
+        let stored_txs = match (db_res, self.fallback_reader()) {
             // top-up: a short DESC page during active pruning indicates we've crossed
             // the watermark. Fetch the remaining pre-watermark rows from KV.
-            //
-            // note: 'watermark > 0' is essential, without pruning, a short page
-            // simply signals end-of-data.
-            Ok(mut rows) => match self
-                .fallback_reader()
-                .filter(|_| is_descending && rows.len() < limit && watermark > 0)
+            (Ok(mut rows), Some(kv_reader))
+                if is_descending && rows.len() < limit && watermark > 0 =>
             {
-                Some(kv_reader) => {
-                    // determine the KV cursor: use the last DB row to continue pagination,
-                    // or fall back to the original cursor if the DB returned no results.
-                    // Avoids restarting KV from the top of history (which would re-fetch
-                    // rows the user already saw).
-                    let cursor = rows
-                        .last()
-                        .map(|tx| {
-                            TransactionDigest::from_bytes(&tx.transaction_digest).map_err(|e| {
+                // determine the KV cursor: use the last DB row to continue pagination,
+                // or fall back to the original cursor if the DB returned no results.
+                // Avoids restarting KV from the top of history (which would re-fetch
+                // rows the user already saw).
+                let kv_cursor = rows
+                    .last()
+                    .map(|tx| -> IndexerResult<TransactionDigest> {
+                        let digest = TransactionDigest::from_bytes(&tx.transaction_digest)
+                            .map_err(|e| {
                                 IndexerError::PersistentStorageDataCorruption(format!(
                                     "failed to decode transaction digest: {:?} with err: {e:?}",
                                     tx.transaction_digest
                                 ))
-                            })
-                        })
-                        .transpose()?
-                        .or(cursor);
+                            })?;
+                        kv_reader
+                            .cursor_cache
+                            .insert(digest, tx.tx_sequence_number as u64);
+                        Ok(digest)
+                    })
+                    .transpose()?
+                    .or(cursor);
 
-                    let remaining = limit - rows.len();
-                    let kv_rows = kv_reader
-                        .transactions_by_address(address, cursor, remaining, !is_descending)
-                        .await?
-                        .into_iter()
-                        .flatten()
-                        .collect::<Vec<StoredTransaction>>();
-
-                    rows.extend(kv_rows);
-                    Ok(rows)
-                }
-                None => Ok(rows),
-            },
-            Err(e) => match self
-                .fallback_reader()
-                .filter(|_| matches!(e, IndexerError::DataPruned(_)))
-            {
-                Some(kv_reader) => Ok(kv_reader
-                    .transactions_by_address(address, cursor, limit, !is_descending)
+                let remaining = limit - rows.len();
+                let kv_rows = kv_reader
+                    .transactions_by_address(address, kv_cursor, remaining, !is_descending)
                     .await?
                     .into_iter()
                     .flatten()
-                    .collect::<Vec<StoredTransaction>>()),
-                None => Err(e),
-            },
+                    .collect::<Vec<StoredTransaction>>();
+
+                rows.extend(kv_rows);
+                Ok(rows)
+            }
+
+            (Err(IndexerError::DataPruned(_)), Some(kv_reader)) => Ok(kv_reader
+                .transactions_by_address(address, cursor, limit, !is_descending)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect()),
+
+            (Ok(rows), _) => Ok(rows),
+            (Err(e), _) => Err(e),
         };
 
         self.stored_transaction_to_transaction_block(stored_txs?, options)
@@ -3228,9 +3225,11 @@ impl<'a> DBReader<'a> {
     /// Returns a list of [`StoredTransaction`]s by their corresponding sequence
     /// numbers.
     ///
+    /// `is_descending` controls the result order by `tx_sequence_number`:
     /// - `true` or `Some(true)` for DESC.
     /// - `false` or `Some(false)` for ASC.
-    /// - `None` for undefined order.
+    /// - `None` for unspecified order (rows returned in whatever order the DB
+    ///   yields).
     async fn get_transactions_by_sequence_numbers<I>(
         &self,
         tx_sequence_numbers: I,

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1182,7 +1182,7 @@ impl IndexerReader {
 
     /// Fetches a paginated list of transactions that affect a given address,
     /// using the fallback storage if the database is pruned.
-    async fn query_transactions_either_sender_or_recipient_address_with_fallback(
+    async fn query_transactions_by_affected_addresses_with_fallback(
         &self,
         address: IotaAddress,
         cursor: Option<TransactionDigest>,

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -136,6 +136,17 @@ pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePac
 
 // Impl for common initialization and utilities
 impl IndexerReader {
+    /// Tables consulted by the `FromOrToAddress` query path.
+    ///
+    /// The reader raises [`IndexerError::DataPruned`] when a requested
+    /// `tx_sequence_number` is below the `min_available_tx` across these
+    /// tables.
+    const TRANSACTIONS_BY_ADDRESS_TABLES: &[CommitterTables] = &[
+        CommitterTables::TxSenders,
+        CommitterTables::TxRecipients,
+        CommitterTables::Transactions,
+    ];
+
     pub fn new(pool: ConnectionPool, watermark_cache: WatermarkCache) -> Self {
         let indexer_store_pkg_resolver = IndexerStorePackageResolver::new(pool.clone());
         let package_cache = PackageStoreWithLruCache::new(indexer_store_pkg_resolver);
@@ -242,6 +253,17 @@ impl IndexerReader {
             }
         }
         Ok(())
+    }
+
+    /// Returns the lowest transaction sequence number that is available across
+    /// the tables consulted by the affected-addresses query path.
+    ///
+    /// Returns `0` when no watermarks have been populated yet (treat as "no
+    /// pruning observed").
+    pub(crate) fn affected_addresses_tx_watermark(&self) -> i64 {
+        self.watermark_cache()
+            .get_lowest_available_tx_for_tables(Self::TRANSACTIONS_BY_ADDRESS_TABLES)
+            .unwrap_or(0)
     }
 
     pub async fn spawn_blocking<F, R, E>(&self, f: F) -> Result<R, E>
@@ -1190,32 +1212,88 @@ impl IndexerReader {
         is_descending: bool,
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
     ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let watermark = self.affected_addresses_tx_watermark();
+
+        // fast path: cursor is known to KV (cached) and in pruned territory
+        // (below watermark). Serve directly from KV until pagination crosses
+        // into the unpruned DB range.
+        if let Some(kv_reader) = self
+            .fallback_reader()
+            .filter(|kv| matches!(cursor, Some(c) if kv.cached_cursor(&c).is_some_and(|s| (s as i64) < watermark)))
+        {
+            let stored_txs = kv_reader
+                .transactions_by_address(address, cursor, limit, !is_descending)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect();
+
+            return self
+                .stored_transaction_to_transaction_block(stored_txs, options)
+                .await;
+        };
+
         let db_res = self
             .db()
             .query_transactions_by_affected_addresses(address, cursor, limit, is_descending)
             .await;
 
-        // when cursor is provided we know if data was pruned.
-        let is_data_pruned = matches!(&db_res, Err(IndexerError::DataPruned(_)));
-        // an empty result is ambiguous, the address may genuinely have no
-        // transactions, or all of its transactions may have been pruned. Probe the
-        // historical fallback to disambiguate.
-        let is_db_response_empty = matches!(&db_res, Ok(v) if v.is_empty());
+        let stored_txs = match db_res {
+            // top-up: a short DESC page during active pruning indicates we've crossed
+            // the watermark. Fetch the remaining pre-watermark rows from KV.
+            //
+            // note: 'watermark > 0' is essential, without pruning, a short page
+            // simply signals end-of-data.
+            Ok(mut rows) => match self
+                .fallback_reader()
+                .filter(|_| is_descending && rows.len() < limit && watermark > 0)
+            {
+                Some(kv_reader) => {
+                    // determine the KV cursor: use the last DB row to continue pagination,
+                    // or fall back to the original cursor if the DB returned no results.
+                    // Avoids restarting KV from the top of history (which would re-fetch
+                    // rows the user already saw).
+                    let cursor = rows
+                        .last()
+                        .map(|tx| {
+                            TransactionDigest::from_bytes(&tx.transaction_digest).map_err(|e| {
+                                IndexerError::PersistentStorageDataCorruption(format!(
+                                    "failed to decode transaction digest: {:?} with err: {e:?}",
+                                    tx.transaction_digest
+                                ))
+                            })
+                        })
+                        .transpose()?
+                        .or(cursor);
 
-        let stored_txs = if let Some(kv_reader) = self
-            .fallback_reader()
-            .filter(|_| is_data_pruned || is_db_response_empty)
-        {
-            kv_reader
-                .transactions_by_address(address, cursor, limit, !is_descending)
-                .await?
-                .into_iter()
-                .flatten()
-                .collect()
-        } else {
-            db_res?
+                    let remaining = limit - rows.len();
+                    let kv_rows = kv_reader
+                        .transactions_by_address(address, cursor, remaining, !is_descending)
+                        .await?
+                        .into_iter()
+                        .flatten()
+                        .collect::<Vec<StoredTransaction>>();
+
+                    rows.extend(kv_rows);
+                    Ok(rows)
+                }
+                None => Ok(rows),
+            },
+            Err(e) => match self
+                .fallback_reader()
+                .filter(|_| matches!(e, IndexerError::DataPruned(_)))
+            {
+                Some(kv_reader) => Ok(kv_reader
+                    .transactions_by_address(address, cursor, limit, !is_descending)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<StoredTransaction>>()),
+                None => Err(e),
+            },
         };
-        self.stored_transaction_to_transaction_block(stored_txs, options)
+
+        self.stored_transaction_to_transaction_block(stored_txs?, options)
             .await
     }
 
@@ -3180,6 +3258,21 @@ impl<'a> DBReader<'a> {
 
     /// Returns a list of [`StoredTransaction`]s that have a given address as
     /// sender or recipient.
+    ///
+    /// Enforces data retention policies by consulting the pruning watermark for
+    /// the underlying index tables
+    /// [`TRANSACTIONS_BY_ADDRESS_TABLES`](IndexerReader::TRANSACTIONS_BY_ADDRESS_TABLES)
+    ///
+    /// # Errors
+    ///
+    /// * [`IndexerError::DataPruned`] — signals the caller to fall back to the
+    ///   historical store. Two triggers:
+    ///   * `cursor` resolves to a sequence number at or below the pruning
+    ///     min_available_tx.
+    ///   * `cursor = None && is_descending = false && min_available_tx > 0`:
+    ///     the DB cannot tell whether the address has pre-watermark history.
+    /// * [`IndexerError::InvalidArgument`]: the cursor is invalid (digest
+    ///   absent from `tx_digests` AND the database is not pruned).
     async fn query_transactions_by_affected_addresses(
         &self,
         addr: IotaAddress,
@@ -3187,26 +3280,40 @@ impl<'a> DBReader<'a> {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
-        let tx_tables = [
-            CommitterTables::TxSenders,
-            CommitterTables::TxRecipients,
-            CommitterTables::Transactions,
-        ];
+        let min_available_tx = self.main_reader.affected_addresses_tx_watermark();
 
         let cursor_tx_seq = if let Some(cursor) = cursor {
-            let tx_seq = self.resolve_cursor_tx_digest_to_seq_num(cursor).await?;
-            self.main_reader
-                .ensure_data_not_pruned_for_tx(tx_seq, &tx_tables)?;
-            Some(tx_seq)
+            match self
+                .resolve_cursor_tx_digest_to_seq_num_maybe(cursor)
+                .await?
+            {
+                Some(tx_seq) => {
+                    self.main_reader.ensure_data_not_pruned_for_tx(
+                        tx_seq,
+                        IndexerReader::TRANSACTIONS_BY_ADDRESS_TABLES,
+                    )?;
+                    Some(tx_seq)
+                }
+                None if min_available_tx > 0 => {
+                    return Err(IndexerError::DataPruned(format!(
+                        "unable to resolve cursor digest: {cursor} potentially pruned"
+                    )));
+                }
+                None => {
+                    return Err(IndexerError::InvalidArgument(format!(
+                        "cursor with digest {cursor} not found"
+                    )));
+                }
+            }
         } else {
             None
         };
 
-        let min_available_tx = self
-            .main_reader
-            .watermark_cache()
-            .get_lowest_available_tx_for_tables(&tx_tables)
-            .unwrap_or(0);
+        if !is_descending && cursor.is_none() && min_available_tx > 0 {
+            return Err(IndexerError::DataPruned(format!(
+                "DB may be missing earliest history for address {addr} due to pruning"
+            )));
+        }
 
         let address_hex = Hex::encode(addr.as_bytes());
         let order = if is_descending { "DESC" } else { "ASC" };

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1239,58 +1239,49 @@ impl IndexerReader {
             .query_transactions_by_affected_addresses(address, cursor, limit, is_descending)
             .await;
 
-        let stored_txs = match (db_res, self.fallback_reader()) {
-            // top-up: a short DESC page during active pruning indicates we've crossed
-            // the watermark. Fetch the remaining pre-watermark rows from KV.
-            (Ok(mut rows), Some(kv_reader))
-                if is_descending && rows.len() < limit && watermark > 0 =>
-            {
-                // determine the KV cursor: use the last DB row to continue pagination,
-                // or fall back to the original cursor if the DB returned no results.
-                // Avoids restarting KV from the top of history (which would re-fetch
-                // rows the user already saw).
-                let kv_cursor = rows
-                    .last()
-                    .map(|tx| -> IndexerResult<TransactionDigest> {
-                        let digest = TransactionDigest::from_bytes(&tx.transaction_digest)
-                            .map_err(|e| {
-                                IndexerError::PersistentStorageDataCorruption(format!(
-                                    "failed to decode transaction digest: {:?} with err: {e:?}",
-                                    tx.transaction_digest
-                                ))
-                            })?;
-                        kv_reader
-                            .cursor_cache
-                            .insert(digest, tx.tx_sequence_number as u64);
-                        Ok(digest)
-                    })
-                    .transpose()?
-                    .or(cursor);
-
-                let remaining = limit - rows.len();
-                let kv_rows = kv_reader
-                    .transactions_by_address(address, kv_cursor, remaining, !is_descending)
-                    .await?
-                    .into_iter()
-                    .flatten()
-                    .collect::<Vec<StoredTransaction>>();
-
-                rows.extend(kv_rows);
-                Ok(rows)
-            }
-
-            (Err(IndexerError::DataPruned(_)), Some(kv_reader)) => Ok(kv_reader
-                .transactions_by_address(address, cursor, limit, !is_descending)
-                .await?
-                .into_iter()
-                .flatten()
-                .collect()),
-
-            (Ok(rows), _) => Ok(rows),
-            (Err(e), _) => Err(e),
+        let Some(kv_reader) = self.fallback_reader() else {
+            return self
+                .stored_transaction_to_transaction_block(db_res?, options)
+                .await;
         };
 
-        self.stored_transaction_to_transaction_block(stored_txs?, options)
+        let (mut rows, id_db_pruned) = match db_res {
+            Err(IndexerError::DataPruned(_)) => (vec![], true),
+            res => (res?, false),
+        };
+
+        // Fill from KV: either the whole page (`id_db_pruned`) or a top-up when
+        // a short DESC page during active pruning indicates we've crossed the
+        // watermark.
+        if id_db_pruned || (is_descending && rows.len() < limit && watermark > 0) {
+            // Continue pagination from the last DB row, or from the original
+            // cursor if the DB returned nothing. Avoids restarting KV from the
+            // top of history and re-fetching rows the user already saw.
+            let kv_cursor = if let Some(tx) = rows.last() {
+                let digest =
+                    TransactionDigest::from_bytes(&tx.transaction_digest).map_err(|e| {
+                        IndexerError::PersistentStorageDataCorruption(format!(
+                            "failed to decode transaction digest: {:?} with err: {e:?}",
+                            tx.transaction_digest
+                        ))
+                    })?;
+                kv_reader
+                    .cursor_cache
+                    .insert(digest, tx.tx_sequence_number as u64);
+                Some(digest)
+            } else {
+                cursor
+            };
+
+            let kv_rows = kv_reader
+                .transactions_by_address(address, kv_cursor, limit - rows.len(), !is_descending)
+                .await?
+                .into_iter()
+                .flatten();
+            rows.extend(kv_rows);
+        }
+
+        self.stored_transaction_to_transaction_block(rows, options)
             .await
     }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1217,12 +1217,12 @@ impl IndexerReader {
         // fast path: cursor is known to KV (cached) and in pruned territory
         // (below watermark). Serve directly from KV until pagination crosses
         // into the unpruned DB range.
-        if let Some(kv_reader) = self
-            .fallback_reader()
-            .filter(|kv| matches!(cursor, Some(c) if kv.cached_cursor(&c).is_some_and(|s| (s as i64) < watermark)))
+        if let Some((cursor, kv_reader)) = cursor
+            .zip(self.fallback_reader())
+            .filter(|(c, kv)| kv.cached_cursor(&c).is_some_and(|s| (s as i64) < watermark))
         {
             let stored_txs = kv_reader
-                .transactions_by_address(address, cursor, limit, !is_descending)
+                .transactions_by_address(address, Some(cursor), limit, !is_descending)
                 .await?
                 .into_iter()
                 .flatten()


### PR DESCRIPTION
# Description of change

This PR adds historical fallback support to the indexer API for `TransactionFilter{V2}::FromOrToAddress`.


### When the fallback is triggered

The fallback is triggered in three explicit cases:

1. **Cursor resolution below watermark**: the DB query raises `DataPruned` after `ensure_data_not_pruned_for_tx` checks the cursor's sequence number against the watermark.

2. **ASC + no cursor while pruning is active**: the DB cannot distinguish between "no history" and "fully pruned history", so it conservatively raises `DataPruned`, triggering the fallback.

3. **DESC page spans the watermark**: a short DESC page (DB returned fewer rows than the limit) with active pruning means the page crossed the pruning boundary. The fallback fetches the missing pre-watermark suffix using the last DB row's digest as the cursor.

A fast path skips the DB entirely when the cursor is in the fallback's in-memory cursor cache and its sequence number is below the watermark. This avoids round-trips during deep pagination through pruned data.

## Links to any relevant issues

fixes #11678 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Synced the indexer and the iota-kvstore worker upon a local netowrk
- Issued `iotax_queryTransactionBlocks` with `FromOrToAddress` filter before pruning.
- Deleted records from `tx_senders` & `tx_recipients`.
- Updated `min_available_tx` in `watermarks` table to reflect pruning.
- Issued the same queries to check if historical fallback would be triggered.
- Pagination works as expected, only limitation is when no cursor is provided in ascending order. We hit the limitation described above.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.