### PR TITLE
feat(protocol-config): enable fast commit sync and block restrictions on all networks in v29

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -162,6 +162,10 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             block epoch close.
 //             Enable median-based commit timestamp calculation in consensus,
 //             and enforce checkpoint timestamp monotonicity for mainnet.
+//             Enable fast commit syncer for faster recovery on all networks.
+//             Enable consensus block restrictions on all networks:
+//             bound block-header size to O(committee_size) and enable
+//             garbage collection in the block manager.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2929,6 +2933,13 @@ impl ProtocolConfig {
                     // enforce checkpoint timestamp monotonicity for mainnet.
                     cfg.feature_flags
                         .consensus_median_timestamp_with_checkpoint_enforcement = true;
+
+                    // Enable fast commit syncer for faster recovery on all networks.
+                    cfg.feature_flags.consensus_fast_commit_sync = true;
+                    // Enable consensus block restrictions on all networks to bound
+                    // header size by committee size and garbage-collect the block
+                    // manager.
+                    cfg.feature_flags.consensus_block_restrictions = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_29.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_29.snap
@@ -38,6 +38,8 @@ feature_flags:
   publish_package_metadata: true
   enable_move_authentication: true
   pass_validator_scores_to_advance_epoch: true
+  consensus_fast_commit_sync: true
+  consensus_block_restrictions: true
   move_native_tx_context: true
   additional_borrow_checks: true
   always_advance_dkg_to_resolution: true


### PR DESCRIPTION
# Description of change

Enables the `consensus_fast_commit_sync` and `consensus_block_restrictions` feature flags for all networks, including Mainnet, in protocol v29 (the current `MAX_PROTOCOL_VERSION`, not yet released on any network).

- `consensus_fast_commit_sync` — already on Devnet since v21 and Testnet since v22; enables parallel large-batch commit sync for faster recovery/catchup. Its dependency `consensus_commit_transactions_only_for_traversed_headers` has been enabled on all networks since v16, so the getter's dependency assert holds on Mainnet.
- `consensus_block_restrictions` — already on Testnet/Devnet since v27; bounds block-header size by committee size and enables garbage collection in the block manager.

Only the Mainnet v29 protocol-config snapshot changes; Testnet/Devnet v29 snapshots already list both flags. The OpenRPC spec and GraphQL schema were regenerated and are unchanged.

## Links to any relevant issues

Fixes #11853

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable fast commit sync, median-based commit timestamps with checkpoint enforcement and consensus block restrictions on Mainnet.