### PR TITLE
upstream(starfish): harden commit observer recovery

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -89,7 +89,11 @@ impl ConsensusAuthority {
         let own_hostname = &committee.authority(own_index).hostname;
         info!(
             "Starting consensus authority {} {}, {:?}, boot counter {}, last processed commit index {}",
-            own_index, own_hostname, protocol_config.version, boot_counter, commit_consumer.last_processed_commit_index
+            own_index,
+            own_hostname,
+            protocol_config.version,
+            boot_counter,
+            commit_consumer.last_processed_commit_index
         );
         info!(
             "Consensus authorities: {}",
@@ -173,7 +177,8 @@ impl ConsensusAuthority {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let fast_sync_ongoing = dag_state.read().fast_sync_ongoing();
 

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -88,8 +88,8 @@ impl ConsensusAuthority {
         );
         let own_hostname = &committee.authority(own_index).hostname;
         info!(
-            "Starting consensus authority {} {}, {:?}, boot counter {}",
-            own_index, own_hostname, protocol_config.version, boot_counter
+            "Starting consensus authority {} {}, {:?}, boot counter {}, last processed commit index {}",
+            own_index, own_hostname, protocol_config.version, boot_counter, commit_consumer.last_processed_commit_index
         );
         info!(
             "Consensus authorities: {}",

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2440,7 +2440,8 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
         // we set sync_last_known_own_block to true and last known proposed round to
         // rounds+5 so that core doesn't start to create its own new blocks,
         // that would be different from the blocks created in dag builder
@@ -2609,7 +2610,8 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
         // we set sync_last_known_own_block to true and last known proposed round to
         // rounds+5 so that core doesn't start to create its own new blocks,
         // that would be different from the blocks created in dag builder
@@ -2793,7 +2795,8 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let core = Core::new(
             context.clone(),
@@ -3125,7 +3128,8 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let core = Core::new(
             context.clone(),
@@ -3269,7 +3273,8 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let core = Core::new(
             context.clone(),
@@ -3435,7 +3440,8 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         // we set sync_last_known_own_block to true and last known proposed round to
         // rounds+5 so that core doesn't start to create its own new blocks,
@@ -3634,7 +3640,8 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let core = Core::new(
             context.clone(),
@@ -3862,7 +3869,8 @@ mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let core = Core::new(
             context.clone(),

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -473,54 +473,94 @@ impl CommitObserver {
             return;
         }
 
-        let unprocessed_commits = self
-            .store
-            .scan_commits((last_processed_commit_index + 1..=last_commit_index).into())
-            .expect("Scanning commits should not fail");
-
         info!(
-            "Resending {} unprocessed commits (indices {}..={})",
-            unprocessed_commits.len(),
-            last_processed_commit_index + 1,
-            last_commit_index
+            "Resending unprocessed commits in range [{}..={last_commit_index}]",
+            last_processed_commit_index + 1
         );
 
-        let num_commits = unprocessed_commits.len();
-        let mut committed_subdags = Vec::new();
-        for (expected_commit_index, (index, commit)) in
-            (self.last_sent_commit_index + 1..).zip(unprocessed_commits.into_iter().enumerate())
+        // To avoid loading too many commits at once and causing OOM under stress
+        // (e.g. when an authority quarantines commits for a long period), process
+        // in bounded batches.
+        const COMMIT_RECOVERY_BATCH_SIZE: u32 = if cfg!(test) { 3 } else { 250 };
+
+        let mut any_sent = false;
+        let mut expected_commit_index = last_processed_commit_index;
+        for start_index in (last_processed_commit_index + 1..=last_commit_index)
+            .step_by(COMMIT_RECOVERY_BATCH_SIZE as usize)
         {
-            let commit_index = commit.index();
-            assert_eq!(commit_index, expected_commit_index);
+            let end_index = start_index
+                .saturating_add(COMMIT_RECOVERY_BATCH_SIZE - 1)
+                .min(last_commit_index);
 
-            // Only the last commit carries scores for leader schedule consumers.
-            let reputation_scores = if index == num_commits - 1 {
-                self.leader_schedule
-                    .leader_swap_table
-                    .read()
-                    .reputation_scores_desc
-                    .clone()
-            } else {
-                vec![]
-            };
+            let batch_commits = self
+                .store
+                .scan_commits((start_index..=end_index).into())
+                .expect("Scanning commits should not fail");
 
-            let Some(committed_subdag) =
-                self.build_committed_subdag_from_commit(&commit, reputation_scores)
-            else {
-                info!(
-                    "Stopping resend at commit {} due to missing transactions",
-                    commit_index
-                );
+            if batch_commits.is_empty() {
                 break;
-            };
+            }
 
-            committed_subdags.push(committed_subdag);
+            info!(
+                "Resending {} unprocessed commits in range [{start_index}..={end_index}]",
+                batch_commits.len()
+            );
+
+            let mut committed_subdags = Vec::new();
+            let mut stop_after_batch = false;
+            for commit in batch_commits {
+                let commit_index = commit.index();
+                expected_commit_index += 1;
+                assert_eq!(commit_index, expected_commit_index);
+
+                // Only the globally-last commit carries reputation scores.
+                let reputation_scores = if commit_index == last_commit_index {
+                    self.leader_schedule
+                        .leader_swap_table
+                        .read()
+                        .reputation_scores_desc
+                        .clone()
+                } else {
+                    vec![]
+                };
+
+                let Some(committed_subdag) =
+                    self.build_committed_subdag_from_commit(&commit, reputation_scores)
+                else {
+                    info!(
+                        "Stopping resend at commit {} due to missing transactions",
+                        commit_index
+                    );
+                    stop_after_batch = true;
+                    break;
+                };
+
+                committed_subdags.push(committed_subdag);
+            }
+
+            if !committed_subdags.is_empty() {
+                any_sent = true;
+                self.finalize_and_send_solid_subdags(&[], &committed_subdags, source)
+                    .expect("We should successfully send committed subdags during resend");
+
+                if let Some(last) = committed_subdags.last() {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .commit_observer_last_recovered_commit_index
+                        .set(last.commit_ref.index as i64);
+                }
+            }
+
+            if stop_after_batch || end_index == last_commit_index {
+                break;
+            }
         }
 
         // If we couldn't resend any commits, still initialize
         // last_solid_subdag_base from last_processed so fast sync
         // starts from the right position instead of index 0.
-        if committed_subdags.is_empty() && last_processed_commit_index > 0 {
+        if !any_sent && last_processed_commit_index > 0 {
             if let Some(commit) = self
                 .store
                 .scan_commits((last_processed_commit_index..=last_processed_commit_index).into())
@@ -532,9 +572,6 @@ impl CommitObserver {
                 }
             }
         }
-
-        self.finalize_and_send_solid_subdags(&[], &committed_subdags, source)
-            .expect("We should successfully send committed subdags during resend");
     }
 
     /// Get all missing transactions from pending subdags along with authorities

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -84,7 +84,7 @@ pub(crate) struct CommitObserver {
 }
 
 impl CommitObserver {
-    pub(crate) fn new(
+    pub(crate) async fn new(
         context: Arc<Context>,
         commit_consumer: CommitConsumer,
         dag_state: Arc<RwLock<DagState>>,
@@ -108,7 +108,8 @@ impl CommitObserver {
         };
 
         observer
-            .recover_and_send_commits(last_processed_commit_index, CommittedSubDagSource::Recover);
+            .recover_and_send_commits(last_processed_commit_index, CommittedSubDagSource::Recover)
+            .await;
         observer
     }
 
@@ -117,7 +118,7 @@ impl CommitObserver {
     /// - Recovering linearizer state (transaction ack tracker, traversed
     ///   headers)
     /// - Only re-sends commits that are > last_commit_index (none in this case)
-    pub(crate) fn reinitialize(&mut self, last_commit_index: CommitIndex) {
+    pub(crate) async fn reinitialize(&mut self, last_commit_index: CommitIndex) {
         let now = Instant::now();
 
         // Clear linearizer state
@@ -126,7 +127,8 @@ impl CommitObserver {
 
         // Reuse existing recovery logic - it won't resend commits since
         // they're all <= last_commit_index
-        self.recover_and_send_commits(last_commit_index, CommittedSubDagSource::FastCommitSyncer);
+        self.recover_and_send_commits(last_commit_index, CommittedSubDagSource::FastCommitSyncer)
+            .await;
 
         info!(
             "CommitObserver reinitialized at commit index {}, took {:?}",
@@ -256,7 +258,7 @@ impl CommitObserver {
         ))
     }
 
-    fn recover_and_send_commits(
+    async fn recover_and_send_commits(
         &mut self,
         last_processed_commit_index: CommitIndex,
         source: CommittedSubDagSource,
@@ -283,7 +285,8 @@ impl CommitObserver {
             last_processed_commit_index,
             last_commit_index,
             source,
-        );
+        )
+        .await;
 
         // Phase 2: Recover linearizer and solidifier state
         // Skip if fast sync is ongoing - block data may not be available and
@@ -292,12 +295,13 @@ impl CommitObserver {
             info!("Skipping linearizer/solidifier recovery - fast sync ongoing");
             return;
         }
-        self.recover_linearizer_and_solidifier_state(last_commit_index, source);
+        self.recover_linearizer_and_solidifier_state(last_commit_index, source)
+            .await;
     }
 
     /// Recovers linearizer trackers from recent commits and seeds the
     /// commit solidifier with any unprocessed commits.
-    fn recover_linearizer_and_solidifier_state(
+    async fn recover_linearizer_and_solidifier_state(
         &mut self,
         last_commit_index: CommitIndex,
         source: CommittedSubDagSource,
@@ -374,6 +378,8 @@ impl CommitObserver {
             if commit_index >= solidifier_recovery_start {
                 pending_for_solidifier.push(pending_sub_dag);
             }
+
+            tokio::task::yield_now().await;
         }
 
         if !pending_for_solidifier.is_empty() {
@@ -441,7 +447,7 @@ impl CommitObserver {
     /// Note: it is possible that some commits in interval
     /// last_processed_commit_index+1.. last_commit_index might be not yet
     /// solid.
-    fn resend_unprocessed_solid_commits(
+    async fn resend_unprocessed_solid_commits(
         &mut self,
         last_processed_commit_index: CommitIndex,
         last_commit_index: CommitIndex,
@@ -555,6 +561,10 @@ impl CommitObserver {
             if stop_after_batch || end_index == last_commit_index {
                 break;
             }
+
+            // Yield between batches so the executor can run other tasks during
+            // a potentially long recovery.
+            tokio::task::yield_now().await;
         }
 
         // If we couldn't resend any commits, still initialize
@@ -734,7 +744,8 @@ mod tests {
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule,
-        );
+        )
+        .await;
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
@@ -854,7 +865,8 @@ mod tests {
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
@@ -954,7 +966,8 @@ mod tests {
             dag_state,
             mem_store,
             leader_schedule,
-        );
+        )
+        .await;
 
         // Check commits sent over consensus output channel is accurate starting
         // from last processed index of 2 and finishing at last sent index of 3.
@@ -1005,7 +1018,8 @@ mod tests {
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
@@ -1058,7 +1072,8 @@ mod tests {
             dag_state,
             mem_store,
             leader_schedule,
-        );
+        )
+        .await;
 
         // No commits should be resubmitted as consensus store's last commit index
         // is equal to last processed index by consumer
@@ -1108,7 +1123,8 @@ mod tests {
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let leaders = builder
             .leader_blocks(1..=num_rounds)
@@ -1183,7 +1199,8 @@ mod tests {
             dag_state,
             mem_store,
             leader_schedule,
-        );
+        )
+        .await;
 
         // Check commits sent over consensus output channel during recovery.
         // Recovery resends subdags with empty headers (like fast sync).
@@ -1314,7 +1331,8 @@ mod tests {
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let mut builder = DagBuilder::new(context.clone());
         builder
@@ -1357,7 +1375,8 @@ mod tests {
             dag_state.clone(),
             mem_store,
             leader_schedule,
-        );
+        )
+        .await;
 
         // Drain recovery commits
         while let Ok(_subdag) = receiver.try_recv() {}
@@ -1445,7 +1464,8 @@ mod tests {
             dag_state.clone(),
             mem_store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let mut builder = DagBuilder::new(context.clone());
         builder
@@ -1496,7 +1516,8 @@ mod tests {
             dag_state.clone(),
             mem_store,
             leader_schedule,
-        );
+        )
+        .await;
         while receiver.try_recv().is_ok() {}
 
         builder.layers(6..=8).build().persist_layers(dag_state);

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -666,7 +666,7 @@ impl Core {
     /// over.
     ///
     /// Block headers should cover the cached_rounds window (~500 rounds).
-    pub(crate) fn reinitialize_components(
+    pub(crate) async fn reinitialize_components(
         &mut self,
         block_headers: Vec<VerifiedBlockHeader>,
     ) -> ConsensusResult<()> {
@@ -717,7 +717,7 @@ impl Core {
         self.last_decided_leader = last_commit_leader;
 
         // 8. Reinitialize CommitObserver with recovery (uses recover_and_send_commits)
-        self.commit_observer.reinitialize(last_commit_index);
+        self.commit_observer.reinitialize(last_commit_index).await;
 
         // 9. Reset signaling state
         self.last_signaled_round = threshold_round.saturating_sub(1);
@@ -1782,7 +1782,10 @@ impl CoreSignalsReceivers {
 /// corresponding stakes. The method returns the cores and their respective
 /// signal receivers are returned in `AuthorityIndex` order asc.
 #[cfg(test)]
-pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<CoreTextFixture> {
+pub(crate) async fn create_cores(
+    context: Context,
+    authorities: Vec<Stake>,
+) -> Vec<CoreTextFixture> {
     let mut cores = Vec::new();
 
     for index in 0..authorities.len() {
@@ -1793,7 +1796,8 @@ pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<Cor
             own_index,
             false,
             false,
-        );
+        )
+        .await;
         cores.push(core);
     }
     cores
@@ -1810,7 +1814,7 @@ pub(crate) struct CoreTextFixture {
 
 #[cfg(test)]
 impl CoreTextFixture {
-    fn new(
+    async fn new(
         context: Context,
         authorities: Vec<Stake>,
         own_index: AuthorityIndex,
@@ -1853,7 +1857,8 @@ impl CoreTextFixture {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let block_signer = signers.remove(own_index.value()).1;
 
@@ -1983,7 +1988,8 @@ mod test {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         // Check no commits have been persisted to dag_state or store.
         let last_commit = store.read_last_commit().unwrap();
@@ -2113,7 +2119,8 @@ mod test {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         // Check no commits have been persisted to dag_state & store
         let last_commit = store.read_last_commit().unwrap();
@@ -2208,7 +2215,8 @@ mod test {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
         let mut encoder = create_encoder(&context);
 
         // First send some transactions, since the block will be created once we recover
@@ -2368,7 +2376,8 @@ mod test {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let mut core = Core::new(
             context.clone(),
@@ -2457,7 +2466,8 @@ mod test {
             AuthorityIndex::new_for_test(0),
             false,
             false,
-        );
+        )
+        .await;
         let core = &fixture.core;
 
         // (1) saturating_sub clamps small clock_rounds to 0.
@@ -2491,7 +2501,8 @@ mod test {
             AuthorityIndex::new_for_test(0),
             false,
             false,
-        );
+        )
+        .await;
         assert_eq!(
             fixture_off.core.min_ancestor_round(1000),
             GENESIS_ROUND,
@@ -2530,7 +2541,8 @@ mod test {
             dag_state.clone(),
             store,
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let mut core = Core::new(
             context.clone(),
@@ -2626,7 +2638,7 @@ mod test {
 
         let (context, _) = Context::new_for_test(4);
         // Create the cores for all authorities
-        let mut all_cores = create_cores(context, vec![1, 1, 1, 1]);
+        let mut all_cores = create_cores(context, vec![1, 1, 1, 1]).await;
 
         // Create blocks for rounds 1..=3 from all Cores except last Core of authority
         // 3, so we miss the block from it. As it will be the leader of round 3
@@ -2747,7 +2759,8 @@ mod test {
             dag_state.clone(),
             store,
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let mut core = Core::new(
             context.clone(),
@@ -2796,7 +2809,7 @@ mod test {
 
         let (context, _) = Context::new_for_test(4);
         // create the cores and their signals for all the authorities
-        let mut cores = create_cores(context, vec![1, 1, 1, 1]);
+        let mut cores = create_cores(context, vec![1, 1, 1, 1]).await;
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
@@ -2959,7 +2972,8 @@ mod test {
             own_index,
             true,
             false,
-        );
+        )
+        .await;
         // create a DAG of 2*gc_depth rounds
         let mut dag_builder = DagBuilder::new(Arc::new(context.clone()));
         let gc_depth = context.protocol_config.gc_depth();
@@ -2976,7 +2990,8 @@ mod test {
             catch_up_index,
             true,
             true,
-        );
+        )
+        .await;
         let active_authorities = (0..(committee_size - 1) as u8)
             .map(AuthorityIndex::new_for_test)
             .collect::<Vec<_>>();
@@ -3174,7 +3189,8 @@ mod test {
         });
 
         let authority_index = AuthorityIndex::new_for_test(0);
-        let core = CoreTextFixture::new(context, vec![1, 1, 1, 1], authority_index, true, false);
+        let core =
+            CoreTextFixture::new(context, vec![1, 1, 1, 1], authority_index, true, false).await;
         let store = core.store.clone();
         let mut core = core.core;
 
@@ -3270,7 +3286,7 @@ mod test {
         let (context, _) = Context::new_for_test(6);
 
         // create the cores and their signals for all the authorities
-        let mut cores = create_cores(context, vec![1, 1, 1, 1, 1, 1]);
+        let mut cores = create_cores(context, vec![1, 1, 1, 1, 1, 1]).await;
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
@@ -3400,7 +3416,7 @@ mod test {
 
         let (context, _) = Context::new_for_test(4);
         // create the cores and their signals for all the authorities
-        let mut cores = create_cores(context, vec![1, 1, 1, 1]);
+        let mut cores = create_cores(context, vec![1, 1, 1, 1]).await;
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
@@ -3493,7 +3509,7 @@ mod test {
 
         let (context, _) = Context::new_for_test(4);
         // create the cores and their signals for all the authorities
-        let mut cores = create_cores(context, vec![1, 1, 1, 1]);
+        let mut cores = create_cores(context, vec![1, 1, 1, 1]).await;
 
         let mut last_round_block_headers = Vec::new();
         let mut all_block_headers = Vec::new();
@@ -3661,7 +3677,8 @@ mod test {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         // Check no commits have been persisted to dag_state or store.
         let last_commit = store.read_last_commit().unwrap();
@@ -3812,7 +3829,8 @@ mod test {
             AuthorityIndex::new_for_test(0),
             false,
             false,
-        );
+        )
+        .await;
 
         let leader = AuthorityIndex::new_for_test(1);
         let strong_vote = StrongVote {

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -301,7 +301,7 @@ impl CoreThread {
                                 "Reinitializing components with {} block headers, exiting fast sync mode",
                                 block_headers.len()
                             );
-                            self.core.reinitialize_components(block_headers)?;
+                            self.core.reinitialize_components(block_headers).await?;
                             self.fast_sync_ongoing = false;
                             sender.send(()).ok();
                         }
@@ -751,7 +751,8 @@ pub(crate) mod tests {
             dag_state.clone(),
             store,
             leader_schedule.clone(),
-        );
+        )
+        .await;
         let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
             dag_state.clone(),

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -199,6 +199,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) last_committed_authority_round: IntGaugeVec,
     pub(crate) last_committed_leader_round: IntGauge,
     pub(crate) last_commit_index: IntGauge,
+    pub(crate) commit_observer_last_recovered_commit_index: IntGauge,
     pub(crate) last_commit_time_diff: Histogram,
     pub(crate) last_known_own_block_header_round: IntGauge,
     pub(crate) sync_last_known_own_block_header_retries: IntCounter,
@@ -817,6 +818,11 @@ impl NodeMetrics {
             last_commit_index: register_int_gauge_with_registry!(
                 "last_commit_index",
                 "Index of the last commit.",
+                registry,
+            ).unwrap(),
+            commit_observer_last_recovered_commit_index: register_int_gauge_with_registry!(
+                "commit_observer_last_recovered_commit_index",
+                "The last commit index recovered by the commit observer",
                 registry,
             ).unwrap(),
             last_commit_time_diff: register_histogram_with_registry!(


### PR DESCRIPTION
# Description of change

Hardens commit observer recovery against two failure modes on validator restart. Both changes are ports of upstream consensus work, consolidated here to keep the review surface small.

**Batched recovery (prevents OOM):** On restart the commit observer scans and resends unprocessed commits in bounded batches of 250 rather than loading the entire unprocessed range into memory at once. This prevents out-of-memory on an authority that has quarantined a large number of commits before restarting. A metric tracking the last recovered commit index is added for observability.

**Non-blocking recovery:** During restart `recover_and_send_commits` can iterate over thousands of stored commits while rebuilding subdags and replaying linearizer state. `CommitObserver::new` and `reinitialize` are made async and yield the tokio runtime at each iteration so other tasks can make progress during long recoveries.

## Ported upstream PRs

- [#22543 — Disable transaction certifier recovery & refactor commit consumer recovery](https://github.com/MystenLabs/sui/pull/22543) (batched recovery; the transaction-certifier hunk does not apply here and was dropped)
- [#22551 — Avoid monopolising current thread during commit observer recovery](https://github.com/MystenLabs/sui/pull/22551) (non-blocking recovery)

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
