### PR TITLE
fix(starfish): add local validation and arithmetic guard rails

### DIFF
--- a/crates/starfish/config/src/committee.rs
+++ b/crates/starfish/config/src/committee.rs
@@ -68,7 +68,6 @@ impl Committee {
             .map(|a| a.stake)
             .try_fold(0u64, u64::checked_add)
             .expect("Total stake must not overflow u64!");
-        assert_ne!(total_stake, 0, "Total stake cannot be zero!");
         // Widen to u128 for the doubling; the result is at most total_stake.
         let quorum_threshold = (2 * total_stake as u128 / 3 + 1) as u64;
         let validity_threshold = total_stake.div_ceil(3);

--- a/crates/starfish/config/src/committee.rs
+++ b/crates/starfish/config/src/committee.rs
@@ -43,6 +43,10 @@ pub struct Committee {
 }
 
 impl Committee {
+    /// Panics on invalid input: empty or oversized committee, or zero or
+    /// overflowing stake. The committee is computed on chain, so violations
+    /// indicate a corrupted or misconstructed configuration rather than a
+    /// recoverable condition.
     pub fn new(epoch: Epoch, authorities: Vec<Authority>) -> Self {
         assert!(!authorities.is_empty(), "Committee cannot be empty!");
         assert!(
@@ -51,9 +55,22 @@ impl Committee {
             authorities.len()
         );
 
-        let total_stake = authorities.iter().map(|a| a.stake).sum::<u64>();
+        for authority in &authorities {
+            assert!(
+                authority.stake > 0,
+                "Authority {} cannot have zero stake!",
+                authority.hostname
+            );
+        }
+
+        let total_stake = authorities
+            .iter()
+            .map(|a| a.stake)
+            .try_fold(0u64, u64::checked_add)
+            .expect("Total stake must not overflow u64!");
         assert_ne!(total_stake, 0, "Total stake cannot be zero!");
-        let quorum_threshold = 2 * total_stake / 3 + 1;
+        // Widen to u128 for the doubling; the result is at most total_stake.
+        let quorum_threshold = (2 * total_stake as u128 / 3 + 1) as u64;
         let validity_threshold = total_stake.div_ceil(3);
         let committee_size = authorities.len();
         // f and info_length are computed for uniform stakes

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -223,6 +223,73 @@ impl Parameters {
         }
     }
 
+    /// Validates local consensus parameters, rejecting zero values that can
+    /// lead to synchronization problems. Returns a description of the first
+    /// offending field.
+    pub fn validate(&self) -> Result<(), String> {
+        let positive_fields = [
+            (
+                "max_headers_per_commit_sync_fetch",
+                self.max_headers_per_commit_sync_fetch as u128,
+            ),
+            (
+                "max_transactions_per_commit_sync_fetch",
+                self.max_transactions_per_commit_sync_fetch as u128,
+            ),
+            (
+                "max_headers_per_header_sync_fetch",
+                self.max_headers_per_header_sync_fetch as u128,
+            ),
+            (
+                "max_transactions_per_transaction_sync_fetch",
+                self.max_transactions_per_transaction_sync_fetch as u128,
+            ),
+            (
+                "dag_state_cached_rounds",
+                self.dag_state_cached_rounds as u128,
+            ),
+            (
+                "commit_sync_parallel_fetches",
+                self.commit_sync_parallel_fetches as u128,
+            ),
+            (
+                "commit_sync_batch_size",
+                self.commit_sync_batch_size as u128,
+            ),
+            (
+                "commit_sync_batches_ahead",
+                self.commit_sync_batches_ahead as u128,
+            ),
+            (
+                "max_headers_per_bundle",
+                self.max_headers_per_bundle as u128,
+            ),
+            ("max_shards_per_bundle", self.max_shards_per_bundle as u128),
+            (
+                "fast_commit_sync_batch_size",
+                self.fast_commit_sync_batch_size as u128,
+            ),
+            (
+                "tonic.connection_buffer_size",
+                self.tonic.connection_buffer_size as u128,
+            ),
+            (
+                "tonic.message_size_limit",
+                self.tonic.message_size_limit as u128,
+            ),
+            (
+                "tonic.keepalive_interval",
+                self.tonic.keepalive_interval.as_nanos(),
+            ),
+        ];
+        for (name, value) in positive_fields {
+            if value == 0 {
+                return Err(format!("{name} must be positive"));
+            }
+        }
+        Ok(())
+    }
+
     // Maximum number of block headers to fetch per commit sync request.
     pub(crate) fn default_max_headers_per_commit_sync_fetch() -> usize {
         if cfg!(msim) {

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -274,6 +274,10 @@ impl Parameters {
                 self.tonic.connection_buffer_size as u128,
             ),
             (
+                "tonic.excessive_message_size",
+                self.tonic.excessive_message_size as u128,
+            ),
+            (
                 "tonic.message_size_limit",
                 self.tonic.message_size_limit as u128,
             ),

--- a/crates/starfish/config/tests/committee_test.rs
+++ b/crates/starfish/config/tests/committee_test.rs
@@ -9,6 +9,25 @@ use starfish_config::{
     Authority, AuthorityKeyPair, Committee, NetworkKeyPair, ProtocolKeyPair, Stake,
 };
 
+fn test_authorities(stakes: &[Stake]) -> Vec<Authority> {
+    let mut authorities = vec![];
+    let mut rng = StdRng::from_seed([9; 32]);
+    for (i, stake) in stakes.iter().enumerate() {
+        let authority_keypair = AuthorityKeyPair::generate(&mut rng);
+        let protocol_keypair = ProtocolKeyPair::generate(&mut rng);
+        let network_keypair = NetworkKeyPair::generate(&mut rng);
+        authorities.push(Authority {
+            stake: *stake,
+            address: Multiaddr::empty(),
+            hostname: format!("test_host_{i}"),
+            authority_key: authority_keypair.public(),
+            protocol_key: protocol_keypair.public(),
+            network_key: network_keypair.public(),
+        });
+    }
+    authorities
+}
+
 // Committee is not sent over network or stored on disk itself, but some of its
 // fields are. So this test can still be useful to detect accidental format
 // changes.
@@ -36,4 +55,26 @@ fn committee_snapshot_matches() {
     let committee = Committee::new(epoch, authorities);
 
     assert_yaml_snapshot!("committee", committee)
+}
+
+#[test]
+#[should_panic(expected = "cannot have zero stake")]
+fn committee_rejects_zero_stake_authority() {
+    Committee::new(0, test_authorities(&[1, 0, 1]));
+}
+
+#[test]
+#[should_panic(expected = "Total stake must not overflow")]
+fn committee_rejects_total_stake_overflow() {
+    Committee::new(0, test_authorities(&[u64::MAX, 1]));
+}
+
+#[test]
+fn committee_computes_thresholds_for_large_total_stake() {
+    let committee = Committee::new(0, test_authorities(&[u64::MAX / 2, u64::MAX / 2]));
+    let total = committee.total_stake();
+    assert_eq!(total, u64::MAX - 1);
+    // A wrapped threshold computation would land near total / 3.
+    assert!(committee.quorum_threshold() > total / 2);
+    assert!(committee.quorum_threshold() <= total);
 }

--- a/crates/starfish/config/tests/parameters_test.rs
+++ b/crates/starfish/config/tests/parameters_test.rs
@@ -122,4 +122,16 @@ fn validate_rejects_zero_values() {
     };
     let error = parameters.validate().unwrap_err();
     assert!(error.contains("keepalive_interval"));
+
+    // `excessive_message_size` is a pure metrics threshold with no "0 disables
+    // it" meaning, so a zero would flag every message as excessive.
+    let parameters = starfish_config::Parameters {
+        tonic: starfish_config::TonicParameters {
+            excessive_message_size: 0,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let error = parameters.validate().unwrap_err();
+    assert!(error.contains("excessive_message_size"));
 }

--- a/crates/starfish/config/tests/parameters_test.rs
+++ b/crates/starfish/config/tests/parameters_test.rs
@@ -98,3 +98,28 @@ tonic:
         defaults.tonic.admission.max_commit_fetches_per_peer
     );
 }
+
+#[test]
+fn validate_accepts_defaults() {
+    starfish_config::Parameters::default().validate().unwrap();
+}
+
+#[test]
+fn validate_rejects_zero_values() {
+    let parameters = starfish_config::Parameters {
+        max_headers_per_bundle: 0,
+        ..Default::default()
+    };
+    let error = parameters.validate().unwrap_err();
+    assert!(error.contains("max_headers_per_bundle"));
+
+    let parameters = starfish_config::Parameters {
+        tonic: starfish_config::TonicParameters {
+            keepalive_interval: std::time::Duration::ZERO,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let error = parameters.validate().unwrap_err();
+    assert!(error.contains("keepalive_interval"));
+}

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -91,6 +91,9 @@ impl ConsensusAuthority {
             committee.is_valid_index(own_index),
             "Invalid own index {own_index}"
         );
+        parameters
+            .validate()
+            .unwrap_or_else(|e| panic!("Invalid consensus parameters: {e}"));
         let own_hostname = &committee.authority(own_index).hostname;
         info!(
             "Starting consensus authority {} {}, {:?}, boot counter {}, last processed commit index {}",

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -986,7 +986,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // will help with liveness.
         let missed_blocks = stream::iter(
             dag_state
-                .get_own_cached_blocks(last_received + 1)
+                .get_own_cached_blocks(last_received.saturating_add(1))
                 .into_iter()
                 .filter_map(|block| match SerializedBlockBundle::try_from(block) {
                     Ok(block_bundle) => Some(block_bundle),

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -24,6 +24,7 @@ use crate::{
         VerifiedBlockHeader, VerifiedTransactions, uleb128_len,
     },
     context::Context,
+    error::{ConsensusError, ConsensusResult},
     leader_scoring::ReputationScores,
     misbehavior_store::MisbehaviorCounts,
     storage::Store,
@@ -890,32 +891,32 @@ pub(crate) fn sort_sub_dag_blocks(block_headers: &mut [VerifiedBlockHeader]) {
 }
 
 // Recovers PendingSubDAG from block store, based on Commit.
-pub fn load_pending_subdag_from_store(
+pub(crate) fn load_pending_subdag_from_store(
     store: &dyn Store,
     commit: TrustedCommit,
     reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
-) -> PendingSubDag {
+) -> ConsensusResult<PendingSubDag> {
     let mut leader_block_idx = None;
-    let commit_block_headers = store
-        .read_verified_block_headers(commit.block_headers())
-        .expect("Block headers referenced in commit data should exist");
+    let commit_block_headers = store.read_verified_block_headers(commit.block_headers())?;
     let block_headers = commit_block_headers
         .into_iter()
+        .zip(commit.block_headers())
         .enumerate()
-        .map(|(idx, commit_block_opt)| {
-            let commit_block = commit_block_opt.expect(
-                "Block header referenced in commit data should exist. \
-                 This could be due to unfinished fast syncing.",
-            );
+        .map(|(idx, (commit_block, block_ref))| {
+            let commit_block = commit_block.ok_or(ConsensusError::MissingBlockHeader {
+                block_ref: *block_ref,
+            })?;
             if commit_block.reference() == commit.leader() {
                 leader_block_idx = Some(idx);
             }
-            commit_block
+            Ok(commit_block)
         })
-        .collect::<Vec<_>>();
-    let leader_block_idx = leader_block_idx.expect("Leader block must be in the sub-dag");
+        .collect::<ConsensusResult<Vec<_>>>()?;
+    let leader_block_idx = leader_block_idx.ok_or(ConsensusError::MissingBlockHeader {
+        block_ref: commit.leader(),
+    })?;
     let leader_block_ref = block_headers[leader_block_idx].reference();
-    PendingSubDag::new(
+    Ok(PendingSubDag::new(
         leader_block_ref,
         block_headers,
         commit.block_headers().to_vec(),
@@ -923,7 +924,7 @@ pub fn load_pending_subdag_from_store(
         commit.timestamp_ms(),
         commit.reference(),
         reputation_scores_desc,
-    )
+    ))
 }
 
 fn format_transaction_ref_digests(transaction_refs: &[GenericTransactionRef]) -> String {
@@ -1372,7 +1373,8 @@ mod tests {
             generic_committed_transactions.clone(),
         );
 
-        let subdag = load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]);
+        let subdag =
+            load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]).unwrap();
         assert_eq!(subdag.leader, leader_ref);
         assert_eq!(subdag.timestamp_ms, leader_block.timestamp_ms());
         assert_eq!(
@@ -1474,7 +1476,8 @@ mod tests {
             generic_committed_transactions.clone(),
         );
 
-        let pending_subdag = load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]);
+        let pending_subdag =
+            load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]).unwrap();
         assert_eq!(pending_subdag.leader, leader_ref);
         assert_eq!(pending_subdag.timestamp_ms, leader_block.timestamp_ms());
         assert_eq!(

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -115,7 +115,8 @@ impl CommitObserver {
 
         observer
             .recover_and_send_commits(last_processed_commit_index, CommittedSubDagSource::Recover)
-            .await;
+            .await
+            .unwrap_or_else(|e| panic!("Failed to recover commits at startup: {e:?}"));
         observer
     }
 
@@ -124,7 +125,10 @@ impl CommitObserver {
     /// - Recovering linearizer state (transaction ack tracker, traversed
     ///   headers)
     /// - Only re-sends commits that are > last_commit_index (none in this case)
-    pub(crate) async fn reinitialize(&mut self, last_commit_index: CommitIndex) {
+    pub(crate) async fn reinitialize(
+        &mut self,
+        last_commit_index: CommitIndex,
+    ) -> ConsensusResult<()> {
         let now = Instant::now();
 
         // Clear linearizer state
@@ -134,13 +138,14 @@ impl CommitObserver {
         // Reuse existing recovery logic - it won't resend commits since
         // they're all <= last_commit_index
         self.recover_and_send_commits(last_commit_index, CommittedSubDagSource::FastCommitSyncer)
-            .await;
+            .await?;
 
         info!(
             "CommitObserver reinitialized at commit index {}, took {:?}",
             last_commit_index,
             now.elapsed()
         );
+        Ok(())
     }
 
     /// Handles the creation of commits from a set of passed leaders.
@@ -233,26 +238,34 @@ impl CommitObserver {
         &self,
         commit: &TrustedCommit,
         reputation_scores: Vec<(AuthorityIndex, u64)>,
-    ) -> Option<CommittedSubDag> {
+    ) -> ConsensusResult<Option<CommittedSubDag>> {
         let tx_refs = commit.committed_transactions();
-        let transactions = match self
+        let transaction_results = self
             .dag_state
             .read()
-            .try_get_all_verified_transactions(&tx_refs)
-        {
-            Ok(transactions) => transactions,
-            Err(missing_refs) => {
-                warn!(
-                    "Missing {} transactions for commit {}: {:?}",
-                    missing_refs.len(),
-                    commit.index(),
-                    missing_refs,
-                );
-                return None;
-            }
-        };
+            .try_get_verified_transactions(&tx_refs)?;
+        let missing_refs: Vec<_> = tx_refs
+            .iter()
+            .zip(&transaction_results)
+            .filter_map(|(transaction_ref, transaction)| {
+                transaction.is_none().then_some(*transaction_ref)
+            })
+            .collect();
+        if !missing_refs.is_empty() {
+            warn!(
+                "Missing {} transactions for commit {}: {:?}",
+                missing_refs.len(),
+                commit.index(),
+                missing_refs,
+            );
+            return Ok(None);
+        }
+        let transactions = transaction_results
+            .into_iter()
+            .map(|transaction| transaction.expect("missing transactions checked above"))
+            .collect();
 
-        Some(CommittedSubDag::new(
+        Ok(Some(CommittedSubDag::new(
             commit.leader(),
             vec![], // Empty headers for recovery
             commit.block_headers().to_vec(),
@@ -261,18 +274,15 @@ impl CommitObserver {
             commit.reference(),
             reputation_scores,
             self.dag_state.read().misbehavior_store().snapshot_totals(),
-        ))
+        )))
     }
 
     async fn recover_and_send_commits(
         &mut self,
         last_processed_commit_index: CommitIndex,
         source: CommittedSubDagSource,
-    ) {
-        let last_commit = self
-            .store
-            .read_last_commit()
-            .expect("Reading the last commit should not fail");
+    ) -> ConsensusResult<()> {
+        let last_commit = self.store.read_last_commit()?;
         let last_commit_index = last_commit
             .as_ref()
             .map(|commit| commit.index())
@@ -283,7 +293,7 @@ impl CommitObserver {
         );
         if last_commit_index == 0 {
             info!("No commits to recover in commit observer");
-            return;
+            return Ok(());
         }
 
         // Phase 1: Resend all solid committed sub-dags that haven't been processed
@@ -292,17 +302,18 @@ impl CommitObserver {
             last_commit_index,
             source,
         )
-        .await;
+        .await?;
 
         // Phase 2: Recover linearizer and solidifier state
         // Skip if fast sync is ongoing - block data may not be available and
         // this will be reinitialized by fast commit syncer anyway
-        if self.store.read_fast_sync_ongoing() {
+        if self.store.read_fast_sync_ongoing()? {
             info!("Skipping linearizer/solidifier recovery - fast sync ongoing");
-            return;
+            return Ok(());
         }
         self.recover_linearizer_and_solidifier_state(last_commit_index, source)
-            .await;
+            .await?;
+        Ok(())
     }
 
     /// Recovers linearizer trackers from recent commits and seeds the
@@ -311,7 +322,7 @@ impl CommitObserver {
         &mut self,
         last_commit_index: CommitIndex,
         source: CommittedSubDagSource,
-    ) {
+    ) -> ConsensusResult<()> {
         let linearizer_recovery_start = last_commit_index
             .saturating_sub(self.context.protocol_config.gc_depth() * 2)
             .max(1);
@@ -320,8 +331,7 @@ impl CommitObserver {
 
         let recovery_commits = self
             .store
-            .scan_commits((recovery_start..=last_commit_index).into())
-            .expect("Scanning commits should not fail");
+            .scan_commits((recovery_start..=last_commit_index).into())?;
 
         info!(
             "Recovering linearizer/solidifier state from {} commits (indices {}..={})",
@@ -339,7 +349,7 @@ impl CommitObserver {
             let commit_index = commit.index();
             let is_optimistic = commit.is_optimistic();
             let pending_sub_dag =
-                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
+                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![])?;
 
             if commit_index >= linearizer_recovery_start {
                 // Rebuild traversed headers tracker
@@ -392,9 +402,9 @@ impl CommitObserver {
             let (solid_sub_dags, _missing) = self
                 .commit_solidifier
                 .try_get_solid_sub_dags(&pending_for_solidifier);
-            self.finalize_and_send_solid_subdags(&[], &solid_sub_dags, source)
-                .expect("We should successfully send solid commits during recovery");
+            self.finalize_and_send_solid_subdags(&[], &solid_sub_dags, source)?;
         }
+        Ok(())
     }
 
     /// Sends committed sub-dags through the channel.
@@ -463,7 +473,7 @@ impl CommitObserver {
         last_processed_commit_index: CommitIndex,
         last_commit_index: CommitIndex,
         source: CommittedSubDagSource,
-    ) {
+    ) -> ConsensusResult<()> {
         if last_processed_commit_index >= last_commit_index {
             info!("No unprocessed commits to resend");
 
@@ -471,23 +481,23 @@ impl CommitObserver {
             // last solid subdag in dag state so that fast sync knows where to start
             // fetching.
             if last_processed_commit_index > 0 {
-                if let Some(commit) = self
+                let commit = self
                     .store
                     .scan_commits(
                         (last_processed_commit_index..=last_processed_commit_index).into(),
-                    )
-                    .ok()
-                    .and_then(|commits| commits.into_iter().next())
-                {
+                    )?
+                    .into_iter()
+                    .next();
+                if let Some(commit) = commit {
                     if let Some(committed_subdag) =
-                        self.build_committed_subdag_from_commit(&commit, vec![])
+                        self.build_committed_subdag_from_commit(&commit, vec![])?
                     {
                         self.update_with_solid_subdags_and_flush(&[committed_subdag]);
                     }
                 }
             }
 
-            return;
+            return Ok(());
         }
 
         info!(
@@ -518,10 +528,7 @@ impl CommitObserver {
                 .saturating_add(COMMIT_RECOVERY_BATCH_SIZE - 1)
                 .min(last_commit_index);
 
-            let batch_commits = self
-                .store
-                .scan_commits((start_index..=end_index).into())
-                .expect("Scanning commits should not fail");
+            let batch_commits = self.store.scan_commits((start_index..=end_index).into())?;
 
             if batch_commits.is_empty() {
                 break;
@@ -551,7 +558,7 @@ impl CommitObserver {
                 };
 
                 let Some(committed_subdag) =
-                    self.build_committed_subdag_from_commit(&commit, reputation_scores)
+                    self.build_committed_subdag_from_commit(&commit, reputation_scores)?
                 else {
                     info!(
                         "Stopping resend at commit {} due to missing transactions",
@@ -566,8 +573,7 @@ impl CommitObserver {
 
             if !committed_subdags.is_empty() {
                 any_sent = true;
-                self.finalize_and_send_solid_subdags(&[], &committed_subdags, source)
-                    .expect("We should successfully send committed subdags during resend");
+                self.finalize_and_send_solid_subdags(&[], &committed_subdags, source)?;
 
                 if let Some(last) = committed_subdags.last() {
                     self.context
@@ -591,17 +597,18 @@ impl CommitObserver {
         // last_solid_subdag_base from last_processed so fast sync
         // starts from the right position instead of index 0.
         if !any_sent && last_processed_commit_index > 0 {
-            if let Some(commit) = self
+            let commit = self
                 .store
-                .scan_commits((last_processed_commit_index..=last_processed_commit_index).into())
-                .ok()
-                .and_then(|commits| commits.into_iter().next())
-            {
-                if let Some(subdag) = self.build_committed_subdag_from_commit(&commit, vec![]) {
+                .scan_commits((last_processed_commit_index..=last_processed_commit_index).into())?
+                .into_iter()
+                .next();
+            if let Some(commit) = commit {
+                if let Some(subdag) = self.build_committed_subdag_from_commit(&commit, vec![])? {
                     self.update_with_solid_subdags_and_flush(&[subdag]);
                 }
             }
         }
+        Ok(())
     }
 
     /// Get all missing transactions from pending subdags along with authorities

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -646,7 +646,7 @@ impl Core {
                         &mut dag_state,
                         commit.index(),
                         reputation_scores,
-                    );
+                    )?;
                 }
 
                 dag_state.add_commit(commit.clone());
@@ -742,7 +742,7 @@ impl Core {
         self.last_decided_leader = last_commit_leader;
 
         // 8. Reinitialize CommitObserver with recovery (uses recover_and_send_commits)
-        self.commit_observer.reinitialize(last_commit_index).await;
+        self.commit_observer.reinitialize(last_commit_index).await?;
 
         // 9. Reset signaling state
         self.last_signaled_round = threshold_round.saturating_sub(1);

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -37,6 +37,7 @@ use crate::{
     },
     context::Context,
     cordial_knowledge::CordialKnowledgeMessage,
+    error::ConsensusResult,
     leader_scoring::{ReputationScores, ScoringSubdag},
     misbehavior_store::{MisbehaviorCounts, MisbehaviorStore},
     storage::{Store, WriteBatch},
@@ -359,7 +360,9 @@ impl DagState {
             };
 
         // Read fast sync flag from storage
-        let fast_sync_ongoing = store.read_fast_sync_ongoing();
+        let fast_sync_ongoing = store
+            .read_fast_sync_ongoing()
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
 
         let mut unscored_committed_subdags = Vec::new();
         let mut scoring_subdag = ScoringSubdag::new(context.clone());
@@ -379,7 +382,10 @@ impl DagState {
                         }
 
                         let committed_subdag =
-                            load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]);
+                            load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![])
+                                .unwrap_or_else(|e| {
+                                    panic!("Failed to recover pending subdag: {e:?}")
+                                });
                         unscored_committed_subdags.push(committed_subdag.base);
                     });
             }
@@ -630,7 +636,8 @@ impl DagState {
         let mut unscored_subdags = Vec::with_capacity(commits.len());
         for commit in commits {
             let pending_subdag =
-                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
+                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![])
+                    .unwrap_or_else(|e| panic!("Failed to recover pending subdag: {e:?}"));
             unscored_subdags.push(pending_subdag.base);
         }
 
@@ -787,7 +794,9 @@ impl DagState {
     }
 
     pub(crate) fn fast_sync_ongoing(&self) -> bool {
-        self.store.read_fast_sync_ongoing()
+        self.store
+            .read_fast_sync_ongoing()
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"))
     }
 
     /// Returns the leader round of the last solid commit (backward
@@ -1047,6 +1056,18 @@ impl DagState {
         &self,
         transactions_refs: &[GenericTransactionRef],
     ) -> Vec<Option<VerifiedTransactions>> {
+        self.try_get_verified_transactions(transactions_refs)
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"))
+    }
+
+    /// Returns verified transactions from memory or storage.
+    ///
+    /// # Errors
+    /// Returns a storage error when persisted transactions cannot be read.
+    pub(crate) fn try_get_verified_transactions(
+        &self,
+        transactions_refs: &[GenericTransactionRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
         let mut transactions = vec![None; transactions_refs.len()];
         let mut missing = Vec::new();
 
@@ -1068,17 +1089,14 @@ impl DagState {
         }
 
         if missing.is_empty() {
-            return transactions;
+            return Ok(transactions);
         }
 
         let missing_refs = missing
             .iter()
             .map(|(_, block_ref)| **block_ref)
             .collect::<Vec<_>>();
-        let store_results = self
-            .store
-            .read_verified_transactions(&missing_refs)
-            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
+        let store_results = self.store.read_verified_transactions(&missing_refs)?;
         self.context
             .metrics
             .node_metrics
@@ -1090,28 +1108,7 @@ impl DagState {
             transactions[index] = result;
         }
 
-        transactions
-    }
-
-    /// Returns all verified transactions or the list of missing transaction
-    /// refs. This is the canonical way to load transactions for
-    /// CommittedSubDag construction.
-    pub(crate) fn try_get_all_verified_transactions(
-        &self,
-        tx_refs: &[GenericTransactionRef],
-    ) -> Result<Vec<VerifiedTransactions>, Vec<GenericTransactionRef>> {
-        let results = self.get_verified_transactions(tx_refs);
-        let mut missing = Vec::new();
-        for (i, tx_opt) in results.iter().enumerate() {
-            if tx_opt.is_none() {
-                missing.push(tx_refs[i]);
-            }
-        }
-        if missing.is_empty() {
-            Ok(results.into_iter().map(|tx| tx.unwrap()).collect())
-        } else {
-            Err(missing)
-        }
+        Ok(transactions)
     }
 
     /// Gets serialized transactions by checking cached recent transactions in

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -90,10 +90,10 @@ pub(crate) enum ConsensusError {
     )]
     InvalidSizeOfHighestAcceptedRounds(usize, usize),
 
-    #[error("Invalid authority index: {index} > {max}")]
+    #[error("Invalid authority index: {index} >= {max}")]
     InvalidAuthorityIndex { index: AuthorityIndex, max: usize },
 
-    #[error("Invalid authority index: {index} > {max} from peer {peer}")]
+    #[error("Invalid authority index: {index} >= {max} from peer {peer}")]
     InvalidAuthorityIndexRequested {
         index: AuthorityIndex,
         max: usize,

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -17,6 +17,7 @@ use crate::{
     commit::{CommitInfo, CommitRange, CommitRef, GENESIS_COMMIT_INDEX},
     context::Context,
     dag_state::DagState,
+    error::ConsensusResult,
     leader_scoring::ReputationScores,
 };
 
@@ -294,14 +295,14 @@ impl LeaderSchedule {
         dag_state_write_lock: &mut DagState,
         commit_index: CommitIndex,
         reputation_scores_desc: &[(AuthorityIndex, u64)],
-    ) {
+    ) -> ConsensusResult<()> {
         // Determine the commit range for these scores.
         // Reputation scores are attached to the *first* commit after a schedule
         // update, so the scores correspond to the previous window ending at
         // commit_index - 1.
         let range_end = commit_index.saturating_sub(1);
         if range_end == GENESIS_COMMIT_INDEX {
-            return;
+            return Ok(());
         }
 
         // Skip stale scores: if the incoming scores are for a range we've already
@@ -315,7 +316,7 @@ impl LeaderSchedule {
                 "[AUTH {}] Skipping stale scores from commit {commit_index} (range_end={range_end} <= last_commit_info_index={last_commit_info_index})",
                 self.context.own_index
             );
-            return;
+            return Ok(());
         }
 
         let range_start = range_end.saturating_sub(self.num_commits_per_schedule as u32 - 1);
@@ -325,7 +326,7 @@ impl LeaderSchedule {
             self.context.committee.size(),
             commit_range,
             reputation_scores_desc,
-        );
+        )?;
 
         tracing::info!(
             "[AUTH {}] Updating leader schedule from commit scores at index {commit_index}: {reputation_scores:?}",
@@ -346,6 +347,7 @@ impl LeaderSchedule {
         );
         self.persist_scores(dag_state_write_lock, reputation_scores);
         self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
+        Ok(())
     }
 
     #[cfg(test)]

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -16,6 +16,7 @@ use crate::{
     block_header::{BlockHeaderAPI, BlockRef},
     commit::{CommitRange, SubDagBase},
     context::Context,
+    error::{ConsensusError, ConsensusResult},
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
 
@@ -74,19 +75,28 @@ impl ReputationScores {
     /// commits). The reputation_scores_desc is Vec<(AuthorityIndex, u64)>
     /// sorted by score descending. This converts it to scores_per_authority
     /// indexed by authority.
+    ///
+    /// Returns `InvalidAuthorityIndex` if an authority index is out of range
+    /// for the committee; the scores originate from fetched commits.
     pub(crate) fn from_scores_desc(
         num_authorities: usize,
         commit_range: CommitRange,
         reputation_scores_desc: &[(AuthorityIndex, u64)],
-    ) -> Self {
+    ) -> ConsensusResult<Self> {
         let mut scores_per_authority = vec![0u64; num_authorities];
         for (authority_index, score) in reputation_scores_desc {
-            scores_per_authority[*authority_index] = *score;
+            let slot = scores_per_authority
+                .get_mut(authority_index.value())
+                .ok_or(ConsensusError::InvalidAuthorityIndex {
+                    index: *authority_index,
+                    max: num_authorities,
+                })?;
+            *slot = *score;
         }
-        Self {
+        Ok(Self {
             scores_per_authority,
             commit_range,
-        }
+        })
     }
 }
 
@@ -247,6 +257,28 @@ mod tests {
 
     use super::*;
     use crate::test_dag_builder::DagBuilder;
+
+    #[test]
+    fn test_from_scores_desc_converts_to_per_authority_scores() {
+        let scores = vec![
+            (AuthorityIndex::new_for_test(1), 10),
+            (AuthorityIndex::new_for_test(3), 5),
+        ];
+        let reputation_scores =
+            ReputationScores::from_scores_desc(4, (1..=10).into(), &scores).unwrap();
+        assert_eq!(reputation_scores.scores_per_authority, vec![0, 10, 0, 5]);
+    }
+
+    #[test]
+    fn test_from_scores_desc_rejects_out_of_range_authority() {
+        let scores = vec![(AuthorityIndex::new_for_test(4), 10)];
+        let result = ReputationScores::from_scores_desc(4, (1..=10).into(), &scores);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::InvalidAuthorityIndex { index, max })
+                if index == AuthorityIndex::new_for_test(4) && max == 4
+        ));
+    }
 
     #[tokio::test]
     async fn test_reputation_scores_authorities_by_score() {

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -542,7 +542,7 @@ impl Store for MemStore {
         Ok(headers)
     }
 
-    fn read_fast_sync_ongoing(&self) -> bool {
-        self.inner.read().fast_sync_ongoing
+    fn read_fast_sync_ongoing(&self) -> ConsensusResult<bool> {
+        Ok(self.inner.read().fast_sync_ongoing)
     }
 }

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -193,8 +193,8 @@ pub(crate) trait Store: Send + Sync {
     ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>>;
 
     /// Returns true if fast commit sync was ongoing when the node last shut
-    /// down.
-    fn read_fast_sync_ongoing(&self) -> bool;
+    /// down. Errors if the flag cannot be read from storage.
+    fn read_fast_sync_ongoing(&self) -> ConsensusResult<bool>;
 }
 
 /// Represents data to be written to the store together atomically.

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -779,10 +779,10 @@ impl Store for RocksDBStore {
             .collect()
     }
 
-    fn read_fast_sync_ongoing(&self) -> bool {
+    fn read_fast_sync_ongoing(&self) -> ConsensusResult<bool> {
         self.fast_commit_sync_flag
             .contains_key(&())
-            .unwrap_or(false)
+            .map_err(ConsensusError::RocksDBFailure)
     }
 }
 

--- a/crates/starfish/core/src/threshold_clock.rs
+++ b/crates/starfish/core/src/threshold_clock.rs
@@ -74,7 +74,7 @@ impl ThresholdClock {
                     .add(block_header.author, &self.context.committee);
             }
         }
-        self.try_advance_round(block_header.round + 1);
+        self.try_advance_round(block_header.round.saturating_add(1));
     }
 
     /// Add the block references that have been successfully processed and
@@ -158,6 +158,21 @@ mod tests {
             BlockHeaderDigest::default(),
         ));
         assert_eq!(aggregator.get_round(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_threshold_clock_max_round_does_not_overflow() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut aggregator = ThresholdClock::new(0, context);
+
+        for authority in 0..3 {
+            aggregator.add_block_header(BlockRef::new(
+                Round::MAX,
+                AuthorityIndex::new_for_test(authority),
+                BlockHeaderDigest::default(),
+            ));
+        }
+        assert_eq!(aggregator.get_round(), Round::MAX);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description of change

Hardens intra-node assumptions in the starfish consensus crates with local guard rails. No peer-protocol or wire-format changes. The change:

- Rejects zero-stake authorities in `Committee::new`.
- Detects total-stake overflow instead of wrapping the sum.
- Computes quorum thresholds safely for large stake values (widened to `u128` for the doubling).
- Rejects invalid zero-valued consensus parameters at startup (`Parameters::validate`).
- Prevents round overflow at `Round::MAX` (saturating arithmetic in the threshold clock and the peer-driven block-bundle subscription).
- Rejects out-of-range authority indices in fetched reputation scores instead of panicking.
- Stops treating storage-read failures as a valid `false` (`read_fast_sync_ongoing`).
- Propagates recovery storage and output-channel errors consistently through the commit-observer recovery chain.
- Reports missing persisted block headers as structured errors.
- Improves validation coverage with focused unit tests.

## Links to any relevant issues

Fixes #11891

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
