### PR TITLE
chore: fix RUSTSEC-2026-0172 and ignore RUSTSEC-2026-0173

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.9"
+version = "2.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
+checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",

--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,9 @@ ignore = [
   # seed derives from the stack pointer and cannot be controlled by msim,
   # breaking simtest determinism (e.g. test_passive_reconfig_determinism).
   "RUSTSEC-2026-0002",
+  # proc-macro-error2 is unmaintained
+  # Can be removed once `getset` updates: https://github.com/jbaublitz/getset/issues/132
+  "RUSTSEC-2026-0173",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
## Description

- Fixes [RUSTSEC-2026-0172](https://rustsec.org/advisories/RUSTSEC-2026-0172) by updating `diesel`
- Ignores [RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173) until `getset` is updated (see https://github.com/jbaublitz/getset/issues/132)