### PR TITLE
fix(typed-store): make iterator bounds consistent and add prefix scans

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1436,7 +1436,7 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables()?
             .running_root_state_hash
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?)
     }
@@ -4853,7 +4853,7 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables()?
             .builder_checkpoint_summary
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
             .map(|(_, s)| s))
@@ -4875,7 +4875,7 @@ impl AuthorityPerEpochStore {
             let seq = self
                 .tables()?
                 .builder_checkpoint_summary
-                .reversed_safe_iter_with_bounds(None, None)?
+                .safe_range_iter_reversed(..)
                 .next()
                 .transpose()?
                 .map(|(seq, s)| (seq, s.summary));
@@ -4933,7 +4933,7 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables()?
             .pending_checkpoint_signatures
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
             .map(|((_, index), _)| index)

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -513,13 +513,10 @@ impl AuthorityStore {
         object_id: &ObjectId,
         epoch_id: EpochId,
     ) -> IotaResult<Option<(SequenceNumber, MarkerValue)>> {
-        let min_key = (epoch_id, ObjectKey::min_for_id(object_id));
-        let max_key = (epoch_id, ObjectKey::max_for_id(object_id));
-
         let marker_entry = self
             .perpetual_tables
             .object_per_epoch_marker_table
-            .reversed_safe_iter_with_bounds(Some(min_key), Some(max_key))?
+            .safe_iter_with_prefix_reversed(&(epoch_id, *object_id))
             .next();
         match marker_entry {
             Some(Ok(((epoch, key), marker))) => {

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -424,7 +424,7 @@ impl AuthorityStore {
         let data = self
             .perpetual_tables
             .events
-            .safe_range_iter((*event_digest, 0)..=(*event_digest, usize::MAX))
+            .safe_iter_with_prefix(event_digest)
             .map_ok(|(_, event)| event)
             .collect::<Result<Vec<_>, TypedStoreError>>()?;
         Ok(data.is_empty().not().then_some(TransactionEvents(data)))
@@ -660,15 +660,12 @@ impl AuthorityStore {
         version: VersionNumber,
         epoch_id: EpochId,
     ) -> Result<bool, IotaError> {
-        let object_key = ObjectKey::max_for_id(object_id);
-        let marker_key = (epoch_id, object_key);
-
         // Find the most recent version of the object that was deleted or wrapped.
         // Return true if the version is >= `version`. Otherwise return false.
         let marker_entry = self
             .perpetual_tables
             .object_per_epoch_marker_table
-            .safe_range_iter_reversed(..=marker_key)
+            .safe_iter_with_prefix_reversed(&(epoch_id, *object_id))
             .next();
         match marker_entry.transpose()? {
             Some(((epoch, key), marker)) => {
@@ -1063,9 +1060,7 @@ impl AuthorityStore {
         let mut iterator = self
             .perpetual_tables
             .live_owned_object_markers
-            .safe_range_iter_reversed(
-                ..=ObjectRef::new(object_id, SequenceNumber::MAX_VALID_EXCL, ObjectDigest::MAX),
-            );
+            .safe_iter_with_prefix_reversed(&object_id);
         Ok(iterator
             .next()
             .transpose()?
@@ -1701,10 +1696,7 @@ impl AuthorityStore {
     pub fn count_object_versions(&self, object_id: ObjectId) -> usize {
         self.perpetual_tables
             .objects
-            .safe_iter_with_bounds(
-                Some(ObjectKey(object_id, VersionNumber::MIN_VALID_INCL)),
-                Some(ObjectKey(object_id, VersionNumber::MAX_VALID_EXCL)),
-            )
+            .safe_iter_with_prefix(&object_id)
             .collect::<Result<Vec<_>, _>>()
             .unwrap()
             .len()

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -668,7 +668,7 @@ impl AuthorityStore {
         let marker_entry = self
             .perpetual_tables
             .object_per_epoch_marker_table
-            .reversed_safe_iter_with_bounds(None, Some(marker_key))?
+            .safe_range_iter_reversed(..=marker_key)
             .next();
         match marker_entry.transpose()? {
             Some(((epoch, key), marker)) => {
@@ -1063,14 +1063,9 @@ impl AuthorityStore {
         let mut iterator = self
             .perpetual_tables
             .live_owned_object_markers
-            .reversed_safe_iter_with_bounds(
-                None,
-                Some(ObjectRef::new(
-                    object_id,
-                    SequenceNumber::MAX_VALID_EXCL,
-                    ObjectDigest::MAX,
-                )),
-            )?;
+            .safe_range_iter_reversed(
+                ..=ObjectRef::new(object_id, SequenceNumber::MAX_VALID_EXCL, ObjectDigest::MAX),
+            );
         Ok(iterator
             .next()
             .transpose()?
@@ -1733,7 +1728,7 @@ impl GlobalStateHashStore for AuthorityStore {
         Ok(self
             .perpetual_tables
             .root_state_hash_by_epoch
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?)
     }

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -247,10 +247,9 @@ impl AuthorityPerpetualTables {
         object_id: ObjectId,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>> {
-        let mut iter = self.objects.reversed_safe_iter_with_bounds(
-            Some(ObjectKey::min_for_id(&object_id)),
-            Some(ObjectKey(object_id, version)),
-        )?;
+        let mut iter = self.objects.safe_range_iter_reversed(
+            ObjectKey::min_for_id(&object_id)..=ObjectKey(object_id, version),
+        );
         match iter.next() {
             Some(Ok((key, o))) => self.object(&key, o),
             Some(Err(e)) => Err(e.into()),
@@ -321,10 +320,9 @@ impl AuthorityPerpetualTables {
         &self,
         object_id: ObjectId,
     ) -> Result<Option<ObjectRef>, IotaError> {
-        let mut iterator = self.objects.reversed_safe_iter_with_bounds(
-            Some(ObjectKey::min_for_id(&object_id)),
-            Some(ObjectKey::max_for_id(&object_id)),
-        )?;
+        let mut iterator = self.objects.safe_range_iter_reversed(
+            ObjectKey::min_for_id(&object_id)..=ObjectKey::max_for_id(&object_id),
+        );
 
         if let Some(Ok((object_key, value))) = iterator.next() {
             if object_key.0 == object_id {
@@ -338,10 +336,9 @@ impl AuthorityPerpetualTables {
         &self,
         object_id: ObjectId,
     ) -> Result<Option<(ObjectKey, StoreObjectWrapper)>, IotaError> {
-        let mut iterator = self.objects.reversed_safe_iter_with_bounds(
-            Some(ObjectKey::min_for_id(&object_id)),
-            Some(ObjectKey::max_for_id(&object_id)),
-        )?;
+        let mut iterator = self.objects.safe_range_iter_reversed(
+            ObjectKey::min_for_id(&object_id)..=ObjectKey::max_for_id(&object_id),
+        );
 
         if let Some(Ok((object_key, value))) = iterator.next() {
             if object_key.0 == object_id {
@@ -511,8 +508,7 @@ impl ObjectStore for AuthorityPerpetualTables {
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
         let obj_entry = self
             .objects
-            .reversed_safe_iter_with_bounds(None, Some(ObjectKey::max_for_id(object_id)))
-            .map_err(iota_types::storage::error::Error::custom)?
+            .safe_range_iter_reversed(..=ObjectKey::max_for_id(object_id))
             .next();
 
         match obj_entry.transpose()? {

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -320,9 +320,7 @@ impl AuthorityPerpetualTables {
         &self,
         object_id: ObjectId,
     ) -> Result<Option<ObjectRef>, IotaError> {
-        let mut iterator = self.objects.safe_range_iter_reversed(
-            ObjectKey::min_for_id(&object_id)..=ObjectKey::max_for_id(&object_id),
-        );
+        let mut iterator = self.objects.safe_iter_with_prefix_reversed(&object_id);
 
         if let Some(Ok((object_key, value))) = iterator.next() {
             if object_key.0 == object_id {
@@ -336,9 +334,7 @@ impl AuthorityPerpetualTables {
         &self,
         object_id: ObjectId,
     ) -> Result<Option<(ObjectKey, StoreObjectWrapper)>, IotaError> {
-        let mut iterator = self.objects.safe_range_iter_reversed(
-            ObjectKey::min_for_id(&object_id)..=ObjectKey::max_for_id(&object_id),
-        );
+        let mut iterator = self.objects.safe_iter_with_prefix_reversed(&object_id);
 
         if let Some(Ok((object_key, value))) = iterator.next() {
             if object_key.0 == object_id {
@@ -508,7 +504,7 @@ impl ObjectStore for AuthorityPerpetualTables {
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
         let obj_entry = self
             .objects
-            .safe_range_iter_reversed(..=ObjectKey::max_for_id(object_id))
+            .safe_iter_with_prefix_reversed(object_id)
             .next();
 
         match obj_entry.transpose()? {

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -413,10 +413,10 @@ impl AuthorityPerpetualTables {
         object: &(ObjectId, SequenceNumber),
     ) -> IotaResult<Vec<ObjectKey>> {
         let mut objects = vec![];
-        for result in self.objects.safe_iter_with_bounds(
-            Some(ObjectKey(object.0, object.1.next().unwrap())),
-            Some(ObjectKey(object.0, VersionNumber::MAX_VALID_EXCL)),
-        ) {
+        for result in self
+            .objects
+            .safe_iter_with_prefix_from(&object.0, &object.1.next().unwrap())
+        {
             let (key, _) = result?;
             objects.push(key);
         }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -332,7 +332,7 @@ impl CheckpointStore {
         Ok(self
             .tables
             .certified_checkpoints
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
             .map(|(_, v)| v.into()))
@@ -344,7 +344,7 @@ impl CheckpointStore {
         Ok(self
             .tables
             .locally_computed_checkpoints
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
             .map(|(_, v)| v))
@@ -472,7 +472,7 @@ impl CheckpointStore {
         if let Some((last_local_summary, _)) = self
             .tables
             .locally_computed_checkpoints
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
         {
@@ -2092,7 +2092,7 @@ impl CheckpointAggregator {
             .store
             .tables
             .certified_checkpoints
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
             .map(|(seq, _)| seq + 1)

--- a/crates/iota-core/src/epoch/committee_store.rs
+++ b/crates/iota-core/src/epoch/committee_store.rs
@@ -104,7 +104,7 @@ impl CommitteeStore {
         Ok(self
             .tables
             .committee_map
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
             // unwrap safe because we guarantee there is at least a genesis epoch

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -888,11 +888,9 @@ impl IndexStoreTables {
         cursor: Option<ObjectId>,
     ) -> Result<impl Iterator<Item = Result<DynamicFieldKey, TypedStoreError>> + '_, TypedStoreError>
     {
-        let lower_bound = DynamicFieldKey::new(parent, cursor.unwrap_or(ObjectId::ZERO));
-        let upper_bound = DynamicFieldKey::new(parent, ObjectId::MAX);
         let iter = self
             .dynamic_field
-            .safe_iter_with_bounds(Some(lower_bound), Some(upper_bound))
+            .safe_iter_with_prefix_from(&parent, &cursor.unwrap_or(ObjectId::ZERO))
             .map(|r| r.map(|(key, ())| key));
         Ok(iter)
     }
@@ -912,17 +910,9 @@ impl IndexStoreTables {
         original_package_id: ObjectId,
         cursor: Option<u64>,
     ) -> Result<impl Iterator<Item = PackageVersionIteratorItem> + '_, TypedStoreError> {
-        let lower_bound = PackageVersionKey {
-            original_package_id,
-            version: cursor.unwrap_or(0),
-        };
-        let upper_bound = PackageVersionKey {
-            original_package_id,
-            version: u64::MAX,
-        };
         Ok(self
             .package_version
-            .safe_iter_with_bounds(Some(lower_bound), Some(upper_bound)))
+            .safe_iter_with_prefix_from(&original_package_id, &cursor.unwrap_or(0)))
     }
 }
 

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -452,8 +452,7 @@ impl IndexStore {
         };
         let next_sequence_number = tables
             .transaction_order
-            .reversed_safe_iter_with_bounds(None, None)
-            .expect("failed to initialize indexes")
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()
             .expect("failed to initialize indexes")
@@ -847,10 +846,7 @@ impl IndexStore {
                     let iter = self
                         .tables
                         .transaction_order
-                        .reversed_safe_iter_with_bounds(
-                            None,
-                            Some(cursor.unwrap_or(TxSequenceNumber::MAX)),
-                        )?
+                        .safe_range_iter_reversed(..=cursor.unwrap_or(TxSequenceNumber::MAX))
                         .skip(usize::from(cursor.is_some()))
                         .map(|result| result.map(|(_, digest)| digest));
                     if let Some(limit) = limit {
@@ -883,10 +879,9 @@ impl IndexStore {
         reverse: bool,
     ) -> IotaResult<Vec<TransactionDigest>> {
         let iter = if reverse {
-            Either::Left(index.reversed_safe_iter_with_bounds(
-                None,
-                Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MAX))),
-            )?)
+            Either::Left(index.safe_range_iter_reversed(
+                ..=(key.clone(), cursor.unwrap_or(TxSequenceNumber::MAX)),
+            ))
         } else {
             Either::Right(index.safe_iter_with_bounds(
                 Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MIN))),
@@ -998,7 +993,7 @@ impl IndexStore {
             Either::Left(
                 self.tables
                     .transactions_by_move_function
-                    .reversed_safe_iter_with_bounds(None, Some(key))?,
+                    .safe_range_iter_reversed(..=key),
             )
         } else {
             Either::Right(
@@ -1055,7 +1050,7 @@ impl IndexStore {
         Ok(if descending {
             self.tables
                 .event_order
-                .reversed_safe_iter_with_bounds(None, Some((tx_seq, event_seq)))?
+                .safe_range_iter_reversed(..=(tx_seq, event_seq))
                 .take(limit)
                 .map(|result| {
                     result.map(|((_, event_seq), (digest, tx_digest, time))| {
@@ -1092,7 +1087,7 @@ impl IndexStore {
             Either::Left(
                 self.tables
                     .event_order
-                    .reversed_safe_iter_with_bounds(None, Some((min(tx_seq, seq), event_seq)))?,
+                    .safe_range_iter_reversed(..=(min(tx_seq, seq), event_seq)),
             )
         } else {
             Either::Right(
@@ -1117,17 +1112,13 @@ impl IndexStore {
         limit: usize,
         descending: bool,
     ) -> IotaResult<Vec<(TransactionEventsDigest, TransactionDigest, usize, u64)>> {
-        let iter =
-            if descending {
-                Either::Left(index.reversed_safe_iter_with_bounds(
-                    None,
-                    Some((key.clone(), (tx_seq, event_seq))),
-                )?)
-            } else {
-                Either::Right(
-                    index.safe_iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None),
-                )
-            };
+        let iter = if descending {
+            Either::Left(index.safe_range_iter_reversed(..=(key.clone(), (tx_seq, event_seq))))
+        } else {
+            Either::Right(
+                index.safe_iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None),
+            )
+        };
         iter.try_take_map_while_and_collect(
             Some(limit),
             |((m, _), _)| m == key,
@@ -1220,7 +1211,7 @@ impl IndexStore {
         if descending {
             self.tables
                 .event_by_time
-                .reversed_safe_iter_with_bounds(None, Some((end_time, (tx_seq, event_seq))))?
+                .safe_range_iter_reversed(..=(end_time, (tx_seq, event_seq)))
                 .try_take_map_while_and_collect(
                     Some(limit),
                     |((m, _), _)| m >= &start_time,
@@ -1248,10 +1239,7 @@ impl IndexStore {
         match self
             .tables
             .event_by_time
-            .reversed_safe_iter_with_bounds(
-                None,
-                Some((cut_time_ms, (TxSequenceNumber::MAX, usize::MAX))),
-            )?
+            .safe_range_iter_reversed(..=(cut_time_ms, (TxSequenceNumber::MAX, usize::MAX)))
             .next()
             .transpose()?
         {

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1265,16 +1265,12 @@ impl IndexStore {
     ) -> IotaResult<impl Iterator<Item = Result<(ObjectId, DynamicFieldInfo), TypedStoreError>> + '_>
     {
         debug!(?object, "get_dynamic_fields");
-        // The object id 0 is the smallest possible
-        let iter_lower_bound = (object, cursor.unwrap_or(ObjectId::ZERO));
-        let iter_upper_bound = (object, ObjectId::MAX);
         Ok(self
             .tables
             .dynamic_field_index
-            .safe_iter_with_bounds(Some(iter_lower_bound), Some(iter_upper_bound))
+            .safe_iter_with_prefix_from(&object, &cursor.unwrap_or(ObjectId::ZERO))
             // skip an extra b/c the cursor is exclusive
             .skip(usize::from(cursor.is_some()))
-            .take_while(move |result| result.is_err() || (result.as_ref().unwrap().0.0 == object))
             .map_ok(|((_, c), object_info)| (c, object_info)))
     }
 

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -169,8 +169,7 @@ impl SimulatorStore for PersistedStore {
     fn get_highest_checkpoint(&self) -> Option<VerifiedCheckpoint> {
         self.read_write
             .checkpoints
-            .reversed_safe_iter_with_bounds(None, None)
-            .expect("failed to fetch highest checkpoint")
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()
             .expect("failed to fetch highest checkpoint")
@@ -476,8 +475,7 @@ impl ReadStore for PersistedStore {
     fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         self.read_write
             .checkpoints
-            .reversed_safe_iter_with_bounds(None, None)
-            .expect("failed to fetch highest checkpoint")
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()
             .expect("failed to fetch highest checkpoint")
@@ -651,7 +649,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
         self.sync();
         self.inner
             .checkpoints
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
             .map(|(_, checkpoint)| checkpoint.into())

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -630,10 +630,10 @@ impl Store for RocksDBStore {
         let mut refs = std::collections::VecDeque::new();
         for kv in self
             .digests_by_authorities
-            .reversed_safe_iter_with_bounds(
-                Some((author, Round::MIN, BlockHeaderDigest::MIN)),
-                Some((author, before_round, BlockHeaderDigest::MAX)),
-            )?
+            .safe_range_iter_reversed(
+                (author, Round::MIN, BlockHeaderDigest::MIN)
+                    ..=(author, before_round, BlockHeaderDigest::MAX),
+            )
             .take(num_of_rounds as usize)
         {
             let ((author, round, digest), _) = kv?;
@@ -663,11 +663,7 @@ impl Store for RocksDBStore {
     }
 
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>> {
-        let Some(result) = self
-            .commits
-            .reversed_safe_iter_with_bounds(None, None)?
-            .next()
-        else {
+        let Some(result) = self.commits.safe_range_iter_reversed(..).next() else {
             return Ok(None);
         };
         let ((_index, digest), serialized) = result?;
@@ -720,10 +716,10 @@ impl Store for RocksDBStore {
         // The commit_votes table is keyed by (CommitIndex, CommitDigest, BlockRef).
         let result = self
             .commit_votes
-            .reversed_safe_iter_with_bounds(
-                Some((CommitIndex::MIN, CommitDigest::MIN, BlockRef::MIN)),
-                Some((up_to_index, CommitDigest::MAX, BlockRef::MAX)),
-            )?
+            .safe_range_iter_reversed(
+                (CommitIndex::MIN, CommitDigest::MIN, BlockRef::MIN)
+                    ..=(up_to_index, CommitDigest::MAX, BlockRef::MAX),
+            )
             .next();
 
         match result {
@@ -753,11 +749,7 @@ impl Store for RocksDBStore {
     }
 
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
-        let Some(result) = self
-            .commit_info
-            .reversed_safe_iter_with_bounds(None, None)?
-            .next()
-        else {
+        let Some(result) = self.commit_info.safe_range_iter_reversed(..).next() else {
             return Ok(None);
         };
         let (key, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -772,6 +772,31 @@ impl<K, V> DBMap<K, V> {
         self.iter_forward_raw(lower_bound, upper_bound)
     }
 
+    /// Forward iterator over entries whose key begins with `prefix`, starting
+    /// at `prefix ++ cursor` rather than at the first key under the prefix.
+    ///
+    /// `cursor` is **not** a full key — it is the remainder of the key that
+    /// follows `prefix` (typically the trailing field(s) of a tuple key). Both
+    /// `prefix` and `cursor` are serialized with `be_fix_int_ser` and
+    /// concatenated, mirroring how a composite key is encoded; the scan then
+    /// covers `[prefix ++ cursor, end-of-prefix)`. This lets a paginated scan
+    /// resume from a cursor without an artificial maximum key for the upper
+    /// bound.
+    pub fn safe_iter_with_prefix_from<P, C>(&self, prefix: &P, cursor: &C) -> DbIterator<'_, (K, V)>
+    where
+        P: ?Sized + Serialize,
+        C: ?Sized + Serialize,
+        K: DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        let (lower_bound, upper_bound) = prefix_iterator_bounds(prefix);
+        let lower_bound = lower_bound.map(|mut lower| {
+            lower.extend_from_slice(&be_fix_int_ser(cursor));
+            lower
+        });
+        self.iter_forward_raw(lower_bound, upper_bound)
+    }
+
     /// Reverse counterpart of [`Self::safe_iter_with_prefix`]: the matching
     /// entries in descending key order (e.g. for "latest entry under a
     /// prefix").

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -784,28 +784,6 @@ impl<K, V> DBMap<K, V> {
         let (lower_bound, upper_bound) = prefix_iterator_bounds(prefix);
         self.iter_reversed_raw(lower_bound, upper_bound)
     }
-
-    /// Creates a reversed iterator with optional inclusive bounds.
-    ///
-    /// Both bounds are inclusive: `(Some(lo), Some(hi))` yields `[lo, hi]` in
-    /// descending order. This is a thin wrapper over
-    /// [`Self::safe_range_iter_reversed`] with `lo..=hi`; use the range method
-    /// directly when you need exclusive bounds.
-    pub fn reversed_safe_iter_with_bounds(
-        &self,
-        lower_bound: Option<K>,
-        upper_bound: Option<K>,
-    ) -> Result<DbIterator<'_, (K, V)>, TypedStoreError>
-    where
-        K: Serialize + DeserializeOwned,
-        V: Serialize + DeserializeOwned,
-    {
-        let range = (
-            lower_bound.map(Bound::Included).unwrap_or(Bound::Unbounded),
-            upper_bound.map(Bound::Included).unwrap_or(Bound::Unbounded),
-        );
-        Ok(self.safe_range_iter_reversed(range))
-    }
 }
 
 /// Provides a mutable struct to form a collection of database write operations,
@@ -1218,7 +1196,7 @@ where
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);
         let last_key = self
-            .reversed_safe_iter_with_bounds(None, None)?
+            .safe_range_iter_reversed(..)
             .next()
             .transpose()?
             .map(|(k, _v)| k);

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -32,7 +32,7 @@ use crate::{
         safe_iter::{SafeIter, SafeRevIter},
     },
     traits::{Map, TableSummary},
-    util::{be_fix_int_ser, iterator_bounds, iterator_bounds_with_range},
+    util::{be_fix_int_ser, iterator_bounds_with_range, prefix_iterator_bounds},
 };
 
 #[derive(Clone)]
@@ -665,9 +665,132 @@ impl<K, V> DBMap<K, V> {
         )
     }
 
-    /// Creates a safe reversed iterator with optional bounds.
-    /// Both upper bound and lower bound are included.
-    #[allow(clippy::complexity)]
+    /// Shared rocksdb `SafeIter` construction (raw iterator + scan metrics)
+    /// used by both the forward and reverse raw iterators.
+    fn rocks_safe_iter<'a>(&self, db: &'a RocksDB, readopts: ReadOptions) -> SafeIter<'a, K, V>
+    where
+        K: DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        let db_iter = db
+            .underlying
+            .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf_name().to_string(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    /// Forward iterator over the raw byte bounds `[lower_bound, upper_bound)`;
+    /// both bounds (already serialized, `upper_bound` exclusive) are applied to
+    /// the read options.
+    fn iter_forward_raw(
+        &self,
+        lower_bound: Option<Vec<u8>>,
+        upper_bound: Option<Vec<u8>>,
+    ) -> DbIterator<'_, (K, V)>
+    where
+        K: DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let readopts =
+                    rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, upper_bound);
+                Box::new(self.rocks_safe_iter(db, readopts))
+            }
+            Storage::InMemory(db) => {
+                db.iterator(self.column_family.name(), lower_bound, upper_bound, false)
+            }
+        }
+    }
+
+    /// Reverse counterpart of [`Self::iter_forward_raw`], yielding the same
+    /// keys in descending order. Only the lower bound is applied to the
+    /// read options; the (exclusive) `upper_bound` is enforced by
+    /// [`SafeRevIter`]'s initial seek, because setting an
+    /// iterate-upper-bound would stop `seek_for_prev` from landing on the
+    /// boundary key.
+    fn iter_reversed_raw(
+        &self,
+        lower_bound: Option<Vec<u8>>,
+        upper_bound: Option<Vec<u8>>,
+    ) -> DbIterator<'_, (K, V)>
+    where
+        K: DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        match &self.db.storage {
+            Storage::Rocks(db) => {
+                let readopts =
+                    rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, None);
+                Box::new(SafeRevIter::new(
+                    self.rocks_safe_iter(db, readopts),
+                    upper_bound,
+                ))
+            }
+            Storage::InMemory(db) => {
+                db.iterator(self.column_family.name(), lower_bound, upper_bound, true)
+            }
+        }
+    }
+
+    /// Reverse counterpart of [`Map::safe_range_iter`]: yields exactly the keys
+    /// of `safe_range_iter(range)` in descending order.
+    ///
+    /// Both directions derive their bounds from the same
+    /// `iterator_bounds_with_range`, so they are guaranteed to cover the
+    /// identical set of keys regardless of the bound inclusivity.
+    pub fn safe_range_iter_reversed(&self, range: impl RangeBounds<K>) -> DbIterator<'_, (K, V)>
+    where
+        K: Serialize + DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        let (lower_bound, upper_bound) = iterator_bounds_with_range(range);
+        self.iter_reversed_raw(lower_bound, upper_bound)
+    }
+
+    /// Forward iterator over every entry whose key begins with `prefix`.
+    ///
+    /// `prefix` is serialized with `be_fix_int_ser` and must form a prefix of
+    /// the column family's key encoding — typically the leading field(s) of a
+    /// tuple key. This avoids constructing artificial maximum keys to bound a
+    /// composite-key scan.
+    pub fn safe_iter_with_prefix<P>(&self, prefix: &P) -> DbIterator<'_, (K, V)>
+    where
+        P: ?Sized + Serialize,
+        K: DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        let (lower_bound, upper_bound) = prefix_iterator_bounds(prefix);
+        self.iter_forward_raw(lower_bound, upper_bound)
+    }
+
+    /// Reverse counterpart of [`Self::safe_iter_with_prefix`]: the matching
+    /// entries in descending key order (e.g. for "latest entry under a
+    /// prefix").
+    pub fn safe_iter_with_prefix_reversed<P>(&self, prefix: &P) -> DbIterator<'_, (K, V)>
+    where
+        P: ?Sized + Serialize,
+        K: DeserializeOwned,
+        V: DeserializeOwned,
+    {
+        let (lower_bound, upper_bound) = prefix_iterator_bounds(prefix);
+        self.iter_reversed_raw(lower_bound, upper_bound)
+    }
+
+    /// Creates a reversed iterator with optional inclusive bounds.
+    ///
+    /// Both bounds are inclusive: `(Some(lo), Some(hi))` yields `[lo, hi]` in
+    /// descending order. This is a thin wrapper over
+    /// [`Self::safe_range_iter_reversed`] with `lo..=hi`; use the range method
+    /// directly when you need exclusive bounds.
     pub fn reversed_safe_iter_with_bounds(
         &self,
         lower_bound: Option<K>,
@@ -677,46 +800,11 @@ impl<K, V> DBMap<K, V> {
         K: Serialize + DeserializeOwned,
         V: Serialize + DeserializeOwned,
     {
-        let (it_lower_bound, it_upper_bound) = iterator_bounds_with_range::<K>((
-            lower_bound
-                .as_ref()
-                .map(Bound::Included)
-                .unwrap_or(Bound::Unbounded),
-            upper_bound
-                .as_ref()
-                .map(Bound::Included)
-                .unwrap_or(Bound::Unbounded),
-        ));
-        match &self.db.storage {
-            Storage::Rocks(db) => {
-                let readopts = rocks_util::apply_range_bounds(
-                    self.opts.readopts(),
-                    it_lower_bound,
-                    it_upper_bound,
-                );
-                let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
-                let db_iter = db
-                    .underlying
-                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
-                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-                let iter = SafeIter::new(
-                    self.cf_name().to_string(),
-                    db_iter,
-                    _timer,
-                    _perf_ctx,
-                    bytes_scanned,
-                    keys_scanned,
-                    Some(self.db_metrics.clone()),
-                );
-                Ok(Box::new(SafeRevIter::new(iter, upper_bound_key)))
-            }
-            Storage::InMemory(db) => Ok(db.iterator(
-                self.column_family.name(),
-                it_lower_bound,
-                it_upper_bound,
-                true,
-            )),
-        }
+        let range = (
+            lower_bound.map(Bound::Included).unwrap_or(Bound::Unbounded),
+            upper_bound.map(Bound::Included).unwrap_or(Bound::Unbounded),
+        );
+        Ok(self.safe_range_iter_reversed(range))
     }
 }
 
@@ -1173,55 +1261,16 @@ where
         lower_bound: Option<K>,
         upper_bound: Option<K>,
     ) -> DbIterator<'a, (K, V)> {
-        let (lower_bound, upper_bound) = iterator_bounds(lower_bound, upper_bound);
-        match &self.db.storage {
-            Storage::Rocks(db) => {
-                let readopts =
-                    rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, upper_bound);
-                let db_iter = db
-                    .underlying
-                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
-                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-                Box::new(SafeIter::new(
-                    self.cf_name().to_string(),
-                    db_iter,
-                    _timer,
-                    _perf_ctx,
-                    bytes_scanned,
-                    keys_scanned,
-                    Some(self.db_metrics.clone()),
-                ))
-            }
-            Storage::InMemory(db) => {
-                db.iterator(self.column_family.name(), lower_bound, upper_bound, false)
-            }
-        }
+        let range = (
+            lower_bound.map(Bound::Included).unwrap_or(Bound::Unbounded),
+            upper_bound.map(Bound::Excluded).unwrap_or(Bound::Unbounded),
+        );
+        self.safe_range_iter(range)
     }
 
     fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
         let (lower_bound, upper_bound) = iterator_bounds_with_range(range);
-        match &self.db.storage {
-            Storage::Rocks(db) => {
-                let readopts =
-                    rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, upper_bound);
-                let db_iter = db
-                    .underlying
-                    .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
-                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-                Box::new(SafeIter::new(
-                    self.cf_name().to_string(),
-                    db_iter,
-                    _timer,
-                    _perf_ctx,
-                    bytes_scanned,
-                    keys_scanned,
-                    Some(self.db_metrics.clone()),
-                ))
-            }
-            Storage::InMemory(db) => {
-                db.iterator(self.column_family.name(), lower_bound, upper_bound, false)
-            }
-        }
+        self.iter_forward_raw(lower_bound, upper_bound)
     }
 
     /// Returns a vector of values corresponding to the keys provided.

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -120,12 +120,22 @@ pub struct SafeRevIter<'a, K, V> {
 }
 
 impl<'a, K, V> SafeRevIter<'a, K, V> {
-    pub(crate) fn new(mut iter: SafeIter<'a, K, V>, upper_bound: Option<Vec<u8>>) -> Self {
+    pub(crate) fn new(
+        mut iter: SafeIter<'a, K, V>,
+        exclusive_upper_bound: Option<Vec<u8>>,
+    ) -> Self {
         iter.is_initialized = true;
         iter.direction = Direction::Reverse;
-        match upper_bound {
+        match exclusive_upper_bound {
             None => iter.db_iter.seek_to_last(),
-            Some(key) => iter.db_iter.seek_for_prev(&key),
+            Some(bound) => {
+                iter.db_iter.seek_for_prev(&bound);
+                // The bound is exclusive: move to the previous key if the
+                // excluded key actually exists in the db.
+                if iter.db_iter.valid() && iter.db_iter.key() == Some(bound.as_slice()) {
+                    iter.db_iter.prev();
+                }
+            }
         }
         Self { iter }
     }

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -79,13 +79,17 @@ impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for SafeIter<'_, K, V> {
                 .expect("Valid iterator failed to get value");
             self.bytes_scanned_counter += raw_key.len() + raw_value.len();
             self.keys_returned_counter += 1;
-            let key = config.deserialize(raw_key).ok();
-            let value = bcs::from_bytes(raw_value).ok();
+            let key = config.deserialize(raw_key);
+            let value = bcs::from_bytes(raw_value);
             match self.direction {
                 Direction::Forward => self.db_iter.next(),
                 Direction::Reverse => self.db_iter.prev(),
             }
-            key.and_then(|k| value.map(|v| Ok((k, v))))
+            match (key, value) {
+                (Ok(key), Ok(value)) => Some(Ok((key, value))),
+                (Err(e), _) => Some(Err(TypedStoreError::Serialization(e.to_string()))),
+                (_, Err(e)) => Some(Err(TypedStoreError::Serialization(e.to_string()))),
+            }
         } else {
             match self.db_iter.status() {
                 Ok(_) => None,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -604,6 +604,147 @@ async fn test_safe_range_iter_exclusive_lower_bound_at_max_with_inclusive_upper(
 }
 
 #[tokio::test]
+async fn test_safe_range_iter_reversed_matches_forward() {
+    use std::ops::Bound::{self, Excluded, Included, Unbounded};
+
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<u32, String> = open_map(tmp_dir.path(), None);
+    // [1, 100) so that bounds like 20 / 50 land on existing keys, exercising the
+    // exclusive-upper "skip the boundary key" path of the reverse seek.
+    for i in 1..100u32 {
+        db.insert(&i, &i.to_string()).unwrap();
+    }
+
+    let check = |range: (Bound<u32>, Bound<u32>)| {
+        let forward: Vec<_> = db.safe_range_iter(range).map(|r| r.unwrap()).collect();
+        let mut reversed: Vec<_> = db
+            .safe_range_iter_reversed(range)
+            .map(|r| r.unwrap())
+            .collect();
+        reversed.reverse();
+        assert_eq!(
+            forward, reversed,
+            "reversed(range) must equal forward(range) reversed; range = {range:?}",
+        );
+    };
+
+    check((Included(10), Excluded(20))); // 10..20, boundary key 20 exists
+    check((Included(10), Included(20))); // 10..=20
+    check((Excluded(10), Excluded(20))); // (10, 20)
+    check((Unbounded, Excluded(20))); // ..20
+    check((Unbounded, Included(20))); // ..=20
+    check((Included(50), Unbounded)); // 50..
+    check((Excluded(50), Unbounded)); // (50, ..)
+    check((Unbounded, Unbounded)); // full table
+    check((Included(40), Excluded(40))); // empty
+    check((Included(50), Included(50))); // single element
+}
+
+#[tokio::test]
+async fn test_safe_iter_with_prefix() {
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<(u64, u64), String> = open_map(tmp_dir.path(), None);
+    for (a, b) in [(1u64, 1u64), (1, 2), (1, 3), (2, 1), (2, 2)] {
+        db.insert(&(a, b), &format!("{a}-{b}")).unwrap();
+    }
+
+    let forward: Vec<_> = db
+        .safe_iter_with_prefix(&1u64)
+        .map(|r| r.unwrap())
+        .collect();
+    assert_eq!(
+        vec![
+            ((1, 1), "1-1".to_string()),
+            ((1, 2), "1-2".to_string()),
+            ((1, 3), "1-3".to_string()),
+        ],
+        forward,
+        "prefix scan must yield exactly the entries under the prefix",
+    );
+
+    let reversed: Vec<_> = db
+        .safe_iter_with_prefix_reversed(&1u64)
+        .map(|r| r.unwrap())
+        .collect();
+    let mut expected = forward;
+    expected.reverse();
+    assert_eq!(
+        expected, reversed,
+        "reversed prefix scan must be forward reversed"
+    );
+
+    // The neighbouring prefix must not leak in.
+    let other: Vec<_> = db
+        .safe_iter_with_prefix(&2u64)
+        .map(|r| r.unwrap())
+        .collect();
+    assert_eq!(
+        vec![((2, 1), "2-1".to_string()), ((2, 2), "2-2".to_string())],
+        other,
+    );
+}
+
+#[tokio::test]
+async fn test_safe_iter_with_prefix_at_max() {
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<(u8, u8), String> = open_map(tmp_dir.path(), None);
+    for (a, b) in [(254u8, 9u8), (255, 1), (255, 2)] {
+        db.insert(&(a, b), &format!("{a}-{b}")).unwrap();
+    }
+
+    // Prefix 0xFF has no representable upper bound; the scan runs to the end of
+    // the column family and must still exclude the lower neighbour.
+    let got: Vec<_> = db
+        .safe_iter_with_prefix(&u8::MAX)
+        .map(|r| r.unwrap())
+        .collect();
+    assert_eq!(
+        vec![
+            ((255, 1), "255-1".to_string()),
+            ((255, 2), "255-2".to_string()),
+        ],
+        got,
+    );
+}
+
+#[tokio::test]
+async fn test_reversed_safe_iter_with_bounds_is_inclusive() {
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<u32, String> = open_map(tmp_dir.path(), None);
+    for i in 1..100u32 {
+        db.insert(&i, &i.to_string()).unwrap();
+    }
+
+    // Both bounds inclusive: [10, 20] in descending order (unchanged contract).
+    let got: Vec<_> = db
+        .reversed_safe_iter_with_bounds(Some(10), Some(20))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    assert_eq!(
+        (10..=20)
+            .rev()
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        got,
+    );
+
+    // Upper-only stays inclusive: [.., 20] in descending order.
+    let got: Vec<_> = db
+        .reversed_safe_iter_with_bounds(None, Some(20))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    assert_eq!(
+        (1..=20)
+            .rev()
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        got,
+    );
+}
+
+#[tokio::test]
 async fn test_is_empty() {
     let tmp_dir = iota_common::tempdir();
     let db: DBMap<i32, String> = open_map(tmp_dir.path(), Some("table"));

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -706,6 +706,95 @@ async fn test_safe_iter_with_prefix_at_max() {
 }
 
 #[tokio::test]
+async fn test_safe_iter_with_prefix_multi_field() {
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<(u64, u64, u64), String> = open_map(tmp_dir.path(), None);
+    for (a, b, c) in [
+        (1u64, 1u64, 9u64), // different second field
+        (1, 2, 0),
+        (1, 2, 7),
+        (1, 2, u64::MAX), // boundary at the third field's max
+        (1, 3, 0),        // next second field
+        (2, 2, 0),        // different first field
+    ] {
+        db.insert(&(a, b, c), &format!("{a}-{b}-{c}")).unwrap();
+    }
+
+    // A two-field prefix must select exactly the keys whose first two fields
+    // match, equivalent to the closed range over the whole third-field space.
+    let by_prefix: Vec<_> = db
+        .safe_iter_with_prefix(&(1u64, 2u64))
+        .map(|r| r.unwrap())
+        .collect();
+    let by_range: Vec<_> = db
+        .safe_range_iter((1u64, 2u64, u64::MIN)..=(1u64, 2u64, u64::MAX))
+        .map(|r| r.unwrap())
+        .collect();
+
+    assert_eq!(by_prefix, by_range);
+    assert_eq!(
+        vec![(1, 2, 0), (1, 2, 7), (1, 2, u64::MAX)],
+        by_prefix.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
+    );
+}
+
+#[tokio::test]
+async fn test_prefix_from_matches_old_bounded_scan() {
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<(u64, u64), String> = open_map(tmp_dir.path(), None);
+    for (a, b) in [(1u64, 10u64), (1, 20), (1, 30), (2, 5)] {
+        db.insert(&(a, b), &format!("{a}-{b}")).unwrap();
+    }
+
+    // Old approach: explicit bounds [(1, cursor), (1, u64::MAX)) -- upper
+    // EXCLUSIVE.
+    let old = |cursor: Option<u64>| -> Vec<(u64, u64)> {
+        db.safe_iter_with_bounds(Some((1u64, cursor.unwrap_or(0))), Some((1u64, u64::MAX)))
+            .skip(usize::from(cursor.is_some()))
+            .map(|r| r.unwrap().0)
+            .collect()
+    };
+    // New approach: prefix-from with the same cursor as the key remainder.
+    let new = |cursor: Option<u64>| -> Vec<(u64, u64)> {
+        db.safe_iter_with_prefix_from(&1u64, &cursor.unwrap_or(0))
+            .skip(usize::from(cursor.is_some()))
+            .map(|r| r.unwrap().0)
+            .collect()
+    };
+
+    // For all realistic data the prefix scan is equivalent to the old bounds.
+    for cursor in [None, Some(10u64), Some(20), Some(30)] {
+        assert_eq!(old(cursor), new(cursor), "cursor {cursor:?}");
+    }
+
+    // The only divergence: the old exclusive `(1, u64::MAX)` upper bound dropped
+    // an entry sitting exactly at that tail; the prefix scan correctly keeps it.
+    db.insert(&(1u64, u64::MAX), &"max".to_string()).unwrap();
+    assert!(!old(None).contains(&(1, u64::MAX)));
+    assert!(new(None).contains(&(1, u64::MAX)));
+}
+
+#[tokio::test]
+async fn test_safe_iter_with_prefix_from() {
+    let tmp_dir = iota_common::tempdir();
+    let db: DBMap<(u64, u64), String> = open_map(tmp_dir.path(), None);
+    for (a, b) in [(1u64, 1u64), (1, 2), (1, 3), (2, 1)] {
+        db.insert(&(a, b), &format!("{a}-{b}")).unwrap();
+    }
+
+    // Resume the prefix-1 scan from cursor 2 (inclusive); the upper bound is still
+    // the end of prefix 1, so (1, 1) and the whole prefix 2 are excluded.
+    let got: Vec<_> = db
+        .safe_iter_with_prefix_from(&1u64, &2u64)
+        .map(|r| r.unwrap())
+        .collect();
+    assert_eq!(
+        vec![((1, 2), "1-2".to_string()), ((1, 3), "1-3".to_string())],
+        got,
+    );
+}
+
+#[tokio::test]
 async fn test_safe_range_iter_reversed_inclusive_ranges() {
     let tmp_dir = iota_common::tempdir();
     let db: DBMap<u32, String> = open_map(tmp_dir.path(), None);

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -739,6 +739,57 @@ async fn test_safe_iter_with_prefix_multi_field() {
 }
 
 #[tokio::test]
+async fn test_safe_iter_surfaces_deserialization_error() {
+    // A bad VALUE: store <u32, u8>, reopen with a wider value type. The stored
+    // 1-byte values cannot deserialize into (u64, u64). Forward and reverse
+    // iteration share `SafeIter::next`, so both must surface the error rather
+    // than silently ending the scan.
+    {
+        let tmp_dir = iota_common::tempdir();
+        let arc = {
+            let db = open_map::<_, u32, u8>(tmp_dir.path(), None);
+            db.insert(&1, &7).unwrap();
+            db.insert(&2, &8).unwrap();
+            db
+        };
+        let db =
+            DBMap::<u32, (u64, u64)>::reopen(&arc.db, None, &ReadWriteOptions::default(), false)
+                .expect("failed to reopen");
+
+        let forward = db.safe_iter().next();
+        assert!(
+            matches!(forward, Some(Err(TypedStoreError::Serialization(_)))),
+            "forward iteration must yield Some(Err(..)) on a bad value; got {forward:?}",
+        );
+        let reverse = db.safe_range_iter_reversed(..).next();
+        assert!(
+            matches!(reverse, Some(Err(TypedStoreError::Serialization(_)))),
+            "reverse iteration must yield Some(Err(..)) on a bad value; got {reverse:?}",
+        );
+    }
+
+    // A bad KEY: store <u8, u32>, reopen with a wider key type so the key itself
+    // fails to deserialize (exercises the other error arm of `SafeIter::next`).
+    {
+        let tmp_dir = iota_common::tempdir();
+        let arc = {
+            let db = open_map::<_, u8, u32>(tmp_dir.path(), None);
+            db.insert(&1, &7).unwrap();
+            db
+        };
+        let db =
+            DBMap::<(u64, u64), u32>::reopen(&arc.db, None, &ReadWriteOptions::default(), false)
+                .expect("failed to reopen");
+
+        let first = db.safe_iter().next();
+        assert!(
+            matches!(first, Some(Err(TypedStoreError::Serialization(_)))),
+            "a key that fails to deserialize must yield Some(Err(..)); got {first:?}",
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_prefix_from_matches_old_bounded_scan() {
     let tmp_dir = iota_common::tempdir();
     let db: DBMap<(u64, u64), String> = open_map(tmp_dir.path(), None);

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -18,17 +18,15 @@ where
     db.safe_iter().map(|item| item.unwrap())
 }
 
-fn get_reverse_iter<K, V>(
-    db: &DBMap<K, V>,
-    lower_bound: Option<K>,
-    upper_bound: Option<K>,
-) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + use<'_, K, V>
+fn get_reverse_iter<'a, K, V>(
+    db: &'a DBMap<K, V>,
+    range: impl RangeBounds<K> + 'a,
+) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + 'a
 where
     K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
-    db.reversed_safe_iter_with_bounds(lower_bound, upper_bound)
-        .unwrap()
+    db.safe_range_iter_reversed(range)
 }
 
 fn get_iter_with_bounds<K, V>(
@@ -195,7 +193,7 @@ async fn test_skip() {
 
     // Skip to last
     assert_eq!(
-        get_reverse_iter(&db, None, None).next(),
+        get_reverse_iter(&db, ..).next(),
         Some(Ok((789, "789".to_string()))),
     );
 
@@ -215,15 +213,15 @@ async fn test_reverse_iter_with_bounds() {
     db.insert(&789, &"789".to_string())
         .expect("Failed to insert");
 
-    let mut iter = get_reverse_iter(&db, None, Some(999));
+    let mut iter = get_reverse_iter(&db, ..=999);
     assert_eq!(iter.next().unwrap(), Ok((789, "789".to_string())));
 
     db.insert(&999, &"999".to_string())
         .expect("Failed to insert");
-    let mut iter = get_reverse_iter(&db, None, Some(999));
+    let mut iter = get_reverse_iter(&db, ..=999);
     assert_eq!(iter.next().unwrap(), Ok((999, "999".to_string())));
 
-    let mut iter = get_reverse_iter(&db, None, None);
+    let mut iter = get_reverse_iter(&db, ..);
     assert_eq!(iter.next().unwrap(), Ok((999, "999".to_string())));
 }
 
@@ -265,7 +263,7 @@ async fn test_iter_reverse() {
     db.insert(&2, &"2".to_string()).expect("Failed to insert");
     db.insert(&3, &"3".to_string()).expect("Failed to insert");
 
-    let mut iter = get_reverse_iter(&db, None, None);
+    let mut iter = get_reverse_iter(&db, ..);
     assert_eq!(Some(Ok((3, "3".to_string()))), iter.next());
     assert_eq!(Some(Ok((2, "2".to_string()))), iter.next());
     assert_eq!(Some(Ok((1, "1".to_string()))), iter.next());
@@ -557,13 +555,13 @@ async fn test_reversed_safe_iter_inclusive_upper_bound_at_max() {
     db.insert(&100u8, &"100".to_string()).unwrap();
     db.insert(&u8::MAX, &"max".to_string()).unwrap();
 
-    let results: Vec<_> = get_reverse_iter(&db, None, Some(u8::MAX))
+    let results: Vec<_> = get_reverse_iter(&db, ..=u8::MAX)
         .map(|item| item.unwrap())
         .collect();
     assert_eq!(
         vec![(u8::MAX, "max".to_string()), (100u8, "100".to_string())],
         results,
-        "reversed_safe_iter_with_bounds upper=u8::MAX must include the entry at u8::MAX",
+        "safe_range_iter_reversed with ..=u8::MAX must include the entry at u8::MAX",
     );
 }
 
@@ -708,17 +706,16 @@ async fn test_safe_iter_with_prefix_at_max() {
 }
 
 #[tokio::test]
-async fn test_reversed_safe_iter_with_bounds_is_inclusive() {
+async fn test_safe_range_iter_reversed_inclusive_ranges() {
     let tmp_dir = iota_common::tempdir();
     let db: DBMap<u32, String> = open_map(tmp_dir.path(), None);
     for i in 1..100u32 {
         db.insert(&i, &i.to_string()).unwrap();
     }
 
-    // Both bounds inclusive: [10, 20] in descending order (unchanged contract).
+    // Closed range: [10, 20] in descending order.
     let got: Vec<_> = db
-        .reversed_safe_iter_with_bounds(Some(10), Some(20))
-        .unwrap()
+        .safe_range_iter_reversed(10..=20)
         .map(|r| r.unwrap())
         .collect();
     assert_eq!(
@@ -729,10 +726,9 @@ async fn test_reversed_safe_iter_with_bounds_is_inclusive() {
         got,
     );
 
-    // Upper-only stays inclusive: [.., 20] in descending order.
+    // Upper-only inclusive range: [.., 20] in descending order.
     let got: Vec<_> = db
-        .reversed_safe_iter_with_bounds(None, Some(20))
-        .unwrap()
+        .safe_range_iter_reversed(..=20)
         .map(|r| r.unwrap())
         .collect();
     assert_eq!(

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -48,17 +48,21 @@ where
     /// Returns true if the map is empty, otherwise false.
     fn is_empty(&self) -> bool;
 
-    /// Same as `iter` but performs status check.
+    /// Iterates over all entries in key order.
     fn safe_iter(&'a self) -> DbIterator<'a, (K, V)>;
 
-    // Same as `iter_with_bounds` but performs status check.
+    /// Iterates over the half-open key range `[lower_bound, upper_bound)` —
+    /// the lower bound is inclusive, the upper bound exclusive, and a `None`
+    /// bound leaves that side unbounded. Equivalent to
+    /// `safe_range_iter(lower_bound..upper_bound)`.
     fn safe_iter_with_bounds(
         &'a self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
     ) -> DbIterator<'a, (K, V)>;
 
-    // Same as `range_iter` but performs status check.
+    /// Iterates over the keys within `range`, honoring the range's own bound
+    /// inclusivity (e.g. `lo..hi` excludes `hi`, `lo..=hi` includes it).
     fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)>;
 
     /// Returns a vector of values corresponding to the keys provided,

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -19,19 +19,6 @@ where
         .expect("failed to serialize via be_fix_int_ser method")
 }
 
-pub(crate) fn iterator_bounds<K>(
-    lower_bound: Option<K>,
-    upper_bound: Option<K>,
-) -> (Option<Vec<u8>>, Option<Vec<u8>>)
-where
-    K: Serialize,
-{
-    (
-        lower_bound.map(|b| be_fix_int_ser(&b)),
-        upper_bound.map(|b| be_fix_int_ser(&b)),
-    )
-}
-
 pub(crate) fn iterator_bounds_with_range<K>(
     range: impl RangeBounds<K>,
 ) -> (Option<Vec<u8>>, Option<Vec<u8>>)
@@ -54,7 +41,7 @@ where
                 key_buf.push(0);
             } else {
                 // Since we want exclusive, we need to increment the key to exclude the previous
-                big_endian_saturating_add_one(&mut key_buf);
+                big_endian_add_one(&mut key_buf);
             }
             Some(key_buf)
         }
@@ -64,15 +51,18 @@ where
         Bound::Included(upper_bound) => {
             let mut key_buf = be_fix_int_ser(&upper_bound);
 
-            // If the key is already at the limit, there's nowhere else to go, so no upper
-            // bound
-            if !is_max(&key_buf) {
-                // Since we want exclusive, we need to increment the key to get the upper bound
-                big_endian_saturating_add_one(&mut key_buf);
-                Some(key_buf)
+            if is_max(&key_buf) {
+                // No same-length key is greater than the maximum, but a longer key
+                // extending it still is. Append a zero byte so the (exclusive) upper
+                // bound is the first such key, keeping any extension out of an
+                // inclusive `..=max` range.
+                key_buf.push(0);
             } else {
-                None
+                // Rocksdb upper bound is exclusive, so increment to make the
+                // caller's inclusive bound inclusive.
+                big_endian_add_one(&mut key_buf);
             }
+            Some(key_buf)
         }
         Bound::Excluded(upper_bound) => {
             // Rocksdb upper bound is exclusive by default so nothing to do
@@ -83,21 +73,53 @@ where
     (iterator_lower_bound, iterator_upper_bound)
 }
 
-/// Given a vec<u8>, find the value which is one more than the vector
-/// if the vector was a big endian number.
-/// If the vector is already minimum, don't change it.
-fn big_endian_saturating_add_one(v: &mut [u8]) {
-    if is_max(v) {
-        return;
-    }
+/// Computes the raw byte bounds for a prefix scan over keys serialized with
+/// [`be_fix_int_ser`].
+///
+/// `prefix` must serialize to a prefix of the column family's key encoding —
+/// typically the leading field(s) of a tuple key. Returns the half-open byte
+/// range `[ser(prefix), ser(prefix) + 1)`, which selects exactly the keys that
+/// begin with `ser(prefix)`. When the serialized prefix is all `0xFF` there is
+/// no representable upper bound, so the scan runs to the end of the column
+/// family.
+pub(crate) fn prefix_iterator_bounds<P>(prefix: &P) -> (Option<Vec<u8>>, Option<Vec<u8>>)
+where
+    P: ?Sized + Serialize,
+{
+    let lower = be_fix_int_ser(prefix);
+    let upper = if is_max(&lower) {
+        None
+    } else {
+        let mut upper = lower.clone();
+        big_endian_add_one(&mut upper);
+        Some(upper)
+    };
+    (Some(lower), upper)
+}
+
+/// Increments the big-endian integer in `v` by one, in place.
+///
+/// Callers must ensure `v` is not all-`0xFF` (each one checks `is_max` and
+/// handles that case separately).
+///
+/// # Panics
+///
+/// Panics if `v` is all-`0xFF`. Incrementing it would overflow, and silently
+/// wrapping to zero would emit a wrong key; panicking instead keeps a buggy
+/// caller from corrupting the keyspace.
+fn big_endian_add_one(v: &mut [u8]) {
     for i in (0..v.len()).rev() {
         if v[i] == u8::MAX {
             v[i] = 0;
         } else {
             v[i] += 1;
-            break;
+            return;
         }
     }
+    // Reaching here means no byte could be incremented, i.e. `v` was all-`0xFF`
+    // and the carry ran off the top — a violated precondition. Panic rather than
+    // return a silently-wrapped, incorrect key.
+    unreachable!("big_endian_add_one called on an all-0xFF value")
 }
 
 /// Check if all the bytes in the vector are 0xFF
@@ -114,7 +136,7 @@ fn test_helpers() {
     fn check_add(v: Vec<u8>) {
         let mut v = v;
         let num = Num32::from_big_endian(&v);
-        big_endian_saturating_add_one(&mut v);
+        big_endian_add_one(&mut v);
         assert!(num + 1 == Num32::from_big_endian(&v));
     }
 
@@ -123,13 +145,48 @@ fn test_helpers() {
         struct Num32(4);
     }
 
-    let mut v = vec![255; 32];
-    big_endian_saturating_add_one(&mut v);
-    assert!(Num32::MAX == Num32::from_big_endian(&v));
-
     check_add(vec![1; 32]);
     check_add(vec![6; 32]);
     check_add(vec![254; 32]);
 
     // TBD: More tests coming with randomized arrays
+}
+
+#[test]
+#[should_panic(expected = "all-0xFF")]
+fn big_endian_add_one_panics_on_max() {
+    big_endian_add_one(&mut [0xFFu8; 4]);
+}
+
+#[test]
+fn test_inclusive_upper_bound_at_max() {
+    // The missed case: an inclusive upper bound whose serialization is all-`0xFF`.
+    // The exclusive rocksdb upper bound must be the first key PAST it
+    // (`ser(hi) ++ [0]`), not `None`. With `None` the scan is unbounded, so a
+    // longer key that extends the max (and therefore sorts *after* it) is wrongly
+    // included in `..=hi`. Verify the actual inclusion/exclusion the bound yields,
+    // for single-byte, multi-byte and array maxima.
+    fn check_max<K: Serialize>(max: K) {
+        let hi = be_fix_int_ser(&max);
+        assert!(is_max(&hi), "test value must serialize to all-0xFF");
+        let (_, upper) = iterator_bounds_with_range::<K>((Bound::Unbounded, Bound::Included(max)));
+        let upper = upper.expect("inclusive upper at the max must be bounded, not None");
+
+        // `hi` itself stays inside the (exclusive) bound; a key extending it does not.
+        let mut extension = hi.clone();
+        extension.push(0);
+        assert!(hi < upper, "the max key itself must stay in range");
+        assert!(
+            extension >= upper,
+            "a key extending the max must be excluded"
+        );
+        assert_eq!(upper, extension, "bound must be exactly ser(hi) ++ [0]");
+    }
+    check_max(u8::MAX);
+    check_max(u64::MAX);
+    check_max([0xFFu8; 32]);
+
+    // Symmetric with the excluded-lower arm at the max.
+    let (lower, _) = iterator_bounds_with_range::<u8>((Bound::Excluded(u8::MAX), Bound::Unbounded));
+    assert_eq!(lower, Some(vec![0xFF, 0x00]));
 }


### PR DESCRIPTION
# Description of change

Make the typed-store iterator wrapper produce consistent key ranges in both directions and remove the need for hand-built maximum keys in composite-key scans.

`safe_iter_with_bounds(lo, hi)` and `reversed_safe_iter_with_bounds(lo, hi)` computed their raw rocksdb bounds independently: the forward iterator covered `[lo, hi)` while the reversed one covered `[lo, hi]`, so reversing a scan did not yield the same key set. Separately, scanning "all entries under a leading key" of a composite key required constructing artificial maximum keys (`ObjectKey::max_for_id`, `usize::MAX` tuple tails, etc.).

Those issues are solved with two new sets of methods:
- Added `safe_range_iter_reversed` - reversed version of pre-existing `safe_range_iter`. It is a better version of `reversed_safe_iter_with_bounds`, because it **explicitly** defines type of bounds (included, excluded). Also `safe_range_iter` and `safe_range_iter_reversed` are now using same underlying logic for bound calculation, so it is impossible that they ever become asymmetric. 
- Added `safe_iter_with_prefix` / `safe_iter_with_prefix_reversed` - enable clear iteration by prefix, which is what magical `MAX` values were mostly used for. This removes most current and future uses of `MAX` values. A `safe_iter_with_prefix_from` variant covers cursor-paginated prefix scans (start from a cursor, no `MAX` upper bound).

The change is split into five self-contained commits (the latter four are independently revertable):

1. **`fix(typed-store): unify iterator bound handling and add prefix scans`** — route all bound computation through one range engine (`iterator_bounds_with_range`) and add `safe_range_iter_reversed`, which by construction yields exactly the keys of `safe_range_iter` in descending order. `SafeRevIter` now takes an exclusive upper boundary and steps off the boundary key when the initial seek lands on it, so exclusive upper bounds work in reverse as well. Add `safe_iter_with_prefix` / `safe_iter_with_prefix_reversed`, which derive the upper bound by incrementing the serialized prefix bytes, and migrate `AuthorityStore::get_latest_marker` as the first consumer. The Option-based wrappers keep their existing documented semantics as thin presets over the range engine.

2. **`refactor(typed-store): remove reversed_safe_iter_with_bounds in favor of safe_range_iter_reversed`** — the Option-based reverse iterator hard-coded inclusive bounds, invisible at the call site. Migrate all callers to the range form, where inclusivity is spelled out by the range syntax, and drop the wrapper together with its vestigial `Result`. The translation is semantics-preserving:

   | old | new |
   |---|---|
   | `(None, None)` | `..` |
   | `(None, Some(hi))` | `..=hi` |
   | `(Some(lo), Some(hi))` | `lo..=hi` |

   Note for upstream ports: Sui still has `reversed_safe_iter_with_bounds`; ported code touching these call sites should apply the mapping above.

3. **`refactor(iota-core): use prefix iterators instead of artificial MAX keys`** — replace the pure prefix scans (`get_events_by_events_digest`, `have_deleted_owned_object_at_version_or_after`, `get_latest_live_version_for_object_id`, `get_latest_object_ref_or_tombstone`, `get_latest_object_or_tombstone`, `try_get_object`, and the `#[cfg(msim)]` `count_object_versions`) with prefix iterators. Sites where a bound carries a real value (cursors, version cutoffs, `range_iter_live_object_set` spanning multiple ids) keep the explicit range form. Two behavior deltas, both safe: (a) a prefix scan also tightens the *lower* bound (from unbounded / `min_for_id` to the prefix start) — safe because every migrated reader re-checks the leading key (epoch / object id) of the first row, so a narrower lower bound cannot change the result; (b) the replaced `..=max_for_id` upper bounds capped the version component at `MAX_VALID_EXCL` while a prefix scan covers the full `u64` space — equivalent because sentinel versions (`CANCELLED_READ`, `CONGESTED_*`, `MAX_VALID_EXCL`) are scheduling-time artifacts, never persisted as object or marker table keys (a write-path invariant; verified by inspecting the write paths, not unit-tested, since a read-side test could only re-demonstrate the inclusion rather than prove the invariant).

4. **`refactor(typed-store,iota-core): add safe_iter_with_prefix_from and drop MAX bounds in cursor scans`** — add `safe_iter_with_prefix_from(&prefix, &cursor)` (the rocksdb `prefix_iterator_from` idiom: lower bound `prefix ++ cursor`, upper bound derived by incrementing the serialized prefix bytes). `cursor` is the remainder of the key after the prefix, **not** a full key, so the prefix is never duplicated and the lower bound is a prefix of the key by construction. Migrates the cursor-paginated prefix scans (`get_dynamic_fields_iterator`, `dynamic_field_iter`, `package_versions_iter`) off their `(prefix, MAX)` upper bounds; those callers keep their `.skip(cursor.is_some())` (the cursor stays the inclusive lower bound). `get_newer_object_keys` is migrated too but has no cursor — its lower bound is `object.1.next()` (version + 1, an exclusive-by-construction start) and it uses no `.skip`. The prefix scan covers the whole prefix, including a key sitting exactly at the type's maximum tail that the old exclusive `(prefix, MAX)` bound dropped — never a real version/marker, a corrected edge for dynamic-field ids, equivalent for all real data. Reversed-pagination scans and the hash-bounded `owner_iter` keep explicit ranges — their bounds are not pure prefixes.

5. **`fix(typed-store): surface deserialization errors in SafeIter instead of ending iteration`** — `SafeIter::next` mapped a failed key/value deserialization to `None` via `.ok()`, indistinguishable from end-of-data, so one undeserializable row silently truncated the rest of the scan (the item type is `Result<(K, V), _>` precisely so the error can be reported; upstream returns it, the IOTA port had regressed to swallowing it with no test on the path). Now returns `Some(Err(TypedStoreError::Serialization(..)))`, matching how the in-memory backend (`memstore`) and `DBMap::get`/`multi_get` already handle deserialization failures, with a regression test that reopens a column family with a wider value type and asserts iteration yields `Some(Err(..))`. Found in review of this PR.

The forward `safe_iter_with_bounds` is intentionally kept: its `[lo, hi)` contract matches the conventional half-open semantics, it is part of the `Map` trait shared with upstream, and it is now implemented as a thin preset over `safe_range_iter` with the contract documented on the trait.

Intentional runtime-behavior changes (no consumer relies on the old behavior):
- Prefix scans include an entry at the type's maximum tail that the old exclusive `(prefix, MAX)` bound excluded (see commits 3-4); only matters for a key exactly at that tail, which the migrated tables never hold.
- `SafeIter::next` now surfaces a deserialization failure as `Some(Err(..))` instead of mapping it to `None` (silently truncating the scan); every iterator consumer is affected — `?`/collect propagate the error, `.next()`-style readers return it. No consumer was relying on silent skip-on-bad-row.

Edge-case note (issue point 2): the inclusive upper-bound arm of `iterator_bounds_with_range` returned `None` (unbounded) when the bound serialized to all-`0xFF`. That is fine for fixed-width keys, but a longer key extending the maximum sorts after it and was wrongly included in a `..=max` range. This PR returns `ser(max) ++ [0]` instead (the first key past the maximum), mirroring the excluded-lower arm, with a regression test. On top of that it adds reverse-direction and prefix regression coverage (forward/reverse symmetry across all bound kinds, prefix scans at the `0xFF` serialization limit, boundary keys present in the DB).

### Remaining `MAX` usages (deliberately not removed)

A few iterator bounds still build `MAX`/`MIN` keys by hand. They are left as-is because they are not pure forward prefix scans, so the new prefix APIs do not fit them cleanly; each would be a separate, higher-risk change:

- **Reversed pagination without a prefix** (`get_transactions` reversed over `transaction_order`, keyed by a bare `TxSequenceNumber`): `..=cursor.unwrap_or(MAX)` — there is no composite prefix here, `MAX` just means "no cursor → start from the end of the table". Removing it means branching on `cursor` (`..=c` vs `..`), pure cosmetics over a non-fragile sentinel.
- **Reversed prefix pagination** (`get_transactions_from_index`, `get_event_from_index`, `events_by_transaction`, `all_events`): these scan a leading key downwards from a cursor. They would fit a *reversed* `safe_iter_with_prefix_from`, but that is a new method with a different shape (in reverse the cursor is the upper bound and the prefix is the lower), and these sites currently stop via a `take_while`/predicate rather than a DB-level lower bound — switching the cutoff mechanism is a behavioral change that warrants its own PR with tests.
- **`owner_iter`** (gRPC): the `OwnerIndexKey` prefix length is filter-dependent (`owner`, or `(owner, id_hash)`, or `(owner, id_hash, params_hash)`), and the `MAX` values span the remaining unfixed fields. Expressible via prefix scans, but only by reworking `owner_bounds` per filter branch — not a mechanical swap.
- **`range_iter_live_object_set`**: `min_for_id(id_A)..=max_for_id(id_B)` spans a range of *different* object ids (table sharding for background scans). The heads differ, so there is no common prefix; the alternative `..(next(id_B), 0)` just moves the synthetic key elsewhere.
- **Range delete / compaction** (`schedule_delete_range` for events, `compact_range` for objects) and config sentinels (`num_epochs_to_retain == u64::MAX` meaning "retain forever"): these are not iterators at all — a "delete/compact by prefix" helper would be a separate API surface, and the config value is not a key.

Net: this PR removes the `MAX` keys that were standing in for a missing forward prefix API. The reversed-prefix cases are the natural next step (a reversed `prefix_from`) and are left for a follow-up.

## Links to any relevant issues

fixes #10929

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check` / `cargo clippy --all-targets --all-features -- -D warnings` are green for `typed-store`, `iota-core`, `iota-transactional-test-runner`, and `starfish-core`; the `typed-store` unit suite passes (48/48, including the new symmetry/prefix regression tests). Each commit builds and passes the typed-store suite on its own. Note: running the typed-store suite with parallel `cargo test` hits a pre-existing Prometheus `AlreadyReg` registry race (also fails on `develop`); the suite is green under `nextest` (process per test) and with `--test-threads=1`.








