### PR TITLE
feat(starfish-core): add consumer-paced backpressure to commit observer recovery

### DIFF
--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -188,6 +188,22 @@ impl ConsensusManagerTrait for StarfishManager {
             );
         }
 
+        // Spin up the starfish consensus handler to listen for committed sub dags
+        // before starting the consensus authority: commit observer recovery paces
+        // itself on consumer progress, so the consumer must already be draining
+        // the channel while the authority starts.
+        let handler = StarfishConsensusHandler::new(
+            last_processed_commit,
+            consensus_handler,
+            commit_receiver,
+            monitor,
+        );
+
+        {
+            let mut consensus_handler = self.consensus_handler.lock().await;
+            *consensus_handler = Some(handler);
+        }
+
         let authority = ConsensusAuthority::start(
             epoch_store.epoch_start_config().epoch_start_timestamp_ms(),
             own_index,
@@ -208,21 +224,10 @@ impl ConsensusManagerTrait for StarfishManager {
         let registry_id = self.registry_service.add(registry.clone());
 
         let registered_authority = Arc::new((authority, registry_id));
-        self.authority.swap(Some(registered_authority.clone()));
+        self.authority.swap(Some(registered_authority));
 
         // Initialize the client to send transactions to this Starfish instance.
         self.client.set(client);
-
-        // spin up the new starfish consensus handler to listen for committed sub dags
-        let handler = StarfishConsensusHandler::new(
-            last_processed_commit,
-            consensus_handler,
-            commit_receiver,
-            monitor,
-        );
-
-        let mut consensus_handler = self.consensus_handler.lock().await;
-        *consensus_handler = Some(handler);
     }
 
     async fn shutdown(&self) {

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -161,6 +161,13 @@ pub struct Parameters {
 }
 
 impl Parameters {
+    /// Threshold for the number of commits sent to the consumer but not yet
+    /// handled, above which commit producers (commit syncers, commit observer
+    /// recovery) pause to let the consumer catch up.
+    pub fn unhandled_commits_threshold(&self) -> u32 {
+        self.commit_sync_batch_size * (self.commit_sync_batches_ahead as u32)
+    }
+
     pub(crate) fn default_leader_timeout() -> Duration {
         Duration::from_millis(200)
     }

--- a/crates/starfish/core/src/commit_consumer.rs
+++ b/crates/starfish/core/src/commit_consumer.rs
@@ -9,6 +9,12 @@ use tokio::sync::watch;
 
 use crate::{CommitIndex, CommittedSubDag};
 
+/// Receiving end of the consensus output: consensus sends committed sub-dags
+/// through the channel and the consumer reports its progress via the monitor.
+///
+/// The consumer must already be draining the channel and reporting progress
+/// when consensus starts, since commit observer recovery paces the resend of
+/// the unprocessed backlog on consumer progress.
 pub struct CommitConsumer {
     // A channel to send the committed sub dags through
     pub(crate) sender: UnboundedSender<CommittedSubDag>,
@@ -85,6 +91,26 @@ impl CommitConsumerMonitor {
             "highest_known_commit_at_startup can only be set once"
         );
         *commit = highest_observed_commit_at_startup;
+    }
+
+    /// Waits until the consumer's highest handled commit is within
+    /// `threshold` commits behind `sent_index`, i.e. until
+    /// `sent_index - highest_handled_commit() < threshold`.
+    pub(crate) async fn wait_until_handled_within(
+        &self,
+        sent_index: CommitIndex,
+        threshold: CommitIndex,
+    ) {
+        let mut rx = self.highest_handled_commit.subscribe();
+        loop {
+            let highest_handled = *rx.borrow_and_update();
+            if sent_index.saturating_sub(highest_handled) < threshold {
+                return;
+            }
+            rx.changed()
+                .await
+                .expect("the watch sender lives in this monitor, so it outlives this wait");
+        }
     }
 
     pub(crate) async fn replay_complete(&self) {

--- a/crates/starfish/core/src/commit_consumer.rs
+++ b/crates/starfish/core/src/commit_consumer.rs
@@ -9,10 +9,12 @@ use tokio::sync::watch;
 
 use crate::{CommitIndex, CommittedSubDag};
 
-/// Receiving end of the consensus output: consensus sends committed sub-dags
-/// through the channel and the consumer reports its progress via the monitor.
+/// The consumer's side of the consensus output channel, passed into consensus
+/// at startup. Holds the sender that consensus emits committed sub-dags
+/// through, plus the monitor the consumer uses to report how far it has
+/// processed; the matching receiver stays with the consumer.
 ///
-/// The consumer must already be draining the channel and reporting progress
+/// The consumer must already be draining that receiver and reporting progress
 /// when consensus starts, since commit observer recovery paces the resend of
 /// the unprocessed backlog on consumer progress.
 pub struct CommitConsumer {

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -15,7 +15,7 @@ use tokio::time::Instant;
 use tracing::{debug, info, instrument, warn};
 
 use crate::{
-    CommitConsumer, CommittedSubDag,
+    CommitConsumer, CommitConsumerMonitor, CommittedSubDag,
     block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
     commit::{
         CommitAPI, CommitIndex, CommitMetastate, PendingSubDag, TrustedCommit,
@@ -56,8 +56,11 @@ impl CommittedSubDagSource {
 /// - The committed subdags are sent as consensus output via an unbounded tokio
 ///   channel.
 ///
-/// No back pressure mechanism is needed as backpressure is handled as input
-/// into consensus.
+/// During normal operation no backpressure mechanism is needed as backpressure
+/// is handled as input into consensus. During recovery, resending the
+/// unprocessed backlog is paced on consumer progress so the channel stays
+/// bounded; the consumer must therefore already be draining the channel when
+/// the observer is created.
 ///
 /// - Commit metadata including index is persisted in store, before the
 ///   CommittedSubDag is sent to the consumer.
@@ -72,6 +75,8 @@ pub(crate) struct CommitObserver {
     /// An unbounded channel to send committed sub-dags to the consumer of
     /// consensus output.
     sender: UnboundedSender<CommittedSubDag>,
+    /// Tracks the consumer's progress, used to pace recovery resends.
+    commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     /// Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
     /// Dag state for direct access to block headers
@@ -100,6 +105,7 @@ impl CommitObserver {
             ),
             commit_solidifier: CommitSolidifier::new(dag_state.clone()),
             context,
+            commit_consumer_monitor: commit_consumer.monitor(),
             sender: commit_consumer.sender,
             store,
             dag_state,
@@ -494,11 +500,20 @@ impl CommitObserver {
         // in bounded batches.
         const COMMIT_RECOVERY_BATCH_SIZE: u32 = if cfg!(test) { 3 } else { 250 };
 
+        let unhandled_commits_threshold = self.context.parameters.unhandled_commits_threshold();
         let mut any_sent = false;
         let mut expected_commit_index = last_processed_commit_index;
         for start_index in (last_processed_commit_index + 1..=last_commit_index)
             .step_by(COMMIT_RECOVERY_BATCH_SIZE as usize)
         {
+            // Pace on consumer progress like the commit syncers do: don't run
+            // more than unhandled_commits_threshold commits ahead of the
+            // consumer, so the consensus output channel stays bounded by the
+            // threshold instead of buffering the entire unprocessed backlog.
+            self.commit_consumer_monitor
+                .wait_until_handled_within(self.last_sent_commit_index, unhandled_commits_threshold)
+                .await;
+
             let end_index = start_index
                 .saturating_add(COMMIT_RECOVERY_BATCH_SIZE - 1)
                 .min(last_commit_index);
@@ -1264,6 +1279,130 @@ mod tests {
 
         // Verify no additional subdags were sent
         verify_channel_empty(&mut receiver);
+    }
+
+    /// Recovery resend must pace itself on consumer progress: once the
+    /// last sent commit runs `unhandled_commits_threshold` ahead of the
+    /// consumer's highest handled commit, the next batch is sent only
+    /// after the consumer catches up.
+    #[tokio::test]
+    async fn test_recovery_resend_paced_by_consumer_progress() {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities = 4;
+
+        // unhandled_commits_threshold = commit_sync_batch_size *
+        // commit_sync_batches_ahead = 3, matching the recovery batch size in
+        // tests, so recovery must wait for consumer progress between batches.
+        let (committee, _keypairs) =
+            starfish_config::local_committee_and_keys(0, vec![1; num_authorities]);
+        let metrics = crate::metrics::test_metrics();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let clock = Arc::new(crate::context::Clock::default());
+        let context = Arc::new(Context::new(
+            0,
+            starfish_config::AuthorityIndex::new_for_test(0),
+            committee,
+            starfish_config::Parameters {
+                db_path: temp_dir.keep(),
+                commit_sync_batch_size: 3,
+                commit_sync_batches_ahead: 1,
+                ..Default::default()
+            },
+            iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE(),
+            metrics,
+            clock,
+        ));
+
+        let mem_store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            mem_store.clone(),
+        )));
+        let (sender, mut receiver) = unbounded_channel("consensus_output");
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
+            context.clone(),
+            dag_state.clone(),
+        ));
+
+        // Produce 10 commits that the consumer never processes.
+        let mut observer = CommitObserver::new(
+            context.clone(),
+            CommitConsumer::new(sender.clone(), 0),
+            dag_state.clone(),
+            mem_store.clone(),
+            leader_schedule.clone(),
+        )
+        .await;
+
+        let num_rounds = 10;
+        let mut builder = DagBuilder::new(context.clone());
+        builder
+            .layers(1..=num_rounds)
+            .build()
+            .persist_layers(dag_state.clone());
+        let leaders = builder
+            .leader_blocks(1..=num_rounds)
+            .into_iter()
+            .map(Option::unwrap)
+            .collect::<Vec<_>>();
+        observer
+            .handle_committed_leaders(with_no_metastate(leaders), CommittedSubDagSource::Consensus)
+            .unwrap();
+        while receiver.try_recv().is_ok() {}
+        drop(observer);
+
+        // Restart with last processed index 0; recovery must resend all 10
+        // commits, paced on the consumer monitor.
+        let commit_consumer = CommitConsumer::new(sender, 0);
+        let monitor = commit_consumer.monitor();
+        let recovery = tokio::spawn(CommitObserver::new(
+            context,
+            commit_consumer,
+            dag_state,
+            mem_store,
+            leader_schedule,
+        ));
+
+        // Without consumer progress, only the first batch is sent before the
+        // producer runs threshold commits ahead of the consumer.
+        assert_eq!(
+            drain_resent_commit_indices(&mut receiver).await,
+            vec![1, 2, 3]
+        );
+
+        monitor.set_highest_handled_commit(3);
+        assert_eq!(
+            drain_resent_commit_indices(&mut receiver).await,
+            vec![4, 5, 6]
+        );
+
+        monitor.set_highest_handled_commit(6);
+        assert_eq!(
+            drain_resent_commit_indices(&mut receiver).await,
+            vec![7, 8, 9]
+        );
+
+        monitor.set_highest_handled_commit(9);
+        assert_eq!(drain_resent_commit_indices(&mut receiver).await, vec![10]);
+
+        let _observer = recovery.await.unwrap();
+        verify_channel_empty(&mut receiver);
+    }
+
+    /// Lets the recovery task run until it parks (waiting on consumer
+    /// progress) or completes, then returns the commit indices sent in the
+    /// meantime.
+    async fn drain_resent_commit_indices(
+        receiver: &mut UnboundedReceiver<CommittedSubDag>,
+    ) -> Vec<CommitIndex> {
+        let mut indices = Vec::new();
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+            while let Ok(subdag) = receiver.try_recv() {
+                indices.push(subdag.commit_ref.index);
+            }
+        }
+        indices
     }
 
     /// After receiving all expected subdags, ensure channel is empty

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -302,7 +302,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         let last_solid_commit_index = self.inner.dag_state.read().last_solid_commit_index();
         let highest_handled_index = self.inner.commit_consumer_monitor.highest_handled_commit();
         let highest_scheduled_index = self.highest_scheduled_index.unwrap_or(0);
-        let unhandled_commits_threshold = self.inner.unhandled_commits_threshold();
+        let unhandled_commits_threshold =
+            self.inner.context.parameters.unhandled_commits_threshold();
         let step = self
             .inner
             .sync_type

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -192,8 +192,7 @@ impl<C: NetworkClient> Inner<C> {
     /// threshold, scheduling new fetches should pause to let the handler
     /// catch up.
     pub(crate) fn unhandled_commits_threshold(&self) -> CommitIndex {
-        self.context.parameters.commit_sync_batch_size
-            * (self.context.parameters.commit_sync_batches_ahead as u32)
+        self.context.parameters.unhandled_commits_threshold()
     }
 
     /// Verifies the commits and also certifies them using the provided vote

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -187,14 +187,6 @@ pub(crate) struct Inner<C: NetworkClient> {
 }
 
 impl<C: NetworkClient> Inner<C> {
-    /// Calculates the threshold for unhandled commits to apply backpressure.
-    /// When the gap between synced and scheduled commits exceeds this
-    /// threshold, scheduling new fetches should pause to let the handler
-    /// catch up.
-    pub(crate) fn unhandled_commits_threshold(&self) -> CommitIndex {
-        self.context.parameters.unhandled_commits_threshold()
-    }
-
     /// Verifies the commits and also certifies them using the provided vote
     /// blocks for the last commit. The method returns the trusted commits
     /// and the verified voting block headers.

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -198,7 +198,8 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         // Update synced_commit_index periodically to make sure it is not smaller than
         // local commit index.
         self.synced_commit_index = self.synced_commit_index.max(dag_state_commit_index);
-        let unhandled_commits_threshold = self.inner.unhandled_commits_threshold();
+        let unhandled_commits_threshold =
+            self.inner.context.parameters.unhandled_commits_threshold();
 
         // TODO: cleanup inflight fetches that are no longer needed.
         let fetch_after_index = self
@@ -848,7 +849,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
 
     #[cfg(test)]
     fn unhandled_commits_threshold(&self) -> CommitIndex {
-        self.inner.unhandled_commits_threshold()
+        self.inner.context.parameters.unhandled_commits_threshold()
     }
 
     #[cfg(test)]

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -101,7 +101,17 @@ impl AuthorityNode {
         config.boot_counter = current_boot_counter;
         config.db_dir = self.db_dir.lock().clone();
         config.last_processed_commit = last_processed;
-        *self.inner.lock() = Some(AuthorityNodeInner::spawn(config).await);
+
+        let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
+        let commit_consumer = CommitConsumer::new(commit_sender, last_processed);
+        let commit_consumer_monitor = commit_consumer.monitor();
+        // Consume commits while the node starts: commit observer recovery
+        // paces itself on consumer progress, so the consumer must already be
+        // draining the channel during startup.
+        self.spawn_committed_subdag_consumer(commit_receiver, commit_consumer_monitor.clone());
+
+        *self.inner.lock() =
+            Some(AuthorityNodeInner::spawn(config, commit_consumer, commit_consumer_monitor).await);
         Ok(())
     }
 
@@ -154,39 +164,35 @@ impl AuthorityNode {
     ///
     /// The spawned task runs until the commit receiver is closed (when the node
     /// stops), so the task handle is intentionally not stored.
-    ///
-    /// Must be called after `start()` to begin tracking commits.
-    pub fn spawn_committed_subdag_consumer(&self) -> Result<()> {
-        let inner = self.inner.lock();
-        if let Some(inner) = inner.as_ref() {
-            let mut commit_receiver = inner.take_commit_receiver();
-            let commit_consumer_monitor = inner.commit_consumer_monitor();
-            let commit_digests = self.commit_digests.clone();
-            let last_processed = self.last_processed_commit.clone();
-            let committed_transactions = self.committed_transactions.clone();
-            let _handle = tokio::spawn(async move {
-                while let Some(subdag) = commit_receiver.recv().await {
-                    // Store commit digest for consistency verification
-                    commit_digests
-                        .write()
-                        .await
-                        .insert(subdag.commit_ref.index, subdag.commit_ref.digest);
-                    // Track committed transactions
-                    for verified_txns in &subdag.transactions {
-                        for txn in verified_txns.transactions() {
-                            committed_transactions
-                                .write()
-                                .await
-                                .insert(txn.data().to_vec());
-                        }
+    fn spawn_committed_subdag_consumer(
+        &self,
+        mut commit_receiver: UnboundedReceiver<CommittedSubDag>,
+        commit_consumer_monitor: Arc<CommitConsumerMonitor>,
+    ) {
+        let commit_digests = self.commit_digests.clone();
+        let last_processed = self.last_processed_commit.clone();
+        let committed_transactions = self.committed_transactions.clone();
+        let _handle = tokio::spawn(async move {
+            while let Some(subdag) = commit_receiver.recv().await {
+                // Store commit digest for consistency verification
+                commit_digests
+                    .write()
+                    .await
+                    .insert(subdag.commit_ref.index, subdag.commit_ref.digest);
+                // Track committed transactions
+                for verified_txns in &subdag.transactions {
+                    for txn in verified_txns.transactions() {
+                        committed_transactions
+                            .write()
+                            .await
+                            .insert(txn.data().to_vec());
                     }
-                    // Track last processed for persistent DB restarts
-                    last_processed.store(subdag.commit_ref.index, Ordering::SeqCst);
-                    commit_consumer_monitor.set_highest_handled_commit(subdag.commit_ref.index);
                 }
-            });
-        }
-        Ok(())
+                // Track last processed for persistent DB restarts
+                last_processed.store(subdag.commit_ref.index, Ordering::SeqCst);
+                commit_consumer_monitor.set_highest_handled_commit(subdag.commit_ref.index);
+            }
+        });
     }
 
     pub fn commit_consumer_monitor(&self) -> Arc<CommitConsumerMonitor> {
@@ -269,7 +275,6 @@ pub(crate) struct AuthorityNodeInner {
     handle: Option<NodeHandle>,
     cancel_sender: Option<tokio::sync::watch::Sender<bool>>,
     consensus_authority: Option<ConsensusAuthority>,
-    commit_receiver: ArcSwapOption<UnboundedReceiver<CommittedSubDag>>,
     commit_consumer_monitor: Arc<CommitConsumerMonitor>,
 }
 
@@ -293,7 +298,11 @@ impl Drop for AuthorityNodeInner {
 
 impl AuthorityNodeInner {
     /// Spawn a new Node.
-    pub async fn spawn(config: Config) -> Self {
+    pub async fn spawn(
+        config: Config,
+        commit_consumer: CommitConsumer,
+        commit_consumer_monitor: Arc<CommitConsumerMonitor>,
+    ) -> Self {
         let (startup_sender, mut startup_receiver) = tokio::sync::watch::channel(false);
         let (cancel_sender, cancel_receiver) = tokio::sync::watch::channel(false);
 
@@ -308,6 +317,7 @@ impl AuthorityNodeInner {
         };
         let init_receiver_swap = Arc::new(ArcSwapOption::empty());
         let int_receiver_swap_clone = init_receiver_swap.clone();
+        let commit_consumer = Arc::new(Mutex::new(Some(commit_consumer)));
 
         let node = builder
             .ip(ip)
@@ -318,17 +328,18 @@ impl AuthorityNodeInner {
                 let mut cancel_receiver = cancel_receiver.clone();
                 let init_receiver_swap_clone = int_receiver_swap_clone.clone();
                 let startup_sender_clone = startup_sender.clone();
+                let commit_consumer = commit_consumer.clone();
 
                 async move {
-                    let (consensus_authority, commit_receiver, commit_consumer_monitor) =
-                        super::node::make_authority(config).await;
+                    let commit_consumer = commit_consumer
+                        .lock()
+                        .take()
+                        .expect("the node init closure runs once per spawn");
+                    let consensus_authority =
+                        super::node::make_authority(config, commit_consumer).await;
 
                     startup_sender_clone.send(true).ok();
-                    init_receiver_swap_clone.store(Some(Arc::new((
-                        consensus_authority,
-                        commit_receiver,
-                        commit_consumer_monitor,
-                    ))));
+                    init_receiver_swap_clone.store(Some(Arc::new(consensus_authority)));
 
                     // run until canceled
                     loop {
@@ -343,21 +354,18 @@ impl AuthorityNodeInner {
 
         startup_receiver.changed().await.unwrap();
 
-        let Some(init_tuple) = init_receiver_swap.swap(None) else {
+        let Some(init_authority) = init_receiver_swap.swap(None) else {
             panic!("Components should be initialised by now");
         };
 
-        let Ok((consensus_authority, commit_receiver, commit_consumer_monitor)) =
-            Arc::try_unwrap(init_tuple)
-        else {
-            panic!("commit receiver still in use");
+        let Ok(consensus_authority) = Arc::try_unwrap(init_authority) else {
+            panic!("consensus authority still in use");
         };
 
         Self {
             handle: Some(NodeHandle { node_id: node.id() }),
             cancel_sender: Some(cancel_sender),
             consensus_authority: Some(consensus_authority),
-            commit_receiver: ArcSwapOption::new(Some(Arc::new(commit_receiver))),
             commit_consumer_monitor,
         }
     }
@@ -376,18 +384,6 @@ impl AuthorityNodeInner {
         }
     }
 
-    pub fn take_commit_receiver(&self) -> UnboundedReceiver<CommittedSubDag> {
-        if let Some(commit_receiver) = self.commit_receiver.swap(None) {
-            let Ok(commit_receiver) = Arc::try_unwrap(commit_receiver) else {
-                panic!("commit receiver still in use");
-            };
-
-            commit_receiver
-        } else {
-            panic!("commit receiver already taken");
-        }
-    }
-
     pub fn commit_consumer_monitor(&self) -> Arc<CommitConsumerMonitor> {
         self.commit_consumer_monitor.clone()
     }
@@ -402,11 +398,8 @@ impl AuthorityNodeInner {
 
 pub(crate) async fn make_authority(
     config: Config,
-) -> (
-    ConsensusAuthority,
-    UnboundedReceiver<CommittedSubDag>,
-    Arc<CommitConsumerMonitor>,
-) {
+    commit_consumer: CommitConsumer,
+) -> ConsensusAuthority {
     let Config {
         authority_index,
         db_dir,
@@ -416,7 +409,7 @@ pub(crate) async fn make_authority(
         boot_counter,
         clock_drift,
         protocol_config,
-        last_processed_commit,
+        last_processed_commit: _,
     } = config;
 
     let registry = Registry::new();
@@ -436,12 +429,7 @@ pub(crate) async fn make_authority(
     let protocol_keypair = keypairs[authority_index].1.clone();
     let network_keypair = keypairs[authority_index].0.clone();
 
-    let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
-
-    let commit_consumer = CommitConsumer::new(commit_sender, last_processed_commit);
-    let commit_consumer_monitor = commit_consumer.monitor();
-
-    let authority = ConsensusAuthority::start(
+    ConsensusAuthority::start(
         0,
         authority_index,
         committee,
@@ -455,7 +443,5 @@ pub(crate) async fn make_authority(
         registry,
         boot_counter,
     )
-    .await;
-
-    (authority, commit_receiver, commit_consumer_monitor)
+    .await
 }

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -239,7 +239,6 @@ mod test {
             };
             let node = AuthorityNode::new(config);
             node.start().await.unwrap();
-            node.spawn_committed_subdag_consumer().unwrap();
 
             transaction_clients.push(node.transaction_client());
             authorities.push(node);
@@ -338,9 +337,6 @@ mod test {
 
                 // Restart the authority with the specified mode
                 authorities[authority_idx].restart(mode).await.unwrap();
-                authorities[authority_idx]
-                    .spawn_committed_subdag_consumer()
-                    .unwrap();
 
                 // Wait for catch-up
                 sleep(restart_config.post_restart_wait).await;


### PR DESCRIPTION
# Description of change

PR #11850 batches the commit observer's recovery reads to bound read-side memory, but the recovered commits are still sent into the unbounded `consensus_output` channel with nothing pacing the producer. In a local 10-validator restart test (wiped `authorities_db`, preserved `consensus_db`), recovery dumped the entire backlog into the channel at once and `monitored_channel_inflight{name="consensus_output"}` spiked to ~10,000 — peak memory effectively moved from the recovery scan into the channel.

This applies the same contract the commit syncers already use at the send side of recovery. `resend_unprocessed_solid_commits` now waits between batches until `last_sent_commit_index - highest_handled_commit() < unhandled_commits_threshold()` before sending the next batch, reusing the existing `CommitConsumerMonitor` so both producers (recovery and fast sync) pace consistently and the channel is bounded by the threshold instead of the full backlog.

Changes:

- `starfish-config`: extract `Parameters::unhandled_commits_threshold()` so the commit syncers and the commit observer share one definition of the threshold.
- `starfish-core`: the commit observer holds the `CommitConsumerMonitor` and awaits consumer progress between recovery resend batches.
- `iota-core`: spawn the `StarfishConsensusHandler` before starting the consensus authority, so the consumer is already draining the channel when recovery runs (otherwise paced recovery would stall at startup).
- `starfish-simtests`: create the commit consumer and spawn its draining task before the authority starts, matching the new startup ordering across node restarts.

Stacked on #11850 — the first two commits belong to that PR and will drop out of this diff once it merges.

## Links to any relevant issues

fixes #11890

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Added `test_recovery_resend_paced_by_consumer_progress`, which restarts the commit observer with a 10-commit backlog and a threshold of 3, and asserts each batch is released only as the consumer monitor advances. All `starfish-core` unit tests pass, and the sequential-restart simtests (clean, persistent, and reset-last-processed modes) pass under the simulator.