### PR TITLE
upstream(core): Don't error when unable to load type layout for dynamic fields

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2818,9 +2818,16 @@ impl AuthorityState {
             return Ok(None);
         }
 
-        let layout = resolver
-            .get_annotated_layout(move_object.struct_tag())?
-            .into_layout();
+        let layout = match resolver.get_annotated_layout(move_object.struct_tag()) {
+            Ok(annotated_layout) => annotated_layout.into_layout(),
+            Err(e) => {
+                error!(
+                    "unable to load layout for type `{:?}`: {e}",
+                    move_object.struct_tag()
+                );
+                return Ok(None);
+            }
+        };
 
         let field =
             DFV::FieldVisitor::deserialize(move_object.contents(), &layout).map_err(|e| {


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.50.1, v1.51.5)
- Port commit:
  - [MystenLabs/sui@1d2dd44](https://github.com/MystenLabs/sui/commit/1d2dd44738d67b468e970671cca36b0f22249b6d)
- Description:

When the annotated type layout for a dynamic field cannot be loaded, log an
error and skip indexing that object instead of propagating
the error and failing the whole indexing operation.


## Links to any relevant issues

Part of #11765

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes