### PR TITLE
fix(iota-grpc-server): add server-timing context to stop log spam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6817,6 +6817,7 @@ dependencies = [
  "bytes",
  "dashmap",
  "futures",
+ "http 1.4.0",
  "once_cell",
  "parking_lot 0.12.3",
  "prometheus",

--- a/crates/iota-grpc-server/src/lib.rs
+++ b/crates/iota-grpc-server/src/lib.rs
@@ -21,6 +21,7 @@ pub mod transaction_filter;
 pub mod types;
 pub mod utils;
 // Internal helpers — not part of the public API.
+pub(crate) mod server_timing;
 pub(crate) mod validation;
 
 // Re-export commonly used types and traits

--- a/crates/iota-grpc-server/src/server.rs
+++ b/crates/iota-grpc-server/src/server.rs
@@ -21,7 +21,8 @@ use tonic::transport::{Identity, Server, ServerTlsConfig};
 use crate::{
     GrpcCheckpointDataBroadcaster, GrpcReader, GrpcServerMetrics, LedgerGrpcService,
     MovePackageGrpcService, StateGrpcService, TransactionExecutionGrpcService,
-    metrics::GrpcMetricsLayer, traffic_control::TrafficControlLayer,
+    metrics::GrpcMetricsLayer, server_timing::ServerTimingLayer,
+    traffic_control::TrafficControlLayer,
 };
 
 /// Handle to control a running gRPC server
@@ -210,8 +211,8 @@ pub async fn start_grpc_server(
             .map_err(|e| anyhow::anyhow!("failed to configure TLS: {}", e))?;
     }
 
-    // Order matters: the metrics layer is outermost so it observes blocked requests
-    // too.
+    // Order matters: metrics outermost to observe blocked requests; server-timing
+    // innermost so the timer covers only accepted requests.
     let mut layered_builder = server_builder.layer(
         tower::ServiceBuilder::new()
             .option_layer(
@@ -222,7 +223,8 @@ pub async fn start_grpc_server(
             .option_layer(
                 traffic_controller
                     .map(|tc| TrafficControlLayer::new(tc, client_id_source.unwrap_or_default())),
-            ),
+            )
+            .layer(ServerTimingLayer),
     );
     let server_handle = build_and_spawn!(
         layered_builder,

--- a/crates/iota-grpc-server/src/server_timing.rs
+++ b/crates/iota-grpc-server/src/server_timing.rs
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use iota_metrics::{add_server_timing, get_server_timing, with_new_server_timing};
+use iota_metrics::{finish_and_set_server_timing_header, with_new_server_timing};
 use tower::{Layer, Service};
 
 /// Tower [`Layer`] that creates a server-timing context per request.
@@ -57,15 +57,7 @@ where
 
         Box::pin(with_new_server_timing(async move {
             let mut response = inner.call(req).await?;
-            add_server_timing("finish_request");
-
-            if let Some(timer) = get_server_timing() {
-                if let Ok(header_value) = http::HeaderValue::try_from(timer.lock().header_value()) {
-                    response
-                        .headers_mut()
-                        .insert(http::HeaderName::from_static("server-timing"), header_value);
-                }
-            }
+            finish_and_set_server_timing_header(response.headers_mut());
             Ok(response)
         }))
     }
@@ -76,6 +68,7 @@ mod tests {
     use std::convert::Infallible;
 
     use http::{Request, Response};
+    use iota_metrics::{add_server_timing, get_server_timing, server_timing_header_key};
     use tower::{ServiceExt, service_fn};
 
     use super::*;
@@ -95,7 +88,7 @@ mod tests {
 
         let header = response
             .headers()
-            .get("server-timing")
+            .get(server_timing_header_key())
             .expect("server-timing header must be set")
             .to_str()
             .unwrap();

--- a/crates/iota-grpc-server/src/server_timing.rs
+++ b/crates/iota-grpc-server/src/server_timing.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tower [`Layer`] that runs each request inside a server-timing context, so
+//! handlers can record timings via [`iota_metrics::add_server_timing`]. The
+//! collected timings are returned in the `Server-Timing` response header.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use iota_metrics::{add_server_timing, get_server_timing, with_new_server_timing};
+use tower::{Layer, Service};
+
+/// Tower [`Layer`] that creates a server-timing context per request.
+#[derive(Clone)]
+pub(crate) struct ServerTimingLayer;
+
+impl<S> Layer<S> for ServerTimingLayer {
+    type Service = ServerTimingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ServerTimingService { inner }
+    }
+}
+
+/// Tower [`Service`] wrapper that runs the inner service inside a
+/// server-timing context.
+#[derive(Clone)]
+pub(crate) struct ServerTimingService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for ServerTimingService<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response, S::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        // Tower contract: `self.inner` is the ready one (poll_ready set it up),
+        // so call it and leave the clone for the next request.
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+
+        Box::pin(with_new_server_timing(async move {
+            let mut response = inner.call(req).await?;
+            add_server_timing("finish_request");
+
+            if let Some(timer) = get_server_timing() {
+                if let Ok(header_value) = http::HeaderValue::try_from(timer.lock().header_value()) {
+                    response
+                        .headers_mut()
+                        .insert(http::HeaderName::from_static("server-timing"), header_value);
+                }
+            }
+            Ok(response)
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use http::{Request, Response};
+    use tower::{ServiceExt, service_fn};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn creates_timing_scope_and_sets_header() {
+        let service = ServerTimingLayer.layer(service_fn(|_req: Request<()>| async {
+            assert!(
+                get_server_timing().is_some(),
+                "handler must run inside a server-timing context"
+            );
+            add_server_timing("handler");
+            Ok::<_, Infallible>(Response::new(()))
+        }));
+
+        let response = service.oneshot(Request::new(())).await.unwrap();
+
+        let header = response
+            .headers()
+            .get("server-timing")
+            .expect("server-timing header must be set")
+            .to_str()
+            .unwrap();
+        assert!(header.contains("handler;dur="), "header: {header}");
+        assert!(header.contains("finish_request;dur="), "header: {header}");
+    }
+}

--- a/crates/iota-metrics/Cargo.toml
+++ b/crates/iota-metrics/Cargo.toml
@@ -18,6 +18,7 @@ axum.workspace = true
 bytes.workspace = true
 dashmap.workspace = true
 futures.workspace = true
+http.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 prometheus.workspace = true

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -214,21 +214,31 @@ pub async fn with_new_server_timing<T>(fut: impl Future<Output = T> + Send + 'st
     ret.unwrap()
 }
 
+/// The `Server-Timing` HTTP header key.
+pub fn server_timing_header_key() -> &'static str {
+    Timer::header_key()
+}
+
+/// Add a final `finish_request` entry and write the collected timings to the
+/// `Server-Timing` response header. No-op outside a server-timing context.
+pub fn finish_and_set_server_timing_header(headers: &mut http::HeaderMap) {
+    let Some(timer) = get_server_timing() else {
+        return;
+    };
+    let header_value = {
+        let mut timer = timer.lock();
+        timer.add("finish_request");
+        timer.header_value()
+    };
+    if let Ok(value) = http::HeaderValue::try_from(header_value) {
+        headers.insert(server_timing_header_key(), value);
+    }
+}
+
 pub async fn server_timing_middleware(request: Request, next: Next) -> Response {
     with_new_server_timing(async move {
         let mut response = next.run(request).await;
-        add_server_timing("finish_request");
-
-        if let Ok(header_value) = get_server_timing()
-            .expect("server timing not set")
-            .lock()
-            .header_value()
-            .try_into()
-        {
-            response
-                .headers_mut()
-                .insert(Timer::header_key(), header_value);
-        }
+        finish_and_set_server_timing_header(response.headers_mut());
         response
     })
     .await


### PR DESCRIPTION
# Description of change

Nodes serving transactions over gRPC log tens of thousands of `ERROR iota_metrics: Server timing context not found lines, one per executed transaction`. The shared execution path calls `add_server_timing(...)`, which needs a task-local context that only the JSON-RPC server installs; our standalone gRPC server lacks it, so every transaction hits the error branch. This PR adds a small `ServerTimingLayer` to the gRPC tower stack that wraps each request in the context and returns the timings via the `Server-Timing` response header to avoid log spam.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes