### PR TITLE
fix(iota-indexer): populate watermark cache promptly on startup

### DIFF
--- a/crates/iota-indexer/src/pruning/watermark_task.rs
+++ b/crates/iota-indexer/src/pruning/watermark_task.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use arc_swap::ArcSwap;
 use iota_metrics::spawn_monitored_task;
-use tokio::time::sleep;
+use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -122,16 +122,16 @@ impl WatermarkTask {
     /// Runs the watermark update loop
     async fn run(self, cancel: CancellationToken) {
         info!("Starting watermark update task");
-
+        let mut interval = interval(self.update_interval);
         loop {
             tokio::select! {
                 _ = cancel.cancelled() => {
                     info!("Watermark update task cancelled");
                     break;
                 }
-                _ = sleep(self.update_interval) => {
+                _ = interval.tick() => {
                     if let Err(e) = self.update_watermarks().await {
-                        error!("Failed to update watermarks: {}", e);
+                        error!("Failed to update watermarks: {e}");
                     }
                 }
             }


### PR DESCRIPTION
# Description of change

Fixes a startup race in the indexer's watermark cache. `WatermarkTask::run` previously slept for `update_interval` before its first refresh, leaving the cache empty during the initial startup window. Any read-path code that consults the cache during that window (e.g `get_lowest_available_tx_for_tables`) sees `None` and treats it as "no pruning observed", even when the database has actually been pruned.

The fix replaces the `sleep` with `tokio::time::interval`, whose first `tick()` fires immediately, so the cache is populated before the first query is served.

## Links to any relevant issues

fixes #11828 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.