### PR TITLE
upstream(core): Init grpc-index db with unordered_writes enabled

### DIFF
--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -395,6 +395,18 @@ impl IndexStoreTables {
         )
     }
 
+    fn open_with_options<P: Into<PathBuf>>(
+        path: P,
+        options: typed_store::rocksdb::Options,
+    ) -> Self {
+        IndexStoreTables::open_tables_read_write(
+            path.into(),
+            MetricConf::new("grpc-index"),
+            Some(options),
+            None,
+        )
+    }
+
     fn needs_to_do_initialization(&self, checkpoint_store: &CheckpointStore) -> bool {
         (match self.meta.get(&()) {
             Ok(Some(metadata)) => metadata.version != CURRENT_DB_VERSION,
@@ -936,13 +948,34 @@ impl GrpcIndexesStore {
                     typed_store::rocks::safe_drop_db(path.clone(), Duration::from_secs(30))
                         .await
                         .expect("unable to destroy old gRPC index db");
-                    IndexStoreTables::open(path)
+
+                    // Open the empty DB with `unordered_write`s enabled in order to get a ~3x
+                    // speedup when indexing
+                    let mut options = typed_store::rocksdb::Options::default();
+                    options.set_unordered_write(true);
+                    IndexStoreTables::open_with_options(&path, options)
                 };
 
                 tables
                     .init(&authority_store, checkpoint_store)
                     .expect("unable to initialize gRPC index");
-                tables
+
+                let weak_db = Arc::downgrade(&tables.meta.db);
+                drop(tables);
+
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+                loop {
+                    if weak_db.strong_count() == 0 {
+                        break;
+                    }
+                    if std::time::Instant::now() > deadline {
+                        panic!("unable to reopen DB after indexing");
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+
+                // Reopen the DB with default options (eg without `unordered_write`s enabled)
+                IndexStoreTables::open(&path)
             } else {
                 tables
             }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.50.1, v1.51.5)
- Port commit:
  - [MystenLabs/sui@88c1abe](https://github.com/MystenLabs/sui/commit/88c1abe8bd780920c0d82c12b946e71c1ae63241)
- Description:

Open the grpc-index RocksDB with `unordered_write` enabled during the initial
bulk indexing for a ~3x speedup, then reopen it with default options once
indexing completes. The reopen waits (up to 30s) for the in-flight DB handle to
be fully dropped before reopening.


## Links to any relevant issues

Part of #11765

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes