### PR TITLE
feat: historical epoch boundaries

### DIFF
--- a/crates/iota-data-ingestion-core/src/errors.rs
+++ b/crates/iota-data-ingestion-core/src/errors.rs
@@ -55,6 +55,9 @@ pub enum IngestionError {
     #[error("reading historical data failed: `{0}`")]
     HistoryRead(String),
 
+    #[error("invalid epoch boundary update: `{0}`")]
+    EpochBoundary(String),
+
     #[error("max downloaded checkpoints limit reached")]
     MaxCheckpointsCapacityReached,
 

--- a/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
+++ b/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
@@ -6,12 +6,9 @@
 use std::{collections::BTreeMap, ops::RangeBounds, time::Duration};
 
 use bytes::Bytes;
-use iota_storage::object_store::{
-    ObjectStoreGetExt, ObjectStorePutExt,
-    util::{exists, get, put},
-};
+use iota_storage::object_store::{ObjectStoreGetExt, util::get};
 use iota_types::{committee::EpochId, messages_checkpoint::CheckpointSequenceNumber};
-use object_store::path::Path;
+use object_store::{ObjectStore, PutMode, path::Path};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -104,17 +101,12 @@ impl EpochBoundaries {
 
 /// Reads the epoch boundaries from the store.
 ///
-/// If the remote file is not found, this returns an empty collection.
-///
 /// # Errors
 ///
-/// Fails if the file fails to decode.
-pub async fn read_epoch_boundaries_or_default<S: ObjectStoreGetExt>(
+/// Fails if the file cannot be fetched, of if it fails to decode.
+pub async fn read_epoch_boundaries<S: ObjectStoreGetExt>(
     remote_store: S,
 ) -> Result<EpochBoundaries> {
-    if !exists(&remote_store, &EpochBoundaries::file_path()).await {
-        return Ok(Default::default());
-    }
     let bytes = tokio::time::timeout(
         Duration::from_secs(GET_TIMEOUT_SECS),
         get(&remote_store, &EpochBoundaries::file_path()),
@@ -140,17 +132,23 @@ pub fn finalize_epoch_boundaries(boundaries: &EpochBoundaries) -> Result<Bytes> 
     finalize_magic_blob(boundaries, EPOCH_BOUNDARIES_FILE_MAGIC)
 }
 
-/// Writes the epoch boundaries to the store.
+/// Writes the epoch boundaries to the store atomically.
+///
+///
 ///
 /// # Errors
 ///
-/// Fails if encoding or the upload fails.
-pub async fn write_epoch_boundaries<S: ObjectStorePutExt>(
+/// Fails if the encoding fails, if the [`PutMode`] invariants are not upheld,
+/// or for any other reason the upload might fail.
+pub async fn write_epoch_boundaries<S: ObjectStore>(
     boundaries: &EpochBoundaries,
     remote_store: S,
+    put_mode: PutMode,
 ) -> Result<()> {
     let bytes = finalize_epoch_boundaries(boundaries)?;
-    put(&remote_store, &EpochBoundaries::file_path(), bytes).await?;
+    remote_store
+        .put_opts(&EpochBoundaries::file_path(), bytes.into(), put_mode.into())
+        .await?;
     Ok(())
 }
 

--- a/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
+++ b/crates/iota-data-ingestion-core/src/history/epoch_boundaries.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Maintain the sequence number of the last checkpoint of each epoch.
+
+use std::{collections::BTreeMap, ops::RangeBounds, time::Duration};
+
+use bytes::Bytes;
+use iota_storage::object_store::{
+    ObjectStoreGetExt, ObjectStorePutExt,
+    util::{exists, get, put},
+};
+use iota_types::{committee::EpochId, messages_checkpoint::CheckpointSequenceNumber};
+use object_store::path::Path;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    IngestionError,
+    errors::IngestionResult as Result,
+    history::{
+        EPOCH_BOUNDARIES_FILE_MAGIC, EPOCH_BOUNDARIES_FILENAME, finalize_magic_blob,
+        read_magic_blob,
+    },
+};
+
+const GET_TIMEOUT_SECS: u64 = 5;
+
+/// Stores the epoch boundaries.
+///
+/// The representation stored is a map between the epoch and the sequence number
+/// of the respective last checkpoint.
+///
+/// # Examples
+///
+/// ```
+/// # use iota_data_ingestion_core::history::epoch_boundaries::EpochBoundaries;
+/// let boundaries: EpochBoundaries = [(0, 5), (1, 100), (2, 1000)].into_iter().collect();
+/// assert_eq!(boundaries.get(1), Some(100));
+/// // The last checkpoints of a range of epochs, in epoch order.
+/// assert_eq!(
+///     boundaries.range(..2).collect::<Vec<_>>(),
+///     vec![(0, 5), (1, 100)]
+/// );
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq)]
+pub struct EpochBoundaries(BTreeMap<EpochId, CheckpointSequenceNumber>);
+
+impl FromIterator<(EpochId, CheckpointSequenceNumber)> for EpochBoundaries {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (EpochId, CheckpointSequenceNumber)>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl EpochBoundaries {
+    /// Returns the boundary of the given epoch.
+    pub fn get(&self, epoch: EpochId) -> Option<CheckpointSequenceNumber> {
+        self.0.get(&epoch).copied()
+    }
+
+    /// Returns the recorded `(epoch, last checkpoint)` pairs for the epochs in
+    /// `range`, in epoch order.
+    pub fn range(
+        &self,
+        range: impl RangeBounds<EpochId>,
+    ) -> impl Iterator<Item = (EpochId, CheckpointSequenceNumber)> + '_ {
+        self.0
+            .range(range)
+            .map(|(&epoch, &boundary)| (epoch, boundary))
+    }
+
+    /// Returns whether the given epoch has a recorded boundary.
+    pub fn contains(&self, epoch: EpochId) -> bool {
+        self.0.contains_key(&epoch)
+    }
+
+    /// Inserts a new epoch boundary, keeping the recorded epochs contiguous.
+    /// Any existing boundary for the same epoch is overwritten.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the previous epoch has not been already recorded.
+    pub fn insert_next(
+        &mut self,
+        epoch: EpochId,
+        boundary: CheckpointSequenceNumber,
+    ) -> Result<()> {
+        if epoch > 0 && !self.contains(epoch - 1) {
+            return Err(IngestionError::EpochBoundary(format!(
+                "epoch {epoch} just ended but its predecessor is not recorded"
+            )));
+        }
+        self.0.insert(epoch, boundary);
+        Ok(())
+    }
+
+    /// The relative path of the file with the serialized boundaries.
+    pub fn file_path() -> Path {
+        Path::from(EPOCH_BOUNDARIES_FILENAME)
+    }
+}
+
+/// Reads the epoch boundaries from the store.
+///
+/// If the remote file is not found, this returns an empty collection.
+///
+/// # Errors
+///
+/// Fails if the file fails to decode.
+pub async fn read_epoch_boundaries_or_default<S: ObjectStoreGetExt>(
+    remote_store: S,
+) -> Result<EpochBoundaries> {
+    if !exists(&remote_store, &EpochBoundaries::file_path()).await {
+        return Ok(Default::default());
+    }
+    let bytes = tokio::time::timeout(
+        Duration::from_secs(GET_TIMEOUT_SECS),
+        get(&remote_store, &EpochBoundaries::file_path()),
+    )
+    .await
+    .map_err(|e| IngestionError::EpochBoundary(e.to_string()))??;
+    read_epoch_boundaries_from_bytes(bytes.to_vec())
+}
+
+/// Decodes epoch boundaries from the given byte vector and verifies their
+/// integrity.
+///
+/// # Errors
+///
+/// Fails if the magic byte or the trailing SHA3-256 checksum does not match.
+pub fn read_epoch_boundaries_from_bytes(vec: Vec<u8>) -> Result<EpochBoundaries> {
+    read_magic_blob(vec, EPOCH_BOUNDARIES_FILE_MAGIC, EPOCH_BOUNDARIES_FILENAME)
+}
+
+/// Encodes the epoch boundaries with its magic byte and a trailing SHA3-256
+/// checksum.
+pub fn finalize_epoch_boundaries(boundaries: &EpochBoundaries) -> Result<Bytes> {
+    finalize_magic_blob(boundaries, EPOCH_BOUNDARIES_FILE_MAGIC)
+}
+
+/// Writes the epoch boundaries to the store.
+///
+/// # Errors
+///
+/// Fails if encoding or the upload fails.
+pub async fn write_epoch_boundaries<S: ObjectStorePutExt>(
+    boundaries: &EpochBoundaries,
+    remote_store: S,
+) -> Result<()> {
+    let bytes = finalize_epoch_boundaries(boundaries)?;
+    put(&remote_store, &EpochBoundaries::file_path(), bytes).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{IngestionError, history::MAGIC_BYTES};
+
+    fn sample() -> EpochBoundaries {
+        [(0, 5), (1, 100), (2, 1000)].into_iter().collect()
+    }
+
+    #[test]
+    fn insert_next_enforces_contiguity() {
+        let mut boundaries = EpochBoundaries::default();
+        // The first recorded epoch must be 0.
+        assert!(matches!(
+            boundaries.insert_next(1, 50),
+            Err(IngestionError::EpochBoundary(_))
+        ));
+        boundaries.insert_next(0, 5).unwrap();
+        boundaries.insert_next(1, 100).unwrap();
+        // A gap is rejected.
+        assert!(boundaries.insert_next(3, 200).is_err());
+    }
+
+    #[test]
+    fn write_read() {
+        for boundaries in [EpochBoundaries::default(), sample()] {
+            let bytes = finalize_epoch_boundaries(&boundaries).unwrap();
+            assert_eq!(
+                read_epoch_boundaries_from_bytes(bytes.to_vec()).unwrap(),
+                boundaries
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_magic() {
+        let mut bytes = finalize_epoch_boundaries(&sample()).unwrap().to_vec();
+        bytes[0] ^= 0xFF;
+        assert!(matches!(
+            read_epoch_boundaries_from_bytes(bytes),
+            Err(IngestionError::HistoryRead(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_corrupted_content() {
+        let mut bytes = finalize_epoch_boundaries(&sample()).unwrap().to_vec();
+        // Flip a byte in the encoded body, past the 4-byte magic.
+        bytes[MAGIC_BYTES + 1] ^= 0xFF;
+        assert!(matches!(
+            read_epoch_boundaries_from_bytes(bytes),
+            Err(IngestionError::HistoryRead(_))
+        ));
+    }
+}

--- a/crates/iota-data-ingestion-core/src/history/manifest.rs
+++ b/crates/iota-data-ingestion-core/src/history/manifest.rs
@@ -13,21 +13,13 @@
 //! │      sha3 <32 bytes>         │
 //! └──────────────────────────────┘
 
-use std::{
-    io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write},
-    num::NonZeroUsize,
-    ops::Range,
-};
+use std::{num::NonZeroUsize, ops::Range};
 
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use bytes::Bytes;
-use fastcrypto::hash::{HashFunction, Sha3_256};
 use iota_config::{
     node::ArchiveReaderConfig as HistoricalReaderConfig, object_storage_config::ObjectStoreConfig,
 };
 use iota_storage::{
-    SHA3_BYTES,
-    blob::{Blob, BlobEncoding},
     compute_sha3_checksum, compute_sha3_checksum_for_bytes,
     object_store::{
         ObjectStoreGetExt, ObjectStorePutExt,
@@ -39,11 +31,10 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::{
-    IngestionError,
     errors::IngestionResult as Result,
     history::{
-        CHECKPOINT_FILE_SUFFIX, MAGIC_BYTES, MANIFEST_FILE_MAGIC, MANIFEST_FILENAME,
-        reader::HistoricalReader,
+        CHECKPOINT_FILE_SUFFIX, MANIFEST_FILE_MAGIC, MANIFEST_FILENAME, finalize_magic_blob,
+        read_magic_blob, reader::HistoricalReader,
     },
 };
 
@@ -171,55 +162,12 @@ pub async fn read_manifest<S: ObjectStoreGetExt>(remote_store: S) -> Result<Mani
 /// Reads the manifest file from the given byte vector and verifies the
 /// integrity of the file.
 pub fn read_manifest_from_bytes(vec: Vec<u8>) -> Result<Manifest> {
-    let manifest_file_size = vec.len();
-    let mut manifest_reader = Cursor::new(vec);
-
-    // Reads from the beginning of the file and verifies the magic byte
-    // is MANIFEST_FILE_MAGIC
-    manifest_reader.rewind()?;
-    let magic = manifest_reader.read_u32::<BigEndian>()?;
-    if magic != MANIFEST_FILE_MAGIC {
-        return Err(IngestionError::HistoryRead(format!(
-            "unexpected magic byte in manifest: {magic}",
-        )));
-    }
-
-    // Reads from the end of the file and gets the SHA3 checksum
-    // of the content.
-    manifest_reader.seek(SeekFrom::End(-(SHA3_BYTES as i64)))?;
-    let mut sha3_digest = [0u8; SHA3_BYTES];
-    manifest_reader.read_exact(&mut sha3_digest)?;
-
-    // Reads the content of the file and verifies the SHA3 checksum
-    // of the content matches the stored checksum.
-    manifest_reader.rewind()?;
-    let mut content_buf = vec![0u8; manifest_file_size - SHA3_BYTES];
-    manifest_reader.read_exact(&mut content_buf)?;
-    let mut hasher = Sha3_256::default();
-    hasher.update(&content_buf);
-    let computed_digest = hasher.finalize().digest;
-    if computed_digest != sha3_digest {
-        return Err(IngestionError::HistoryRead(format!(
-            "manifest corrupted, computed checksum: {computed_digest:?}, stored checksum: {sha3_digest:?}"
-        )));
-    }
-    manifest_reader.rewind()?;
-    manifest_reader.seek(SeekFrom::Start(MAGIC_BYTES as u64))?;
-    Ok(Blob::read(&mut manifest_reader)?.decode()?)
+    read_magic_blob(vec, MANIFEST_FILE_MAGIC, MANIFEST_FILENAME)
 }
 
 /// Computes the SHA3 checksum of the Manifest and writes it to a byte vector.
 pub fn finalize_manifest(manifest: Manifest) -> Result<Bytes> {
-    let mut buf = BufWriter::new(vec![]);
-    buf.write_u32::<BigEndian>(MANIFEST_FILE_MAGIC)?;
-    let blob = Blob::encode(&manifest, BlobEncoding::Bcs)?;
-    blob.write(&mut buf)?;
-    buf.flush()?;
-    let mut hasher = Sha3_256::default();
-    hasher.update(buf.get_ref());
-    let computed_digest = hasher.finalize().digest;
-    buf.write_all(&computed_digest)?;
-    Ok(Bytes::from(buf.into_inner().map_err(|e| e.into_error())?))
+    finalize_magic_blob(&manifest, MANIFEST_FILE_MAGIC)
 }
 
 /// Writes the Manifest to the remote store.

--- a/crates/iota-data-ingestion-core/src/history/mod.rs
+++ b/crates/iota-data-ingestion-core/src/history/mod.rs
@@ -12,11 +12,16 @@
 //! file. MANIFEST is the index and source of truth for all files present in the
 //! ingestion source history.
 //!
+//! EPOCH_BOUNDARIES holds the map between the epochs and the sequence number of
+//! the respective last checkpoint. This allows reading directly the last
+//! checkpoints from the store, which is useful for verification purposes.
+//!
 //! Ingestion Source History Directory Layout
 //! ```text
 //!  - ingestion/
 //!     - historical/
 //!          - MANIFEST
+//!          - EPOCH_BOUNDARIES
 //!          - 0.chk
 //!          - 1000.chk
 //!          - 3000.chk
@@ -44,16 +49,30 @@
 //! │ len <uvarint> │ encoding <1 byte> │ data <bytes> │
 //! └───────────────┴───────────────────┴──────────────┘
 //!
-//! MANIFEST File Disk Format
+//! MANIFEST and EPOCH_BOUNDARIES File Disk Format
 //! ┌──────────────────────────────┐
 //! │        magic<4 byte>         │
 //! ├──────────────────────────────┤
-//! │   serialized manifest        │
+//! │   serialized contents        │
 //! ├──────────────────────────────┤
 //! │      sha3 <32 bytes>         │
 //! └──────────────────────────────┘
 //! ```
 
+use std::io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write};
+
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use bytes::Bytes;
+use fastcrypto::hash::{HashFunction, Sha3_256};
+use iota_storage::{
+    SHA3_BYTES,
+    blob::{Blob, BlobEncoding},
+};
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::{IngestionError, errors::IngestionResult as Result};
+
+pub mod epoch_boundaries;
 pub mod manifest;
 pub mod reader;
 
@@ -62,3 +81,69 @@ pub const CHECKPOINT_FILE_SUFFIX: &str = "chk";
 pub const MAGIC_BYTES: usize = 4;
 pub const MANIFEST_FILE_MAGIC: u32 = 0x0000FACE;
 pub const MANIFEST_FILENAME: &str = "MANIFEST";
+pub const EPOCH_BOUNDARIES_FILE_MAGIC: u32 = 0x0000E90C;
+pub const EPOCH_BOUNDARIES_FILENAME: &str = "EPOCH_BOUNDARIES";
+
+/// Encodes `value` as a BCS [`Blob`] framed with a 4-byte `magic` prefix and a
+/// trailing SHA3-256 checksum computed over the magic and the blob.
+///
+/// This is the on-disk format shared by the MANIFEST and EPOCH_BOUNDARIES
+/// files.
+pub(crate) fn finalize_magic_blob<T: Serialize>(value: &T, magic: u32) -> Result<Bytes> {
+    let mut buf = BufWriter::new(vec![]);
+    buf.write_u32::<BigEndian>(magic)?;
+    Blob::encode(value, BlobEncoding::Bcs)?.write(&mut buf)?;
+    buf.flush()?;
+    let mut hasher = Sha3_256::default();
+    hasher.update(buf.get_ref());
+    let computed_digest = hasher.finalize().digest;
+    buf.write_all(&computed_digest)?;
+    Ok(Bytes::from(buf.into_inner().map_err(|e| e.into_error())?))
+}
+
+/// Decodes a value written by [`finalize_magic_blob`] and verifies its
+/// integrity.
+///
+/// `filename` names the file in error messages (e.g. `"manifest"`).
+///
+/// # Errors
+///
+/// Fails if the `magic` prefix or the trailing SHA3-256 checksum does not
+/// match.
+pub(crate) fn read_magic_blob<T: DeserializeOwned>(
+    vec: Vec<u8>,
+    magic: u32,
+    filename: &str,
+) -> Result<T> {
+    let file_size = vec.len();
+    let mut reader = Cursor::new(vec);
+
+    // Reads from the beginning of the file and verifies the magic byte.
+    let found = reader.read_u32::<BigEndian>()?;
+    if found != magic {
+        return Err(IngestionError::HistoryRead(format!(
+            "unexpected magic byte in {filename}: {found}",
+        )));
+    }
+
+    // Reads the SHA3 checksum stored at the end of the file.
+    reader.seek(SeekFrom::End(-(SHA3_BYTES as i64)))?;
+    let mut sha3_digest = [0u8; SHA3_BYTES];
+    reader.read_exact(&mut sha3_digest)?;
+
+    // Reads the content and verifies it against the stored checksum.
+    reader.rewind()?;
+    let mut content_buf = vec![0u8; file_size - SHA3_BYTES];
+    reader.read_exact(&mut content_buf)?;
+    let mut hasher = Sha3_256::default();
+    hasher.update(&content_buf);
+    let computed_digest = hasher.finalize().digest;
+    if computed_digest != sha3_digest {
+        return Err(IngestionError::HistoryRead(format!(
+            "{filename} corrupted, computed checksum: {computed_digest:?}, stored checksum: {sha3_digest:?}"
+        )));
+    }
+
+    reader.seek(SeekFrom::Start(MAGIC_BYTES as u64))?;
+    Ok(Blob::read(&mut reader)?.decode()?)
+}

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -26,7 +26,7 @@ use crate::{
     errors::IngestionResult as Result,
     history::{
         CHECKPOINT_FILE_MAGIC,
-        epoch_boundaries::{EpochBoundaries, read_epoch_boundaries_or_default},
+        epoch_boundaries::{EpochBoundaries, read_epoch_boundaries},
         manifest::{FileMetadata, Manifest, read_manifest},
     },
 };
@@ -234,9 +234,10 @@ impl HistoricalReader {
     ///
     /// # Errors
     ///
-    /// Fails if the epoch boundaries file cannot be read.
+    /// Fails if the epoch boundaries file cannot be read or if it fails to
+    /// decode.
     pub async fn epoch_boundaries(&self) -> Result<EpochBoundaries> {
-        read_epoch_boundaries_or_default(self.remote_object_store.clone()).await
+        read_epoch_boundaries(self.remote_object_store.clone()).await
     }
 
     /// Syncs the Manifest from remote store.

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -26,6 +26,7 @@ use crate::{
     errors::IngestionResult as Result,
     history::{
         CHECKPOINT_FILE_MAGIC,
+        epoch_boundaries::{EpochBoundaries, read_epoch_boundaries_or_default},
         manifest::{FileMetadata, Manifest, read_manifest},
     },
 };
@@ -224,6 +225,18 @@ impl HistoricalReader {
 
     pub fn remote_store_identifier(&self) -> String {
         self.remote_object_store.to_string()
+    }
+
+    /// Returns the last checkpoint of each epoch, indexed by epoch.
+    ///
+    /// Read from the epoch boundaries file maintained alongside the manifest.
+    /// Callers slice the boundaries by epoch range as needed.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the epoch boundaries file cannot be read.
+    pub async fn epoch_boundaries(&self) -> Result<EpochBoundaries> {
+        read_epoch_boundaries_or_default(self.remote_object_store.clone()).await
     }
 
     /// Syncs the Manifest from remote store.

--- a/crates/iota-data-ingestion/src/workers/historical.rs
+++ b/crates/iota-data-ingestion/src/workers/historical.rs
@@ -2,16 +2,18 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{io::Cursor, ops::Range, sync::Arc};
+use std::{io::Cursor, ops::Range, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use backoff::{SystemClock, exponential::ExponentialBackoffBuilder, future::retry};
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
 use iota_config::object_storage_config::ObjectStoreConfig;
 use iota_data_ingestion_core::{
-    Reducer,
+    IngestionError, Reducer,
     history::{
         CHECKPOINT_FILE_MAGIC, MAGIC_BYTES,
+        epoch_boundaries::{EpochBoundaries, read_epoch_boundaries, write_epoch_boundaries},
         manifest::{
             Manifest, create_file_metadata_from_bytes, finalize_manifest, read_manifest_from_bytes,
         },
@@ -23,18 +25,28 @@ use iota_storage::{
     compress,
 };
 use iota_types::{
-    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
+    committee::EpochId, full_checkpoint_content::CheckpointData,
+    messages_checkpoint::CheckpointSequenceNumber,
 };
-use object_store::{DynObjectStore, Error as ObjectStoreError, ObjectStore, ObjectStoreExt};
+use object_store::{
+    DynObjectStore, Error as ObjectStoreError, ObjectStore, ObjectStoreExt, PutMode,
+};
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use crate::RelayWorker;
+
+const RECORD_EPOCH_BOUNDARY_TIMEOUT_SECS: u64 = 5;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct HistoricalWriterConfig {
     pub object_store_config: ObjectStoreConfig,
     pub commit_duration_seconds: u64,
+    /// Optional seed for the epoch boundaries. When set, it initializes the
+    /// epoch boundaries if not already initialized.
+    #[serde(default)]
+    pub epoch_boundaries: Option<EpochBoundaries>,
 }
 
 pub struct HistoricalReducer {
@@ -46,10 +58,16 @@ impl HistoricalReducer {
     pub async fn new(config: HistoricalWriterConfig) -> anyhow::Result<Self> {
         let remote_store = config.object_store_config.make()?;
 
-        Ok(Self {
+        let reducer = Self {
             remote_store,
             commit_duration_ms: config.commit_duration_seconds * 1000,
-        })
+        };
+
+        if let Some(epoch_boundaries) = config.epoch_boundaries {
+            reducer.seed_epoch_boundaries(epoch_boundaries).await?;
+        }
+
+        Ok(reducer)
     }
 
     async fn upload(
@@ -96,6 +114,60 @@ impl HistoricalReducer {
             Err(err) => Err(err)?,
         })
     }
+
+    /// Initializes the epoch boundaries from the provided seed if not already
+    /// initialized.
+    async fn seed_epoch_boundaries(&self, epoch_boundaries: EpochBoundaries) -> anyhow::Result<()> {
+        match write_epoch_boundaries(
+            &epoch_boundaries,
+            self.remote_store.clone(),
+            PutMode::Create,
+        )
+        .await
+        {
+            Ok(_) => {
+                tracing::info!("Initialized epoch boundaries");
+                Ok(())
+            }
+            Err(IngestionError::ObjectStore(ObjectStoreError::AlreadyExists { .. })) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Adds a new entry in the epoch boundaries maintained in the remote store.
+    ///
+    /// # Errors
+    ///
+    /// Fails if there is a gap between the epochs already recorded and the
+    /// current one.
+    async fn record_epoch_boundary(
+        &self,
+        epoch_id: EpochId,
+        checkpoint_sequence_number: CheckpointSequenceNumber,
+    ) -> anyhow::Result<()> {
+        let mut epoch_boundaries = read_epoch_boundaries(self.remote_store.clone())
+            .await
+            .unwrap_or_default();
+        epoch_boundaries.insert_next(epoch_id, checkpoint_sequence_number)?;
+
+        let backoff = ExponentialBackoffBuilder::<SystemClock>::new()
+            .with_max_interval(Duration::from_secs(RECORD_EPOCH_BOUNDARY_TIMEOUT_SECS))
+            .build();
+        retry(backoff, || async {
+            write_epoch_boundaries(
+                &epoch_boundaries,
+                self.remote_store.clone(),
+                PutMode::Overwrite,
+            )
+            .await
+            .map_err(|e| {
+                error!("failed to write epoch boundaries to the store: {:?}", &e);
+                backoff::Error::transient(e)
+            })
+        })
+        .await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -111,9 +183,17 @@ impl Reducer<RelayWorker> for HistoricalReducer {
         for checkpoint in batch {
             let data = Blob::encode(&checkpoint, BlobEncoding::Bcs)?;
             data.write(&mut buffer)?;
+            if checkpoint.checkpoint_summary.is_last_checkpoint_of_epoch() {
+                self.record_epoch_boundary(
+                    checkpoint.checkpoint_summary.epoch,
+                    checkpoint.checkpoint_summary.sequence_number,
+                )
+                .await?;
+            }
         }
         self.upload(uploaded_range, self.prepare_data_to_upload(buffer)?)
-            .await
+            .await?;
+        Ok(())
     }
 
     fn should_close_batch(

--- a/dev-tools/iota-data-ingestion/historical/config.yaml
+++ b/dev-tools/iota-data-ingestion/historical/config.yaml
@@ -74,3 +74,14 @@ tasks:
       # checkpoint production rate.
       #
       commit-duration-seconds: 250
+      # Set the seed to initialize EPOCH_BOUNDARIES in existing instances.
+      #
+      # The seed has an effect only if the remote EPOCH_BOUNDARIES is not present.
+      #
+      # The last epoch in the seed MUST be greater than or equal to the last completed epoch on the network.
+      # Otherwise, when the current epoch changes the ingestion will fail to ensure that EPOCH_BOUNDARIES is contiguous
+      # with respect to epochs.
+      epoch-boundaries:
+        0: 1
+        1: 100
+        2: 20000


### PR DESCRIPTION
# Description of change

This replays already approved patches that support writing epoch boundaries in the historical checkpoint store.

## Links to any relevant issues

Closes #11694  

