### PR TITLE
refactor(iota-data-ingestion): add hybrid historical checkpoint store for all workers.

### DIFF
--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::BTreeSet, env, path::PathBuf, time::Duration};
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use iota_data_ingestion::{
     ArchivalConfig, ArchivalReducer, BlobTaskConfig, BlobWorker, HistoricalReducer,
     HistoricalWriterConfig, KVStoreTaskConfig, KVStoreWorker, RelayWorker, common,
@@ -64,8 +64,8 @@ struct IndexerConfig {
     /// The inclusive sequence number of the checkpoint to end ingestion at.
     #[serde(skip_serializing_if = "Option::is_none")]
     end_checkpoint: Option<CheckpointSequenceNumber>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    remote_store_url: Option<String>,
+    #[serde(rename = "remote-store", skip_serializing_if = "Option::is_none")]
+    remote_store_url: Option<RemoteStoreUrl>,
     #[serde(default = "default_remote_read_batch_size")]
     remote_read_batch_size: usize,
     #[serde(default = "default_metrics_host")]
@@ -84,6 +84,33 @@ fn default_metrics_port() -> u16 {
 
 fn default_remote_read_batch_size() -> usize {
     100
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all_fields = "kebab-case")]
+enum RemoteStoreUrl {
+    #[serde(rename = "fullnode-url")]
+    Fullnode(String),
+    #[serde(rename = "hybrid")]
+    HybridHistoricalStore {
+        historical_url: String,
+        live_url: Option<String>,
+    },
+}
+
+impl From<RemoteStoreUrl> for RemoteUrl {
+    fn from(value: RemoteStoreUrl) -> Self {
+        match value {
+            RemoteStoreUrl::Fullnode(url) => RemoteUrl::Fullnode(url),
+            RemoteStoreUrl::HybridHistoricalStore {
+                historical_url,
+                live_url,
+            } => RemoteUrl::HybridHistoricalStore {
+                historical_url,
+                live_url,
+            },
+        }
+    }
 }
 
 fn setup_env(token: CancellationToken) {
@@ -160,10 +187,9 @@ async fn main() -> Result<()> {
                 executor.register(worker_pool).await?;
             }
             Task::Blob(blob_config) => {
-                let url = config
-                    .remote_store_url
-                    .as_ref()
-                    .ok_or(anyhow!("Blob worker type requires remote store URL"))?;
+                let Some(RemoteStoreUrl::Fullnode(url)) = config.remote_store_url.as_ref() else {
+                    anyhow::bail!("Blob worker type requires a fullnode remote store URL");
+                };
 
                 let grpc_client = Client::new(url)?;
                 let watermark = executor.read_watermark(task_config.name.clone()).await?;
@@ -277,7 +303,7 @@ async fn main() -> Result<()> {
     };
 
     let config = CheckpointReaderConfig {
-        remote_store_url: config.remote_store_url.map(RemoteUrl::Fullnode),
+        remote_store_url: config.remote_store_url.map(Into::into),
         ingestion_path: Some(config.path),
         reader_options,
     };

--- a/dev-tools/iota-data-ingestion/README.md
+++ b/dev-tools/iota-data-ingestion/README.md
@@ -28,8 +28,12 @@ An example of `config.yaml` for the Blob worker:
 # IndexerExecutor config
 #
 path: "./test-checkpoints"
-# IOTA Node gRPC URL
-remote-store-url: "http://localhost:50051"
+# Remote checkpoint store can either be a fullnode gRPC URL or a hybrid historical store.
+remote-store:
+  fullnode-url: "http://localhost:50051"
+  # hybrid:
+  #   historical-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/historical"
+  #   live-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/live"
 
 # Path to the progress store JSON file.
 #

--- a/dev-tools/iota-data-ingestion/historical/config.yaml
+++ b/dev-tools/iota-data-ingestion/historical/config.yaml
@@ -5,22 +5,34 @@
 # Using the same path as the Node allows direct file access instead of HTTP requests,
 # significantly improving sync speed.
 path: "./test-checkpoints"
-# IOTA Node gRPC URL
+# Remote checkpoint store
 #
-# The IOTA Node's gRPC URL acts as a fallback mechanism for fetching checkpoints
-# when they are not available in the local ingestion path. This provides redundancy
-# and ensures data availability even when local files are not accessible.
+# Acts as a fallback mechanism for fetching checkpoints that are not available in the local
+# ingestion path. Provides redundancy and keeps ingestion running even when local
+# files are not accessible.
 #
-# Note: This URL is optional when:
-# 1. The ingestion path matches the IOTA Node's path on same host machine)
-# 2. You don't need a fallback mechanism for data retrieval
-# 3. Local filesystem access is sufficient for your use case
+# Two source types are supported (pick one):
+#
+#   fullnode-url: the gRPC URL of an IOTA Node that streams checkpoint data.
+#
+#   hybrid:
+#     - historical-url (required): exposes historical checkpoint data from genesis up to the tip of the network.
+#     - live-url (optional): real-time streaming of current epoch checkpoints only.
+#
+# Optional when:
+#   1. The ingestion `path` matches the IOTA Node's path on the same host.
+#   2. You don't need a fallback for data retrieval.
+#   3. Local filesystem access is sufficient for your use case.
 #
 # Required when:
-# 1. Running on a different host than the IOTA Node
-# 2. Using a different path than the Node
-# 3. HTTP access is preferred over local filesystem
-remote-store-url: "http://localhost:50051"
+#   1. Running on a different host than the IOTA Node.
+#   2. Using a different path than the Node.
+#   3. Remote access is preferred over local filesystem.
+remote-store:
+  fullnode-url: "http://localhost:50051"
+  # hybrid:
+  #   historical-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/historical"
+  #   live-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/live"
 
 # Path to the progress store JSON file.
 #

--- a/dev-tools/iota-data-ingestion/kv-store/config/aws.yaml
+++ b/dev-tools/iota-data-ingestion/kv-store/config/aws.yaml
@@ -5,22 +5,34 @@
 # Using the same path as the Node allows direct file access instead of HTTP requests,
 # significantly improving sync speed.
 path: "./test-checkpoints"
-# IOTA Node gRPC URL
+# Remote checkpoint store
 #
-# The IOTA Node's gRPC URL acts as a fallback mechanism for fetching checkpoints
-# when they are not available in the local ingestion path. This provides redundancy
-# and ensures data availability even when local files are not accessible.
+# Acts as a fallback mechanism for fetching checkpoints that are not available in the local
+# ingestion path. Provides redundancy and keeps ingestion running even when local
+# files are not accessible.
 #
-# Note: This URL is optional when:
-# 1. The ingestion path matches the IOTA Node's path on same host machine)
-# 2. You don't need a fallback mechanism for data retrieval
-# 3. Local filesystem access is sufficient for your use case
+# Two source types are supported (pick one):
+#
+#   fullnode-url: the gRPC URL of an IOTA Node that streams checkpoint data.
+#
+#   hybrid:
+#     - historical-url (required): exposes historical checkpoint data from genesis up to the tip of the network.
+#     - live-url (optional): real-time streaming of current epoch checkpoints only.
+#
+# Optional when:
+#   1. The ingestion `path` matches the IOTA Node's path on the same host.
+#   2. You don't need a fallback for data retrieval.
+#   3. Local filesystem access is sufficient for your use case.
 #
 # Required when:
-# 1. Running on a different host than the IOTA Node
-# 2. Using a different path than the Node
-# 3. HTTP access is preferred over local filesystem
-remote-store-url: "http://localhost:50051"
+#   1. Running on a different host than the IOTA Node.
+#   2. Using a different path than the Node.
+#   3. Remote access is preferred over local filesystem.
+remote-store:
+  fullnode-url: "http://localhost:50051"
+  # hybrid:
+  #   historical-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/historical"
+  #   live-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/live"
 
 # Path to the progress store JSON file.
 #

--- a/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
+++ b/dev-tools/iota-data-ingestion/kv-store/config/bigtable.yaml
@@ -5,22 +5,34 @@
 # Using the same path as the Node allows direct file access instead of HTTP requests,
 # significantly improving sync speed.
 path: "./test-checkpoints"
-# IOTA Node gRPC URL
+# Remote checkpoint store
 #
-# The IOTA Node's gRPC URL acts as a fallback mechanism for fetching checkpoints
-# when they are not available in the local ingestion path. This provides redundancy
-# and ensures data availability even when local files are not accessible.
+# Acts as a fallback mechanism for fetching checkpoints that are not available in the local
+# ingestion path. Provides redundancy and keeps ingestion running even when local
+# files are not accessible.
 #
-# Note: This URL is optional when:
-# 1. The ingestion path matches the IOTA Node's path on same host machine)
-# 2. You don't need a fallback mechanism for data retrieval
-# 3. Local filesystem access is sufficient for your use case
+# Two source types are supported (pick one):
+#
+#   fullnode-url: the gRPC URL of an IOTA Node that streams checkpoint data.
+#
+#   hybrid:
+#     - historical-url (required): exposes historical checkpoint data from genesis up to the tip of the network.
+#     - live-url (optional): real-time streaming of current epoch checkpoints only.
+#
+# Optional when:
+#   1. The ingestion `path` matches the IOTA Node's path on the same host.
+#   2. You don't need a fallback for data retrieval.
+#   3. Local filesystem access is sufficient for your use case.
 #
 # Required when:
-# 1. Running on a different host than the IOTA Node
-# 2. Using a different path than the Node
-# 3. HTTP access is preferred over local filesystem
-remote-store-url: "http://localhost:50051"
+#   1. Running on a different host than the IOTA Node.
+#   2. Using a different path than the Node.
+#   3. Remote access is preferred over local filesystem.
+remote-store:
+  fullnode-url: "http://localhost:50051"
+  # hybrid:
+  #   historical-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/historical"
+  #   live-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/live"
 
 # Path to the progress store JSON file.
 #

--- a/dev-tools/iota-data-ingestion/live/config.yaml
+++ b/dev-tools/iota-data-ingestion/live/config.yaml
@@ -5,22 +5,34 @@
 # Using the same path as the Node allows direct file access instead of HTTP requests,
 # significantly improving sync speed.
 path: "./test-checkpoints"
-# IOTA Node gRPC URL
+# Remote checkpoint store
 #
-# The IOTA Node's gRPC URL acts as a fallback mechanism for fetching checkpoints
-# when they are not available in the local ingestion path. This provides redundancy
-# and ensures data availability even when local files are not accessible.
+# Acts as a fallback mechanism for fetching checkpoints that are not available in the local
+# ingestion path. Provides redundancy and keeps ingestion running even when local
+# files are not accessible.
 #
-# Note: This URL is optional when:
-# 1. The ingestion path matches the IOTA Node's path on same host machine)
-# 2. You don't need a fallback mechanism for data retrieval
-# 3. Local filesystem access is sufficient for your use case
+# Two source types are supported (pick one):
+#
+#   fullnode-url: the gRPC URL of an IOTA Node that streams checkpoint data.
+#
+#   hybrid:
+#     - historical-url (required): exposes historical checkpoint data from genesis up to the tip of the network.
+#     - live-url (optional): real-time streaming of current epoch checkpoints only.
+#
+# Optional when:
+#   1. The ingestion `path` matches the IOTA Node's path on the same host.
+#   2. You don't need a fallback for data retrieval.
+#   3. Local filesystem access is sufficient for your use case.
 #
 # Required when:
-# 1. Running on a different host than the IOTA Node
-# 2. Using a different path than the Node
-# 3. HTTP access is preferred over local filesystem
-remote-store-url: "http://localhost:50051"
+#   1. Running on a different host than the IOTA Node.
+#   2. Using a different path than the Node.
+#   3. Remote access is preferred over local filesystem.
+remote-store:
+  fullnode-url: "http://localhost:50051"
+  # hybrid:
+  #   historical-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/historical"
+  #   live-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/live"
 
 # Path to the progress store JSON file.
 #

--- a/dev-tools/iota-data-ingestion/live/config.yaml
+++ b/dev-tools/iota-data-ingestion/live/config.yaml
@@ -5,34 +5,18 @@
 # Using the same path as the Node allows direct file access instead of HTTP requests,
 # significantly improving sync speed.
 path: "./test-checkpoints"
-# Remote checkpoint store
+# IOTA Node gRPC URL
 #
-# Acts as a fallback mechanism for fetching checkpoints that are not available in the local
-# ingestion path. Provides redundancy and keeps ingestion running even when local
-# files are not accessible.
+# The IOTA Node's gRPC URL acts as a fallback mechanism for fetching checkpoints
+# when they are not available in the local ingestion path. This provides redundancy
+# and ensures data availability even when local files are not accessible.
 #
-# Two source types are supported (pick one):
-#
-#   fullnode-url: the gRPC URL of an IOTA Node that streams checkpoint data.
-#
-#   hybrid:
-#     - historical-url (required): exposes historical checkpoint data from genesis up to the tip of the network.
-#     - live-url (optional): real-time streaming of current epoch checkpoints only.
-#
-# Optional when:
-#   1. The ingestion `path` matches the IOTA Node's path on the same host.
-#   2. You don't need a fallback for data retrieval.
-#   3. Local filesystem access is sufficient for your use case.
-#
-# Required when:
-#   1. Running on a different host than the IOTA Node.
-#   2. Using a different path than the Node.
-#   3. Remote access is preferred over local filesystem.
+# Note: This URL is optional when:
+# 1. The ingestion path matches the IOTA Node's path on same host machine)
+# 2. You don't need a fallback mechanism for data retrieval
+# 3. Local filesystem access is sufficient for your use case
 remote-store:
   fullnode-url: "http://localhost:50051"
-  # hybrid:
-  #   historical-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/historical"
-  #   live-url: "https://checkpoints.<NETWORK>.iota.cafe/ingestion/live"
 
 # Path to the progress store JSON file.
 #


### PR DESCRIPTION
# Description of change

This PR adds the ability to either provide the fullnode gRPC URL or the hybrid historical store as a remote source for checkpoint ingestion.

> [!NOTE]
> The `Blob` worker only works with the fullnode gRPC URL, this is because by design its purpose is to only ingest current epoch checkpoint only, making the historical ingestion unnecessary.

## Links to any relevant issues

fixes #10791 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran the ingestion workers by providing the hybrid historical urls. 

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.
