### PR TITLE
upstream(core): Reduce error message noise in ValidatorTxFinalizer

### DIFF
--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -195,7 +195,7 @@ where
                 }
             }
             Err(err) => {
-                error!(?tx_digest, ?err, "Failed to finalize transaction");
+                debug!(?tx_digest, "Failed to finalize transaction: {err}");
             }
         }
     }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.50.1, v1.51.5)
- Port commit:
  - [MystenLabs/sui@19a081e1f2](https://github.com/MystenLabs/sui/commit/19a081e1f23da1f4fced2e8945d0b4207fe5f3e7)
- Description:

Do not print the stacktrace, and make it a debug instead of error.

## Links to any relevant issues

Part of #11765

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes