### PR TITLE
chore: remove some `iota_sdk_types` re-export

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -47,6 +47,7 @@ use iota_metrics::{
 use iota_sdk_types::{
     ExecutionStatus, ObjectId, Owner, StructTag, TransactionExpiration, TransactionKind, TypeTag,
     crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
+    gas::GasCostSummary,
 };
 use iota_storage::{
     key_value_store::{
@@ -83,7 +84,7 @@ use iota_types::{
     executable_transaction::VerifiedExecutableTransaction,
     execution_config_utils::to_binary_config,
     fp_ensure,
-    gas::{GasCostSummary, IotaGasStatus},
+    gas::IotaGasStatus,
     gas_coin::NANOS_PER_IOTA,
     inner_temporary_store::{
         InnerTemporaryStore, ObjectMap, PackageStoreWithFallback, TemporaryModuleResolver, TxCoins,

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -6,10 +6,10 @@ use std::{sync::Arc, time::Duration};
 
 use iota_config::node::ExpensiveSafetyCheckConfig;
 use iota_metrics::spawn_monitored_task;
+use iota_sdk_types::gas::GasCostSummary;
 use iota_swarm_config::test_utils::{CommitteeFixture, empty_contents};
 use iota_types::{
     committee::ProtocolVersion,
-    gas::GasCostSummary,
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemState,
     messages_checkpoint::{
         ECMHLiveObjectSetDigest, EndOfEpochData, VerifiedCheckpoint, VerifiedCheckpointContents,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2695,7 +2695,7 @@ mod tests {
     use futures::{FutureExt as _, future::BoxFuture};
     use iota_macros::sim_test;
     use iota_protocol_config::{Chain, ProtocolConfig};
-    use iota_sdk_types::{Identifier, ObjectId, Owner, move_package::MovePackage};
+    use iota_sdk_types::{GenesisObject, Identifier, ObjectId, Owner, move_package::MovePackage};
     use iota_types::{
         base_types::{SequenceNumber, TransactionEffectsDigest},
         crypto::Signature,
@@ -2705,7 +2705,7 @@ mod tests {
         },
         messages_checkpoint::SignedCheckpointSummary,
         object,
-        transaction::{GenesisObject, VerifiedTransaction},
+        transaction::VerifiedTransaction,
     };
     use tokio::sync::mpsc;
 

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -13,8 +13,8 @@ use iota_sdk_crypto::{
 use iota_sdk_types::{
     Argument, ChangeEpoch, Command, CommandArgumentError, ConsensusCommitPrologueV1,
     ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus, GenesisObject,
-    Identifier, MoveLocation, ObjectId, Owner, PackageUpgradeError, SimpleSignature, StructTag,
-    TransactionExpiration, TransactionKind, TypeArgumentError, TypeTag,
+    GenesisTransaction, Identifier, MoveLocation, ObjectId, Owner, PackageUpgradeError,
+    SimpleSignature, StructTag, TransactionExpiration, TransactionKind, TypeArgumentError, TypeTag,
     crypto::{Intent, IntentMessage, PersonalMessage},
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
 };
@@ -45,9 +45,8 @@ use iota_types::{
     signature::GenericSignature,
     storage::DeleteKind,
     transaction::{
-        CallArg, EndOfEpochTransactionKind, GenesisTransaction, ProgrammableTransaction,
-        RandomnessStateUpdate, SenderSignedData, SharedObjectRef, Transaction, TransactionData,
-        TransactionDataAPI,
+        CallArg, EndOfEpochTransactionKind, ProgrammableTransaction, RandomnessStateUpdate,
+        SenderSignedData, SharedObjectRef, Transaction, TransactionData, TransactionDataAPI,
     },
 };
 use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -12,8 +12,8 @@ use iota_sdk_crypto::{
 };
 use iota_sdk_types::{
     Argument, ChangeEpoch, Command, CommandArgumentError, ConsensusCommitPrologueV1,
-    ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus, Identifier,
-    MoveLocation, ObjectId, Owner, PackageUpgradeError, SimpleSignature, StructTag,
+    ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus, GenesisObject,
+    Identifier, MoveLocation, ObjectId, Owner, PackageUpgradeError, SimpleSignature, StructTag,
     TransactionExpiration, TransactionKind, TypeArgumentError, TypeTag,
     crypto::{Intent, IntentMessage, PersonalMessage},
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
@@ -45,9 +45,9 @@ use iota_types::{
     signature::GenericSignature,
     storage::DeleteKind,
     transaction::{
-        CallArg, EndOfEpochTransactionKind, GenesisObject, GenesisTransaction,
-        ProgrammableTransaction, RandomnessStateUpdate, SenderSignedData, SharedObjectRef,
-        Transaction, TransactionData, TransactionDataAPI,
+        CallArg, EndOfEpochTransactionKind, GenesisTransaction, ProgrammableTransaction,
+        RandomnessStateUpdate, SenderSignedData, SharedObjectRef, Transaction, TransactionData,
+        TransactionDataAPI,
     },
 };
 use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -15,6 +15,7 @@ use iota_sdk_types::{
     ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus, GenesisObject,
     GenesisTransaction, Identifier, MoveLocation, ObjectId, Owner, PackageUpgradeError,
     SimpleSignature, StructTag, TransactionExpiration, TransactionKind, TypeArgumentError, TypeTag,
+    UnchangedSharedKind,
     crypto::{Intent, IntentMessage, PersonalMessage},
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
 };
@@ -31,7 +32,7 @@ use iota_types::{
     digests::ConsensusCommitDigest,
     effects::{
         IDOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsExt,
-        TransactionEvents, UnchangedSharedKind,
+        TransactionEvents,
     },
     event::Event,
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},

--- a/crates/iota-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/iota-core/src/unit_tests/batch_verification_tests.rs
@@ -8,10 +8,10 @@ use fastcrypto::traits::KeyPair;
 use futures::future::join_all;
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
+use iota_sdk_types::gas::GasCostSummary;
 use iota_types::{
     committee::Committee,
     crypto::{AccountKeyPair, AuthorityKeyPair, get_key_pair},
-    gas::GasCostSummary,
     messages_checkpoint::{CheckpointContents, CheckpointSummary, SignedCheckpointSummary},
     transaction::CertifiedTransaction,
 };

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -7,11 +7,10 @@ use std::{collections::HashSet, time::Duration};
 use fastcrypto::traits::KeyPair;
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Identifier, ObjectId};
+use iota_sdk_types::{Identifier, ObjectId, gas::GasCostSummary};
 use iota_types::{
     base_types::ExecutionDigests,
     crypto::deterministic_random_account_key,
-    gas::GasCostSummary,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSignatureMessage,
         CheckpointSummary, SignedCheckpointSummary,

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -9,12 +9,12 @@ use iota_protocol_config::{
 };
 use iota_sdk_types::{
     CancelledTransaction, ConsensusDeterminedVersionAssignments, ExecutionError, ExecutionStatus,
-    ObjectId, TransactionKind, VersionAssignment,
+    ObjectId, TransactionKind, UnchangedSharedKind, VersionAssignment,
 };
 use iota_types::{
     base_types::{IotaAddress, ObjectRef, SequenceNumber},
     crypto::{AccountKeyPair, get_key_pair},
-    effects::{TransactionEffects, TransactionEffectsAPI, UnchangedSharedKind},
+    effects::{TransactionEffects, TransactionEffectsAPI},
     executable_transaction::VerifiedExecutableTransaction,
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -11,7 +11,8 @@ use fastcrypto::traits::KeyPair;
 use iota_macros::sim_test;
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
-    ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, Identifier, TransactionKind,
+    ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, GenesisTransaction,
+    Identifier, TransactionKind,
     crypto::{Intent, IntentScope},
 };
 use iota_types::{
@@ -19,7 +20,7 @@ use iota_types::{
     crypto::{AccountKeyPair, Signature, get_key_pair},
     error::{IotaError, UserInputError},
     messages_grpc::HandleSoftBundleCertificatesRequestV1,
-    transaction::{GenesisTransaction, TransactionDataAPI},
+    transaction::TransactionDataAPI,
     utils::to_sender_signed_transaction,
 };
 use starfish_core::{BlockRef, BlockStatus};

--- a/crates/iota-cost/tests/empirical_transaction_cost.rs
+++ b/crates/iota-cost/tests/empirical_transaction_cost.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use insta::assert_json_snapshot;
 use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
-use iota_sdk_types::{Identifier, ObjectId};
+use iota_sdk_types::{Identifier, ObjectId, gas::GasCostSummary};
 use iota_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use iota_test_transaction_builder::{
     TestTransactionBuilder, publish_basics_package_and_make_counter,
@@ -14,7 +14,6 @@ use iota_test_transaction_builder::{
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     coin::{COIN_JOIN_FUNC_NAME, PAY_SPLIT_VEC_FUNC_NAME},
-    gas::GasCostSummary,
     gas_coin::GAS,
     transaction::{CallArg, SharedObjectRef, TransactionData},
 };

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -13,7 +13,7 @@ use std::{
 
 use async_trait::async_trait;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{ObjectId, TransactionKind};
+use iota_sdk_types::{ObjectId, TransactionKind, gas::GasCostSummary};
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef, SequenceNumber},
@@ -22,7 +22,6 @@ use iota_types::{
     digests::ObjectDigest,
     effects::{TransactionEffects, TransactionEffectsExt},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
-    gas::GasCostSummary,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
         CheckpointSummary, SignedCheckpointSummary,

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -21,6 +21,7 @@ use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::{
     TransactionExpiration,
     crypto::{Intent, IntentMessage, IntentScope},
+    gas::GasCostSummary,
 };
 use iota_swarm_config::genesis_config::{ValidatorGenesisConfig, ValidatorGenesisConfigBuilder};
 use iota_test_transaction_builder::{TestTransactionBuilder, make_transfer_iota_transaction};
@@ -30,7 +31,6 @@ use iota_types::{
     effects::TransactionEffectsAPI,
     error::IotaError,
     execution_config_utils::to_binary_config,
-    gas::GasCostSummary,
     governance::MIN_VALIDATOR_JOINING_STAKE_NANOS,
     iota_system_state::{
         IotaSystemStateTrait, get_validator_from_table,

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -31,7 +31,7 @@ use iota_framework::{BuiltInFramework, SystemPackage};
 use iota_genesis_common::{execute_genesis_transaction, get_genesis_protocol_config};
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
-    Command, Identifier, ObjectId, Owner, StructTag,
+    Command, GenesisObject, Identifier, ObjectId, Owner, StructTag,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 use iota_types::{
@@ -65,9 +65,7 @@ use iota_types::{
         stardust_upgrade_label::STARDUST_UPGRADE_LABEL_VALUE,
         timelocked_staked_iota::TimelockedStakedIota,
     },
-    transaction::{
-        CallArg, CheckedInputObjects, GenesisObject, InputObjectKind, ObjectReadResult, Transaction,
-    },
+    transaction::{CallArg, CheckedInputObjects, InputObjectKind, ObjectReadResult, Transaction},
 };
 use move_binary_format::CompiledModule;
 use serde::{Deserialize, Serialize};

--- a/crates/iota-graphql-rpc/src/types/gas.rs
+++ b/crates/iota-graphql-rpc/src/types/gas.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::{connection::Connection, *};
+use iota_sdk_types::gas::GasCostSummary as NativeGasCostSummary;
 use iota_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
-    gas::GasCostSummary as NativeGasCostSummary,
     transaction::GasData,
 };
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -6,10 +6,8 @@ use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
 };
-use iota_types::{
-    digests::TransactionDigest, object::Object as NativeObject,
-    transaction::GenesisTransaction as NativeGenesisTransaction,
-};
+use iota_sdk_types::GenesisTransaction as NativeGenesisTransaction;
+use iota_types::{digests::TransactionDigest, object::Object as NativeObject};
 
 use crate::{
     consistency::ConsistentIndexCursor,

--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -178,7 +178,7 @@ pub enum IndexerError {
     SdkTypeConversion(#[from] SdkTypeConversionError),
 
     #[error(transparent)]
-    IdentifierParse(#[from] iota_types::error::TypeParseError),
+    IdentifierParse(#[from] iota_sdk_types::move_core::TypeParseError),
 }
 
 pub type IndexerResult<T> = Result<T, IndexerError>;

--- a/crates/iota-indexer/src/models/checkpoints.rs
+++ b/crates/iota-indexer/src/models/checkpoints.rs
@@ -4,7 +4,8 @@
 
 use diesel::prelude::*;
 use iota_json_rpc_types::Checkpoint as RpcCheckpoint;
-use iota_types::{base_types::TransactionDigest, digests::CheckpointDigest, gas::GasCostSummary};
+use iota_sdk_types::gas::GasCostSummary;
+use iota_types::{base_types::TransactionDigest, digests::CheckpointDigest};
 
 use crate::{
     errors::IndexerError,

--- a/crates/iota-json-rpc-types/src/iota_checkpoint.rs
+++ b/crates/iota-json-rpc-types/src/iota_checkpoint.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_protocol_config::ProtocolVersion;
+use iota_sdk_types::gas::GasCostSummary;
 use iota_types::{
     base_types::{AuthorityName, TransactionDigest},
     committee::{EpochId, StakeUnit},
     crypto::AggregateAuthoritySignature,
     digests::{CheckpointDigest, Digest},
-    gas::GasCostSummary,
     iota_serde::BigInt,
     message_envelope::Message,
     messages_checkpoint::{

--- a/crates/iota-json-rpc-types/src/iota_gas_cost_summary.rs
+++ b/crates/iota-json-rpc-types/src/iota_gas_cost_summary.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::gas::GasCostSummary;
+use iota_sdk_types::gas::GasCostSummary;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeAs, DisplayFromStr, SerializeAs, serde_as};

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -14,7 +14,7 @@ use iota_sdk_types::{
     Argument, CancelledTransaction, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,
     Command, ConsensusDeterminedVersionAssignments, ExecutionError as ExecutionFailureStatus,
     ExecutionStatus, GenesisObject, Identifier, MoveCall, ObjectId, Owner, TransactionKind,
-    TransferObjects, TypeTag, VersionAssignment,
+    TransferObjects, TypeTag, VersionAssignment, gas::GasCostSummary,
 };
 use iota_types::{
     base_types::{EpochId, IotaAddress, ObjectRef, SequenceNumber, TransactionDigest},
@@ -23,7 +23,6 @@ use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{ExecutionError, IotaError, IotaResult},
     event::EventID,
-    gas::GasCostSummary,
     iota_sdk_types_conversions::type_tag_core_to_sdk,
     iota_serde::BigInt,
     layout_resolver::{LayoutResolver, get_layout_from_struct_tag},

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -13,8 +13,8 @@ use iota_package_resolver::{CleverError, ErrorConstants, PackageStore, Resolver}
 use iota_sdk_types::{
     Argument, CancelledTransaction, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,
     Command, ConsensusDeterminedVersionAssignments, ExecutionError as ExecutionFailureStatus,
-    ExecutionStatus, Identifier, MoveCall, ObjectId, Owner, TransactionKind, TransferObjects,
-    TypeTag, VersionAssignment,
+    ExecutionStatus, GenesisObject, Identifier, MoveCall, ObjectId, Owner, TransactionKind,
+    TransferObjects, TypeTag, VersionAssignment,
 };
 use iota_types::{
     base_types::{EpochId, IotaAddress, ObjectRef, SequenceNumber, TransactionDigest},
@@ -34,9 +34,8 @@ use iota_types::{
     signature::GenericSignature,
     storage::{DeleteKind, WriteKind},
     transaction::{
-        CallArg, EndOfEpochTransactionKind, GenesisObject, InputObjectKind,
-        ProgrammableTransaction, SenderSignedData, SharedObjectRef, TransactionData,
-        TransactionDataAPI,
+        CallArg, EndOfEpochTransactionKind, InputObjectKind, ProgrammableTransaction,
+        SenderSignedData, SharedObjectRef, TransactionData, TransactionDataAPI,
     },
 };
 use move_binary_format::CompiledModule;

--- a/crates/iota-light-client/src/checkpoint.rs
+++ b/crates/iota-light-client/src/checkpoint.rs
@@ -523,9 +523,9 @@ impl ObjectStore for CheckpointSummaryFileStore {
 
 #[cfg(test)]
 mod tests {
+    use iota_sdk_types::gas::GasCostSummary;
     use iota_types::{
         crypto::AuthorityQuorumSignInfo,
-        gas::GasCostSummary,
         message_envelope::Envelope,
         messages_checkpoint::{CheckpointContents, CheckpointSummary},
         supported_protocol_versions::ProtocolConfig,

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -26,7 +26,7 @@ use iota_json_rpc_types::{
 };
 use iota_open_rpc::ExamplePairing;
 use iota_protocol_config::{Chain, ProtocolConfig};
-use iota_sdk_types::{Identifier, ObjectId, Owner, StructTag, TypeTag};
+use iota_sdk_types::{Identifier, ObjectId, Owner, StructTag, TypeTag, gas::GasCostSummary};
 use iota_types::{
     balance::Supply,
     base_types::{
@@ -38,7 +38,6 @@ use iota_types::{
     digests::TransactionEventsDigest,
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType},
     event::EventID,
-    gas::GasCostSummary,
     gas_coin::GasCoin,
     id::UID,
     iota_sdk_types_conversions::struct_tag_sdk_to_core,

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -34,7 +34,7 @@ use iota_node_storage::GrpcStateReader;
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::{
     Argument, Command, ExecutionStatus, Identifier, ObjectId, TransactionKind, TypeTag,
-    move_package::MovePackage,
+    gas::GasCostSummary, move_package::MovePackage,
 };
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
@@ -47,7 +47,6 @@ use iota_types::{
     digests::{ConsensusCommitDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     event::Event,
-    gas::GasCostSummary,
     iota_sdk_types_conversions::type_tag_core_to_sdk,
     messages_checkpoint::{
         CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, VerifiedCheckpoint,

--- a/crates/iota-types/src/effects/mod.rs
+++ b/crates/iota-types/src/effects/mod.rs
@@ -6,12 +6,12 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use iota_sdk_types::{
     Digest, EpochId, ExecutionStatus, GasCostSummary, IntentScope, ObjectId, Owner,
-    UnchangedSharedObject, Version, crypto::Intent,
+    UnchangedSharedKind, UnchangedSharedObject, Version, crypto::Intent,
 };
 pub use iota_sdk_types::{
     effects::{
         ChangedObject as EffectsObjectChange, IdOperation as IDOperation, ObjectIn, ObjectOut,
-        TransactionEffects, TransactionEffectsV1, UnchangedSharedKind,
+        TransactionEffects, TransactionEffectsV1,
     },
     events::TransactionEvents,
 };

--- a/crates/iota-types/src/effects/test_effects_builder.rs
+++ b/crates/iota-types/src/effects/test_effects_builder.rs
@@ -4,7 +4,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use iota_sdk_types::{ExecutionStatus, ObjectId, Owner};
+use iota_sdk_types::{ExecutionStatus, ObjectId, Owner, gas::GasCostSummary};
 
 use crate::{
     base_types::{ObjectRef, SequenceNumber},
@@ -14,7 +14,6 @@ use crate::{
         TransactionEffectsExt,
     },
     execution::SharedInput,
-    gas::GasCostSummary,
     message_envelope::Message,
     transaction::{InputObjectKind, SenderSignedData, TransactionDataAPI},
 };

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -5,7 +5,6 @@
 
 use std::{collections::BTreeMap, convert::AsRef, fmt::Debug};
 
-pub use iota_sdk_types::move_core::TypeParseError;
 use iota_sdk_types::{CommandArgumentError, ObjectId, Owner};
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, IntoStaticStr};

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -10,7 +10,7 @@ pub mod checked {
 
     use enum_dispatch::enum_dispatch;
     use iota_protocol_config::ProtocolConfig;
-    pub use iota_sdk_types::gas::GasCostSummary;
+    use iota_sdk_types::gas::GasCostSummary;
 
     use crate::{
         ObjectId,

--- a/crates/iota-types/src/gas_model/gas_v1.rs
+++ b/crates/iota-types/src/gas_model/gas_v1.rs
@@ -8,12 +8,13 @@ pub use checked::*;
 #[iota_macros::with_checked_arithmetic]
 mod checked {
     use iota_protocol_config::*;
+    use iota_sdk_types::gas::GasCostSummary;
     use move_core_types::vm_status::StatusCode;
 
     use crate::{
         ObjectId,
         error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInputResult},
-        gas::{self, GasCostSummary, IotaGasStatusAPI},
+        gas::{self, IotaGasStatusAPI},
         gas_model::{
             gas_predicates::cost_table_for_version,
             tables::{GasStatus, ZERO_COST_SCHEDULE},

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -11,7 +11,10 @@ use std::{
 use anyhow::Result;
 use fastcrypto::hash::MultisetHash;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::crypto::{Intent, IntentScope};
+use iota_sdk_types::{
+    crypto::{Intent, IntentScope},
+    gas::GasCostSummary,
+};
 use once_cell::sync::OnceCell;
 #[cfg(not(target_arch = "wasm32"))]
 use prometheus::Histogram;
@@ -36,7 +39,6 @@ use crate::{
     digests::Digest,
     effects::{TestEffectsBuilder, TransactionEffectsAPI},
     error::{IotaError, IotaResult},
-    gas::GasCostSummary,
     global_state_hash::GlobalStateHash,
     iota_serde::{AsProtocolVersion, BigInt, Readable},
     message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope},

--- a/crates/iota-types/src/mock_checkpoint_builder.rs
+++ b/crates/iota-types/src/mock_checkpoint_builder.rs
@@ -5,13 +5,13 @@
 use std::mem;
 
 use fastcrypto::traits::Signer;
+use iota_sdk_types::gas::GasCostSummary;
 
 use crate::{
     base_types::{AuthorityName, VerifiedExecutionData},
     committee::Committee,
     crypto::{AuthoritySignInfo, AuthoritySignature, IotaAuthoritySignature},
     effects::{TransactionEffects, TransactionEffectsAPI},
-    gas::GasCostSummary,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary,
         CheckpointVersionSpecificData, EndOfEpochData, FullCheckpointContents, VerifiedCheckpoint,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -18,13 +18,13 @@ use fastcrypto::{encoding::Base64, hash::HashFunction};
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Argument, CancelledTransaction, Command, ConsensusCommitPrologueV1,
-    ConsensusDeterminedVersionAssignments, Digest, GenesisObject, Identifier, Input,
-    MakeMoveVector, MergeCoins, MoveCall, ObjectId, Owner, Publish, SplitCoins,
+    ConsensusDeterminedVersionAssignments, Digest, GenesisObject, GenesisTransaction, Identifier,
+    Input, MakeMoveVector, MergeCoins, MoveCall, ObjectId, Owner, Publish, SplitCoins,
     TransactionExpiration, TransactionKind, TransferObjects, TypeTag, Upgrade,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 pub use iota_sdk_types::{
-    EndOfEpochTransactionKind, GasPayment as GasData, GenesisTransaction, ProgrammableTransaction,
+    EndOfEpochTransactionKind, GasPayment as GasData, ProgrammableTransaction,
     RandomnessStateUpdate, SharedObjectReference as SharedObjectRef, SystemPackage,
     Transaction as TransactionData, TransactionV1 as TransactionDataV1,
 };

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -18,15 +18,15 @@ use fastcrypto::{encoding::Base64, hash::HashFunction};
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Argument, CancelledTransaction, Command, ConsensusCommitPrologueV1,
-    ConsensusDeterminedVersionAssignments, Digest, Identifier, Input, MakeMoveVector, MergeCoins,
-    MoveCall, ObjectId, Owner, Publish, SplitCoins, TransactionExpiration, TransactionKind,
-    TransferObjects, TypeTag, Upgrade,
+    ConsensusDeterminedVersionAssignments, Digest, GenesisObject, Identifier, Input,
+    MakeMoveVector, MergeCoins, MoveCall, ObjectId, Owner, Publish, SplitCoins,
+    TransactionExpiration, TransactionKind, TransferObjects, TypeTag, Upgrade,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 pub use iota_sdk_types::{
-    EndOfEpochTransactionKind, GasPayment as GasData, GenesisObject, GenesisTransaction,
-    ProgrammableTransaction, RandomnessStateUpdate, SharedObjectReference as SharedObjectRef,
-    SystemPackage, Transaction as TransactionData, TransactionV1 as TransactionDataV1,
+    EndOfEpochTransactionKind, GasPayment as GasData, GenesisTransaction, ProgrammableTransaction,
+    RandomnessStateUpdate, SharedObjectReference as SharedObjectRef, SystemPackage,
+    Transaction as TransactionData, TransactionV1 as TransactionDataV1,
 };
 use itertools::Either;
 use nonempty::{NonEmpty, nonempty};

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -13,7 +13,7 @@ use fastcrypto::{
     traits::{AggregateAuthenticator, KeyPair},
 };
 use iota_sdk_crypto::simple::SimpleKeypair;
-use iota_sdk_types::{ExecutionStatus, Owner, StructTag};
+use iota_sdk_types::{ExecutionStatus, Owner, StructTag, gas::GasCostSummary};
 use roaring::RoaringBitmap;
 
 use super::*;
@@ -29,7 +29,6 @@ use crate::{
     },
     digests::TransactionEventsDigest,
     effects::{SignedTransactionEffects, TestEffectsBuilder, TransactionEffectsAPIForTesting},
-    gas::GasCostSummary,
     signature::ZkLoginAuthenticatorDeprecated,
     utils::{
         blake2b256_of_sig, make_move_authenticator_sig, make_move_authenticator_tx,

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -53,6 +53,7 @@ use iota_sdk::{
 use iota_sdk_types::{
     Identifier, ObjectId, Owner, TransactionKind, TypeTag,
     crypto::{Intent, IntentMessage},
+    gas::GasCostSummary,
     move_package::MovePackage,
 };
 use iota_source_validation::{BytecodeSourceVerifier, ValidationMode};
@@ -65,7 +66,7 @@ use iota_types::{
     digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::{self, DynamicFieldInfo, Field},
     error::IotaError,
-    gas::{GasCostSummary, get_gas_balance},
+    gas::get_gas_balance,
     gas_coin::GasCoin,
     iota_serde,
     message_envelope::Envelope,

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -9,10 +9,8 @@ use clap::{Args, ValueHint, arg, builder::StyledStr};
 use iota_json_rpc_types::{DevInspectResults, IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
 use iota_keys::keystore::AccountKeystore;
 use iota_sdk::{IotaClient, wallet_context::WalletContext};
-use iota_sdk_types::{Address, TransactionKind};
-use iota_types::{
-    digests::TransactionDigest, gas::GasCostSummary, transaction::ProgrammableTransaction,
-};
+use iota_sdk_types::{Address, TransactionKind, gas::GasCostSummary};
+use iota_types::{digests::TransactionDigest, transaction::ProgrammableTransaction};
 use move_core_types::account_address::AccountAddress;
 use serde::Serialize;
 

--- a/crates/iota/src/displays/gas_cost_summary.rs
+++ b/crates/iota/src/displays/gas_cost_summary.rs
@@ -4,7 +4,7 @@
 
 use std::fmt::{Display, Formatter};
 
-use iota_types::gas::GasCostSummary;
+use iota_sdk_types::gas::GasCostSummary;
 
 use crate::displays::Pretty;
 

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -19,6 +19,7 @@ mod checked {
     use iota_sdk_types::{
         Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command,
         ExecutionStatus, GenesisTransaction, Identifier, ObjectId, TransactionKind,
+        gas::GasCostSummary,
     };
     #[cfg(msim)]
     use iota_types::iota_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -36,7 +37,7 @@ mod checked {
         error::{ExecutionError, ExecutionErrorKind},
         execution::{ExecutionResults, ExecutionResultsV1, SharedInput, is_certificate_denied},
         execution_config_utils::to_binary_config,
-        gas::{GasCostSummary, IotaGasStatus, IotaGasStatusAPI},
+        gas::{IotaGasStatus, IotaGasStatusAPI},
         gas_coin::GAS,
         inner_temporary_store::InnerTemporaryStore,
         iota_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, AdvanceEpochParams},

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -18,7 +18,7 @@ mod checked {
     use iota_protocol_config::{LimitThresholdCrossed, ProtocolConfig, check_limit_by_meter};
     use iota_sdk_types::{
         Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command,
-        ExecutionStatus, Identifier, ObjectId, TransactionKind,
+        ExecutionStatus, GenesisTransaction, Identifier, ObjectId, TransactionKind,
     };
     #[cfg(msim)]
     use iota_types::iota_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -48,9 +48,9 @@ mod checked {
         randomness_state::RANDOMNESS_STATE_UPDATE_FUNCTION_NAME,
         storage::{BackingStore, Storage},
         transaction::{
-            CallArg, CheckedInputObjects, EndOfEpochTransactionKind, GasData, GenesisTransaction,
-            InputObjects, ProgrammableTransaction, RandomnessStateUpdate, SharedObjectRef,
-            SystemPackage, TransactionKindExt,
+            CallArg, CheckedInputObjects, EndOfEpochTransactionKind, GasData, InputObjects,
+            ProgrammableTransaction, RandomnessStateUpdate, SharedObjectRef, SystemPackage,
+            TransactionKindExt,
         },
     };
     use move_binary_format::CompiledModule;

--- a/iota-execution/latest/iota-adapter/src/gas_charger.rs
+++ b/iota-execution/latest/iota-adapter/src/gas_charger.rs
@@ -9,13 +9,13 @@ pub use checked::*;
 pub mod checked {
 
     use iota_protocol_config::ProtocolConfig;
-    use iota_sdk_types::ObjectId;
+    use iota_sdk_types::{ObjectId, gas::GasCostSummary};
     use iota_types::{
         base_types::ObjectRef,
         deny_list_v1::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS,
         digests::TransactionDigest,
         error::ExecutionError,
-        gas::{GasCostSummary, IotaGasStatus, deduct_gas},
+        gas::{IotaGasStatus, deduct_gas},
         gas_model::tables::GasStatus,
         object::{Data, MoveObjectExt},
     };

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -11,7 +11,7 @@ use std::{
 #[cfg(not(target_arch = "wasm32"))]
 use iota_metrics::monitored_scope;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{ExecutionStatus, ObjectId, Owner};
+use iota_sdk_types::{ExecutionStatus, ObjectId, Owner, gas::GasCostSummary};
 use iota_types::{
     auth_context::AuthContext,
     base_types::{IotaAddress, ObjectRef, SequenceNumber, TransactionDigest, VersionDigest},
@@ -27,7 +27,6 @@ use iota_types::{
     },
     execution_config_utils::to_binary_config,
     fp_bail,
-    gas::GasCostSummary,
     inner_temporary_store::InnerTemporaryStore,
     iota_sdk_types_conversions::struct_tag_core_to_sdk,
     iota_system_state::{AdvanceEpochParams, get_iota_system_state_wrapper},


### PR DESCRIPTION
# Description of change

`iota-types` re-exported a number of types whose canonical home is `iota_sdk_types` (per the repo's "types live in the narrowest scope" guidance, client-visible types belong in the Rust SDK). These re-exports let crates reach SDK types through `iota_types::…`, blurring where a type actually comes from.

This PR removes five such re-exports and points every call site at `iota_sdk_types` directly:

- `gas::GasCostSummary`
- `effects::UnchangedSharedKind`
- `move_core::TypeParseError`
- `transaction::GenesisTransaction`
- `transaction::GenesisObject`

Pure mechanical refactor — only imports change, no behavior is affected.

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/11567

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage) — N/A, import-only change
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, no behavior change
- [x] I have checked that new and existing unit tests pass locally with my changes