### PR TITLE
fix(docs): correct notarization wasm references copy path

### DIFF
--- a/docs/site/scripts/get-iota-notarization-references.sh
+++ b/docs/site/scripts/get-iota-notarization-references.sh
@@ -8,7 +8,7 @@ cd tmp
 curl -sL https://s3.eu-central-1.amazonaws.com/files.iota.org/iota-wiki/iota-notarization/0.1/wasm.tar.gz  | tar xzv
 # Create the target directory structure if it doesn't exist
 mkdir -p ../../content/developer/iota-notarization/references/wasm
-cp -Rv ./docs/wasm/* ../../content/developer/iota-notarization/references/wasm/
+cp -Rv ./notarization-docs/docs/wasm/* ../../content/developer/iota-notarization/references/wasm/
 
 # Return to root and cleanup
 cd -

--- a/docs/site/scripts/get-iota-notarization-references.sh
+++ b/docs/site/scripts/get-iota-notarization-references.sh
@@ -10,6 +10,14 @@ curl -sL https://s3.eu-central-1.amazonaws.com/files.iota.org/iota-wiki/iota-not
 mkdir -p ../../content/developer/iota-notarization/references/wasm
 cp -Rv ./notarization-docs/docs/wasm/* ../../content/developer/iota-notarization/references/wasm/
 
+# Work around a malformed anchor link in the upstream-generated TypeDoc output:
+# LockMetadata.md links to "NotarizationClient.mdupdatemetadata", missing the '#'
+# before the anchor. Docusaurus (onBrokenLinks: throw) fails the build on it.
+# Remove once https://github.com/iotaledger/notarization regenerates the link correctly.
+lock_metadata=../../content/developer/iota-notarization/references/wasm/notarization_wasm/classes/LockMetadata.md
+tmp_file=$(mktemp)
+sed 's|NotarizationClient\.mdupdatemetadata|NotarizationClient.md#updatemetadata|g' "$lock_metadata" > "$tmp_file" && mv "$tmp_file" "$lock_metadata"
+
 # Return to root and cleanup
 cd -
 rm -rf tmp

--- a/docs/site/scripts/get-iota-notarization-references.sh
+++ b/docs/site/scripts/get-iota-notarization-references.sh
@@ -13,7 +13,8 @@ cp -Rv ./notarization-docs/docs/wasm/* ../../content/developer/iota-notarization
 # Work around a malformed anchor link in the upstream-generated TypeDoc output:
 # LockMetadata.md links to "NotarizationClient.mdupdatemetadata", missing the '#'
 # before the anchor. Docusaurus (onBrokenLinks: throw) fails the build on it.
-# Remove once https://github.com/iotaledger/notarization regenerates the link correctly.
+# Tracked upstream in https://github.com/iotaledger/notarization/issues/282;
+# remove once the link is regenerated correctly and a new tarball is published.
 lock_metadata=../../content/developer/iota-notarization/references/wasm/notarization_wasm/classes/LockMetadata.md
 tmp_file=$(mktemp)
 sed 's|NotarizationClient\.mdupdatemetadata|NotarizationClient.md#updatemetadata|g' "$lock_metadata" > "$tmp_file" && mv "$tmp_file" "$lock_metadata"


### PR DESCRIPTION
# Description of change

The scheduled **Release Wiki** workflow has been failing in the Docusaurus build ([example run](https://github.com/iotaledger/iota/actions/runs/27177256168)) with `Sidebar category Wasm has neither any subitem nor a link`.

## Root cause

The notarization **Wasm** sidebar category is autogenerated from `developer/iota-notarization/references/wasm`, which is populated at build time by `get-iota-notarization-references.sh`. The notarization `wasm.tar.gz` was repackaged with an extra top-level `notarization-docs/` prefix, so the script's `cp` from `./docs/wasm/*` silently copied nothing, leaving the directory empty and the sidebar category empty (which Docusaurus rejects). Identity/hierarchies use the flat `docs/wasm/` layout, so only notarization broke.

## Changes

1. Copy from `./notarization-docs/docs/wasm/*` to match the new tarball layout.
2. Patch a malformed link in the upstream-generated `LockMetadata.md` (`NotarizationClient.mdupdatemetadata` → `NotarizationClient.md#updatemetadata`), which otherwise fails the build under `onBrokenLinks: throw`. Tracked upstream in iotaledger/notarization#282; remove the `sed` workaround once a fixed tarball is published.

https://claude.ai/code/session_01BJxVLbmQFgJxFajfMRi8Po