### PR TITLE
refactor(indexer): consolidate ObjectStatus and BackwardHistoryObjectStatus

### DIFF
--- a/crates/iota-graphql-rpc/src/backward_view/consistent.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/consistent.rs
@@ -80,10 +80,7 @@ fn consistent_historical_objects(
 
     let history_window = filter!(
         history_filtered,
-        format!(
-            "superseded_at_checkpoint > {} AND object_status = {ACTIVE}",
-            checkpoint_viewed_at
-        )
+        format!("superseded_at_checkpoint > {checkpoint_viewed_at} AND object_status = {ACTIVE}")
     );
 
     let oldest_subquery = query!(format!(

--- a/crates/iota-graphql-rpc/src/backward_view/consistent.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/consistent.rs
@@ -6,7 +6,7 @@
 //! versions from `objects_backward_history`.
 
 use crate::{
-    backward_view::{CHECKPOINTED_ACTIVE, HISTORY_ACTIVE, OBJECT_COLUMNS, merge_and_deduplicate},
+    backward_view::{ACTIVE, OBJECT_COLUMNS, merge_and_deduplicate},
     filter, query,
     raw_query::RawQuery,
     types::{
@@ -44,7 +44,7 @@ fn consistent_checkpointed_objects(
         filter_fn(query!(format!(
             "SELECT {OBJECT_COLUMNS} FROM checkpointed_objects"
         ))),
-        format!("object_status = {CHECKPOINTED_ACTIVE}")
+        format!("object_status = {ACTIVE}")
     );
 
     let changed_subquery = query!(format!(
@@ -81,7 +81,7 @@ fn consistent_historical_objects(
     let history_window = filter!(
         history_filtered,
         format!(
-            "superseded_at_checkpoint > {} AND object_status = {HISTORY_ACTIVE}",
+            "superseded_at_checkpoint > {} AND object_status = {ACTIVE}",
             checkpoint_viewed_at
         )
     );

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -53,10 +53,7 @@ fn historical_objects(page: &Page<Cursor>, filter_fn: &impl Fn(RawQuery) -> RawQ
     let history_filtered = filter_fn(query!(format!(
         "SELECT {OBJECT_COLUMNS} FROM objects_backward_history"
     )));
-    let history_window = filter!(
-        history_filtered,
-        format!("object_status = {ACTIVE}")
-    );
+    let history_window = filter!(history_filtered, format!("object_status = {ACTIVE}"));
     let source = query!("SELECT candidates.* FROM ({}) candidates", history_window);
     page.apply::<StoredBackwardObject>(source)
 }

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -7,10 +7,7 @@
 //! tombstones are excluded, so such versions resolve as non-existent.
 
 use crate::{
-    backward_view::{
-        CHECKPOINTED_ACTIVE, HISTORY_ACTIVE, HistoricalFilter, OBJECT_COLUMNS,
-        merge_and_deduplicate,
-    },
+    backward_view::{ACTIVE, HistoricalFilter, OBJECT_COLUMNS, merge_and_deduplicate},
     filter, query,
     raw_query::RawQuery,
     types::{
@@ -41,7 +38,7 @@ fn checkpointed_objects(
         filter_fn(query!(format!(
             "SELECT {OBJECT_COLUMNS} FROM checkpointed_objects"
         ))),
-        format!("object_status = {CHECKPOINTED_ACTIVE}")
+        format!("object_status = {ACTIVE}")
     );
     let source = query!(
         "SELECT candidates.* FROM ({}) candidates",
@@ -58,7 +55,7 @@ fn historical_objects(page: &Page<Cursor>, filter_fn: &impl Fn(RawQuery) -> RawQ
     )));
     let history_window = filter!(
         history_filtered,
-        format!("object_status = {HISTORY_ACTIVE}")
+        format!("object_status = {ACTIVE}")
     );
     let source = query!("SELECT candidates.* FROM ({}) candidates", history_window);
     page.apply::<StoredBackwardObject>(source)

--- a/crates/iota-graphql-rpc/src/backward_view/mod.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/mod.rs
@@ -8,9 +8,7 @@ pub(crate) mod consistent;
 pub(crate) mod dynamic_fields;
 pub(crate) mod historical;
 
-use iota_indexer::{
-    models::objects::BackwardHistoryObjectStatus, types::ObjectStatus as NativeObjectStatus,
-};
+use iota_indexer::types::ObjectStatus as NativeObjectStatus;
 
 use crate::{query, raw_query::RawQuery, types::object::ObjectFilter};
 
@@ -50,14 +48,10 @@ impl HistoricalFilter {
     }
 }
 
-/// Active status in `checkpointed_objects` (`ObjectStatus`). Backward-view
-/// sources keep only these rows; wrapped or deleted tombstones and
-/// `NotYetCreated` markers are excluded.
-pub(super) const CHECKPOINTED_ACTIVE: i16 = NativeObjectStatus::Active as i16;
-
-/// Active status in `objects_backward_history` (`BackwardHistoryObjectStatus`).
-/// Counterpart of [`CHECKPOINTED_ACTIVE`] for the backward-history table.
-pub(super) const HISTORY_ACTIVE: i16 = BackwardHistoryObjectStatus::Active as i16;
+/// Active status used by backward-view sources in both `checkpointed_objects`
+/// and `objects_backward_history`. Backward-view queries keep only these rows;
+/// wrapped or deleted tombstones and `NotYetCreated` markers are excluded.
+pub(super) const ACTIVE: i16 = NativeObjectStatus::Active as i16;
 
 /// Watermark entity name for `objects_backward_history`. Must match the
 /// `CommitterTables::ObjectsBackwardHistory` strum serialization in

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -43,13 +43,13 @@ use crate::{
         display::StoredDisplay,
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate},
         obj_indices::StoredObjectVersion,
-        objects::{BackwardHistoryObjectStatus, StoredBackwardHistoryObject},
+        objects::StoredBackwardHistoryObject,
     },
     store::{IndexerStore, PgIndexerStore},
     types::{
         EventIndex, IndexedBalanceChange, IndexedCheckpoint, IndexedEpochInfoEvent, IndexedEvent,
         IndexedObject, IndexedObjectChange, IndexedPackage, IndexedTransaction, IndexerResult,
-        TxIndex,
+        ObjectStatus, TxIndex,
     },
 };
 
@@ -619,7 +619,7 @@ impl PrimaryWorker {
                 result.push(StoredBackwardHistoryObject::from_empty(
                     r.object_id,
                     r.version.as_u64() as i64 - 1,
-                    BackwardHistoryObjectStatus::NotYetCreated,
+                    ObjectStatus::NotYetCreated,
                     checkpoint_seq,
                 ));
             }
@@ -632,7 +632,7 @@ impl PrimaryWorker {
                 result.push(StoredBackwardHistoryObject::from_empty(
                     r.object_id,
                     r.version.as_u64() as i64 - 1,
-                    BackwardHistoryObjectStatus::WrappedOrDeleted,
+                    ObjectStatus::WrappedOrDeleted,
                     checkpoint_seq,
                 ));
             }

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -168,47 +168,58 @@ impl StoredHistoryObject {
             ))
         })?;
 
-        if let ObjectStatus::WrappedOrDeleted = object_status {
-            let object_ref = ObjectRef::new(
-                ObjectId::from_bytes(self.object_id.clone())
-                    .map_err(|_| IndexerError::ObjectIdParse(ObjectIdParseError::TryFromSlice))?,
-                SequenceNumber::from_u64(self.object_version as u64),
-                ObjectDigest::OBJECT_DELETED,
-            );
-            return Ok(PastObjectRead::ObjectDeleted(object_ref));
-        }
+        match object_status {
+            ObjectStatus::Active => {
+                let object: Object = self.try_into()?;
+                let object_ref = object.object_ref();
 
-        let object: Object = self.try_into()?;
-        let object_ref = object.object_ref();
+                let Some(move_object) = object.data.as_struct_opt().cloned() else {
+                    return Ok(PastObjectRead::VersionFound(object_ref, object, None));
+                };
 
-        let Some(move_object) = object.data.as_struct_opt().cloned() else {
-            return Ok(PastObjectRead::VersionFound(object_ref, object, None));
-        };
+                let move_type_layout = package_resolver
+                    .type_layout(move_object.type_tag())
+                    .await
+                    .map_err(|e| {
+                    IndexerError::ResolveMoveStruct(format!(
+                        "failed to convert into object read for obj {}:{}, type: {}. error: {e}",
+                        object.id(),
+                        object.version(),
+                        move_object.struct_tag(),
+                    ))
+                })?;
 
-        let move_type_layout = package_resolver
-            .type_layout(move_object.type_tag())
-            .await
-            .map_err(|e| {
-                IndexerError::ResolveMoveStruct(format!(
-                    "failed to convert into object read for obj {}:{}, type: {}. error: {e}",
-                    object.id(),
-                    object.version(),
-                    move_object.struct_tag(),
+                let move_struct_layout = match move_type_layout {
+                    MoveTypeLayout::Struct(s) => Ok(s),
+                    _ => Err(IndexerError::ResolveMoveStruct(
+                        "MoveTypeLayout is not a Struct".to_string(),
+                    )),
+                }?;
+
+                Ok(PastObjectRead::VersionFound(
+                    object_ref,
+                    object,
+                    Some(*move_struct_layout),
                 ))
-            })?;
-
-        let move_struct_layout = match move_type_layout {
-            MoveTypeLayout::Struct(s) => Ok(s),
-            _ => Err(IndexerError::ResolveMoveStruct(
-                "MoveTypeLayout is not a Struct".to_string(),
-            )),
-        }?;
-
-        Ok(PastObjectRead::VersionFound(
-            object_ref,
-            object,
-            Some(*move_struct_layout),
-        ))
+            }
+            ObjectStatus::WrappedOrDeleted => {
+                let object_ref = ObjectRef::new(
+                    ObjectId::from_bytes(self.object_id.clone()).map_err(|_| {
+                        IndexerError::ObjectIdParse(ObjectIdParseError::TryFromSlice)
+                    })?,
+                    SequenceNumber::from_u64(self.object_version as u64),
+                    ObjectDigest::OBJECT_DELETED,
+                );
+                Ok(PastObjectRead::ObjectDeleted(object_ref))
+            }
+            ObjectStatus::NotYetCreated => {
+                Err(IndexerError::PersistentStorageDataCorruption(format!(
+                    "Object {} at version {} has status NotYetCreated for past object read",
+                    ObjectId::from_bytes(self.object_id.clone()).unwrap(),
+                    self.object_version,
+                )))
+            }
+        }
     }
 }
 
@@ -268,7 +279,7 @@ impl TryFrom<IndexedObject> for StoredBackwardHistoryObject {
         Ok(Self {
             object_id: object.id().as_bytes().to_vec(),
             object_version: object.version().as_u64() as i64,
-            object_status: BackwardHistoryObjectStatus::Active as i16,
+            object_status: ObjectStatus::Active as i16,
             object_digest: Some(object.digest().into_inner().to_vec()),
             superseded_at_checkpoint: checkpoint_sequence_number,
             owner_type: Some(owner_type as i16),
@@ -703,17 +714,6 @@ mod tests {
     }
 }
 
-/// Status of an object in the backward history table.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BackwardHistoryObjectStatus {
-    /// The object existed and was active before being superseded.
-    Active = 0,
-    /// The object was wrapped or deleted (no data available).
-    WrappedOrDeleted = 1,
-    /// The object did not exist yet (it was created in this checkpoint).
-    NotYetCreated = 2,
-}
-
 #[derive(Queryable, Insertable, Selectable, Debug, Identifiable, Clone, QueryableByName)]
 #[diesel(table_name = objects_backward_history, primary_key(superseded_at_checkpoint, object_id, object_version))]
 pub struct StoredBackwardHistoryObject {
@@ -741,7 +741,7 @@ impl StoredBackwardHistoryObject {
     pub fn from_empty(
         object_id: ObjectId,
         object_version: i64,
-        status: BackwardHistoryObjectStatus,
+        status: ObjectStatus,
         superseded_at_checkpoint: i64,
     ) -> Self {
         Self {

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -268,6 +268,10 @@ pub enum OwnerType {
 pub enum ObjectStatus {
     Active = 0,
     WrappedOrDeleted = 1,
+    /// Only `objects_backward_history` stores this status, to mark that the
+    /// object did not yet exist at the recorded version. Encountering it when
+    /// reading any other table is data corruption.
+    NotYetCreated = 2,
 }
 
 impl TryFrom<i16> for ObjectStatus {
@@ -277,6 +281,7 @@ impl TryFrom<i16> for ObjectStatus {
         Ok(match value {
             0 => ObjectStatus::Active,
             1 => ObjectStatus::WrappedOrDeleted,
+            2 => ObjectStatus::NotYetCreated,
             value => {
                 return Err(IndexerError::PersistentStorageDataCorruption(format!(
                     "{value} as ObjectStatus"

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -21,7 +21,7 @@ mod ingestion_tests {
         models::{
             checkpoints::StoredCheckpoint,
             obj_indices::StoredObjectVersion,
-            objects::{BackwardHistoryObjectStatus, StoredCheckpointedObject, StoredObject},
+            objects::{StoredCheckpointedObject, StoredObject},
             transactions::{StoredTransaction, TxGlobalOrder},
             tx_indices::StoredTxDigest,
         },
@@ -712,10 +712,7 @@ mod ingestion_tests {
         // minus one).
         let entry = find_backward_entry(&pg_store, created_coin_1.as_bytes(), 1)?
             .expect("created coin 1 must have a backward history entry at cp 1");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::NotYetCreated as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         assert_eq!(
             entry.object_version,
             created_coin_1_version.as_u64() as i64 - 1
@@ -725,10 +722,7 @@ mod ingestion_tests {
 
         let entry = find_backward_entry(&pg_store, created_coin_2.as_bytes(), 1)?
             .expect("created coin 2 must have a backward history entry at cp 1");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::NotYetCreated as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         assert_eq!(
             entry.object_version,
             created_coin_2_version.as_u64() as i64 - 1
@@ -742,10 +736,7 @@ mod ingestion_tests {
             2,
             "gas object should have 2 backward history entries in cp 1 (one per tx)"
         );
-        assert_eq!(
-            gas_entries[0].object_status,
-            BackwardHistoryObjectStatus::Active as i16
-        );
+        assert_eq!(gas_entries[0].object_status, ObjectStatus::Active as i16);
         assert_eq!(
             gas_entries[0].object_version,
             gas_version_before_tx1.as_u64() as i64
@@ -754,10 +745,7 @@ mod ingestion_tests {
         assert!(gas_entries[0].object_digest.is_some());
         assert!(gas_entries[0].owner_type.is_some());
 
-        assert_eq!(
-            gas_entries[1].object_status,
-            BackwardHistoryObjectStatus::Active as i16
-        );
+        assert_eq!(gas_entries[1].object_status, ObjectStatus::Active as i16);
         assert_eq!(
             gas_entries[1].object_version,
             gas_version_before_tx2.as_u64() as i64
@@ -768,10 +756,7 @@ mod ingestion_tests {
 
         let entry = find_backward_entry(&pg_store, created_coin_3.as_bytes(), 2)?
             .expect("created coin 3 must have a backward history entry at cp 2");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::NotYetCreated as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         assert_eq!(
             entry.object_version,
             created_coin_3_version.as_u64() as i64 - 1
@@ -779,10 +764,7 @@ mod ingestion_tests {
 
         let entry = find_backward_entry(&pg_store, gas_object_id.as_bytes(), 2)?
             .expect("gas object must have a backward history entry at cp 2");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::Active as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert_eq!(entry.object_version, gas_version_before_tx3.as_u64() as i64);
         assert!(entry.serialized_object.is_some());
 

--- a/crates/iota-indexer/tests/rpc-tests/backward_history.rs
+++ b/crates/iota-indexer/tests/rpc-tests/backward_history.rs
@@ -7,7 +7,7 @@
 
 use std::str::FromStr;
 
-use iota_indexer::{models::objects::BackwardHistoryObjectStatus, store::PgIndexerStore};
+use iota_indexer::{store::PgIndexerStore, types::ObjectStatus};
 use iota_json::{IotaJsonValue, call_args};
 use iota_json_rpc_api::ReadApiClient;
 use iota_json_rpc_types::{
@@ -178,10 +178,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
 
         let entry = find_backward_entry(store, item_id.as_bytes(), create_cp)?
             .expect("item should have backward history at create checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::NotYetCreated as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         // NotYetCreated rows carry lamport - 1 so MIN(object_version) stays
         // monotonic across the object's lifecycle.
         assert_eq!(
@@ -209,10 +206,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
 
         let entry = find_backward_entry(store, item_id.as_bytes(), mutate_cp)?
             .expect("item should have backward history at mutate checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::Active as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(
             entry.serialized_object.is_some(),
             "ACTIVE entry must have data"
@@ -241,19 +235,13 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         // Item was wrapped → ACTIVE backward entry with previous data.
         let entry = find_backward_entry(store, item_id.as_bytes(), wrap_cp)?
             .expect("item should have backward history at wrap checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::Active as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(entry.serialized_object.is_some());
 
         // Box was created → NOT_YET_CREATED.
         let entry = find_backward_entry(store, box_id.as_bytes(), wrap_cp)?
             .expect("box should have backward history at wrap checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::NotYetCreated as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         assert_eq!(entry.object_version, box_create_version.as_u64() as i64 - 1);
 
         // ================================================================
@@ -277,10 +265,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         // Version should be lamport - 1 (the output version minus one).
         let entry = find_backward_entry(store, item_id.as_bytes(), unwrap_cp)?
             .expect("item should have backward history at unwrap checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::WrappedOrDeleted as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::WrappedOrDeleted as i16);
         assert_eq!(
             entry.object_version,
             item_unwrap_version.as_u64() as i64 - 1,
@@ -292,10 +277,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         // Box was deleted → ACTIVE backward entry with data.
         let entry = find_backward_entry(store, box_id.as_bytes(), unwrap_cp)?
             .expect("box should have backward history at unwrap checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::Active as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(entry.serialized_object.is_some());
 
         // ================================================================
@@ -317,10 +299,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         // Item was deleted → ACTIVE backward entry with previous data.
         let entry = find_backward_entry(store, item_id.as_bytes(), delete_cp)?
             .expect("item should have backward history at delete checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::Active as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(entry.serialized_object.is_some());
 
         // ================================================================
@@ -372,20 +351,14 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         // Box was deleted → ACTIVE backward entry.
         let entry = find_backward_entry(store, box2_id.as_bytes(), unwrap_delete_cp)?
             .expect("box2 should have backward history at unwrap_and_delete checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::Active as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(entry.serialized_object.is_some());
 
         // Item inside was unwrapped-then-deleted → WRAPPED_OR_DELETED.
         let item2_utd_version = unwrapped_then_deleted_version(&resp, item2_id);
         let entry = find_backward_entry(store, item2_id.as_bytes(), unwrap_delete_cp)?
             .expect("item2 should have backward history at unwrap_and_delete checkpoint");
-        assert_eq!(
-            entry.object_status,
-            BackwardHistoryObjectStatus::WrappedOrDeleted as i16
-        );
+        assert_eq!(entry.object_status, ObjectStatus::WrappedOrDeleted as i16);
         assert_eq!(
             entry.object_version,
             item2_utd_version.as_u64() as i64 - 1,
@@ -407,11 +380,11 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         assert_eq!(
             statuses,
             vec![
-                BackwardHistoryObjectStatus::NotYetCreated as i16, // create
-                BackwardHistoryObjectStatus::Active as i16,        // mutate
-                BackwardHistoryObjectStatus::Active as i16,        // wrap
-                BackwardHistoryObjectStatus::WrappedOrDeleted as i16, // unwrap
-                BackwardHistoryObjectStatus::Active as i16,        // delete
+                ObjectStatus::NotYetCreated as i16,    // create
+                ObjectStatus::Active as i16,           // mutate
+                ObjectStatus::Active as i16,           // wrap
+                ObjectStatus::WrappedOrDeleted as i16, // unwrap
+                ObjectStatus::Active as i16,           // delete
             ]
         );
 


### PR DESCRIPTION
# Description of change

Merge the two object status enums into a single `ObjectStatus` with a new `NotYetCreated` variant.
Single enum can be used for queries that join `checkpointed_objects` and `objects_backward_history`.

`NotYetCreated` is only valid in `objects_backward_history` and is always filtered out by the queries.
The deserialization path `StoredHistoryObject::try_into_past_object_read` rejects it as data corruption; on the GraphQL side, the existing `TryFrom<StoredHistoryObject> for ActiveObject` already rejects any non-Active status with `Error::Internal`, so the consolidated `NotYetCreated` is automatically handled.

## Links to any relevant issues

fixes #11861

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.