### PR TITLE
fix(indexer): nest snapshot deprecation notice correctly

### DIFF
--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -443,16 +443,18 @@ impl RetentionConfig {
     }
 }
 
-/// DEPRECATED: will be removed in v1.31.0. The objects_snapshot pipeline has
-/// been removed; these flags are now no-ops.
 #[derive(Args, Default, Debug, Clone)]
 pub struct SnapshotLagConfig {
+    /// DEPRECATED: will be removed in v1.31.0. The objects_snapshot pipeline
+    /// has been removed. This flag is a no-op.
     #[arg(
         long = "objects-snapshot-min-checkpoint-lag",
         env = "OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG"
     )]
     pub snapshot_min_lag: Option<usize>,
 
+    /// DEPRECATED: will be removed in v1.31.0. The objects_snapshot pipeline
+    /// has been removed. This flag is a no-op.
     #[arg(long = "objects-snapshot-sleep-duration")]
     pub sleep_duration: Option<u64>,
 }


### PR DESCRIPTION
# Description of change

This patch ensures that the deprecation notice for snapshot-related cli options are properly attached to the options.

## Links to any relevant issues

Fixes #11878 

## How the change has been tested

```sh
Usage: iota-indexer indexer [OPTIONS] <--data-ingestion-path <DATA_INGESTION_PATH>|--remote-store-url <REMOTE_STORE_URL>|--live-checkpoints-store-url <LIVE_CHECKPOINTS_STORE_URL>>

Options:
      ...
      --objects-snapshot-min-checkpoint-lag <SNAPSHOT_MIN_LAG>
          DEPRECATED: will be removed in v1.31.0. The objects_snapshot pipeline has been removed. This flag is a no-op
          
          [env: OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG=]

      --objects-snapshot-sleep-duration <SLEEP_DURATION>
          DEPRECATED: will be removed in v1.31.0. The objects_snapshot pipeline has been removed. This flag is a no-op
     ....
      --reset-db
          

  -h, --help
          Print help (see a summary with '-h')

```

### Release Notes

- [x] Indexer: Fixes the CLI doc for the `indexer` subcommand which was marked `DEPRECATED` erroneously.
