### PR TITLE
feat(indexer): simplify pruner logic and add pruning options

### DIFF
--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -319,8 +319,13 @@ pub struct PruningOptions {
     pub pruning_delay_ms: u64,
     /// Upper bound on units (checkpoints, transactions, or global sequence
     /// numbers) pruned per chunk, and on rows deleted per statement for the
-    /// `WithLimit` strategies.
-    #[arg(long, env = "PRUNING_BATCH_SIZE", default_value_t = DEFAULT_PRUNING_BATCH_SIZE)]
+    /// `WithLimit` strategies. Must be > 0.
+    #[arg(
+        long,
+        env = "PRUNING_BATCH_SIZE",
+        default_value_t = DEFAULT_PRUNING_BATCH_SIZE,
+        value_parser = clap::value_parser!(u64).range(1..),
+    )]
     pub pruning_batch_size: u64,
     /// DEPRECATED: will be removed in v1.29.0. This parameter is no longer
     /// used. Optimistic transactions are now pruned by the unified pruner.

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -300,7 +300,10 @@ pub enum Command {
     },
 }
 
-#[derive(Args, Default, Debug, Clone)]
+pub const DEFAULT_PRUNING_DELAY_MS: u64 = 2 * 60 * 60 * 1000; // 2 hours
+pub const DEFAULT_PRUNING_BATCH_SIZE: u64 = 1000;
+
+#[derive(Args, Debug, Clone)]
 pub struct PruningOptions {
     /// DEPRECATED: will be removed in v1.28.0. Use `--pruning-config-path`
     /// pointing at a TOML retention config instead.
@@ -309,10 +312,32 @@ pub struct PruningOptions {
     /// Path to TOML file containing configuration for retention policies.
     #[arg(long)]
     pub pruning_config_path: Option<PathBuf>,
-    /// DEPRECATED: This parameter is no longer used. Optimistic transactions
-    /// are now pruned by the unified pruner with the same batching strategy.
+    /// Delay in milliseconds between a watermark's lower bound being advanced
+    /// and the pruner acting on it. Lets in-flight reads complete or timeout
+    /// before their data is pruned.
+    #[arg(long, env = "PRUNING_DELAY_MS", default_value_t = DEFAULT_PRUNING_DELAY_MS)]
+    pub pruning_delay_ms: u64,
+    /// Upper bound on units (checkpoints, transactions, or global sequence
+    /// numbers) pruned per chunk, and on rows deleted per statement for the
+    /// `WithLimit` strategies.
+    #[arg(long, env = "PRUNING_BATCH_SIZE", default_value_t = DEFAULT_PRUNING_BATCH_SIZE)]
+    pub pruning_batch_size: u64,
+    /// DEPRECATED: will be removed in v1.29.0. This parameter is no longer
+    /// used. Optimistic transactions are now pruned by the unified pruner.
     #[arg(long, env = "OPTIMISTIC_PRUNER_BATCH_SIZE")]
     pub optimistic_pruner_batch_size: Option<u64>,
+}
+
+impl Default for PruningOptions {
+    fn default() -> Self {
+        Self {
+            epochs_to_keep: None,
+            pruning_config_path: None,
+            pruning_delay_ms: DEFAULT_PRUNING_DELAY_MS,
+            pruning_batch_size: DEFAULT_PRUNING_BATCH_SIZE,
+            optimistic_pruner_batch_size: None,
+        }
+    }
 }
 
 /// Represents the default retention policy and overrides for prunable tables.
@@ -530,9 +555,8 @@ mod test {
         temp_file.write_all(toml_content.as_bytes()).unwrap();
         let temp_path: PathBuf = temp_file.path().to_path_buf();
         let pruning_options = PruningOptions {
-            epochs_to_keep: None,
             pruning_config_path: Some(temp_path),
-            optimistic_pruner_batch_size: None,
+            ..Default::default()
         };
         let retention_config = pruning_options.load_from_file().unwrap().unwrap();
 

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -40,6 +40,8 @@ impl Indexer {
         store: PgIndexerStore,
         metrics: IndexerMetrics,
         retention_config: Option<RetentionConfig>,
+        pruning_delay_ms: u64,
+        pruning_batch_size: u64,
         cancel: CancellationToken,
     ) -> Result<(), IndexerError> {
         info!(
@@ -59,7 +61,13 @@ impl Indexer {
             resolve_remote_url(&config.sources, MAX_URL_RESOLUTION_TIMEOUT).await?;
 
         if let Some(retention_config) = retention_config {
-            let pruner = Pruner::new(store.clone(), retention_config, metrics.clone())?;
+            let pruner = Pruner::new(
+                store.clone(),
+                retention_config,
+                pruning_delay_ms,
+                pruning_batch_size,
+                metrics.clone(),
+            )?;
             let cancel_clone = cancel.clone();
             spawn_monitored_task!(pruner.start(cancel_clone));
         }

--- a/crates/iota-indexer/src/main.rs
+++ b/crates/iota-indexer/src/main.rs
@@ -78,6 +78,7 @@ async fn main() -> Result<(), IndexerError> {
             if pruning_options.optimistic_pruner_batch_size.is_some() {
                 warn!(
                     "the --optimistic-pruner-batch-size argument is deprecated and no longer used. \
+                     This argument will be removed in v1.29.0. \
                      Optimistic transactions are now pruned by the unified pruner."
                 );
             }
@@ -97,6 +98,8 @@ async fn main() -> Result<(), IndexerError> {
                 store,
                 indexer_metrics,
                 retention_config,
+                pruning_options.pruning_delay_ms,
+                pruning_options.pruning_batch_size,
                 cancel.clone(),
             )
             .await?;

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -14,29 +14,13 @@ use crate::{
     errors::IndexerError,
     ingestion::primary::prepare::PrimaryWorker,
     metrics::IndexerMetrics,
+    models::watermarks::StoredWatermark,
     spawn_monitored_task,
     store::{IndexerStore, PgIndexerStore, pg_partition_manager::PgPartitionManager},
     types::IndexerResult,
 };
 
 const UPDATE_WATERMARKS_LOWER_BOUNDS_TASK_INTERVAL: Duration = Duration::from_secs(5);
-/// Delay in milliseconds before pruning data after watermark timestamp.
-/// This delay allows in-flight reads that may be accessing data scheduled for
-/// pruning to complete or timeout, ensuring safe pruning without affecting
-/// active queries.
-#[cfg(any(test, feature = "pg_integration", feature = "shared_test_runtime"))]
-const PRUNING_DELAY_MS: u64 = 1000; // 1 second for tests
-
-#[cfg(not(any(test, feature = "pg_integration", feature = "shared_test_runtime")))]
-const PRUNING_DELAY_MS: u64 = 2 * 60 * 60 * 1000; // 2 hours for production
-
-/// Maximum number of transactions to prune in a single batch for ByTransaction
-/// strategy
-const MAX_TRANSACTIONS_PER_PRUNE_BATCH: u64 = 1000;
-
-/// Maximum number of checkpoints to prune in a single batch for ByCheckpoint
-/// strategy
-const MAX_CHECKPOINTS_PER_PRUNE_BATCH: u64 = 1000;
 
 /// Interval for running the pruning task
 const PRUNING_TASK_INTERVAL: Duration = Duration::from_secs(5);
@@ -48,6 +32,8 @@ pub struct Pruner {
     pub store: PgIndexerStore,
     pub partition_manager: PgPartitionManager,
     pub retention_policies: HashMap<PrunableTable, u64>,
+    pub pruning_delay_ms: u64,
+    pub pruning_batch_size: u64,
     pub metrics: IndexerMetrics,
 }
 
@@ -120,31 +106,27 @@ pub enum PruningStrategy {
     ByCheckpointWithLimit,
 }
 
-/// Represents a specific chunk of data to be pruned
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PruningChunk {
-    /// Prune an entire epoch partition
-    Epoch(u64),
-    /// Prune a range of checkpoints [start..=end] inclusive
-    CheckpointRange(u64, u64),
-    /// Prune a range of transactions [start..=end] inclusive
-    TransactionRange(u64, u64),
-    /// Prune by global_sequence_number range [start..=end] inclusive
-    GlobalSeqRange(u64, u64),
-    /// Prune by checkpoint range [start..=end] with row-limited deletes
-    CheckpointRangeWithLimit(u64, u64),
-}
-
-impl PruningChunk {
-    /// Returns the start of the next chunk to prune (used for updating
-    /// pruner_hi watermark)
-    fn next_chunk_start(&self) -> u64 {
+impl PruningStrategy {
+    /// Whether chunk sizing for this strategy uses the configurable pruning
+    /// batch size. `ByEpochPartition` is not batched — partitions are dropped
+    /// one at a time.
+    fn is_batched(&self) -> bool {
         match self {
-            PruningChunk::Epoch(epoch) => epoch + 1,
-            PruningChunk::CheckpointRange(_, end) => end + 1,
-            PruningChunk::TransactionRange(_, end) => end + 1,
-            PruningChunk::GlobalSeqRange(_, end) => end + 1,
-            PruningChunk::CheckpointRangeWithLimit(_, end) => end + 1,
+            Self::ByEpochPartition => false,
+            Self::ByCheckpoint
+            | Self::ByCheckpointWithLimit
+            | Self::ByTransaction
+            | Self::ByGlobalSeq => true,
+        }
+    }
+
+    /// Exclusive upper bound of the pruning range for this strategy, taken
+    /// from the watermark's `min_available_*` columns.
+    fn range_end(&self, watermark: &StoredWatermark) -> u64 {
+        match self {
+            Self::ByEpochPartition => watermark.min_available_epoch as u64,
+            Self::ByCheckpoint | Self::ByCheckpointWithLimit => watermark.min_available_cp as u64,
+            Self::ByTransaction | Self::ByGlobalSeq => watermark.min_available_tx as u64,
         }
     }
 }
@@ -199,6 +181,8 @@ pub struct TablePruner<'a> {
     table: PrunableTable,
     store: &'a PgIndexerStore,
     partition_manager: &'a PgPartitionManager,
+    pruning_delay_ms: u64,
+    pruning_batch_size: u64,
     #[allow(dead_code)]
     metrics: &'a IndexerMetrics,
     cancel: CancellationToken,
@@ -209,6 +193,8 @@ impl<'a> TablePruner<'a> {
         table: PrunableTable,
         store: &'a PgIndexerStore,
         partition_manager: &'a PgPartitionManager,
+        pruning_delay_ms: u64,
+        pruning_batch_size: u64,
         metrics: &'a IndexerMetrics,
         cancel: CancellationToken,
     ) -> Self {
@@ -216,6 +202,8 @@ impl<'a> TablePruner<'a> {
             table,
             store,
             partition_manager,
+            pruning_delay_ms,
+            pruning_batch_size,
             metrics,
             cancel,
         }
@@ -274,23 +262,21 @@ impl<'a> TablePruner<'a> {
 
         let pruning_chunks = self.create_pruning_chunks(&watermark);
 
-        for pruning_chunk in pruning_chunks {
+        for (start, end) in pruning_chunks {
             info!(
-                "Pruning table {} for {:?}",
+                "Pruning table {} in range [{start}..={end}]",
                 self.table.as_ref(),
-                pruning_chunk
             );
-            if let Err(err) = self.prune_by_chunk(pruning_chunk).await {
+            if let Err(err) = self.prune_by_chunk(start, end).await {
                 error!(
-                    "failed to prune table {} for {:?}: {err}",
+                    "failed to prune table {} in range [{start}..={end}]: {err}",
                     self.table.as_ref(),
-                    pruning_chunk
                 );
                 break;
             }
 
             // Update lowest_unpruned_key to the next chunk to prune
-            let next_chunk_start = pruning_chunk.next_chunk_start();
+            let next_chunk_start = end + 1;
             if let Err(err) = self
                 .store
                 .update_watermark_lowest_unpruned_key(&self.table, next_chunk_start)
@@ -314,87 +300,30 @@ impl<'a> TablePruner<'a> {
         Ok(())
     }
 
-    /// Creates an iterator of pruning chunks based on the watermark and pruning
-    /// strategy
+    /// Creates an iterator of `(start, end)` inclusive ranges to prune,
+    /// derived from the watermark and the table's pruning strategy.
     fn create_pruning_chunks(
         &self,
-        watermark: &crate::models::watermarks::StoredWatermark,
-    ) -> Box<dyn Iterator<Item = PruningChunk> + Send> {
-        let min_available_epoch = watermark.min_available_epoch as u64;
+        watermark: &StoredWatermark,
+    ) -> impl Iterator<Item = (u64, u64)> + Send {
+        let strategy = self.table.pruning_strategy();
         let lowest_unpruned_key = watermark.lowest_unpruned_key as u64;
-        let min_available_cp = watermark.min_available_cp as u64;
-        let min_available_tx = watermark.min_available_tx as u64;
-
-        match self.table.pruning_strategy() {
-            PruningStrategy::ByEpochPartition => {
-                let range_end = min_available_epoch;
-                info!(
-                    "pruning table {} in epoch range: [{lowest_unpruned_key}..{range_end})",
-                    self.table.as_ref()
-                );
-                Box::new((lowest_unpruned_key..range_end).map(PruningChunk::Epoch))
-            }
-            PruningStrategy::ByCheckpoint => {
-                let range_end = min_available_cp;
-                info!(
-                    "pruning table {} in checkpoint range: [{lowest_unpruned_key}..{range_end})",
-                    self.table.as_ref()
-                );
-                Box::new(
-                    (lowest_unpruned_key..range_end)
-                        .step_by(MAX_CHECKPOINTS_PER_PRUNE_BATCH as usize)
-                        .map(move |start| {
-                            let end = (start + MAX_CHECKPOINTS_PER_PRUNE_BATCH).min(range_end);
-                            PruningChunk::CheckpointRange(start, end - 1)
-                        }),
-                )
-            }
-            PruningStrategy::ByTransaction => {
-                let range_end = min_available_tx;
-                info!(
-                    "pruning table {} in transaction range: [{lowest_unpruned_key}..{range_end})",
-                    self.table.as_ref()
-                );
-                Box::new(
-                    (lowest_unpruned_key..range_end)
-                        .step_by(MAX_TRANSACTIONS_PER_PRUNE_BATCH as usize)
-                        .map(move |start| {
-                            let end = (start + MAX_TRANSACTIONS_PER_PRUNE_BATCH).min(range_end);
-                            PruningChunk::TransactionRange(start, end - 1)
-                        }),
-                )
-            }
-            PruningStrategy::ByGlobalSeq => {
-                let range_end = min_available_tx;
-                info!(
-                    "pruning table {} by global_sequence_number in range: [{lowest_unpruned_key}..{range_end})",
-                    self.table.as_ref()
-                );
-                Box::new(
-                    (lowest_unpruned_key..range_end)
-                        .step_by(MAX_TRANSACTIONS_PER_PRUNE_BATCH as usize)
-                        .map(move |start| {
-                            let end = (start + MAX_TRANSACTIONS_PER_PRUNE_BATCH).min(range_end);
-                            PruningChunk::GlobalSeqRange(start, end - 1)
-                        }),
-                )
-            }
-            PruningStrategy::ByCheckpointWithLimit => {
-                let range_end = min_available_cp;
-                info!(
-                    "pruning table {} in checkpoint range (with limit): [{lowest_unpruned_key}..{range_end})",
-                    self.table.as_ref()
-                );
-                Box::new(
-                    (lowest_unpruned_key..range_end)
-                        .step_by(MAX_CHECKPOINTS_PER_PRUNE_BATCH as usize)
-                        .map(move |start| {
-                            let end = (start + MAX_CHECKPOINTS_PER_PRUNE_BATCH).min(range_end);
-                            PruningChunk::CheckpointRangeWithLimit(start, end - 1)
-                        }),
-                )
-            }
-        }
+        let range_end = strategy.range_end(watermark);
+        let batch_size = if strategy.is_batched() {
+            self.pruning_batch_size
+        } else {
+            1
+        };
+        info!(
+            "pruning table {} ({strategy:?}) in range: [{lowest_unpruned_key}..{range_end})",
+            self.table.as_ref(),
+        );
+        (lowest_unpruned_key..range_end)
+            .step_by(batch_size as usize)
+            .map(move |start| {
+                let end = (start + batch_size).min(range_end) - 1;
+                (start, end)
+            })
     }
 
     /// Waits for the pruning delay to ensure in-flight reads complete or
@@ -403,7 +332,7 @@ impl<'a> TablePruner<'a> {
         // The watermark timestamp indicates when data was marked for pruning.
         // We delay pruning to allow any reads accessing this data to complete or
         // timeout.
-        let pruning_allowed_timestamp_ms = watermark_timestamp_ms as u64 + PRUNING_DELAY_MS;
+        let pruning_allowed_timestamp_ms = watermark_timestamp_ms as u64 + self.pruning_delay_ms;
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -416,7 +345,7 @@ impl<'a> TablePruner<'a> {
                 wait_duration.as_millis(),
                 self.table.as_ref(),
                 watermark_timestamp_ms,
-                PRUNING_DELAY_MS
+                self.pruning_delay_ms,
             );
 
             self.cancel
@@ -434,21 +363,22 @@ impl<'a> TablePruner<'a> {
         Ok(())
     }
 
-    /// Prune data based on the specified chunk
-    async fn prune_by_chunk(&self, chunk: PruningChunk) -> Result<(), IndexerError> {
-        match chunk {
-            PruningChunk::Epoch(epoch) => {
-                // Drop the partition for this epoch
-                self.partition_manager
-                    .drop_table_partition(self.table.as_ref().to_string(), epoch)?;
-                info!(
-                    "dropped epoch {epoch} partition for table {}",
-                    self.table.as_ref()
-                );
+    /// Prune the inclusive range `[start..=end]` using the table's pruning
+    /// strategy.
+    async fn prune_by_chunk(&self, start: u64, end: u64) -> Result<(), IndexerError> {
+        match self.table.pruning_strategy() {
+            PruningStrategy::ByEpochPartition => {
+                for epoch in start..=end {
+                    self.partition_manager
+                        .drop_table_partition(self.table.as_ref().to_string(), epoch)?;
+                    info!(
+                        "dropped epoch {epoch} partition for table {}",
+                        self.table.as_ref()
+                    );
+                }
             }
 
-            PruningChunk::CheckpointRange(start, end) => {
-                // Prune by checkpoint range
+            PruningStrategy::ByCheckpoint => {
                 if let Err(e) = self
                     .store
                     .prune_table_by_checkpoint_range(&self.table, start, end)
@@ -465,8 +395,7 @@ impl<'a> TablePruner<'a> {
                 );
             }
 
-            PruningChunk::TransactionRange(start, end) => {
-                // Prune by transaction range
+            PruningStrategy::ByTransaction => {
                 if let Err(e) = self
                     .store
                     .prune_table_by_tx_range(&self.table, start, end)
@@ -483,11 +412,11 @@ impl<'a> TablePruner<'a> {
                 );
             }
 
-            PruningChunk::GlobalSeqRange(start, end) => {
+            PruningStrategy::ByGlobalSeq => {
                 self.prune_by_global_seq_with_limit(start, end).await?;
             }
 
-            PruningChunk::CheckpointRangeWithLimit(start, end) => {
+            PruningStrategy::ByCheckpointWithLimit => {
                 self.prune_by_checkpoint_with_limit(start, end).await?;
             }
         }
@@ -501,18 +430,14 @@ impl<'a> TablePruner<'a> {
         start: u64,
         end: u64,
     ) -> Result<(), IndexerError> {
+        let row_limit = self.pruning_batch_size;
         loop {
             let deleted = self
                 .store
-                .prune_table_by_global_seq_with_limit(
-                    &self.table,
-                    start,
-                    end,
-                    MAX_TRANSACTIONS_PER_PRUNE_BATCH as i64,
-                )
+                .prune_table_by_global_seq_with_limit(&self.table, start, end, row_limit as i64)
                 .await?;
 
-            if deleted < MAX_TRANSACTIONS_PER_PRUNE_BATCH as usize {
+            if deleted < row_limit as usize {
                 info!(
                     "finished pruning table {} for global_seq range [{start}..={end}]",
                     self.table.as_ref(),
@@ -538,18 +463,14 @@ impl<'a> TablePruner<'a> {
         start: u64,
         end: u64,
     ) -> Result<(), IndexerError> {
+        let row_limit = self.pruning_batch_size;
         loop {
             let deleted = self
                 .store
-                .prune_table_by_checkpoint_with_limit(
-                    &self.table,
-                    start,
-                    end,
-                    MAX_CHECKPOINTS_PER_PRUNE_BATCH as i64,
-                )
+                .prune_table_by_checkpoint_with_limit(&self.table, start, end, row_limit as i64)
                 .await?;
 
-            if deleted < MAX_CHECKPOINTS_PER_PRUNE_BATCH as usize {
+            if deleted < row_limit as usize {
                 info!(
                     "finished pruning table {} for checkpoint range [{start}..={end}]",
                     self.table.as_ref(),
@@ -575,6 +496,8 @@ impl Pruner {
     pub fn new(
         store: PgIndexerStore,
         retention_config: RetentionConfig,
+        pruning_delay_ms: u64,
+        pruning_batch_size: u64,
         metrics: IndexerMetrics,
     ) -> Result<Self, IndexerError> {
         let blocking_cp = PrimaryWorker::pg_blocking_cp(store.clone()).unwrap();
@@ -585,6 +508,8 @@ impl Pruner {
             store,
             partition_manager,
             retention_policies,
+            pruning_delay_ms,
+            pruning_batch_size,
             metrics,
         })
     }
@@ -603,6 +528,8 @@ impl Pruner {
         for table in PrunableTable::iter() {
             let store_clone = self.store.clone();
             let partition_manager_clone = self.partition_manager.clone();
+            let pruning_delay_ms = self.pruning_delay_ms;
+            let pruning_batch_size = self.pruning_batch_size;
             let metrics_clone = self.metrics.clone();
             let cancel_clone = cancel.clone();
 
@@ -611,6 +538,8 @@ impl Pruner {
                     table,
                     &store_clone,
                     &partition_manager_clone,
+                    pruning_delay_ms,
+                    pruning_batch_size,
                     &metrics_clone,
                     cancel_clone,
                 );

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -321,7 +321,7 @@ impl<'a> TablePruner<'a> {
         (lowest_unpruned_key..range_end)
             .step_by(batch_size as usize)
             .map(move |start| {
-                let end = (start + batch_size).min(range_end) - 1;
+                let end = (start + batch_size).min(range_end).saturating_sub(1);
                 (start, end)
             })
     }
@@ -379,16 +379,9 @@ impl<'a> TablePruner<'a> {
             }
 
             PruningStrategy::ByCheckpoint => {
-                if let Err(e) = self
-                    .store
+                self.store
                     .prune_table_by_checkpoint_range(&self.table, start, end)
-                    .await
-                {
-                    error!(
-                        "failed to prune table {} for checkpoint range [{start}..={end}]: {e}",
-                        self.table.as_ref(),
-                    );
-                }
+                    .await?;
                 info!(
                     "pruned table {} for checkpoint range [{start}..={end}]",
                     self.table.as_ref(),
@@ -396,16 +389,9 @@ impl<'a> TablePruner<'a> {
             }
 
             PruningStrategy::ByTransaction => {
-                if let Err(e) = self
-                    .store
+                self.store
                     .prune_table_by_tx_range(&self.table, start, end)
-                    .await
-                {
-                    error!(
-                        "failed to prune table {} for transaction range [{start}..={end}]: {e}",
-                        self.table.as_ref(),
-                    );
-                }
+                    .await?;
                 info!(
                     "pruned table {} for transaction range [{start}..={end}]",
                     self.table.as_ref(),

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -20,6 +20,9 @@ use crate::{
     store::{PgIndexerAnalyticalStore, PgIndexerStore},
 };
 
+/// Shorter pruning delay used by the test indexer.
+const TEST_PRUNING_DELAY_MS: u64 = 1000; // 1 second
+
 /// Type to create hooks to alter initial indexer DB state in tests.
 /// Those hooks are meant to be called after DB reset (if it occurs) and before
 /// indexer is started.
@@ -64,6 +67,8 @@ pub enum IndexerTypeConfig {
     },
     Writer {
         retention_config: Option<RetentionConfig>,
+        pruning_delay_ms: u64,
+        pruning_batch_size: u64,
     },
     AnalyticalWorker,
 }
@@ -76,12 +81,13 @@ impl IndexerTypeConfig {
     }
 
     pub fn writer_mode(pruning_options: Option<PruningOptions>) -> Self {
+        let opts = pruning_options.unwrap_or_default();
         Self::Writer {
-            retention_config: pruning_options.as_ref().and_then(|pruning_options| {
-                pruning_options
-                    .epochs_to_keep
-                    .map(RetentionConfig::new_with_default_retention_only_for_testing)
-            }),
+            retention_config: opts
+                .epochs_to_keep
+                .map(RetentionConfig::new_with_default_retention_only_for_testing),
+            pruning_delay_ms: TEST_PRUNING_DELAY_MS,
+            pruning_batch_size: opts.pruning_batch_size,
         }
     }
 }
@@ -166,7 +172,11 @@ pub async fn start_test_indexer_impl(
                 .await
             })
         }
-        IndexerTypeConfig::Writer { retention_config } => {
+        IndexerTypeConfig::Writer {
+            retention_config,
+            pruning_delay_ms,
+            pruning_batch_size,
+        } => {
             let fullnode_rpc_url = rpc_url.parse::<Url>().unwrap();
             let store_clone = store.clone();
             let mut ingestion_config = IngestionConfig::default();
@@ -180,6 +190,8 @@ pub async fn start_test_indexer_impl(
                     store_clone,
                     indexer_metrics,
                     retention_config,
+                    pruning_delay_ms,
+                    pruning_batch_size,
                     cancel,
                 )
                 .await

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1000,8 +1000,7 @@ async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
         None,
         Some(PruningOptions {
             epochs_to_keep: Some(1),
-            pruning_config_path: None,
-            optimistic_pruner_batch_size: None,
+            ..Default::default()
         }),
     )
     .await;


### PR DESCRIPTION
# Description of change

This PR simplifies pruner logic and also cleans up a few things:

- replaces the PruningChunk enum with `(start, end)` tuples, so create_pruning_chunks has a single batching loop instead of one per strategy.
- removes hardcoded and feature dependent constants, replaced with `--pruning-delay-ms` and `--pruning-batch-size` (and matching env vars), passed from CLI down to the Pruner.
- sets v1.29.0 as the removal release for the deprecated `--optimistic-pruner-batch-size` argument. (removal issue https://github.com/iotaledger/iota/issues/11847)

## Links to any relevant issues

fixes #11381

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: added `--pruning-delay-ms` and `--pruning-batch-size` arguments (also configurable via `PRUNING_DELAY_MS` and `PRUNING_BATCH_SIZE` env vars). The already deprecated `--optimistic-pruner-batch-size` argument will be removed in v1.29.0.

