### PR TITLE
upstream(core): Wrap notify_read_effects with within_alive_epoch

### DIFF
--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -393,7 +393,7 @@ where
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.transaction.digest()))]
     pub async fn execute_transaction_impl(
         &self,
-        epoch_store: &AuthorityPerEpochStore,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
     ) -> Result<(VerifiedTransaction, QuorumDriverResponse), QuorumDriverError> {
@@ -434,7 +434,12 @@ where
         });
 
         let ticket = self
-            .submit(transaction.clone(), request, client_addr)
+            .submit(
+                epoch_store.clone(),
+                transaction.clone(),
+                request,
+                client_addr,
+            )
             .await
             .map_err(|e| {
                 warn!(?tx_digest, "QuorumDriverInternalError: {e:?}");
@@ -470,6 +475,7 @@ where
     #[instrument(name = "tx_orchestrator_submit", level = "trace", skip_all)]
     async fn submit(
         &self,
+        epoch_store: Arc<AuthorityPerEpochStore>,
         transaction: VerifiedTransaction,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
@@ -497,7 +503,8 @@ where
         let qd = self.clone_quorum_driver();
         Ok(async move {
             let digests = [tx_digest];
-            let effects_await = cache_reader.try_notify_read_executed_effects(&digests);
+            let effects_await = epoch_store
+                .within_alive_epoch(cache_reader.try_notify_read_executed_effects(&digests));
             // let-and-return necessary to satisfy borrow checker.
             let res = match select(ticket, effects_await.boxed()).await {
                 Either::Left((quorum_driver_response, _)) => Ok(quorum_driver_response),


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.51.5, v1.52.3)
- Port commit:
  - [MystenLabs/sui@0471c68](https://github.com/MystenLabs/sui/commit/0471c68e336c863f595a6f2da5589eb82b41319f)
- Description:

Wrap the effects notify-read in `submit` with `epoch_store.within_alive_epoch(...)`
so the future is cancelled at the epoch boundary instead of hanging across a
reconfiguration. This avoids the `fatal!("digests must exist")` panic in
`execution_cache.rs` that occurs when the digests become available but their
effects are no longer present after an epoch change.

To enable this, `epoch_store` is threaded into `submit` (now taking an owned
`Arc<AuthorityPerEpochStore>`), and `execute_transaction_impl` takes
`&Arc<AuthorityPerEpochStore>` so it can clone it down.

Upstream fixes the following test failure:

```
thread '<unnamed>' panicked at crates/sui-core/src/execution_cache.rs:540:46:
digests must exist
```

## Links to any relevant issues

Part of #11885

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes