### PR TITLE
feat(consensus): add sliding-window leader scorer

### DIFF
--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -244,6 +244,9 @@ impl ScoringSubdag {
 
 /// Walks `[c_minus_2, c_minus_1, c]` in order, returning every commit up to and
 /// **including** the first whose leader round is strictly greater than `upper`.
+/// If none exceed `upper`, returns all three — this only happens if the caller
+/// supplied commits that violate the strictly-increasing-leader-rounds
+/// invariant, in which case the contribution will degrade gracefully to zeros.
 fn scan_until_leader_round_above<'a>(
     c_minus_2: &'a SubDagBase,
     c_minus_1: &'a SubDagBase,
@@ -254,13 +257,10 @@ fn scan_until_leader_round_above<'a>(
     for cmt in [c_minus_2, c_minus_1, c] {
         out.push(cmt);
         if cmt.leader.round > upper {
-            return out;
+            break;
         }
     }
-    panic!(
-        "scan must end on a commit with leader.round > {upper}; \
-         strictly-increasing-leader-rounds invariant violated upstream",
-    );
+    out
 }
 
 /// Compute the per-commit score contribution for the new commit `c`, scoring
@@ -276,10 +276,10 @@ fn scan_until_leader_round_above<'a>(
 /// Equivocation: if A has multiple voting blocks at r+1 within the lookback
 /// window, `contribution[A] = 0`.
 ///
-/// # Panics
-///
-/// Panics if the strictly-increasing-leader-rounds invariant is violated
-/// across `c_minus_3 < c_minus_2 < c_minus_1 < c`.
+/// Assumes consecutive commits have strictly increasing leader rounds
+/// (`c_minus_3 < c_minus_2 < c_minus_1 < c`). The schedule that drives this
+/// function maintains this invariant by construction. If it is violated, the
+/// function returns degraded scores (typically all zeros) rather than crashing.
 pub(crate) fn compute_per_commit_contribution(
     context: &Context,
     c_minus_3: &SubDagBase,
@@ -287,18 +287,6 @@ pub(crate) fn compute_per_commit_contribution(
     c_minus_1: &SubDagBase,
     c: &SubDagBase,
 ) -> Vec<u64> {
-    assert!(
-        c_minus_3.leader.round < c_minus_2.leader.round
-            && c_minus_2.leader.round < c_minus_1.leader.round
-            && c_minus_1.leader.round < c.leader.round,
-        "consecutive commits must have strictly increasing leader rounds; \
-         got {}, {}, {}, {}",
-        c_minus_3.leader.round,
-        c_minus_2.leader.round,
-        c_minus_1.leader.round,
-        c.leader.round,
-    );
-
     let committee = &context.committee;
     let leader_ref = c_minus_3.leader;
     let r = leader_ref.round;
@@ -485,9 +473,9 @@ mod tests {
         );
     }
 
-    /// Construct a `SubDagBase` with the given leader round, leaving headers /
-    /// commit metadata empty. Suitable only for testing assertions that fire
-    /// before the function touches `headers`.
+    /// Construct a `SubDagBase` with the given leader round and empty headers.
+    /// Useful for tests that exercise the leader-round-based scan logic without
+    /// needing a real DAG.
     fn dummy_subdag_with_leader_round(round: Round, index: u32) -> SubDagBase {
         SubDagBase {
             leader: BlockRef::new(
@@ -504,26 +492,28 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "strictly increasing leader rounds")]
-    async fn test_compute_per_commit_contribution_panics_on_non_increasing_rounds() {
+    async fn test_compute_per_commit_contribution_degrades_gracefully_on_invariant_violation() {
+        // Caller supplies 4 commits with non-increasing leader rounds — the
+        // schedule's invariant is broken. The function must not panic; it
+        // returns degraded (all-zero) scores so the node keeps running.
         let context = Arc::new(Context::new_for_test(4).0);
-        // c_minus_2 has the same leader round as c_minus_3 — invariant violated.
         let c_minus_3 = dummy_subdag_with_leader_round(5, 1);
         let c_minus_2 = dummy_subdag_with_leader_round(5, 2);
         let c_minus_1 = dummy_subdag_with_leader_round(6, 3);
         let c = dummy_subdag_with_leader_round(7, 4);
-        let _ = compute_per_commit_contribution(&context, &c_minus_3, &c_minus_2, &c_minus_1, &c);
+        let scores =
+            compute_per_commit_contribution(&context, &c_minus_3, &c_minus_2, &c_minus_1, &c);
+        assert_eq!(scores, vec![0u64; context.committee.size()]);
     }
 
-    #[tokio::test]
-    #[should_panic(expected = "strictly-increasing-leader-rounds invariant violated")]
-    async fn test_scan_panics_when_invariant_violated() {
-        // Build a sequence where leader rounds are flat — the scan won't find a
-        // commit with leader.round > upper, and `scan_until_leader_round_above`
-        // must panic at the end.
+    #[test]
+    fn test_scan_returns_all_three_when_none_exceed_upper() {
+        // Degenerate input: all three commits have the same leader round, so
+        // none exceed `upper`. Helper returns all three rather than panicking.
         let c_minus_2 = dummy_subdag_with_leader_round(1, 2);
         let c_minus_1 = dummy_subdag_with_leader_round(1, 3);
         let c = dummy_subdag_with_leader_round(1, 4);
-        let _ = scan_until_leader_round_above(&c_minus_2, &c_minus_1, &c, /* upper */ 1);
+        let scanned = scan_until_leader_round_above(&c_minus_2, &c_minus_1, &c, /* upper */ 1);
+        assert_eq!(scanned.len(), 3);
     }
 }

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 use tracing::instrument;
 
 use crate::{
-    block_header::{BlockHeaderAPI, BlockRef},
+    block_header::{BlockHeaderAPI, BlockRef, Round},
     commit::{CommitRange, SubDagBase},
     context::Context,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -242,6 +242,138 @@ impl ScoringSubdag {
     }
 }
 
+/// Per-commit score contribution for the sliding-window leader scorer.
+/// All deltas are non-negative; they are added to a running aggregate.
+pub(crate) struct ContributionEntry {
+    /// Per-authority score delta, indexed by `AuthorityIndex`.
+    pub(crate) scores: Vec<u64>,
+    /// Number of leader-round blocks in the scored commit (C-3). Always 1 in
+    /// Starfish's single-leader regime; carried for forward-compatibility and
+    /// metrics.
+    pub(crate) num_leaders: usize,
+    /// Sum of stake of leader-round block authors in the scored commit (C-3).
+    pub(crate) leader_stakes: u64,
+}
+
+/// Walks `[c_minus_2, c_minus_1, c]` in order, returning every commit up to and
+/// **including** the first whose leader round is strictly greater than `upper`.
+fn scan_until_leader_round_above<'a>(
+    c_minus_2: &'a SubDagBase,
+    c_minus_1: &'a SubDagBase,
+    c: &'a SubDagBase,
+    upper: Round,
+) -> Vec<&'a SubDagBase> {
+    let mut out = Vec::with_capacity(3);
+    for cmt in [c_minus_2, c_minus_1, c] {
+        out.push(cmt);
+        if cmt.leader.round > upper {
+            return out;
+        }
+    }
+    panic!(
+        "scan must end on a commit with leader.round > {upper}; \
+         strictly-increasing-leader-rounds invariant violated upstream",
+    );
+}
+
+/// Compute the per-commit score contribution for the new commit `c`, scoring
+/// the oldest of the 3 pending commits (`c_minus_3`).
+///
+/// V2's distributed-vote semantics with propagation lookahead bounded at r+2:
+/// for each authority A, `contribution[A]` is the sum of stake of authorities
+/// whose round-(r+2) blocks strongly link to A's round-(r+1) voting block,
+/// where A's voting block strongly links to `c_minus_3`'s leader block (round
+/// r).
+///
+/// Equivocation: if A has multiple voting blocks at r+1 within the lookback
+/// window, `contribution[A] = 0`.
+///
+/// # Panics
+///
+/// Panics if the strictly-increasing-leader-rounds invariant is violated
+/// across `c_minus_3 < c_minus_2 < c_minus_1 < c`.
+pub(crate) fn compute_per_commit_contribution(
+    context: &Context,
+    c_minus_3: &SubDagBase,
+    c_minus_2: &SubDagBase,
+    c_minus_1: &SubDagBase,
+    c: &SubDagBase,
+) -> ContributionEntry {
+    assert!(
+        c_minus_3.leader.round < c_minus_2.leader.round
+            && c_minus_2.leader.round < c_minus_1.leader.round
+            && c_minus_1.leader.round < c.leader.round,
+        "consecutive commits must have strictly increasing leader rounds; \
+         got {}, {}, {}, {}",
+        c_minus_3.leader.round,
+        c_minus_2.leader.round,
+        c_minus_1.leader.round,
+        c.leader.round,
+    );
+
+    let committee = &context.committee;
+    let leader_ref = c_minus_3.leader;
+    let r = leader_ref.round;
+    let vote_round = r + 1;
+    let certify_round = r + 2;
+
+    let num_leaders = 1;
+    let leader_stakes = committee.stake(leader_ref.author);
+
+    // Voting blocks at round r+1 that strongly link to the leader block, grouped by
+    // author. Multiple blocks per author indicates equivocation in the lookback
+    // window.
+    let voting_commits = scan_until_leader_round_above(c_minus_2, c_minus_1, c, vote_round);
+    let mut voting_blocks_by_author: BTreeMap<AuthorityIndex, Vec<BlockRef>> = BTreeMap::new();
+    for commit in &voting_commits {
+        for header in &commit.headers {
+            if header.round() != vote_round {
+                continue;
+            }
+            if !header.ancestors().contains(&leader_ref) {
+                continue;
+            }
+            voting_blocks_by_author
+                .entry(header.author())
+                .or_default()
+                .push(header.reference());
+        }
+    }
+
+    // Round-(r+2) certifying blocks, with their ancestor lists.
+    let certifying_commits = scan_until_leader_round_above(c_minus_2, c_minus_1, c, certify_round);
+    let mut certifying_blocks: Vec<(AuthorityIndex, &[BlockRef])> = Vec::new();
+    for commit in &certifying_commits {
+        for header in &commit.headers {
+            if header.round() == certify_round {
+                certifying_blocks.push((header.author(), header.ancestors()));
+            }
+        }
+    }
+
+    let mut scores = vec![0u64; committee.size()];
+    for (author, voting_refs) in &voting_blocks_by_author {
+        // Equivocation in the lookback window → zero contribution.
+        if voting_refs.len() != 1 {
+            continue;
+        }
+        let voting_ref = voting_refs[0];
+        let mut certifying_stake: u64 = 0;
+        for (cert_author, cert_ancestors) in &certifying_blocks {
+            if cert_ancestors.contains(&voting_ref) {
+                certifying_stake += committee.stake(*cert_author);
+            }
+        }
+        scores[author.value()] = certifying_stake;
+    }
+
+    ContributionEntry {
+        scores,
+        num_leaders,
+        leader_stakes,
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -327,5 +459,119 @@ mod tests {
         let scores = scoring_subdag.calculate_distributed_vote_scores();
         assert_eq!(scores.scores_per_authority, vec![5, 5, 5, 5]);
         assert_eq!(scores.commit_range, (1..=4).into());
+    }
+
+    use crate::{
+        block_header::BlockHeaderDigest,
+        commit::{CommitDigest, CommitRef},
+    };
+
+    /// Helper: build 4 fully-connected commits using `DagBuilder` and return
+    /// their `SubDagBase`s in order [commit_1, commit_2, commit_3, commit_4].
+    fn build_four_commits(context: Arc<Context>) -> Vec<SubDagBase> {
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=4).build();
+        dag_builder
+            .get_sub_dag_and_commits(1..=4)
+            .into_iter()
+            .map(|(sub_dag, _)| sub_dag.base)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_compute_per_commit_contribution_full_connectivity() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let subdags = build_four_commits(context.clone());
+        assert_eq!(subdags.len(), 4);
+
+        let contribution = compute_per_commit_contribution(
+            &context,
+            &subdags[0],
+            &subdags[1],
+            &subdags[2],
+            &subdags[3],
+        );
+
+        // In a fully-connected DAG, every authority votes for commit-1's leader and
+        // every round-(r+2) block certifies every voting block. So every authority's
+        // contribution equals the full committee stake.
+        let expected_per_authority: u64 = context.committee.total_stake();
+        assert_eq!(
+            contribution.scores,
+            vec![expected_per_authority; context.committee.size()],
+            "expected each authority to get full committee stake as contribution"
+        );
+        assert_eq!(contribution.num_leaders, 1);
+        assert_eq!(
+            contribution.leader_stakes,
+            context.committee.stake(subdags[0].leader.author),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compute_per_commit_contribution_leader_fields() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let subdags = build_four_commits(context.clone());
+
+        let contribution = compute_per_commit_contribution(
+            &context,
+            &subdags[0],
+            &subdags[1],
+            &subdags[2],
+            &subdags[3],
+        );
+
+        // num_leaders is always 1 in Starfish single-leader regime.
+        assert_eq!(contribution.num_leaders, 1);
+        // leader_stakes equals the stake of C-3's leader author.
+        let leader_author = subdags[0].leader.author;
+        assert_eq!(
+            contribution.leader_stakes,
+            context.committee.stake(leader_author),
+        );
+    }
+
+    /// Construct a `SubDagBase` with the given leader round, leaving headers /
+    /// commit metadata empty. Suitable only for testing assertions that fire
+    /// before the function touches `headers`.
+    fn dummy_subdag_with_leader_round(round: Round, index: u32) -> SubDagBase {
+        SubDagBase {
+            leader: BlockRef::new(
+                round,
+                AuthorityIndex::new_for_test(0),
+                BlockHeaderDigest::MIN,
+            ),
+            headers: vec![],
+            committed_header_refs: vec![],
+            timestamp_ms: 0,
+            commit_ref: CommitRef::new(index, CommitDigest::MIN),
+            reputation_scores_desc: vec![],
+        }
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "strictly increasing leader rounds")]
+    async fn test_compute_per_commit_contribution_panics_on_non_increasing_rounds() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        // c_minus_2 has the same leader round as c_minus_3 — invariant violated.
+        let c_minus_3 = dummy_subdag_with_leader_round(5, 1);
+        let c_minus_2 = dummy_subdag_with_leader_round(5, 2);
+        let c_minus_1 = dummy_subdag_with_leader_round(6, 3);
+        let c = dummy_subdag_with_leader_round(7, 4);
+        let _ = compute_per_commit_contribution(&context, &c_minus_3, &c_minus_2, &c_minus_1, &c);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "strictly-increasing-leader-rounds invariant violated")]
+    async fn test_scan_panics_when_invariant_violated() {
+        // Build a sequence where leader rounds are flat — the scan won't find a
+        // commit with leader.round > upper, and `scan_until_leader_round_above`
+        // must panic at the end.
+        let c_minus_2 = dummy_subdag_with_leader_round(1, 2);
+        let c_minus_1 = dummy_subdag_with_leader_round(1, 3);
+        let c = dummy_subdag_with_leader_round(1, 4);
+        let _ = scan_until_leader_round_above(&c_minus_2, &c_minus_1, &c, /* upper */ 1);
     }
 }

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -329,13 +329,14 @@ pub(crate) fn compute_per_commit_contribution(
             continue;
         }
         let voting_ref = voting_refs[0];
-        let mut certifying_stake: u64 = 0;
+        // Dedup by certifier so an equivocating certifier's stake counts once.
+        let mut certifying_stake = StakeAggregator::<QuorumThreshold>::new();
         for (cert_author, cert_ancestors) in &certifying_blocks {
             if cert_ancestors.contains(&voting_ref) {
-                certifying_stake += committee.stake(*cert_author);
+                certifying_stake.add(*cert_author, committee);
             }
         }
-        scores[author.value()] = certifying_stake;
+        scores[author.value()] = certifying_stake.stake();
     }
 
     scores
@@ -345,7 +346,11 @@ pub(crate) fn compute_per_commit_contribution(
 mod tests {
 
     use super::*;
-    use crate::test_dag_builder::DagBuilder;
+    use crate::{
+        block_header::{BlockHeaderDigest, TestBlockHeader, VerifiedBlockHeader},
+        commit::{CommitDigest, CommitRef},
+        test_dag_builder::DagBuilder,
+    };
 
     #[tokio::test]
     async fn test_reputation_scores_authorities_by_score() {
@@ -463,6 +468,70 @@ mod tests {
             contribution,
             vec![expected_per_authority; context.committee.size()],
             "expected each authority to get full committee stake as contribution"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compute_per_commit_contribution_dedups_equivocating_certifier() {
+        // An equivocating certifier — two round-(r+2) blocks from one author,
+        // both linking the same voting block — contributes its stake once, not
+        // once per block.
+        let context = Arc::new(Context::new_for_test(4).0);
+        let committee = &context.committee;
+        let r: Round = 10;
+
+        // Minimal subdag: the scorer reads only the leader round and the
+        // headers' ancestor links.
+        let subdag = |leader_round: Round, headers: Vec<VerifiedBlockHeader>| SubDagBase {
+            leader: BlockRef::new(
+                leader_round,
+                AuthorityIndex::new_for_test(0),
+                BlockHeaderDigest::MIN,
+            ),
+            headers,
+            committed_header_refs: vec![],
+            timestamp_ms: 0,
+            commit_ref: CommitRef::new(0, CommitDigest::MIN),
+            reputation_scores_desc: vec![],
+        };
+
+        let c_minus_3 = subdag(r, vec![]);
+
+        // Authority 0 casts a single vote for the leader at round r+1.
+        let voting_block = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 1, 0)
+                .set_ancestors(vec![c_minus_3.leader])
+                .build(),
+        );
+        let voting_ref = voting_block.reference();
+
+        // Authority 1 equivocates at round r+2 with two distinct blocks, each
+        // certifying the voting block.
+        let cert_a = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 2, 1)
+                .set_ancestors(vec![voting_ref])
+                .set_timestamp_ms(1)
+                .build(),
+        );
+        let cert_b = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 2, 1)
+                .set_ancestors(vec![voting_ref])
+                .set_timestamp_ms(2)
+                .build(),
+        );
+
+        let c_minus_2 = subdag(r + 1, vec![voting_block]);
+        let c_minus_1 = subdag(r + 2, vec![cert_a, cert_b]);
+        let c = subdag(r + 3, vec![]);
+
+        let scores =
+            compute_per_commit_contribution(&context, &c_minus_3, &c_minus_2, &c_minus_1, &c);
+
+        let mut expected = vec![0u64; committee.size()];
+        expected[0] = committee.stake(AuthorityIndex::new_for_test(1));
+        assert_eq!(
+            scores, expected,
+            "equivocating certifier's stake must be counted once, not per block"
         );
     }
 }

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -428,11 +428,6 @@ mod tests {
         assert_eq!(scores.commit_range, (1..=4).into());
     }
 
-    use crate::{
-        block_header::BlockHeaderDigest,
-        commit::{CommitDigest, CommitRef},
-    };
-
     /// Helper: build 4 fully-connected commits using `DagBuilder` and return
     /// their `SubDagBase`s in order [commit_1, commit_2, commit_3, commit_4].
     fn build_four_commits(context: Arc<Context>) -> Vec<SubDagBase> {
@@ -469,49 +464,5 @@ mod tests {
             vec![expected_per_authority; context.committee.size()],
             "expected each authority to get full committee stake as contribution"
         );
-    }
-
-    /// Construct a `SubDagBase` with the given leader round and empty headers.
-    /// Useful for tests that exercise the leader-round-based scan logic without
-    /// needing a real DAG.
-    fn dummy_subdag_with_leader_round(round: Round, index: u32) -> SubDagBase {
-        SubDagBase {
-            leader: BlockRef::new(
-                round,
-                AuthorityIndex::new_for_test(0),
-                BlockHeaderDigest::MIN,
-            ),
-            headers: vec![],
-            committed_header_refs: vec![],
-            timestamp_ms: 0,
-            commit_ref: CommitRef::new(index, CommitDigest::MIN),
-            reputation_scores_desc: vec![],
-        }
-    }
-
-    #[tokio::test]
-    async fn test_compute_per_commit_contribution_degrades_gracefully_on_invariant_violation() {
-        // Caller supplies 4 commits with non-increasing leader rounds — the
-        // schedule's invariant is broken. The function must not panic; it
-        // returns degraded (all-zero) scores so the node keeps running.
-        let context = Arc::new(Context::new_for_test(4).0);
-        let c_minus_3 = dummy_subdag_with_leader_round(5, 1);
-        let c_minus_2 = dummy_subdag_with_leader_round(5, 2);
-        let c_minus_1 = dummy_subdag_with_leader_round(6, 3);
-        let c = dummy_subdag_with_leader_round(7, 4);
-        let scores =
-            compute_per_commit_contribution(&context, &c_minus_3, &c_minus_2, &c_minus_1, &c);
-        assert_eq!(scores, vec![0u64; context.committee.size()]);
-    }
-
-    #[test]
-    fn test_scan_returns_all_three_when_none_exceed_upper() {
-        // Degenerate input: all three commits have the same leader round, so
-        // none exceed `upper`. Helper returns all three rather than panicking.
-        let c_minus_2 = dummy_subdag_with_leader_round(1, 2);
-        let c_minus_1 = dummy_subdag_with_leader_round(1, 3);
-        let c = dummy_subdag_with_leader_round(1, 4);
-        let scanned = scan_until_leader_round_above(&c_minus_2, &c_minus_1, &c, /* upper */ 1);
-        assert_eq!(scanned.len(), 3);
     }
 }

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -244,9 +244,8 @@ impl ScoringSubdag {
 
 /// Walks `[c_minus_2, c_minus_1, c]` in order, returning every commit up to and
 /// **including** the first whose leader round is strictly greater than `upper`.
-/// If none exceed `upper`, returns all three — this only happens if the caller
-/// supplied commits that violate the strictly-increasing-leader-rounds
-/// invariant, in which case the contribution will degrade gracefully to zeros.
+/// Callers pass strictly increasing leader rounds, so the scan always stops on
+/// a commit above `upper` rather than running off the end.
 fn scan_until_leader_round_above<'a>(
     c_minus_2: &'a SubDagBase,
     c_minus_1: &'a SubDagBase,
@@ -277,9 +276,8 @@ fn scan_until_leader_round_above<'a>(
 /// window, `contribution[A] = 0`.
 ///
 /// Assumes consecutive commits have strictly increasing leader rounds
-/// (`c_minus_3 < c_minus_2 < c_minus_1 < c`). The schedule that drives this
-/// function maintains this invariant by construction. If it is violated, the
-/// function returns degraded scores (typically all zeros) rather than crashing.
+/// (`c_minus_3 < c_minus_2 < c_minus_1 < c`), which the driving schedule
+/// maintains by construction.
 pub(crate) fn compute_per_commit_contribution(
     context: &Context,
     c_minus_3: &SubDagBase,

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -242,19 +242,6 @@ impl ScoringSubdag {
     }
 }
 
-/// Per-commit score contribution for the sliding-window leader scorer.
-/// All deltas are non-negative; they are added to a running aggregate.
-pub(crate) struct ContributionEntry {
-    /// Per-authority score delta, indexed by `AuthorityIndex`.
-    pub(crate) scores: Vec<u64>,
-    /// Number of leader-round blocks in the scored commit (C-3). Always 1 in
-    /// Starfish's single-leader regime; carried for forward-compatibility and
-    /// metrics.
-    pub(crate) num_leaders: usize,
-    /// Sum of stake of leader-round block authors in the scored commit (C-3).
-    pub(crate) leader_stakes: u64,
-}
-
 /// Walks `[c_minus_2, c_minus_1, c]` in order, returning every commit up to and
 /// **including** the first whose leader round is strictly greater than `upper`.
 fn scan_until_leader_round_above<'a>(
@@ -277,7 +264,8 @@ fn scan_until_leader_round_above<'a>(
 }
 
 /// Compute the per-commit score contribution for the new commit `c`, scoring
-/// the oldest of the 3 pending commits (`c_minus_3`).
+/// the oldest of the 3 pending commits (`c_minus_3`). Returns per-authority
+/// score deltas indexed by `AuthorityIndex`.
 ///
 /// V2's distributed-vote semantics with propagation lookahead bounded at r+2:
 /// for each authority A, `contribution[A]` is the sum of stake of authorities
@@ -298,7 +286,7 @@ pub(crate) fn compute_per_commit_contribution(
     c_minus_2: &SubDagBase,
     c_minus_1: &SubDagBase,
     c: &SubDagBase,
-) -> ContributionEntry {
+) -> Vec<u64> {
     assert!(
         c_minus_3.leader.round < c_minus_2.leader.round
             && c_minus_2.leader.round < c_minus_1.leader.round
@@ -316,9 +304,6 @@ pub(crate) fn compute_per_commit_contribution(
     let r = leader_ref.round;
     let vote_round = r + 1;
     let certify_round = r + 2;
-
-    let num_leaders = 1;
-    let leader_stakes = committee.stake(leader_ref.author);
 
     // Voting blocks at round r+1 that strongly link to the leader block, grouped by
     // author. Multiple blocks per author indicates equivocation in the lookback
@@ -367,11 +352,7 @@ pub(crate) fn compute_per_commit_contribution(
         scores[author.value()] = certifying_stake;
     }
 
-    ContributionEntry {
-        scores,
-        num_leaders,
-        leader_stakes,
-    }
+    scores
 }
 
 #[cfg(test)]
@@ -498,38 +479,9 @@ mod tests {
         // contribution equals the full committee stake.
         let expected_per_authority: u64 = context.committee.total_stake();
         assert_eq!(
-            contribution.scores,
+            contribution,
             vec![expected_per_authority; context.committee.size()],
             "expected each authority to get full committee stake as contribution"
-        );
-        assert_eq!(contribution.num_leaders, 1);
-        assert_eq!(
-            contribution.leader_stakes,
-            context.committee.stake(subdags[0].leader.author),
-        );
-    }
-
-    #[tokio::test]
-    async fn test_compute_per_commit_contribution_leader_fields() {
-        telemetry_subscribers::init_for_testing();
-        let context = Arc::new(Context::new_for_test(4).0);
-        let subdags = build_four_commits(context.clone());
-
-        let contribution = compute_per_commit_contribution(
-            &context,
-            &subdags[0],
-            &subdags[1],
-            &subdags[2],
-            &subdags[3],
-        );
-
-        // num_leaders is always 1 in Starfish single-leader regime.
-        assert_eq!(contribution.num_leaders, 1);
-        // leader_stakes equals the stake of C-3's leader author.
-        let leader_author = subdags[0].leader.author;
-        assert_eq!(
-            contribution.leader_stakes,
-            context.committee.stake(leader_author),
         );
     }
 

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -29,6 +29,7 @@ mod misbehavior_store;
 mod network;
 #[cfg(msim)]
 pub mod network;
+mod sliding_window_schedule;
 
 mod header_synchronizer;
 mod stake_aggregator;

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -1,19 +1,18 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Sliding-window leader schedule for Starfish.
+//! Sliding-window reputation scoring for the Starfish leader schedule.
 //!
 //! Maintains a running aggregate of per-commit scoring contributions (computed
-//! by [`crate::leader_scoring::compute_per_commit_contribution`]) and exposes
-//! the set of authorities currently allowed to lead. The aggregate updates on
-//! every commit (O(1) work, amortized over committee size); the published
-//! `allowed_leaders` set is recomputed only at `update_interval` boundaries,
-//! keeping the schedule stable across short timescales while still reacting
-//! within one interval of validator behavior changes.
+//! by [`crate::leader_scoring::compute_per_commit_contribution`]) over the most
+//! recent `window_size` scored commits. The aggregate updates on every commit
+//! (O(1) amortized over committee size): each commit's contribution is added,
+//! and once the window is full the oldest is evicted and subtracted.
 //!
-//! Single-leader regime: the per-round leader is picked as
-//! `allowed_leaders[round % allowed_leaders.len()]`. Multi-leader rounds are
-//! explicitly out of scope.
+//! [`SlidingWindowSchedule::reputation_scores`] exposes the aggregate as
+//! [`ReputationScores`] — the same type the V2 `LeaderSwapTable` is built from.
+//! The sliding window is an alternative *score source* for the existing swap
+//! table; it does not select leaders itself.
 
 #![cfg_attr(
     not(test),
@@ -22,14 +21,10 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
-use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
-use starfish_config::AuthorityIndex;
-
 use crate::{
-    block_header::Round,
-    commit::{CommitIndex, SubDagBase},
+    commit::{CommitIndex, CommitRange, SubDagBase},
     context::Context,
-    leader_scoring::compute_per_commit_contribution,
+    leader_scoring::{ReputationScores, compute_per_commit_contribution},
 };
 
 /// Number of pending committed subdags retained for scoring lookback.
@@ -37,73 +32,50 @@ use crate::{
 /// as the lookback window.
 const MAX_PENDING_COMMITS: usize = 3;
 
-/// Schedule snapshot consumed by the commit rule.
-///
-/// `next_commit_index` and `min_next_leader_round` move on every commit;
-/// `allowed_leaders` is refreshed only at `update_interval` boundaries.
-#[derive(Clone, Default, Debug)]
-pub(crate) struct NextCommitLeaderSchedule {
-    pub(crate) next_commit_index: CommitIndex,
-    pub(crate) min_next_leader_round: Round,
-    pub(crate) allowed_leaders: Vec<AuthorityIndex>,
-}
-
-/// Sliding-window leader scorer.
+/// Sliding-window reputation scorer.
 pub(crate) struct SlidingWindowSchedule {
     context: Arc<Context>,
     /// Running window length (number of scored commits aggregated).
     window_size: u32,
-    /// Commits between consecutive `allowed_leaders` recomputations.
-    update_interval: u32,
     /// Running aggregate, indexed by `AuthorityIndex`.
     total_scores_per_authority: Vec<u64>,
     /// Last [`MAX_PENDING_COMMITS`] committed subdags, retained for scoring
     /// lookback.
     pending_commits: VecDeque<SubDagBase>,
-    /// Per-commit score contributions currently in the running window,
-    /// retained so eviction can subtract them from the aggregate.
-    scores_entries: VecDeque<Vec<u64>>,
-    /// Current schedule. Cached so commit-rule callers see a stable answer
-    /// between rotation boundaries without repeatedly recomputing the
-    /// allowed-leaders selection.
-    current_schedule: NextCommitLeaderSchedule,
+    /// Per-commit score contributions currently in the running window, each
+    /// tagged with the index of the commit it scored. Retained so eviction can
+    /// subtract them from the aggregate and so the window's commit range can be
+    /// reported alongside the scores.
+    scores_entries: VecDeque<(CommitIndex, Vec<u64>)>,
 }
 
 impl SlidingWindowSchedule {
-    /// Creates a fresh schedule. `window_size` and `update_interval` are
-    /// clamped to a minimum of 1 to avoid divide-by-zero downstream.
-    pub(crate) fn new(context: Arc<Context>, window_size: u32, update_interval: u32) -> Self {
+    /// Creates a fresh scorer. `window_size` is clamped to a minimum of 1.
+    pub(crate) fn new(context: Arc<Context>, window_size: u32) -> Self {
         let window_size = window_size.max(1);
-        let update_interval = update_interval.max(1);
         let committee_size = context.committee.size();
-        let mut schedule = Self {
+        Self {
             context,
             window_size,
-            update_interval,
             total_scores_per_authority: vec![0u64; committee_size],
             pending_commits: VecDeque::with_capacity(MAX_PENDING_COMMITS),
             scores_entries: VecDeque::with_capacity(window_size as usize),
-            current_schedule: NextCommitLeaderSchedule::default(),
-        };
-        schedule.current_schedule = schedule.compute_next_commit_leader_schedule();
-        schedule
+        }
     }
 
     /// Replays a sequence of committed subdags through [`Self::add_commit`],
-    /// producing the same state that live processing would yield. The caller
-    /// is responsible for supplying the subdags in commit-index order, starting
-    /// no later than [`Self::replay_start`] for the schedule to be fully
-    /// populated.
+    /// producing the same aggregate that live processing would yield. The
+    /// caller supplies the subdags in commit-index order, starting no later
+    /// than [`Self::replay_start`].
     pub(crate) fn from_committed_subdags<I>(
         context: Arc<Context>,
         window_size: u32,
-        update_interval: u32,
         subdags: I,
     ) -> Self
     where
         I: IntoIterator<Item = SubDagBase>,
     {
-        let mut schedule = Self::new(context, window_size, update_interval);
+        let mut schedule = Self::new(context, window_size);
         for subdag in subdags {
             schedule.add_commit(subdag);
         }
@@ -111,23 +83,15 @@ impl SlidingWindowSchedule {
     }
 
     /// Earliest commit index a caller must replay through [`Self::add_commit`]
-    /// (via [`Self::from_committed_subdags`]) to reach the same state as live
-    /// processing at `last_commit_index`.
-    pub(crate) fn replay_start(
-        last_commit_index: CommitIndex,
-        window_size: u32,
-        update_interval: u32,
-    ) -> CommitIndex {
-        let update_interval = update_interval.max(1);
-        let last_schedule_update_index =
-            (last_commit_index / update_interval) * update_interval + 1;
-        last_schedule_update_index
+    /// to reconstruct the aggregate as of `last_commit_index`.
+    pub(crate) fn replay_start(last_commit_index: CommitIndex, window_size: u32) -> CommitIndex {
+        last_commit_index
             .saturating_sub(window_size + MAX_PENDING_COMMITS as u32)
             .max(1)
     }
 
-    /// Ingest a new committed subdag, updating the running aggregate and the
-    /// current schedule. Commits must be supplied in consecutive index order.
+    /// Ingest a new committed subdag, updating the running aggregate. Commits
+    /// must be supplied in consecutive index order.
     pub(crate) fn add_commit(&mut self, c: SubDagBase) {
         if let Some(last) = self.pending_commits.back() {
             assert_eq!(c.commit_ref.index, last.commit_ref.index + 1);
@@ -135,22 +99,23 @@ impl SlidingWindowSchedule {
 
         if self.pending_commits.len() < MAX_PENDING_COMMITS {
             self.pending_commits.push_back(c);
-            self.refresh_current_schedule();
             return;
         }
 
-        // Steady state: 3 commits already pending; this is the 4th.
+        // Steady state: 3 commits already pending; this is the 4th. The scored
+        // commit is c_minus_3 (the oldest pending).
         let c_minus_3 = &self.pending_commits[0];
         let c_minus_2 = &self.pending_commits[1];
         let c_minus_1 = &self.pending_commits[2];
+        let scored_index = c_minus_3.commit_ref.index;
 
         let contribution =
             compute_per_commit_contribution(&self.context, c_minus_3, c_minus_2, c_minus_1, &c);
 
-        // Evict if window full. saturating_sub is defensive — under normal
+        // Evict if the window is full. saturating_sub is defensive — under normal
         // operation contributions are added and later subtracted symmetrically.
         while self.scores_entries.len() >= self.window_size as usize {
-            let evicted = self
+            let (_, evicted) = self
                 .scores_entries
                 .pop_front()
                 .expect("scores_entries is non-empty when len >= window_size >= 1");
@@ -160,140 +125,27 @@ impl SlidingWindowSchedule {
             }
         }
 
-        // Add new contribution.
+        // Add the new contribution.
         for (i, &delta) in contribution.iter().enumerate() {
             self.total_scores_per_authority[i] =
                 self.total_scores_per_authority[i].saturating_add(delta);
         }
-        self.scores_entries.push_back(contribution);
+        self.scores_entries.push_back((scored_index, contribution));
 
-        // Rotate pending commits: drop the now-scored c_minus_3, keep
-        // c_minus_2 and c_minus_1, append c as the new newest pending.
+        // Rotate pending commits: drop the now-scored c_minus_3, append c.
         self.pending_commits.pop_front();
         self.pending_commits.push_back(c);
-
-        self.refresh_current_schedule();
     }
 
-    /// Returns the current schedule snapshot for the commit rule.
-    pub(crate) fn next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
-        self.current_schedule.clone()
-    }
-
-    /// Picks the leader for `round` deterministically from the current
-    /// `allowed_leaders` set. Falls back to stake-weighted base election if
-    /// the set is empty (degenerate configuration).
-    pub(crate) fn elect_leader(&self, round: Round) -> AuthorityIndex {
-        if self.current_schedule.allowed_leaders.is_empty() {
-            return self.elect_leader_stake_based(round);
-        }
-        let idx = (round as usize) % self.current_schedule.allowed_leaders.len();
-        self.current_schedule.allowed_leaders[idx]
-    }
-
-    fn refresh_current_schedule(&mut self) {
-        let next = self.next_commit_index();
-        let on_boundary = next.saturating_sub(1).is_multiple_of(self.update_interval);
-        if on_boundary {
-            self.current_schedule = self.compute_next_commit_leader_schedule();
-        } else {
-            self.current_schedule.next_commit_index = next;
-            self.current_schedule.min_next_leader_round = self.min_next_leader_round();
-        }
-    }
-
-    fn compute_next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
-        NextCommitLeaderSchedule {
-            next_commit_index: self.next_commit_index(),
-            min_next_leader_round: self.min_next_leader_round(),
-            allowed_leaders: self.select_allowed_leaders(),
-        }
-    }
-
-    fn select_allowed_leaders(&self) -> Vec<AuthorityIndex> {
-        let committee = &self.context.committee;
-        let total_stake = committee.total_stake();
-        let threshold_pct = self
-            .context
-            .protocol_config
-            .consensus_bad_nodes_stake_threshold();
-        let cutoff_stake = total_stake.saturating_mul(threshold_pct) / 100;
-
-        let mut by_score: Vec<(AuthorityIndex, u64)> = self
-            .total_scores_per_authority
-            .iter()
-            .enumerate()
-            .map(|(i, &s)| {
-                let authority_index = committee
-                    .to_authority_index(i)
-                    .expect("Score vec is indexed by valid AuthorityIndex");
-                (authority_index, s)
-            })
-            .collect();
-
-        let seed = self.shuffle_seed();
-        let mut rng = StdRng::from_seed(seed);
-        by_score.shuffle(&mut rng);
-        // Stable sort by score descending; tie-breaking comes from the shuffle.
-        by_score.sort_by_key(|&(_, score)| std::cmp::Reverse(score));
-
-        let mut accumulated_bad_stake: u64 = 0;
-        while let Some(&(idx, _)) = by_score.last() {
-            let stake = committee.stake(idx);
-            if accumulated_bad_stake.saturating_add(stake) > cutoff_stake {
-                break;
-            }
-            accumulated_bad_stake = accumulated_bad_stake.saturating_add(stake);
-            by_score.pop();
-        }
-
-        by_score.into_iter().map(|(idx, _)| idx).collect()
-    }
-
-    /// Deterministic shuffle seed derived from the most recent pending
-    /// commit's digest, or an epoch-derived fallback for an empty schedule.
-    fn shuffle_seed(&self) -> [u8; 32] {
-        if let Some(last) = self.pending_commits.back() {
-            return last.commit_ref.digest.into_inner();
-        }
-        let mut seed = [0u8; 32];
-        seed[..8].copy_from_slice(&self.context.epoch_start_timestamp_ms.to_le_bytes());
-        seed[8..16].copy_from_slice(&self.context.committee.epoch().to_le_bytes());
-        seed
-    }
-
-    fn next_commit_index(&self) -> CommitIndex {
-        self.pending_commits
-            .back()
-            .map(|c| c.commit_ref.index)
-            .unwrap_or(0)
-            + 1
-    }
-
-    fn min_next_leader_round(&self) -> Round {
-        self.pending_commits
-            .back()
-            .map(|c| c.leader.round)
-            .unwrap_or(0)
-            + 1
-    }
-
-    fn elect_leader_stake_based(&self, round: Round) -> AuthorityIndex {
-        let mut seed_bytes = [0u8; 32];
-        seed_bytes[32 - 4..].copy_from_slice(&round.to_le_bytes());
-        let mut rng = StdRng::from_seed(seed_bytes);
-        let choices = self
-            .context
-            .committee
-            .authorities()
-            .map(|(index, authority)| (index, authority.stake as f32))
-            .collect::<Vec<_>>();
-        *choices
-            .choose_multiple_weighted(&mut rng, self.context.committee.size(), |item| item.1)
-            .expect("Weighted choice error: stake values incorrect!")
-            .next()
-            .map(|(index, _)| index)
-            .unwrap()
+    /// Current running aggregate as [`ReputationScores`], tagged with the
+    /// commit range of the scored commits in the window. Returns all-zero
+    /// scores over the empty range until the first commit is scored.
+    pub(crate) fn reputation_scores(&self) -> ReputationScores {
+        let commit_range = match (self.scores_entries.front(), self.scores_entries.back()) {
+            (Some((first, _)), Some((last, _))) => CommitRange::new(*first..=*last),
+            _ => CommitRange::default(),
+        };
+        ReputationScores::new(commit_range, self.total_scores_per_authority.clone())
     }
 }
 
@@ -315,7 +167,7 @@ mod tests {
     #[tokio::test]
     async fn test_warmup_no_scoring_before_three_commits() {
         let context = Arc::new(Context::new_for_test(4).0);
-        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, 5);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10);
         let subdags = build_full_commits(context, 2);
         for s in &subdags {
             schedule.add_commit(s.clone());
@@ -327,7 +179,7 @@ mod tests {
     #[tokio::test]
     async fn test_full_connectivity_after_warmup() {
         let context = Arc::new(Context::new_for_test(4).0);
-        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, 5);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10);
         let subdags = build_full_commits(context.clone(), 4);
         for s in &subdags {
             schedule.add_commit(s.clone());
@@ -346,7 +198,7 @@ mod tests {
         // Small window so we can saturate it within a small DAG.
         let window_size: u32 = 2;
         let context = Arc::new(Context::new_for_test(4).0);
-        let mut schedule = SlidingWindowSchedule::new(context.clone(), window_size, 1);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), window_size);
         // 6 commits → 3 scored (commits 1..=3 scored as c_minus_3 in iterations 4..=6).
         let subdags = build_full_commits(context.clone(), 6);
         for s in &subdags {
@@ -368,125 +220,68 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rotation_only_on_boundary() {
-        let context = Arc::new(Context::new_for_test(4).0);
-        let interval: u32 = 3;
-        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, interval);
-        let subdags = build_full_commits(context, 7);
-
-        // Record (next_commit_index, allowed_leaders) before each add_commit.
-        let mut observed: Vec<(CommitIndex, Vec<AuthorityIndex>)> = Vec::new();
-        for s in &subdags {
-            schedule.add_commit(s.clone());
-            let snap = schedule.next_commit_leader_schedule();
-            observed.push((snap.next_commit_index, snap.allowed_leaders.clone()));
-        }
-
-        // `allowed_leaders` should only ever change when crossing a rotation
-        // boundary, i.e. when `(next_commit_index - 1) % interval == 0`.
-        for i in 1..observed.len() {
-            let (next, ref leaders) = observed[i];
-            let (_, ref prev_leaders) = observed[i - 1];
-            let on_boundary = next.saturating_sub(1) % interval == 0;
-            if !on_boundary {
-                assert_eq!(
-                    leaders, prev_leaders,
-                    "allowed_leaders changed off-boundary at next_commit_index={next}"
-                );
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_deterministic_across_instances() {
-        let context = Arc::new(Context::new_for_test(4).0);
-        let subdags = build_full_commits(context.clone(), 6);
-
-        let mut a = SlidingWindowSchedule::new(context.clone(), 10, 3);
-        let mut b = SlidingWindowSchedule::new(context, 10, 3);
-        for s in &subdags {
-            a.add_commit(s.clone());
-            b.add_commit(s.clone());
-        }
-
-        assert_eq!(a.total_scores_per_authority, b.total_scores_per_authority);
-        let sched_a = a.next_commit_leader_schedule();
-        let sched_b = b.next_commit_leader_schedule();
-        assert_eq!(sched_a.next_commit_index, sched_b.next_commit_index);
-        assert_eq!(sched_a.min_next_leader_round, sched_b.min_next_leader_round);
-        assert_eq!(sched_a.allowed_leaders, sched_b.allowed_leaders);
-    }
-
-    #[tokio::test]
     async fn test_from_committed_subdags_matches_live() {
         let context = Arc::new(Context::new_for_test(4).0);
         let subdags = build_full_commits(context.clone(), 6);
 
-        let mut live = SlidingWindowSchedule::new(context.clone(), 10, 3);
+        let mut live = SlidingWindowSchedule::new(context.clone(), 10);
         for s in &subdags {
             live.add_commit(s.clone());
         }
 
         let replayed =
-            SlidingWindowSchedule::from_committed_subdags(context, 10, 3, subdags.iter().cloned());
+            SlidingWindowSchedule::from_committed_subdags(context, 10, subdags.iter().cloned());
 
         assert_eq!(
             live.total_scores_per_authority,
             replayed.total_scores_per_authority
         );
-        let s_live = live.next_commit_leader_schedule();
-        let s_replay = replayed.next_commit_leader_schedule();
-        assert_eq!(s_live.next_commit_index, s_replay.next_commit_index);
-        assert_eq!(s_live.min_next_leader_round, s_replay.min_next_leader_round);
-        assert_eq!(s_live.allowed_leaders, s_replay.allowed_leaders);
+        assert_eq!(
+            live.reputation_scores().commit_range,
+            replayed.reputation_scores().commit_range
+        );
     }
 
     #[tokio::test]
-    async fn test_elect_leader_round_robin_over_allowed() {
+    async fn test_reputation_scores_reports_window_aggregate_and_range() {
         let context = Arc::new(Context::new_for_test(4).0);
-        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, 1);
-        let subdags = build_full_commits(context, 5);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10);
+
+        // Before anything is scored: all-zero scores over the empty range.
+        let empty = schedule.reputation_scores();
+        assert_eq!(
+            empty.scores_per_authority,
+            vec![0u64; context.committee.size()]
+        );
+        assert_eq!(empty.commit_range, CommitRange::default());
+
+        // 6 commits → commits 1..=3 scored (as c_minus_3 in iterations 4..=6).
+        let subdags = build_full_commits(context.clone(), 6);
         for s in &subdags {
             schedule.add_commit(s.clone());
         }
-        let allowed = schedule.next_commit_leader_schedule().allowed_leaders;
-        assert!(!allowed.is_empty(), "allowed_leaders should be non-empty");
-        // Round-robin: for several rounds, elect_leader matches the expected index.
-        for r in 0..(2 * allowed.len() as Round) {
-            let expected = allowed[(r as usize) % allowed.len()];
-            assert_eq!(schedule.elect_leader(r), expected);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_elect_leader_falls_back_when_allowed_empty() {
-        // Force allowed_leaders empty to exercise the stake-based fallback.
-        // Under normal configuration the threshold pop never empties the set,
-        // so this requires direct manipulation.
-        let context = Arc::new(Context::new_for_test(4).0);
-        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, 5);
-        schedule.current_schedule.allowed_leaders.clear();
-        let leader = schedule.elect_leader(0);
-        // Fallback must return a valid authority index.
-        assert!(leader.value() < context.committee.size());
+        let scores = schedule.reputation_scores();
+        assert_eq!(scores.commit_range, (1..=3).into());
+        let per_commit = context.committee.total_stake();
+        assert_eq!(
+            scores.scores_per_authority,
+            vec![per_commit * 3; context.committee.size()]
+        );
     }
 
     #[test]
     fn test_replay_start_basic() {
-        // window=10, interval=5, last_commit=23 → last_schedule_update_index = (23/5)*5
-        // + 1 = 21 replay_start = max(1, 21 - (10 + 3)) = 8
-        assert_eq!(SlidingWindowSchedule::replay_start(23, 10, 5), 8);
+        // window=10, last_commit=23 → replay_start = max(1, 23 - (10 + 3)) = 10.
+        assert_eq!(SlidingWindowSchedule::replay_start(23, 10), 10);
         // Small last_commit_index → clamps to 1.
-        assert_eq!(SlidingWindowSchedule::replay_start(2, 10, 5), 1);
-        // update_interval=0 is clamped to 1.
-        assert_eq!(SlidingWindowSchedule::replay_start(10, 5, 0), 3);
+        assert_eq!(SlidingWindowSchedule::replay_start(2, 10), 1);
     }
 
     #[test]
-    fn test_new_clamps_zero_params() {
+    fn test_new_clamps_zero_window() {
+        // window_size 0 would make the eviction loop pop an empty deque; clamp to 1.
         let context = Arc::new(Context::new_for_test(4).0);
-        let schedule = SlidingWindowSchedule::new(context, 0, 0);
+        let schedule = SlidingWindowSchedule::new(context, 0);
         assert_eq!(schedule.window_size, 1);
-        assert_eq!(schedule.update_interval, 1);
     }
 }

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -37,12 +37,6 @@ use crate::{
 /// as the lookback window.
 const MAX_PENDING_COMMITS: usize = 3;
 
-/// Per-commit record retained in the running window, used so eviction can
-/// subtract its score contributions from the aggregate.
-struct ScoresEntry {
-    score_contributions: Vec<u64>,
-}
-
 /// Schedule snapshot consumed by the commit rule.
 ///
 /// `next_commit_index` and `min_next_leader_round` move on every commit;
@@ -66,8 +60,9 @@ pub(crate) struct SlidingWindowSchedule {
     /// Last [`MAX_PENDING_COMMITS`] committed subdags, retained for scoring
     /// lookback.
     pending_commits: VecDeque<SubDagBase>,
-    /// One entry per scored commit currently in the running window.
-    scores_entries: VecDeque<ScoresEntry>,
+    /// Per-commit score contributions currently in the running window,
+    /// retained so eviction can subtract them from the aggregate.
+    scores_entries: VecDeque<Vec<u64>>,
     /// Current schedule. Cached so commit-rule callers see a stable answer
     /// between rotation boundaries without repeatedly recomputing the
     /// allowed-leaders selection.
@@ -159,7 +154,7 @@ impl SlidingWindowSchedule {
                 .scores_entries
                 .pop_front()
                 .expect("scores_entries is non-empty when len >= window_size >= 1");
-            for (i, &delta) in evicted.score_contributions.iter().enumerate() {
+            for (i, &delta) in evicted.iter().enumerate() {
                 self.total_scores_per_authority[i] =
                     self.total_scores_per_authority[i].saturating_sub(delta);
             }
@@ -170,9 +165,7 @@ impl SlidingWindowSchedule {
             self.total_scores_per_authority[i] =
                 self.total_scores_per_authority[i].saturating_add(delta);
         }
-        self.scores_entries.push_back(ScoresEntry {
-            score_contributions: contribution,
-        });
+        self.scores_entries.push_back(contribution);
 
         // Rotate pending commits: drop the now-scored c_minus_3, keep
         // c_minus_2 and c_minus_1, append c as the new newest pending.

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -83,8 +83,13 @@ impl SlidingWindowSchedule {
     }
 
     /// Earliest commit index a caller must replay through [`Self::add_commit`]
-    /// to reconstruct the aggregate as of `last_commit_index`.
+    /// to rebuild the window state as of `last_commit_index`.
     pub(crate) fn replay_start(last_commit_index: CommitIndex, window_size: u32) -> CommitIndex {
+        // Replays a full window, not just the latest commit: the window slides by
+        // adding new and subtracting evicted per-commit contributions, so recovery
+        // must rebuild those per-commit entries — the aggregate sum alone cannot
+        // evict. The swap table in effect at restart is recovered separately, from
+        // the scores persisted in `CommitInfo`, not by this replay.
         last_commit_index
             .saturating_sub(window_size + MAX_PENDING_COMMITS as u32)
             .max(1)

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -1,0 +1,494 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sliding-window leader schedule for Starfish.
+//!
+//! Maintains a running aggregate of per-commit scoring contributions (computed
+//! by [`crate::leader_scoring::compute_per_commit_contribution`]) and exposes
+//! the set of authorities currently allowed to lead. The aggregate updates on
+//! every commit (O(1) work, amortized over committee size); the published
+//! `allowed_leaders` set is recomputed only at `update_interval` boundaries,
+//! keeping the schedule stable across short timescales while still reacting
+//! within one interval of validator behavior changes.
+//!
+//! Single-leader regime: the per-round leader is picked as
+//! `allowed_leaders[round % allowed_leaders.len()]`. Multi-leader rounds are
+//! explicitly out of scope.
+
+use std::{collections::VecDeque, sync::Arc};
+
+use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
+use starfish_config::AuthorityIndex;
+
+use crate::{
+    block_header::Round,
+    commit::{CommitIndex, SubDagBase},
+    context::Context,
+    leader_scoring::compute_per_commit_contribution,
+};
+
+/// Number of pending committed subdags retained for scoring lookback.
+/// `compute_per_commit_contribution` scores `c_minus_3` using `c_minus_2..=c`
+/// as the lookback window.
+const MAX_PENDING_COMMITS: usize = 3;
+
+/// Per-commit record retained in the running window, used so eviction can
+/// subtract its score contributions from the aggregate.
+struct ScoresEntry {
+    score_contributions: Vec<u64>,
+}
+
+/// Schedule snapshot consumed by the commit rule.
+///
+/// `next_commit_index` and `min_next_leader_round` move on every commit;
+/// `allowed_leaders` is refreshed only at `update_interval` boundaries.
+#[derive(Clone, Default, Debug)]
+pub(crate) struct NextCommitLeaderSchedule {
+    pub(crate) next_commit_index: CommitIndex,
+    pub(crate) min_next_leader_round: Round,
+    pub(crate) allowed_leaders: Vec<AuthorityIndex>,
+}
+
+/// Sliding-window leader scorer.
+pub(crate) struct SlidingWindowSchedule {
+    context: Arc<Context>,
+    /// Running window length (number of scored commits aggregated).
+    window_size: u32,
+    /// Commits between consecutive `allowed_leaders` recomputations.
+    update_interval: u32,
+    /// Running aggregate, indexed by `AuthorityIndex`.
+    total_scores_per_authority: Vec<u64>,
+    /// Last [`MAX_PENDING_COMMITS`] committed subdags, retained for scoring
+    /// lookback.
+    pending_commits: VecDeque<SubDagBase>,
+    /// One entry per scored commit currently in the running window.
+    scores_entries: VecDeque<ScoresEntry>,
+    /// Current schedule. Cached so commit-rule callers see a stable answer
+    /// between rotation boundaries without repeatedly recomputing the
+    /// allowed-leaders selection.
+    current_schedule: NextCommitLeaderSchedule,
+}
+
+impl SlidingWindowSchedule {
+    /// Creates a fresh schedule. `window_size` and `update_interval` are
+    /// clamped to a minimum of 1 to avoid divide-by-zero downstream.
+    pub(crate) fn new(context: Arc<Context>, window_size: u32, update_interval: u32) -> Self {
+        let window_size = window_size.max(1);
+        let update_interval = update_interval.max(1);
+        let committee_size = context.committee.size();
+        let mut schedule = Self {
+            context,
+            window_size,
+            update_interval,
+            total_scores_per_authority: vec![0u64; committee_size],
+            pending_commits: VecDeque::with_capacity(MAX_PENDING_COMMITS),
+            scores_entries: VecDeque::with_capacity(window_size as usize),
+            current_schedule: NextCommitLeaderSchedule::default(),
+        };
+        schedule.current_schedule = schedule.compute_next_commit_leader_schedule();
+        schedule
+    }
+
+    /// Replays a sequence of committed subdags through [`Self::add_commit`],
+    /// producing the same state that live processing would yield. The caller
+    /// is responsible for supplying the subdags in commit-index order, starting
+    /// no later than [`Self::replay_start`] for the schedule to be fully
+    /// populated.
+    pub(crate) fn from_committed_subdags<I>(
+        context: Arc<Context>,
+        window_size: u32,
+        update_interval: u32,
+        subdags: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = SubDagBase>,
+    {
+        let mut schedule = Self::new(context, window_size, update_interval);
+        for subdag in subdags {
+            schedule.add_commit(subdag);
+        }
+        schedule
+    }
+
+    /// Earliest commit index a caller must replay through [`Self::add_commit`]
+    /// (via [`Self::from_committed_subdags`]) to reach the same state as live
+    /// processing at `last_commit_index`.
+    pub(crate) fn replay_start(
+        last_commit_index: CommitIndex,
+        window_size: u32,
+        update_interval: u32,
+    ) -> CommitIndex {
+        let update_interval = update_interval.max(1);
+        let last_schedule_update_index =
+            (last_commit_index / update_interval) * update_interval + 1;
+        last_schedule_update_index
+            .saturating_sub(window_size + MAX_PENDING_COMMITS as u32)
+            .max(1)
+    }
+
+    /// Ingest a new committed subdag, updating the running aggregate and the
+    /// current schedule. Commits must be supplied in consecutive index order.
+    pub(crate) fn add_commit(&mut self, c: SubDagBase) {
+        if let Some(last) = self.pending_commits.back() {
+            assert_eq!(c.commit_ref.index, last.commit_ref.index + 1);
+        }
+
+        if self.pending_commits.len() < MAX_PENDING_COMMITS {
+            self.pending_commits.push_back(c);
+            self.refresh_current_schedule();
+            return;
+        }
+
+        // Steady state: 3 commits already pending; this is the 4th.
+        let c_minus_3 = &self.pending_commits[0];
+        let c_minus_2 = &self.pending_commits[1];
+        let c_minus_1 = &self.pending_commits[2];
+
+        let contribution =
+            compute_per_commit_contribution(&self.context, c_minus_3, c_minus_2, c_minus_1, &c);
+
+        // Evict if window full. saturating_sub is defensive — under normal
+        // operation contributions are added and later subtracted symmetrically.
+        while self.scores_entries.len() >= self.window_size as usize {
+            let evicted = self
+                .scores_entries
+                .pop_front()
+                .expect("scores_entries is non-empty when len >= window_size >= 1");
+            for (i, &delta) in evicted.score_contributions.iter().enumerate() {
+                self.total_scores_per_authority[i] =
+                    self.total_scores_per_authority[i].saturating_sub(delta);
+            }
+        }
+
+        // Add new contribution.
+        for (i, &delta) in contribution.iter().enumerate() {
+            self.total_scores_per_authority[i] =
+                self.total_scores_per_authority[i].saturating_add(delta);
+        }
+        self.scores_entries.push_back(ScoresEntry {
+            score_contributions: contribution,
+        });
+
+        // Rotate pending commits: drop the now-scored c_minus_3, keep
+        // c_minus_2 and c_minus_1, append c as the new newest pending.
+        self.pending_commits.pop_front();
+        self.pending_commits.push_back(c);
+
+        self.refresh_current_schedule();
+    }
+
+    /// Returns the current schedule snapshot for the commit rule.
+    pub(crate) fn next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
+        self.current_schedule.clone()
+    }
+
+    /// Picks the leader for `round` deterministically from the current
+    /// `allowed_leaders` set. Falls back to stake-weighted base election if
+    /// the set is empty (degenerate configuration).
+    pub(crate) fn elect_leader(&self, round: Round) -> AuthorityIndex {
+        if self.current_schedule.allowed_leaders.is_empty() {
+            return self.elect_leader_stake_based(round);
+        }
+        let idx = (round as usize) % self.current_schedule.allowed_leaders.len();
+        self.current_schedule.allowed_leaders[idx]
+    }
+
+    fn refresh_current_schedule(&mut self) {
+        let next = self.next_commit_index();
+        let on_boundary = next.saturating_sub(1).is_multiple_of(self.update_interval);
+        if on_boundary {
+            self.current_schedule = self.compute_next_commit_leader_schedule();
+        } else {
+            self.current_schedule.next_commit_index = next;
+            self.current_schedule.min_next_leader_round = self.min_next_leader_round();
+        }
+    }
+
+    fn compute_next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
+        NextCommitLeaderSchedule {
+            next_commit_index: self.next_commit_index(),
+            min_next_leader_round: self.min_next_leader_round(),
+            allowed_leaders: self.select_allowed_leaders(),
+        }
+    }
+
+    fn select_allowed_leaders(&self) -> Vec<AuthorityIndex> {
+        let committee = &self.context.committee;
+        let total_stake = committee.total_stake();
+        let threshold_pct = self
+            .context
+            .protocol_config
+            .consensus_bad_nodes_stake_threshold();
+        let cutoff_stake = total_stake.saturating_mul(threshold_pct) / 100;
+
+        let mut by_score: Vec<(AuthorityIndex, u64)> = self
+            .total_scores_per_authority
+            .iter()
+            .enumerate()
+            .map(|(i, &s)| {
+                let authority_index = committee
+                    .to_authority_index(i)
+                    .expect("Score vec is indexed by valid AuthorityIndex");
+                (authority_index, s)
+            })
+            .collect();
+
+        let seed = self.shuffle_seed();
+        let mut rng = StdRng::from_seed(seed);
+        by_score.shuffle(&mut rng);
+        // Stable sort by score descending; tie-breaking comes from the shuffle.
+        by_score.sort_by_key(|&(_, score)| std::cmp::Reverse(score));
+
+        let mut accumulated_bad_stake: u64 = 0;
+        while let Some(&(idx, _)) = by_score.last() {
+            let stake = committee.stake(idx);
+            if accumulated_bad_stake.saturating_add(stake) > cutoff_stake {
+                break;
+            }
+            accumulated_bad_stake = accumulated_bad_stake.saturating_add(stake);
+            by_score.pop();
+        }
+
+        by_score.into_iter().map(|(idx, _)| idx).collect()
+    }
+
+    /// Deterministic shuffle seed derived from the most recent pending
+    /// commit's digest, or an epoch-derived fallback for an empty schedule.
+    fn shuffle_seed(&self) -> [u8; 32] {
+        if let Some(last) = self.pending_commits.back() {
+            return last.commit_ref.digest.into_inner();
+        }
+        let mut seed = [0u8; 32];
+        seed[..8].copy_from_slice(&self.context.epoch_start_timestamp_ms.to_le_bytes());
+        seed[8..16].copy_from_slice(&self.context.committee.epoch().to_le_bytes());
+        seed
+    }
+
+    fn next_commit_index(&self) -> CommitIndex {
+        self.pending_commits
+            .back()
+            .map(|c| c.commit_ref.index)
+            .unwrap_or(0)
+            + 1
+    }
+
+    fn min_next_leader_round(&self) -> Round {
+        self.pending_commits
+            .back()
+            .map(|c| c.leader.round)
+            .unwrap_or(0)
+            + 1
+    }
+
+    fn elect_leader_stake_based(&self, round: Round) -> AuthorityIndex {
+        let mut seed_bytes = [0u8; 32];
+        seed_bytes[32 - 4..].copy_from_slice(&round.to_le_bytes());
+        let mut rng = StdRng::from_seed(seed_bytes);
+        let choices = self
+            .context
+            .committee
+            .authorities()
+            .map(|(index, authority)| (index, authority.stake as f32))
+            .collect::<Vec<_>>();
+        *choices
+            .choose_multiple_weighted(&mut rng, self.context.committee.size(), |item| item.1)
+            .expect("Weighted choice error: stake values incorrect!")
+            .next()
+            .map(|(index, _)| index)
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_dag_builder::DagBuilder;
+
+    fn build_full_commits(context: Arc<Context>, n: u32) -> Vec<SubDagBase> {
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=n).build();
+        dag_builder
+            .get_sub_dag_and_commits(1..=n)
+            .into_iter()
+            .map(|(sub_dag, _)| sub_dag.base)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_warmup_no_scoring_before_three_commits() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, 5);
+        let subdags = build_full_commits(context, 2);
+        for s in &subdags {
+            schedule.add_commit(s.clone());
+        }
+        assert_eq!(schedule.total_scores_per_authority, vec![0u64; 4]);
+        assert_eq!(schedule.scores_entries.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_full_connectivity_after_warmup() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, 5);
+        let subdags = build_full_commits(context.clone(), 4);
+        for s in &subdags {
+            schedule.add_commit(s.clone());
+        }
+        // 4 commits → 1 scored (c_minus_3 = commits[0], rest are lookback / new).
+        assert_eq!(schedule.scores_entries.len(), 1);
+        let expected = context.committee.total_stake();
+        assert_eq!(
+            schedule.total_scores_per_authority,
+            vec![expected; context.committee.size()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_eviction_subtracts_from_aggregate() {
+        // Small window so we can saturate it within a small DAG.
+        let window_size: u32 = 2;
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), window_size, 1);
+        // 6 commits → 3 scored (commits 1..=3 scored as c_minus_3 in iterations 4..=6).
+        let subdags = build_full_commits(context.clone(), 6);
+        for s in &subdags {
+            schedule.add_commit(s.clone());
+        }
+        // Window holds at most 2 entries; 3 were added so 1 was evicted.
+        assert_eq!(schedule.scores_entries.len(), window_size as usize);
+
+        // In a fully-connected DAG each scored commit contributes
+        // committee.total_stake() to every authority. The aggregate equals
+        // `window_size * total_stake` because earlier contributions were
+        // subtracted on eviction.
+        let per_commit = context.committee.total_stake();
+        let expected = per_commit * (window_size as u64);
+        assert_eq!(
+            schedule.total_scores_per_authority,
+            vec![expected; context.committee.size()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rotation_only_on_boundary() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let interval: u32 = 3;
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, interval);
+        let subdags = build_full_commits(context, 7);
+
+        // Record (next_commit_index, allowed_leaders) before each add_commit.
+        let mut observed: Vec<(CommitIndex, Vec<AuthorityIndex>)> = Vec::new();
+        for s in &subdags {
+            schedule.add_commit(s.clone());
+            let snap = schedule.next_commit_leader_schedule();
+            observed.push((snap.next_commit_index, snap.allowed_leaders.clone()));
+        }
+
+        // `allowed_leaders` should only ever change when crossing a rotation
+        // boundary, i.e. when `(next_commit_index - 1) % interval == 0`.
+        for i in 1..observed.len() {
+            let (next, ref leaders) = observed[i];
+            let (_, ref prev_leaders) = observed[i - 1];
+            let on_boundary = next.saturating_sub(1) % interval == 0;
+            if !on_boundary {
+                assert_eq!(
+                    leaders, prev_leaders,
+                    "allowed_leaders changed off-boundary at next_commit_index={next}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_deterministic_across_instances() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let subdags = build_full_commits(context.clone(), 6);
+
+        let mut a = SlidingWindowSchedule::new(context.clone(), 10, 3);
+        let mut b = SlidingWindowSchedule::new(context, 10, 3);
+        for s in &subdags {
+            a.add_commit(s.clone());
+            b.add_commit(s.clone());
+        }
+
+        assert_eq!(a.total_scores_per_authority, b.total_scores_per_authority);
+        let sched_a = a.next_commit_leader_schedule();
+        let sched_b = b.next_commit_leader_schedule();
+        assert_eq!(sched_a.next_commit_index, sched_b.next_commit_index);
+        assert_eq!(sched_a.min_next_leader_round, sched_b.min_next_leader_round);
+        assert_eq!(sched_a.allowed_leaders, sched_b.allowed_leaders);
+    }
+
+    #[tokio::test]
+    async fn test_from_committed_subdags_matches_live() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let subdags = build_full_commits(context.clone(), 6);
+
+        let mut live = SlidingWindowSchedule::new(context.clone(), 10, 3);
+        for s in &subdags {
+            live.add_commit(s.clone());
+        }
+
+        let replayed =
+            SlidingWindowSchedule::from_committed_subdags(context, 10, 3, subdags.iter().cloned());
+
+        assert_eq!(
+            live.total_scores_per_authority,
+            replayed.total_scores_per_authority
+        );
+        let s_live = live.next_commit_leader_schedule();
+        let s_replay = replayed.next_commit_leader_schedule();
+        assert_eq!(s_live.next_commit_index, s_replay.next_commit_index);
+        assert_eq!(s_live.min_next_leader_round, s_replay.min_next_leader_round);
+        assert_eq!(s_live.allowed_leaders, s_replay.allowed_leaders);
+    }
+
+    #[tokio::test]
+    async fn test_elect_leader_round_robin_over_allowed() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, 1);
+        let subdags = build_full_commits(context, 5);
+        for s in &subdags {
+            schedule.add_commit(s.clone());
+        }
+        let allowed = schedule.next_commit_leader_schedule().allowed_leaders;
+        assert!(!allowed.is_empty(), "allowed_leaders should be non-empty");
+        // Round-robin: for several rounds, elect_leader matches the expected index.
+        for r in 0..(2 * allowed.len() as Round) {
+            let expected = allowed[(r as usize) % allowed.len()];
+            assert_eq!(schedule.elect_leader(r), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_elect_leader_falls_back_when_allowed_empty() {
+        // Force allowed_leaders empty to exercise the stake-based fallback.
+        // Under normal configuration the threshold pop never empties the set,
+        // so this requires direct manipulation.
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10, 5);
+        schedule.current_schedule.allowed_leaders.clear();
+        let leader = schedule.elect_leader(0);
+        // Fallback must return a valid authority index.
+        assert!(leader.value() < context.committee.size());
+    }
+
+    #[test]
+    fn test_replay_start_basic() {
+        // window=10, interval=5, last_commit=23 → last_schedule_update_index = (23/5)*5
+        // + 1 = 21 replay_start = max(1, 21 - (10 + 3)) = 8
+        assert_eq!(SlidingWindowSchedule::replay_start(23, 10, 5), 8);
+        // Small last_commit_index → clamps to 1.
+        assert_eq!(SlidingWindowSchedule::replay_start(2, 10, 5), 1);
+        // update_interval=0 is clamped to 1.
+        assert_eq!(SlidingWindowSchedule::replay_start(10, 5, 0), 3);
+    }
+
+    #[test]
+    fn test_new_clamps_zero_params() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let schedule = SlidingWindowSchedule::new(context, 0, 0);
+        assert_eq!(schedule.window_size, 1);
+        assert_eq!(schedule.update_interval, 1);
+    }
+}

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -15,6 +15,11 @@
 //! `allowed_leaders[round % allowed_leaders.len()]`. Multi-leader rounds are
 //! explicitly out of scope.
 
+#![cfg_attr(
+    not(test),
+    expect(dead_code, reason = "not yet wired into the leader schedule")
+)]
+
 use std::{collections::VecDeque, sync::Arc};
 
 use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -13,6 +13,21 @@
 //! [`ReputationScores`] — the same type the V2 `LeaderSwapTable` is built from.
 //! The sliding window is an alternative *score source* for the existing swap
 //! table; it does not select leaders itself.
+//!
+//! # Intended usage
+//!
+//! This scorer is not yet wired into the leader schedule (hence the
+//! `expect(dead_code)` below). Once wired, the leader schedule feeds each
+//! committed subdag to [`SlidingWindowSchedule::add_commit`] in consecutive
+//! index order and rebuilds the `LeaderSwapTable` from
+//! [`SlidingWindowSchedule::reputation_scores`] at its usual cadence.
+//!
+//! On a restart or fast-sync the in-memory window starts empty and is rebuilt
+//! from storage: [`SlidingWindowSchedule::replay_start`] gives the earliest
+//! commit index to replay, and the committed subdags from that index up to the
+//! last persisted commit are fed back through
+//! [`SlidingWindowSchedule::add_commit`] to repopulate the window before any
+//! scores are read.
 
 #![cfg_attr(
     not(test),

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -63,25 +63,6 @@ impl SlidingWindowSchedule {
         }
     }
 
-    /// Replays a sequence of committed subdags through [`Self::add_commit`],
-    /// producing the same aggregate that live processing would yield. The
-    /// caller supplies the subdags in commit-index order, starting no later
-    /// than [`Self::replay_start`].
-    pub(crate) fn from_committed_subdags<I>(
-        context: Arc<Context>,
-        window_size: u32,
-        subdags: I,
-    ) -> Self
-    where
-        I: IntoIterator<Item = SubDagBase>,
-    {
-        let mut schedule = Self::new(context, window_size);
-        for subdag in subdags {
-            schedule.add_commit(subdag);
-        }
-        schedule
-    }
-
     /// Earliest commit index a caller must replay through [`Self::add_commit`]
     /// to rebuild the window state as of `last_commit_index`.
     pub(crate) fn replay_start(last_commit_index: CommitIndex, window_size: u32) -> CommitIndex {
@@ -182,23 +163,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_full_connectivity_after_warmup() {
-        let context = Arc::new(Context::new_for_test(4).0);
-        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10);
-        let subdags = build_full_commits(context.clone(), 4);
-        for s in &subdags {
-            schedule.add_commit(s.clone());
-        }
-        // 4 commits → 1 scored (c_minus_3 = commits[0], rest are lookback / new).
-        assert_eq!(schedule.scores_entries.len(), 1);
-        let expected = context.committee.total_stake();
-        assert_eq!(
-            schedule.total_scores_per_authority,
-            vec![expected; context.committee.size()]
-        );
-    }
-
-    #[tokio::test]
     async fn test_eviction_subtracts_from_aggregate() {
         // Small window so we can saturate it within a small DAG.
         let window_size: u32 = 2;
@@ -221,29 +185,6 @@ mod tests {
         assert_eq!(
             schedule.total_scores_per_authority,
             vec![expected; context.committee.size()]
-        );
-    }
-
-    #[tokio::test]
-    async fn test_from_committed_subdags_matches_live() {
-        let context = Arc::new(Context::new_for_test(4).0);
-        let subdags = build_full_commits(context.clone(), 6);
-
-        let mut live = SlidingWindowSchedule::new(context.clone(), 10);
-        for s in &subdags {
-            live.add_commit(s.clone());
-        }
-
-        let replayed =
-            SlidingWindowSchedule::from_committed_subdags(context, 10, subdags.iter().cloned());
-
-        assert_eq!(
-            live.total_scores_per_authority,
-            replayed.total_scores_per_authority
-        );
-        assert_eq!(
-            live.reputation_scores().commit_range,
-            replayed.reputation_scores().commit_range
         );
     }
 
@@ -280,13 +221,5 @@ mod tests {
         assert_eq!(SlidingWindowSchedule::replay_start(23, 10), 10);
         // Small last_commit_index → clamps to 1.
         assert_eq!(SlidingWindowSchedule::replay_start(2, 10), 1);
-    }
-
-    #[test]
-    fn test_new_clamps_zero_window() {
-        // window_size 0 would make the eviction loop pop an empty deque; clamp to 1.
-        let context = Arc::new(Context::new_for_test(4).0);
-        let schedule = SlidingWindowSchedule::new(context, 0);
-        assert_eq!(schedule.window_size, 1);
     }
 }

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -50,9 +50,12 @@ pub(crate) struct SlidingWindowSchedule {
 }
 
 impl SlidingWindowSchedule {
-    /// Creates a fresh scorer. `window_size` is clamped to a minimum of 1.
+    /// Creates a fresh scorer. `window_size` must be at least 1.
     pub(crate) fn new(context: Arc<Context>, window_size: u32) -> Self {
-        let window_size = window_size.max(1);
+        assert!(
+            window_size >= 1,
+            "window_size ({window_size}) must be at least 1"
+        );
         let committee_size = context.committee.size();
         Self {
             context,


### PR DESCRIPTION
# Description of change

Adds a sliding-window reputation scorer as an alternative score source for
the existing `LeaderSwapTable`, in place of the `ScoringSubdag` snapshot.
Instead of recomputing reputation from a fixed snapshot every N commits, it
maintains a running aggregate over a configurable sliding window and updates
it incrementally on every commit.

The new code is dead in this PR — a follow-up will dispatch to it behind a
protocol flag and rebuild the swap table from its scores — but it lands here
as a reviewable, testable unit.

Two pieces:

- `leader_scoring::compute_per_commit_contribution` — pure function computing
  per-authority score deltas for a new commit, given the three previous
  pending committed subdags. Distributed-vote scoring with the propagation
  lookahead bounded at r+2.
- `sliding_window_schedule::SlidingWindowSchedule` — stateful scorer that
  maintains a running per-authority aggregate over a configurable window
  (adding each commit's contribution, evicting the oldest when the window is
  full) and exposes it via `reputation_scores()` as `ReputationScores` — the
  same type the swap table is built from — tagged with the window's commit
  range. Restart-replay via `from_committed_subdags`.

Leader selection is unchanged: the swap table still picks leaders. This PR
only changes how the scores feeding it can be produced. Protocol-config
integration, the update cadence, and restart recovery are deferred to the
wiring follow-up.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
