### PR TITLE
upstream(core): Properly override protocol config in test authority builder

### DIFF
--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -185,22 +185,39 @@ impl<'a> TestAuthorityBuilder<'a> {
     }
 
     pub async fn build(self) -> Arc<AuthorityState> {
+        let protocol_config = self.protocol_config.clone();
+
+        // Genesis must build the system framework at the binary format version it was
+        // compiled with. A test override that lowers `move_binary_format_version`
+        // must not apply while genesis verifies the system packages.
+        // Build genesis with the framework's binary format version
+        // restored, then apply the unmodified override below for transaction
+        // execution.
+        let local_network_config = {
+            let _genesis_guard = protocol_config.clone().map(|mut config| {
+                let framework_binary_format_version =
+                    ProtocolConfig::get_for_version(config.version, Chain::Unknown)
+                        .move_binary_format_version();
+                config.set_move_binary_format_version_for_testing(framework_binary_format_version);
+                ProtocolConfig::apply_overrides_for_testing(move |_, _| config.clone())
+            });
+
+            let mut local_network_config_builder =
+                iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                    .with_accounts(self.accounts)
+                    .with_reference_gas_price(self.reference_gas_price.unwrap_or(500));
+            if let Some(protocol_config) = &self.protocol_config {
+                local_network_config_builder =
+                    local_network_config_builder.with_protocol_version(protocol_config.version);
+            }
+            local_network_config_builder.build()
+        };
+
         // `_guard` must be declared here so it is not dropped before
         // `AuthorityPerEpochStore::new` is called
-        let protocol_config = self.protocol_config.clone();
         let _guard = protocol_config
             .map(|config| ProtocolConfig::apply_overrides_for_testing(move |_, _| config.clone()));
 
-        let mut local_network_config_builder =
-            iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
-                .with_accounts(self.accounts)
-                .with_reference_gas_price(self.reference_gas_price.unwrap_or(500));
-        if let Some(protocol_config) = &self.protocol_config {
-            local_network_config_builder =
-                local_network_config_builder.with_protocol_version(protocol_config.version);
-        }
-
-        let local_network_config = local_network_config_builder.build();
         let genesis = &self.genesis.unwrap_or(&local_network_config.genesis);
         let genesis_committee = genesis.committee().unwrap();
         let storage_dir = self

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -185,6 +185,12 @@ impl<'a> TestAuthorityBuilder<'a> {
     }
 
     pub async fn build(self) -> Arc<AuthorityState> {
+        // `_guard` must be declared here so it is not dropped before
+        // `AuthorityPerEpochStore::new` is called
+        let protocol_config = self.protocol_config.clone();
+        let _guard = protocol_config
+            .map(|config| ProtocolConfig::apply_overrides_for_testing(move |_, _| config.clone()));
+
         let mut local_network_config_builder =
             iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
                 .with_accounts(self.accounts)
@@ -250,11 +256,6 @@ impl<'a> TestAuthorityBuilder<'a> {
         let name: AuthorityName = secret.public().into();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
         let signature_verifier_metrics = SignatureVerifierMetrics::new(&registry);
-        // `_guard` must be declared here so it is not dropped before
-        // `AuthorityPerEpochStore::new` is called
-        let _guard = self
-            .protocol_config
-            .map(|config| ProtocolConfig::apply_overrides_for_testing(move |_, _| config.clone()));
         let epoch_flags = EpochFlag::default_flags_for_new_epoch(&config);
         let epoch_start_configuration = EpochStartConfiguration::new(
             genesis.iota_system_object().into_epoch_start_state(),


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.51.5, v1.52.3)
- Port commit:
  - [MystenLabs/sui@847b3a0e](https://github.com/MystenLabs/sui/commit/847b3a0e00a49ad15c55db9ef2145a959bb1bc6d)
- Description:

We need to override the protocol config at the very beginning because
the genesis process depends on it.

### **Additional fix: genesis must not inherit a lowered move_binary_format_version**
Applying the override at the start of build() made genesis verify the v7 system framework under whatever move_binary_format_version a test set, panicking the fork's mbf_6 enum tests with UNKNOWN_VERSION (move-binary-format-version 6 < framework's compiled version 7). 

Fix: build genesis with the binary format version restored to the framework's, and apply the unmodified override only to the per-epoch store used for transaction execution — the test's lowered cap still applies to the publish, so its assertion is unchanged.

## Links to any relevant issues

Part of #11885

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes