### PR TITLE
upstream: Porting core-protocol related upstream changes in range mainnet-1.49.2 to mainnet-1.50.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13099,6 +13099,7 @@ dependencies = [
  "cfg-if",
  "dashmap",
  "enum_dispatch",
+ "eyre",
  "fastcrypto",
  "futures",
  "http 1.4.0",

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2587,9 +2587,10 @@ impl AuthorityState {
         tx_coins: Option<TxCoins>,
         written: &WrittenObjects,
         inner_temporary_store: &InnerTemporaryStore,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<u64> {
         let changes = self
-            .process_object_index(effects, written, inner_temporary_store)
+            .process_object_index(effects, written, inner_temporary_store, epoch_store)
             .tap_err(|e| warn!(tx_digest=?digest, "Failed to process object index, index_tx is skipped: {e}"))?;
 
         indexes.index_tx(
@@ -2658,8 +2659,8 @@ impl AuthorityState {
         effects: &TransactionEffects,
         written: &WrittenObjects,
         inner_temporary_store: &InnerTemporaryStore,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<ObjectIndexChanges> {
-        let epoch_store = self.load_epoch_store_one_call_per_task();
         let mut layout_resolver =
             epoch_store
                 .executor()
@@ -2936,6 +2937,7 @@ impl AuthorityState {
                     tx_coins,
                     written,
                     inner_temporary_store,
+                    epoch_store,
                 )
                 .tap_ok(|_| self.metrics.post_processing_total_tx_indexed.inc())
                 .tap_err(|e| error!(?tx_digest, "Post processing - Couldn't index tx: {e}"))

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1237,9 +1237,12 @@ impl AuthorityState {
             .inc();
     }
 
-    /// Executes a certificate for its effects.
+    /// Wait for a certificate to be executed.
+    /// For consensus transactions, it needs to be sequenced by the consensus.
+    /// For owned object transactions, this function will enqueue the
+    /// transaction for execution.
     #[instrument(level = "trace", skip_all)]
-    pub async fn execute_certificate(
+    pub async fn wait_for_certificate_execution(
         &self,
         certificate: &VerifiedCertificate,
         epoch_store: &Arc<AuthorityPerEpochStore>,
@@ -1253,7 +1256,7 @@ impl AuthorityState {
                 .execute_certificate_latency_single_writer
                 .start_timer()
         };
-        trace!("execute_certificate");
+        trace!("wait_for_certificate_execution");
 
         self.metrics.total_cert_attempts.inc();
 
@@ -1285,7 +1288,7 @@ impl AuthorityState {
     ///
     /// It is caller's responsibility to ensure input objects are available and
     /// locks are set. If this cannot be satisfied by the caller,
-    /// execute_certificate() should be called instead.
+    /// wait_for_certificate_execution() should be called instead.
     ///
     /// Should only be called within iota-core.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?certificate.digest()))]
@@ -1493,12 +1496,12 @@ impl AuthorityState {
             });
         }
 
-        // Errors originating from prepare_certificate may be transient (failure to read
+        // Errors originating from execute_certificate may be transient (failure to read
         // locks) or non-transient (transaction input is invalid, move vm
         // errors). However, all errors from this function occur before we have
         // written anything to the db, so we commit the tx guard and rely on the
         // client to retry the tx (if it was transient).
-        let (inner_temporary_store, effects, execution_error_opt) = match self.prepare_certificate(
+        let (inner_temporary_store, effects, execution_error_opt) = match self.execute_certificate(
             &execution_guard,
             certificate,
             tx_input_objects,
@@ -1687,19 +1690,19 @@ impl AuthorityState {
         );
     }
 
-    /// prepare_certificate validates the transaction input, and executes the
+    /// execute_certificate validates the transaction input, and executes the
     /// certificate, returning effects, output objects, events, etc.
     ///
     /// It reads state from the db (both owned and shared locks), but it has no
     /// side effects.
     ///
-    /// It can be generally understood that a failure of prepare_certificate
+    /// It can be generally understood that a failure of execute_certificate
     /// indicates a non-transient error, e.g. the transaction input is
     /// somehow invalid, the correct locks are not held, etc. However, this
     /// is not entirely true, as a transient db read error may also cause
     /// this function to fail.
     #[instrument(level = "trace", skip_all)]
-    fn prepare_certificate(
+    fn execute_certificate(
         &self,
         _execution_guard: &ExecutionLockReadGuard<'_>,
         certificate: &VerifiedExecutableTransaction,
@@ -1711,7 +1714,7 @@ impl AuthorityState {
         TransactionEffects,
         Option<ExecutionError>,
     )> {
-        let _scope = monitored_scope("Execution::prepare_certificate");
+        let _scope = monitored_scope("Execution::execute_certificate");
         let _metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
         let prepare_certificate_start_time = tokio::time::Instant::now();
 
@@ -1946,7 +1949,7 @@ impl AuthorityState {
         let lock = RwLock::new(epoch_store.epoch());
         let execution_guard = lock.try_read().unwrap();
 
-        self.prepare_certificate(
+        self.execute_certificate(
             &execution_guard,
             certificate,
             input_objects,
@@ -5392,7 +5395,7 @@ impl AuthorityState {
         let (input_objects, _) =
             self.read_objects_for_execution(&tx_lock, &executable_tx, epoch_store)?;
 
-        let (temporary_store, effects, _execution_error_opt) = self.prepare_certificate(
+        let (temporary_store, effects, _execution_error_opt) = self.execute_certificate(
             &execution_guard,
             &executable_tx,
             input_objects,

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -323,7 +323,7 @@ impl ValidatorService {
             |certificate| async move {
                 let effects = self
                     .state
-                    .execute_certificate(&certificate, epoch_store)
+                    .wait_for_certificate_execution(&certificate, epoch_store)
                     .await?;
                 let events = if include_events {
                     if effects.events_digest().is_some() {

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -82,6 +82,7 @@ use crate::{
         checkpoint_output::{CertifiedCheckpointOutput, CheckpointOutput},
     },
     consensus_handler::SequencedConsensusTransactionKey,
+    consensus_manager::ReplayWaiter,
     execution_cache::TransactionCacheRead,
     global_state_hasher::GlobalStateHasher,
     stake_aggregator::{InsertResult, MultiStakeAggregator},
@@ -1005,9 +1006,20 @@ impl CheckpointBuilder {
         }
     }
 
-    /// Runs the `CheckpointBuilder` in an asynchronous loop, managing the
-    /// creation of checkpoints.
-    async fn run(mut self) {
+    /// This function first waits for ConsensusCommitHandler to finish
+    /// reprocessing commits that have been processed before the last
+    /// restart, if consensus_replay_waiter is supplied. Then it starts
+    /// building checkpoints in a loop.
+    ///
+    /// It is optional to pass in consensus_replay_waiter, to make it easier to
+    /// attribute if slow recovery of previously built checkpoints is due to
+    /// consensus replay or checkpoint building.
+    async fn run(mut self, consensus_replay_waiter: Option<ReplayWaiter>) {
+        if let Some(replay_waiter) = consensus_replay_waiter {
+            info!("Waiting for consensus commits to replay ...");
+            replay_waiter.wait_for_replay().await;
+            info!("Consensus commits finished replaying");
+        }
         info!("Starting CheckpointBuilder");
         loop {
             self.maybe_build_checkpoints().await;
@@ -2521,11 +2533,11 @@ impl CheckpointService {
     /// have a number of consensus commits and resulting checkpoints that
     /// were built but not committed to disk. We want to reprocess the
     /// commits and rebuild the checkpoints before starting normal operation.
-    pub async fn spawn(&self) -> JoinSet<()> {
+    pub async fn spawn(&self, consensus_replay_waiter: Option<ReplayWaiter>) -> JoinSet<()> {
         let mut tasks = JoinSet::new();
 
         let (builder, aggregator, state_hasher) = self.state.lock().take_unstarted();
-        tasks.spawn(monitored_future!(builder.run()));
+        tasks.spawn(monitored_future!(builder.run(consensus_replay_waiter)));
         tasks.spawn(monitored_future!(aggregator.run()));
         tasks.spawn(monitored_future!(state_hasher.run()));
 
@@ -2852,7 +2864,7 @@ mod tests {
             3,
             100_000,
         );
-        let _tasks = checkpoint_service.spawn().await;
+        let _tasks = checkpoint_service.spawn(None).await;
 
         checkpoint_service
             .write_and_notify_checkpoint_for_testing(&epoch_store, p(0, vec![4], 0))

--- a/crates/iota-core/src/consensus_manager/mod.rs
+++ b/crates/iota-core/src/consensus_manager/mod.rs
@@ -12,10 +12,11 @@ use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use fastcrypto::traits::KeyPair as _;
 use iota_config::{ConsensusConfig, NodeConfig};
-use iota_metrics::RegistryService;
+use iota_metrics::{RegistryID, RegistryService};
 use iota_protocol_config::ProtocolVersion;
 use iota_types::{committee::EpochId, error::IotaResult, messages_consensus::ConsensusTransaction};
 use prometheus::{IntGauge, Registry, register_int_gauge_with_registry};
+use starfish_core::ConsensusAuthority;
 use tokio::{
     sync::{Mutex, MutexGuard},
     time::{sleep, timeout},
@@ -52,6 +53,8 @@ pub trait ConsensusManagerTrait {
     async fn shutdown(&self);
 
     async fn is_running(&self) -> bool;
+
+    fn replay_waiter(&self) -> Option<ReplayWaiter>;
 }
 
 /// Used by IOTA validator to start consensus protocol for each epoch.
@@ -118,6 +121,10 @@ impl ConsensusManagerTrait for ConsensusManager {
     async fn is_running(&self) -> bool {
         self.starfish_manager.is_running().await
     }
+
+    fn replay_waiter(&self) -> Option<ReplayWaiter> {
+        self.starfish_manager.replay_waiter()
+    }
 }
 
 /// A ConsensusClient that can be updated internally at any time. This usually
@@ -174,6 +181,21 @@ impl ConsensusClient for UpdatableConsensusClient {
     ) -> IotaResult<BlockStatusReceiver> {
         let client = self.get().await;
         client.submit(transactions, epoch_store).await
+    }
+}
+
+#[derive(Clone)]
+pub struct ReplayWaiter {
+    authority: Arc<(ConsensusAuthority, RegistryID)>,
+}
+
+impl ReplayWaiter {
+    pub(crate) fn new(authority: Arc<(ConsensusAuthority, RegistryID)>) -> Self {
+        Self { authority }
+    }
+
+    pub(crate) async fn wait_for_replay(&self) {
+        self.authority.0.replay_complete().await;
     }
 }
 

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -25,7 +25,7 @@ use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
     consensus_handler::{ConsensusHandlerInitializer, StarfishConsensusHandler},
     consensus_manager::{
-        ConsensusManagerMetrics, ConsensusManagerTrait, Running, RunningLockGuard,
+        ConsensusManagerMetrics, ConsensusManagerTrait, ReplayWaiter, Running, RunningLockGuard,
     },
     consensus_validator::IotaTxValidator,
     starfish_adapter::LazyStarfishClient,
@@ -204,11 +204,6 @@ impl ConsensusManagerTrait for StarfishManager {
 
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);
-
-        // Wait until all locally available commits have been processed
-        info!("replaying commits at startup");
-        registered_authority.0.replay_complete().await;
-        info!("Startup commit replay complete");
     }
 
     async fn shutdown(&self) {
@@ -242,5 +237,10 @@ impl ConsensusManagerTrait for StarfishManager {
 
     async fn is_running(&self) -> bool {
         Running::False != *self.running.lock().await
+    }
+
+    fn replay_waiter(&self) -> Option<ReplayWaiter> {
+        let authority = self.authority.load_full()?;
+        Some(ReplayWaiter::new(authority))
     }
 }

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -783,7 +783,7 @@ async fn test_lt_or_eq_caching() {
         };
 
         // latest object not yet cached
-        assert!(!s.cache.cached.object_by_id_cache.contains_key(&s.obj_id(1)));
+        assert!(!s.cache.object_by_id_cache.contains_key(&s.obj_id(1)));
 
         // version <= 0 does not exist
         assert!(
@@ -795,7 +795,6 @@ async fn test_lt_or_eq_caching() {
         // query above populates cache
         assert_eq!(
             s.cache
-                .cached
                 .object_by_id_cache
                 .get(&s.obj_id(1))
                 .unwrap()
@@ -842,13 +841,13 @@ async fn test_lt_or_eq_with_cached_tombstone() {
         };
 
         // latest object not yet cached
-        assert!(!s.cache.cached.object_by_id_cache.contains_key(&s.obj_id(1)));
+        assert!(!s.cache.object_by_id_cache.contains_key(&s.obj_id(1)));
 
         // version 2 is deleted
         check_version(2, None);
 
         // checking the version pulled the tombstone into the cache
-        assert!(s.cache.cached.object_by_id_cache.contains_key(&s.obj_id(1)));
+        assert!(s.cache.object_by_id_cache.contains_key(&s.obj_id(1)));
 
         // version 1 is still found, tombstone in cache is ignored
         check_version(1, Some(1));
@@ -1242,10 +1241,7 @@ async fn latest_object_cache_race_test() {
             while start.elapsed() < Duration::from_secs(2) {
                 // If you move the get_ticket_for_read to after we get the latest version,
                 // the test will fail! (this is good, it means the test is doing something)
-                let ticket = cache
-                    .cached
-                    .object_by_id_cache
-                    .get_ticket_for_read(&object_id);
+                let ticket = cache.object_by_id_cache.get_ticket_for_read(&object_id);
 
                 // get the latest version, but then let it become stale
                 let Some(latest_version) = cache
@@ -1285,7 +1281,7 @@ async fn latest_object_cache_race_test() {
         let start = Instant::now();
         std::thread::spawn(move || {
             while start.elapsed() < Duration::from_secs(2) {
-                cache.cached.object_by_id_cache.invalidate(&object_id);
+                cache.object_by_id_cache.invalidate(&object_id);
                 // sleep for 1 to 10µs
                 std::thread::sleep(Duration::from_micros(rand::thread_rng().gen_range(1..10)));
             }
@@ -1301,7 +1297,6 @@ async fn latest_object_cache_race_test() {
 
             while start.elapsed() < Duration::from_secs(2) {
                 let Some(cur) = cache
-                    .cached
                     .object_by_id_cache
                     .get(&object_id)
                     .and_then(|e| e.lock().version())
@@ -1416,14 +1411,13 @@ async fn concurrent_latest_object_cache_race_test() {
 
     // invalidate the cache on request
     let invalidator = || {
-        cache.cached.object_by_id_cache.invalidate(&object_id);
+        cache.object_by_id_cache.invalidate(&object_id);
     };
 
     // check cache consistency, ie. it can't contain an older version
     let mut checked_latest = OBJECT_START_VERSION;
     let mut checker = || {
         if let Some(cur) = cache
-            .cached
             .object_by_id_cache
             .get(&object_id)
             .and_then(|e| e.lock().version())
@@ -1439,10 +1433,7 @@ async fn concurrent_latest_object_cache_race_test() {
     // a reader that pretends it saw some previous version on the db
     {
         // acquire the ticket before getting the latest version
-        let ticket = cache
-            .cached
-            .object_by_id_cache
-            .get_ticket_for_read(&object_id);
+        let ticket = cache.object_by_id_cache.get_ticket_for_read(&object_id);
 
         // get the latest cached version
         let latest_version = cache
@@ -1538,7 +1529,7 @@ async fn concurrent_latest_object_cache_collision_test() {
 
     // invalidate the cache on request
     let invalidator = |object_id: ObjectId| {
-        cache.cached.object_by_id_cache.invalidate(&object_id);
+        cache.object_by_id_cache.invalidate(&object_id);
     };
 
     // populate the cache
@@ -1548,10 +1539,7 @@ async fn concurrent_latest_object_cache_collision_test() {
     // a reader that pretends it saw some previous version on the db
     {
         // acquire the ticket before getting the latest version
-        let ticket2 = cache
-            .cached
-            .object_by_id_cache
-            .get_ticket_for_read(&object2_id);
+        let ticket2 = cache.object_by_id_cache.get_ticket_for_read(&object2_id);
 
         // get the latest version
         let latest2_version = cache
@@ -1587,7 +1575,6 @@ async fn concurrent_latest_object_cache_collision_test() {
     // object1 is up to date in the cache
     assert_eq!(
         cache
-            .cached
             .object_by_id_cache
             .get(&object1_id)
             .unwrap()
@@ -1597,5 +1584,5 @@ async fn concurrent_latest_object_cache_collision_test() {
         OBJECT_START_VERSION.next().unwrap()
     );
     // but now we get a cache miss on object2 instead of getting the latest version
-    assert!(cache.cached.object_by_id_cache.get(&object2_id).is_none());
+    assert!(cache.object_by_id_cache.get(&object2_id).is_none());
 }

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -319,13 +319,6 @@ struct CachedCommittedData {
     // See module level comment for an explanation of caching strategy.
     object_cache: MokaCache<ObjectId, Arc<Mutex<CachedVersionMap<ObjectEntry>>>>,
 
-    // We separately cache the latest version of each object. Although this seems
-    // redundant, it is the only way to support populating the cache after a read.
-    // We cannot simply insert objects that we read off the disk into `object_cache`,
-    // since that may violate the no-missing-versions property.
-    // `object_by_id_cache` is also written to on writes so that it is always coherent.
-    object_by_id_cache: MonotonicCache<ObjectId, LatestObjectCacheEntry>,
-
     // See module level comment for an explanation of caching strategy.
     marker_cache: MokaCache<MarkerKey, Arc<Mutex<CachedVersionMap<MarkerValue>>>>,
 
@@ -378,9 +371,6 @@ impl CachedCommittedData {
 
         Self {
             object_cache,
-            object_by_id_cache: MonotonicCache::new(randomize_cache_capacity_in_tests(
-                config.object_by_id_cache_size(),
-            )),
             marker_cache,
             transactions,
             transaction_effects,
@@ -392,7 +382,6 @@ impl CachedCommittedData {
 
     fn clear_and_assert_empty(&self) {
         self.object_cache.invalidate_all();
-        self.object_by_id_cache.invalidate_all();
         self.marker_cache.invalidate_all();
         self.transactions.invalidate_all();
         self.transaction_effects.invalidate_all();
@@ -401,7 +390,6 @@ impl CachedCommittedData {
         self._transaction_objects.invalidate_all();
 
         assert_empty(&self.object_cache);
-        assert!(&self.object_by_id_cache.is_empty());
         assert_empty(&self.marker_cache);
         assert!(self.transactions.is_empty());
         assert!(self.transaction_effects.is_empty());
@@ -424,6 +412,14 @@ where
 pub struct WritebackCache {
     dirty: UncommittedData,
     cached: CachedCommittedData,
+
+    // We separately cache the latest version of each object. Although this seems
+    // redundant, it is the only way to support populating the cache after a read.
+    // We cannot simply insert objects that we read off the disk into `object_cache`,
+    // since that may violate the no-missing-versions property.
+    // `object_by_id_cache` is also written to on writes so that it is always coherent.
+    // Hence it contains both committed and dirty object data.
+    object_by_id_cache: MonotonicCache<ObjectId, LatestObjectCacheEntry>,
 
     // The packages cache is treated separately from objects, because they are immutable and can be
     // used by any number of transactions. Additionally, many operations require loading large
@@ -499,6 +495,9 @@ impl WritebackCache {
         Self {
             dirty: UncommittedData::new(),
             cached: CachedCommittedData::new(config),
+            object_by_id_cache: MonotonicCache::new(randomize_cache_capacity_in_tests(
+                config.object_by_id_cache_size(),
+            )),
             packages,
             object_locks: ObjectLocks::new(),
             executed_effects_digests_notify_read: NotifyRead::new(),
@@ -564,8 +563,7 @@ impl WritebackCache {
         //   fullnodes.
         let mut entry = self.dirty.objects.entry(*object_id).or_default();
 
-        self.cached
-            .object_by_id_cache
+        self.object_by_id_cache
             .insert(
                 object_id,
                 LatestObjectCacheEntry::Object(version, object.clone()),
@@ -688,7 +686,7 @@ impl WritebackCache {
     ) -> CacheResult<(SequenceNumber, ObjectEntry)> {
         self.metrics
             .record_cache_request(request_type, "object_by_id");
-        let entry = self.cached.object_by_id_cache.get(object_id);
+        let entry = self.object_by_id_cache.get(object_id);
 
         if cfg!(debug_assertions) {
             if let Some(entry) = &entry {
@@ -829,7 +827,7 @@ impl WritebackCache {
         request_type: &'static str,
         id: &ObjectId,
     ) -> IotaResult<Option<Object>> {
-        let ticket = self.cached.object_by_id_cache.get_ticket_for_read(id);
+        let ticket = self.object_by_id_cache.get_ticket_for_read(id);
         match self.get_object_entry_by_id_cache_only(request_type, id) {
             CacheResult::Hit((_, object)) => match object {
                 ObjectEntry::Object(object) => Ok(Some(object)),
@@ -1243,7 +1241,6 @@ impl WritebackCache {
     ) {
         trace!("caching object by id: {} {:?}", object_id, object);
         if self
-            .cached
             .object_by_id_cache
             .insert(object_id, object, ticket)
             .is_ok()
@@ -1292,12 +1289,12 @@ impl WritebackCache {
                 info!("removing non-finalized package from cache: {}", object_id);
                 self.packages.invalidate(object_id);
             }
-            self.cached.object_by_id_cache.invalidate(object_id);
+            self.object_by_id_cache.invalidate(object_id);
             self.cached.object_cache.invalidate(object_id);
         }
 
         for ObjectKey(object_id, _) in outputs.deleted.iter().chain(outputs.wrapped.iter()) {
-            self.cached.object_by_id_cache.invalidate(object_id);
+            self.object_by_id_cache.invalidate(object_id);
             self.cached.object_cache.invalidate(object_id);
         }
 
@@ -1310,13 +1307,13 @@ impl WritebackCache {
         self.store.bulk_insert_genesis_objects(objects)?;
         for obj in objects {
             self.cached.object_cache.invalidate(&obj.id());
-            self.cached.object_by_id_cache.invalidate(&obj.id());
+            self.object_by_id_cache.invalidate(&obj.id());
         }
         Ok(())
     }
 
     fn insert_genesis_object_impl(&self, object: Object) -> IotaResult {
-        self.cached.object_by_id_cache.invalidate(&object.id());
+        self.object_by_id_cache.invalidate(&object.id());
         self.cached.object_cache.invalidate(&object.id());
         self.store.insert_genesis_object(object)
     }
@@ -1324,6 +1321,8 @@ impl WritebackCache {
     pub fn clear_caches_and_assert_empty(&self) {
         info!("clearing caches");
         self.cached.clear_and_assert_empty();
+        self.object_by_id_cache.invalidate_all();
+        assert!(&self.object_by_id_cache.is_empty());
         self.packages.invalidate_all();
         assert_empty(&self.packages);
     }
@@ -1581,7 +1580,7 @@ impl ObjectCacheRead for WritebackCache {
         // if we have the latest version cached, and it is within the bound, we are done
         self.metrics
             .record_cache_request("object_lt_or_eq_version", "object_by_id");
-        let latest_cache_entry = self.cached.object_by_id_cache.get(&object_id);
+        let latest_cache_entry = self.object_by_id_cache.get(&object_id);
         if let Some(latest) = &latest_cache_entry {
             let latest = latest.lock();
             match &*latest {
@@ -1674,9 +1673,7 @@ impl ObjectCacheRead for WritebackCache {
                         LatestObjectCacheEntry::Object(obj_version, obj_entry.clone()),
                         // We can get a ticket at the last second, because we are holding the lock
                         // on dirty, so there cannot be any concurrent writes.
-                        self.cached
-                            .object_by_id_cache
-                            .get_ticket_for_read(&object_id),
+                        self.object_by_id_cache.get_ticket_for_read(&object_id),
                     );
 
                     if obj_version <= version_bound {
@@ -1709,9 +1706,7 @@ impl ObjectCacheRead for WritebackCache {
                     self.cache_object_not_found(
                         &object_id,
                         // okay to get ticket at last second - see above
-                        self.cached
-                            .object_by_id_cache
-                            .get_ticket_for_read(&object_id),
+                        self.object_by_id_cache.get_ticket_for_read(&object_id),
                     );
                     Ok(None)
                 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -2273,7 +2273,7 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
         &authority_state,
     );
     let effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -2308,7 +2308,7 @@ async fn test_handle_confirmation_transaction_ok() {
     let old_account = authority_state.get_object(&object_id).await.unwrap();
 
     let signed_effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction.clone(),
             &authority_state.epoch_store_for_testing(),
         )
@@ -2364,7 +2364,7 @@ async fn test_handle_confirmation_transaction_idempotent() {
     );
 
     let effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -2373,7 +2373,7 @@ async fn test_handle_confirmation_transaction_idempotent() {
     assert_eq!(effects.status(), &ExecutionStatus::Success);
 
     let signed_effects2 = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -2521,7 +2521,7 @@ async fn test_move_call_insufficient_gas() {
         &authority_state,
     );
     let effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -2882,7 +2882,7 @@ async fn test_idempotent_reversed_confirmation() {
         &authority_state,
     );
     let result1 = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority_state.epoch_store_for_testing(),
         )
@@ -3147,7 +3147,7 @@ async fn test_transfer_iota_no_amount() {
 
     let certificate = init_certified_transaction(transaction.into(), &authority_state);
     let effects = authority_state
-        .execute_certificate(&certificate, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&certificate, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
     // Check that the transaction was successful, and the gas object is the only
@@ -3189,7 +3189,7 @@ async fn test_transfer_iota_with_amount() {
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     let certificate = init_certified_transaction(transaction, &authority_state);
     let effects = authority_state
-        .execute_certificate(&certificate, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&certificate, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
     // Check that the transaction was successful, the gas object remains in the
@@ -3239,7 +3239,7 @@ async fn test_store_revert_transfer_iota() {
     let certificate = init_certified_transaction(transaction, &authority_state);
     let tx_digest = *certificate.digest();
     authority_state
-        .execute_certificate(&certificate, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&certificate, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
 
@@ -3321,7 +3321,7 @@ async fn test_store_revert_wrap_move_call() {
     let wrap_digest = *wrap_cert.digest();
 
     let wrap_effects = authority_state
-        .execute_certificate(&wrap_cert, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&wrap_cert, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
 
@@ -3420,7 +3420,7 @@ async fn test_store_revert_unwrap_move_call() {
     let unwrap_digest = *unwrap_cert.digest();
 
     let unwrap_effects = authority_state
-        .execute_certificate(&unwrap_cert, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&unwrap_cert, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
 
@@ -3700,7 +3700,7 @@ async fn test_store_revert_add_ofield() {
     let add_digest = *add_cert.digest();
 
     let add_effects = authority_state
-        .execute_certificate(&add_cert, &authority_state.epoch_store_for_testing())
+        .wait_for_certificate_execution(&add_cert, &authority_state.epoch_store_for_testing())
         .await
         .unwrap();
 
@@ -3826,7 +3826,7 @@ async fn test_store_revert_remove_ofield() {
     let remove_ofield_digest = *remove_ofield_cert.digest();
 
     let remove_effects = authority_state
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &remove_ofield_cert,
             &authority_state.epoch_store_for_testing(),
         )
@@ -3893,7 +3893,7 @@ async fn test_iter_live_object_set() {
         &authority,
     );
     authority
-        .execute_certificate(
+        .wait_for_certificate_execution(
             &certified_transfer_transaction,
             &authority.epoch_store_for_testing(),
         )

--- a/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/starfish_manager_tests.rs
@@ -54,7 +54,7 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
         3,
         100_000,
     );
-    checkpoint_service.spawn().now_or_never().unwrap();
+    checkpoint_service.spawn(None).now_or_never().unwrap();
     checkpoint_service
 }
 

--- a/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
@@ -239,7 +239,7 @@ impl TestRunner {
         // `execute_certificate_with_execution_error` to make sure we go through TM
         let effects = self
             .authority_state
-            .execute_certificate(&ct, &epoch_store)
+            .wait_for_certificate_execution(&ct, &epoch_store)
             .await
             .unwrap();
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1309,9 +1309,10 @@ impl IotaNode {
                 ),
             )
             .await;
+        let consensus_replay_waiter = consensus_manager.replay_waiter();
 
         info!("Spawning checkpoint service");
-        let checkpoint_service_tasks = checkpoint_service.spawn().await;
+        let checkpoint_service_tasks = checkpoint_service.spawn(consensus_replay_waiter).await;
 
         Ok(ValidatorComponents {
             validator_server_handle,

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -170,7 +170,7 @@ impl SingleValidator {
                         .enqueue_certificates_for_execution(vec![cert.clone()], &self.epoch_store);
                 }
                 self.get_validator()
-                    .execute_certificate(&cert, &self.epoch_store)
+                    .wait_for_certificate_execution(&cert, &self.epoch_store)
                     .await
                     .unwrap()
             }

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     io,
     io::{BufReader, Read, Write},
     ops::Range,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -298,89 +298,4 @@ pub async fn verify_checkpoint_range<S>(
     store
         .try_update_highest_verified_checkpoint(&final_checkpoint)
         .expect("Failed to update highest verified checkpoint");
-}
-
-fn hard_link(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    fs::create_dir_all(&dst)?;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            hard_link(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        } else {
-            fs::hard_link(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use tempfile::TempDir;
-    use typed_store::{
-        Map, reopen,
-        rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options, open_cf_opts},
-    };
-
-    use crate::hard_link;
-
-    #[tokio::test]
-    pub async fn test_db_hard_link() -> anyhow::Result<()> {
-        let input = TempDir::new()?;
-        let input_path = input.path();
-
-        let output = TempDir::new()?;
-        let output_path = output.path();
-
-        const FIRST_CF: &str = "First_CF";
-        const SECOND_CF: &str = "Second_CF";
-
-        let db_a = open_cf_opts(
-            input_path,
-            None,
-            MetricConf::new("test_db_hard_link_1"),
-            &[
-                (FIRST_CF, default_db_options().options),
-                (SECOND_CF, default_db_options().options),
-            ],
-        )
-        .unwrap();
-
-        let (db_map_1, db_map_2) = reopen!(&db_a, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-
-        let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
-        let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
-
-        assert!(db_map_1.multi_insert(keys_vals_cf1).is_ok());
-        assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
-
-        // set up db hard link
-        hard_link(input_path, output_path)?;
-        let db_b = open_cf_opts(
-            output_path,
-            None,
-            MetricConf::new("test_db_hard_link_2"),
-            &[
-                (FIRST_CF, default_db_options().options),
-                (SECOND_CF, default_db_options().options),
-            ],
-        )
-        .unwrap();
-
-        let (db_map_1, db_map_2) = reopen!(&db_b, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-        for i in 1..100 {
-            assert!(
-                db_map_1
-                    .contains_key(&i)
-                    .expect("Failed to call contains key")
-            );
-            assert!(
-                db_map_2
-                    .contains_key(&i)
-                    .expect("Failed to call contains key")
-            );
-        }
-
-        Ok(())
-    }
 }

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -19,6 +19,7 @@ bytes.workspace = true
 cfg-if = "1.0.0"
 dashmap.workspace = true
 enum_dispatch.workspace = true
+eyre.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
 http.workspace = true
@@ -34,6 +35,7 @@ rs_merkle.workspace = true
 serde.workspace = true
 strum_macros.workspace = true
 tap.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net"] }
 tokio-stream.workspace = true
@@ -61,7 +63,6 @@ typed-store.workspace = true
 # external dependencies
 rstest.workspace = true
 serial_test.workspace = true
-tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 
 # internal dependencies

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -9,10 +9,9 @@ use iota_macros::fail_point;
 use starfish_config::AuthorityIndex;
 use tracing::debug;
 use typed_store::{
-    Map as _,
+    DBMapUtils, Map as _,
     metrics::SamplingInterval,
-    reopen,
-    rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options, open_cf_opts},
+    rocks::{DBMap, DBMapTableConfigMap, MetricConf, default_db_options},
 };
 
 use super::{CommitInfo, Store, WriteBatch};
@@ -30,6 +29,7 @@ use crate::{
 };
 
 /// Persistent storage with RocksDB.
+#[derive(DBMapUtils)]
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlockHeader by refs.
     block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
@@ -38,6 +38,7 @@ pub(crate) struct RocksDBStore {
     /// Stores Transactions by transaction refs
     transactions_by_tx_refs: DBMap<(Round, AuthorityIndex, TransactionsCommitment), Bytes>,
     /// A secondary index that orders refs first by authors.
+    #[rename = "digests"]
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
     /// A secondary index that orders transaction commitments first by authors.
     transaction_commitments_by_authorities:
@@ -81,93 +82,58 @@ impl RocksDBStore {
         let db_options = default_db_options().optimize_db_for_write_throughput(2);
         let mut metrics_conf = MetricConf::new("consensus");
         metrics_conf.read_sample_interval = SamplingInterval::new(Duration::from_secs(60), 0);
-        let cf_options = default_db_options().optimize_for_write_throughput().options;
-        let column_family_options = vec![
+        let cf_options = default_db_options().optimize_for_write_throughput();
+        let column_family_options = DBMapTableConfigMap::new(BTreeMap::from([
             (
-                Self::TRANSACTIONS_CF,
+                Self::TRANSACTIONS_CF.to_string(),
                 default_db_options()
                     .optimize_for_write_throughput_no_deletion()
                     // Using larger block is ok since there is not much point reads on the cf.
-                    .set_block_options(512, 128 << 10)
-                    .options,
+                    .set_block_options(512, 128 << 10),
             ),
             (
-                Self::TRANSACTIONS_BY_TX_REF_CF,
+                Self::TRANSACTIONS_BY_TX_REF_CF.to_string(),
                 default_db_options()
                     .optimize_for_write_throughput_no_deletion()
                     // Using larger block is ok since there is not much point reads on the cf.
-                    .set_block_options(512, 128 << 10)
-                    .options,
+                    .set_block_options(512, 128 << 10),
             ),
             (
-                Self::BLOCK_HEADERS_CF,
+                Self::BLOCK_HEADERS_CF.to_string(),
                 default_db_options()
                     .optimize_for_write_throughput_no_deletion()
                     // TODO:think about these constants, for now it is a copy from blocks
-                    .set_block_options(512, 128 << 10)
-                    .options,
+                    .set_block_options(512, 128 << 10),
             ),
-            (Self::DIGESTS_BY_AUTHORITIES_CF, cf_options.clone()),
             (
-                Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF,
+                Self::DIGESTS_BY_AUTHORITIES_CF.to_string(),
                 cf_options.clone(),
             ),
-            (Self::COMMITS_CF, cf_options.clone()),
-            (Self::COMMIT_VOTES_CF, cf_options.clone()),
-            (Self::COMMIT_INFO_CF, cf_options.clone()),
+            (
+                Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF.to_string(),
+                cf_options.clone(),
+            ),
+            (Self::COMMITS_CF.to_string(), cf_options.clone()),
+            (Self::COMMIT_VOTES_CF.to_string(), cf_options.clone()),
+            (Self::COMMIT_INFO_CF.to_string(), cf_options.clone()),
             // Voting block headers are much fewer than regular block headers,
             // so using standard options is sufficient.
-            (Self::VOTING_BLOCK_HEADERS_CF, cf_options.clone()),
-            (Self::FAST_COMMIT_SYNC_FLAG_CF, cf_options.clone()),
-            (Self::MISBEHAVIOR_COUNTS_CF, cf_options),
-        ];
-        let rocksdb = open_cf_opts(
-            path,
-            Some(db_options.options),
+            (
+                Self::VOTING_BLOCK_HEADERS_CF.to_string(),
+                cf_options.clone(),
+            ),
+            (
+                Self::FAST_COMMIT_SYNC_FLAG_CF.to_string(),
+                cf_options.clone(),
+            ),
+            (Self::MISBEHAVIOR_COUNTS_CF.to_string(), cf_options),
+        ]));
+        Self::open_tables_read_write(
+            path.into(),
             metrics_conf,
-            &column_family_options,
+            Some(db_options.options),
+            Some(column_family_options),
         )
-        .expect("Cannot open database");
-
-        let (
-            block_headers,
-            transactions,
-            transactions_by_tx_refs,
-            digests_by_authorities,
-            transaction_commitments_by_authorities,
-            commits,
-            commit_votes,
-            commit_info,
-            voting_block_headers,
-            fast_commit_sync_flag,
-            misbehavior_counts,
-        ) = reopen!(&rocksdb,
-            Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-            Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-            Self::TRANSACTIONS_BY_TX_REF_CF;<(Round, AuthorityIndex, TransactionsCommitment), Bytes>,
-            Self::DIGESTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
-            Self::TRANSACTION_COMMITMENTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, TransactionsCommitment), ()>,
-            Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
-            Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
-            Self::COMMIT_INFO_CF;<(CommitIndex, CommitDigest), CommitInfo>,
-            Self::VOTING_BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-            Self::FAST_COMMIT_SYNC_FLAG_CF;<(), ()>,
-            Self::MISBEHAVIOR_COUNTS_CF;<AuthorityIndex, MisbehaviorCounts>
-        );
-
-        Self {
-            block_headers,
-            transactions,
-            transactions_by_tx_refs,
-            digests_by_authorities,
-            transaction_commitments_by_authorities,
-            commits,
-            commit_votes,
-            commit_info,
-            voting_block_headers,
-            fast_commit_sync_flag,
-            misbehavior_counts,
-        }
     }
 }
 

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -49,18 +49,6 @@ const DB_CORRUPTED_KEY: &[u8] = b"db_corrupted";
 #[cfg(test)]
 mod tests;
 
-// TODO: deprecate macros use
-#[macro_export]
-macro_rules! reopen {
-    ( $db:expr, $($cf:expr;<$K:ty, $V:ty>),*) => {
-        (
-            $(
-                DBMap::<$K, $V>::reopen($db, Some($cf), &ReadWriteOptions::default(), false).expect(&format!("Cannot open {} CF.", $cf)[..])
-            ),*
-        )
-    };
-}
-
 #[derive(Debug)]
 pub(crate) struct RocksDB {
     pub(crate) underlying: rocksdb::DBWithThreadMode<MultiThreaded>,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::*;
-use crate::{reopen, traits::Map};
+use crate::traits::Map;
 
 fn get_iter<K, V>(db: &DBMap<K, V>) -> impl Iterator<Item = (K, V)> + use<'_, K, V>
 where
@@ -76,35 +76,6 @@ async fn test_reopen() {
         db.contains_key(&123456789)
             .expect("Failed to retrieve item in storage")
     );
-}
-
-#[tokio::test]
-async fn test_reopen_macro() {
-    const FIRST_CF: &str = "First_CF";
-    const SECOND_CF: &str = "Second_CF";
-
-    let tmp_dir = iota_common::tempdir();
-    let rocks = open_cf_opts(
-        tmp_dir.path(),
-        None,
-        MetricConf::default(),
-        &[
-            (FIRST_CF, rocksdb::Options::default()),
-            (SECOND_CF, rocksdb::Options::default()),
-        ],
-    )
-    .unwrap();
-
-    let (db_map_1, db_map_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-
-    let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
-    let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
-
-    assert_eq!(db_map_1.cf_name(), FIRST_CF);
-    assert_eq!(db_map_2.cf_name(), SECOND_CF);
-
-    assert!(db_map_1.multi_insert(keys_vals_cf1).is_ok());
-    assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
 }
 
 #[tokio::test]

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -3,9 +3,13 @@
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
-if [ "$1" != "simtest" ]; then
-  echo "expected to be invoked via \`cargo simtest\`"
+die() {
+  echo "$0: $*" >&2
   exit 1
+}
+
+if [[ "$1" != "simtest" ]]; then
+  die "expected to be invoked via \`cargo simtest\`"
 fi
 
 # consume simtest arg
@@ -15,10 +19,7 @@ shift
 # ourselves.
 STARTING_DIR=$(pwd)
 MANIFEST_DIR="$STARTING_DIR"
-while true; do
-  if grep -q '^\[workspace\]$' Cargo.toml 2> /dev/null; then
-    break
-  fi
+until grep -q '^\[workspace\]$' Cargo.toml 2> /dev/null; do
   cd ..
   MANIFEST_DIR=$(pwd)
 done
@@ -28,25 +29,24 @@ done
 #   echo "Please commit or revert your changes to Cargo.lock before running cargo simtest"
 #   exit 1
 # fi
-cd "$STARTING_DIR" || exit 1
+cd "$STARTING_DIR" || die "failed to cd to '$STARTING_DIR'"
 
-cleanup () {
-  cd "$MANIFEST_DIR" || exit 1
-  git checkout Cargo.lock > /dev/null
-  cd "$STARTING_DIR" || exit 1
-}
+cleanup () (
+  cd "$MANIFEST_DIR" || die "failed to cd to '$MANIFEST_DIR'"
+  git checkout -- Cargo.lock > /dev/null
+)
 
-trap cleanup SIGINT
+trap cleanup EXIT
 
-if [ -z "$MSIM_TEST_SEED" ]; then
+if [[ -z "$MSIM_TEST_SEED" ]]; then
   export MSIM_TEST_SEED=1
 else
   echo "Using MSIM_TEST_SEED=$MSIM_TEST_SEED from the environment"
 fi
 
-RUST_FLAGS=('"--cfg"' '"msim"')
+rust_flags=( '"--cfg"' '"msim"' )
 
-if [ -n "$LOCAL_MSIM_PATH" ]; then
+if [[ -n "$LOCAL_MSIM_PATH" ]]; then
   cargo_patch_args=(
     --config "patch.crates-io.tokio.path = \"$LOCAL_MSIM_PATH/msim-tokio\""
     --config "patch.'https://github.com/iotaledger/iota-sim'.msim.path = \"$LOCAL_MSIM_PATH/msim\""
@@ -64,9 +64,9 @@ fi
 # Mock out the blst crate to massively speed up the simulation.
 # You should not assume that test runs will be repeatable with and without blst mocking,
 # as blst samples from the PRNG when not mocked.
-if [ -n "$USE_MOCK_CRYPTO" ]; then
+if [[ -n "$USE_MOCK_CRYPTO" ]]; then
   echo "Using mocked crypto crates - no cryptographic verification will occur"
-  RUST_FLAGS+=(
+  rust_flags+=(
     '"--cfg"'
     '"use_mock_crypto"'
   )
@@ -75,8 +75,6 @@ if [ -n "$USE_MOCK_CRYPTO" ]; then
     --config 'patch.crates-io.blst.rev = "630ca4d55de8e199e62c5b6a695c702d95fe6498"'
   )
 fi
-
-rust_flags_str=$(IFS=, ; echo "${RUST_FLAGS[*]}")
 
 if ! cargo nextest --help > /dev/null 2>&1; then
   echo "nextest (https://nexte.st) does not appear to be installed. Please install before proceeding."
@@ -88,10 +86,10 @@ if ! cargo nextest --help > /dev/null 2>&1; then
   exit 1
 fi
 
-CARGO_COMMAND=(nextest run --cargo-profile simulator)
-if [ "$1" = "build" ]; then
+cargo_command=( nextest run --cargo-profile simulator )
+if [[ "$1" = "build" ]]; then
   shift
-  CARGO_COMMAND=(build --profile simulator)
+  cargo_command=( build --profile simulator )
 fi
 
 # Must supply a new temp dir - the test is deterministic and can't choose one randomly itself.
@@ -104,13 +102,7 @@ root_dir=$(git rev-parse --show-toplevel)
 export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"
 
 # we need to use "target.'cfg(all())'.rustflags" instead of "build.rustflags" because the latter are ignored if any "target" flags are set
-cargo "${CARGO_COMMAND[@]}" \
-  --config "target.'cfg(all())'.rustflags = [$rust_flags_str]" \
+cargo "${cargo_command[@]}" \
+  --config "target.'cfg(all())'.rustflags = [$(IFS=, ; echo "${rust_flags[*]}")]" \
   "${cargo_patch_args[@]}" \
   "$@"
-
-STATUS=$?
-
-cleanup
-
-exit $STATUS

--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -21,7 +21,7 @@ parser.add_argument(
     default=int(subprocess.check_output(["date", "+%s"]).decode("utf-8").strip()) * 1000
 )
 parser.add_argument('--concurrency', type=int, help='Number of concurrent tests to run', default=os.cpu_count())
-parser.add_argument('--no-build', type=bool, help='Skip building the test binary', default=False)
+parser.add_argument('--no-build', action='store_true', help='Skip building the test binary')
 args = parser.parse_args()
 
 def run_command(command, env_vars):


### PR DESCRIPTION
# Description of change

This PR contains a batch of core-protocol related upstream changes. The changes have been individually reviewed before squash-merging. None of them modify protocol parameters, so a new protocol version is not necessary.

## Links to any relevant issues

List of included PRs:
- #11639 
- #11638 
- #11663 
- #11677 
- #11763 
- #11764 
- #11785


Closes #11322 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)


