### PR TITLE
fix(core): Weight Move Authenticator errors at one

### DIFF
--- a/crates/iota-core/src/authority_server/mod.rs
+++ b/crates/iota-core/src/authority_server/mod.rs
@@ -313,14 +313,25 @@ fn make_tonic_request_for_testing<T>(message: T) -> tonic::Request<T> {
 pub(super) fn normalize(err: &IotaError) -> Weight {
     match err {
         IotaError::UserInput {
-            error: UserInputError::IncorrectUserSignature { .. },
+            error:
+                UserInputError::IncorrectUserSignature { .. }
+                | UserInputError::MoveAuthenticatorNotFound { .. }
+                | UserInputError::UnableToGetMoveAuthenticatorId { .. }
+                | UserInputError::InvalidAuthenticatorFunctionRefField { .. }
+                | UserInputError::PackageIsInMoveAuthenticatorInput { .. }
+                | UserInputError::AddressOwnedIsInMoveAuthenticatorInput { .. }
+                | UserInputError::ObjectOwnedIsInMoveAuthenticatorInput { .. }
+                | UserInputError::MutableSharedIsInMoveAuthenticatorInput { .. },
         } => Weight::one(),
         IotaError::InvalidSignature { .. }
         | IotaError::SignerSignatureAbsent { .. }
         | IotaError::SignerSignatureNumberMismatch { .. }
         | IotaError::IncorrectSigner { .. }
         | IotaError::UnknownSigner { .. }
-        | IotaError::WrongEpoch { .. } => Weight::one(),
+        | IotaError::WrongEpoch { .. }
+        | IotaError::MoveAuthenticatorExecutionFailure { .. }
+        | IotaError::InvalidMoveAuthenticatorDigest
+        | IotaError::InvalidAuthenticator => Weight::one(),
         _ => Weight::zero(),
     }
 }


### PR DESCRIPTION
# Description of change
Weight Move authenticator errors at one so the AA spam are counted by the error policy and can trigger blocking in traffic controller.


## Links to any relevant issues

Part of #11643 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

