### PR TITLE
fix(graphql-rpc): resolve child parent relations consistently

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/owner.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/owner.move
@@ -1,0 +1,203 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// 1. create Parent (version 2)
+// 2. create Child (version 3)
+// 3. add Child to Parent -> Parent (v4) - Field(v4) - Child (v4)
+// 4. mutate Parent -> Parent (v5)
+// 5. reclaim Child -> Parent(v6), Child (v6), Field deleted
+
+// We check consistency by querying the dynamic fields rooted on parent
+// throughout the parent's evolution.
+
+// The stored values should resolve the owner to the correct version of the Field.
+
+// Parent - dynamic fields resolve the owner correctly to Field1(v4)
+// Child1 (v4) should have the Field as an owner
+// Child1 (v5) does not exist
+// Child1 (v6) does not have an owner
+
+//# init --protocol-version 29 --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use iota::dynamic_object_field as ofield;
+
+    public struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    public struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun mutate_parent(parent: &mut Parent) {
+        parent.count = parent.count + 42;
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64, recipient: address) {
+        let child: Child =  ofield::remove(&mut parent.id, name);
+        transfer::public_transfer(child, recipient)
+    }
+}
+
+//# run Test::M1::parent --sender A --args @A
+
+//# run Test::M1::child --sender A --args @A
+
+//# run Test::M1::add_child --sender A --args object(2,0) object(3,0) 42
+
+//# run Test::M1::mutate_parent --sender A --args object(2,0)
+
+//# run Test::M1::reclaim_child --sender A --args object(2,0) 42 @A
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}", version: 4) {
+    dynamicFields {
+      nodes {
+        value {
+            ... on MoveObject {
+              address
+              version
+              contents {
+                json
+              }
+              owner {
+                ... on Parent {
+                  parent {
+                    address
+                    version
+                    status
+                    asMoveObject {
+                      contents {
+                        type {
+                          repr
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}", version: 5) {
+    dynamicFields {
+      nodes {
+        value {
+            ... on MoveObject {
+              address
+              version
+              contents {
+                json
+              }
+              owner {
+                ... on Parent {
+                  parent {
+                    address
+                    version
+                    status
+                    asMoveObject {
+                      contents {
+                        type {
+                          repr
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_3_0}", version: 4) {
+    asMoveObject {
+          address
+          version
+          contents {
+            json
+          }
+    }
+    owner {
+        ... on Parent {
+          parent {
+            address
+            version
+            status
+            asMoveObject {
+              contents {
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_3_0}", version: 6) {
+    asMoveObject {
+          address
+          version
+          contents {
+            json
+          }
+    }
+    owner {
+        ... on Parent {
+          parent {
+            address
+            version
+            status
+            asMoveObject {
+              contents {
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/owner.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/owner.snap
@@ -1,0 +1,159 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 12 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 23-63:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 7607600, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 65:
+//# run Test::M1::parent --sender A --args @A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2287600, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 67:
+//# run Test::M1::child --sender A --args @A
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2280000, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 4, line 69:
+//# run Test::M1::add_child --sender A --args object(2,0) object(3,0) 42
+created: object(4,0)
+mutated: object(0,0), object(2,0), object(3,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6034400, storage_rebate: 3587200, non_refundable_storage_fee: 0
+
+task 5, line 71:
+//# run Test::M1::mutate_parent --sender A --args object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2287600, storage_rebate: 2287600, non_refundable_storage_fee: 0
+
+task 6, line 73:
+//# run Test::M1::reclaim_child --sender A --args object(2,0) 42 @A
+mutated: object(0,0), object(2,0), object(3,0)
+deleted: object(4,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3587200, storage_rebate: 6034400, non_refundable_storage_fee: 0
+
+task 7, line 75:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 8, lines 77-110:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "dynamicFields": {
+        "nodes": [
+          {
+            "value": {
+              "address": "0xf8bd01ed36b3e184a19756b946deb54bde2b99f135c0b3e9ea3731348c9b53f2",
+              "contents": {
+                "json": {
+                  "count": "0",
+                  "id": "0xf8bd01ed36b3e184a19756b946deb54bde2b99f135c0b3e9ea3731348c9b53f2"
+                }
+              },
+              "owner": {
+                "parent": {
+                  "address": "0xef56dc60514d77afc263f46f4585053c475cb58c017724a54dc8b4ec42d18bfd",
+                  "asMoveObject": null,
+                  "status": "WRAPPED_OR_DELETED",
+                  "version": 6
+                }
+              },
+              "version": 4
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 9, lines 112-145:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "dynamicFields": {
+        "nodes": [
+          {
+            "value": {
+              "address": "0xf8bd01ed36b3e184a19756b946deb54bde2b99f135c0b3e9ea3731348c9b53f2",
+              "contents": {
+                "json": {
+                  "count": "0",
+                  "id": "0xf8bd01ed36b3e184a19756b946deb54bde2b99f135c0b3e9ea3731348c9b53f2"
+                }
+              },
+              "owner": {
+                "parent": {
+                  "address": "0xef56dc60514d77afc263f46f4585053c475cb58c017724a54dc8b4ec42d18bfd",
+                  "asMoveObject": null,
+                  "status": "WRAPPED_OR_DELETED",
+                  "version": 6
+                }
+              },
+              "version": 4
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10, lines 147-174:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "address": "0xf8bd01ed36b3e184a19756b946deb54bde2b99f135c0b3e9ea3731348c9b53f2",
+        "contents": {
+          "json": {
+            "count": "0",
+            "id": "0xf8bd01ed36b3e184a19756b946deb54bde2b99f135c0b3e9ea3731348c9b53f2"
+          }
+        },
+        "version": 4
+      },
+      "owner": {
+        "parent": {
+          "address": "0xef56dc60514d77afc263f46f4585053c475cb58c017724a54dc8b4ec42d18bfd",
+          "asMoveObject": null,
+          "status": "WRAPPED_OR_DELETED",
+          "version": 6
+        }
+      }
+    }
+  }
+}
+
+task 11, lines 176-203:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "address": "0xf8bd01ed36b3e184a19756b946deb54bde2b99f135c0b3e9ea3731348c9b53f2",
+        "contents": {
+          "json": {
+            "count": "0",
+            "id": "0xf8bd01ed36b3e184a19756b946deb54bde2b99f135c0b3e9ea3731348c9b53f2"
+          }
+        },
+        "version": 6
+      },
+      "owner": null
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/owner.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/owner.snap
@@ -64,9 +64,15 @@ Response: {
               "owner": {
                 "parent": {
                   "address": "0xef56dc60514d77afc263f46f4585053c475cb58c017724a54dc8b4ec42d18bfd",
-                  "asMoveObject": null,
-                  "status": "WRAPPED_OR_DELETED",
-                  "version": 6
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_object_field::Wrapper<u64>,0x0000000000000000000000000000000000000000000000000000000000000002::object::ID>"
+                      }
+                    }
+                  },
+                  "status": "INDEXED",
+                  "version": 4
                 }
               },
               "version": 4
@@ -97,9 +103,15 @@ Response: {
               "owner": {
                 "parent": {
                   "address": "0xef56dc60514d77afc263f46f4585053c475cb58c017724a54dc8b4ec42d18bfd",
-                  "asMoveObject": null,
-                  "status": "WRAPPED_OR_DELETED",
-                  "version": 6
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_object_field::Wrapper<u64>,0x0000000000000000000000000000000000000000000000000000000000000002::object::ID>"
+                      }
+                    }
+                  },
+                  "status": "INDEXED",
+                  "version": 4
                 }
               },
               "version": 4
@@ -129,9 +141,15 @@ Response: {
       "owner": {
         "parent": {
           "address": "0xef56dc60514d77afc263f46f4585053c475cb58c017724a54dc8b4ec42d18bfd",
-          "asMoveObject": null,
-          "status": "WRAPPED_OR_DELETED",
-          "version": 6
+          "asMoveObject": {
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_object_field::Wrapper<u64>,0x0000000000000000000000000000000000000000000000000000000000000002::object::ID>"
+              }
+            }
+          },
+          "status": "INDEXED",
+          "version": 4
         }
       }
     }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -654,7 +654,7 @@ impl ObjectImpl<'_> {
                 let parent = Object::query(
                     ctx,
                     address.into(),
-                    Object::latest_at(self.0.checkpoint_viewed_at),
+                    Object::under_parent(self.0.root_version, self.0.checkpoint_viewed_at),
                 )
                 .await
                 .ok()


### PR DESCRIPTION
# Description of change

This patch fixes the resolution of consistent object owners in GraphQL. To illustrate the problem (and the solution) a dedicated test `owner.move` is hereby added, that was returning incorrect results with the original setting. See 3ebd14341a1d14c70bf2dd4955221dfdb6fb9267

## Links to any relevant issues

Fixes #11834

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Release Notes

- [x] GraphQL: :screwdriver: Fixes a bug in the consistent resolution of object owners
