### PR TITLE
feat(iota-types+light-client+ingestion-core): deduplicate committee-chain verification into `CommitteeChainVerifier`

### DIFF
--- a/crates/iota-data-ingestion-core/src/history/verifier.rs
+++ b/crates/iota-data-ingestion-core/src/history/verifier.rs
@@ -24,7 +24,7 @@
 use futures::{Stream, stream::TryStreamExt};
 use iota_config::genesis::Genesis;
 use iota_types::{
-    committee::{Committee, EpochId},
+    committee::{Committee, CommitteeChainVerifier, EpochId},
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointSequenceNumber, VerifiedCheckpoint,
     },
@@ -59,8 +59,9 @@ use crate::{
 /// ```
 pub struct EpochBoundaryVerifier {
     reader: HistoricalReader,
-    /// Committee expected to have signed the next checkpoint to verify
-    committee: Committee,
+    /// The committee-chain walk; its committee is the one expected to have
+    /// signed the next checkpoint to verify.
+    chain_verifier: CommitteeChainVerifier,
     /// The epoch boundaries stored in the remote store.
     epoch_boundaries: EpochBoundaries,
     /// The final epoch to verify.
@@ -88,7 +89,7 @@ impl EpochBoundaryVerifier {
         let epoch_boundaries = reader.epoch_boundaries().await?;
         Ok(Self {
             reader,
-            committee: starting_committee,
+            chain_verifier: CommitteeChainVerifier::new(starting_committee),
             epoch_boundaries,
             target_epoch,
         })
@@ -130,8 +131,8 @@ impl EpochBoundaryVerifier {
         Ok(last)
     }
 
-    /// Streams the verified last checkpoints from Genesis up to the target
-    /// epoch of the verifier.
+    /// Streams the verified last checkpoints from the starting committee's
+    /// epoch up to the target epoch of the verifier.
     ///
     /// This consumes the verifier. Each checkpoint is fetched into memory and
     /// verified only when the stream is polled. Upon successful verification
@@ -160,10 +161,9 @@ impl EpochBoundaryVerifier {
         Ok(futures::stream::try_unfold(
             self,
             |mut verifier| async move {
-                let Some((verified, next_epoch_committee)) = verifier.verify_next().await? else {
+                let Some(verified) = verifier.verify_next().await? else {
                     return Ok(None);
                 };
-                verifier.committee = next_epoch_committee;
                 Ok(Some((verified, verifier)))
             },
         ))
@@ -178,8 +178,8 @@ impl EpochBoundaryVerifier {
     /// The method returns [`None`] if the target epoch has been already
     /// verified.
     ///
-    /// Otherwise it returns the verified checkpoint along with the
-    /// [`Committee`] of the next epoch.
+    /// Otherwise it returns the verified checkpoint, advancing the committee
+    /// chain to the next epoch.
     ///
     /// # Errors
     ///
@@ -190,8 +190,8 @@ impl EpochBoundaryVerifier {
     /// * If the summary cannot be fetched from the remote store
     /// * If signature verification fails
     /// * If the checkpoint is not the last checkpoint of the epoch
-    async fn verify_next(&self) -> Result<Option<(VerifiedCheckpoint, Committee)>> {
-        let epoch_to_verify = self.committee.epoch;
+    async fn verify_next(&mut self) -> Result<Option<VerifiedCheckpoint>> {
+        let epoch_to_verify = self.chain_verifier.epoch();
         if epoch_to_verify > self.target_epoch {
             return Ok(None);
         }
@@ -203,33 +203,17 @@ impl EpochBoundaryVerifier {
 
         let summary = self.fetch_summary(sequence_number).await?;
 
-        let verified = summary.try_into_verified(&self.committee).map_err(|e| {
-            IngestionError::Verification(format!(
-                "failed to verify checkpoint {sequence_number} against the committee for epoch \
+        let verified = self
+            .chain_verifier
+            .verify_epoch_close(summary)
+            .map_err(|e| {
+                IngestionError::Verification(format!(
+                    "failed to verify checkpoint {sequence_number} as the close of epoch \
                  {epoch_to_verify}: {e}"
-            ))
-        })?;
+                ))
+            })?;
 
-        let end_of_epoch_data = verified.end_of_epoch_data.as_ref().ok_or_else(|| {
-            IngestionError::Verification(format!(
-                "checkpoint {sequence_number} is not the last checkpoint of an epoch (no end-of-epoch data)"
-            ))
-        })?;
-
-        let next_epoch = verified
-            .epoch()
-            .checked_add(1)
-            .expect("epoch number overflow");
-        let next_epoch_committee = Committee::new(
-            next_epoch,
-            end_of_epoch_data
-                .next_epoch_committee
-                .iter()
-                .cloned()
-                .collect(),
-        );
-
-        Ok(Some((verified, next_epoch_committee)))
+        Ok(Some(verified))
     }
 
     /// Fetches a single checkpoint summary into memory.

--- a/crates/iota-light-client/src/checkpoint.rs
+++ b/crates/iota-light-client/src/checkpoint.rs
@@ -17,8 +17,8 @@ use iota_config::{genesis::Genesis, node::ArchiveReaderConfig};
 use iota_json_rpc_types::CheckpointId;
 use iota_sdk::IotaClientBuilder;
 use iota_types::{
-    committee::Committee,
-    messages_checkpoint::{CertifiedCheckpointSummary, EndOfEpochData, VerifiedCheckpoint},
+    committee::{Committee, CommitteeChainVerifier},
+    messages_checkpoint::{CertifiedCheckpointSummary, VerifiedCheckpoint},
     storage::{ObjectStore, ReadStore, WriteStore},
 };
 use prometheus::Registry;
@@ -305,8 +305,9 @@ pub async fn sync_and_verify_checkpoints(config: &Config) -> anyhow::Result<()> 
 
     info!("Verifying summaries.");
 
-    // Check the signatures of all checkpoints
-    let mut prev_committee = genesis_committee;
+    // Walk the committee chain over the end-of-epoch checkpoints, anchored at
+    // the genesis committee.
+    let mut chain_verifier = CommitteeChainVerifier::new(genesis_committee);
     for seq in checkpoints_list.checkpoints {
         // Check if there is a corresponding checkpoint summary file in the checkpoints
         // directory
@@ -319,27 +320,15 @@ pub async fn sync_and_verify_checkpoints(config: &Config) -> anyhow::Result<()> 
             panic!("corrupted checkpoint directory");
         };
 
-        // Verify the checkpoint
-        summary.clone().try_into_verified(&prev_committee)?;
+        let verified = chain_verifier
+            .verify_epoch_close(summary)
+            .with_context(|| format!("Failed to verify checkpoint {seq}"))?;
 
         info!(
             "Verified epoch: {}, checkpoint: {seq}, checkpoint digest: {}",
-            summary.epoch(),
-            summary.digest()
+            verified.epoch(),
+            verified.digest()
         );
-
-        // Extract the next committee information
-        if let Some(EndOfEpochData {
-            next_epoch_committee,
-            ..
-        }) = &summary.end_of_epoch_data
-        {
-            let next_committee = next_epoch_committee.iter().cloned().collect();
-            prev_committee =
-                Committee::new(summary.epoch().checked_add(1).unwrap(), next_committee);
-        } else {
-            bail!("Expected all checkpoints to be end-of-epoch checkpoints");
-        }
     }
 
     Ok(())

--- a/crates/iota-types/src/committee.rs
+++ b/crates/iota-types/src/committee.rs
@@ -529,7 +529,12 @@ impl CommitteeChainVerifier {
             .expect("checked before verification");
 
         self.committee = Committee::new(
-            self.committee.epoch + 1,
+            self.committee
+                .epoch
+                .checked_add(1)
+                .ok_or(IotaError::AdvanceEpoch {
+                    error: "epoch number overflow".to_string(),
+                })?,
             end_of_epoch_data
                 .next_epoch_committee
                 .iter()

--- a/crates/iota-types/src/committee.rs
+++ b/crates/iota-types/src/committee.rs
@@ -25,6 +25,7 @@ use crate::{
         AuthorityKeyPair, AuthorityPublicKey, NetworkPublicKey, random_committee_key_pairs_of_size,
     },
     error::{IotaError, IotaResult},
+    messages_checkpoint::{CertifiedCheckpointSummary, VerifiedCheckpoint},
     multiaddr::Multiaddr,
 };
 
@@ -451,12 +452,109 @@ impl Display for CommitteeWithNetworkMetadata {
     }
 }
 
+/// Verifies the committee chain: the sequence of committees linked by each
+/// epoch's certified closing checkpoint, whose `end_of_epoch_data` elects the
+/// committee of the next epoch.
+///
+/// Starting from a trusted committee (typically the genesis committee, the
+/// operator's trust root), feed it each epoch's closing
+/// [`CertifiedCheckpointSummary`] in epoch order via
+/// [`Self::verify_epoch_close`]; every summary a consumer obtains this way is
+/// committee-verified, with no trust in whatever transport delivered it.
+///
+/// The walk is transport-agnostic by design — callers drive their own loop
+/// (an in-memory list, a remote-store stream, files on disk) and feed
+/// summaries in; this type only holds the verification state.
+#[derive(Debug)]
+pub struct CommitteeChainVerifier {
+    committee: Committee,
+}
+
+impl CommitteeChainVerifier {
+    /// Start the walk at a trusted committee — the trust root for everything
+    /// verified after it.
+    pub fn new(trusted_committee: Committee) -> Self {
+        Self {
+            committee: trusted_committee,
+        }
+    }
+
+    /// The epoch whose closing checkpoint must be fed next.
+    pub fn epoch(&self) -> EpochId {
+        self.committee.epoch
+    }
+
+    /// The committee of [`Self::epoch`] (trusted root or chain-verified).
+    pub fn committee(&self) -> &Committee {
+        &self.committee
+    }
+
+    /// Verify `summary` as the certified closing checkpoint of
+    /// [`Self::epoch`] and advance to the committee it elects for the next
+    /// epoch.
+    ///
+    /// Errors leave the verifier unchanged, e.g. if the summary is for a
+    /// different epoch, its signatures don't verify under the current
+    /// committee, or it is not a close-of-epoch checkpoint (no
+    /// `end_of_epoch_data`).
+    pub fn verify_epoch_close(
+        &mut self,
+        summary: CertifiedCheckpointSummary,
+    ) -> IotaResult<VerifiedCheckpoint> {
+        // The structural checks run before the (expensive) signature
+        // verification. They can only ever reject; nothing from the summary
+        // is trusted until the signatures verify.
+        if summary.data().epoch != self.committee.epoch {
+            return Err(IotaError::WrongEpoch {
+                expected_epoch: self.committee.epoch,
+                actual_epoch: summary.data().epoch,
+            });
+        }
+
+        if summary.data().end_of_epoch_data.is_none() {
+            return Err(IotaError::GenericAuthority {
+                error: format!(
+                    "checkpoint {} is not the closing checkpoint of epoch {} (no \
+                     end-of-epoch data)",
+                    summary.data().sequence_number,
+                    self.committee.epoch,
+                ),
+            });
+        }
+
+        let verified = summary.try_into_verified(&self.committee)?;
+        let end_of_epoch_data = verified
+            .end_of_epoch_data
+            .as_ref()
+            .expect("checked before verification");
+
+        self.committee = Committee::new(
+            self.committee.epoch + 1,
+            end_of_epoch_data
+                .next_epoch_committee
+                .iter()
+                .cloned()
+                .collect(),
+        );
+        Ok(verified)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use fastcrypto::traits::KeyPair;
 
     use super::*;
-    use crate::crypto::{AuthorityKeyPair, get_key_pair};
+    use crate::{
+        crypto::{AuthorityKeyPair, get_key_pair},
+        messages_checkpoint::{CheckpointSummary, EndOfEpochData, SignedCheckpointSummary},
+        utils::make_committee_key,
+    };
+
+    const RNG_SEED: [u8; 32] = [
+        21, 23, 199, 200, 234, 250, 252, 178, 94, 15, 202, 178, 62, 186, 88, 137, 233, 192, 130,
+        157, 179, 179, 65, 9, 31, 249, 221, 123, 225, 112, 199, 247,
+    ];
 
     #[test]
     fn test_shuffle_by_weight() {
@@ -505,5 +603,106 @@ mod test {
 
         let res = committee.shuffle_by_stake(None, Some(&BTreeSet::new()));
         assert_eq!(0, res.len());
+    }
+
+    /// `CommitteeChainVerifier` accepts a correctly signed chain of closing
+    /// checkpoints, advancing one committee per epoch — and rejects, without
+    /// advancing, a summary for the wrong epoch, one signed by a different
+    /// committee, and one that is not a close of epoch.
+    #[test]
+    fn committee_chain_verifier_walks_and_rejects() {
+        let mut rng = StdRng::from_seed(RNG_SEED);
+        let (keys, committee) = make_committee_key(&mut rng);
+        let (other_keys, other_committee) = make_committee_key(&mut rng);
+
+        let close_of_epoch = |epoch: EpochId, end_of_epoch_data: Option<EndOfEpochData>| {
+            let summary = CheckpointSummary {
+                epoch,
+                sequence_number: epoch,
+                network_total_transactions: 0,
+                content_digest: Default::default(),
+                previous_digest: None,
+                epoch_rolling_gas_cost_summary: Default::default(),
+                end_of_epoch_data,
+                timestamp_ms: 0,
+                version_specific_data: Vec::new(),
+                checkpoint_commitments: Vec::new(),
+            };
+            let signatures = keys
+                .iter()
+                .map(|k| SignedCheckpointSummary::sign(epoch, &summary, k, k.public().into()))
+                .collect();
+            let committee_at_epoch =
+                Committee::new(epoch, committee.voting_rights.iter().cloned().collect());
+            CertifiedCheckpointSummary::new(summary, signatures, &committee_at_epoch)
+                .expect("test summary must certify")
+        };
+        let handing_forward = Some(EndOfEpochData {
+            next_epoch_committee: committee.voting_rights.clone(),
+            next_epoch_protocol_version: 1.into(),
+            epoch_commitments: Vec::new(),
+            epoch_supply_change: 0,
+        });
+
+        let mut verifier = CommitteeChainVerifier::new(committee.clone());
+
+        // Wrong epoch: epoch 1's close fed while epoch 0 is expected.
+        assert!(matches!(
+            verifier.verify_epoch_close(close_of_epoch(1, handing_forward.clone())),
+            Err(IotaError::WrongEpoch { .. })
+        ));
+        assert_eq!(verifier.epoch(), 0, "a rejected summary must not advance");
+
+        // Not a close of epoch.
+        verifier
+            .verify_epoch_close(close_of_epoch(0, None))
+            .expect_err("a non-closing checkpoint must be rejected");
+        assert_eq!(verifier.epoch(), 0);
+
+        // The close-of-epoch check runs before the (expensive) signature
+        // verification: a non-closing summary certified by a foreign
+        // committee yields the structural error, not a signature error.
+        let foreign_non_closing = {
+            let summary = CheckpointSummary {
+                epoch: 0,
+                sequence_number: 0,
+                network_total_transactions: 0,
+                content_digest: Default::default(),
+                previous_digest: None,
+                epoch_rolling_gas_cost_summary: Default::default(),
+                end_of_epoch_data: None,
+                timestamp_ms: 0,
+                version_specific_data: Vec::new(),
+                checkpoint_commitments: Vec::new(),
+            };
+            let signatures = other_keys
+                .iter()
+                .map(|k| SignedCheckpointSummary::sign(0, &summary, k, k.public().into()))
+                .collect();
+            CertifiedCheckpointSummary::new(summary, signatures, &other_committee)
+                .expect("certifies under the foreign committee")
+        };
+        assert!(matches!(
+            verifier.verify_epoch_close(foreign_non_closing),
+            Err(IotaError::GenericAuthority { .. })
+        ));
+        assert_eq!(verifier.epoch(), 0);
+
+        // The valid chain walks: epoch 0 then epoch 1.
+        verifier
+            .verify_epoch_close(close_of_epoch(0, handing_forward.clone()))
+            .expect("epoch 0 close must verify");
+        assert_eq!(verifier.epoch(), 1);
+        verifier
+            .verify_epoch_close(close_of_epoch(1, handing_forward.clone()))
+            .expect("epoch 1 close must verify");
+        assert_eq!(verifier.epoch(), 2);
+
+        // A different trust root rejects the same (validly signed) chain.
+        let mut wrong_root = CommitteeChainVerifier::new(other_committee);
+        wrong_root
+            .verify_epoch_close(close_of_epoch(0, handing_forward))
+            .expect_err("a chain signed by a different committee must be rejected");
+        assert_eq!(wrong_root.epoch(), 0);
     }
 }


### PR DESCRIPTION
# Description of change

The "walk over end-of-epoch checkpoints, verify each epoch's certified closing checkpoint against the current committee, then advance to the committee its end_of_epoch_data elects" was implemented independently in `iota-light-client` and in `iota-data-ingestion-core::EpochBoundaryVerifier`. Duplicating this logic risks the security-relevant checks drifting apart.

This PR extracts the per-epoch step into a single shared type, `committee::CommitteeChainVerifier` in `iota-types`:
- verify_epoch_close(summary) verifies the summary as the certified close of the current epoch and advances to the next committee; errors leave the verifier unchanged.
- Deliberately a sync, transport-agnostic state machine: consumers keep their own fetch loops (files/RPC, remote-store stream, in-memory list), while all verification logic (epoch match, signatures, close-of-epoch requirement, next-committee construction) is single-sourced.
- Cheap structural checks run before the expensive BLS verification; they can only reject, nothing is trusted until signatures verify.
- iota-light-client and EpochBoundaryVerifier are refactored onto it (net code removal, behavior unchanged).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes