### PR TITLE
fix(ci): generate release notes explicit bash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.generate-tag.outputs.iota_ref }}
       - name: Generate release notes
+        shell: bash
         run: |
           new_commit_hash=$(git rev-parse HEAD)
           echo "New commit hash: $new_commit_hash"


### PR DESCRIPTION
# Description of change

In the v1.25.0-rc release build ([run 27269889117](https://github.com/iotaledger/iota/actions/runs/27269889117/job/80536371988)), `release_notes.py` crashed with `http.client.RemoteDisconnected` while fetching PR bodies from the GitHub API — yet the step, the job, and the release publication all succeeded, and v1.25.0-rc went out with an empty release notes body.

The crash was swallowed because the generator runs in a pipeline:

```bash
./run.sh generate $previous_commit_hash $new_commit_hash | tee -a "../../${RELEASE_NOTES_FILE}" > /dev/null
```

A bash pipeline's exit status is the last command's (`tee`, which exits 0), and the step's default shell on Linux runners is `bash -e {0}` — without `pipefail`. Declaring `shell: bash` explicitly makes GitHub Actions run the step with `bash --noprofile --norc -eo pipefail {0}`, so a generator crash now propagates through the pipeline and fails the job instead of silently publishing a release with empty notes.

## Links to any relevant issues

None — root-caused from the run linked above.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

Verified the masking behavior locally: a failing command piped into `tee` exits 0 under `bash -e` and non-zero under `bash -eo pipefail`. The workflow only runs on release events, so the full path can't be exercised before the next release.