### PR TITLE
feat(iota-{indexer,kvstore,rest-kv,data-ingestion}): support address-transaction relation

### DIFF
--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, path::PathBuf, time::Duration};
+use std::{collections::BTreeSet, env, path::PathBuf, time::Duration};
 
 use anyhow::{Result, anyhow};
 use iota_data_ingestion::{
@@ -10,11 +10,13 @@ use iota_data_ingestion::{
     HistoricalWriterConfig, KVStoreTaskConfig, KVStoreWorker, RelayWorker, common,
 };
 use iota_data_ingestion_core::{
-    DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, WorkerPool,
+    DataIngestionMetrics, FileProgressStore, IndexerExecutor, IngestionLimit, ReaderOptions,
+    WorkerPool,
     reader::v2::{CheckpointReaderConfig, RemoteUrl},
 };
 use iota_grpc_client::Client;
-use iota_kvstore::{BigTableClient, KvWorker};
+use iota_kvstore::{BigTableClient, KvWorker, Table};
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
@@ -37,6 +39,8 @@ struct BigTableTaskConfig {
     timeout_secs: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     emulator_host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tables: Option<BTreeSet<Table>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -54,6 +58,12 @@ struct IndexerConfig {
     path: PathBuf,
     tasks: Vec<TaskConfig>,
     progress_store_path: String,
+    /// The sequence number of the checkpoint to start ingestion from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_checkpoint: Option<CheckpointSequenceNumber>,
+    /// The inclusive sequence number of the checkpoint to end ingestion at.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_checkpoint: Option<CheckpointSequenceNumber>,
     #[serde(skip_serializing_if = "Option::is_none")]
     remote_store_url: Option<String>,
     #[serde(default = "default_remote_read_batch_size")]
@@ -193,6 +203,12 @@ async fn main() -> Result<()> {
                 executor.register(worker_pool).await?;
             }
             Task::BigTableKv(kv_config) => {
+                if let Some(start_checkpoint) = config.start_checkpoint {
+                    executor
+                        .update_watermark(task_config.name.clone(), start_checkpoint)
+                        .await?;
+                }
+
                 let client = if let Some(emulator_host) = kv_config.emulator_host {
                     std::env::set_var("BIGTABLE_EMULATOR_HOST", &emulator_host);
                     BigTableClient::new_local(
@@ -211,13 +227,23 @@ async fn main() -> Result<()> {
                     )
                     .await?
                 };
+
+                let kv_worker = match kv_config.tables.filter(|s| !s.is_empty()) {
+                    Some(tables) => KvWorker::new_selective(client, tables),
+                    None => KvWorker::new(client),
+                };
+
                 let worker_pool = WorkerPool::new(
-                    KvWorker { client },
+                    kv_worker,
                     task_config.name,
                     task_config.concurrency,
                     Default::default(),
                 );
                 executor.register(worker_pool).await?;
+
+                if let Some(end_checkpoint) = config.end_checkpoint {
+                    executor.with_ingestion_limit(IngestionLimit::MaxCheckpoint(end_checkpoint));
+                }
             }
             Task::Kv(kv_config) => {
                 let worker_pool = WorkerPool::new(

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -3,7 +3,7 @@
 
 //! Module containing the client for interacting with the REST API KV server.
 
-use std::time::Duration;
+use std::{fmt::Display, num::NonZeroUsize, time::Duration};
 
 use bytes::Bytes;
 use futures::{
@@ -13,7 +13,7 @@ use futures::{
 use iota_sdk_types::ObjectId;
 use iota_storage::http_key_value_store::{ItemType, Key};
 use iota_types::{
-    base_types::SequenceNumber,
+    base_types::{IotaAddress, SequenceNumber},
     digests::{CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     messages_checkpoint::{
@@ -37,7 +37,11 @@ use crate::{
     historical_fallback::metrics::HistoricalFallbackClientMetrics,
 };
 
-const CACHE_TIME_TO_IDLE: Duration = Duration::from_secs(600);
+pub(crate) const CACHE_TIME_TO_IDLE: Duration = Duration::from_secs(600);
+
+/// Represents the sequence number of a transaction.
+pub type TransactionSequenceNumber = u64;
+
 /// Request payload for multi_get containing list of keys.
 #[derive(Serialize, Debug)]
 struct MultiGetRequest {
@@ -127,6 +131,41 @@ pub(crate) trait KeyValueStoreClient {
         object_refs: &[(ObjectId, SequenceNumber)],
         before_version: bool,
     ) -> IndexerResult<Vec<Option<Object>>>;
+}
+
+/// Paginated reads against the historical KV store.
+///
+/// Provides an interface for retrieving ordered subsets of values associated
+/// with a single primary key. Distinct from [`KeyValueStoreClient`], which
+/// is designed for point lookups.
+#[async_trait::async_trait]
+pub(crate) trait PaginatedKeyValueStoreClient {
+    /// Fetches a paginated list of transaction digests that affect a given
+    /// address.
+    ///
+    /// An address is considered "affected" by a transaction if it appears
+    /// as the sender, a recipient, or the gas payer.
+    ///
+    /// # Pagination
+    ///
+    /// * **Cursor:** The `cursor` is an *exclusive* boundary. Pass `None` to
+    ///   fetch the first page. For subsequent pages, provide the
+    ///   [`TransactionSequenceNumber`] from the last item of the previous
+    ///   result.
+    /// * **Limit:** The `limit` is the maximum number of items per page. The
+    ///   actual result may contain fewer items than requested.
+    /// * **Ordering:**
+    ///   - `oldest_first = false` (default): newest to oldest.
+    ///   - `oldest_first = true`: oldest to newest.
+    ///
+    /// The `cursor` semantics remain exclusive regardless of scan direction.
+    async fn transaction_digests_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionSequenceNumber>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> IndexerResult<Vec<(TransactionSequenceNumber, TransactionDigest)>>;
 }
 
 #[derive(Clone)]
@@ -277,6 +316,75 @@ impl HttpRestKVClient {
         let bytes = resp.bytes().await?;
         bcs::from_bytes::<Vec<Option<Bytes>>>(&bytes).map_err(|e| {
             IndexerError::Serde(format!("failed to deserialize multi_get response: {e:?}"))
+        })
+    }
+
+    /// Fetches a paginated list of items from a range-query endpoint.
+    ///
+    /// This method performs a one-to-many lookup, retrieving a paginated list
+    /// of records associated with the given `key`.
+    ///
+    /// # Pagination Logic
+    ///
+    /// * **Cursor-based:** The `cursor` is an *exclusive* boundary. When
+    ///   requesting the first page, pass `None`. For subsequent pages, use the
+    ///   cursor identifier from the last item of the previous result set.
+    /// * **Limits:** The `limit` enforces an upper bound on items returned.
+    /// * **Reversed:** The `reversed` flag determines the scan direction.
+    ///   - `false` (default): Follows the natural storage order of the `Key`.
+    ///   - `true`: Attempts to reverse the scan direction.
+    async fn paginate<C, T>(
+        &self,
+        key: Key,
+        cursor: Option<C>,
+        limit: impl TryInto<NonZeroUsize>,
+        reversed: bool,
+    ) -> IndexerResult<Vec<T>>
+    where
+        C: Display,
+        T: for<'de> Deserialize<'de>,
+    {
+        let limit = limit.try_into().map_err(|_| {
+            IndexerError::HistoricalFallbackInput("limit must be greater than 0".into())
+        })?;
+
+        let (item_type, encoded_key) = key.to_path_elements();
+        let mut url = self.base_url.join(&format!("{item_type}/{encoded_key}"))?;
+
+        url.query_pairs_mut()
+            .append_pair("limit", &limit.get().to_string());
+
+        if let Some(cursor) = cursor {
+            url.query_pairs_mut()
+                .append_pair("cursor", &cursor.to_string());
+        }
+
+        if reversed {
+            url.query_pairs_mut().append_pair("oldest_first", "true");
+        }
+
+        trace!("fetching from url: {url}");
+
+        let resp = self.client.get(url.clone()).send().await?;
+
+        trace!(
+            "got response {} for url: {url}, len: {:?}",
+            resp.status(),
+            resp.headers()
+                .get(CONTENT_LENGTH)
+                .unwrap_or(&HeaderValue::from_static("0"))
+        );
+
+        if !resp.status().is_success() {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "multi_fetch request failed with status: {}",
+                resp.status()
+            )));
+        }
+
+        let bytes = resp.bytes().await?;
+        bcs::from_bytes::<Vec<T>>(&bytes).map_err(|e| {
+            IndexerError::Serde(format!("failed to deserialize paginated response: {e:?}"))
         })
     }
 
@@ -615,5 +723,25 @@ impl KeyValueStoreClient for HttpRestKVClient {
             .collect();
 
         Ok(objects)
+    }
+}
+
+#[async_trait::async_trait]
+impl PaginatedKeyValueStoreClient for HttpRestKVClient {
+    #[instrument(level = "trace", skip_all)]
+    async fn transaction_digests_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionSequenceNumber>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> IndexerResult<Vec<(TransactionSequenceNumber, TransactionDigest)>> {
+        self.paginate(
+            Key::TransactionDigestsByAddress(address),
+            cursor,
+            limit,
+            oldest_first,
+        )
+        .await
     }
 }

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -15,7 +15,7 @@ use futures::future;
 use iota_json_rpc_types::{CheckpointId, IotaEvent};
 use iota_sdk_types::ObjectId;
 use iota_types::{
-    base_types::SequenceNumber,
+    base_types::{IotaAddress, SequenceNumber},
     digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
     event::EventID,
@@ -26,12 +26,16 @@ use iota_types::{
     object::Object,
 };
 use itertools::{Either, Itertools, izip};
+use moka::sync::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
 use prometheus::Registry;
 
 use crate::{
     errors::{IndexerError, IndexerResult},
     historical_fallback::{
-        client::{HttpRestKVClient, KeyValueStoreClient},
+        client::{
+            CACHE_TIME_TO_IDLE, HttpRestKVClient, KeyValueStoreClient,
+            PaginatedKeyValueStoreClient, TransactionSequenceNumber,
+        },
         convert::{
             HistoricalFallbackCheckpoint, HistoricalFallbackEvents, HistoricalFallbackTransaction,
         },
@@ -62,6 +66,9 @@ pub(crate) struct HistoricalFallbackReader {
     /// storage through REST API interface.
     client: HttpRestKVClient,
     package_resolver: PackageResolver,
+    /// Caches transaction sequence numbers to enable efficient pagination
+    /// cursors for "transactions by address" queries.
+    pub(crate) cursor_cache: MokaCache<TransactionDigest, TransactionSequenceNumber>,
 }
 
 impl HistoricalFallbackReader {
@@ -80,9 +87,15 @@ impl HistoricalFallbackReader {
             fallback_kv_concurrent_fetches,
             HistoricalFallbackClientMetrics::new(registry),
         )?;
+
+        let cursor_cache = MokaCacheBuilder::new(cache_size)
+            .time_to_idle(CACHE_TIME_TO_IDLE)
+            .build();
+
         Ok(Self {
             client,
             package_resolver,
+            cursor_cache,
         })
     }
 
@@ -497,5 +510,86 @@ impl HistoricalFallbackReader {
         };
 
         Ok(events)
+    }
+
+    /// Resolves the sequence number for a given [`TransactionDigest`] by
+    /// retrieving its corresponding checkpoint data from the fallback storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IndexerError::HistoricalFallbackInput`] when the checkpoint
+    /// data associated with the digest is not found in the historical fallback
+    /// store.
+    ///
+    /// # Panics
+    ///
+    /// If the resolved checkpoint's contents do not contain the digest,
+    /// which would indicate inconsistency between the historical store's index
+    /// and its checkpoint contents.
+    async fn resolve_transaction_sequence_number(
+        &self,
+        digest: TransactionDigest,
+    ) -> IndexerResult<TransactionSequenceNumber> {
+        let checkpoints = self.resolve_checkpoints(&[digest]).await?;
+        let (summary, contents) = checkpoints.get(&digest).cloned().ok_or_else(|| {
+            IndexerError::HistoricalFallbackInput(format!(
+                "checkpoint summary and contents linked to transaction: {digest} not found",
+            ))
+        })?;
+
+        let transaction_sequence_number = contents
+            .enumerate_transactions(&summary)
+            .find_map(|(seq, ed)| (ed.transaction == digest).then_some(seq))
+            .expect(
+                "historical fallback store inconsistency: checkpoint resolved via transaction digest does not contain the transaction digest in its contents",
+            );
+
+        Ok(transaction_sequence_number)
+    }
+
+    /// Fetches a paginated list of transaction digests that affect a given
+    /// address.
+    pub(crate) async fn paginate_transaction_digests_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> IndexerResult<Vec<TransactionDigest>> {
+        let cursor = match cursor {
+            Some(digest) => match self.cursor_cache.get(&digest) {
+                Some(tx_sequence_number) => Some(tx_sequence_number),
+                None => Some(self.resolve_transaction_sequence_number(digest).await?),
+            },
+            None => None,
+        };
+
+        let pairs = self
+            .client
+            .transaction_digests_by_address(address, cursor, limit, oldest_first)
+            .await?;
+
+        Ok(pairs
+            .into_iter()
+            .map(|(seq, digest)| {
+                self.cursor_cache.insert(digest, seq);
+                digest
+            })
+            .collect())
+    }
+
+    /// Fetches a paginated list of transactions that affect a given address.
+    pub(crate) async fn transactions_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> IndexerResult<Vec<Option<StoredTransaction>>> {
+        let digests = self
+            .paginate_transaction_digests_by_address(address, cursor, limit, oldest_first)
+            .await?;
+
+        self.transactions(&digests).await
     }
 }

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -136,6 +136,17 @@ pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePac
 
 // Impl for common initialization and utilities
 impl IndexerReader {
+    /// Tables consulted by the `FromOrToAddress` query path.
+    ///
+    /// The reader raises [`IndexerError::DataPruned`] when a requested
+    /// `tx_sequence_number` is below the `min_available_tx` across these
+    /// tables.
+    const TRANSACTIONS_BY_ADDRESS_TABLES: &[CommitterTables] = &[
+        CommitterTables::TxSenders,
+        CommitterTables::TxRecipients,
+        CommitterTables::Transactions,
+    ];
+
     pub fn new(pool: ConnectionPool, watermark_cache: WatermarkCache) -> Self {
         let indexer_store_pkg_resolver = IndexerStorePackageResolver::new(pool.clone());
         let package_cache = PackageStoreWithLruCache::new(indexer_store_pkg_resolver);
@@ -242,6 +253,17 @@ impl IndexerReader {
             }
         }
         Ok(())
+    }
+
+    /// Returns the lowest transaction sequence number that is available across
+    /// the tables consulted by the affected-addresses query path.
+    ///
+    /// Returns `0` when no watermarks have been populated yet (treat as "no
+    /// pruning observed").
+    pub(crate) fn affected_addresses_tx_watermark(&self) -> i64 {
+        self.watermark_cache()
+            .get_lowest_available_tx_for_tables(Self::TRANSACTIONS_BY_ADDRESS_TABLES)
+            .unwrap_or(0)
     }
 
     pub async fn spawn_blocking<F, R, E>(&self, f: F) -> Result<R, E>
@@ -904,27 +926,6 @@ impl IndexerReader {
         Ok(tx_blocks)
     }
 
-    fn multi_get_transactions_with_sequence_numbers(
-        &self,
-        tx_sequence_numbers: &[i64],
-        // Some(true) for desc, Some(false) for asc, None for undefined order
-        is_descending: Option<bool>,
-    ) -> Result<Vec<StoredTransaction>, IndexerError> {
-        let mut query = transactions::table
-            .filter(transactions::tx_sequence_number.eq_any(tx_sequence_numbers))
-            .into_boxed();
-        match is_descending {
-            Some(true) => {
-                query = query.order(transactions::dsl::tx_sequence_number.desc());
-            }
-            Some(false) => {
-                query = query.order(transactions::dsl::tx_sequence_number.asc());
-            }
-            None => (),
-        }
-        run_query!(&self.pool, |conn| query.load::<StoredTransaction>(conn))
-    }
-
     pub fn multi_get_transactions_by_sequence_numbers_range(
         &self,
         min_seq: i64,
@@ -1203,6 +1204,89 @@ impl IndexerReader {
             .await
     }
 
+    /// Fetches a paginated list of transactions that affect a given address,
+    /// using the fallback storage if the database is pruned.
+    async fn query_transactions_by_affected_addresses_with_fallback(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let watermark = self.affected_addresses_tx_watermark();
+
+        // fast path: cursor is known to KV (cached) and in pruned territory
+        // (below watermark). Serve directly from KV until pagination crosses
+        // into the unpruned DB range.
+        if let Some((cursor, kv_reader)) = cursor.zip(self.fallback_reader()).filter(|(c, kv)| {
+            kv.cursor_cache
+                .get(c)
+                .is_some_and(|s| (s as i64) < watermark)
+        }) {
+            let stored_txs = kv_reader
+                .transactions_by_address(address, Some(cursor), limit, !is_descending)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect();
+
+            return self
+                .stored_transaction_to_transaction_block(stored_txs, options)
+                .await;
+        };
+
+        let db_res = self
+            .db()
+            .query_transactions_by_affected_addresses(address, cursor, limit, is_descending)
+            .await;
+
+        let Some(kv_reader) = self.fallback_reader() else {
+            return self
+                .stored_transaction_to_transaction_block(db_res?, options)
+                .await;
+        };
+
+        let (mut rows, id_db_pruned) = match db_res {
+            Err(IndexerError::DataPruned(_)) => (vec![], true),
+            res => (res?, false),
+        };
+
+        // Fill from KV: either the whole page (`id_db_pruned`) or a top-up when
+        // a short DESC page during active pruning indicates we've crossed the
+        // watermark.
+        if id_db_pruned || (is_descending && rows.len() < limit && watermark > 0) {
+            // Continue pagination from the last DB row, or from the original
+            // cursor if the DB returned nothing. Avoids restarting KV from the
+            // top of history and re-fetching rows the user already saw.
+            let kv_cursor = if let Some(tx) = rows.last() {
+                let digest =
+                    TransactionDigest::from_bytes(&tx.transaction_digest).map_err(|e| {
+                        IndexerError::PersistentStorageDataCorruption(format!(
+                            "failed to decode transaction digest: {:?} with err: {e:?}",
+                            tx.transaction_digest
+                        ))
+                    })?;
+                kv_reader
+                    .cursor_cache
+                    .insert(digest, tx.tx_sequence_number as u64);
+                Some(digest)
+            } else {
+                cursor
+            };
+
+            let kv_rows = kv_reader
+                .transactions_by_address(address, kv_cursor, limit - rows.len(), !is_descending)
+                .await?
+                .into_iter()
+                .flatten();
+            rows.extend(kv_rows);
+        }
+
+        self.stored_transaction_to_transaction_block(rows, options)
+            .await
+    }
+
     async fn query_transaction_blocks_impl_with_checkpointed_data_only(
         &self,
         filter: Option<TransactionFilterKind>,
@@ -1217,6 +1301,20 @@ impl IndexerReader {
             return self
                 .query_transactions_by_checkpoint_seq_with_fallback(
                     seq,
+                    cursor,
+                    limit,
+                    is_descending,
+                    options,
+                )
+                .await;
+        };
+
+        if let Some(TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { addr }))
+        | Some(TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { addr })) = filter
+        {
+            return self
+                .query_transactions_by_affected_addresses_with_fallback(
+                    addr,
                     cursor,
                     limit,
                     is_descending,
@@ -1267,7 +1365,9 @@ impl IndexerReader {
         let (table_name, main_where_clause) = match filter {
             // Processed above
             Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(_)))
-            | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(_))) => {
+            | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(_)))
+            | Some(TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { .. }))
+            | Some(TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { .. })) => {
                 unreachable!("handled in earlier match statement")
             }
             // FIXME: sanitize module & function
@@ -1371,28 +1471,6 @@ impl IndexerReader {
                     ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
                     LIMIT {limit}) AS inner_query
                     ",
-                );
-                (inner_query, "1 = 1".into())
-            }
-            Some(TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { addr }))
-            | Some(TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { addr })) => {
-                let address = Hex::encode(addr.as_bytes());
-                let inner_query = format!(
-                    "( \
-                        ( \
-                            SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_senders \
-                            WHERE sender = '\\x{address}'::BYTEA {cursor_clause} \
-                            ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
-                            LIMIT {limit} \
-                        ) \
-                        UNION \
-                        ( \
-                            SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_recipients \
-                            WHERE recipient = '\\x{address}'::BYTEA {cursor_clause} \
-                            ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
-                            LIMIT {limit} \
-                        ) \
-                    ) AS combined",
                 );
                 (inner_query, "1 = 1".into())
             }
@@ -1546,15 +1624,8 @@ impl IndexerReader {
         is_descending: Option<bool>,
     ) -> Result<Vec<iota_json_rpc_types::IotaTransactionBlockResponse>, IndexerError> {
         let stored_txes: Vec<StoredTransaction> = self
-            .spawn_blocking({
-                let tx_sequence_numbers = tx_sequence_numbers.clone();
-                move |this| {
-                    this.multi_get_transactions_with_sequence_numbers(
-                        &tx_sequence_numbers,
-                        is_descending,
-                    )
-                }
-            })
+            .db()
+            .get_transactions_by_sequence_numbers(tx_sequence_numbers.clone(), is_descending)
             .await?;
 
         let fetched_transactions = match self
@@ -3163,6 +3234,152 @@ impl<'a> DBReader<'a> {
                 })
             })
             .collect()
+    }
+
+    /// Returns a list of [`StoredTransaction`]s by their corresponding sequence
+    /// numbers.
+    ///
+    /// `is_descending` controls the result order by `tx_sequence_number`:
+    /// - `true` or `Some(true)` for DESC.
+    /// - `false` or `Some(false)` for ASC.
+    /// - `None` for unspecified order (rows returned in whatever order the DB
+    ///   yields).
+    async fn get_transactions_by_sequence_numbers<I>(
+        &self,
+        tx_sequence_numbers: I,
+        is_descending: impl Into<Option<bool>>,
+    ) -> IndexerResult<Vec<StoredTransaction>>
+    where
+        I: IntoIterator<Item = i64> + Send,
+        I::IntoIter: Send,
+    {
+        let mut query = transactions::table
+            .filter(transactions::tx_sequence_number.eq_any(tx_sequence_numbers.into_iter()))
+            .into_boxed();
+        match is_descending.into() {
+            Some(true) => {
+                query = query.order(transactions::dsl::tx_sequence_number.desc());
+            }
+            Some(false) => {
+                query = query.order(transactions::dsl::tx_sequence_number.asc());
+            }
+            None => (),
+        }
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, |conn| query.load::<StoredTransaction>(conn))
+    }
+
+    /// Returns a list of [`StoredTransaction`]s that have a given address as
+    /// sender or recipient.
+    ///
+    /// Enforces data retention policies by consulting the pruning watermark for
+    /// the underlying index tables
+    /// [`TRANSACTIONS_BY_ADDRESS_TABLES`](IndexerReader::TRANSACTIONS_BY_ADDRESS_TABLES)
+    ///
+    /// # Errors
+    ///
+    /// * [`IndexerError::DataPruned`] — signals the caller to fall back to the
+    ///   historical store. Two triggers:
+    ///   * `cursor` resolves to a sequence number below the pruning
+    ///     min_available_tx.
+    ///   * `cursor = None && is_descending = false && min_available_tx > 0`:
+    ///     the DB cannot tell whether the address has pre-watermark history.
+    /// * [`IndexerError::InvalidArgument`]: the cursor is invalid (digest
+    ///   absent from `tx_digests` AND the database is not pruned).
+    async fn query_transactions_by_affected_addresses(
+        &self,
+        addr: IotaAddress,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let min_available_tx = self.main_reader.affected_addresses_tx_watermark();
+
+        let cursor_tx_seq = if let Some(cursor) = cursor {
+            match self
+                .resolve_cursor_tx_digest_to_seq_num_maybe(cursor)
+                .await?
+            {
+                Some(tx_seq) => {
+                    self.main_reader.ensure_data_not_pruned_for_tx(
+                        tx_seq,
+                        IndexerReader::TRANSACTIONS_BY_ADDRESS_TABLES,
+                    )?;
+                    Some(tx_seq)
+                }
+                None if min_available_tx > 0 => {
+                    return Err(IndexerError::DataPruned(format!(
+                        "unable to resolve cursor digest: {cursor} potentially pruned"
+                    )));
+                }
+                None => {
+                    return Err(IndexerError::InvalidArgument(format!(
+                        "cursor with digest {cursor} not found"
+                    )));
+                }
+            }
+        } else {
+            None
+        };
+
+        if !is_descending && cursor.is_none() && min_available_tx > 0 {
+            return Err(IndexerError::DataPruned(format!(
+                "DB may be missing earliest history for address {addr} due to pruning"
+            )));
+        }
+
+        let address_hex = Hex::encode(addr.as_bytes());
+        let order = if is_descending { "DESC" } else { "ASC" };
+        let cursor_clause = if let Some(cursor_tx_seq) = cursor_tx_seq {
+            if is_descending {
+                format!("AND {TX_SEQUENCE_NUMBER_STR} < {cursor_tx_seq}")
+            } else {
+                format!("AND {TX_SEQUENCE_NUMBER_STR} > {cursor_tx_seq}")
+            }
+        } else {
+            "".into()
+        };
+
+        let query = format!(
+            "SELECT {TX_SEQUENCE_NUMBER_STR} FROM ( \
+                   ( \
+                       SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_senders \
+                       WHERE sender = '\\x{address_hex}'::BYTEA
+                       AND {TX_SEQUENCE_NUMBER_STR} >= {min_available_tx} {cursor_clause} \
+                       ORDER BY {TX_SEQUENCE_NUMBER_STR} {order} \
+                       LIMIT {limit} \
+                   ) \
+                   UNION \
+                   ( \
+                       SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_recipients \
+                       WHERE recipient = '\\x{address_hex}'::BYTEA \
+                       AND {TX_SEQUENCE_NUMBER_STR} >= {min_available_tx} {cursor_clause} \
+                       ORDER BY {TX_SEQUENCE_NUMBER_STR} {order} \
+                       LIMIT {limit} \
+                   ) \
+                ) AS combined \
+                ORDER BY {TX_SEQUENCE_NUMBER_STR} {order} \
+                LIMIT {limit}"
+        );
+
+        // using two-step query to allow partition pruning during execution for
+        // transactions table.
+        let pool = self.main_reader.get_pool();
+        let tx_sequence_numbers = run_query_async!(&pool, move |conn| {
+            diesel::sql_query(query).load::<TxSequenceNumber>(conn)
+        })?;
+
+        if tx_sequence_numbers.is_empty() {
+            return Ok(vec![]);
+        }
+
+        self.get_transactions_by_sequence_numbers(
+            tx_sequence_numbers
+                .into_iter()
+                .map(|tsn| tsn.tx_sequence_number),
+            is_descending,
+        )
+        .await
     }
 }
 

--- a/crates/iota-kvstore/init.sh
+++ b/crates/iota-kvstore/init.sh
@@ -19,7 +19,7 @@ elif [[ -n $PROJECT_ID ]]; then
   command+=(-project "$PROJECT_ID")
 fi
 
-for table in objects transactions checkpoints checkpoints_by_digest watermark; do
+for table in objects transactions checkpoints checkpoints_by_digest watermark transactions_by_address; do
   (
     set -x
     "${command[@]}" createtable $table

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -2,10 +2,19 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroUsize;
+
 use async_trait::async_trait;
-use iota_bigtable::{BigTableClient, Cell, Row};
+use iota_bigtable::{
+    BigTableClient, Cell, Row,
+    proto::bigtable::v2::{
+        RowFilter,
+        row_filter::Filter,
+        row_range::{EndKey, StartKey},
+    },
+};
 use iota_types::{
-    base_types::TransactionDigest,
+    base_types::{IotaAddress, TransactionDigest},
     digests::CheckpointDigest,
     effects::{TransactionEffects, TransactionEvents},
     full_checkpoint_content::CheckpointData,
@@ -16,6 +25,7 @@ use iota_types::{
     storage::ObjectKey,
     transaction::Transaction,
 };
+use serde::{Deserialize, Serialize};
 use tracing::error;
 
 use crate::{Checkpoint, KeyValueStoreReader, KeyValueStoreWriter, TransactionData};
@@ -24,6 +34,7 @@ pub const OBJECTS_TABLE: &str = "objects";
 pub const TRANSACTIONS_TABLE: &str = "transactions";
 pub const CHECKPOINTS_TABLE: &str = "checkpoints";
 pub const CHECKPOINTS_BY_DIGEST_TABLE: &str = "checkpoints_by_digest";
+pub const TRANSACTIONS_BY_ADDRESS_TABLE: &str = "transactions_by_address";
 
 pub const DEFAULT_COLUMN_QUALIFIER: &str = "";
 pub const CHECKPOINT_SUMMARY_COLUMN_QUALIFIER: &str = "cs";
@@ -32,6 +43,8 @@ pub const TRANSACTION_COLUMN_QUALIFIER: &str = "tx";
 pub const EFFECTS_COLUMN_QUALIFIER: &str = "fx";
 pub const EVENTS_COLUMN_QUALIFIER: &str = "evtx";
 pub const TRANSACTION_TO_CHECKPOINT: &str = "tx2c";
+
+pub type TransactionSequenceNumber = u64;
 
 #[async_trait]
 impl KeyValueStoreWriter for BigTableClient {
@@ -85,6 +98,27 @@ impl KeyValueStoreWriter for BigTableClient {
             rows.push(Row::new(transaction.digest().inner().to_vec(), cells));
         }
         self.multi_set(TRANSACTIONS_TABLE, rows)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn save_transactions_by_address<I>(&mut self, entries: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = (IotaAddress, u64, TransactionDigest)> + Send,
+        I::IntoIter: Send,
+    {
+        let rows = entries
+            .into_iter()
+            .map(|(address, seq, transaction_digest)| {
+                let key = encode_transaction_by_address_key(&address, seq.into());
+                let cells = [Cell::new(
+                    DEFAULT_COLUMN_QUALIFIER.as_bytes().into(),
+                    transaction_digest.inner().into(),
+                )];
+                Row::new(key.into(), cells.into())
+            });
+
+        self.multi_set(TRANSACTIONS_BY_ADDRESS_TABLE, rows)
             .await
             .map_err(Into::into)
     }
@@ -175,6 +209,80 @@ impl KeyValueStoreReader for BigTableClient {
         Ok(result)
     }
 
+    async fn get_transaction_digests_by_address(
+        &mut self,
+        address: IotaAddress,
+        cursor: impl Into<Option<TransactionSequenceNumber>> + Send,
+        limit: impl TryInto<NonZeroUsize> + Send,
+        order: TransactionsOrder,
+    ) -> Result<Vec<(TransactionSequenceNumber, TransactionDigest)>, Self::Error> {
+        let limit = limit
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("limit must be greater than 0"))?;
+
+        let cursor = cursor.into();
+
+        let newest = encode_transaction_by_address_key(&address, u64::MAX.into()).to_vec();
+        let oldest = encode_transaction_by_address_key(&address, 0.into()).to_vec();
+
+        let (start_key, end_key) = match (cursor, order) {
+            // no cursor: whole address block, direction handled by order.
+            (None, _) => (
+                StartKey::StartKeyClosed(newest),
+                EndKey::EndKeyClosed(oldest),
+            ),
+            // newest-first, continue past cursor: tx seq < cursor.
+            (Some(cursor), TransactionsOrder::NewestFirst) => {
+                // no transactions can have seq < 0, the scan would be empty
+                // and BigTable rejects empty ranges.
+                if cursor == 0 {
+                    return Ok(vec![]);
+                }
+                let k = encode_transaction_by_address_key(&address, cursor.into()).to_vec();
+                (StartKey::StartKeyOpen(k), EndKey::EndKeyClosed(oldest))
+            }
+            // oldest-first, continue past cursor: tx seq > cursor.
+            (Some(cursor), TransactionsOrder::OldestFirst) => {
+                // no transactions can have seq > u64::MAX, the scan would be
+                // empty and BigTable rejects empty ranges.
+                if cursor == u64::MAX {
+                    return Ok(vec![]);
+                }
+                let k = encode_transaction_by_address_key(&address, cursor.into()).to_vec();
+                (StartKey::StartKeyClosed(newest), EndKey::EndKeyOpen(k))
+            }
+        };
+
+        // row keys are encoded as `address || ReverseSequenceNumber`, so a
+        // forward scan already returns newest-first. OldestFirst requires a
+        // reverse scan.
+        let descending = matches!(order, TransactionsOrder::OldestFirst);
+
+        let rows = self
+            .range_scan(
+                TRANSACTIONS_BY_ADDRESS_TABLE,
+                Some(start_key),
+                Some(end_key),
+                limit.get(),
+                descending,
+                Some(RowFilter {
+                    filter: Some(Filter::ColumnQualifierRegexFilter(
+                        format!("^{DEFAULT_COLUMN_QUALIFIER}$").into_bytes(),
+                    )),
+                }),
+            )
+            .await?;
+
+        rows.into_iter()
+            .filter_map(|row| row.cells.into_iter().next().map(|cell| (row.key, cell)))
+            .map(|(key, cell)| -> Result<_, anyhow::Error> {
+                let (_addr, seq) = decode_transaction_by_address_key(&key)?;
+                let digest = TransactionDigest::from_bytes(&cell.value)?;
+                Ok((u64::from(seq), digest))
+            })
+            .collect()
+    }
+
     async fn get_checkpoints(
         &mut self,
         sequence_numbers: &[CheckpointSequenceNumber],
@@ -237,4 +345,145 @@ pub fn raw_object_key(object_key: &ObjectKey) -> Vec<u8> {
     let mut raw_key = object_key.0.as_bytes().to_vec();
     raw_key.extend(object_key.1.as_u64().to_be_bytes());
     raw_key
+}
+
+/// Represents the order of transactions returned by a BigTable range scan.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize,
+)]
+pub enum TransactionsOrder {
+    #[default]
+    NewestFirst,
+    OldestFirst,
+}
+
+/// A sequence number stored as its bitwise complement (`!seq`), so that
+/// BigTable's ascending lexicographic row-key order yields newest-first
+/// results on a forward range scan.
+///
+/// By storing the complement, higher original sequence numbers map to
+/// smaller byte representations and therefore sort earlier. This turns
+/// "newest first" into a cheap forward scan instead of an expensive
+/// reverse one.
+///
+/// # Conversions
+/// - `From<u64>`: produces a `ReverseSequenceNumber` holding `!seq`.
+/// - `Into<u64>`: returns the original `seq` from the wrapped `!seq`.
+/// - [`ReverseSequenceNumber::to_be_bytes`]: encodes the stored value as
+///   big-endian bytes for BigTable storage.
+/// - [`ReverseSequenceNumber::from_be_bytes`]: decodes the stored value from
+///   big-endian bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ReverseSequenceNumber(u64);
+
+impl ReverseSequenceNumber {
+    pub const LENGTH: usize = std::mem::size_of::<u64>();
+
+    /// Encodes the reversed sequence number into a big-endian byte array.
+    pub fn to_be_bytes(self) -> [u8; Self::LENGTH] {
+        self.0.to_be_bytes()
+    }
+
+    /// Decodes a reversed sequence number from a big-endian byte array.
+    pub fn from_be_bytes(bytes: [u8; Self::LENGTH]) -> Self {
+        Self(u64::from_be_bytes(bytes))
+    }
+}
+
+impl From<u64> for ReverseSequenceNumber {
+    fn from(seq: u64) -> Self {
+        Self(!seq)
+    }
+}
+impl From<ReverseSequenceNumber> for u64 {
+    fn from(rev: ReverseSequenceNumber) -> u64 {
+        !rev.0
+    }
+}
+
+/// The length of an address-to-transaction row key, in bytes.
+pub const ADDRESS_TX_KEY_LEN: usize = IotaAddress::LENGTH + ReverseSequenceNumber::LENGTH;
+
+/// Encodes a row key for the address-to-transaction index.
+///
+/// Layout: `address (32 bytes) || complement (8 bytes)`.
+///
+/// Storing the complement ensures that transactions are ordered
+/// lexicographically by descending sequence number, allowing for efficient
+/// forward scans when retrieving the most recent transactions for an address.
+///
+/// See [`decode_transaction_by_address_key`] for the inverse operation.
+pub fn encode_transaction_by_address_key(
+    address: &IotaAddress,
+    sequence_number: ReverseSequenceNumber,
+) -> [u8; ADDRESS_TX_KEY_LEN] {
+    let mut key = [0u8; ADDRESS_TX_KEY_LEN];
+    key[..IotaAddress::LENGTH].copy_from_slice(address.as_ref());
+    key[IotaAddress::LENGTH..].copy_from_slice(&sequence_number.to_be_bytes());
+    key
+}
+
+/// Decodes an address-to-transaction row key.
+///
+/// This is the inverse of [`encode_transaction_by_address_key`]. It
+/// extracts the address and restores the reversed sequence number.
+pub fn decode_transaction_by_address_key(
+    key: &[u8],
+) -> Result<(IotaAddress, ReverseSequenceNumber), anyhow::Error> {
+    anyhow::ensure!(key.len() == ADDRESS_TX_KEY_LEN, "invalid key length");
+    let address = IotaAddress::from_bytes(&key[..IotaAddress::LENGTH])?;
+    let reversed_tx_sequence =
+        ReverseSequenceNumber::from_be_bytes(key[IotaAddress::LENGTH..].try_into()?);
+    Ok((address, reversed_tx_sequence))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reverse_sequence_number_round_trips_through_bytes() {
+        for seq in [0u64, 1, 42, u64::MAX - 1, u64::MAX] {
+            let rev = ReverseSequenceNumber::from(seq);
+            let recovered = ReverseSequenceNumber::from_be_bytes(rev.to_be_bytes());
+            assert_eq!(u64::from(recovered), seq);
+        }
+    }
+
+    #[test]
+    fn transaction_sequence_number_orders_descending() {
+        // higher seq must sort earlier (smaller bytes) so forward range scans
+        // return newest transactions first.
+        let older = ReverseSequenceNumber::from(1).to_be_bytes();
+        let newer = ReverseSequenceNumber::from(2).to_be_bytes();
+        assert!(newer < older);
+
+        // boundary: u64::MAX (newest possible) sorts before 0 (oldest possible).
+        let newest = ReverseSequenceNumber::from(u64::MAX).to_be_bytes();
+        let oldest = ReverseSequenceNumber::from(0).to_be_bytes();
+        assert!(newest < oldest);
+        assert_eq!(newest, [0; 8]);
+        assert_eq!(oldest, [0xFF; 8]);
+    }
+
+    #[test]
+    fn transaction_by_address_key_encode() {
+        let address = IotaAddress::random();
+        let transaction_sequence_number = ReverseSequenceNumber::from(42);
+        let key = encode_transaction_by_address_key(&address, transaction_sequence_number);
+        assert_eq!(key[..IotaAddress::LENGTH], address.into_bytes());
+        assert_eq!(key[IotaAddress::LENGTH..], (u64::MAX - 42).to_be_bytes());
+    }
+
+    #[test]
+    fn transaction_by_address_key_decode() {
+        let address = IotaAddress::random();
+        let transaction_sequence_number = ReverseSequenceNumber::from(42);
+        let key = encode_transaction_by_address_key(&address, transaction_sequence_number);
+        let (decoded_address, decoded_sequence_number) =
+            decode_transaction_by_address_key(&key).unwrap();
+        assert_eq!(decoded_address, address);
+        assert_eq!(decoded_sequence_number, transaction_sequence_number);
+        assert_eq!(u64::from(decoded_sequence_number), 42);
+    }
 }

--- a/crates/iota-kvstore/src/bigtable/client.rs
+++ b/crates/iota-kvstore/src/bigtable/client.rs
@@ -137,14 +137,27 @@ impl KeyValueStoreWriter for BigTableClient {
                 bcs::to_bytes(contents)?,
             ),
         ];
-        let row = Row::new(key.clone(), cells);
-        self.multi_set(CHECKPOINTS_TABLE, [row]).await?;
+        let row = Row::new(key, cells);
+        self.multi_set(CHECKPOINTS_TABLE, [row])
+            .await
+            .map_err(Into::into)
+    }
 
-        let cells = vec![Cell::new(DEFAULT_COLUMN_QUALIFIER.as_bytes().to_vec(), key)];
-        let row = Row::new(
-            checkpoint.checkpoint_summary.digest().inner().to_vec(),
-            cells,
-        );
+    async fn save_checkpoint_by_digest(
+        &mut self,
+        checkpoint: &CheckpointData,
+    ) -> Result<(), Self::Error> {
+        let key = checkpoint.checkpoint_summary.digest().inner();
+
+        let value = checkpoint
+            .checkpoint_summary
+            .sequence_number()
+            .to_be_bytes();
+
+        let cells = [Cell::new(DEFAULT_COLUMN_QUALIFIER.into(), value.into())];
+
+        let row = Row::new(key.into(), cells.into());
+
         self.multi_set(CHECKPOINTS_BY_DIGEST_TABLE, [row])
             .await
             .map_err(Into::into)
@@ -318,16 +331,20 @@ impl KeyValueStoreReader for BigTableClient {
         Ok(checkpoints)
     }
 
-    async fn get_checkpoints_by_digest(
+    async fn get_checkpoint_sequence_numbers<I>(
         &mut self,
-        digests: &[CheckpointDigest],
-    ) -> Result<Vec<Checkpoint>, Self::Error> {
+        digests: I,
+    ) -> Result<Vec<CheckpointSequenceNumber>, Self::Error>
+    where
+        I: IntoIterator<Item = CheckpointDigest> + Send,
+        I::IntoIter: Send,
+    {
         let keys = digests
-            .iter()
+            .into_iter()
             .map(|digest| digest.inner().to_vec())
             .collect::<Vec<_>>();
-        let seq_nums = self
-            .multi_get(CHECKPOINTS_BY_DIGEST_TABLE, keys, None)
+
+        self.multi_get(CHECKPOINTS_BY_DIGEST_TABLE, keys, None)
             .await?
             .into_iter()
             .filter_map(|row| {
@@ -336,8 +353,20 @@ impl KeyValueStoreReader for BigTableClient {
                     .next()
                     .map(|cell| cell.value.as_slice().try_into().map(u64::from_be_bytes))
             })
-            .collect::<Result<Vec<_>, _>>()?;
-        self.get_checkpoints(&seq_nums).await
+            .collect::<Result<Vec<CheckpointSequenceNumber>, _>>()
+            .map_err(Into::into)
+    }
+
+    async fn get_checkpoints_by_digest<I>(
+        &mut self,
+        digests: I,
+    ) -> Result<Vec<Checkpoint>, Self::Error>
+    where
+        I: IntoIterator<Item = CheckpointDigest> + Send,
+        I::IntoIter: Send,
+    {
+        let sequence_numbers = self.get_checkpoint_sequence_numbers(digests).await?;
+        self.get_checkpoints(&sequence_numbers).await
     }
 }
 

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -2,11 +2,14 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
-use iota_types::full_checkpoint_content::CheckpointData;
+use iota_types::{
+    base_types::IotaAddress, effects::TransactionEffectsExt,
+    full_checkpoint_content::CheckpointData, object::Owner, transaction::TransactionDataAPI,
+};
 
 use crate::{BigTableClient, KeyValueStoreWriter, TransactionData};
 
@@ -26,6 +29,7 @@ impl Worker for KvWorker {
         let mut client = self.client.clone();
         let mut objects = vec![];
         let mut transactions = Vec::with_capacity(checkpoint.transactions.len());
+
         for transaction in &checkpoint.transactions {
             for object in &transaction.output_objects {
                 objects.push(object);
@@ -35,8 +39,36 @@ impl Worker for KvWorker {
                 checkpoint.checkpoint_summary.sequence_number,
             ));
         }
+
         client.save_objects(&objects).await?;
         client.save_transactions(&transactions).await?;
+
+        let entries_by_address = checkpoint
+            .checkpoint_contents
+            .enumerate_transactions(&checkpoint.checkpoint_summary)
+            .zip(&checkpoint.transactions)
+            .flat_map(|((seq, exec_digest), tx)| {
+                let digest = exec_digest.transaction;
+                let tx_data = tx.transaction.transaction_data();
+
+                let affected = std::iter::once(tx_data.sender())
+                    .chain(std::iter::once(tx_data.gas_owner()))
+                    .chain(tx.effects.all_changed_objects().into_iter().filter_map(
+                        |(_object_ref, owner, _write_kind)| match owner {
+                            Owner::Address(a) => Some(a),
+                            _ => None,
+                        },
+                    ))
+                    .collect::<HashSet<IotaAddress>>();
+
+                affected
+                    .into_iter()
+                    .map(move |address| (address, seq, digest))
+            });
+
+        client
+            .save_transactions_by_address(entries_by_address)
+            .await?;
         client.save_checkpoint(&checkpoint).await?;
 
         Ok(())

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
@@ -10,14 +13,116 @@ use iota_types::{
     base_types::IotaAddress, effects::TransactionEffectsExt,
     full_checkpoint_content::CheckpointData, object::Owner, transaction::TransactionDataAPI,
 };
+use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
 
 use crate::{BigTableClient, KeyValueStoreWriter, TransactionData};
+
+/// Represents the BigTable tables used by the KvWorker.
+
+// Variants are declared in write order; the BTreeSet<Table> field
+// iterates by derived Ord, which follows declaration order.
+//
+// Order matters: data tables (Objects, Transactions, Checkpoints)
+// are written before their indexes (TransactionsByAddress,
+// CheckpointsByDigest), so a reader that sees an index entry can
+// always resolve the underlying row. Reordering variants will
+// reorder writes and may break that read-after-write invariant.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    strum::EnumIter,
+)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum Table {
+    Objects,
+    Transactions,
+    TransactionsByAddress,
+    Checkpoints,
+    CheckpointsByDigest,
+}
 
 /// This worker implementation is responsible for processing checkpoints by
 /// storing its data as Key-Value pairs. The Key-Value pairs are stored in a
 /// BigTableDB.
 pub struct KvWorker {
     pub client: BigTableClient,
+    /// The tables enabled for writing by this worker.
+    pub enabled_tables: BTreeSet<Table>,
+}
+
+impl KvWorker {
+    /// Creates a new KvWorker that writes data to all tables.
+    ///
+    /// For selective writing, use [`KvWorker::new_selective`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use iota_kvstore::KvWorker;
+    /// # use iota_kvstore::{Table, BigTableClient};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost");
+    /// let client = BigTableClient::new_local("instance_id", "column_family")
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// /// Write all available tables to BigTable.
+    /// let worker = KvWorker::new(client);
+    ///
+    /// # drop(worker);
+    /// # }
+    /// ```
+    pub fn new(client: BigTableClient) -> Self {
+        Self {
+            client,
+            // All tables are enabled by default.
+            enabled_tables: Table::iter().collect(),
+        }
+    }
+
+    /// Creates a new KvWorker that writes only to the specified tables.
+    ///
+    /// # NOTE
+    /// Passing an empty iterator yields a worker that performs no writes.
+    /// Use [`KvWorker::new`] to write to all tables.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use iota_kvstore::KvWorker;
+    /// # use iota_kvstore::{Table, BigTableClient};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost");
+    /// let client = BigTableClient::new_local("instance_id", "column_family")
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// /// Write only the `Objects` table to BigTable.
+    /// let worker = KvWorker::new_selective(client, [Table::Objects]);
+    ///
+    /// # drop(worker);
+    /// # }
+    /// ```
+    pub fn new_selective(client: BigTableClient, tables: impl IntoIterator<Item = Table>) -> Self {
+        Self {
+            client,
+            enabled_tables: BTreeSet::from_iter(tables),
+        }
+    }
 }
 
 #[async_trait]
@@ -27,50 +132,63 @@ impl Worker for KvWorker {
 
     async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> anyhow::Result<()> {
         let mut client = self.client.clone();
-        let mut objects = vec![];
-        let mut transactions = Vec::with_capacity(checkpoint.transactions.len());
 
-        for transaction in &checkpoint.transactions {
-            for object in &transaction.output_objects {
-                objects.push(object);
+        for table in &self.enabled_tables {
+            match table {
+                Table::Objects => {
+                    let objects = checkpoint
+                        .transactions
+                        .iter()
+                        .flat_map(|t| &t.output_objects)
+                        .collect::<Vec<_>>();
+                    client.save_objects(&objects).await?;
+                }
+                Table::Transactions => {
+                    let transactions = checkpoint
+                        .transactions
+                        .iter()
+                        .map(|t| {
+                            TransactionData::new(t, checkpoint.checkpoint_summary.sequence_number)
+                        })
+                        .collect::<Vec<_>>();
+                    client.save_transactions(&transactions).await?;
+                }
+                Table::TransactionsByAddress => {
+                    let entries_by_address = checkpoint
+                        .checkpoint_contents
+                        .enumerate_transactions(&checkpoint.checkpoint_summary)
+                        .zip(&checkpoint.transactions)
+                        .flat_map(|((seq, exec_digest), tx)| {
+                            let digest = exec_digest.transaction;
+                            let tx_data = tx.transaction.transaction_data();
+
+                            let affected = std::iter::once(tx_data.sender())
+                                .chain(std::iter::once(tx_data.gas_owner()))
+                                .chain(tx.effects.all_changed_objects().into_iter().filter_map(
+                                    |(_object_ref, owner, _write_kind)| match owner {
+                                        Owner::Address(a) => Some(a),
+                                        _ => None,
+                                    },
+                                ))
+                                .collect::<HashSet<IotaAddress>>();
+
+                            affected
+                                .into_iter()
+                                .map(move |address| (address, seq, digest))
+                        });
+
+                    client
+                        .save_transactions_by_address(entries_by_address)
+                        .await?;
+                }
+                Table::Checkpoints => {
+                    client.save_checkpoint(&checkpoint).await?;
+                }
+                Table::CheckpointsByDigest => {
+                    client.save_checkpoint_by_digest(&checkpoint).await?;
+                }
             }
-            transactions.push(TransactionData::new(
-                transaction,
-                checkpoint.checkpoint_summary.sequence_number,
-            ));
         }
-
-        client.save_objects(&objects).await?;
-        client.save_transactions(&transactions).await?;
-
-        let entries_by_address = checkpoint
-            .checkpoint_contents
-            .enumerate_transactions(&checkpoint.checkpoint_summary)
-            .zip(&checkpoint.transactions)
-            .flat_map(|((seq, exec_digest), tx)| {
-                let digest = exec_digest.transaction;
-                let tx_data = tx.transaction.transaction_data();
-
-                let affected = std::iter::once(tx_data.sender())
-                    .chain(std::iter::once(tx_data.gas_owner()))
-                    .chain(tx.effects.all_changed_objects().into_iter().filter_map(
-                        |(_object_ref, owner, _write_kind)| match owner {
-                            Owner::Address(a) => Some(a),
-                            _ => None,
-                        },
-                    ))
-                    .collect::<HashSet<IotaAddress>>();
-
-                affected
-                    .into_iter()
-                    .map(move |address| (address, seq, digest))
-            });
-
-        client
-            .save_transactions_by_address(entries_by_address)
-            .await?;
-        client.save_checkpoint(&checkpoint).await?;
-
         Ok(())
     }
 }

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -9,9 +9,10 @@ use std::{
 
 use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
+use iota_sdk_types::Owner;
 use iota_types::{
     base_types::IotaAddress, effects::TransactionEffectsExt,
-    full_checkpoint_content::CheckpointData, object::Owner, transaction::TransactionDataAPI,
+    full_checkpoint_content::CheckpointData, transaction::TransactionDataAPI,
 };
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -2,9 +2,12 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroUsize;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use iota_types::{
+    base_types::IotaAddress,
     digests::{CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEvents},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
@@ -22,6 +25,8 @@ mod bigtable;
 
 pub use bigtable::{client, worker::KvWorker};
 pub use iota_bigtable::{BigTableClient, Cell, Row, proto};
+
+use crate::bigtable::client::{TransactionSequenceNumber, TransactionsOrder};
 
 /// Read key-value data from a persistent store, such as objects, transactions,
 /// and checkpoints.
@@ -41,6 +46,28 @@ pub trait KeyValueStoreReader {
         &mut self,
         transactions: &[TransactionDigest],
     ) -> Result<Vec<TransactionData>, Self::Error>;
+
+    /// Fetches a list `(sequence number, digest)` pairs for transactions
+    /// affecting the given address, ordered by [`TransactionsOrder`] and capped
+    /// at `limit`.
+    ///
+    /// # Pagination
+    /// `cursor` is **exclusive**.
+    ///
+    /// - [`TransactionsOrder::NewestFirst`]: returns entries with `tx_seq <
+    ///   cursor`.
+    /// - [`TransactionsOrder::OldestFirst`]: returns entries with `tx_seq >
+    ///   cursor`.
+    ///
+    /// When `None`, the scan starts from the beginning of the requested
+    /// [`TransactionsOrder`].
+    async fn get_transaction_digests_by_address(
+        &mut self,
+        address: IotaAddress,
+        cursor: impl Into<Option<TransactionSequenceNumber>> + Send,
+        limit: impl TryInto<NonZeroUsize> + Send,
+        order: TransactionsOrder,
+    ) -> Result<Vec<(TransactionSequenceNumber, TransactionDigest)>, Self::Error>;
 
     /// Fetches a list of checkpoints by their sequence numbers.
     ///
@@ -73,6 +100,16 @@ pub trait KeyValueStoreWriter {
         &mut self,
         transactions: &[TransactionData],
     ) -> Result<(), Self::Error>;
+
+    /// Persists a mapping of `(` [`IotaAddress`], `transaction_sequence_number`
+    /// `)` to `TransactionDigest` for every affected address.
+    ///
+    /// An address is considered "affected" if it appears as the sender, a
+    /// recipient, or the gas payer.
+    async fn save_transactions_by_address<I>(&mut self, entries: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = (IotaAddress, u64, TransactionDigest)> + Send,
+        I::IntoIter: Send;
 
     /// Persists a checkpoint to the store.
     async fn save_checkpoint(&mut self, checkpoint: &CheckpointData) -> Result<(), Self::Error>;

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -23,7 +23,10 @@ use serde::{Deserialize, Serialize};
 /// BigTable Key Value store implementation.
 mod bigtable;
 
-pub use bigtable::{client, worker::KvWorker};
+pub use bigtable::{
+    client,
+    worker::{KvWorker, Table},
+};
 pub use iota_bigtable::{BigTableClient, Cell, Row, proto};
 
 use crate::bigtable::client::{TransactionSequenceNumber, TransactionsOrder};
@@ -80,10 +83,24 @@ pub trait KeyValueStoreReader {
     /// Fetches a list of checkpoints by their digests.
     ///
     /// Not found checkpoints are omitted from the output list.
-    async fn get_checkpoints_by_digest(
+    async fn get_checkpoints_by_digest<I>(
         &mut self,
-        digests: &[CheckpointDigest],
-    ) -> Result<Vec<Checkpoint>, Self::Error>;
+        digests: I,
+    ) -> Result<Vec<Checkpoint>, Self::Error>
+    where
+        I: IntoIterator<Item = CheckpointDigest> + Send,
+        I::IntoIter: Send;
+
+    /// Fetches a list of checkpoint sequence numbers by their digests.
+    ///
+    /// Not found checkpoints are omitted from the output list.
+    async fn get_checkpoint_sequence_numbers<I>(
+        &mut self,
+        digests: I,
+    ) -> Result<Vec<CheckpointSequenceNumber>, Self::Error>
+    where
+        I: IntoIterator<Item = CheckpointDigest> + Send,
+        I::IntoIter: Send;
 }
 
 /// Writing key-value data to a persistent store, such as objects, transactions,
@@ -113,6 +130,13 @@ pub trait KeyValueStoreWriter {
 
     /// Persists a checkpoint to the store.
     async fn save_checkpoint(&mut self, checkpoint: &CheckpointData) -> Result<(), Self::Error>;
+
+    /// Persists a checkpoint digest to its corresponding sequence number to the
+    /// store.
+    async fn save_checkpoint_by_digest(
+        &mut self,
+        checkpoint: &CheckpointData,
+    ) -> Result<(), Self::Error>;
 }
 
 /// Represents all stored Key-Value data associated to a checkpoint containing

--- a/crates/iota-rest-kv/src/aws.rs
+++ b/crates/iota-rest-kv/src/aws.rs
@@ -8,7 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use aws_config::{BehaviorVersion, Region, timeout::TimeoutConfig};
 use aws_sdk_dynamodb::{Client, config::Credentials, primitives::Blob, types::AttributeValue};
 use bytes::Bytes;
@@ -319,6 +319,9 @@ impl KvStoreClient {
         let item_type = key.item_type().to_string();
 
         match key {
+            Key::TransactionDigestsByAddress(_address) => {
+                bail!("unsupported key");
+            }
             Key::Transaction(transaction_digest) => {
                 self.get_from_dynamodb(transaction_digest, item_type).await
             }

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -12,13 +12,13 @@ use anyhow::Result;
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt, stream};
 use iota_kvstore::{
-    BigTableClient, Cell,
+    BigTableClient, Cell, KeyValueStoreReader,
     client::{
         CHECKPOINT_CONTENTS_COLUMN_QUALIFIER, CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
         CHECKPOINTS_BY_DIGEST_TABLE, CHECKPOINTS_TABLE, DEFAULT_COLUMN_QUALIFIER,
         EFFECTS_COLUMN_QUALIFIER, EVENTS_COLUMN_QUALIFIER, OBJECTS_TABLE,
         TRANSACTION_COLUMN_QUALIFIER, TRANSACTION_TO_CHECKPOINT, TRANSACTIONS_TABLE,
-        raw_object_key,
+        TransactionSequenceNumber, TransactionsOrder, raw_object_key,
     },
     proto::bigtable::v2::{
         RowFilter,
@@ -27,7 +27,10 @@ use iota_kvstore::{
     },
 };
 use iota_storage::http_key_value_store::{ItemType, Key};
-use iota_types::{effects::TransactionEvents, storage::ObjectKey};
+use iota_types::{
+    base_types::IotaAddress, digests::TransactionDigest, effects::TransactionEvents,
+    storage::ObjectKey,
+};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -135,6 +138,9 @@ impl KvStoreClient {
 
         // Use the first key to determine the type - all keys should be of the same type
         match keys.first().expect("emptiness was checked earlier") {
+            Key::TransactionDigestsByAddress(_address) => {
+                return Err(ApiError::BadRequest("unsupported key".into()));
+            }
             Key::Transaction(_) => {
                 let digests = extract_keys(&keys, |k| match k {
                     Key::Transaction(digest) => Some(*digest),
@@ -411,6 +417,37 @@ impl KvStoreClient {
             .map(|range| self.object_before_version(range))
             .buffered(max_buffered_concurrent_futures)
             .try_collect::<Vec<Option<Bytes>>>()
+            .await
+    }
+
+    /// Fetches a list `(sequence number, digest)` pairs for transactions
+    /// affecting the given address, ordered by `oldest_first` and capped
+    /// at `limit`.
+    ///
+    /// # Pagination
+    /// `cursor` is **exclusive**.
+    ///
+    /// - oldest_first = `false`: returns entries with `tx_seq < cursor`.
+    /// - oldest_first = `true`: returns entries with `tx_seq > cursor`.
+    ///
+    /// When `None`, the scan starts from the beginning of the requested
+    /// `oldest_first` order.
+    pub async fn transactions_by_address(
+        &self,
+        address: IotaAddress,
+        cursor: Option<TransactionSequenceNumber>,
+        limit: usize,
+        oldest_first: bool,
+    ) -> Result<Vec<(TransactionSequenceNumber, TransactionDigest)>, anyhow::Error> {
+        let mut client = self.bigtable_client.clone();
+
+        let order = match oldest_first {
+            true => TransactionsOrder::OldestFirst,
+            false => TransactionsOrder::NewestFirst,
+        };
+
+        client
+            .get_transaction_digests_by_address(address, cursor, limit, order)
             .await
     }
 }

--- a/crates/iota-rest-kv/src/routes/kv_store.rs
+++ b/crates/iota-rest-kv/src/routes/kv_store.rs
@@ -1,5 +1,8 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
+use std::num::NonZeroUsize;
+
 use axum::{
     Json,
     body::Body,
@@ -7,7 +10,9 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use iota_kvstore::client::TransactionSequenceNumber;
 use iota_storage::http_key_value_store::{ItemType, Key};
+use iota_types::base_types::IotaAddress;
 use serde::Deserialize;
 
 use crate::{
@@ -161,5 +166,76 @@ pub async fn multi_get_data(
     };
 
     let bcs_data = bcs::to_bytes(&results).map_err(|_| ApiError::InternalServerError)?;
+    Ok(bcs_data.into_response())
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct TransactionDigestsByAddressQuery {
+    pub(crate) cursor: Option<TransactionSequenceNumber>,
+    pub(crate) limit: Option<NonZeroUsize>,
+    #[serde(default)]
+    pub(crate) oldest_first: bool,
+}
+
+/// Retrieves a paginated list of transactions that affect a given address.
+///
+/// An address is considered "affected" by a transaction if it appears as the
+/// sender, a recipient, or the gas payer.
+///
+/// # Path Parameters
+///
+/// * `address`: Base64-url-encoded [`IotaAddress`].
+///
+/// # Query Parameters
+///
+/// * `cursor` (optional): The [`TransactionSequenceNumber`] used as an
+///   exclusive pagination boundary. Omit for the first request.
+/// * `limit` (optional): The maximum number of results to return. Defaults to
+///   the server's configured `multiget_max_items` when omitted.
+/// * `oldest_first` (optional, default `false`):
+///   - `true`: Ascending sequence order (oldest first).
+///   - `false`: Descending sequence order (newest first).
+///
+/// # Responses
+///
+/// * `200 OK`: A BCS-encoded `Vec<(TransactionSequenceNumber,
+///   TransactionDigest)>`. Returns an empty list when no transaction digests
+///   are found in the range scan.
+/// * `400 Bad Request`: Returned if the provided `address` is malformed or
+///   invalid.
+/// * `500 Internal Server Error`: Returned if an error occurs interacting with
+///   the KV store.
+pub async fn transaction_digests_by_address(
+    State(app_state): State<SharedRestServerAppState>,
+    Path(address): Path<String>,
+    Query(query): Query<TransactionDigestsByAddressQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let address = base64_url::decode(&address)
+        .map_err(|_| ApiError::BadRequest("address is not valid base64-url".into()))?;
+
+    let address = IotaAddress::from_bytes(&address)
+        .map_err(|_| ApiError::BadRequest("invalid address".into()))?;
+
+    let TransactionDigestsByAddressQuery {
+        cursor,
+        limit,
+        oldest_first,
+    } = query;
+
+    let max_limit = app_state.multiget_max_items.get();
+    let limit = limit.map_or(max_limit, |l| l.get());
+
+    if limit > max_limit {
+        return Err(ApiError::BadRequest(format!(
+            "limit too large: maximum allowed is {max_limit}",
+        )));
+    }
+
+    let transactions = app_state
+        .kv_store_client
+        .transactions_by_address(address, cursor, limit, oldest_first)
+        .await?;
+
+    let bcs_data = bcs::to_bytes(&transactions).map_err(|_| ApiError::InternalServerError)?;
     Ok(bcs_data.into_response())
 }

--- a/crates/iota-rest-kv/src/server.rs
+++ b/crates/iota-rest-kv/src/server.rs
@@ -11,6 +11,7 @@ use axum::{
     response::IntoResponse,
     routing::{get, post},
 };
+use iota_storage::http_key_value_store::ItemType;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -46,6 +47,12 @@ impl Server {
             .route("/health", get(health::health))
             .route("/{item_type}", post(kv_store::multi_get_data))
             .route("/{item_type}/{key}", get(kv_store::data_as_bytes))
+            // static and dynamic route segments are allowed to overlap. If they do, static segments
+            // will be given higher priority.
+            .route(
+                &format!("/{}/{{address}}", ItemType::TransactionDigestsByAddress),
+                get(kv_store::transaction_digests_by_address),
+            )
             .with_state(shared_state)
             .fallback(fallback);
 

--- a/crates/iota-storage/src/http_key_value_store.rs
+++ b/crates/iota-storage/src/http_key_value_store.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use futures::stream::{self, StreamExt};
 use iota_sdk_types::ObjectId;
 use iota_types::{
-    base_types::SequenceNumber,
+    base_types::{IotaAddress, SequenceNumber},
     digests::{CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{IotaError, IotaResult},
@@ -114,6 +114,9 @@ pub enum ItemType {
     #[strum(serialize = "evtx")]
     #[serde(rename = "evtx")]
     EventTransactionDigest,
+    #[strum(serialize = "txa")]
+    #[serde(rename = "txa")]
+    TransactionDigestsByAddress,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -126,6 +129,7 @@ pub enum Key {
     TransactionToCheckpoint(TransactionDigest),
     ObjectKey(ObjectKey),
     EventsByTransactionDigest(TransactionDigest),
+    TransactionDigestsByAddress(IotaAddress),
 }
 
 impl Key {
@@ -199,6 +203,9 @@ impl Key {
             ItemType::EventTransactionDigest => Ok(Key::EventsByTransactionDigest(
                 TransactionDigest::from_bytes(decoded_key.as_slice())?,
             )),
+            ItemType::TransactionDigestsByAddress => Ok(Key::TransactionDigestsByAddress(
+                IotaAddress::from_bytes(decoded_key.as_slice())?,
+            )),
         }
     }
 
@@ -231,6 +238,7 @@ impl Key {
             Key::TransactionToCheckpoint(_) => ItemType::TransactionToCheckpoint,
             Key::ObjectKey(_) => ItemType::Object,
             Key::EventsByTransactionDigest(_) => ItemType::EventTransactionDigest,
+            Key::TransactionDigestsByAddress(_) => ItemType::TransactionDigestsByAddress,
         }
     }
 
@@ -278,6 +286,9 @@ impl Key {
             Key::TransactionToCheckpoint(digest) => encode_digest(digest),
             Key::ObjectKey(object_key) => encode_object_key(object_key),
             Key::EventsByTransactionDigest(digest) => encode_digest(digest),
+            // TODO: `encode_digest` could be renamed to `encode` to fit more use cases.
+            // tracking issue: https://github.com/iotaledger/iota/issues/11754
+            Key::TransactionDigestsByAddress(address) => encode_digest(address),
         };
 
         (self.item_type(), encoded_key_digest)

--- a/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
+++ b/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
@@ -29,6 +29,17 @@ remote-store-url: "http://localhost:50051"
 #
 progress-store-path: "/iota/output/kv_ingestion_progress.json"
 
+# The starting checkpoint for the ingestion pipeline (inclusive).
+# If omitted, the pipeline resumes from the latest watermark stored in 'progress-store-path'.
+# If provided, the pipeline starts from the specified checkpoint (e.g., 0 for genesis).
+#
+# start-checkpoint: 0
+
+# The ending checkpoint for the ingestion pipeline (inclusive).
+# If omitted, the pipeline continues indefinitely until the end of the data stream.
+#
+# end-checkpoint: 1000000
+
 metrics-port: 8084
 
 # Workers Configs
@@ -55,3 +66,19 @@ tasks:
       column-family: "iota"
       timeout-secs: 60
       # emulator-host: "localhost:8086"
+
+      # Subset of BigTable tables this worker writes to.
+      #
+      # Default (field omitted or empty list): writes every supported
+      # table. Production deployments should leave this unset.
+      #
+      # Set to a list of tables when running a backfill that should
+      # populate only those tables, without re-writing data the main
+      # ingestion pipeline already owns.
+      #
+      # tables:
+      #   - objects
+      #   - transactions
+      #   - transactions-by-address
+      #   - checkpoints
+      #   - checkpoints-by-digest


### PR DESCRIPTION
# Description of change

This PR adds support for efficient address-to-transaction lookups across the data pipeline. Clients can now query all transactions involving an `IotaAddress` (as `sender`, `recipient`, or `gas payer`), including historical data that has been pruned from the indexer's relational store.

- **`iota-kvstore`**: Refactored the `KvWorker` to write the address-transaction relation during checkpoint ingestion. The worker now accepts an optional list of tables at startup, so a backfill instance can populate only a subset.

- **`iota-data-ingestion`**: The `BigTableKV` task type now accepts an optional `tables` list from `config.yaml`, enabling targeted backfills. To bound a backfill to a checkpoint range, the `IndexerConfig` accepts two new optional parameters: `start-checkpoint` and `end-checkpoint` (both inclusive).

- **`iota-rest-kv`**: Adds a `GET /txa/{address}` endpoint. Unlike existing endpoints, which are 1:1 key-value lookups, this one exposes a one-to-many relation. It returns an ordered list of transaction digests with cursor-based pagination (defaulting to descending order) to handle addresses with long histories.

- **`iota-indexer`**: Adds historical fallback support to the JSON-RPC API for the `TransactionFilter{V2}::FromOrToAddress` filter. When the indexer's relational store has pruned the requested data, the query is served from the historical KV store.

## Links to any relevant issues

fixes #11632

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Each commit corresponds to a previously-reviewed sub-PR. Test coverage (unit-tests or manual) is documented in the individual commit messages.


### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.
