### PR TITLE
feat(docs): documentation for checkpoint filtering for the `RemoteUrl::Fullnode` gRPC stream.

### DIFF
--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -57,13 +57,17 @@ In this example, the [`CheckpointData`](https://iotaledger.github.io/iota/iota_t
 
 ## Checkpoint Stream Sources
 
-Data ingestion for your indexer supports several checkpoint stream sources.
+Data ingestion for your indexer supports several checkpoint stream sources. A source can be [remote](#remote-reader), [local](#local-reader), or a [combination of both](#hybrid-mode).
 
 ### Remote Reader
 
-The most straightforward stream source is to subscribe to a remote store of checkpoint contents. The IOTA Foundation provides the following endpoints for downloading checkpoint data:
+The most straightforward stream source is to subscribe to a remote store of checkpoint contents. A remote source can be either a historical checkpoint store or a direct gRPC stream to an IOTA full node.
 
-#### Historical Checkpoint Data
+#### Historical Checkpoint Store
+
+An IOTA full node is not guaranteed to retain all historical data, depending on its configuration, older checkpoints may be pruned. To sync from genesis up to the tip of the network, the indexer must rely on a dedicated checkpoint store. The IOTA Foundation provides the following endpoints for downloading historical checkpoint data.
+
+**Historical Checkpoint Data**
 
 For syncing historical data up to the tip of the network:
 
@@ -71,7 +75,7 @@ For syncing historical data up to the tip of the network:
 - Testnet: `https://checkpoints.testnet.iota.cafe/ingestion/historical`
 - Mainnet: `https://checkpoints.mainnet.iota.cafe/ingestion/historical`
 
-#### Live Checkpoint Streaming (Optional)
+**Live Checkpoint Streaming (Optional)**
 
 For real-time streaming of current epoch checkpoints only:
 
@@ -115,7 +119,11 @@ In this example, we'll explore a simple custom indexer that can ingest data from
 ```rust file=<rootDir>/examples/custom-indexer/rust/remote_reader.rs
 ```
 
-#### Filtering Checkpoint Data
+#### Fullnode gRPC Checkpoint Data Stream
+
+For local development against a local network, or for public networks that expose a fullnode gRPC API, you can use the [`RemoteUrl::Fullnode`](https://iotaledger.github.io/iota/iota_data_ingestion_core/reader/v2/enum.RemoteUrl.html#variant.Fullnode) variant to connect directly to a fullnode. The gRPC stream delivers checkpoint data efficiently and with minimal latency. For more advanced use cases, it also exposes a filtering mechanism that lets you include only specific transactions in each checkpoint payload.
+
+**Filtering Checkpoint Data**
 
 When using the [`RemoteUrl::Fullnode`](https://iotaledger.github.io/iota/iota_data_ingestion_core/reader/v2/enum.RemoteUrl.html#variant.Fullnode) gRPC checkpoint stream API, you can register a filter that instructs the fullnode to include only specific transactions in each checkpoint payload.
 

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -158,9 +158,9 @@ let filter = TransactionFilter::new()
     .or(!TransactionFilter::new().receiver(bob));
 ```
 
-<a id="negate-scoping"></a>
+:::caution
 
-:::caution `negate` scoping
+#### `negate` scoping {#negate-scoping}
 
 The `negate()` method (or the `!` operator) applies a logical **NOT** to the filter chain. Because the filter is built with a chained builder, `negate()` operates on everything accumulated up to that point, not just the most recent method call. The position of `negate()` determines its scope: calling it early negates only the criteria accumulated before it, which are then **AND**ed with whatever follows; calling it at the end negates the entire accumulated expression.
 

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -11,7 +11,7 @@ import Quiz from '@site/src/components/Quiz';
 import questions from '/json/developer/advanced-topics/custom-indexer.json';
 import CodeBlock from '@theme/CodeBlock';
 
-You can build custom indexers using the IOTA data ingestion framework, which is maintained through the [iota-data-ingestion-core][] library. To create an indexer, you subscribe to a checkpoint stream with full checkpoint content. This stream can be one of the publicly available streams from IOTA, one that you set up in your local environment, or a combination of the two.
+You can build custom indexers using the IOTA data ingestion framework, which is maintained through the [iota-data-ingestion-core][iota-data-ingestion-core] library. To create an indexer, you subscribe to a checkpoint stream with full checkpoint content. This stream can be one of the publicly available streams from IOTA, one that you set up in your local environment, or a combination of the two.
 
 Establishing a custom indexer helps improve latency, allows pruning the data of your IOTA full node, and provides efficient assemblage of checkpoint data.
 
@@ -114,6 +114,73 @@ In this example, we'll explore a simple custom indexer that can ingest data from
 
 ```rust file=<rootDir>/examples/custom-indexer/rust/remote_reader.rs
 ```
+
+#### Filtering Checkpoint Data
+
+When using the [`RemoteUrl::Fullnode`](https://iotaledger.github.io/iota/iota_data_ingestion_core/reader/v2/enum.RemoteUrl.html#variant.Fullnode) gRPC checkpoint stream API, you can register a filter that instructs the fullnode to include only specific transactions in each checkpoint payload.
+
+Filtering occurs entirely server-side, so the ingestion framework performs no client-side filtering of its own. This is especially useful when a custom indexer targets specific data, since it avoids transferring irrelevant transactions over the network.
+
+```rust file=<rootDir>/examples/custom-indexer/rust/remote_reader_with_filters.rs
+```
+
+In the example above, `CustomWorker::process_checkpoint` is only invoked for checkpoints that contain at least one matching transaction. Checkpoints with no matches are skipped.
+
+A [`TransactionFilter`](https://iotaledger.github.io/iota/iota_data_ingestion_core/reader/filters/fullnode/struct.TransactionFilter.html) is built with a chained builder. Start from `TransactionFilter::new()` and add leaves with the named methods, such as `kinds()`, `sender()`, `receiver()`, and `execution_status()`. An empty `TransactionFilter::new()` is rejected by the fullnode, so always add at least one leaf before passing it to the reader.
+
+:::info Composition semantics
+
+- Each leaf you add **implicitly ANDs** with everything accumulated so far.
+- Use `or()` to compose a logical **OR** with another `TransactionFilter`.
+- Use `negate()` (or the `!` operator) for **NOT**. It wraps the entire filter accumulated so far, not just the most recent leaf ([see below](#negate-scoping)).
+
+:::
+
+A simple filter, showcasing implicit **AND** composition:
+
+```rust
+use iota_data_ingestion_core::filters::fullnode::{TransactionFilter, TransactionKind};
+
+// Programmable AND success
+let filter = TransactionFilter::new()
+    .kinds([TransactionKind::Programmable])
+    .execution_status(true);
+```
+
+Composition with **AND**, **OR**, and **NOT**:
+
+```rust
+// (Programmable AND success AND sender == Alice) OR NOT(receiver == Bob)
+let filter = TransactionFilter::new()
+    .kinds([TransactionKind::Programmable])
+    .execution_status(true)
+    .sender(alice)
+    .or(!TransactionFilter::new().receiver(bob));
+```
+
+<a id="negate-scoping"></a>
+
+:::caution `negate` scoping
+
+The `negate()` method (or the `!` operator) applies a logical **NOT** to the filter chain. Because the filter is built with a chained builder, `negate()` operates on everything accumulated up to that point, not just the most recent method call. The position of `negate()` determines its scope: calling it early negates only the criteria accumulated before it, which are then **AND**ed with whatever follows; calling it at the end negates the entire accumulated expression.
+
+```rust
+// (NOT Programmable) AND sender == Alice
+TransactionFilter::new()
+    .kinds([TransactionKind::Programmable])
+    .negate()
+    .sender(alice);
+
+// NOT (Programmable AND sender == Alice)
+TransactionFilter::new()
+    .kinds([TransactionKind::Programmable])
+    .sender(alice)
+    .negate();
+```
+
+For complex expressions where the scoping is not visually obvious, build sub-filters as named bindings and combine them with `or()`.
+
+:::
 
 ### Local Reader
 

--- a/examples/custom-indexer/rust/Cargo.toml
+++ b/examples/custom-indexer/rust/Cargo.toml
@@ -26,3 +26,7 @@ path = "remote_reader.rs"
 [[bin]]
 name = "hybrid_reader"
 path = "hybrid_reader.rs"
+
+[[bin]]
+name = "remote_reader_with_filters"
+path = "remote_reader_with_filters.rs"

--- a/examples/custom-indexer/rust/remote_reader_with_filters.rs
+++ b/examples/custom-indexer/rust/remote_reader_with_filters.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{env, sync::Arc};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use iota_data_ingestion_core::{
+    DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, Worker, WorkerPool,
+    reader::{
+        config::{CheckpointReaderConfig, CheckpointReaderConfigExt, RemoteUrl},
+        filters::fullnode::{TransactionFilter, TransactionKind},
+    },
+};
+use iota_types::full_checkpoint_content::CheckpointData;
+use prometheus::Registry;
+
+struct CustomWorker;
+
+#[async_trait]
+impl Worker for CustomWorker {
+    type Message = ();
+    type Error = anyhow::Error;
+
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<Self::Message> {
+        // custom processing logic
+        println!("Processing checkpoint: {}", *checkpoint.checkpoint_summary);
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Number of Workers to process checkpoints in parallel.
+    let concurrency = 5;
+    let metrics = DataIngestionMetrics::new(&Registry::new());
+    let progress_file_path =
+        env::var("PROGRESS_FILE_PATH").unwrap_or("/tmp/remote_reader_progress".to_string());
+    // Save last processed checkpoint to a file.
+    let progress_store = FileProgressStore::new(progress_file_path).await?;
+
+    let mut executor = IndexerExecutor::new(
+        progress_store,
+        1, // should match the total number of registered workers.
+        metrics,
+        Default::default(),
+    );
+    let worker_pool = WorkerPool::new(
+        CustomWorker,
+        "remote_reader".to_string(),
+        concurrency,
+        Default::default(),
+    );
+
+    executor.register(worker_pool).await?;
+
+    let base_config = CheckpointReaderConfig {
+        reader_options: ReaderOptions::default(),
+        remote_store_url: Some(RemoteUrl::Fullnode("http://127.0.0.1:50051".into())),
+        ..Default::default()
+    };
+
+    // Programmable transaction kind AND successful execution status
+    let filter = TransactionFilter::new()
+        .kinds([TransactionKind::Programmable])
+        .execution_status(true);
+
+    let config =
+        CheckpointReaderConfigExt::from(base_config).with_fullnode_transaction_filter(filter);
+
+    executor.run_with_config(config).await?;
+    Ok(())
+}


### PR DESCRIPTION
# Description of change

This PR adds documentation for checkpoint filtering in the `RemoteUrl::Fullnode` gRPC stream, covering filter composition (`AND`/`OR`/`NOT`) and `negate()` scoping. 

Also added anew custom indexer example (`remote_reader_with_filters.rs`) showcasing the usage of a new filter. 

## Links to any relevant issues

fixes #11611 

## How the change has been tested

- Newly added example works as expected.
- Compiled locally the docs.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.
