### PR TITLE
chore: fix clippy warnings in cfg(msim) / simtest-gated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13144,8 +13144,8 @@ dependencies = [
 name = "starfish-simtests"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arc-swap",
+ "eyre",
  "iota-config",
  "iota-macros",
  "iota-metrics",

--- a/crates/iota-config/src/local_ip_utils.rs
+++ b/crates/iota-config/src/local_ip_utils.rs
@@ -39,7 +39,7 @@ impl SimAddressManager {
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         // If offset ever goes beyond 255, we could use more bytes in the IP.
         assert!(offset <= 255);
-        format!("10.10.0.{}", offset)
+        format!("10.10.0.{offset}")
     }
 
     pub fn get_next_available_port(&self) -> u16 {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4870,7 +4870,11 @@ impl AuthorityState {
         #[cfg(msim)]
         let extra_packages = framework_injection::get_extra_packages(self.name);
         #[cfg(msim)]
-        let system_packages = system_packages.map(|p| p).chain(extra_packages.iter());
+        let system_packages = {
+            let mut packages: Vec<_> = system_packages.collect();
+            packages.extend(extra_packages.iter());
+            packages
+        };
 
         for system_package in system_packages {
             let modules = system_package.modules().to_vec();

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -1052,8 +1052,7 @@ async fn test_epoch_flag_upgrade() {
     assert_eq!(
         all_flags.len(),
         2,
-        "expected 2 different sets of flags: {:?}",
-        all_flags
+        "expected 2 different sets of flags: {all_flags:?}"
     );
 
     // When the epoch changes, flags on some nodes should be re-initialized to be

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -52,6 +52,8 @@ iota-genesis-common.workspace = true
 iota-move-build.workspace = true
 iota-move-natives-latest = { path = "../../iota-execution/latest/iota-move-natives" }
 iota-protocol-config.workspace = true
+# iota-sdk-crypto is only used when compiling the test-outputs feature
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "e7af68b7ed6428dbb1e2bb434c6692993d41e9c3", optional = true, features = ["ed25519", "mnemonic"] }
 iota-sdk-types.workspace = true
 iota-stardust-types = { path = "../iota-stardust-types", features = ["irc_27", "irc_30", "std"] }
 iota-types.workspace = true
@@ -75,10 +77,6 @@ iota-swarm-config.workspace = true
 
 [features]
 test-outputs = ["dep:iota-sdk-crypto"]
-
-[target.'cfg(not(msim))'.dependencies]
-# iota-sdk-crypto is only used when compiling test-outputs feature
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "e7af68b7ed6428dbb1e2bb434c6692993d41e9c3", optional = true, features = ["ed25519", "mnemonic"] }
 
 [[example]]
 name = "snapshot_add_test_outputs"

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -171,8 +171,6 @@ pub struct ValidatorComponents {
 mod simulator {
     use std::sync::atomic::AtomicBool;
 
-    use super::*;
-
     pub(super) struct SimState {
         pub sim_node: iota_simulator::runtime::NodeHandle,
         pub sim_safe_mode_expected: AtomicBool,

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -356,8 +356,7 @@ where
                 get_dynamic_field_from_store(object_store, versioned.id.id.bytes, &version)
                     .map_err(|err| {
                         IotaError::IotaSystemStateRead(format!(
-                            "Failed to load inner validator from the wrapper: {:?}",
-                            err
+                            "Failed to load inner validator from the wrapper: {err:?}"
                         ))
                     })?;
             Ok(validator.into_iota_validator_summary())
@@ -368,8 +367,7 @@ where
                 get_dynamic_field_from_store(object_store, versioned.id.id.bytes, &version)
                     .map_err(|err| {
                         IotaError::IotaSystemStateRead(format!(
-                            "Failed to load inner validator from the wrapper: {:?}",
-                            err
+                            "Failed to load inner validator from the wrapper: {err:?}"
                         ))
                     })?;
             Ok(validator.into_iota_validator_summary())

--- a/crates/iota/tests/shell_tests.rs
+++ b/crates/iota/tests/shell_tests.rs
@@ -2,11 +2,16 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(not(msim))]
 use std::{fs, path::Path, process::Command};
 
+#[cfg(not(msim))]
 use fs_extra::dir::CopyOptions;
+#[cfg(not(msim))]
 use insta_cmd::get_cargo_bin;
+#[cfg(not(msim))]
 use iota_config::IOTA_CLIENT_CONFIG;
+#[cfg(not(msim))]
 use test_cluster::TestClusterBuilder;
 
 // [test_shell_snapshot] is run on every file matching [TEST_PATTERN] in
@@ -16,8 +21,11 @@ use test_cluster::TestClusterBuilder;
 // These run the files as shell scripts and compares their output to the
 // snapshots; use `cargo insta test --review` to update the snapshots.
 
+#[cfg(not(msim))]
 const TEST_DIR: &str = "tests/shell_tests";
+#[cfg(not(msim))]
 const TEST_NET_DIR: &str = "tests/shell_tests/with_network";
+#[cfg(not(msim))]
 const TEST_PATTERN: &str = r"\.sh$";
 
 /// run the bash script at [path], comparing its output to the insta snapshot of
@@ -27,6 +35,7 @@ const TEST_PATTERN: &str = r"\.sh$";
 ///
 /// If [cluster] is provided, the config file for the cluster is passed as the
 /// `CONFIG` environment variable.
+#[cfg(not(msim))]
 #[tokio::main]
 async fn test_shell_snapshot(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     // set up test cluster
@@ -82,6 +91,7 @@ async fn test_shell_snapshot(path: &Path) -> Result<(), Box<dyn std::error::Erro
 }
 
 /// return the path to the `iota` binary that is currently under test
+#[cfg(not(msim))]
 fn get_iota_bin_path() -> String {
     get_cargo_bin("iota")
         .parent()

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2914,12 +2914,15 @@ mod test {
     }
 
     #[rstest]
+    #[case(true, true)]
+    #[case(true, false)]
+    #[case(false, false)]
     #[tokio::test]
     #[serial]
     async fn test_sequenced_transactions_no_headers(
-        #[values((true, true), (true, false), (false, false))] params: (bool, bool),
+        #[case] commit_only_for_traversed_headers: bool,
+        #[case] consensus_fast_commit_sync: bool,
     ) {
-        let (commit_only_for_traversed_headers, consensus_fast_commit_sync) = params;
         test_sequenced_transactions_no_headers_impl(
             commit_only_for_traversed_headers,
             consensus_fast_commit_sync,

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -251,17 +251,7 @@ impl WriteBatch {
 /// Simulation-test-only helper that deletes all transactions from the consensus
 /// RocksDB store while preserving other data.
 #[cfg(msim)]
-pub fn delete_all_transactions_from_store(
-    db_path: &std::path::Path,
-    authority_index: starfish_config::AuthorityIndex,
-    committee: starfish_config::Committee,
-    protocol_config: iota_protocol_config::ProtocolConfig,
-) -> Result<(), String> {
-    rocksdb_store::RocksDBStore::delete_all_transactions_from_store(
-        db_path,
-        authority_index,
-        committee,
-        protocol_config,
-    )
-    .map_err(|e| format!("failed to delete transactions: {}", e))
+pub fn delete_all_transactions_from_store(db_path: &std::path::Path) -> Result<(), String> {
+    rocksdb_store::RocksDBStore::delete_all_transactions_from_store(db_path)
+        .map_err(|e| format!("failed to delete transactions: {e}"))
 }

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -852,32 +852,7 @@ impl RocksDBStore {
     ///
     /// Deletes all transactions from the consensus RocksDB store while
     /// preserving commits, block headers, and other data.
-    pub fn delete_all_transactions_from_store(
-        db_path: &std::path::Path,
-        authority_index: AuthorityIndex,
-        committee: starfish_config::Committee,
-        protocol_config: iota_protocol_config::ProtocolConfig,
-    ) -> ConsensusResult<()> {
-        use prometheus::Registry;
-        use starfish_config::Parameters;
-
-        use crate::{Clock, context::Context, metrics::initialise_metrics};
-
-        let metrics = initialise_metrics(Registry::new());
-        let clock = Arc::new(Clock::default());
-        let context = Arc::new(Context::new(
-            0,
-            authority_index,
-            committee,
-            Parameters {
-                db_path: db_path.to_path_buf(),
-                ..Default::default()
-            },
-            protocol_config,
-            metrics,
-            clock,
-        ));
-
+    pub fn delete_all_transactions_from_store(db_path: &std::path::Path) -> ConsensusResult<()> {
         let store = RocksDBStore::new(
             db_path
                 .to_str()

--- a/crates/starfish/simtests/Cargo.toml
+++ b/crates/starfish/simtests/Cargo.toml
@@ -11,8 +11,8 @@ workspace = true
 
 [target.'cfg(msim)'.dependencies]
 # external dependencies
-anyhow.workspace = true
 arc-swap.workspace = true
+eyre.workspace = true
 parking_lot.workspace = true
 prometheus.workspace = true
 rand.workspace = true

--- a/crates/starfish/simtests/src/lib.rs
+++ b/crates/starfish/simtests/src/lib.rs
@@ -2,9 +2,9 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(msim)]
+#[cfg(all(msim, test))]
 mod node;
 
-#[cfg(msim)]
+#[cfg(all(msim, test))]
 #[path = "tests/simtests.rs"]
 mod simtests;

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -12,8 +12,8 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Result;
 use arc_swap::ArcSwapOption;
+use eyre::Result;
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
 use iota_protocol_config::{ConsensusNetwork, ProtocolConfig};
 use parking_lot::Mutex;
@@ -218,8 +218,9 @@ impl AuthorityNode {
 
             if let Some(handle) = inner.handle.take() {
                 tracing::info!("shutting down {}", handle.node_id);
-                iota_simulator::runtime::Handle::try_current()
-                    .map(|h| h.delete_node(handle.node_id));
+                if let Some(h) = iota_simulator::runtime::Handle::try_current() {
+                    h.delete_node(handle.node_id);
+                }
             }
         }
         info!(index =% self.config.authority_index, "node stopped");
@@ -240,8 +241,9 @@ impl AuthorityNode {
 
             if let Some(handle) = inner.handle.take() {
                 tracing::info!("shutting down {}", handle.node_id);
-                iota_simulator::runtime::Handle::try_current()
-                    .map(|h| h.delete_node(handle.node_id));
+                if let Some(h) = iota_simulator::runtime::Handle::try_current() {
+                    h.delete_node(handle.node_id);
+                }
             }
         }
         info!(index =% self.config.authority_index, "node stopped");
@@ -249,7 +251,7 @@ impl AuthorityNode {
 
     /// If this Node is currently running
     pub fn is_running(&self) -> bool {
-        self.inner.lock().as_ref().map_or(false, |c| c.is_alive())
+        self.inner.lock().as_ref().is_some_and(|c| c.is_alive())
     }
 
     /// Get the commit digest for a specific commit index
@@ -282,7 +284,9 @@ impl Drop for AuthorityNodeInner {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.take() {
             tracing::info!("shutting down {}", handle.node_id);
-            iota_simulator::runtime::Handle::try_current().map(|h| h.delete_node(handle.node_id));
+            if let Some(h) = iota_simulator::runtime::Handle::try_current() {
+                h.delete_node(handle.node_id);
+            }
         }
     }
 }

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -234,7 +234,7 @@ mod test {
                 network_type: iota_protocol_config::ConsensusNetwork::Tonic,
                 boot_counter: 0,
                 protocol_config: protocol_config.clone(),
-                clock_drift: clock_drifts[authority_index.value() as usize],
+                clock_drift: clock_drifts[authority_index.value()],
                 last_processed_commit: 0,
             };
             let node = AuthorityNode::new(config);


### PR DESCRIPTION
# Description of change

`cargo ci-clippy` (the CI clippy gate) builds **without** `--cfg msim`, so clippy never lints the simtest-only (`cfg(msim)`) code paths and warnings had accumulated there unnoticed. Running `scripts/simtest/clippy.sh` surfaces them.

This fixes **one compile error and all clippy warnings** that script reports across the node-team crates, so `scripts/simtest/clippy.sh` now passes with `-D warnings`. The normal `cargo ci-clippy` stays green as well.

Highlights:

- **iota-genesis-builder** — the optional `iota-sdk-crypto` dep lived under `[target.'cfg(not(msim))'.dependencies]`, but the `test_outputs` module that uses it is gated only by the `test-outputs` feature, so `--all-features` under msim failed to compile (E0432). Moved it to `[dependencies]` (still optional).
- **iota-core** — `.map(|p| p)` (an identity map kept only to shorten the `'static` built-in-package refs so they `chain` with the locally-owned extras) tripped `map_identity`; replaced with `collect` + `extend`, which satisfies the lint without the lifetime breakage that simply removing the map causes.
- **starfish-simtests** — gated the test-only `node`/`simtests` modules to `cfg(all(msim, test))` (kills a `dead_code` on `RestartMode` variants that are constructed only in `#[sim_test]` fns); `anyhow::Result` → `eyre::Result` (disallowed-types); plus `option_map_unit_fn` / `unnecessary_map_or` / `unnecessary_cast`.
- **starfish-core** — dropped the unused `context`/params from the orphaned `delete_all_transactions_from_store` helper; rstest `#[values]` → `#[case]` for snake_case generated test names (the msim `#[tokio::test]` wrapper otherwise produces `_params_1__true_true__internal`).
- **iota/tests/shell_tests.rs** — `#[cfg(not(msim))]` on the non-msim test helpers (matching `ptb_files_tests.rs`) to fix `dead_code`.
- **iota-types / iota-config / iota-node / reconfiguration_tests** — assorted `uninlined_format_args` and an unused `use super::*`.

Two decisions worth a reviewer's eye:

1. `RestartMode` `dead_code` is fixed by cfg-gating the test modules rather than `#[expect(dead_code)]`. The crate already uses `#[expect]` elsewhere, so say the word if you'd prefer that for consistency.
2. `delete_all_transactions_from_store` has no callers yet — the in-progress erase-transactions path currently goes through `ConsensusAuthority::stop_and_clear_transactions`. I simplified its signature rather than keep dead params; happy to restore them if they're intended scaffolding.

> Follow-up (out of scope here): these warnings will regress unless `scripts/simtest/clippy.sh` is wired into CI — worth a separate issue.

## Links to any relevant issues

fixes #7999

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

Verified locally:
- `scripts/simtest/clippy.sh` (i.e. `cargo ci-clippy` with `--cfg msim`) → **0 warnings**.
- normal `cargo ci-clippy` (`--all-targets --all-features -D warnings`) → **0 warnings**.
- `cargo +nightly fmt --check`, `dprint check`, `scripts/cargo_sort` consolidate → clean.

The change is a behavior-preserving lint/build cleanup: all targets (incl. tests) compile under both configs, but the test **suite was not executed** — no runtime behavior is altered, so no new tests are added.

