### PR TITLE
fix(starfish): drop stale own-block accepted-count assert

### DIFF
--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1190,12 +1190,16 @@ impl Core {
             verified_block_header,
             verified_transactions,
         };
-        // Accept the block into BlockManager and DagState.
-        let (accepted_blocks, missing) = self
+        // Accept the block into BlockManager and DagState. The accepted set may also
+        // include blocks unsuspended by the GC sweep, so its size is not necessarily
+        // one; for an own block only the absence of missing ancestors is guaranteed.
+        let (_, missing) = self
             .block_manager
             .try_accept_blocks(vec![verified_block.clone()], DataSource::OwnBlock);
-        assert_eq!(accepted_blocks.len(), 1);
-        assert!(missing.is_empty());
+        debug_assert!(
+            missing.is_empty(),
+            "own block must have no missing ancestors"
+        );
         // Ensure the new block and its ancestors are persisted, before broadcasting it.
         let mut dag_state_guard = self.dag_state.write();
         dag_state_guard.flush();

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -23,7 +23,7 @@ use tokio::{
     sync::{broadcast, watch},
     time::Instant,
 };
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 #[cfg(test)]
 use crate::storage::Store;
@@ -1196,6 +1196,13 @@ impl Core {
         let (_, missing) = self
             .block_manager
             .try_accept_blocks(vec![verified_block.clone()], DataSource::OwnBlock);
+        if !missing.is_empty() {
+            error!(
+                ?missing,
+                block_ref = ?verified_block.reference(),
+                "own block proposal returned unexpected missing ancestors"
+            );
+        }
         debug_assert!(
             missing.is_empty(),
             "own block must have no missing ancestors"

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -479,7 +479,6 @@ mod test {
     /// Persistent DB after each restart, short run before stop, short stop
     /// duration.
     #[sim_test(config = "test_config()")]
-    #[ignore]
     async fn test_sequential_restarts_persistent_db_short_run_short_stop() {
         run_sequential_restarts_test(RestartMode::PersistAll, false, false).await;
     }


### PR DESCRIPTION
# Description of change

When proposing its own block, `Core` accepts it through `try_accept_blocks`. That call returns the newly accepted header merged with any blocks unsuspended by the GC-floor sweep that runs at the start of every accept, so the accepted set can contain more than one header. The long-standing `assert_eq!(accepted_blocks.len(), 1)` therefore encoded an invariant that no longer holds and could panic during block production.

This removes the count assert — the accepted count is not meaningful at this call site. The remaining invariant, that an own block has no missing ancestors, is preserved and now guarded two ways: an `error!` log so a violation is observable in production, and a `debug_assert!` so the same case still hard-fails tests and simtests.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
