### PR TITLE
feat(iota-tool): add backfill-checkpoint-summaries tool

### DIFF
--- a/crates/iota-archival/src/reader.rs
+++ b/crates/iota-archival/src/reader.rs
@@ -287,12 +287,11 @@ impl ArchiveReader {
     /// A summary already present in `store` is left untouched; a new one is
     /// inserted only after [`verify_checkpoint`] checks it against the
     /// previous summary (its committee signature and `previous_digest`
-    /// linkage) when `verify` is set. Unlike a bulk unverified load, this
-    /// never overwrites an existing summary and never persists an unverified
-    /// one — so it is safe to run against a live node's store. Summaries are
-    /// processed in order (via [`get_or_insert_verified_checkpoint`]'s
-    /// dependency on the previous checkpoint), so the genesis checkpoint must
-    /// already be present.
+    /// linkage). Unlike a bulk unverified load, this never overwrites an
+    /// existing summary and never persists an unverified one — so it is safe
+    /// to run against a live node's store. Summaries are processed in order
+    /// (via [`get_or_insert_verified_checkpoint`]'s dependency on the previous
+    /// checkpoint), so the genesis checkpoint must already be present.
     ///
     /// [`get_or_insert_verified_checkpoint`]: Self::get_or_insert_verified_checkpoint
     pub async fn read_summaries_for_range<S>(
@@ -300,7 +299,6 @@ impl ArchiveReader {
         store: S,
         checkpoint_range: Range<CheckpointSequenceNumber>,
         checkpoint_counter: Arc<AtomicU64>,
-        verify: bool,
     ) -> Result<()>
     where
         S: WriteStore + Clone,
@@ -338,7 +336,7 @@ impl ArchiveReader {
                                     && s.sequence_number < checkpoint_range.end
                             })
                             .try_for_each(|summary| {
-                                Self::get_or_insert_verified_checkpoint(&store, summary, verify)?;
+                                Self::get_or_insert_verified_checkpoint(&store, summary, true)?;
                                 checkpoint_counter.fetch_add(1, Ordering::Relaxed);
                                 Ok::<(), anyhow::Error>(())
                             })

--- a/crates/iota-archival/src/reader.rs
+++ b/crates/iota-archival/src/reader.rs
@@ -281,11 +281,26 @@ impl ArchiveReader {
     /// Load checkpoints from archive into the input store `S` for the given
     /// checkpoint range. Summaries are downloaded out of order and inserted
     /// without verification
-    pub async fn read_summaries_for_range_no_verify<S>(
+    /// Load checkpoint summaries for `checkpoint_range` from the archive into
+    /// `store`, in sequence order.
+    ///
+    /// A summary already present in `store` is left untouched; a new one is
+    /// inserted only after [`verify_checkpoint`] checks it against the
+    /// previous summary (its committee signature and `previous_digest`
+    /// linkage) when `verify` is set. Unlike a bulk unverified load, this
+    /// never overwrites an existing summary and never persists an unverified
+    /// one — so it is safe to run against a live node's store. Summaries are
+    /// processed in order (via [`get_or_insert_verified_checkpoint`]'s
+    /// dependency on the previous checkpoint), so the genesis checkpoint must
+    /// already be present.
+    ///
+    /// [`get_or_insert_verified_checkpoint`]: Self::get_or_insert_verified_checkpoint
+    pub async fn read_summaries_for_range<S>(
         &self,
         store: S,
         checkpoint_range: Range<CheckpointSequenceNumber>,
         checkpoint_counter: Arc<AtomicU64>,
+        verify: bool,
     ) -> Result<()>
     where
         S: WriteStore + Clone,
@@ -307,7 +322,9 @@ impl ArchiveReader {
             })
             .boxed();
         stream
-            .buffer_unordered(self.concurrency)
+            // Ordered: `get_or_insert_verified_checkpoint` verifies each
+            // summary against the previous one, which must already be inserted.
+            .buffered(self.concurrency)
             .try_for_each(|summary_data| {
                 let result: Result<(), anyhow::Error> =
                     make_iterator::<CertifiedCheckpointSummary, Reader<Bytes>>(
@@ -321,7 +338,7 @@ impl ArchiveReader {
                                     && s.sequence_number < checkpoint_range.end
                             })
                             .try_for_each(|summary| {
-                                Self::insert_certified_checkpoint(&store, summary)?;
+                                Self::get_or_insert_verified_checkpoint(&store, summary, verify)?;
                                 checkpoint_counter.fetch_add(1, Ordering::Relaxed);
                                 Ok::<(), anyhow::Error>(())
                             })

--- a/crates/iota-archival/src/reader.rs
+++ b/crates/iota-archival/src/reader.rs
@@ -278,9 +278,6 @@ impl ArchiveReader {
             .await
     }
 
-    /// Load checkpoints from archive into the input store `S` for the given
-    /// checkpoint range. Summaries are downloaded out of order and inserted
-    /// without verification
     /// Load checkpoint summaries for `checkpoint_range` from the archive into
     /// `store`, in sequence order.
     ///
@@ -289,11 +286,9 @@ impl ArchiveReader {
     /// previous summary (its committee signature and `previous_digest`
     /// linkage). Unlike a bulk unverified load, this never overwrites an
     /// existing summary and never persists an unverified one — so it is safe
-    /// to run against a live node's store. Summaries are processed in order
-    /// (via [`get_or_insert_verified_checkpoint`]'s dependency on the previous
-    /// checkpoint), so the genesis checkpoint must already be present.
-    ///
-    /// [`get_or_insert_verified_checkpoint`]: Self::get_or_insert_verified_checkpoint
+    /// to run against a live node's store. Summaries are processed in
+    /// sequence order (each is verified against the previous one), so the
+    /// genesis checkpoint must already be present.
     pub async fn read_summaries_for_range<S>(
         &self,
         store: S,

--- a/crates/iota-core/src/epoch/committee_store.rs
+++ b/crates/iota-core/src/epoch/committee_store.rs
@@ -37,17 +37,23 @@ fn committee_table_default_config() -> DBOptions {
 }
 
 impl CommitteeStore {
-    pub fn new(path: PathBuf, genesis_committee: &Committee, db_options: Option<Options>) -> Self {
+    /// Open the on-disk tables at `path` into an empty-cache store, without
+    /// touching the genesis committee.
+    fn open_tables(path: PathBuf, db_options: Option<Options>) -> Self {
         let tables = CommitteeStoreTables::open_tables_read_write(
             path,
             MetricConf::new("committee"),
             db_options,
             None,
         );
-        let store = Self {
+        Self {
             tables,
             cache: RwLock::new(HashMap::new()),
-        };
+        }
+    }
+
+    pub fn new(path: PathBuf, genesis_committee: &Committee, db_options: Option<Options>) -> Self {
+        let store = Self::open_tables(path, db_options);
         if store
             .database_is_empty()
             .expect("CommitteeStore initialization failed")
@@ -62,6 +68,20 @@ impl CommitteeStore {
     pub fn new_for_testing(genesis_committee: &Committee) -> Self {
         let path = iota_common::tempdir().keep();
         Self::new(path, genesis_committee, None)
+    }
+
+    /// Open an existing committee store whose genesis committee is already
+    /// persisted (e.g. a restored or synced node's store). Unlike [`Self::new`]
+    /// it takes no genesis committee — it errors if the store has none, rather
+    /// than initializing one.
+    pub fn open(path: PathBuf, db_options: Option<Options>) -> IotaResult<Self> {
+        let store = Self::open_tables(path, db_options);
+        if store.database_is_empty()? {
+            return Err(IotaError::Storage(
+                "committee store has no genesis committee".to_string(),
+            ));
+        }
+        Ok(store)
     }
 
     pub fn init_genesis_committee(&self, genesis_committee: Committee) -> IotaResult {
@@ -140,5 +160,33 @@ impl CommitteeStore {
             .next()
             .transpose()?
             .is_none())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_types::committee::Committee;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn open_reads_existing_genesis_and_rejects_empty() {
+        let dir = iota_common::tempdir();
+        let path = dir.path().to_path_buf();
+        let (genesis_committee, _) = Committee::new_simple_test_committee();
+
+        // A fresh directory has no genesis committee yet.
+        assert!(CommitteeStore::open(path.clone(), None).is_err());
+
+        // `new` initializes the genesis committee; `open` then reads it back
+        // without being handed one.
+        {
+            let _store = CommitteeStore::new(path.clone(), &genesis_committee, None);
+        }
+        let opened = CommitteeStore::open(path, None).expect("store has a genesis committee");
+        assert_eq!(
+            *opened.get_committee(&0).unwrap().unwrap(),
+            genesis_committee,
+        );
     }
 }

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -373,25 +373,19 @@ pub enum ToolCommand {
     /// from genesis (to serve historical checkpoint queries, or to be a full
     /// summary source for syncing peers). Only historical summaries are added;
     /// no watermark is moved.
+    ///
+    /// The network — and thus the archive bucket to read from — is derived
+    /// from the node's own genesis checkpoint (override the bucket via the
+    /// `CUSTOM_ARCHIVE_BUCKET` env vars).
     BackfillCheckpointSummaries {
         /// Path to the node's live database directory (the one containing
         /// `checkpoints/`, `store/`, and `epochs/`). The node must be stopped.
         #[arg(long)]
         path: PathBuf,
-        /// Path to the network's `genesis.blob`.
-        #[arg(long)]
-        genesis: PathBuf,
         /// Number of parallel downloads to perform. Defaults to a reasonable
         /// value based on number of available logical cores.
         #[arg(long)]
         num_parallel_downloads: Option<usize>,
-        /// Network whose default archive bucket to read from. Defaults to
-        /// "mainnet". Overridable via the `CUSTOM_ARCHIVE_BUCKET` env vars.
-        #[arg(long, default_value = "mainnet")]
-        network: Chain,
-        /// Skip the pairwise chain verification of the downloaded summaries.
-        #[arg(long)]
-        skip_verify: bool,
         /// If false (default), log level will be overridden to "off", and
         /// output will be reduced to necessary status information.
         #[arg(long)]
@@ -451,90 +445,6 @@ pub enum ToolCommand {
         #[arg(long, default_value = "http://localhost:50051")]
         address: String,
     },
-}
-
-/// Build the checkpoint-archive `ObjectStoreConfig` for `network`: the
-/// permissionless public archive by default, or a custom bucket when the
-/// `CUSTOM_ARCHIVE_BUCKET` env vars are set.
-fn default_archive_store_config(network: Chain) -> ObjectStoreConfig {
-    let archive_bucket = Some(
-        env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET").unwrap_or_else(|_| match network {
-            Chain::Mainnet => "iota-mainnet-archive".to_string(),
-            Chain::Testnet => "iota-testnet-archive".to_string(),
-            Chain::Unknown => {
-                panic!("Cannot generate default archive bucket for unknown network");
-            }
-        }),
-    );
-
-    let custom_archive_enabled = env::var("CUSTOM_ARCHIVE_BUCKET").is_ok_and(|v| v == "true");
-    if custom_archive_enabled {
-        let aws_region =
-            Some(env::var("FORMAL_SNAPSHOT_ARCHIVE_REGION").unwrap_or("us-west-2".to_string()));
-        let archive_bucket_type = env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE").expect(
-            "If setting `CUSTOM_ARCHIVE_BUCKET=true` Must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE, and credentials",
-        );
-        match archive_bucket_type.to_ascii_lowercase().as_str() {
-            "s3" => ObjectStoreConfig {
-                object_store: Some(ObjectStoreType::S3),
-                bucket: archive_bucket.filter(|s| !s.is_empty()),
-                aws_access_key_id: env::var("AWS_ARCHIVE_ACCESS_KEY_ID").ok(),
-                aws_secret_access_key: env::var("AWS_ARCHIVE_SECRET_ACCESS_KEY").ok(),
-                aws_region,
-                aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
-                aws_virtual_hosted_style_request: env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
-                    .ok()
-                    .and_then(|b| b.parse().ok())
-                    .unwrap_or(false),
-                object_store_connection_limit: 50,
-                no_sign_request: false,
-                ..Default::default()
-            },
-            "gcs" => ObjectStoreConfig {
-                object_store: Some(ObjectStoreType::GCS),
-                bucket: archive_bucket,
-                google_service_account: env::var("GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH").ok(),
-                object_store_connection_limit: 50,
-                no_sign_request: false,
-                ..Default::default()
-            },
-            "azure" => ObjectStoreConfig {
-                object_store: Some(ObjectStoreType::Azure),
-                bucket: archive_bucket,
-                azure_storage_account: env::var("AZURE_ARCHIVE_STORAGE_ACCOUNT").ok(),
-                azure_storage_access_key: env::var("AZURE_ARCHIVE_STORAGE_ACCESS_KEY").ok(),
-                object_store_connection_limit: 50,
-                no_sign_request: false,
-                ..Default::default()
-            },
-            _ => panic!(
-                "If setting `CUSTOM_ARCHIVE_BUCKET=true` must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE to one of 'gcs', 'azure', or 's3' "
-            ),
-        }
-    } else {
-        // Default to the permissionless archive store.
-        let aws_endpoint = env::var("AWS_ARCHIVE_ENDPOINT")
-            .ok()
-            .or_else(|| match network {
-                Chain::Mainnet => Some("https://archive.mainnet.iota.cafe".to_string()),
-                Chain::Testnet => Some("https://archive.testnet.iota.cafe".to_string()),
-                Chain::Unknown => None,
-            });
-        let aws_virtual_hosted_style_request = env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
-            .ok()
-            .and_then(|b| b.parse().ok())
-            .unwrap_or(matches!(network, Chain::Mainnet | Chain::Testnet));
-        ObjectStoreConfig {
-            object_store: Some(ObjectStoreType::S3),
-            bucket: archive_bucket.filter(|s| !s.is_empty()),
-            aws_region: Some("us-west-2".to_string()),
-            aws_endpoint,
-            aws_virtual_hosted_style_request,
-            object_store_connection_limit: 200,
-            no_sign_request: true,
-            ..Default::default()
-        }
-    }
 }
 
 async fn check_locked_object(
@@ -913,10 +823,7 @@ impl ToolCommand {
             }
             ToolCommand::BackfillCheckpointSummaries {
                 path,
-                genesis,
                 num_parallel_downloads,
-                network,
-                skip_verify,
                 verbose,
             } => {
                 if !verbose {
@@ -929,14 +836,7 @@ impl ToolCommand {
                         .checked_sub(1)
                         .expect("Failed to get number of CPUs")
                 });
-                backfill_checkpoint_summaries(
-                    &path,
-                    &genesis,
-                    default_archive_store_config(network),
-                    num_parallel_downloads,
-                    !skip_verify,
-                )
-                .await?;
+                backfill_checkpoint_summaries(&path, num_parallel_downloads).await?;
             }
             ToolCommand::DownloadDBSnapshot {
                 epoch,

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -33,7 +33,7 @@ use telemetry_subscribers::TracingHandle;
 
 use crate::{
     ConciseObjectOutput, GroupedObjectOutput, SnapshotVerifyMode, VerboseObjectOutput,
-    check_completed_snapshot,
+    backfill_checkpoint_summaries, check_completed_snapshot,
     db_tool::{DbToolCommand, execute_db_tool_command, print_db_all_tables},
     download_db_snapshot, download_formal_snapshot, dump_checkpoints_from_archive,
     get_latest_available_epoch, get_object, get_transaction_block, make_clients,
@@ -299,10 +299,14 @@ pub enum ToolCommand {
         about = "Downloads formal database snapshot via cloud object store, outputs to local disk"
     )]
     DownloadFormalSnapshot {
+        /// Epoch to restore to the end of. Mutually exclusive with `--latest`.
         #[arg(long, conflicts_with = "latest")]
         epoch: Option<u64>,
+        /// Path to the network's `genesis.blob`.
         #[arg(long)]
         genesis: PathBuf,
+        /// Directory to restore into. The restored database is written to a
+        /// `live` subdirectory of this path.
         #[arg(long)]
         path: PathBuf,
         /// Number of parallel downloads to perform. Defaults to a reasonable
@@ -313,8 +317,8 @@ pub enum ToolCommand {
         #[arg(long, default_value = "normal")]
         verify: Option<SnapshotVerifyMode>,
         /// Network to download snapshot for. Defaults to "mainnet".
-        /// If `--snapshot-bucket` or `--archive-bucket` is not specified,
-        /// the value of this flag is used to construct default bucket names.
+        /// If `--snapshot-bucket` is not specified, the value of this flag is
+        /// used to construct the default bucket name.
         #[arg(long, default_value = "mainnet")]
         network: Chain,
         /// Snapshot bucket name. If not specified, defaults are
@@ -352,21 +356,46 @@ pub enum ToolCommand {
         #[arg(long)]
         verbose: bool,
 
-        /// If provided, all checkpoint summaries from genesis to the end of the
-        /// target epoch will be downloaded and (if --verify is
-        /// provided) full checkpoint chain verification
-        /// will be performed. If omitted, only end of epoch checkpoint
-        /// summaries will be downloaded, and (if --verify is provided)
-        /// will be verified via committee signature.
-        #[arg(long)]
-        all_checkpoints: bool,
-
         /// Skip building the gRPC index store during the restore. By default
         /// it is built from the same object stream that restores the state,
         /// so a fullnode started with gRPC enabled opens it in place instead
         /// of re-indexing the whole restored state on first start.
         #[arg(long)]
         skip_grpc_indexes: bool,
+    },
+
+    /// Backfill the full checkpoint summary history from the checkpoint
+    /// archive into a stopped node's checkpoint store.
+    ///
+    /// A node restored from a formal snapshot holds only the end-of-epoch
+    /// summaries. This downloads every intermediate summary up to the node's
+    /// highest synced checkpoint, so the node holds the complete header chain
+    /// from genesis (to serve historical checkpoint queries, or to be a full
+    /// summary source for syncing peers). Only historical summaries are added;
+    /// no watermark is moved.
+    BackfillCheckpointSummaries {
+        /// Path to the node's live database directory (the one containing
+        /// `checkpoints/`, `store/`, and `epochs/`). The node must be stopped.
+        #[arg(long)]
+        path: PathBuf,
+        /// Path to the network's `genesis.blob`.
+        #[arg(long)]
+        genesis: PathBuf,
+        /// Number of parallel downloads to perform. Defaults to a reasonable
+        /// value based on number of available logical cores.
+        #[arg(long)]
+        num_parallel_downloads: Option<usize>,
+        /// Network whose default archive bucket to read from. Defaults to
+        /// "mainnet". Overridable via the `CUSTOM_ARCHIVE_BUCKET` env vars.
+        #[arg(long, default_value = "mainnet")]
+        network: Chain,
+        /// Skip the pairwise chain verification of the downloaded summaries.
+        #[arg(long)]
+        skip_verify: bool,
+        /// If false (default), log level will be overridden to "off", and
+        /// output will be reduced to necessary status information.
+        #[arg(long)]
+        verbose: bool,
     },
 
     Replay {
@@ -422,6 +451,90 @@ pub enum ToolCommand {
         #[arg(long, default_value = "http://localhost:50051")]
         address: String,
     },
+}
+
+/// Build the checkpoint-archive `ObjectStoreConfig` for `network`: the
+/// permissionless public archive by default, or a custom bucket when the
+/// `CUSTOM_ARCHIVE_BUCKET` env vars are set.
+fn default_archive_store_config(network: Chain) -> ObjectStoreConfig {
+    let archive_bucket = Some(
+        env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET").unwrap_or_else(|_| match network {
+            Chain::Mainnet => "iota-mainnet-archive".to_string(),
+            Chain::Testnet => "iota-testnet-archive".to_string(),
+            Chain::Unknown => {
+                panic!("Cannot generate default archive bucket for unknown network");
+            }
+        }),
+    );
+
+    let custom_archive_enabled = env::var("CUSTOM_ARCHIVE_BUCKET").is_ok_and(|v| v == "true");
+    if custom_archive_enabled {
+        let aws_region =
+            Some(env::var("FORMAL_SNAPSHOT_ARCHIVE_REGION").unwrap_or("us-west-2".to_string()));
+        let archive_bucket_type = env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE").expect(
+            "If setting `CUSTOM_ARCHIVE_BUCKET=true` Must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE, and credentials",
+        );
+        match archive_bucket_type.to_ascii_lowercase().as_str() {
+            "s3" => ObjectStoreConfig {
+                object_store: Some(ObjectStoreType::S3),
+                bucket: archive_bucket.filter(|s| !s.is_empty()),
+                aws_access_key_id: env::var("AWS_ARCHIVE_ACCESS_KEY_ID").ok(),
+                aws_secret_access_key: env::var("AWS_ARCHIVE_SECRET_ACCESS_KEY").ok(),
+                aws_region,
+                aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
+                aws_virtual_hosted_style_request: env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
+                    .ok()
+                    .and_then(|b| b.parse().ok())
+                    .unwrap_or(false),
+                object_store_connection_limit: 50,
+                no_sign_request: false,
+                ..Default::default()
+            },
+            "gcs" => ObjectStoreConfig {
+                object_store: Some(ObjectStoreType::GCS),
+                bucket: archive_bucket,
+                google_service_account: env::var("GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH").ok(),
+                object_store_connection_limit: 50,
+                no_sign_request: false,
+                ..Default::default()
+            },
+            "azure" => ObjectStoreConfig {
+                object_store: Some(ObjectStoreType::Azure),
+                bucket: archive_bucket,
+                azure_storage_account: env::var("AZURE_ARCHIVE_STORAGE_ACCOUNT").ok(),
+                azure_storage_access_key: env::var("AZURE_ARCHIVE_STORAGE_ACCESS_KEY").ok(),
+                object_store_connection_limit: 50,
+                no_sign_request: false,
+                ..Default::default()
+            },
+            _ => panic!(
+                "If setting `CUSTOM_ARCHIVE_BUCKET=true` must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE to one of 'gcs', 'azure', or 's3' "
+            ),
+        }
+    } else {
+        // Default to the permissionless archive store.
+        let aws_endpoint = env::var("AWS_ARCHIVE_ENDPOINT")
+            .ok()
+            .or_else(|| match network {
+                Chain::Mainnet => Some("https://archive.mainnet.iota.cafe".to_string()),
+                Chain::Testnet => Some("https://archive.testnet.iota.cafe".to_string()),
+                Chain::Unknown => None,
+            });
+        let aws_virtual_hosted_style_request = env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
+            .ok()
+            .and_then(|b| b.parse().ok())
+            .unwrap_or(matches!(network, Chain::Mainnet | Chain::Testnet));
+        ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::S3),
+            bucket: archive_bucket.filter(|s| !s.is_empty()),
+            aws_region: Some("us-west-2".to_string()),
+            aws_endpoint,
+            aws_virtual_hosted_style_request,
+            object_store_connection_limit: 200,
+            no_sign_request: true,
+            ..Default::default()
+        }
+    }
 }
 
 async fn check_locked_object(
@@ -673,7 +786,6 @@ impl ToolCommand {
                 no_sign_request,
                 latest,
                 verbose,
-                all_checkpoints,
                 skip_grpc_indexes,
             } => {
                 if !verbose {
@@ -775,102 +887,6 @@ impl ToolCommand {
                     }
                 };
 
-                let archive_bucket = Some(
-                    env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET").unwrap_or_else(|_| match network {
-                        Chain::Mainnet => "iota-mainnet-archive".to_string(),
-                        Chain::Testnet => "iota-testnet-archive".to_string(),
-                        Chain::Unknown => {
-                            panic!("Cannot generate default archive bucket for unknown network");
-                        }
-                    }),
-                );
-
-                let mut custom_archive_enabled = false;
-                if let Ok(custom_archive_check) = env::var("CUSTOM_ARCHIVE_BUCKET") {
-                    if custom_archive_check == "true" {
-                        custom_archive_enabled = true;
-                    }
-                }
-                let archive_store_config = if custom_archive_enabled {
-                    let aws_region = Some(
-                        env::var("FORMAL_SNAPSHOT_ARCHIVE_REGION")
-                            .unwrap_or("us-west-2".to_string()),
-                    );
-
-                    let archive_bucket_type = env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE").expect("If setting `CUSTOM_ARCHIVE_BUCKET=true` Must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE, and credentials");
-                    match archive_bucket_type.to_ascii_lowercase().as_str() {
-                        "s3" => ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::S3),
-                            bucket: archive_bucket.filter(|s| !s.is_empty()),
-                            aws_access_key_id: env::var("AWS_ARCHIVE_ACCESS_KEY_ID").ok(),
-                            aws_secret_access_key: env::var("AWS_ARCHIVE_SECRET_ACCESS_KEY").ok(),
-                            aws_region,
-                            aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
-                            aws_virtual_hosted_style_request: env::var(
-                                "AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS",
-                            )
-                            .ok()
-                            .and_then(|b| b.parse().ok())
-                            .unwrap_or(false),
-                            object_store_connection_limit: 50,
-                            no_sign_request: false,
-                            ..Default::default()
-                        },
-                        "gcs" => ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::GCS),
-                            bucket: archive_bucket,
-                            google_service_account: env::var(
-                                "GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH",
-                            )
-                            .ok(),
-                            object_store_connection_limit: 50,
-                            no_sign_request: false,
-                            ..Default::default()
-                        },
-                        "azure" => ObjectStoreConfig {
-                            object_store: Some(ObjectStoreType::Azure),
-                            bucket: archive_bucket,
-                            azure_storage_account: env::var("AZURE_ARCHIVE_STORAGE_ACCOUNT").ok(),
-                            azure_storage_access_key: env::var("AZURE_ARCHIVE_STORAGE_ACCESS_KEY")
-                                .ok(),
-                            object_store_connection_limit: 50,
-                            no_sign_request: false,
-                            ..Default::default()
-                        },
-                        _ => panic!(
-                            "If setting `CUSTOM_ARCHIVE_BUCKET=true` must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE to one of 'gcs', 'azure', or 's3' "
-                        ),
-                    }
-                } else {
-                    // if not explicitly overridden, just default to the permissionless archive
-                    // store
-                    let aws_endpoint = env::var("AWS_ARCHIVE_ENDPOINT").ok().or_else(|| {
-                        if network == Chain::Mainnet {
-                            Some("https://archive.mainnet.iota.cafe".to_string())
-                        } else if network == Chain::Testnet {
-                            Some("https://archive.testnet.iota.cafe".to_string())
-                        } else {
-                            None
-                        }
-                    });
-
-                    let aws_virtual_hosted_style_request =
-                        env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
-                            .ok()
-                            .and_then(|b| b.parse().ok())
-                            .unwrap_or(matches!(network, Chain::Mainnet | Chain::Testnet));
-
-                    ObjectStoreConfig {
-                        object_store: Some(ObjectStoreType::S3),
-                        bucket: archive_bucket.filter(|s| !s.is_empty()),
-                        aws_region: Some("us-west-2".to_string()),
-                        aws_endpoint,
-                        aws_virtual_hosted_style_request,
-                        object_store_connection_limit: 200,
-                        no_sign_request: true,
-                        ..Default::default()
-                    }
-                };
                 let latest_available_epoch =
                     latest.then_some(get_latest_available_epoch(&snapshot_store_config).await?);
                 let epoch_to_download = epoch.or(latest_available_epoch).expect(
@@ -889,14 +905,36 @@ impl ToolCommand {
                     epoch_to_download,
                     &genesis,
                     snapshot_store_config,
-                    // The archive is only read in `--all-checkpoints` mode;
-                    // the default mode is archive-free.
-                    all_checkpoints.then_some(archive_store_config),
                     num_parallel_downloads,
-                    network,
                     verify,
-                    all_checkpoints,
                     skip_grpc_indexes,
+                )
+                .await?;
+            }
+            ToolCommand::BackfillCheckpointSummaries {
+                path,
+                genesis,
+                num_parallel_downloads,
+                network,
+                skip_verify,
+                verbose,
+            } => {
+                if !verbose {
+                    tracing_handle
+                        .update_log("off")
+                        .expect("Failed to update log level");
+                }
+                let num_parallel_downloads = num_parallel_downloads.unwrap_or_else(|| {
+                    num_cpus::get()
+                        .checked_sub(1)
+                        .expect("Failed to get number of CPUs")
+                });
+                backfill_checkpoint_summaries(
+                    &path,
+                    &genesis,
+                    default_archive_store_config(network),
+                    num_parallel_downloads,
+                    !skip_verify,
                 )
                 .await?;
             }

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -19,7 +19,6 @@ use std::{
 
 use anyhow::{Result, anyhow, bail};
 use clap::ValueEnum;
-use eyre::ContextCompat;
 use fastcrypto::{hash::MultisetHash, traits::ToFromBytes};
 use futures::{
     StreamExt, TryStreamExt,
@@ -46,7 +45,6 @@ use iota_core::{
     storage::RocksDbStore,
 };
 use iota_network::default_iota_network_config;
-use iota_protocol_config::Chain;
 use iota_sdk::{IotaClient, IotaClientBuilder};
 use iota_sdk_types::{ObjectId, Owner};
 use iota_snapshot::{
@@ -79,7 +77,7 @@ use iota_types::{
 use itertools::Itertools;
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
-use tokio::{sync::mpsc, task::JoinHandle, time::Instant};
+use tokio::{sync::mpsc, time::Instant};
 use tracing::info;
 
 pub mod commands;
@@ -619,146 +617,143 @@ fn set_restore_watermarks(
     Ok(())
 }
 
-/// Sync **every** checkpoint summary in `[genesis, end of `epoch`]` from the
-/// checkpoint archive — the `--all-checkpoints` restore mode. The default
-/// mode needs no archive: it seeds only the end-of-epoch summaries, from the
-/// snapshot's chain-verified EPOCH_INFO (`sync_summaries_from_epoch_info`).
-fn start_summary_sync_from_archive(
-    perpetual_db: Arc<AuthorityPerpetualTables>,
-    committee_store: Arc<CommitteeStore>,
-    checkpoint_store: Arc<CheckpointStore>,
-    m: MultiProgress,
-    genesis: Genesis,
+/// Backfill **every** checkpoint summary up to the node's highest synced
+/// checkpoint from the checkpoint archive, into an existing (stopped) node's
+/// checkpoint store at `node_db_path`.
+///
+/// A node restored from a formal snapshot holds only the end-of-epoch
+/// summaries; this fills in every intermediate one so the node holds the
+/// complete header chain from genesis (e.g. to serve historical checkpoint
+/// queries, or to be a full summary source for syncing peers). It only adds
+/// historical summaries below the node's existing watermarks — it never moves
+/// a watermark, so the node's synced/executed/pruned state is untouched.
+pub async fn backfill_checkpoint_summaries(
+    node_db_path: &Path,
+    genesis: &Path,
     archive_store_config: ObjectStoreConfig,
-    epoch: u64,
     num_parallel_downloads: usize,
     verify: bool,
-) -> JoinHandle<Result<(), anyhow::Error>> {
-    tokio::spawn(async move {
-        info!("Starting summary sync");
-        let store = AuthorityStore::open_no_genesis(perpetual_db, false, &Registry::default())?;
-        let cache_traits = build_execution_cache_from_env(&Registry::default(), &store);
-        let state_sync_store =
-            RocksDbStore::new(cache_traits, committee_store, checkpoint_store.clone());
-        insert_genesis_checkpoint(&checkpoint_store, &genesis)?;
-        // set up download of checkpoint summaries
-        let config = ArchiveReaderConfig {
-            remote_store_config: archive_store_config,
-            download_concurrency: NonZeroUsize::new(num_parallel_downloads).unwrap(),
-            use_for_pruning_watermark: false,
-        };
-        let metrics = ArchiveReaderMetrics::new(&Registry::default());
-        let archive_reader = ArchiveReader::new(config, &metrics)?;
-        archive_reader.sync_manifest_once().await?;
-        let manifest = archive_reader.get_manifest().await?;
+) -> Result<(), anyhow::Error> {
+    let m = MultiProgress::new();
+    let genesis =
+        Genesis::load(genesis).map_err(|e| anyhow!("Failed to load genesis blob: {e}"))?;
+    let genesis_committee = genesis.committee()?;
 
-        let last_checkpoint = manifest.next_checkpoint_after_epoch(epoch) - 1;
+    // Open the stopped node's existing stores in place.
+    let perpetual_db = Arc::new(AuthorityPerpetualTables::open(
+        &node_db_path.join("store"),
+        None,
+    ));
+    let committee_store = Arc::new(CommitteeStore::new(
+        node_db_path.join("epochs"),
+        &genesis_committee,
+        None,
+    ));
+    let checkpoint_store = CheckpointStore::new(&node_db_path.join("checkpoints"));
+    let store = AuthorityStore::open_no_genesis(perpetual_db, false, &Registry::default())?;
+    let cache_traits = build_execution_cache_from_env(&Registry::default(), &store);
+    let state_sync_store =
+        RocksDbStore::new(cache_traits, committee_store, checkpoint_store.clone());
 
-        let num_to_sync = last_checkpoint;
-        let sync_progress_bar = m.add(
-            ProgressBar::new(num_to_sync).with_style(
+    insert_genesis_checkpoint(&checkpoint_store, &genesis)?;
+    let highest_synced = checkpoint_store
+        .get_highest_synced_checkpoint()?
+        .map(|c| c.sequence_number)
+        .ok_or_else(|| {
+            anyhow!("checkpoint store at {node_db_path:?} is empty; restore the node first")
+        })?;
+
+    let config = ArchiveReaderConfig {
+        remote_store_config: archive_store_config,
+        download_concurrency: NonZeroUsize::new(num_parallel_downloads).unwrap(),
+        use_for_pruning_watermark: false,
+    };
+    let metrics = ArchiveReaderMetrics::new(&Registry::default());
+    let archive_reader = ArchiveReader::new(config, &metrics)?;
+    archive_reader.sync_manifest_once().await?;
+
+    // Fill the contiguous range `[1, target]`; genesis (0) is the chain root
+    // and must already be present. Cap `target` at the archive's latest:
+    // summaries above the restore point the node already holds in full from
+    // p2p, and the archive may not reach as far as the node has synced.
+    let archive_latest = archive_reader
+        .get_manifest()
+        .await?
+        .next_checkpoint_seq_num()
+        .saturating_sub(1);
+    let target = highest_synced.min(archive_latest);
+    if target == 0 {
+        m.println("Nothing to backfill: no archived summaries below the node's state.")?;
+        return Ok(());
+    }
+
+    // Download summaries for `[1, target]`. Inserts are idempotent, so the
+    // end-of-epoch summaries already present are harmlessly overwritten.
+    let download_bar = m.add(ProgressBar::new(target).with_style(
+        ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})").unwrap(),
+    ));
+    let download_counter = Arc::new(AtomicU64::new(0));
+    spawn_rate_ticker(
+        download_bar.clone(),
+        download_counter.clone(),
+        "checkpoints synced per sec",
+    );
+    archive_reader
+        .read_summaries_for_range_no_verify(
+            state_sync_store.clone(),
+            1..target + 1,
+            download_counter,
+        )
+        .await?;
+    download_bar.finish_with_message("Checkpoint summary download is complete");
+
+    if verify {
+        // Verify the chain pairwise from genesis: every summary's
+        // `previous_digest` linkage and committee signature, rooted at the
+        // genesis checkpoint already in the store. Its terminal
+        // `try_update_highest_verified_checkpoint` targets `target`, at or
+        // below where the node already is, so no watermark moves.
+        let verify_bar = m.add(
+            ProgressBar::new(target).with_style(
                 ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})")
                     .unwrap(),
             ),
         );
+        let verify_counter = Arc::new(AtomicU64::new(0));
+        spawn_rate_ticker(
+            verify_bar.clone(),
+            verify_counter.clone(),
+            "checkpoints verified per sec",
+        );
+        verify_checkpoint_range(
+            0..target + 1,
+            state_sync_store,
+            verify_counter,
+            num_parallel_downloads,
+        )
+        .await;
+        verify_bar.finish_with_message("Checkpoint summary verification is complete");
+    }
 
-        let cloned_progress_bar = sync_progress_bar.clone();
-        let sync_checkpoint_counter = Arc::new(AtomicU64::new(0));
-        let s_instant = Instant::now();
+    println!("Backfilled checkpoint summaries up to checkpoint {target}");
+    Ok(())
+}
 
-        let cloned_counter = sync_checkpoint_counter.clone();
-        let latest_synced = checkpoint_store
-            .get_highest_synced_checkpoint()?
-            .map(|c| c.sequence_number)
-            .unwrap_or(0);
-        let s_start = latest_synced
-            .checked_add(1)
-            .context("Checkpoint overflow")
-            .map_err(|_| anyhow!("Failed to increment checkpoint"))?;
-        tokio::spawn(async move {
-            loop {
-                if cloned_progress_bar.is_finished() {
-                    break;
-                }
-                let num_summaries = cloned_counter.load(Ordering::Relaxed);
-                let total_checkpoints_per_sec =
-                    num_summaries as f64 / s_instant.elapsed().as_secs_f64();
-                cloned_progress_bar.set_position(s_start + num_summaries);
-                cloned_progress_bar.set_message(format!(
-                    "checkpoints synced per sec: {total_checkpoints_per_sec}"
-                ));
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-        });
-
-        archive_reader
-            .read_summaries_for_range_no_verify(
-                state_sync_store.clone(),
-                s_start..last_checkpoint + 1,
-                sync_checkpoint_counter,
-            )
-            .await?;
-        sync_progress_bar.finish_with_message("Checkpoint summary sync is complete");
-
-        let checkpoint = checkpoint_store
-            .get_checkpoint_by_sequence_number(last_checkpoint)?
-            .ok_or(anyhow!("Failed to read last checkpoint"))?;
-        if verify {
-            let verify_progress_bar = m.add(
-                ProgressBar::new(num_to_sync).with_style(
-                    ProgressStyle::with_template(
-                        "[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})",
-                    )
-                    .unwrap(),
-                ),
-            );
-            let cloned_verify_progress_bar = verify_progress_bar.clone();
-            let verify_checkpoint_counter = Arc::new(AtomicU64::new(0));
-            let cloned_verify_counter = verify_checkpoint_counter.clone();
-            let v_instant = Instant::now();
-
-            tokio::spawn(async move {
-                loop {
-                    if cloned_verify_progress_bar.is_finished() {
-                        break;
-                    }
-                    let num_summaries = cloned_verify_counter.load(Ordering::Relaxed);
-                    let total_checkpoints_per_sec =
-                        num_summaries as f64 / v_instant.elapsed().as_secs_f64();
-                    cloned_verify_progress_bar.set_position(s_start + num_summaries);
-                    cloned_verify_progress_bar.set_message(format!(
-                        "checkpoints verified per sec: {total_checkpoints_per_sec}"
-                    ));
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                }
-            });
-
-            // Verify all the checkpoints in the range pairwise.
-            // Update highest verified to be highest synced. We will move back
-            // iff parallel verification succeeds.
-            let latest_verified = checkpoint_store
-                .get_checkpoint_by_sequence_number(latest_synced)
-                .expect("Failed to get checkpoint")
-                .expect("Expected checkpoint to exist after summary sync");
-            checkpoint_store
-                .update_highest_verified_checkpoint(&latest_verified)
-                .expect("Failed to update highest verified checkpoint");
-
-            let verify_range = s_start..last_checkpoint + 1;
-            verify_checkpoint_range(
-                verify_range,
-                state_sync_store,
-                verify_checkpoint_counter,
-                num_parallel_downloads,
-            )
-            .await;
-
-            verify_progress_bar.finish_with_message("Checkpoint summary verification is complete");
+/// Spawn a background task that, once per second until `bar` finishes, mirrors
+/// `counter` into the bar's position and reports `{unit}: {rate}`.
+fn spawn_rate_ticker(bar: ProgressBar, counter: Arc<AtomicU64>, unit: &'static str) {
+    let start = Instant::now();
+    tokio::spawn(async move {
+        while !bar.is_finished() {
+            let count = counter.load(Ordering::Relaxed);
+            bar.set_position(count);
+            bar.set_message(format!(
+                "{unit}: {}",
+                count as f64 / start.elapsed().as_secs_f64()
+            ));
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
-
-        set_restore_watermarks(&checkpoint_store, &checkpoint)?;
-        Ok::<(), anyhow::Error>(())
-    })
+    });
 }
 
 /// Seed the checkpoint store from the snapshot's chain-verified EPOCH_INFO —
@@ -839,16 +834,13 @@ pub async fn download_formal_snapshot(
     epoch: EpochId,
     genesis: &Path,
     snapshot_store_config: ObjectStoreConfig,
-    archive_store_config: Option<ObjectStoreConfig>,
     num_parallel_downloads: usize,
-    network: Chain,
     verify: SnapshotVerifyMode,
-    all_checkpoints: bool,
     skip_grpc_indexes: bool,
 ) -> Result<(), anyhow::Error> {
     let m = MultiProgress::new();
     m.println(format!(
-        "Beginning formal snapshot restore to end of epoch {epoch}, network: {network:?}, verification mode: {verify:?}",
+        "Beginning formal snapshot restore to end of epoch {epoch}, verification mode: {verify:?}",
     ))?;
     let path = path.join("staging").to_path_buf();
     if path.exists() {
@@ -881,33 +873,18 @@ pub async fn download_formal_snapshot(
     ));
     let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
 
-    // Default mode seeds only the end-of-epoch summaries, straight from the
-    // verified EPOCH_INFO; `--all-checkpoints` syncs the full summary history,
-    // which only the checkpoint archive can provide.
-    let summaries_handle = if all_checkpoints {
-        let archive_store_config = archive_store_config
-            .ok_or_else(|| anyhow!("--all-checkpoints requires an archive bucket to read from"))?;
-        Some(start_summary_sync_from_archive(
-            perpetual_db.clone(),
-            committee_store.clone(),
-            checkpoint_store.clone(),
-            m.clone(),
-            genesis.clone(),
-            archive_store_config,
-            epoch,
-            num_parallel_downloads,
-            verify != SnapshotVerifyMode::None,
-        ))
-    } else {
-        sync_summaries_from_epoch_info(
-            &checkpoint_store,
-            &committee_store,
-            &genesis,
-            &verified_epoch_info,
-            epoch,
-        )?;
-        None
-    };
+    // Seed the end-of-epoch summaries and committees straight from the
+    // chain-verified EPOCH_INFO — the restore needs no checkpoint archive. A
+    // node that additionally wants the full intermediate summary history can
+    // run `iota-tool backfill-checkpoint-summaries` afterwards.
+    sync_summaries_from_epoch_info(
+        &checkpoint_store,
+        &committee_store,
+        &genesis,
+        &verified_epoch_info,
+        epoch,
+    )?;
+
     // Unless `--skip-grpc-indexes` is passed, the gRPC index store is built
     // from the same object stream that restores the perpetual tables, so a
     // fullnode started with gRPC enabled opens it in place instead of
@@ -977,12 +954,6 @@ pub async fn download_formal_snapshot(
     while let Some((partial_hash, num_objects)) = receiver.recv().await {
         num_live_objects += num_objects;
         root_global_state_hash.union(&partial_hash);
-    }
-    if let Some(summaries_handle) = summaries_handle {
-        summaries_handle
-            .await
-            .expect("Task join failed")
-            .expect("Summaries task failed");
     }
 
     let last_checkpoint = checkpoint_store

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::BTreeMap,
+    env,
     fmt::Write,
     fs, io,
     num::NonZeroUsize,
@@ -45,6 +46,7 @@ use iota_core::{
     storage::RocksDbStore,
 };
 use iota_network::default_iota_network_config;
+use iota_protocol_config::Chain;
 use iota_sdk::{IotaClient, IotaClientBuilder};
 use iota_sdk_types::{ObjectId, Owner};
 use iota_snapshot::{
@@ -626,53 +628,40 @@ fn set_restore_watermarks(
 /// a watermark, so the node's synced/executed/pruned state is untouched.
 pub async fn backfill_checkpoint_summaries(
     node_db_path: &Path,
-    genesis: &Path,
-    archive_store_config: ObjectStoreConfig,
     num_parallel_downloads: usize,
-    verify: bool,
 ) -> Result<(), anyhow::Error> {
     let m = MultiProgress::new();
-    let genesis =
-        Genesis::load(genesis).map_err(|e| anyhow!("Failed to load genesis blob: {e}"))?;
-    let genesis_committee = genesis.committee()?;
 
-    // Open the stopped node's existing stores in place.
+    // Open the stopped node's existing stores in place. The committee store
+    // already holds the genesis committee (from restore/sync), so it is opened
+    // without re-supplying one.
     let perpetual_db = Arc::new(AuthorityPerpetualTables::open(
         &node_db_path.join("store"),
         None,
     ));
-    let committee_store = Arc::new(CommitteeStore::new(
-        node_db_path.join("epochs"),
-        &genesis_committee,
-        None,
-    ));
+    let committee_store = Arc::new(CommitteeStore::open(node_db_path.join("epochs"), None)?);
     let checkpoint_store = CheckpointStore::new(&node_db_path.join("checkpoints"));
     let store = AuthorityStore::open_no_genesis(perpetual_db, false, &Registry::default())?;
     let cache_traits = build_execution_cache_from_env(&Registry::default(), &store);
     let state_sync_store =
         RocksDbStore::new(cache_traits, committee_store, checkpoint_store.clone());
 
-    // The node must already hold its own genesis (it is restored or synced).
-    // Refuse a mismatched (wrong-network or stale) genesis before touching
-    // anything: `read_summaries_for_range` chains from genesis, and a foreign
-    // genesis would otherwise corrupt the store.
     let highest_synced = checkpoint_store
         .get_highest_synced_checkpoint()?
         .map(|c| c.sequence_number)
         .ok_or_else(|| {
             anyhow!("checkpoint store at {node_db_path:?} is empty; restore the node first")
         })?;
-    let stored_genesis = checkpoint_store
+
+    // Derive the network — and hence the archive bucket — from the node's own
+    // genesis checkpoint.
+    let genesis_checkpoint = checkpoint_store
         .get_checkpoint_by_sequence_number(0)?
         .ok_or_else(|| anyhow!("node has no genesis checkpoint; restore the node first"))?;
-    anyhow::ensure!(
-        stored_genesis.digest() == genesis.checkpoint().digest(),
-        "the provided genesis does not match the node's genesis checkpoint \
-         (wrong network or stale genesis?)"
-    );
+    let network = ChainIdentifier::from(*genesis_checkpoint.digest()).chain();
 
     let config = ArchiveReaderConfig {
-        remote_store_config: archive_store_config,
+        remote_store_config: default_archive_store_config(network),
         download_concurrency: NonZeroUsize::new(num_parallel_downloads).unwrap(),
         use_for_pruning_watermark: false,
     };
@@ -703,23 +692,107 @@ pub async fn backfill_checkpoint_summaries(
         ))?;
     }
 
-    // Download and (when `verify`) chain-verify summaries for `[1, target]` in
-    // one ordered pass. `read_summaries_for_range` leaves already-present
-    // summaries untouched and never persists an unverified one, so it adds
-    // only the missing historical summaries below the node's watermarks
-    // without moving any of them.
+    // Download and chain-verify summaries for `[1, target]` in one ordered
+    // pass. `read_summaries_for_range` leaves already-present summaries
+    // untouched and never persists an unverified one, so it adds only the
+    // missing historical summaries below the node's watermarks without moving
+    // any of them.
     let bar = m.add(ProgressBar::new(target).with_style(
         ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})").unwrap(),
     ));
     let counter = Arc::new(AtomicU64::new(0));
     spawn_rate_ticker(bar.clone(), counter.clone(), "checkpoints per sec");
     archive_reader
-        .read_summaries_for_range(state_sync_store, 1..target + 1, counter, verify)
+        .read_summaries_for_range(state_sync_store, 1..target + 1, counter)
         .await?;
     bar.finish_with_message("Checkpoint summary backfill is complete");
 
     println!("Backfilled checkpoint summaries up to checkpoint {target}");
     Ok(())
+}
+
+/// Build the checkpoint-archive `ObjectStoreConfig` for `network`: the
+/// permissionless public archive by default, or a custom bucket when the
+/// `CUSTOM_ARCHIVE_BUCKET` env vars are set.
+fn default_archive_store_config(network: Chain) -> ObjectStoreConfig {
+    let archive_bucket = Some(
+        env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET").unwrap_or_else(|_| match network {
+            Chain::Mainnet => "iota-mainnet-archive".to_string(),
+            Chain::Testnet => "iota-testnet-archive".to_string(),
+            Chain::Unknown => {
+                panic!("Cannot generate default archive bucket for unknown network");
+            }
+        }),
+    );
+
+    let custom_archive_enabled = env::var("CUSTOM_ARCHIVE_BUCKET").is_ok_and(|v| v == "true");
+    if custom_archive_enabled {
+        let aws_region =
+            Some(env::var("FORMAL_SNAPSHOT_ARCHIVE_REGION").unwrap_or("us-west-2".to_string()));
+        let archive_bucket_type = env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE").expect(
+            "If setting `CUSTOM_ARCHIVE_BUCKET=true` Must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE, and credentials",
+        );
+        match archive_bucket_type.to_ascii_lowercase().as_str() {
+            "s3" => ObjectStoreConfig {
+                object_store: Some(ObjectStoreType::S3),
+                bucket: archive_bucket.filter(|s| !s.is_empty()),
+                aws_access_key_id: env::var("AWS_ARCHIVE_ACCESS_KEY_ID").ok(),
+                aws_secret_access_key: env::var("AWS_ARCHIVE_SECRET_ACCESS_KEY").ok(),
+                aws_region,
+                aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
+                aws_virtual_hosted_style_request: env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
+                    .ok()
+                    .and_then(|b| b.parse().ok())
+                    .unwrap_or(false),
+                object_store_connection_limit: 50,
+                no_sign_request: false,
+                ..Default::default()
+            },
+            "gcs" => ObjectStoreConfig {
+                object_store: Some(ObjectStoreType::GCS),
+                bucket: archive_bucket,
+                google_service_account: env::var("GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH").ok(),
+                object_store_connection_limit: 50,
+                no_sign_request: false,
+                ..Default::default()
+            },
+            "azure" => ObjectStoreConfig {
+                object_store: Some(ObjectStoreType::Azure),
+                bucket: archive_bucket,
+                azure_storage_account: env::var("AZURE_ARCHIVE_STORAGE_ACCOUNT").ok(),
+                azure_storage_access_key: env::var("AZURE_ARCHIVE_STORAGE_ACCESS_KEY").ok(),
+                object_store_connection_limit: 50,
+                no_sign_request: false,
+                ..Default::default()
+            },
+            _ => panic!(
+                "If setting `CUSTOM_ARCHIVE_BUCKET=true` must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE to one of 'gcs', 'azure', or 's3' "
+            ),
+        }
+    } else {
+        // Default to the permissionless archive store.
+        let aws_endpoint = env::var("AWS_ARCHIVE_ENDPOINT")
+            .ok()
+            .or_else(|| match network {
+                Chain::Mainnet => Some("https://archive.mainnet.iota.cafe".to_string()),
+                Chain::Testnet => Some("https://archive.testnet.iota.cafe".to_string()),
+                Chain::Unknown => None,
+            });
+        let aws_virtual_hosted_style_request = env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
+            .ok()
+            .and_then(|b| b.parse().ok())
+            .unwrap_or(matches!(network, Chain::Mainnet | Chain::Testnet));
+        ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::S3),
+            bucket: archive_bucket.filter(|s| !s.is_empty()),
+            aws_region: Some("us-west-2".to_string()),
+            aws_endpoint,
+            aws_virtual_hosted_style_request,
+            object_store_connection_limit: 200,
+            no_sign_request: true,
+            ..Default::default()
+        }
+    }
 }
 
 /// Spawn a background task that, once per second until `bar` finishes, mirrors

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -51,13 +51,10 @@ use iota_snapshot::{
     VerifiedEpochInfo, reader::StateSnapshotReaderV1, restore::RestoreWithGrpcIndexes,
     setup_db_state,
 };
-use iota_storage::{
-    object_store::{
-        ObjectStoreGetExt,
-        http::HttpDownloaderBuilder,
-        util::{MANIFEST_FILENAME, PerEpochManifest, RootManifest, copy_file, exists, get_path},
-    },
-    verify_checkpoint_range,
+use iota_storage::object_store::{
+    ObjectStoreGetExt,
+    http::HttpDownloaderBuilder,
+    util::{MANIFEST_FILENAME, PerEpochManifest, RootManifest, copy_file, exists, get_path},
 };
 use iota_types::{
     base_types::*,
@@ -655,13 +652,24 @@ pub async fn backfill_checkpoint_summaries(
     let state_sync_store =
         RocksDbStore::new(cache_traits, committee_store, checkpoint_store.clone());
 
-    insert_genesis_checkpoint(&checkpoint_store, &genesis)?;
+    // The node must already hold its own genesis (it is restored or synced).
+    // Refuse a mismatched (wrong-network or stale) genesis before touching
+    // anything: `read_summaries_for_range` chains from genesis, and a foreign
+    // genesis would otherwise corrupt the store.
     let highest_synced = checkpoint_store
         .get_highest_synced_checkpoint()?
         .map(|c| c.sequence_number)
         .ok_or_else(|| {
             anyhow!("checkpoint store at {node_db_path:?} is empty; restore the node first")
         })?;
+    let stored_genesis = checkpoint_store
+        .get_checkpoint_by_sequence_number(0)?
+        .ok_or_else(|| anyhow!("node has no genesis checkpoint; restore the node first"))?;
+    anyhow::ensure!(
+        stored_genesis.digest() == genesis.checkpoint().digest(),
+        "the provided genesis does not match the node's genesis checkpoint \
+         (wrong network or stale genesis?)"
+    );
 
     let config = ArchiveReaderConfig {
         remote_store_config: archive_store_config,
@@ -673,9 +681,9 @@ pub async fn backfill_checkpoint_summaries(
     archive_reader.sync_manifest_once().await?;
 
     // Fill the contiguous range `[1, target]`; genesis (0) is the chain root
-    // and must already be present. Cap `target` at the archive's latest:
-    // summaries above the restore point the node already holds in full from
-    // p2p, and the archive may not reach as far as the node has synced.
+    // and is already present. Cap `target` at the archive's latest: summaries
+    // above the restore point the node already holds in full from p2p, and the
+    // archive may not reach as far as the node has synced.
     let archive_latest = archive_reader
         .get_manifest()
         .await?
@@ -686,54 +694,29 @@ pub async fn backfill_checkpoint_summaries(
         m.println("Nothing to backfill: no archived summaries below the node's state.")?;
         return Ok(());
     }
+    if archive_latest < highest_synced {
+        m.println(format!(
+            "Note: the archive only reaches checkpoint {archive_latest}, below this node's \
+             highest synced checkpoint {highest_synced}. Summaries in \
+             ({archive_latest}, {highest_synced}] are left as the node already has them; re-run \
+             once the archive catches up to fill any remaining gaps."
+        ))?;
+    }
 
-    // Download summaries for `[1, target]`. Inserts are idempotent, so the
-    // end-of-epoch summaries already present are harmlessly overwritten.
-    let download_bar = m.add(ProgressBar::new(target).with_style(
+    // Download and (when `verify`) chain-verify summaries for `[1, target]` in
+    // one ordered pass. `read_summaries_for_range` leaves already-present
+    // summaries untouched and never persists an unverified one, so it adds
+    // only the missing historical summaries below the node's watermarks
+    // without moving any of them.
+    let bar = m.add(ProgressBar::new(target).with_style(
         ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})").unwrap(),
     ));
-    let download_counter = Arc::new(AtomicU64::new(0));
-    spawn_rate_ticker(
-        download_bar.clone(),
-        download_counter.clone(),
-        "checkpoints synced per sec",
-    );
+    let counter = Arc::new(AtomicU64::new(0));
+    spawn_rate_ticker(bar.clone(), counter.clone(), "checkpoints per sec");
     archive_reader
-        .read_summaries_for_range_no_verify(
-            state_sync_store.clone(),
-            1..target + 1,
-            download_counter,
-        )
+        .read_summaries_for_range(state_sync_store, 1..target + 1, counter, verify)
         .await?;
-    download_bar.finish_with_message("Checkpoint summary download is complete");
-
-    if verify {
-        // Verify the chain pairwise from genesis: every summary's
-        // `previous_digest` linkage and committee signature, rooted at the
-        // genesis checkpoint already in the store. Its terminal
-        // `try_update_highest_verified_checkpoint` targets `target`, at or
-        // below where the node already is, so no watermark moves.
-        let verify_bar = m.add(
-            ProgressBar::new(target).with_style(
-                ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})")
-                    .unwrap(),
-            ),
-        );
-        let verify_counter = Arc::new(AtomicU64::new(0));
-        spawn_rate_ticker(
-            verify_bar.clone(),
-            verify_counter.clone(),
-            "checkpoints verified per sec",
-        );
-        verify_checkpoint_range(
-            0..target + 1,
-            state_sync_store,
-            verify_counter,
-            num_parallel_downloads,
-        )
-        .await;
-        verify_bar.finish_with_message("Checkpoint summary verification is complete");
-    }
+    bar.finish_with_message("Checkpoint summary backfill is complete");
 
     println!("Backfilled checkpoint summaries up to checkpoint {target}");
     Ok(())

--- a/docs/content/developer/references/cli/iota-tool.mdx
+++ b/docs/content/developer/references/cli/iota-tool.mdx
@@ -163,5 +163,6 @@ Run `iota-tool --help` to see all available commands, including:
 - `verify-archive` — Verify the archive store
 - `download-db-snapshot` — Download a database snapshot
 - `download-formal-snapshot` — Download a formal snapshot
+- `backfill-checkpoint-summaries` — Backfill the full checkpoint summary history from the archive into a stopped node
 - `dump-packages` — Download all packages from a GraphQL service
 - `sign-transaction` — Sign a transaction with a given keypair

--- a/docs/content/operator/common/snapshots.mdx
+++ b/docs/content/operator/common/snapshots.mdx
@@ -251,6 +251,26 @@ state-snapshot-read-config:
 
 With this set, the node downloads the per-epoch metadata from the latest formal snapshot at startup (a few seconds; the large object files are not downloaded) and then starts normally. If even the latest snapshot is older than the node's executed history and the missing epochs' data is already pruned locally, the node still refuses to start: wait for a newer snapshot, restore from a formal snapshot, or disable the gRPC API.
 
+### Backfilling the full checkpoint summary history
+
+A node restored from a formal snapshot holds only the end-of-epoch checkpoint summaries (one per epoch). That is enough to run, but the node cannot serve historical checkpoint queries below its restore point, nor act as a complete summary source for peers syncing the header chain. To fill in every intermediate summary from the checkpoint archive, stop the node and run:
+
+```shell
+iota-tool backfill-checkpoint-summaries \
+   --path "<PATH-TO-NODE-DB>/live" \
+   --genesis "<PATH-TO-GENESIS-BLOB>" \
+   --network mainnet \
+   --num-parallel-downloads 50 \
+   --verbose
+```
+
+   - `--path`: The node's live database directory (the one containing `checkpoints/`, `store/`, and `epochs/`).
+   - `--genesis`: The path to the network's `genesis.blob`.
+   - `--network`: Network whose default archive bucket to read from. Defaults to "mainnet".
+   - `--skip-verify`: Skip the pairwise chain verification of the downloaded summaries (verification is on by default).
+
+This only adds historical summaries below the node's existing watermarks — it never changes how far the node has synced or executed. It is safe to re-run.
+
 ## IOTA Foundation managed snapshots
 
 The IOTA Foundation provides the public snapshot access:

--- a/docs/content/operator/common/snapshots.mdx
+++ b/docs/content/operator/common/snapshots.mdx
@@ -258,18 +258,13 @@ A node restored from a formal snapshot holds only the end-of-epoch checkpoint su
 ```shell
 iota-tool backfill-checkpoint-summaries \
    --path "<PATH-TO-NODE-DB>/live" \
-   --genesis "<PATH-TO-GENESIS-BLOB>" \
-   --network mainnet \
    --num-parallel-downloads 50 \
    --verbose
 ```
 
-   - `--path`: The node's live database directory (the one containing `checkpoints/`, `store/`, and `epochs/`).
-   - `--genesis`: The path to the network's `genesis.blob`.
-   - `--network`: Network whose default archive bucket to read from. Defaults to "mainnet".
-   - `--skip-verify`: Skip the pairwise chain verification of the downloaded summaries (verification is on by default).
+   - `--path`: The node's live database directory (the one containing `checkpoints/`, `store/`, and `epochs/`). The network — and thus the archive bucket — is derived from the node's own genesis checkpoint, so no genesis file or network flag is needed. Override the bucket with the `CUSTOM_ARCHIVE_BUCKET` environment variables for a custom network.
 
-This only adds historical summaries below the node's existing watermarks — it never changes how far the node has synced or executed. It is safe to re-run.
+Each downloaded summary is verified against the committee chain before it is stored. This only adds historical summaries below the node's existing watermarks — it never changes how far the node has synced or executed, and it never overwrites the summaries the node already has. It is safe to re-run.
 
 ## IOTA Foundation managed snapshots
 


### PR DESCRIPTION
# Description of change

Formal-snapshot restore no longer touches the checkpoint archive. The default (and now only) path seeds the end-of-epoch summaries and committees from the snapshot's chain-verified EPOCH_INFO; the `--all-checkpoints flag`, the `archive_store_config` plumbing, and the `start_summary_sync_from_archive` machinery are removed from download_formal_snapshot.

The full-summary-history download, previously bolted onto restore as `--all-checkpoints`, becomes a standalone command, iota-tool `backfill-checkpoint-summaries`, runnable on any stopped node. It downloads every intermediate checkpoint summary from the archive into the node's checkpoint store up to `min(highest_synced, archive_latest)`, optionally verifying the chain pairwise from genesis. It only adds historical summaries below the node's existing watermarks. No watermark is moved, so it's safe to re-run, and it's decoupled from restore (a node restored from a formal snapshot can become a full-header source for peers, or serve historical checkpoint queries).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Added `backfill-checkpoint-summaries` command to `iota-tool` to download the full checkpoint summary history for a stopped node
- [ ] Rust SDK:
- [ ] gRPC:
