### PR TITLE
feat: allow mutable shared objects in Move authenticators (POC)

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5720,6 +5720,7 @@ impl AuthorityState {
                     let authenticator_checked_input_objects =
                         iota_transaction_checks::check_move_authenticator_input_for_validation(
                             authenticator_input_objects,
+                            protocol_config,
                         )?;
 
                     Ok((

--- a/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account_keyed.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account_keyed.move
@@ -13,6 +13,13 @@ use iota::authenticator_function::AuthenticatorFunctionRefV1;
 
 // === Structs ===
 
+/// A simple shared counter used to exercise a Move authenticator that takes a
+/// *mutable* shared object (see `authenticate_ed25519_and_increment`).
+public struct Counter has key {
+    id: UID,
+    value: u64,
+}
+
 // === Events ===
 
 // === Method Aliases ===
@@ -143,7 +150,43 @@ public fun authenticate_with_sponsor_and_sender(
     assert!(ctx.sponsor().borrow() == sponsor.account_address());
 }
 
+/// Create and share a `Counter` initialised to zero.
+public fun create_counter(ctx: &mut TxContext) {
+    transfer::share_object(Counter { id: object::new(ctx), value: 0 });
+}
+
+/// Ed25519 authenticator that *mutates* a shared `Counter` while authenticating.
+///
+/// This requires the `enable_mutable_shared_in_move_authenticator` protocol
+/// feature flag to be enabled, both to publish (the verifier must accept the
+/// `&mut Counter` parameter) and to execute (the mutable shared object is
+/// allowed as an authenticator input).
+#[authenticator]
+public fun authenticate_ed25519_and_increment(
+    account: &AbstractAccount,
+    counter: &mut Counter,
+    signature: vector<u8>,
+    actx: &AuthContext,
+    ctx: &TxContext,
+) {
+    // Mutate the shared object as part of authentication.
+    counter.value = counter.value + 1;
+
+    // Verify the ed25519 signature against the account public key.
+    basic_keyed_aa::authenticate_ed25519(
+        &signature,
+        borrow_public_key(account),
+        actx,
+        ctx,
+    );
+}
+
 // === View Functions ===
+
+/// Read the current value of a `Counter`.
+public fun counter_value(counter: &Counter): u64 {
+    counter.value
+}
 
 /// An utility function to borrow the account-related public key.
 public fun borrow_public_key(account: &AbstractAccount): &vector<u8> {

--- a/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account_keyed.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account_keyed.move
@@ -6,6 +6,7 @@ module abstract_account::abstract_account_keyed;
 use abstract_account::abstract_account::{Self, AbstractAccount};
 use abstract_account::basic_keyed_aa;
 use iota::authenticator_function::{Self, AuthenticatorFunctionRefV1};
+use iota::dynamic_object_field;
 use iota::package_metadata::PackageMetadataV1;
 use std::ascii;
 
@@ -25,6 +26,16 @@ public struct Counter has key {
 /// Dynamic-field key for a per-account authentication counter, mutated by
 /// `authenticate_ed25519_and_mutate_account`.
 public struct AuthCount has copy, drop, store {}
+
+/// A fresh top-level object minted by `authenticate_ed25519_and_create_object`,
+/// and also stored as a dynamic object field on a `Counter` for the extraction
+/// test (`authenticate_ed25519_and_extract_from_counter`).
+public struct Marker has key, store {
+    id: UID,
+}
+
+/// Dynamic-object-field key under which a `Marker` is stored on a `Counter`.
+public struct MarkerKey has copy, drop, store {}
 
 // === Events ===
 
@@ -161,6 +172,14 @@ public fun create_counter(ctx: &mut TxContext) {
     transfer::share_object(Counter { id: object::new(ctx), value: 0 });
 }
 
+/// Create and share a `Counter` that holds a `Marker` as a dynamic object
+/// field, used by the `authenticate_ed25519_and_extract_from_counter` test.
+public fun create_counter_with_marker(ctx: &mut TxContext) {
+    let mut counter = Counter { id: object::new(ctx), value: 0 };
+    dynamic_object_field::add(&mut counter.id, MarkerKey {}, Marker { id: object::new(ctx) });
+    transfer::share_object(counter);
+}
+
 /// Ed25519 authenticator that *mutates* a shared `Counter` while authenticating.
 ///
 /// This requires the `enable_mutable_shared_in_move_authenticator` protocol
@@ -252,6 +271,75 @@ public fun authenticate_ed25519_and_rotate_to_free_access(
         new_ref,
         ctx,
     );
+}
+
+/// Ed25519 authenticator that attempts to *delete an object* by removing a
+/// dynamic field from the account. Object deletion during authenticator
+/// execution is forbidden, so any transaction using this authenticator must be
+/// rejected.
+#[authenticator]
+public fun authenticate_ed25519_and_delete_field(
+    account: &mut AbstractAccount,
+    signature: vector<u8>,
+    actx: &AuthContext,
+    ctx: &TxContext,
+) {
+    basic_keyed_aa::authenticate_ed25519(
+        &signature,
+        borrow_public_key(account),
+        actx,
+        ctx,
+    );
+
+    // Removing a dynamic field deletes its child object.
+    let _: vector<u8> = account.remove_field(basic_keyed_aa::owner_public_key(), ctx);
+}
+
+/// Ed25519 authenticator that *creates a fresh top-level object* (a new UID via
+/// `object::new`) and transfers it to the account. This requires a
+/// `&mut TxContext`, which is only accepted when
+/// `enable_mutable_shared_in_move_authenticator` is enabled.
+#[authenticator]
+public fun authenticate_ed25519_and_create_object(
+    account: &AbstractAccount,
+    signature: vector<u8>,
+    actx: &AuthContext,
+    ctx: &mut TxContext,
+) {
+    basic_keyed_aa::authenticate_ed25519(
+        &signature,
+        borrow_public_key(account),
+        actx,
+        ctx,
+    );
+
+    // Mint a brand-new object and transfer it to the account.
+    transfer::transfer(Marker { id: object::new(ctx) }, account.account_address());
+}
+
+/// Ed25519 authenticator that *removes an object* — it extracts the `Marker`
+/// stored as a dynamic object field on a mutable shared `Counter` and transfers
+/// it to the account. Removing the dynamic object field deletes the internal
+/// wrapper object, so this requires
+/// `enable_mutable_shared_in_move_authenticator` (which permits deletion).
+#[authenticator]
+public fun authenticate_ed25519_and_extract_from_counter(
+    account: &AbstractAccount,
+    counter: &mut Counter,
+    signature: vector<u8>,
+    actx: &AuthContext,
+    ctx: &TxContext,
+) {
+    basic_keyed_aa::authenticate_ed25519(
+        &signature,
+        borrow_public_key(account),
+        actx,
+        ctx,
+    );
+
+    // Extract the stored object and transfer it to the account.
+    let marker: Marker = dynamic_object_field::remove(&mut counter.id, MarkerKey {});
+    transfer::public_transfer(marker, account.account_address());
 }
 
 // === View Functions ===

--- a/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account_keyed.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account_keyed.move
@@ -5,7 +5,9 @@ module abstract_account::abstract_account_keyed;
 
 use abstract_account::abstract_account::{Self, AbstractAccount};
 use abstract_account::basic_keyed_aa;
-use iota::authenticator_function::AuthenticatorFunctionRefV1;
+use iota::authenticator_function::{Self, AuthenticatorFunctionRefV1};
+use iota::package_metadata::PackageMetadataV1;
+use std::ascii;
 
 // === Errors ===
 
@@ -19,6 +21,10 @@ public struct Counter has key {
     id: UID,
     value: u64,
 }
+
+/// Dynamic-field key for a per-account authentication counter, mutated by
+/// `authenticate_ed25519_and_mutate_account`.
+public struct AuthCount has copy, drop, store {}
 
 // === Events ===
 
@@ -177,6 +183,73 @@ public fun authenticate_ed25519_and_increment(
         &signature,
         borrow_public_key(account),
         actx,
+        ctx,
+    );
+}
+
+/// Ed25519 authenticator that *mutates the authenticated account itself*: it
+/// initialises or bumps an `AuthCount` dynamic field on the account.
+///
+/// Requires `enable_mutable_shared_in_move_authenticator`: the account must be
+/// passed by mutable reference (`&mut AbstractAccount`) and as a mutable shared
+/// authenticator input.
+#[authenticator]
+public fun authenticate_ed25519_and_mutate_account(
+    account: &mut AbstractAccount,
+    signature: vector<u8>,
+    actx: &AuthContext,
+    ctx: &TxContext,
+) {
+    // Verify the signature first (immutable borrow, released before mutation).
+    basic_keyed_aa::authenticate_ed25519(
+        &signature,
+        borrow_public_key(account),
+        actx,
+        ctx,
+    );
+
+    // Mutate the account itself: initialise or bump the auth counter.
+    if (account.has_field(AuthCount {})) {
+        let count: &mut u64 = account.borrow_field_mut(AuthCount {}, ctx);
+        *count = *count + 1;
+    } else {
+        account.add_field(AuthCount {}, 1u64, ctx);
+    };
+}
+
+/// Ed25519 authenticator that *rotates the account's own
+/// `AuthenticatorFunctionRef`* to `authenticate_free_access` while
+/// authenticating.
+///
+/// Requires `enable_mutable_shared_in_move_authenticator` (the account is taken
+/// by mutable reference). After a transaction authenticated with this function,
+/// the account is authenticated by `authenticate_free_access`. The package
+/// metadata is passed as an immutable input so the new authenticator reference
+/// can be constructed.
+#[authenticator]
+public fun authenticate_ed25519_and_rotate_to_free_access(
+    account: &mut AbstractAccount,
+    package_metadata: &PackageMetadataV1,
+    signature: vector<u8>,
+    actx: &AuthContext,
+    ctx: &TxContext,
+) {
+    // Verify the signature first (immutable borrow, released before mutation).
+    basic_keyed_aa::authenticate_ed25519(
+        &signature,
+        borrow_public_key(account),
+        actx,
+        ctx,
+    );
+
+    // Build a reference to the free-access authenticator and rotate to it.
+    let new_ref = authenticator_function::create_auth_function_ref_v1<AbstractAccount>(
+        package_metadata,
+        ascii::string(b"abstract_account_keyed"),
+        ascii::string(b"authenticate_free_access"),
+    );
+    let _prev: AuthenticatorFunctionRefV1<AbstractAccount> = account.rotate_auth_function_ref_v1(
+        new_ref,
         ctx,
     );
 }

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -68,6 +68,10 @@ const AA_AUTHENTICATE_FN_NAME_WITH_SPONSOR_AND_SENDER: &str =
 const AA_AUTHENTICATE_FN_NAME_ED25519_VIA_SIGNING_DIGEST: &str =
     "authenticate_ed25519_via_signing_digest";
 const AA_AUTHENTICATE_FN_NAME_ED25519_AND_INCREMENT: &str = "authenticate_ed25519_and_increment";
+const AA_AUTHENTICATE_FN_NAME_ED25519_AND_MUTATE_ACCOUNT: &str =
+    "authenticate_ed25519_and_mutate_account";
+const AA_AUTHENTICATE_FN_NAME_ED25519_AND_ROTATE: &str =
+    "authenticate_ed25519_and_rotate_to_free_access";
 const AA_RECEIVE_OBJECT_FN_NAME: &str = "receive_object";
 const AA_RECEIVE_OBJECT_FN_NAME_NO_SENDER_CHECK: &str = "receive_object_without_sender_check";
 
@@ -193,6 +197,148 @@ async fn test_authenticator_with_mutable_shared_object() -> Result<(), anyhow::E
             > counter_ref.version,
         "the shared counter version should have been bumped by the mutation"
     );
+
+    Ok(())
+}
+
+/// Test that a Move authenticator can mutate the *authenticated account object
+/// itself* (passed by `&mut`), gated by the
+/// `enable_mutable_shared_in_move_authenticator` protocol feature flag.
+///
+/// The authenticator initialises an `AuthCount` dynamic field on the account.
+/// The transaction body deliberately does not touch the account, so the bump of
+/// the account's object version is attributable solely to the authenticator.
+#[sim_test]
+async fn test_authenticator_mutates_account_object() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_mutable_shared_in_move_authenticator_for_testing(true);
+        config
+    });
+
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519_AND_MUTATE_ACCOUNT)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+
+    // The auth counter does not exist on the account yet.
+    assert_eq!(
+        test_env.read_account_auth_count(aa_ref.object_id).await?,
+        None,
+        "the account should not have an AuthCount field before authentication"
+    );
+
+    // Transaction body that does not reference the account, so any change to the
+    // account is attributable solely to the authenticator.
+    let pt = test_env.craft_create_counter_ptb()?;
+    let tx_data = test_env
+        .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+
+    // Authenticate with the MoveAuthenticator that passes the account as a
+    // *mutable* shared object and mutates it.
+    let signature = test_env.create_move_authenticator_ed25519_mutate_account(&tx_digest)?;
+    let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
+    test_env.execute_and_check_tx_correctness(tx).await?;
+
+    // The authenticator initialised the account's auth counter to 1, proving the
+    // mutation of the account itself was committed to effects.
+    assert_eq!(
+        test_env.read_account_auth_count(aa_ref.object_id).await?,
+        Some(1),
+        "the authenticator should have set the account's AuthCount to 1"
+    );
+    // ... and bumped the account object version.
+    assert!(
+        test_env
+            .test_cluster
+            .get_latest_object_ref(&aa_ref.object_id)
+            .await
+            .version
+            > aa_ref.version,
+        "the account object version should have been bumped by the authenticator"
+    );
+
+    Ok(())
+}
+
+/// Test that a Move authenticator can change the account's own
+/// `AuthenticatorFunctionRef` while authenticating, gated by the
+/// `enable_mutable_shared_in_move_authenticator` protocol feature flag.
+///
+/// The first transaction authenticates with ed25519 and rotates the account's
+/// authenticator to `authenticate_free_access`. A second transaction then
+/// authenticates with free-access (no signature), which only succeeds if the
+/// authenticator reference was actually changed by the first transaction.
+#[sim_test]
+async fn test_authenticator_rotates_account_auth_function_ref() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_mutable_shared_in_move_authenticator_for_testing(true);
+        config
+    });
+
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519_AND_ROTATE)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+
+    // First tx: authenticate with ed25519 and rotate the account's authenticator
+    // to free-access.
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+    let pt = test_env.craft_create_counter_ptb()?;
+    let tx_data = test_env
+        .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+    let signature = test_env.create_move_authenticator_ed25519_rotate(&tx_digest)?;
+    let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
+    test_env.execute_and_check_tx_correctness(tx).await?;
+
+    // The authenticator mutated the account (rotated its auth ref): version bumped.
+    assert!(
+        test_env
+            .test_cluster
+            .get_latest_object_ref(&aa_ref.object_id)
+            .await
+            .version
+            > aa_ref.version,
+        "the account version should have been bumped by the auth-ref rotation"
+    );
+
+    // Second tx: the account is now authenticated by free-access (no signature),
+    // proving the first authenticator changed the AuthenticatorFunctionRef.
+    // Shared objects are referenced by their initial shared version (`aa_ref`).
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+    let pt = test_env.craft_create_counter_ptb()?;
+    let tx_data = test_env
+        .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
+        .await?;
+    let free_access_signature =
+        test_env.create_move_authenticator_for_free_access_for_ref(aa_ref)?;
+    let tx = Transaction::from_generic_sig_data(tx_data, vec![free_access_signature]);
+    test_env.execute_and_check_tx_correctness(tx).await?;
 
     Ok(())
 }
@@ -2486,6 +2632,42 @@ impl TestEnvironment {
         Ok(value)
     }
 
+    /// Read the `AuthCount` dynamic-field value on the account (the counter
+    /// mutated by `authenticate_ed25519_and_mutate_account`). Returns `None` if
+    /// the field has not been created yet.
+    async fn read_account_auth_count(&self, account_id: ObjectId) -> anyhow::Result<Option<u64>> {
+        // Look the field up by name rather than deriving its id, to avoid any
+        // key-encoding assumptions.
+        let fields = self
+            .test_cluster
+            .iota_client()
+            .read_api()
+            .get_dynamic_fields(account_id, None, None)
+            .await?;
+        let Some(field) = fields
+            .data
+            .iter()
+            .find(|f| f.name.type_.to_string().ends_with("::AuthCount"))
+        else {
+            return Ok(None);
+        };
+        let object = self
+            .test_cluster
+            .get_object_from_fullnode_store(&field.object_id)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("auth count field object not found"))?;
+        let move_object = object
+            .data
+            .as_struct_opt()
+            .ok_or_else(|| anyhow::anyhow!("auth count field is not a Move object"))?;
+        // `Field<AuthCount, u64> { id: UID, name: AuthCount, value: u64 }`: the
+        // empty `name` contributes no bytes, so `value` is the trailing 8 bytes.
+        let contents = move_object.contents();
+        Ok(Some(u64::from_le_bytes(<[u8; 8]>::try_from(
+            &contents[contents.len() - 8..],
+        )?)))
+    }
+
     /// Build a `MoveAuthenticator` for `authenticate_ed25519_and_increment`,
     /// passing the `Counter` as a *mutable* shared call argument.
     // public fun authenticate_ed25519_and_increment(
@@ -2533,6 +2715,98 @@ impl TestEnvironment {
         Ok(GenericSignature::MoveAuthenticator(
             MoveAuthenticator::new_v1(
                 vec![counter_call_arg, signature_call_arg],
+                vec![],
+                account_call_arg,
+            ),
+        ))
+    }
+
+    /// Build a PTB that creates a shared `Counter`. Used as an
+    /// account-independent transaction body so account mutations can be
+    /// attributed solely to the authenticator.
+    fn craft_create_counter_ptb(&self) -> anyhow::Result<ProgrammableTransaction> {
+        let Some(aa_package_id) = self.aa_package_id else {
+            anyhow::bail!("Account abstraction package not published yet");
+        };
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.programmable_move_call(
+            aa_package_id,
+            Identifier::from_static(AA_CREATE_MODULE_NAME),
+            Identifier::from_static("create_counter"),
+            vec![],
+            vec![],
+        );
+        Ok(builder.finish())
+    }
+
+    /// Build a `MoveAuthenticator` for
+    /// `authenticate_ed25519_and_mutate_account`, passing the account
+    /// itself as a *mutable* shared object so the authenticator can mutate
+    /// it.
+    fn create_move_authenticator_ed25519_mutate_account(
+        &self,
+        tx_digest: &[u8; 32],
+    ) -> anyhow::Result<GenericSignature> {
+        let (Some(aa_ref), Some(owner)) = (self.aa_ref, self.owner) else {
+            anyhow::bail!("Abstract account not created yet");
+        };
+        let signature = self
+            .test_cluster
+            .wallet
+            .config()
+            .keystore()
+            .sign_hashed(&owner, tx_digest)?;
+
+        // `object_to_authenticate`: the account itself, as a *mutable* shared object.
+        let account_call_arg =
+            CallArg::Shared(SharedObjectRef::new(aa_ref.object_id, aa_ref.version, true));
+        let hex_encoded_signature: String = Hex::encode(signature)
+            .chars()
+            .skip(2)
+            .take(Ed25519Signature::LENGTH * 2)
+            .collect();
+        let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
+
+        Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_v1(vec![signature_call_arg], vec![], account_call_arg),
+        ))
+    }
+
+    /// Build a `MoveAuthenticator` for
+    /// `authenticate_ed25519_and_rotate_to_free_access`, passing the account as
+    /// a *mutable* shared object and the package metadata as an immutable input
+    /// (needed to construct the new authenticator reference).
+    fn create_move_authenticator_ed25519_rotate(
+        &self,
+        tx_digest: &[u8; 32],
+    ) -> anyhow::Result<GenericSignature> {
+        let (Some(aa_ref), Some(owner), Some(aa_package_metadata_ref)) =
+            (self.aa_ref, self.owner, self.aa_package_metadata_ref)
+        else {
+            anyhow::bail!("Abstract account not created yet");
+        };
+        let signature = self
+            .test_cluster
+            .wallet
+            .config()
+            .keystore()
+            .sign_hashed(&owner, tx_digest)?;
+
+        // `object_to_authenticate`: the account itself, as a *mutable* shared object.
+        let account_call_arg =
+            CallArg::Shared(SharedObjectRef::new(aa_ref.object_id, aa_ref.version, true));
+        // First call arg: the package metadata (immutable), used to build the new ref.
+        let metadata_call_arg = CallArg::ImmutableOrOwned(aa_package_metadata_ref);
+        let hex_encoded_signature: String = Hex::encode(signature)
+            .chars()
+            .skip(2)
+            .take(Ed25519Signature::LENGTH * 2)
+            .collect();
+        let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
+
+        Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_v1(
+                vec![metadata_call_arg, signature_call_arg],
                 vec![],
                 account_call_arg,
             ),

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -67,6 +67,7 @@ const AA_AUTHENTICATE_FN_NAME_WITH_SPONSOR_AND_SENDER: &str =
     "authenticate_with_sponsor_and_sender";
 const AA_AUTHENTICATE_FN_NAME_ED25519_VIA_SIGNING_DIGEST: &str =
     "authenticate_ed25519_via_signing_digest";
+const AA_AUTHENTICATE_FN_NAME_ED25519_AND_INCREMENT: &str = "authenticate_ed25519_and_increment";
 const AA_RECEIVE_OBJECT_FN_NAME: &str = "receive_object";
 const AA_RECEIVE_OBJECT_FN_NAME_NO_SENDER_CHECK: &str = "receive_object_without_sender_check";
 
@@ -114,6 +115,86 @@ async fn test_abstract_account_creation_and_issue_tx() -> Result<(), anyhow::Err
     test_env
         .execute_and_check_tx_correctness(aa_simple_tx)
         .await
+}
+
+/// Test that a Move authenticator can take a *mutable* shared object (`&mut
+/// Counter`) as input and mutate it during authentication, gated by the
+/// `enable_mutable_shared_in_move_authenticator` protocol feature flag.
+///
+/// This exercises the full path:
+/// - publish: the verifier accepts the `&mut Counter` authenticator parameter;
+/// - signing / consensus / input checks: the mutable shared object is accepted
+///   as a `MoveAuthenticator` input;
+/// - execution: the authenticator's mutation of the shared counter is committed
+///   to effects (the counter is incremented from 0 to 1).
+#[sim_test]
+async fn test_authenticator_with_mutable_shared_object() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+
+    // Allow mutable shared objects in Move authenticators (both at publish time
+    // for the verifier and at execution time for the input checks).
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_mutable_shared_in_move_authenticator_for_testing(true);
+        config
+    });
+
+    // Build a test environment and create an AbstractAccount whose authenticator
+    // mutates a shared `Counter`.
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519_AND_INCREMENT)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    // Request faucet coins for the AbstractAccount.
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+
+    // Create the shared `Counter` (starts at 0).
+    let counter_ref = test_env.create_shared_counter().await?;
+    let counter_id = counter_ref.object_id;
+    assert_eq!(
+        test_env.read_counter_value(counter_id).await?,
+        0,
+        "counter should start at zero"
+    );
+
+    // Build a simple AA transaction.
+    let pt = test_env.craft_aa_simple_ptb(AA_MODULE_NAME)?;
+    let tx_data = test_env
+        .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+
+    // Authenticate with the MoveAuthenticator that takes the mutable shared
+    // counter as an input and increments it.
+    let signature =
+        test_env.create_move_authenticator_ed25519_and_increment(counter_ref, &tx_digest)?;
+    let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
+    test_env.execute_and_check_tx_correctness(tx).await?;
+
+    // The authenticator must have incremented (i.e. mutated) the shared counter,
+    // proving the mutation was committed to effects.
+    assert_eq!(
+        test_env.read_counter_value(counter_id).await?,
+        1,
+        "the authenticator should have incremented the shared counter"
+    );
+    assert!(
+        test_env
+            .test_cluster
+            .get_latest_object_ref(&counter_id)
+            .await
+            .version
+            > counter_ref.version,
+        "the shared counter version should have been bumped by the mutation"
+    );
+
+    Ok(())
 }
 
 /// Test that the AuthContext byte fields are correctly populated during
@@ -2345,6 +2426,117 @@ impl TestEnvironment {
             .authority_client()
             .handle_transaction(tx, Some(SocketAddr::new([127, 0, 0, 1].into(), 0)))
             .await
+    }
+
+    /// Create and share a `Counter` (initialised to zero) and return its object
+    /// reference.
+    async fn create_shared_counter(&self) -> anyhow::Result<ObjectRef> {
+        let Some(aa_package_id) = self.aa_package_id else {
+            anyhow::bail!("Account abstraction package not published yet");
+        };
+
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder.programmable_move_call(
+                aa_package_id,
+                Identifier::from_static(AA_CREATE_MODULE_NAME),
+                Identifier::from_static("create_counter"),
+                vec![],
+                vec![],
+            );
+            builder.finish()
+        };
+
+        let tx_data = self
+            .test_cluster
+            .test_transaction_builder()
+            .await
+            .programmable(pt)
+            .build();
+        let transaction = self.test_cluster.wallet.sign_transaction(&tx_data);
+        let (effects, _) = self
+            .test_cluster
+            .execute_transaction_return_raw_effects(transaction)
+            .await?;
+
+        // The transaction creates exactly one shared object: the `Counter`.
+        Ok(effects
+            .all_changed_objects()
+            .iter()
+            .find_map(|(obj_ref, owner, kind)| {
+                matches!((owner, kind), (Owner::Shared(_), WriteKind::Create)).then_some(*obj_ref)
+            })
+            .expect("expected a created shared Counter object"))
+    }
+
+    /// Read the `value` field of a `Counter` shared object.
+    async fn read_counter_value(&self, counter_id: ObjectId) -> anyhow::Result<u64> {
+        let object = self
+            .test_cluster
+            .get_object_from_fullnode_store(&counter_id)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("counter object not found"))?;
+        let move_object = object
+            .data
+            .as_struct_opt()
+            .ok_or_else(|| anyhow::anyhow!("counter is not a Move object"))?;
+        // `Counter { id: UID, value: u64 }`: `value` is the trailing 8 bytes.
+        let contents = move_object.contents();
+        let value = u64::from_le_bytes(<[u8; 8]>::try_from(&contents[contents.len() - 8..])?);
+        Ok(value)
+    }
+
+    /// Build a `MoveAuthenticator` for `authenticate_ed25519_and_increment`,
+    /// passing the `Counter` as a *mutable* shared call argument.
+    // public fun authenticate_ed25519_and_increment(
+    //    account: &AbstractAccount,
+    //    counter: &mut Counter,
+    //    signature: vector<u8>,
+    //    _: &AuthContext,
+    //    _: &TxContext,
+    // )
+    fn create_move_authenticator_ed25519_and_increment(
+        &self,
+        counter_ref: ObjectRef,
+        tx_digest: &[u8; 32],
+    ) -> anyhow::Result<GenericSignature> {
+        let (Some(aa_ref), Some(owner)) = (self.aa_ref, self.owner) else {
+            anyhow::bail!("Abstract account not created yet");
+        };
+        let signature = self
+            .test_cluster
+            .wallet
+            .config()
+            .keystore()
+            .sign_hashed(&owner, tx_digest)?;
+
+        // `object_to_authenticate`: the account, as an immutable shared object.
+        let account_call_arg = CallArg::Shared(SharedObjectRef::new(
+            aa_ref.object_id,
+            aa_ref.version,
+            false,
+        ));
+        // First call arg: the counter, as a *mutable* shared object.
+        let counter_call_arg = CallArg::Shared(SharedObjectRef::new(
+            counter_ref.object_id,
+            counter_ref.version,
+            true,
+        ));
+        // Second call arg: the hex-encoded ed25519 signature.
+        let hex_encoded_signature: String = Hex::encode(signature)
+            .chars()
+            .skip(2) // flag prefix length
+            .take(Ed25519Signature::LENGTH * 2)
+            .collect();
+        let signature_call_arg = CallArg::Pure(bcs::to_bytes(&hex_encoded_signature)?);
+
+        Ok(GenericSignature::MoveAuthenticator(
+            MoveAuthenticator::new_v1(
+                vec![counter_call_arg, signature_call_arg],
+                vec![],
+                account_call_arg,
+            ),
+        ))
     }
 }
 

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -72,6 +72,12 @@ const AA_AUTHENTICATE_FN_NAME_ED25519_AND_MUTATE_ACCOUNT: &str =
     "authenticate_ed25519_and_mutate_account";
 const AA_AUTHENTICATE_FN_NAME_ED25519_AND_ROTATE: &str =
     "authenticate_ed25519_and_rotate_to_free_access";
+const AA_AUTHENTICATE_FN_NAME_ED25519_AND_CREATE_OBJECT: &str =
+    "authenticate_ed25519_and_create_object";
+const AA_AUTHENTICATE_FN_NAME_ED25519_AND_DELETE_FIELD: &str =
+    "authenticate_ed25519_and_delete_field";
+const AA_AUTHENTICATE_FN_NAME_ED25519_AND_EXTRACT_FROM_COUNTER: &str =
+    "authenticate_ed25519_and_extract_from_counter";
 const AA_RECEIVE_OBJECT_FN_NAME: &str = "receive_object";
 const AA_RECEIVE_OBJECT_FN_NAME_NO_SENDER_CHECK: &str = "receive_object_without_sender_check";
 
@@ -167,8 +173,10 @@ async fn test_authenticator_with_mutable_shared_object() -> Result<(), anyhow::E
         "counter should start at zero"
     );
 
-    // Build a simple AA transaction.
-    let pt = test_env.craft_aa_simple_ptb(AA_MODULE_NAME)?;
+    // Build a transaction whose body does not touch the input counter (it creates
+    // an unrelated shared object), so the counter's change is attributable to the
+    // authenticator.
+    let pt = test_env.craft_create_counter_ptb()?;
     let tx_data = test_env
         .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
         .await?;
@@ -179,7 +187,29 @@ async fn test_authenticator_with_mutable_shared_object() -> Result<(), anyhow::E
     let signature =
         test_env.create_move_authenticator_ed25519_and_increment(counter_ref, &tx_digest)?;
     let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
-    test_env.execute_and_check_tx_correctness(tx).await?;
+    let (effects, _) = test_env
+        .test_cluster
+        .execute_transaction_return_raw_effects(tx)
+        .await?;
+    assert!(
+        effects.status().is_success(),
+        "tx should succeed, got: {:?}",
+        effects.status()
+    );
+
+    // The increment is a pure mutation:
+    // - created: 0 — no new objects.
+    // - mutated: 1 — the shared `Counter` (its `value` field is bumped).
+    // - deleted: 0 — nothing removed.
+    assert_eq!(
+        authenticator_object_changes(&effects),
+        ObjectChanges {
+            created: 0,
+            mutated: 1,
+            deleted: 0
+        },
+        "incrementing the counter should mutate only the counter"
+    );
 
     // The authenticator must have incremented (i.e. mutated) the shared counter,
     // proving the mutation was committed to effects.
@@ -225,10 +255,6 @@ async fn test_authenticator_mutates_account_object() -> Result<(), anyhow::Error
     let aa_sender: IotaAddress = aa_ref.object_id.into();
 
     let rgp = test_env.test_cluster.get_reference_gas_price().await;
-    let aa_gas = test_env
-        .test_cluster
-        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
-        .await;
 
     // The auth counter does not exist on the account yet.
     assert_eq!(
@@ -237,28 +263,63 @@ async fn test_authenticator_mutates_account_object() -> Result<(), anyhow::Error
         "the account should not have an AuthCount field before authentication"
     );
 
-    // Transaction body that does not reference the account, so any change to the
-    // account is attributable solely to the authenticator.
-    let pt = test_env.craft_create_counter_ptb()?;
-    let tx_data = test_env
-        .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
-        .await?;
-    let tx_digest = tx_data.digest().into_inner();
+    // Run the authenticator several times. The first call initialises the counter
+    // and each subsequent call *mutates* (increments) the existing field, so the
+    // accumulated value proves the account's state is mutated and persisted across
+    // transactions.
+    for expected in 1..=3u64 {
+        let aa_gas = test_env
+            .test_cluster
+            .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+            .await;
+        // Transaction body that does not reference the account, so the change to
+        // the account is attributable solely to the authenticator.
+        let pt = test_env.craft_create_counter_ptb()?;
+        let tx_data = test_env
+            .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
+            .await?;
+        let tx_digest = tx_data.digest().into_inner();
 
-    // Authenticate with the MoveAuthenticator that passes the account as a
-    // *mutable* shared object and mutates it.
-    let signature = test_env.create_move_authenticator_ed25519_mutate_account(&tx_digest)?;
-    let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
-    test_env.execute_and_check_tx_correctness(tx).await?;
+        // Authenticate with the MoveAuthenticator that passes the account as a
+        // *mutable* shared object and mutates it.
+        let signature = test_env.create_move_authenticator_ed25519_mutate_account(&tx_digest)?;
+        let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
+        let (effects, _) = test_env
+            .test_cluster
+            .execute_transaction_return_raw_effects(tx)
+            .await?;
+        assert!(
+            effects.status().is_success(),
+            "tx should succeed, got: {:?}",
+            effects.status()
+        );
 
-    // The authenticator initialised the account's auth counter to 1, proving the
-    // mutation of the account itself was committed to effects.
-    assert_eq!(
-        test_env.read_account_auth_count(aa_ref.object_id).await?,
-        Some(1),
-        "the authenticator should have set the account's AuthCount to 1"
-    );
-    // ... and bumped the account object version.
+        // First call vs. later calls:
+        // - created: 1 then 0 — the first call `add_field`s the `AuthCount` field (a
+        //   new child object); later calls reuse it.
+        // - mutated: 1 then 2 — the first call only mutates the account (the parent);
+        //   later calls mutate both the account and the existing `AuthCount` field
+        //   (whose `u64` value is incremented).
+        // - deleted: 0 — nothing removed.
+        let expected_changes = ObjectChanges {
+            created: if expected == 1 { 1 } else { 0 },
+            mutated: if expected == 1 { 1 } else { 2 },
+            deleted: 0,
+        };
+        assert_eq!(
+            authenticator_object_changes(&effects),
+            expected_changes,
+            "unexpected authenticator object changes on call {expected}"
+        );
+
+        assert_eq!(
+            test_env.read_account_auth_count(aa_ref.object_id).await?,
+            Some(expected),
+            "the authenticator should have incremented the account's AuthCount to {expected}"
+        );
+    }
+
+    // The repeated mutations also bumped the account object version.
     assert!(
         test_env
             .test_cluster
@@ -311,7 +372,31 @@ async fn test_authenticator_rotates_account_auth_function_ref() -> Result<(), an
     let tx_digest = tx_data.digest().into_inner();
     let signature = test_env.create_move_authenticator_ed25519_rotate(&tx_digest)?;
     let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
-    test_env.execute_and_check_tx_correctness(tx).await?;
+    let (effects, _) = test_env
+        .test_cluster
+        .execute_transaction_return_raw_effects(tx)
+        .await?;
+    assert!(
+        effects.status().is_success(),
+        "tx should succeed, got: {:?}",
+        effects.status()
+    );
+
+    // Rotating replaces the value under the *same* dynamic-field key, so the
+    // field's child object is reused (not re-created), making it a pure mutation:
+    // - created: 0 — the key is unchanged, so no new field object.
+    // - mutated: 2 — the auth-ref field (its stored ref is replaced) and the
+    //   account (the parent).
+    // - deleted: 0 — the old field object is overwritten in place, not deleted.
+    assert_eq!(
+        authenticator_object_changes(&effects),
+        ObjectChanges {
+            created: 0,
+            mutated: 2,
+            deleted: 0
+        },
+        "rotating the auth ref should neither create nor delete objects"
+    );
 
     // The authenticator mutated the account (rotated its auth ref): version bumped.
     assert!(
@@ -339,6 +424,241 @@ async fn test_authenticator_rotates_account_auth_function_ref() -> Result<(), an
         test_env.create_move_authenticator_for_free_access_for_ref(aa_ref)?;
     let tx = Transaction::from_generic_sig_data(tx_data, vec![free_access_signature]);
     test_env.execute_and_check_tx_correctness(tx).await?;
+
+    Ok(())
+}
+
+/// Test that a Move authenticator can *create a fresh top-level object* via
+/// `object::new`, which requires a `&mut TxContext`. This is gated by the
+/// `enable_mutable_shared_in_move_authenticator` protocol feature flag (the
+/// verifier otherwise forces `&TxContext`). Object ids stay unique and
+/// deterministic because the authenticator shares the transaction's TxContext.
+#[sim_test]
+async fn test_authenticator_creates_fresh_top_level_object() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_mutable_shared_in_move_authenticator_for_testing(true);
+        config
+    });
+
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519_AND_CREATE_OBJECT)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+
+    // The transaction body creates only an (unrelated) shared object; the fresh
+    // address-owned object below can therefore only come from the authenticator.
+    let pt = test_env.craft_create_counter_ptb()?;
+    let tx_data = test_env
+        .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+    // Same call-arg shape as the plain ed25519 authenticator (account immutable +
+    // signature); this authenticator additionally mints a fresh object.
+    let signature = test_env.create_move_authenticator_for_ed25519(&tx_digest)?;
+    let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
+
+    let (effects, _) = test_env
+        .test_cluster
+        .execute_transaction_return_raw_effects(tx)
+        .await?;
+    assert!(
+        effects.status().is_success(),
+        "tx should succeed, got: {:?}",
+        effects.status()
+    );
+
+    // The authenticator mints a fresh object and transfers it away:
+    // - created: 1 — the new `Marker` (`object::new`).
+    // - mutated: 0 — the account is the authenticated object but is passed
+    //   immutably, so it is not mutated.
+    // - deleted: 0 — nothing removed.
+    assert_eq!(
+        authenticator_object_changes(&effects),
+        ObjectChanges {
+            created: 1,
+            mutated: 0,
+            deleted: 0
+        },
+        "the authenticator should have created exactly one fresh object"
+    );
+    // ...and that fresh object is address-owned (transferred to the account).
+    assert!(
+        effects
+            .created()
+            .iter()
+            .any(|(_, owner)| matches!(owner, Owner::Address(_))),
+        "the created object should be address-owned"
+    );
+
+    Ok(())
+}
+
+/// Test that a Move authenticator can *delete an object* — removing a dynamic
+/// field from the account deletes that field's child object — gated by the
+/// `enable_mutable_shared_in_move_authenticator` protocol feature flag.
+#[sim_test]
+async fn test_authenticator_deletes_object() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_mutable_shared_in_move_authenticator_for_testing(true);
+        config
+    });
+
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519_AND_DELETE_FIELD)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+
+    // The account starts with exactly two dynamic fields: its owner public key
+    // and its authenticator reference.
+    assert_eq!(test_env.count_dynamic_fields(aa_ref.object_id).await?, 2);
+
+    let pt = test_env.craft_create_counter_ptb()?;
+    let tx_data = test_env
+        .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+    // Account passed as a mutable shared object; the authenticator removes one of
+    // its dynamic fields (deleting that field's child object).
+    let signature = test_env.create_move_authenticator_ed25519_mutate_account(&tx_digest)?;
+    let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
+    let (effects, _) = test_env
+        .test_cluster
+        .execute_transaction_return_raw_effects(tx)
+        .await?;
+    assert!(effects.status().is_success());
+
+    // Removing a dynamic field deletes its child object:
+    // - created: 0 — no new objects.
+    // - mutated: 1 — the account (the parent the field was removed from).
+    // - deleted: 1 — the removed field's child object.
+    assert_eq!(
+        authenticator_object_changes(&effects),
+        ObjectChanges {
+            created: 0,
+            mutated: 1,
+            deleted: 1
+        },
+        "the authenticator should have deleted exactly one object and created none"
+    );
+    // The account now has exactly one dynamic field (the public key was removed,
+    // the authenticator reference remains).
+    assert_eq!(
+        test_env.count_dynamic_fields(aa_ref.object_id).await?,
+        1,
+        "the authenticator should have removed exactly one dynamic field from the account"
+    );
+
+    Ok(())
+}
+
+/// Test that a Move authenticator can *remove (extract) an object* stored as a
+/// dynamic object field on a mutable shared object and transfer it out. The
+/// extraction deletes the internal wrapper object, so this relies on deletion
+/// being permitted under `enable_mutable_shared_in_move_authenticator`.
+#[sim_test]
+async fn test_authenticator_extracts_object_via_dof() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_mutable_shared_in_move_authenticator_for_testing(true);
+        config
+    });
+
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519_AND_EXTRACT_FROM_COUNTER)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let aa_sender: IotaAddress = aa_ref.object_id.into();
+
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+
+    // Create a shared counter that holds a `Marker` as a dynamic object field.
+    let counter_ref = test_env.create_shared_counter_with_marker().await?;
+    let counter_id = counter_ref.object_id;
+    assert_eq!(
+        test_env.count_dynamic_fields(counter_id).await?,
+        1,
+        "the counter should start with one dynamic object field"
+    );
+
+    let pt = test_env.craft_create_counter_ptb()?;
+    let tx_data = test_env
+        .craft_tx_from_pt(pt, aa_gas, aa_sender, None)
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+    // Same call-arg shape as the increment authenticator (counter passed as a
+    // mutable shared object); this authenticator extracts the stored Marker.
+    let signature =
+        test_env.create_move_authenticator_ed25519_and_increment(counter_ref, &tx_digest)?;
+    let tx = Transaction::from_generic_sig_data(tx_data, vec![signature]);
+
+    let (effects, _) = test_env
+        .test_cluster
+        .execute_transaction_return_raw_effects(tx)
+        .await?;
+    assert!(
+        effects.status().is_success(),
+        "tx should succeed, got: {:?}",
+        effects.status()
+    );
+
+    // Extracting a dynamic object field unwraps the stored object and discards the
+    // field's internal wrapper:
+    // - created: 0 — the `Marker` already existed (created during setup), it is
+    //   only moved out.
+    // - mutated: 2 — the counter (the parent the field was removed from) and the
+    //   `Marker` (re-parented from the field to the account address).
+    // - deleted: 1 — the field's internal wrapper object.
+    assert_eq!(
+        authenticator_object_changes(&effects),
+        ObjectChanges {
+            created: 0,
+            mutated: 2,
+            deleted: 1
+        },
+        "the extraction should have deleted exactly one object (the wrapper) and created none"
+    );
+    // The dynamic object field was removed from the counter.
+    assert_eq!(
+        test_env.count_dynamic_fields(counter_id).await?,
+        0,
+        "the authenticator should have removed the counter's dynamic object field"
+    );
+    // The extracted Marker is now an address-owned object (transferred to the
+    // account).
+    let extracted_marker_owned = effects
+        .all_changed_objects()
+        .iter()
+        .any(|(_, owner, _)| matches!(owner, Owner::Address(_)));
+    assert!(
+        extracted_marker_owned,
+        "the extracted Marker should now be address-owned by the account"
+    );
 
     Ok(())
 }
@@ -2577,6 +2897,19 @@ impl TestEnvironment {
     /// Create and share a `Counter` (initialised to zero) and return its object
     /// reference.
     async fn create_shared_counter(&self) -> anyhow::Result<ObjectRef> {
+        self.create_shared_counter_via("create_counter").await
+    }
+
+    /// Create a shared `Counter` that holds a `Marker` as a dynamic object
+    /// field.
+    async fn create_shared_counter_with_marker(&self) -> anyhow::Result<ObjectRef> {
+        self.create_shared_counter_via("create_counter_with_marker")
+            .await
+    }
+
+    /// Create and share a `Counter` by calling `function_name`, returning the
+    /// created shared object reference. Sent by the default (non-AA) wallet.
+    async fn create_shared_counter_via(&self, function_name: &str) -> anyhow::Result<ObjectRef> {
         let Some(aa_package_id) = self.aa_package_id else {
             anyhow::bail!("Account abstraction package not published yet");
         };
@@ -2586,7 +2919,7 @@ impl TestEnvironment {
             builder.programmable_move_call(
                 aa_package_id,
                 Identifier::from_static(AA_CREATE_MODULE_NAME),
-                Identifier::from_static("create_counter"),
+                Identifier::new(function_name)?,
                 vec![],
                 vec![],
             );
@@ -2666,6 +2999,18 @@ impl TestEnvironment {
         Ok(Some(u64::from_le_bytes(<[u8; 8]>::try_from(
             &contents[contents.len() - 8..],
         )?)))
+    }
+
+    /// Number of dynamic fields attached to an object.
+    async fn count_dynamic_fields(&self, object_id: ObjectId) -> anyhow::Result<usize> {
+        Ok(self
+            .test_cluster
+            .iota_client()
+            .read_api()
+            .get_dynamic_fields(object_id, None, None)
+            .await?
+            .data
+            .len())
     }
 
     /// Build a `MoveAuthenticator` for `authenticate_ed25519_and_increment`,
@@ -2821,6 +3166,40 @@ impl TestEnvironment {
 fn abstract_account_type_tag(aa_package_id: &ObjectId) -> TypeTag {
     TypeTag::from_str(format!("{aa_package_id}::{AA_MODULE_NAME}::{AA_ACCOUNT_NAME}").as_str())
         .unwrap()
+}
+
+/// Object-change counts attributable to the authenticator.
+///
+/// The mutable-shared authenticator tests use a `create_counter` transaction
+/// body, which creates exactly one *shared* object, mutates nothing and deletes
+/// nothing. After excluding the body's shared created object and the gas coin,
+/// these counts reflect only the authenticator's own object changes.
+#[derive(Debug, PartialEq, Eq)]
+struct ObjectChanges {
+    /// Created objects, excluding the shared object produced by the transaction
+    /// body.
+    created: usize,
+    /// Mutated objects, excluding the gas coin.
+    mutated: usize,
+    /// Deleted objects.
+    deleted: usize,
+}
+
+fn authenticator_object_changes(effects: &TransactionEffects) -> ObjectChanges {
+    let gas_id = effects.gas_object().0.object_id;
+    ObjectChanges {
+        created: effects
+            .created()
+            .iter()
+            .filter(|(_, owner)| !matches!(owner, Owner::Shared(_)))
+            .count(),
+        mutated: effects
+            .mutated()
+            .iter()
+            .filter(|(obj_ref, _)| obj_ref.object_id != gas_id)
+            .count(),
+        deleted: effects.deleted().len(),
+    }
 }
 
 fn delayed_abstract_account_type_tag(aa_package_id: &ObjectId) -> TypeTag {

--- a/crates/iota-framework-tests/src/metered_verifier.rs
+++ b/crates/iota-framework-tests/src/metered_verifier.rs
@@ -49,6 +49,7 @@ fn test_metered_move_bytecode_verifier() {
     let r = run_metered_move_bytecode_verifier(
         &compiled_modules,
         &verifier_config,
+        &protocol_config,
         &mut meter,
         &bytecode_verifier_metrics,
     );
@@ -128,6 +129,7 @@ fn test_metered_move_bytecode_verifier() {
     let r = run_metered_move_bytecode_verifier(
         &compiled_modules,
         &verifier_config,
+        &protocol_config,
         &mut meter,
         &bytecode_verifier_metrics,
     );
@@ -219,6 +221,7 @@ fn test_metered_move_bytecode_verifier() {
         run_metered_move_bytecode_verifier(
             modules,
             &verifier_config,
+            &protocol_config,
             &mut meter,
             &bytecode_verifier_metrics,
         )
@@ -246,6 +249,7 @@ fn test_meter_system_packages() {
         run_metered_move_bytecode_verifier(
             &system_package.modules(),
             &verifier_config,
+            &protocol_config,
             &mut meter,
             &bytecode_verifier_metrics,
         )
@@ -318,6 +322,7 @@ fn test_build_and_verify_programmability_examples() {
         run_metered_move_bytecode_verifier(
             &modules,
             &verifier_config,
+            &protocol_config,
             &mut meter,
             &bytecode_verifier_metrics,
         )

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -402,7 +402,12 @@ fn verify_bytecode(package: &MoveCompiledPackage, fn_info: &FnInfoMap) -> IotaRe
                 error: err.to_string(),
             }
         })?;
-        iota_bytecode_verifier::iota_verify_module_unmetered(m, fn_info)?;
+        // TEMPORARY: hardcode `true` to allow mutable references to objects in
+        // authenticator functions at build time. This should instead be derived
+        // from the target network's `enable_mutable_shared_in_move_authenticator`
+        // protocol feature flag (e.g. threaded in via `BuildConfig`). The
+        // network re-verifies at publish time under its own protocol config.
+        iota_bytecode_verifier::iota_verify_module_unmetered(m, fn_info, true)?;
     }
     // Don't change the link components to iota. It is correct as it is.
     // TODO(https://github.com/MystenLabs/sui/issues/69): Run Move linker

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -467,6 +467,12 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     enable_move_authentication_for_sponsor: bool,
 
+    // If true, Move authenticator functions may take mutable references (`&mut T`)
+    // to shared objects, and such objects may appear as mutable inputs in a
+    // `MoveAuthenticator`.
+    #[serde(skip_serializing_if = "is_false")]
+    enable_mutable_shared_in_move_authenticator: bool,
+
     // If true, the change epoch transaction will contain validator scores.
     #[serde(skip_serializing_if = "is_false")]
     pass_validator_scores_to_advance_epoch: bool,
@@ -1699,6 +1705,17 @@ impl ProtocolConfig {
         enable_move_authentication_for_sponsor
     }
 
+    pub fn enable_mutable_shared_in_move_authenticator(&self) -> bool {
+        let enable_mutable_shared_in_move_authenticator = self
+            .feature_flags
+            .enable_mutable_shared_in_move_authenticator;
+        assert!(
+            !enable_mutable_shared_in_move_authenticator || self.enable_move_authentication(),
+            "enable_mutable_shared_in_move_authenticator requires enable_move_authentication to be set"
+        );
+        enable_mutable_shared_in_move_authenticator
+    }
+
     pub fn pass_validator_scores_to_advance_epoch(&self) -> bool {
         self.feature_flags.pass_validator_scores_to_advance_epoch
     }
@@ -2914,6 +2931,13 @@ impl ProtocolConfig {
                         cfg.feature_flags
                             .pre_consensus_sponsor_only_move_authentication = true;
                     }
+
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        // Allow mutable references to shared objects in Move
+                        // authenticators on devnet first.
+                        cfg.feature_flags
+                            .enable_mutable_shared_in_move_authenticator = true;
+                    }
                 }
                 29 => {
                     // Keep advancing the random beacon DKG state machine on every commit
@@ -3147,6 +3171,11 @@ impl ProtocolConfig {
 
     pub fn set_enable_move_authentication_for_sponsor_for_testing(&mut self, val: bool) {
         self.feature_flags.enable_move_authentication_for_sponsor = val;
+    }
+
+    pub fn set_enable_mutable_shared_in_move_authenticator_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .enable_mutable_shared_in_move_authenticator = val;
     }
 
     pub fn set_consensus_fast_commit_sync_for_testing(&mut self, val: bool) {

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_28.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_28.snap
@@ -43,6 +43,7 @@ feature_flags:
   publish_package_metadata: true
   enable_move_authentication: true
   enable_move_authentication_for_sponsor: true
+  enable_mutable_shared_in_move_authenticator: true
   pass_validator_scores_to_advance_epoch: true
   calculate_validator_scores: true
   adjust_rewards_by_score: true

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -214,8 +214,9 @@ mod checked {
     #[instrument(level = "trace", skip_all)]
     pub fn check_move_authenticator_input_for_validation(
         authenticator_input_objects: InputObjects,
+        protocol_config: &ProtocolConfig,
     ) -> IotaResult<CheckedInputObjects> {
-        check_move_authenticator_objects(&authenticator_input_objects)?;
+        check_move_authenticator_objects(&authenticator_input_objects, protocol_config)?;
 
         Ok(authenticator_input_objects.into_checked())
     }
@@ -262,7 +263,7 @@ mod checked {
         // Check Move authenticator inputs first
         per_authenticator_input_objects
             .iter()
-            .try_for_each(check_move_authenticator_objects)?;
+            .try_for_each(|objects| check_move_authenticator_objects(objects, protocol_config))?;
 
         // Check certificate inputs next
         let transaction = cert.data().transaction_data();
@@ -720,13 +721,18 @@ mod checked {
     #[instrument(level = "trace", skip_all)]
     fn check_move_authenticator_objects(
         authenticator_objects: &InputObjects,
+        protocol_config: &ProtocolConfig,
     ) -> UserInputResult<()> {
         for object in authenticator_objects.iter() {
             let input_object_kind = object.input_object_kind;
 
             match &object.object {
                 ObjectReadResultKind::Object(object) => {
-                    check_one_move_authenticator_object(input_object_kind, object)?;
+                    check_one_move_authenticator_object(
+                        input_object_kind,
+                        object,
+                        protocol_config,
+                    )?;
                 }
                 // We skip checking a deleted shared object because it no longer exists.
                 ObjectReadResultKind::DeletedSharedObject(_, _) => (),
@@ -743,6 +749,7 @@ mod checked {
     fn check_one_move_authenticator_object(
         object_kind: InputObjectKind,
         object: &Object,
+        protocol_config: &ProtocolConfig,
     ) -> UserInputResult {
         match object_kind {
             InputObjectKind::MovePackage(package_id) => {
@@ -814,7 +821,7 @@ mod checked {
             }
             InputObjectKind::SharedMoveObject {
                 id, mutable: true, ..
-            } => {
+            } if !protocol_config.enable_mutable_shared_in_move_authenticator() => {
                 return Err(UserInputError::MutableSharedIsInMoveAuthenticatorInput {
                     object_id: id,
                 });

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -354,18 +354,12 @@ impl MoveAuthenticatorV1 {
                 Some(object_ref.version),
                 Some(object_ref.digest),
             ),
-            CallArg::Shared(SharedObjectRef {
-                object_id, mutable, ..
-            }) => {
-                if *mutable {
-                    return Err(UserInputError::Unsupported(
-                        "MoveAuthenticatorV1 cannot authenticate mutable shared objects"
-                            .to_string(),
-                    ));
-                }
-
-                (*object_id, None, None)
-            }
+            // A mutable shared object as the authenticated account is gated by the
+            // `enable_mutable_shared_in_move_authenticator` feature flag, enforced on the
+            // authenticator input objects by `check_move_authenticator_objects`. Here we
+            // only extract the components, which are identical for mutable and immutable
+            // shared objects.
+            CallArg::Shared(SharedObjectRef { object_id, .. }) => (*object_id, None, None),
             CallArg::Receiving(_) => {
                 return Err(UserInputError::Unsupported(
                     "MoveAuthenticator cannot authenticate receiving objects".to_string(),

--- a/iota-execution/latest/iota-adapter/src/adapter.rs
+++ b/iota-execution/latest/iota-adapter/src/adapter.rs
@@ -170,6 +170,7 @@ mod checked {
     pub fn run_metered_move_bytecode_verifier(
         modules: &[CompiledModule],
         verifier_config: &VerifierConfig,
+        protocol_config: &ProtocolConfig,
         meter: &mut (impl Meter + ?Sized),
         metrics: &Arc<BytecodeVerifierMetrics>,
     ) -> Result<(), IotaError> {
@@ -179,7 +180,9 @@ mod checked {
                 .verifier_runtime_per_module_success_latency
                 .start_timer();
 
-            if let Err(e) = verify_module_timeout_only(module, verifier_config, meter) {
+            if let Err(e) =
+                verify_module_timeout_only(module, verifier_config, protocol_config, meter)
+            {
                 // We only checked that the failure was due to timeout
                 // Discard success timer, but record timeout/failure timer
                 metrics
@@ -217,6 +220,7 @@ mod checked {
     fn verify_module_timeout_only(
         module: &CompiledModule,
         verifier_config: &VerifierConfig,
+        protocol_config: &ProtocolConfig,
         meter: &mut (impl Meter + ?Sized),
     ) -> Result<(), IotaError> {
         meter.enter_scope(module.self_id().name().as_str(), Scope::Module);
@@ -241,9 +245,12 @@ mod checked {
                     error: format!("Verification timed out: {e}"),
                 });
             }
-        } else if let Err(err) =
-            iota_verify_module_metered_check_timeout_only(module, &BTreeMap::new(), meter)
-        {
+        } else if let Err(err) = iota_verify_module_metered_check_timeout_only(
+            module,
+            &BTreeMap::new(),
+            meter,
+            protocol_config.enable_mutable_shared_in_move_authenticator(),
+        ) {
             return Err(err.into());
         }
 

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -332,7 +332,9 @@ mod checked {
 
         // Input objects come from both authentication and transaction inputs
         let input_objects = authenticator_and_transaction_input_objects.into_inner();
-        // Mutable inputs come only from the transaction inputs
+        // Mutable inputs come from the transaction inputs and, when
+        // `enable_mutable_shared_in_move_authenticator` is set, also from
+        // authenticator inputs (mutable shared objects).
         let mutable_inputs = if enable_expensive_checks {
             input_objects.mutable_inputs().keys().copied().collect()
         } else {
@@ -607,12 +609,13 @@ mod checked {
             "Only programmable transactions are allowed"
         );
         debug_assert!(
-            authenticator_input_objects
-                .mutable_inputs()
-                .keys()
-                .copied()
-                .collect::<HashSet<_>>()
-                .is_empty(),
+            protocol_config.enable_mutable_shared_in_move_authenticator()
+                || authenticator_input_objects
+                    .mutable_inputs()
+                    .keys()
+                    .copied()
+                    .collect::<HashSet<_>>()
+                    .is_empty(),
             "No mutable inputs are allowed"
         );
         debug_assert!(
@@ -732,7 +735,7 @@ mod checked {
                 trace_builder_opt,
             )
             .and_then(|ok_result| {
-                temporary_store.check_move_authenticator_results_consistency()?;
+                temporary_store.check_move_authenticator_results_consistency(protocol_config)?;
                 Ok(ok_result)
             })
         })

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -1157,7 +1157,13 @@ mod checked {
         for module in modules {
             // Run IOTA bytecode verifier, which runs some additional checks that assume the
             // Move bytecode verifier has passed.
-            iota_verifier::verifier::iota_verify_module_unmetered(module, &BTreeMap::new())?;
+            iota_verifier::verifier::iota_verify_module_unmetered(
+                module,
+                &BTreeMap::new(),
+                context
+                    .protocol_config
+                    .enable_mutable_shared_in_move_authenticator(),
+            )?;
         }
 
         Ok(())

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -1008,9 +1008,10 @@ mod checked {
         let fn_handle = module.function_handle_at(fn_definition.function);
         let fn_signature = module.signature_at(fn_handle.parameters);
         // We need the first parameter to be a reference type so we can extract the
-        // inner as the type tag.
+        // inner as the type tag. The account may be passed by immutable or (when
+        // `enable_mutable_shared_in_move_authenticator` is set) mutable reference.
         match &fn_signature.0[0] {
-            SignatureToken::Reference(ref_param) => {
+            SignatureToken::Reference(ref_param) | SignatureToken::MutableReference(ref_param) => {
                 let pool = &mut normalized::RcPool::new();
                 if let Some(type_tag) =
                     normalized::Type::new(pool, module, ref_param).to_type_tag(pool)

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -797,27 +797,37 @@ impl TemporaryStore<'_> {
         &self,
         protocol_config: &ProtocolConfig,
     ) -> Result<(), ExecutionError> {
+        // Object deletion during authenticator execution is never allowed: the
+        // authenticator must not delete its mutable shared inputs nor remove their
+        // dynamic fields.
+        assert_invariant!(
+            self.execution_results.deleted_object_ids.is_empty(),
+            "Objects cannot be deleted during authenticator execution"
+        );
+
+        // When mutable shared objects are allowed in Move authenticators, the
+        // authenticator may otherwise mutate them — including adding and modifying
+        // their dynamic fields, which create and write child objects. The set of
+        // writable objects is still constrained upstream to the mutable shared
+        // authenticator inputs: the authenticator's `&TxContext` is immutable, so it
+        // cannot create fresh top-level objects.
+        if protocol_config.enable_mutable_shared_in_move_authenticator() {
+            return Ok(());
+        }
+
+        // Otherwise, authenticator execution must be fully read-only.
         assert_invariant!(
             self.execution_results.created_object_ids.is_empty(),
             "Objects cannot be created during authenticator execution"
         );
         assert_invariant!(
-            self.execution_results.deleted_object_ids.is_empty(),
-            "Objects cannot be deleted during authenticator execution"
+            self.execution_results.written_objects.is_empty(),
+            "Objects cannot be written during authenticator execution"
         );
-        // When mutable shared objects are allowed in Move authenticators, the
-        // authenticator may legitimately write/modify them (no other inputs are
-        // mutable). Otherwise, authenticator execution must not write any object.
-        if !protocol_config.enable_mutable_shared_in_move_authenticator() {
-            assert_invariant!(
-                self.execution_results.written_objects.is_empty(),
-                "Objects cannot be written during authenticator execution"
-            );
-            assert_invariant!(
-                self.execution_results.modified_objects.is_empty(),
-                "Objects cannot be modified during authenticator execution"
-            );
-        }
+        assert_invariant!(
+            self.execution_results.modified_objects.is_empty(),
+            "Objects cannot be modified during authenticator execution"
+        );
         Ok(())
     }
 }

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -797,20 +797,12 @@ impl TemporaryStore<'_> {
         &self,
         protocol_config: &ProtocolConfig,
     ) -> Result<(), ExecutionError> {
-        // Object deletion during authenticator execution is never allowed: the
-        // authenticator must not delete its mutable shared inputs nor remove their
-        // dynamic fields.
-        assert_invariant!(
-            self.execution_results.deleted_object_ids.is_empty(),
-            "Objects cannot be deleted during authenticator execution"
-        );
-
         // When mutable shared objects are allowed in Move authenticators, the
-        // authenticator may otherwise mutate them — including adding and modifying
-        // their dynamic fields, which create and write child objects. The set of
-        // writable objects is still constrained upstream to the mutable shared
-        // authenticator inputs: the authenticator's `&TxContext` is immutable, so it
-        // cannot create fresh top-level objects.
+        // authenticator may freely mutate its mutable shared inputs — creating,
+        // writing, modifying and deleting objects, including their dynamic fields
+        // and dynamic object fields. The set of writable objects is constrained
+        // upstream to the mutable shared authenticator inputs (and objects the
+        // authenticator itself creates).
         if protocol_config.enable_mutable_shared_in_move_authenticator() {
             return Ok(());
         }
@@ -827,6 +819,10 @@ impl TemporaryStore<'_> {
         assert_invariant!(
             self.execution_results.modified_objects.is_empty(),
             "Objects cannot be modified during authenticator execution"
+        );
+        assert_invariant!(
+            self.execution_results.deleted_object_ids.is_empty(),
+            "Objects cannot be deleted during authenticator execution"
         );
         Ok(())
     }

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -793,23 +793,31 @@ impl TemporaryStore<'_> {
         Ok(())
     }
 
-    pub fn check_move_authenticator_results_consistency(&self) -> Result<(), ExecutionError> {
+    pub fn check_move_authenticator_results_consistency(
+        &self,
+        protocol_config: &ProtocolConfig,
+    ) -> Result<(), ExecutionError> {
         assert_invariant!(
             self.execution_results.created_object_ids.is_empty(),
             "Objects cannot be created during authenticator execution"
         );
         assert_invariant!(
-            self.execution_results.written_objects.is_empty(),
-            "Objects cannot be written during authenticator execution"
-        );
-        assert_invariant!(
-            self.execution_results.modified_objects.is_empty(),
-            "Objects cannot be modified during authenticator execution"
-        );
-        assert_invariant!(
             self.execution_results.deleted_object_ids.is_empty(),
             "Objects cannot be deleted during authenticator execution"
         );
+        // When mutable shared objects are allowed in Move authenticators, the
+        // authenticator may legitimately write/modify them (no other inputs are
+        // mutable). Otherwise, authenticator execution must not write any object.
+        if !protocol_config.enable_mutable_shared_in_move_authenticator() {
+            assert_invariant!(
+                self.execution_results.written_objects.is_empty(),
+                "Objects cannot be written during authenticator execution"
+            );
+            assert_invariant!(
+                self.execution_results.modified_objects.is_empty(),
+                "Objects cannot be modified during authenticator execution"
+            );
+        }
         Ok(())
     }
 }

--- a/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
@@ -85,8 +85,13 @@ pub fn verify_authenticate_func_v1(
     // Additional restrictions on the first argument type are enforced in the
     // following check.
     let account_parameter = &function_signature.0[0];
-    verify_authenticate_account_type(module, &function_handle.type_parameters, account_parameter)
-        .map_err(verification_failure)?;
+    verify_authenticate_account_type(
+        module,
+        &function_handle.type_parameters,
+        account_parameter,
+        enable_mutable_shared,
+    )
+    .map_err(verification_failure)?;
 
     // Check params 2nd to N-2th /////////////////////////////
 
@@ -152,21 +157,34 @@ pub fn verify_authenticate_func_v1(
     Ok(())
 }
 
-/// Verify that the first parameter type of the authenticator function is an
-/// immutable reference to an Object type, i.e., a Datatype with `key` ability.
+/// Verify that the first parameter type of the authenticator function is a
+/// reference to an Object type, i.e., a Datatype with `key` ability.
+///
+/// The reference must be immutable, unless `enable_mutable_shared` is set, in
+/// which case a mutable reference (`&mut`) to the account is also allowed — the
+/// account may then be mutated during authentication. As with the other object
+/// parameters, the verifier cannot tell shared from owned objects here;
+/// restricting `&mut` to *shared* accounts is enforced at runtime.
 fn verify_authenticate_account_type(
     module: &CompiledModule,
     function_type_args: &[AbilitySet],
     param: &SignatureToken,
+    enable_mutable_shared: bool,
 ) -> Result<(), String> {
     use SignatureToken::*;
 
-    // Check that the parameter is an immutable reference
-    if let Reference(ref_param) = param {
+    // The account must be passed by reference: always immutable, and mutable too
+    // when the feature flag is set.
+    let account_type = match param {
+        Reference(ref_param) => Some(&**ref_param),
+        MutableReference(ref_param) if enable_mutable_shared => Some(&**ref_param),
+        _ => None,
+    };
+
+    if let Some(s) = account_type {
         // Check if a type is a concrete object type (i.e., a Datatype with
         // `key` ability or a DatatypeInstantiation with `key` ability
         // and all type arguments being concrete object types).
-        let s = &**ref_param;
         match s {
             Datatype(_) => {
                 let abilities = module
@@ -189,7 +207,7 @@ fn verify_authenticate_account_type(
         }
     }
     Err(format!(
-        "Invalid authenticator function account type: {}. Valid types for the first parameter are immutable references to an object type (with no generics).",
+        "Invalid authenticator function account type: {}. Valid types for the first parameter are references to an object type (with no generics).",
         format_signature_token(module, param),
     ))
 }

--- a/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
@@ -133,13 +133,15 @@ pub fn verify_authenticate_func_v1(
         )));
     }
 
-    // TxContext can only be an immutable reference. Passing it as mutable would
-    // allow authenticator functions to create objects, which would be
-    // problematic.
-    if !matches!(
-        TxContext::kind(module, tx_context),
-        TxContextKind::Immutable
-    ) {
+    // TxContext must be an immutable reference, unless `enable_mutable_shared` is
+    // set. A `&mut TxContext` lets the authenticator create fresh objects via
+    // `object::new`; this is safe because the authenticator shares the
+    // transaction's `TxContext`, so created object ids stay unique and
+    // deterministic across the authentication and transaction phases.
+    let tx_context_kind = TxContext::kind(module, tx_context);
+    let tx_context_allowed = matches!(tx_context_kind, TxContextKind::Immutable)
+        || (enable_mutable_shared && matches!(tx_context_kind, TxContextKind::Mutable));
+    if !tx_context_allowed {
         return Err(verification_failure(format!(
             "Authenticator function '{function_identifier}' can only receive 'TxContext' as immutable reference"
         )));

--- a/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/authenticator_verifier.rs
@@ -36,9 +36,16 @@ use crate::verification_failure;
 /// - the last two arguments in order are AuthContext and TxContext
 /// - AuthContext has to be an immutable reference
 /// - TxContext has to be an immutable reference
+///
+/// When `enable_mutable_shared` is set, object parameters may also be passed by
+/// mutable reference (`&mut T`). The verifier only sees the Move type, so it
+/// cannot distinguish shared from owned objects here; restricting mutable
+/// references to *shared* objects is enforced at runtime when checking the
+/// authenticator input objects.
 pub fn verify_authenticate_func_v1(
     module: &CompiledModule,
     function_identifier: &IdentStr,
+    enable_mutable_shared: bool,
 ) -> Result<(), ExecutionError> {
     let module_name = module.name();
 
@@ -83,16 +90,22 @@ pub fn verify_authenticate_func_v1(
 
     // Check params 2nd to N-2th /////////////////////////////
 
-    // Apart from AuthContext and TxContext we only require that the arguments are
-    // not mutable references. They can be mutable pure values, as their mutability
-    // cannot affect outside state.
+    // Apart from AuthContext and TxContext, object arguments must be passed by
+    // immutable reference — unless `enable_mutable_shared` is set, in which case
+    // they may also be passed by mutable reference. Pure values are always
+    // allowed, as their mutability cannot affect outside state.
     for param in function_signature
         .0
         .iter()
         .take(function_signature.len() - 2)
     {
-        verify_authenticate_param_type(module, &function_handle.type_parameters, param)
-            .map_err(verification_failure)?;
+        verify_authenticate_param_type(
+            module,
+            &function_handle.type_parameters,
+            param,
+            enable_mutable_shared,
+        )
+        .map_err(verification_failure)?;
     }
 
     // Check params N-1th and Nth ////////////////////////////
@@ -184,13 +197,15 @@ fn verify_authenticate_account_type(
 /// Verify that the parameter type is a valid type for an authenticator
 /// function. Check that:
 /// - no Receiving objects are passed at all;
-/// - no objects are passed by value or by mutable reference, but only by
-///   immutable reference;
+/// - objects are passed by immutable reference (and, when
+///   `enable_mutable_shared` is set, also by mutable reference), never by
+///   value;
 /// - only primitive types are allowed by value.
 fn verify_authenticate_param_type(
     module: &CompiledModule,
     function_type_args: &[AbilitySet],
     param: &SignatureToken,
+    enable_mutable_shared: bool,
 ) -> Result<(), String> {
     use SignatureToken::*;
 
@@ -213,12 +228,22 @@ fn verify_authenticate_param_type(
                 ))
             }
         }
+        MutableReference(inner) if enable_mutable_shared => {
+            if is_object_struct(module, function_type_args, inner)? {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Invalid parameter type for authenticator function: {}. Non object mutable references are invalid. Valid types are references to objects or primitive types.",
+                    format_signature_token(module, param)
+                ))
+            }
+        }
         _ => {
             if is_primitive_strict(module, function_type_args, param) {
                 Ok(())
             } else {
                 Err(format!(
-                    "Invalid parameter type for authenticator function: {}. Valid types are immutable references to objects or primitive types.",
+                    "Invalid parameter type for authenticator function: {}. Valid types are references to objects or primitive types.",
                     format_signature_token(module, param)
                 ))
             }

--- a/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
+++ b/iota-execution/latest/iota-verifier/src/runtime_module_metadata.rs
@@ -28,7 +28,10 @@ use crate::{authenticator_verifier::verify_authenticate_func_v1, verification_fa
 ///    `RuntimeModuleMetadataWrapper`.
 /// 3. The deserialized metadata must satisfy any additional checks imposed by
 ///    the runtime metadata version.
-pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
+pub fn verify_module(
+    module: &CompiledModule,
+    enable_mutable_shared_in_authenticator: bool,
+) -> Result<(), ExecutionError> {
     if !module.metadata.is_empty() {
         if module.metadata.len() > 1 {
             return Err(verification_failure(
@@ -55,7 +58,7 @@ pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
                     "Failed to deserialize runtime IOTA module metadata from wrapper: {err}",
                 ))
             })?;
-        verify_runtime_metadata(module, &metadata)?;
+        verify_runtime_metadata(module, &metadata, enable_mutable_shared_in_authenticator)?;
     }
 
     Ok(())
@@ -64,6 +67,7 @@ pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
 fn verify_runtime_metadata(
     module: &CompiledModule,
     metadata: &RuntimeModuleMetadata,
+    enable_mutable_shared_in_authenticator: bool,
 ) -> Result<(), ExecutionError> {
     for (fn_name, fn_attributes) in metadata.fun_attributes_iter() {
         let mut seen = BTreeSet::new();
@@ -87,6 +91,7 @@ fn verify_runtime_metadata(
                                         "Failed to read function name: {err}",
                                     ))
                                 })?,
+                                enable_mutable_shared_in_authenticator,
                             )?;
                         }
                         _ => {

--- a/iota-execution/latest/iota-verifier/src/verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/verifier.rs
@@ -14,10 +14,16 @@ use crate::{
 };
 
 /// Helper for a "canonical" verification of a module.
+///
+/// `enable_mutable_shared_in_authenticator` relaxes the authenticator verifier
+/// to accept mutable references to object types (see
+/// [`crate::authenticator_verifier::verify_authenticate_func_v1`]); it is gated
+/// by the `enable_mutable_shared_in_move_authenticator` protocol feature flag.
 pub fn iota_verify_module_metered(
     module: &CompiledModule,
     fn_info_map: &FnInfoMap,
     meter: &mut (impl Meter + ?Sized),
+    enable_mutable_shared_in_authenticator: bool,
 ) -> Result<(), ExecutionError> {
     struct_with_key_verifier::verify_module(module)?;
     global_storage_access_verifier::verify_module(module)?;
@@ -25,7 +31,7 @@ pub fn iota_verify_module_metered(
     private_generics::verify_module(module)?;
     entry_points_verifier::verify_module(module, fn_info_map)?;
     one_time_witness_verifier::verify_module(module, fn_info_map)?;
-    runtime_module_metadata::verify_module(module)
+    runtime_module_metadata::verify_module(module, enable_mutable_shared_in_authenticator)
 }
 
 /// Runs the IOTA verifier and checks if the error counts as an IOTA verifier
@@ -35,9 +41,15 @@ pub fn iota_verify_module_metered_check_timeout_only(
     module: &CompiledModule,
     fn_info_map: &FnInfoMap,
     meter: &mut (impl Meter + ?Sized),
+    enable_mutable_shared_in_authenticator: bool,
 ) -> Result<(), ExecutionError> {
     // Checks if the error counts as an IOTA verifier timeout
-    if let Err(error) = iota_verify_module_metered(module, fn_info_map, meter) {
+    if let Err(error) = iota_verify_module_metered(
+        module,
+        fn_info_map,
+        meter,
+        enable_mutable_shared_in_authenticator,
+    ) {
         if matches!(
             error.kind(),
             iota_sdk_types::ExecutionError::IotaMoveVerificationTimeout
@@ -52,8 +64,15 @@ pub fn iota_verify_module_metered_check_timeout_only(
 pub fn iota_verify_module_unmetered(
     module: &CompiledModule,
     fn_info_map: &FnInfoMap,
+    enable_mutable_shared_in_authenticator: bool,
 ) -> Result<(), ExecutionError> {
-    iota_verify_module_metered(module, fn_info_map, &mut DummyMeter).inspect_err(|err| {
+    iota_verify_module_metered(
+        module,
+        fn_info_map,
+        &mut DummyMeter,
+        enable_mutable_shared_in_authenticator,
+    )
+    .inspect_err(|err| {
         // We must never see timeout error in execution
         debug_assert!(
             !matches!(

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -310,10 +310,16 @@ impl verifier::Verifier for Verifier<'_> {
 
     fn meter_compiled_modules(
         &mut self,
-        _protocol_config: &ProtocolConfig,
+        protocol_config: &ProtocolConfig,
         modules: &[CompiledModule],
         meter: &mut dyn Meter,
     ) -> IotaResult<()> {
-        run_metered_move_bytecode_verifier(modules, &self.config, meter, self.metrics)
+        run_metered_move_bytecode_verifier(
+            modules,
+            &self.config,
+            protocol_config,
+            meter,
+            self.metrics,
+        )
     }
 }


### PR DESCRIPTION
# Description of change

Enables using mutable shared objects in authenticators.

> [!WARNING]  
> It is a POC, not an implementation that can be considered as ready for being merged.

## Links to any relevant issues

fixes #11806 
