### PR TITLE
feat(snapshot+tool+node): chain-verified, archive-free summary sync from formal snapshot's EPOCH_INFO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7589,6 +7589,7 @@ dependencies = [
  "num_enum",
  "object_store 0.13.1",
  "prometheus",
+ "rand 0.8.6",
  "serde",
  "tempfile",
  "tokio",

--- a/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
+++ b/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
@@ -10,6 +10,30 @@ use iota_types::{
 };
 use test_cluster::TestClusterBuilder;
 
+/// Wait until the fullnode has executed every closed epoch's closing
+/// checkpoint (its executed open epoch reached `open_epoch`). The tests below
+/// read closed-epoch data from the live stores; without this, a closing
+/// checkpoint executed mid-test shifts the gap computation under the
+/// assertions (the cluster keeps running while the test works).
+async fn wait_until_executed_open_epoch(checkpoint_store: &CheckpointStore, open_epoch: u64) {
+    loop {
+        let executed_open_epoch = checkpoint_store
+            .get_highest_executed_checkpoint()
+            .unwrap()
+            .map(|checkpoint| {
+                if checkpoint.is_last_checkpoint_of_epoch() {
+                    checkpoint.epoch + 1
+                } else {
+                    checkpoint.epoch
+                }
+            });
+        if executed_open_epoch >= Some(open_epoch) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
 /// A formal-snapshot restore (unless `--skip-grpc-indexes` is passed) writes
 /// the store's contents and then `finalize_restore`s it (`Watermark::Indexed`
 /// + `meta`).
@@ -67,8 +91,10 @@ async fn finalized_restore_survives_grpc_indexes_store_init() {
     );
 }
 
-/// A matching manifest `chain_id` seeds every closed epoch; a mismatching one
-/// is rejected before any write, leaving `epochs_v2` untouched.
+/// EPOCH_INFO that matches the manifest `chain_id` and chain-verifies against
+/// the genesis committee seeds every closed epoch; a chain-id mismatch or a
+/// non-genesis trust root never yields the verified witness required to
+/// write anything.
 #[sim_test]
 async fn epoch_info_backfill_verifies_chain_before_seeding() {
     // Long epoch duration so the epoch only advances when forced, keeping the
@@ -88,6 +114,7 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
     // Closed epochs are `[0, current)`; EPOCH_INFO covers exactly those.
     let current_epoch = state.current_epoch_for_testing();
     assert!(current_epoch >= 2, "need at least two closed epochs");
+    wait_until_executed_open_epoch(&checkpoint_store, current_epoch).await;
 
     // This node's chain id — what a same-chain snapshot's manifest carries.
     let expected_chain_id = state.get_chain_identifier();
@@ -98,17 +125,28 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
     )
     .expect("system state must BCS-encode");
 
-    // SUCCESS: a matching chain_id seeds every closed epoch into a fresh store.
+    // The trust root for the committee-chain walk over the real summaries.
+    let genesis_committee = test_cluster
+        .swarm
+        .config()
+        .genesis
+        .committee()
+        .expect("genesis committee");
+
+    // SUCCESS: a matching chain_id + committee chain seeds every closed epoch
+    // into a fresh store.
     let ok_tmp = tempfile::tempdir().unwrap();
     let ok_grpc = GrpcIndexesStore::new_without_init(ok_tmp.path().to_path_buf());
-    iota_snapshot::verify_and_restore_epoch_info(
-        &ok_grpc,
+    iota_snapshot::verify_epoch_info_chain(
         real_epoch_info(&checkpoint_store, &system_state_bytes, current_epoch),
+        genesis_committee.clone(),
         expected_chain_id,
         expected_chain_id,
     )
+    .expect("a same-chain snapshot must verify")
+    .restore_epoch_info(&ok_grpc)
     .await
-    .expect("a same-chain snapshot must seed");
+    .expect("a verified snapshot must seed");
     for epoch in 0..current_epoch {
         assert!(
             ok_grpc.get_epoch_info(epoch).unwrap().is_some(),
@@ -120,12 +158,14 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
     // epoch, so the write skips the whole prefix.
     let watermark = ok_grpc.highest_indexed_epoch().unwrap();
     assert_eq!(watermark, Some(current_epoch - 1));
-    iota_snapshot::verify_and_restore_epoch_info(
-        &ok_grpc,
+    iota_snapshot::verify_epoch_info_chain(
         real_epoch_info(&checkpoint_store, &system_state_bytes, current_epoch),
+        genesis_committee.clone(),
         expected_chain_id,
         expected_chain_id,
     )
+    .expect("re-verification must succeed")
+    .restore_epoch_info(&ok_grpc)
     .await
     .expect("re-seeding a covered store must succeed as a no-op");
     assert_eq!(
@@ -134,31 +174,33 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
         "re-seeding must leave the watermark unchanged"
     );
 
-    // FAILURE: a different chain_id is rejected and NOTHING is written.
-    let bad_tmp = tempfile::tempdir().unwrap();
-    let bad_grpc = GrpcIndexesStore::new_without_init(bad_tmp.path().to_path_buf());
-    let err = iota_snapshot::verify_and_restore_epoch_info(
-        &bad_grpc,
+    // FAILURE: a different chain_id never yields a verified witness, so
+    // NOTHING can be written.
+    let err = iota_snapshot::verify_epoch_info_chain(
         real_epoch_info(&checkpoint_store, &system_state_bytes, current_epoch),
+        genesis_committee.clone(),
         ChainIdentifier::default(),
         expected_chain_id,
     )
-    .await
     .expect_err("a wrong-network snapshot must be rejected");
     assert!(
         err.to_string().contains("chain_id"),
         "expected a chain_id mismatch error, got: {err}"
     );
+
+    // FAILURE: a wrong trust root (the current committee instead of the
+    // genesis one, after two reconfigurations) fails the chain walk.
+    let err = iota_snapshot::verify_epoch_info_chain(
+        real_epoch_info(&checkpoint_store, &system_state_bytes, current_epoch),
+        state.clone_committee_for_testing(),
+        expected_chain_id,
+        expected_chain_id,
+    )
+    .expect_err("a non-genesis trust root must be rejected");
     assert!(
-        bad_grpc.highest_indexed_epoch().unwrap().is_none(),
-        "verification failure must leave the epochs_v2 watermark unset"
+        err.to_string().contains("genesis committee"),
+        "expected a trust-root error, got: {err}"
     );
-    for epoch in 0..current_epoch {
-        assert!(
-            bad_grpc.get_epoch_info(epoch).unwrap().is_none(),
-            "no epoch row may be written when verification fails"
-        );
-    }
 }
 
 /// `epochs_v2_gap` (the startup guard's check) reports no gap for a
@@ -181,7 +223,9 @@ async fn epochs_v2_gap_detects_incomplete_index() {
         .with(|node| node.state());
     let authority_store = state.database_for_testing();
     let checkpoint_store = state.get_checkpoint_store().clone();
-    assert!(state.current_epoch_for_testing() >= 2);
+    let current_epoch = state.current_epoch_for_testing();
+    assert!(current_epoch >= 2);
+    wait_until_executed_open_epoch(&checkpoint_store, current_epoch).await;
 
     // Full-history `new()` indexes `[0, current)` from local data → no gap, so a
     // gRPC node here would NOT panic.
@@ -232,6 +276,7 @@ async fn missing_epochs_above_snapshot_prefix_are_indexed_locally() {
     let checkpoint_store = state.get_checkpoint_store().clone();
     let current_epoch = state.current_epoch_for_testing();
     assert!(current_epoch >= 2, "need at least two closed epochs");
+    wait_until_executed_open_epoch(&checkpoint_store, current_epoch).await;
 
     let expected_chain_id = state.get_chain_identifier();
     let system_state_bytes = bcs::to_bytes(
@@ -245,12 +290,19 @@ async fn missing_epochs_above_snapshot_prefix_are_indexed_locally() {
     // the later closed epochs missing.
     let tmp = tempfile::tempdir().unwrap();
     let grpc = GrpcIndexesStore::new_without_init(tmp.path().to_path_buf());
-    iota_snapshot::verify_and_restore_epoch_info(
-        &grpc,
+    iota_snapshot::verify_epoch_info_chain(
         real_epoch_info(&checkpoint_store, &system_state_bytes, 1),
+        test_cluster
+            .swarm
+            .config()
+            .genesis
+            .committee()
+            .expect("genesis committee"),
         expected_chain_id,
         expected_chain_id,
     )
+    .expect("the lagging snapshot's prefix must verify")
+    .restore_epoch_info(&grpc)
     .await
     .expect("seeding the lagging snapshot's prefix must succeed");
     assert_eq!(grpc.highest_indexed_epoch().unwrap(), Some(0));

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -560,6 +560,7 @@ impl IotaNode {
                 Self::backfill_epochs_v2_from_snapshot(
                     grpc_indexes_store,
                     remote_store_config,
+                    genesis.committee()?,
                     chain_identifier,
                     &store,
                     &checkpoint_store,
@@ -885,6 +886,7 @@ impl IotaNode {
     async fn backfill_epochs_v2_from_snapshot(
         grpc_indexes_store: &GrpcIndexesStore,
         remote_store_config: &ObjectStoreConfig,
+        genesis_committee: Committee,
         expected_chain_id: ChainIdentifier,
         authority_store: &AuthorityStore,
         checkpoint_store: &CheckpointStore,
@@ -893,13 +895,15 @@ impl IotaNode {
         info!("backfilling gRPC epochs_v2 from snapshot EPOCH_INFO up to epoch {epoch}");
         let (snapshot_chain_id, epoch_info) =
             StateSnapshotReaderV1::read_epoch_info_only(epoch, remote_store_config).await?;
-        iota_snapshot::verify_and_restore_epoch_info(
-            grpc_indexes_store,
+        // Anchor the bucket's data to this node's trust roots: the chain id
+        // and the committee chain walked from the genesis committee.
+        let verified = iota_snapshot::verify_epoch_info_chain(
             epoch_info,
+            genesis_committee,
             snapshot_chain_id,
             expected_chain_id,
-        )
-        .await?;
+        )?;
+        verified.restore_epoch_info(grpc_indexes_store).await?;
         // The published snapshot can lag local execution (a delayed snapshot
         // pipeline); close as much of the residual gap as pruning still
         // allows by replaying the missing epochs' closing checkpoints.

--- a/crates/iota-snapshot/Cargo.toml
+++ b/crates/iota-snapshot/Cargo.toml
@@ -35,6 +35,7 @@ iota-storage.workspace = true
 iota-types.workspace = true
 
 [dev-dependencies]
+rand.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -38,6 +38,7 @@ use iota_storage::{
     FileCompression, SHA3_BYTES, compute_sha3_checksum, object_store::util::path_to_filesystem,
 };
 use iota_types::{
+    committee::{Committee, CommitteeChainVerifier},
     digests::ChainIdentifier,
     global_state_hash::GlobalStateHash,
     iota_system_state::{
@@ -342,24 +343,84 @@ impl EpochInfo {
     }
 }
 
-/// Verify the snapshot's `chain_id`, then restore its `EPOCH_INFO` rows into
-/// the given consumer's epoch store; a foreign-chain snapshot is rejected
-/// before any write. Generic over [`RestoreEpochInfo`] so the gRPC index and
-/// an external indexer each provide their own persistence.
-pub async fn verify_and_restore_epoch_info(
-    db: &impl RestoreEpochInfo,
+/// Chain-verified `EPOCH_INFO`: the snapshot's `chain_id` matched, and every
+/// entry's certified `last_checkpoint_summary` was verified against its
+/// epoch's committee, walking the committee handoffs from the genesis
+/// committee. The only constructor is [`verify_epoch_info_chain`], so holding
+/// one is proof the data is anchored to the operator-provided genesis — the
+/// same trust model as the checkpoint-archive sync.
+#[derive(Debug)]
+pub struct VerifiedEpochInfo {
     epoch_info: EpochInfo,
+    committees: Vec<Committee>,
+}
+
+impl VerifiedEpochInfo {
+    /// Entries for epochs `[0, snapshot_epoch]`, in epoch order.
+    pub fn entries(&self) -> &[EpochInfoV1Entry] {
+        self.epoch_info.entries()
+    }
+
+    /// Committees for epochs `[0, snapshot_epoch + 1]`: the genesis committee
+    /// plus one handed forward by each entry's `end_of_epoch_data`.
+    pub fn committees(&self) -> &[Committee] {
+        &self.committees
+    }
+
+    /// Restore the verified rows `[0, snapshot_epoch]` into the given
+    /// consumer's epoch store.
+    pub async fn restore_epoch_info(self, db: &impl RestoreEpochInfo) -> anyhow::Result<()> {
+        let rows = self.epoch_info.into_epoch_info_v2_rows()?;
+        db.restore_epoch_info(rows).await
+    }
+}
+
+/// Verify a snapshot's `EPOCH_INFO` against the operator's trust roots: the
+/// expected `chain_id`, and the committee chain walked from the genesis
+/// committee — each entry must be the certified close of its epoch (contiguous
+/// from epoch 0, carrying `end_of_epoch_data`), signed by the committee the
+/// previous entry handed forward. Nothing is written; the returned
+/// [`VerifiedEpochInfo`] is the witness consumers require.
+pub fn verify_epoch_info_chain(
+    epoch_info: EpochInfo,
+    genesis_committee: Committee,
     snapshot_chain_id: ChainIdentifier,
     expected_chain_id: ChainIdentifier,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<VerifiedEpochInfo> {
     anyhow::ensure!(
         snapshot_chain_id == expected_chain_id,
         "snapshot chain_id {snapshot_chain_id} does not match this node's chain \
          {expected_chain_id} (snapshot from the wrong network's bucket?)"
     );
+    anyhow::ensure!(
+        genesis_committee.epoch == 0,
+        "the trust root must be the genesis committee, got epoch {}",
+        genesis_committee.epoch
+    );
 
-    let rows = epoch_info.into_epoch_info_v2_rows()?;
-    db.restore_epoch_info(rows).await
+    let mut chain_verifier = CommitteeChainVerifier::new(genesis_committee);
+    let mut committees = vec![chain_verifier.committee().clone()];
+    for (index, entry) in epoch_info.entries().iter().enumerate() {
+        // EPOCH_INFO-specific: entries must be the contiguous epochs from 0.
+        // Everything else (summary epoch, signatures, close-of-epoch,
+        // committee handover) is the chain walk itself.
+        anyhow::ensure!(
+            entry.epoch == index as u64,
+            "EPOCH_INFO entry at index {index} declares epoch {}",
+            entry.epoch,
+        );
+        chain_verifier
+            .verify_epoch_close(entry.last_checkpoint_summary.clone())
+            .map_err(|e| {
+                anyhow::anyhow!("EPOCH_INFO entry for epoch {index} failed verification: {e}")
+            })?;
+        committees.push(chain_verifier.committee().clone());
+    }
+
+    Ok(VerifiedEpochInfo {
+        epoch_info,
+        committees,
+    })
 }
 
 impl TryFrom<EpochInfoV1Entry> for EpochInfoV2 {

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -7,11 +7,14 @@ use std::{
     fs,
     io::Write,
     num::NonZeroUsize,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use byteorder::{BigEndian, ByteOrder};
-use fastcrypto::hash::{HashFunction, MultisetHash, Sha3_256};
+use fastcrypto::{
+    hash::{HashFunction, MultisetHash, Sha3_256},
+    traits::KeyPair,
+};
 use futures::future::AbortHandle;
 use indicatif::MultiProgress;
 use iota_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
@@ -24,14 +27,17 @@ use iota_node_storage::GrpcIndexes;
 use iota_sdk_types::{GasCostSummary, ObjectId};
 use iota_types::{
     base_types::IotaAddress,
-    committee::EpochId,
-    crypto::AuthorityStrongQuorumSignInfo,
+    committee::{Committee, EpochId},
+    crypto::{AuthorityKeyPair, get_key_pair_from_rng},
     digests::{ChainIdentifier, TransactionDigest},
     effects::TransactionEvents,
     global_state_hash::GlobalStateHash,
     iota_system_state::IotaSystemState,
     message_envelope::Envelope,
-    messages_checkpoint::{CheckpointSummary, ECMHLiveObjectSetDigest},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointSummary, ECMHLiveObjectSetDigest, EndOfEpochData,
+        SignedCheckpointSummary,
+    },
     object::Object,
     storage::{
         CoinInfo, DynamicFieldIteratorItem, EpochInfoV2, OwnedObjectCursor,
@@ -39,11 +45,13 @@ use iota_types::{
         error::Result as StorageResult,
     },
 };
+use rand::SeedableRng;
 
 use crate::{
     EPOCH_INFO_FILE_MAGIC, EpochInfo, EpochInfoV1, EpochInfoV1Entry, FileCompression, FileMetadata,
     FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC, Manifest, ManifestV2, OBJECT_REF_BYTES,
-    reader::StateSnapshotReaderV1, restore::RestoreWithGrpcIndexes, writer::StateSnapshotWriterV1,
+    reader::StateSnapshotReaderV1, restore::RestoreWithGrpcIndexes, verify_epoch_info_chain,
+    writer::StateSnapshotWriterV1,
 };
 
 /// In-memory `GrpcIndexes` stub for snapshot tests.
@@ -118,27 +126,61 @@ fn test_system_state() -> IotaSystemState {
     state
 }
 
-fn fully_populated_checkpoint_summary(
-    epoch: EpochId,
-) -> iota_types::messages_checkpoint::CertifiedCheckpointSummary {
-    let summary = CheckpointSummary {
+/// One validator set for the whole test process, shared by every fixture:
+/// summaries signed in one helper must verify against committees built in
+/// another. (`new_simple_test_committee` is fixed-seed deterministic; the
+/// `OnceLock` just makes the sharing explicit and skips repeated keygen.)
+fn test_validator_set() -> &'static (Committee, Vec<AuthorityKeyPair>) {
+    static SET: OnceLock<(Committee, Vec<AuthorityKeyPair>)> = OnceLock::new();
+    SET.get_or_init(Committee::new_simple_test_committee)
+}
+
+/// The fixed validator set's committee at `epoch` (the set never rotates in
+/// these fixtures, only the epoch advances).
+fn test_committee_at(epoch: EpochId) -> Committee {
+    let (genesis_committee, _) = test_validator_set();
+    Committee::new(
+        epoch,
+        genesis_committee.voting_rights.iter().cloned().collect(),
+    )
+}
+
+/// An end-of-epoch summary for `epoch`, handing the fixed validator set
+/// forward to `epoch + 1`.
+fn end_of_epoch_summary(epoch: EpochId) -> CheckpointSummary {
+    CheckpointSummary {
         epoch,
         sequence_number: 0,
         network_total_transactions: 0,
         content_digest: Default::default(),
         previous_digest: None,
         epoch_rolling_gas_cost_summary: GasCostSummary::default(),
-        end_of_epoch_data: None,
+        end_of_epoch_data: Some(EndOfEpochData {
+            next_epoch_committee: test_validator_set().0.voting_rights.clone(),
+            next_epoch_protocol_version: 1.into(),
+            epoch_commitments: Vec::new(),
+            epoch_supply_change: 0,
+        }),
         timestamp_ms: 0,
         version_specific_data: Vec::new(),
         checkpoint_commitments: Vec::new(),
-    };
-    let sig = AuthorityStrongQuorumSignInfo {
-        epoch,
-        signature: Default::default(),
-        signers_map: Default::default(),
-    };
-    Envelope::new_from_data_and_sig(summary, sig)
+    }
+}
+
+/// Certify `summary` with the fixed validator set (all four sign — a quorum).
+fn certify_summary(summary: CheckpointSummary) -> CertifiedCheckpointSummary {
+    let (_, keys) = test_validator_set();
+    let committee = test_committee_at(summary.epoch);
+    let signatures = keys
+        .iter()
+        .map(|key| SignedCheckpointSummary::sign(summary.epoch, &summary, key, key.public().into()))
+        .collect();
+    CertifiedCheckpointSummary::new(summary, signatures, &committee)
+        .expect("test summary must certify under the test committee")
+}
+
+fn fully_populated_checkpoint_summary(epoch: EpochId) -> CertifiedCheckpointSummary {
+    certify_summary(end_of_epoch_summary(epoch))
 }
 
 fn fully_populated_epoch_info(epoch: EpochId) -> EpochInfoV2 {
@@ -664,15 +706,16 @@ async fn snapshot_restore_builds_grpc_indexes() -> Result<(), anyhow::Error> {
         .collect::<Result<_, _>>()?;
     assert_eq!(restored_ids, owned_ids);
 
-    // The remaining restore-tool steps: seed the epoch rows and finalize.
+    // The remaining restore-tool steps: chain-verify EPOCH_INFO, seed the
+    // epoch rows, and finalize.
     let epoch_info = snapshot_reader.read_epoch_info().await?;
-    crate::verify_and_restore_epoch_info(
-        &restored_grpc,
+    let verified = verify_epoch_info_chain(
         epoch_info,
+        test_committee_at(0),
         snapshot_reader.chain_id(),
         ChainIdentifier::default(),
-    )
-    .await?;
+    )?;
+    verified.restore_epoch_info(&restored_grpc).await?;
     assert_eq!(restored_grpc.highest_indexed_epoch()?, Some(0));
     restored_grpc.finalize_restore(0)?;
     Ok(())
@@ -1158,4 +1201,142 @@ fn snapshot_epoch_info_field_order_is_locked() {
         "EpochInfoV1Entry BCS layout changed; re-anchor this test only if \
          the schema change is deliberate and reviewers have signed off"
     );
+}
+
+/// A valid `EPOCH_INFO` for epochs `[0, snapshot_epoch]`, certified by the
+/// fixed test validator set with the committee handed forward at every close.
+fn signed_epoch_info(snapshot_epoch: EpochId) -> EpochInfo {
+    EpochInfo::V1(EpochInfoV1 {
+        entries: (0..=snapshot_epoch)
+            .map(fully_populated_snapshot_epoch_entry)
+            .collect(),
+    })
+}
+
+/// Happy path: a committee-signed EPOCH_INFO verifies against the genesis
+/// committee, yields the committee chain for `[0, snapshot_epoch + 1]`, and
+/// restores into the gRPC epoch index with the watermark advanced.
+#[tokio::test]
+async fn verify_epoch_info_chain_accepts_and_restores() {
+    let verified = verify_epoch_info_chain(
+        signed_epoch_info(2),
+        test_committee_at(0),
+        ChainIdentifier::default(),
+        ChainIdentifier::default(),
+    )
+    .expect("a committee-signed EPOCH_INFO must verify");
+
+    assert_eq!(verified.entries().len(), 3);
+    let committee_epochs: Vec<_> = verified.committees().iter().map(|c| c.epoch).collect();
+    assert_eq!(committee_epochs, vec![0, 1, 2, 3]);
+
+    let tmp_dir = iota_common::tempdir();
+    let grpc = GrpcIndexesStore::new_without_init(tmp_dir.path().to_path_buf());
+    verified.restore_epoch_info(&grpc).await.expect("restore");
+    assert_eq!(grpc.highest_indexed_epoch().unwrap(), Some(2));
+}
+
+/// A wrong-network snapshot is rejected on the chain id, before any
+/// signature work.
+#[test]
+fn verify_epoch_info_chain_rejects_wrong_chain_id() {
+    let err = verify_epoch_info_chain(
+        signed_epoch_info(1),
+        test_committee_at(0),
+        ChainIdentifier::default(),
+        ChainIdentifier::from(iota_types::digests::CheckpointDigest::new([7; 32])),
+    )
+    .expect_err("a foreign chain id must be rejected");
+    assert!(err.to_string().contains("chain_id"), "got: {err}");
+}
+
+/// A trust root other than the signing committee fails at the first entry.
+#[test]
+fn verify_epoch_info_chain_rejects_wrong_genesis_committee() {
+    // `new_simple_test_committee` derives its keys from a fixed seed (it would
+    // return the fixture's own validator set), so generate a genuinely
+    // different one.
+    let mut rng = rand::rngs::StdRng::from_seed([7; 32]);
+    let other_rights: std::collections::BTreeMap<_, _> = (0..4)
+        .map(|_| {
+            let (_, key): (_, AuthorityKeyPair) = get_key_pair_from_rng(&mut rng);
+            (key.public().into(), 2500)
+        })
+        .collect();
+    let other_committee = Committee::new_for_testing_with_normalized_voting_power(0, other_rights);
+
+    let err = verify_epoch_info_chain(
+        signed_epoch_info(1),
+        other_committee,
+        ChainIdentifier::default(),
+        ChainIdentifier::default(),
+    )
+    .expect_err("a different validator set must be rejected");
+    assert!(
+        err.to_string().contains("epoch 0"),
+        "the chain walk must fail at the first entry: {err}"
+    );
+}
+
+/// A summary mutated after certification fails signature verification, even
+/// though it carries an otherwise valid quorum signature.
+#[test]
+fn verify_epoch_info_chain_rejects_tampered_summary() {
+    let mut epoch_info = signed_epoch_info(2);
+    let EpochInfo::V1(info) = &mut epoch_info;
+    let certified = &info.entries[1].last_checkpoint_summary;
+    let mut tampered_summary = certified.data().clone();
+    tampered_summary.timestamp_ms = 42; // not what the committee signed
+    info.entries[1].last_checkpoint_summary =
+        Envelope::new_from_data_and_sig(tampered_summary, certified.auth_sig().clone());
+
+    let err = verify_epoch_info_chain(
+        epoch_info,
+        test_committee_at(0),
+        ChainIdentifier::default(),
+        ChainIdentifier::default(),
+    )
+    .expect_err("a tampered summary must be rejected");
+    assert!(
+        err.to_string().contains("epoch 1"),
+        "the chain walk must fail at the tampered entry: {err}"
+    );
+}
+
+/// An entry that is not a close-of-epoch checkpoint cannot hand a committee
+/// forward and must be rejected.
+#[test]
+fn verify_epoch_info_chain_rejects_missing_end_of_epoch_data() {
+    let mut epoch_info = signed_epoch_info(2);
+    let EpochInfo::V1(info) = &mut epoch_info;
+    let mut summary = end_of_epoch_summary(1);
+    summary.end_of_epoch_data = None;
+    info.entries[1].last_checkpoint_summary = certify_summary(summary);
+
+    let err = verify_epoch_info_chain(
+        epoch_info,
+        test_committee_at(0),
+        ChainIdentifier::default(),
+        ChainIdentifier::default(),
+    )
+    .expect_err("an entry without end_of_epoch_data must be rejected");
+    assert!(err.to_string().contains("end-of-epoch data"), "got: {err}");
+}
+
+/// Entries must be contiguous from epoch 0: a hole breaks the committee
+/// handoff and must be rejected, not skipped over.
+#[test]
+fn verify_epoch_info_chain_rejects_non_contiguous_entries() {
+    let mut epoch_info = signed_epoch_info(2);
+    let EpochInfo::V1(info) = &mut epoch_info;
+    info.entries.remove(1);
+
+    let err = verify_epoch_info_chain(
+        epoch_info,
+        test_committee_at(0),
+        ChainIdentifier::default(),
+        ChainIdentifier::default(),
+    )
+    .expect_err("a hole in the entries must be rejected");
+    assert!(err.to_string().contains("declares epoch"), "got: {err}");
 }

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -889,7 +889,9 @@ impl ToolCommand {
                     epoch_to_download,
                     &genesis,
                     snapshot_store_config,
-                    archive_store_config,
+                    // The archive is only read in `--all-checkpoints` mode;
+                    // the default mode is archive-free.
+                    all_checkpoints.then_some(archive_store_config),
                     num_parallel_downloads,
                     network,
                     verify,

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -50,7 +50,8 @@ use iota_protocol_config::Chain;
 use iota_sdk::{IotaClient, IotaClientBuilder};
 use iota_sdk_types::{ObjectId, Owner};
 use iota_snapshot::{
-    EpochInfo, reader::StateSnapshotReaderV1, restore::RestoreWithGrpcIndexes, setup_db_state,
+    VerifiedEpochInfo, reader::StateSnapshotReaderV1, restore::RestoreWithGrpcIndexes,
+    setup_db_state,
 };
 use iota_storage::{
     object_store::{
@@ -66,7 +67,7 @@ use iota_types::{
     crypto::AuthorityPublicKeyBytes,
     digests::ChainIdentifier,
     global_state_hash::GlobalStateHash,
-    messages_checkpoint::{CheckpointCommitment, ECMHLiveObjectSetDigest},
+    messages_checkpoint::{CheckpointCommitment, ECMHLiveObjectSetDigest, VerifiedCheckpoint},
     messages_grpc::{
         LayoutGenerationOption, ObjectInfoRequest, ObjectInfoRequestKind, ObjectInfoResponse,
         TransactionInfoRequest, TransactionStatus,
@@ -586,7 +587,43 @@ pub async fn restore_from_db_checkpoint(
     Ok(())
 }
 
-fn start_summary_sync(
+/// Insert the genesis checkpoint if the store doesn't hold it yet.
+fn insert_genesis_checkpoint(
+    checkpoint_store: &CheckpointStore,
+    genesis: &Genesis,
+) -> Result<(), anyhow::Error> {
+    if checkpoint_store
+        .get_checkpoint_by_digest(genesis.checkpoint().digest())?
+        .is_none()
+    {
+        checkpoint_store.insert_checkpoint_contents(genesis.checkpoint_contents().clone())?;
+        checkpoint_store.insert_verified_checkpoint(&genesis.checkpoint())?;
+        checkpoint_store.update_highest_synced_checkpoint(&genesis.checkpoint())?;
+    }
+    Ok(())
+}
+
+/// Set all four checkpoint watermarks to the restore checkpoint.
+///
+/// SAFETY: they must be set together so the executor starts from
+/// `highest_executed + 1` and never tries to access checkpoint contents in
+/// the restored (summary-only) range.
+fn set_restore_watermarks(
+    checkpoint_store: &CheckpointStore,
+    checkpoint: &VerifiedCheckpoint,
+) -> Result<(), anyhow::Error> {
+    checkpoint_store.update_highest_verified_checkpoint(checkpoint)?;
+    checkpoint_store.update_highest_synced_checkpoint(checkpoint)?;
+    checkpoint_store.update_highest_executed_checkpoint(checkpoint)?;
+    checkpoint_store.update_highest_pruned_checkpoint(checkpoint)?;
+    Ok(())
+}
+
+/// Sync **every** checkpoint summary in `[genesis, end of `epoch`]` from the
+/// checkpoint archive — the `--all-checkpoints` restore mode. The default
+/// mode needs no archive: it seeds only the end-of-epoch summaries, from the
+/// snapshot's chain-verified EPOCH_INFO (`sync_summaries_from_epoch_info`).
+fn start_summary_sync_from_archive(
     perpetual_db: Arc<AuthorityPerpetualTables>,
     committee_store: Arc<CommitteeStore>,
     checkpoint_store: Arc<CheckpointStore>,
@@ -596,7 +633,6 @@ fn start_summary_sync(
     epoch: u64,
     num_parallel_downloads: usize,
     verify: bool,
-    all_checkpoints: bool,
 ) -> JoinHandle<Result<(), anyhow::Error>> {
     tokio::spawn(async move {
         info!("Starting summary sync");
@@ -604,17 +640,7 @@ fn start_summary_sync(
         let cache_traits = build_execution_cache_from_env(&Registry::default(), &store);
         let state_sync_store =
             RocksDbStore::new(cache_traits, committee_store, checkpoint_store.clone());
-        // Only insert the genesis checkpoint if the DB is empty and doesn't have it
-        // already
-        if checkpoint_store
-            .get_checkpoint_by_digest(genesis.checkpoint().digest())
-            .unwrap()
-            .is_none()
-        {
-            checkpoint_store.insert_checkpoint_contents(genesis.checkpoint_contents().clone())?;
-            checkpoint_store.insert_verified_checkpoint(&genesis.checkpoint())?;
-            checkpoint_store.update_highest_synced_checkpoint(&genesis.checkpoint())?;
-        }
+        insert_genesis_checkpoint(&checkpoint_store, &genesis)?;
         // set up download of checkpoint summaries
         let config = ArchiveReaderConfig {
             remote_store_config: archive_store_config,
@@ -626,18 +652,9 @@ fn start_summary_sync(
         archive_reader.sync_manifest_once().await?;
         let manifest = archive_reader.get_manifest().await?;
 
-        let end_of_epoch_checkpoint_seq_nums = (0..=epoch)
-            .map(|e| manifest.next_checkpoint_after_epoch(e) - 1)
-            .collect::<Vec<_>>();
-        let last_checkpoint = end_of_epoch_checkpoint_seq_nums
-            .last()
-            .expect("Expected at least one checkpoint");
+        let last_checkpoint = manifest.next_checkpoint_after_epoch(epoch) - 1;
 
-        let num_to_sync = if all_checkpoints {
-            *last_checkpoint
-        } else {
-            end_of_epoch_checkpoint_seq_nums.len() as u64
-        };
+        let num_to_sync = last_checkpoint;
         let sync_progress_bar = m.add(
             ProgressBar::new(num_to_sync).with_style(
                 ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})")
@@ -674,27 +691,17 @@ fn start_summary_sync(
             }
         });
 
-        if all_checkpoints {
-            archive_reader
-                .read_summaries_for_range_no_verify(
-                    state_sync_store.clone(),
-                    s_start..last_checkpoint + 1,
-                    sync_checkpoint_counter,
-                )
-                .await?;
-        } else {
-            archive_reader
-                .read_summaries_for_list_no_verify(
-                    state_sync_store.clone(),
-                    end_of_epoch_checkpoint_seq_nums.clone(),
-                    sync_checkpoint_counter,
-                )
-                .await?;
-        }
+        archive_reader
+            .read_summaries_for_range_no_verify(
+                state_sync_store.clone(),
+                s_start..last_checkpoint + 1,
+                sync_checkpoint_counter,
+            )
+            .await?;
         sync_progress_bar.finish_with_message("Checkpoint summary sync is complete");
 
         let checkpoint = checkpoint_store
-            .get_checkpoint_by_sequence_number(*last_checkpoint)?
+            .get_checkpoint_by_sequence_number(last_checkpoint)?
             .ok_or(anyhow!("Failed to read last checkpoint"))?;
         if verify {
             let verify_progress_bar = m.add(
@@ -711,7 +718,6 @@ fn start_summary_sync(
             let v_instant = Instant::now();
 
             tokio::spawn(async move {
-                let v_start = if all_checkpoints { s_start } else { 0 };
                 loop {
                     if cloned_verify_progress_bar.is_finished() {
                         break;
@@ -719,7 +725,7 @@ fn start_summary_sync(
                     let num_summaries = cloned_verify_counter.load(Ordering::Relaxed);
                     let total_checkpoints_per_sec =
                         num_summaries as f64 / v_instant.elapsed().as_secs_f64();
-                    cloned_verify_progress_bar.set_position(v_start + num_summaries);
+                    cloned_verify_progress_bar.set_position(s_start + num_summaries);
                     cloned_verify_progress_bar.set_message(format!(
                         "checkpoints verified per sec: {total_checkpoints_per_sec}"
                     ));
@@ -727,58 +733,72 @@ fn start_summary_sync(
                 }
             });
 
-            if all_checkpoints {
-                // in this case we need to verify all the checkpoints in the range pairwise
-                let v_start = s_start;
-                // update highest verified to be highest synced. We will move back
-                // iff parallel verification succeeds
-                let latest_verified = checkpoint_store
-                    .get_checkpoint_by_sequence_number(latest_synced)
-                    .expect("Failed to get checkpoint")
-                    .expect("Expected checkpoint to exist after summary sync");
-                checkpoint_store
-                    .update_highest_verified_checkpoint(&latest_verified)
-                    .expect("Failed to update highest verified checkpoint");
+            // Verify all the checkpoints in the range pairwise.
+            // Update highest verified to be highest synced. We will move back
+            // iff parallel verification succeeds.
+            let latest_verified = checkpoint_store
+                .get_checkpoint_by_sequence_number(latest_synced)
+                .expect("Failed to get checkpoint")
+                .expect("Expected checkpoint to exist after summary sync");
+            checkpoint_store
+                .update_highest_verified_checkpoint(&latest_verified)
+                .expect("Failed to update highest verified checkpoint");
 
-                let verify_range = v_start..last_checkpoint + 1;
-                verify_checkpoint_range(
-                    verify_range,
-                    state_sync_store,
-                    verify_checkpoint_counter,
-                    num_parallel_downloads,
-                )
-                .await;
-            } else {
-                // in this case we only need to verify the end of epoch checkpoints by checking
-                // signatures against the corresponding epoch committee.
-                for (cp_epoch, epoch_last_cp_seq_num) in
-                    end_of_epoch_checkpoint_seq_nums.iter().enumerate()
-                {
-                    let epoch_last_checkpoint = checkpoint_store
-                        .get_checkpoint_by_sequence_number(*epoch_last_cp_seq_num)?
-                        .ok_or(anyhow!("Failed to read checkpoint"))?;
-                    let committee = state_sync_store.get_committee(cp_epoch as u64).expect(
-                        "Expected committee to exist after syncing all end of epoch checkpoints",
-                    );
-                    epoch_last_checkpoint
-                        .verify_authority_signatures(&committee)
-                        .expect("Failed to verify checkpoint");
-                    verify_checkpoint_counter.fetch_add(1, Ordering::Relaxed);
-                }
-            }
+            let verify_range = s_start..last_checkpoint + 1;
+            verify_checkpoint_range(
+                verify_range,
+                state_sync_store,
+                verify_checkpoint_counter,
+                num_parallel_downloads,
+            )
+            .await;
 
             verify_progress_bar.finish_with_message("Checkpoint summary verification is complete");
         }
 
-        // SAFETY: All four watermarks must be set together so the executor
-        // starts from `highest_executed + 1` and never tries to access
-        // checkpoint contents in the restored (summary-only) range.
-        checkpoint_store.update_highest_verified_checkpoint(&checkpoint)?;
-        checkpoint_store.update_highest_synced_checkpoint(&checkpoint)?;
-        checkpoint_store.update_highest_executed_checkpoint(&checkpoint)?;
-        checkpoint_store.update_highest_pruned_checkpoint(&checkpoint)?;
+        set_restore_watermarks(&checkpoint_store, &checkpoint)?;
         Ok::<(), anyhow::Error>(())
     })
+}
+
+/// Seed the checkpoint store from the snapshot's chain-verified EPOCH_INFO —
+/// the archive-free default of the formal restore: the genesis checkpoint
+/// plus every epoch's certified closing summary, with the committees handed
+/// to the committee store.
+fn sync_summaries_from_epoch_info(
+    checkpoint_store: &CheckpointStore,
+    committee_store: &CommitteeStore,
+    genesis: &Genesis,
+    verified: &VerifiedEpochInfo,
+    epoch: EpochId,
+) -> Result<(), anyhow::Error> {
+    anyhow::ensure!(
+        verified.entries().len() as u64 == epoch + 1,
+        "EPOCH_INFO covers {} epochs but the restore targets the end of epoch {epoch}",
+        verified.entries().len(),
+    );
+
+    insert_genesis_checkpoint(checkpoint_store, genesis)?;
+
+    // `committees()[i + 1]` is the committee that entry `i`'s
+    // `end_of_epoch_data` handed forward.
+    for (entry, next_committee) in verified.entries().iter().zip(&verified.committees()[1..]) {
+        committee_store.insert_new_committee(next_committee)?;
+        checkpoint_store.insert_verified_checkpoint(&VerifiedCheckpoint::new_unchecked(
+            entry.last_checkpoint_summary.clone(),
+        ))?;
+    }
+
+    let last_checkpoint = VerifiedCheckpoint::new_unchecked(
+        verified
+            .entries()
+            .last()
+            .expect("length checked above")
+            .last_checkpoint_summary
+            .clone(),
+    );
+    set_restore_watermarks(checkpoint_store, &last_checkpoint)?;
+    Ok(())
 }
 
 pub async fn get_latest_available_epoch(
@@ -819,7 +839,7 @@ pub async fn download_formal_snapshot(
     epoch: EpochId,
     genesis: &Path,
     snapshot_store_config: ObjectStoreConfig,
-    archive_store_config: ObjectStoreConfig,
+    archive_store_config: Option<ObjectStoreConfig>,
     num_parallel_downloads: usize,
     network: Chain,
     verify: SnapshotVerifyMode,
@@ -837,6 +857,23 @@ pub async fn download_formal_snapshot(
     let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&path.join("store"), None));
     let genesis = Genesis::load(genesis).unwrap();
     let genesis_committee = genesis.committee()?;
+    let expected_chain_id = ChainIdentifier::from(*genesis.checkpoint().digest());
+
+    // Download and chain-verify the snapshot's EPOCH_INFO up front (one small
+    // file): every entry's certified closing summary is checked against the
+    // committee chain walked from the operator's genesis. It drives the
+    // default (archive-free) summary sync and the gRPC epoch seeding, and
+    // rejects a wrong-network or tampered snapshot before anything large is
+    // downloaded.
+    let (snapshot_chain_id, epoch_info) =
+        StateSnapshotReaderV1::read_epoch_info_only(epoch, &snapshot_store_config).await?;
+    let verified_epoch_info = iota_snapshot::verify_epoch_info_chain(
+        epoch_info,
+        genesis_committee.clone(),
+        snapshot_chain_id,
+        expected_chain_id,
+    )?;
+
     let committee_store = Arc::new(CommitteeStore::new(
         path.join("epochs"),
         &genesis_committee,
@@ -844,18 +881,33 @@ pub async fn download_formal_snapshot(
     ));
     let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
 
-    let summaries_handle = start_summary_sync(
-        perpetual_db.clone(),
-        committee_store.clone(),
-        checkpoint_store.clone(),
-        m.clone(),
-        genesis.clone(),
-        archive_store_config.clone(),
-        epoch,
-        num_parallel_downloads,
-        verify != SnapshotVerifyMode::None,
-        all_checkpoints,
-    );
+    // Default mode seeds only the end-of-epoch summaries, straight from the
+    // verified EPOCH_INFO; `--all-checkpoints` syncs the full summary history,
+    // which only the checkpoint archive can provide.
+    let summaries_handle = if all_checkpoints {
+        let archive_store_config = archive_store_config
+            .ok_or_else(|| anyhow!("--all-checkpoints requires an archive bucket to read from"))?;
+        Some(start_summary_sync_from_archive(
+            perpetual_db.clone(),
+            committee_store.clone(),
+            checkpoint_store.clone(),
+            m.clone(),
+            genesis.clone(),
+            archive_store_config,
+            epoch,
+            num_parallel_downloads,
+            verify != SnapshotVerifyMode::None,
+        ))
+    } else {
+        sync_summaries_from_epoch_info(
+            &checkpoint_store,
+            &committee_store,
+            &genesis,
+            &verified_epoch_info,
+            epoch,
+        )?;
+        None
+    };
     // Unless `--skip-grpc-indexes` is passed, the gRPC index store is built
     // from the same object stream that restores the perpetual tables, so a
     // fullnode started with gRPC enabled opens it in place instead of
@@ -918,13 +970,7 @@ pub async fn download_formal_snapshot(
                 .unwrap_or_else(|err| panic!("Failed during read: {err}"));
         }
 
-        let snapshot_chain_id = reader.chain_id();
-        let epoch_info = reader
-            .read_epoch_info()
-            .await
-            .unwrap_or_else(|err| panic!("Failed to read EPOCH_INFO: {err}"));
-
-        Ok::<(ChainIdentifier, EpochInfo), anyhow::Error>((snapshot_chain_id, epoch_info))
+        Ok::<(), anyhow::Error>(())
     });
     let mut root_global_state_hash = GlobalStateHash::default();
     let mut num_live_objects = 0;
@@ -932,10 +978,12 @@ pub async fn download_formal_snapshot(
         num_live_objects += num_objects;
         root_global_state_hash.union(&partial_hash);
     }
-    summaries_handle
-        .await
-        .expect("Task join failed")
-        .expect("Summaries task failed");
+    if let Some(summaries_handle) = summaries_handle {
+        summaries_handle
+            .await
+            .expect("Task join failed")
+            .expect("Summaries task failed");
+    }
 
     let last_checkpoint = checkpoint_store
         .get_highest_verified_checkpoint()?
@@ -991,16 +1039,10 @@ pub async fn download_formal_snapshot(
         )?;
     }
 
-    let (snapshot_chain_id, epoch_info) = snapshot_handle
+    snapshot_handle
         .await
         .expect("Task join failed")
         .expect("Snapshot restore task failed");
-
-    // TODO we should ensure this map is being updated for all end of epoch
-    // checkpoints during summary sync. This happens in
-    // `insert_{verified|certified}_checkpoint` in checkpoint store, but not in
-    // the corresponding functions in ObjectStore trait
-    checkpoint_store.insert_epoch_last_checkpoint(epoch, &last_checkpoint)?;
 
     setup_db_state(
         epoch,
@@ -1020,14 +1062,9 @@ pub async fn download_formal_snapshot(
     // the node open the store in place instead of re-indexing. All RocksDB
     // handles are dropped before the rename below.
     if let Some(grpc_indexes) = grpc_indexes {
-        let expected_chain_id = ChainIdentifier::from(*genesis.checkpoint().digest());
-        iota_snapshot::verify_and_restore_epoch_info(
-            &*grpc_indexes,
-            epoch_info,
-            snapshot_chain_id,
-            expected_chain_id,
-        )
-        .await?;
+        verified_epoch_info
+            .restore_epoch_info(&*grpc_indexes)
+            .await?;
         let authority_store =
             AuthorityStore::open_no_genesis(perpetual_db.clone(), false, &Registry::default())?;
         grpc_indexes.ensure_current_epoch_info(&authority_store, &checkpoint_store)?;


### PR DESCRIPTION
# Description of change

The formal-snapshot restore currently depends on two buckets: the snapshot bucket and the checkpoint-archive bucket, where the default summary-sync mode only ever fetches the end-of-epoch summaries. Snapshot V2's EPOCH_INFO file already carries exactly those. It contains one certified closing summary per epoch since genesis. Additionally, the gRPC epochs_v2 seeding (restore and node startup backfill) trusted the bucket after a chain-id check only.

This PR makes the default restore archive-free and anchors every consumed EPOCH_INFO byte to the operator's genesis:

- `VerifiedEpochInfo` witness (iota-snapshot): `verify_epoch_info_chain` is its only constructor -> chain-id check, contiguity from epoch 0, and the committee-chain walk from the genesis committee (built on `CommitteeChainVerifier`). Holding the witness is proof of verification; `restore_epoch_info` now lives on it, so unverified rows structurally cannot be written.
- Archive-free default restore (iota-tool): EPOCH_INFO is downloaded and chain-verified up front (one small file — also rejecting wrong-network/tampered snapshots before any large download); `sync_summaries_from_epoch_info` seeds the genesis checkpoint, every epoch's verified closing summary (via `CheckpointStore::insert_verified_checkpoint`, which also maintains the never-pruned `epoch_last_checkpoint_map`), and the committees, then sets the four watermarks.
- `--all-checkpoints` stays archive-backed (full summary history has no snapshot replacement); the archive config is now required only with that flag. `start_summary_sync` is reduced to that mode, and the stale TODO plus the redundant manual `insert_epoch_last_checkpoint` are removed (summary sync maintains the map in both modes).
- Node startup backfill chain-verifies too: `backfill_epochs_v2_from_snapshot` takes the genesis committee from the node config and goes through the witness, closing the bucket-trust gap.

Tests: snapshot-test fixtures upgraded to real committee-signed summaries; six new unit tests cover accept+restore and every rejection path (wrong chain id, wrong genesis committee, tampered summary, missing end-of-epoch data, non-contiguous entries); e2e tests adapted to the witness API and hardened against a timing flake  `wait_until_executed_open_epoch`).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Restoring a node from a formal snapshot no longer requires a checkpoint-archive bucket. The required checkpoint summaries now come from the snapshot itself and are cryptographically verified against the genesis committee.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
