### PR TITLE
feat(iota-protocol-config): enable median timestamp with checkpoint enforcement for mainnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -160,6 +160,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             round passes) even with no fresh inbound traffic, e.g. after a
 //             validator restart. Without this it can stay pending forever and
 //             block epoch close.
+//             Enable median-based commit timestamp calculation in consensus,
+//             and enforce checkpoint timestamp monotonicity for mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2922,6 +2924,11 @@ impl ProtocolConfig {
                     // fresh inbound traffic -- e.g. after a validator restart -- instead of
                     // staying pending forever and blocking epoch close.
                     cfg.feature_flags.always_advance_dkg_to_resolution = true;
+
+                    // Enable median-based commit timestamp calculation in consensus and
+                    // enforce checkpoint timestamp monotonicity for mainnet.
+                    cfg.feature_flags
+                        .consensus_median_timestamp_with_checkpoint_enforcement = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_29.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_29.snap
@@ -30,6 +30,7 @@ feature_flags:
   select_committee_from_eligible_validators: true
   track_non_committee_eligible_validators: true
   select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
   consensus_commit_transactions_only_for_traversed_headers: true
   congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
   separate_gas_price_feedback_mechanism_for_randomness: true


### PR DESCRIPTION
# Description of change

Enables the `consensus_median_timestamp_with_checkpoint_enforcement` feature flag on Mainnet in protocol version 29. The flag — median-based commit timestamp calculation in consensus plus checkpoint timestamp monotonicity enforcement — was enabled for testnet/devnet in protocol version 14 behind a `chain != Chain::Mainnet` guard, but no later version arm ever enabled it on Mainnet.

Since protocol version 29 has not shipped in any release yet (the latest cut release, v1.25.0-rc, ships protocol version 28), the enablement is added to the existing v29 arm instead of cutting a new version. The Mainnet v29 config snapshot is updated accordingly.

## Links to any relevant issues

fixes #11797

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes