### PR TITLE
feat(starfish-core): derive fetch response byte limits from per-fetch caps

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -60,13 +60,14 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_max_transactions_per_commit_sync_fetch")]
     pub max_transactions_per_commit_sync_fetch: usize,
 
-    /// Number of block headers to fetch per periodic or live sync request
-    #[serde(default = "Parameters::default_max_headers_per_regular_sync_fetch")]
-    pub max_headers_per_regular_sync_fetch: usize,
+    /// Number of block headers to fetch per header sync (periodic or live)
+    /// request.
+    #[serde(default = "Parameters::default_max_headers_per_header_sync_fetch")]
+    pub max_headers_per_header_sync_fetch: usize,
 
-    /// Number of transactions to fetch per request.
-    #[serde(default = "Parameters::default_max_transactions_per_regular_sync_fetch")]
-    pub max_transactions_per_regular_sync_fetch: usize,
+    /// Number of transactions to fetch per transaction sync request.
+    #[serde(default = "Parameters::default_max_transactions_per_transaction_sync_fetch")]
+    pub max_transactions_per_transaction_sync_fetch: usize,
 
     /// Time to wait during node start up until the node has synced the last
     /// proposed block via the network peers. When set to `0` the sync
@@ -184,13 +185,12 @@ impl Parameters {
     }
 
     /// Maximum number of block headers served per fetch request, depending on
-    /// whether the request comes from commit sync or the periodic/live
-    /// synchronizer.
+    /// whether the request comes from commit sync or the header synchronizer.
     pub fn max_headers_per_fetch(&self, commit_sync: bool) -> usize {
         if commit_sync {
             self.max_headers_per_commit_sync_fetch
         } else {
-            self.max_headers_per_regular_sync_fetch
+            self.max_headers_per_header_sync_fetch
         }
     }
 
@@ -214,8 +214,9 @@ impl Parameters {
         }
     }
 
-    // Maximum number of block headers to fetch per periodic or live sync request.
-    pub(crate) fn default_max_headers_per_regular_sync_fetch() -> usize {
+    // Maximum number of block headers to fetch per header sync (periodic or
+    // live) request.
+    pub(crate) fn default_max_headers_per_header_sync_fetch() -> usize {
         if cfg!(msim) {
             // Exercise hitting blocks per fetch limit.
             10
@@ -225,8 +226,8 @@ impl Parameters {
         }
     }
 
-    // Maximum number of transactions to fetch per request.
-    pub(crate) fn default_max_transactions_per_regular_sync_fetch() -> usize {
+    // Maximum number of transactions to fetch per transaction sync request.
+    pub(crate) fn default_max_transactions_per_transaction_sync_fetch() -> usize {
         if cfg!(msim) { 10 } else { 1000 }
     }
 
@@ -323,10 +324,10 @@ impl Default for Parameters {
                 Parameters::default_max_headers_per_commit_sync_fetch(),
             max_transactions_per_commit_sync_fetch:
                 Parameters::default_max_transactions_per_commit_sync_fetch(),
-            max_headers_per_regular_sync_fetch:
-                Parameters::default_max_headers_per_regular_sync_fetch(),
-            max_transactions_per_regular_sync_fetch:
-                Parameters::default_max_transactions_per_regular_sync_fetch(),
+            max_headers_per_header_sync_fetch:
+                Parameters::default_max_headers_per_header_sync_fetch(),
+            max_transactions_per_transaction_sync_fetch:
+                Parameters::default_max_transactions_per_transaction_sync_fetch(),
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),
             dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -183,6 +183,17 @@ impl Parameters {
         (self.block_rate_window.as_millis() as u64 / interval_ms).max(1)
     }
 
+    /// Maximum number of block headers served per fetch request, depending on
+    /// whether the request comes from commit sync or the periodic/live
+    /// synchronizer.
+    pub fn max_headers_per_fetch(&self, commit_sync: bool) -> usize {
+        if commit_sync {
+            self.max_headers_per_commit_sync_fetch
+        } else {
+            self.max_headers_per_regular_sync_fetch
+        }
+    }
+
     // Maximum number of block headers to fetch per commit sync request.
     pub(crate) fn default_max_headers_per_commit_sync_fetch() -> usize {
         if cfg!(msim) {

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -16,8 +16,8 @@ block_rate_window:
   nanos: 0
 max_headers_per_commit_sync_fetch: 1000
 max_transactions_per_commit_sync_fetch: 1000
-max_headers_per_regular_sync_fetch: 100
-max_transactions_per_regular_sync_fetch: 1000
+max_headers_per_header_sync_fetch: 100
+max_transactions_per_transaction_sync_fetch: 1000
 sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1000,12 +1000,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
     }
 
     /// Handles two types of fetch headers requests:
-    /// 1. Missing block headers for regular sync:
+    /// 1. Missing block headers for header sync (periodic or live):
     ///    - uses highest_accepted_rounds.
-    ///    - at most max_blocks_per_regular_sync blocks should be returned.
+    ///    - at most max_headers_per_header_sync_fetch headers are returned.
     /// 2. Committed block headers for commit sync:
     ///    - does not use highest_accepted_rounds.
-    ///    - at most max_blocks_per_commit_sync blocks should be returned.
+    ///    - at most max_headers_per_commit_sync_fetch headers are returned.
     async fn handle_fetch_headers(
         &self,
         peer: AuthorityIndex,
@@ -3322,7 +3322,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_fetch_headers_regular_sync() {
+    async fn test_handle_fetch_headers_header_sync() {
         // GIVEN
         let rounds = 10;
         let validators = 4;

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1164,7 +1164,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     lowest_missing_round,
                     self.context
                         .parameters
-                        .max_headers_per_regular_sync_fetch
+                        .max_headers_per_header_sync_fetch
                         .saturating_sub(headers.len()),
                 );
                 let serialized_missing_headers: Vec<_> = missing_headers
@@ -1172,8 +1172,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     .map(|header| header.serialized().clone())
                     .collect();
                 headers.extend(serialized_missing_headers);
-                if headers.len() >= self.context.parameters.max_headers_per_regular_sync_fetch {
-                    headers.truncate(self.context.parameters.max_headers_per_regular_sync_fetch);
+                if headers.len() >= self.context.parameters.max_headers_per_header_sync_fetch {
+                    headers.truncate(self.context.parameters.max_headers_per_header_sync_fetch);
                     break;
                 }
             }
@@ -1440,7 +1440,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                         .max_transactions_per_commit_sync_fetch,
                     self.context
                         .parameters
-                        .max_transactions_per_regular_sync_fetch,
+                        .max_transactions_per_transaction_sync_fetch,
                 );
 
                 if committed_transactions_refs.len() > max_transactions {
@@ -3357,7 +3357,7 @@ mod tests {
         let (context, key_pairs) = Context::new_for_test(validators);
         let context = Context {
             parameters: Parameters {
-                max_headers_per_regular_sync_fetch: 20,
+                max_headers_per_header_sync_fetch: 20,
                 ..context.parameters
             },
             ..context
@@ -3486,9 +3486,9 @@ mod tests {
         // Verify that we received requested block headers
         assert_eq!(
             truncated_headers.len(),
-            context.parameters.max_headers_per_regular_sync_fetch,
+            context.parameters.max_headers_per_header_sync_fetch,
             "Should receive {} block headers",
-            context.parameters.max_headers_per_regular_sync_fetch
+            context.parameters.max_headers_per_header_sync_fetch
         );
 
         // Check the correctness of the received blocks
@@ -3502,7 +3502,7 @@ mod tests {
         }
 
         // check that missing headers from previous rounds would be added
-        block_refs_to_request.truncate(context.parameters.max_headers_per_regular_sync_fetch / 2);
+        block_refs_to_request.truncate(context.parameters.max_headers_per_header_sync_fetch / 2);
 
         let serialized_block_headers = authority_service
             .handle_fetch_headers(peer, block_refs_to_request.clone(), vec![1; validators])
@@ -3753,7 +3753,7 @@ mod tests {
             .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         let context = Context {
             parameters: Parameters {
-                max_transactions_per_regular_sync_fetch: 20,
+                max_transactions_per_transaction_sync_fetch: 20,
                 max_transactions_per_commit_sync_fetch: 10,
                 enable_fast_commit_syncer: consensus_fast_commit_sync,
                 ..context.parameters
@@ -3894,8 +3894,11 @@ mod tests {
             .await
             .expect("We should expect a correct return of serialized transactions");
 
-        block_refs_to_request_first_batch
-            .truncate(context.parameters.max_transactions_per_regular_sync_fetch);
+        block_refs_to_request_first_batch.truncate(
+            context
+                .parameters
+                .max_transactions_per_transaction_sync_fetch,
+        );
         // Verify that we received the correct number of requested transactions
         assert_eq!(
             serialized_transactions.len(),
@@ -3957,8 +3960,11 @@ mod tests {
             }
         }
 
-        block_refs_to_request_second_batch
-            .truncate(context.parameters.max_transactions_per_regular_sync_fetch);
+        block_refs_to_request_second_batch.truncate(
+            context
+                .parameters
+                .max_transactions_per_transaction_sync_fetch,
+        );
 
         let serialized_transactions = authority_service
             .handle_fetch_transactions(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -16,7 +16,7 @@ use dashmap::DashSet;
 use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
-use starfish_config::{AuthorityIndex, Stake};
+use starfish_config::AuthorityIndex;
 use tokio::sync::{Mutex, broadcast, mpsc::Sender};
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, error, info, warn};
@@ -60,11 +60,15 @@ const MAX_FILTER_SIZE: u32 = 100000;
 const MAX_BCS_LENGTH_PREFIX_BYTES: usize = 10;
 
 fn serialized_transactions_size_limit(context: &Context) -> usize {
-    (context.protocol_config.max_transactions_in_block_bytes() as usize)
-        .saturating_add(
-            (context.protocol_config.max_num_transactions_in_block() as usize)
-                .saturating_mul(MAX_BCS_LENGTH_PREFIX_BYTES),
-        )
+    let max_bytes = context.protocol_config.max_transactions_in_block_bytes() as usize;
+    let max_count = context.protocol_config.max_num_transactions_in_block() as usize;
+    // A zero protocol limit disables the corresponding check in the block
+    // verifier; without both bounds no finite serialized size is implied.
+    if max_bytes == 0 || max_count == 0 {
+        return usize::MAX;
+    }
+    max_bytes
+        .saturating_add(max_count.saturating_mul(MAX_BCS_LENGTH_PREFIX_BYTES))
         .saturating_add(MAX_BCS_LENGTH_PREFIX_BYTES)
 }
 
@@ -232,20 +236,13 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 size: serialized_transactions.len(),
                 limit: max_serialized_transactions_size,
             };
-            self.record_invalid_transactions(peer, peer_hostname, signed_block_header.author(), &e);
+            self.record_invalid_transactions(peer, peer_hostname, &e);
             return Err(e);
         }
 
         let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
             .map_err(ConsensusError::MalformedTransactions)
-            .inspect_err(|e| {
-                self.record_invalid_transactions(
-                    peer,
-                    peer_hostname,
-                    signed_block_header.author(),
-                    e,
-                );
-            })?;
+            .inspect_err(|e| self.record_invalid_transactions(peer, peer_hostname, e))?;
         let (transaction_commitment, our_shard, proof_for_shard) =
             TransactionsCommitment::compute_merkle_root_shard_and_proof(
                 &serialized_transactions,
@@ -258,7 +255,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 author: signed_block_header.author(),
                 peer,
             };
-            self.record_invalid_transactions(peer, peer_hostname, signed_block_header.author(), &e);
+            self.record_invalid_transactions(peer, peer_hostname, &e);
             return Err(e);
         }
 
@@ -267,14 +264,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 
         self.block_verifier
             .check_and_verify_transactions(&transactions)
-            .inspect_err(|e| {
-                self.record_invalid_transactions(
-                    peer,
-                    peer_hostname,
-                    verified_block_header.author(),
-                    e,
-                );
-            })?;
+            .inspect_err(|e| self.record_invalid_transactions(peer, peer_hostname, e))?;
 
         let verified_transactions = VerifiedTransactions::new(
             transactions,
@@ -300,11 +290,12 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         Ok((verified_block, shard_for_core))
     }
 
+    /// Only called after the `UnexpectedAuthority` check, so the peer is also
+    /// the block author.
     fn record_invalid_transactions(
         &self,
         peer: AuthorityIndex,
         peer_hostname: &str,
-        author: AuthorityIndex,
         error: &ConsensusError,
     ) {
         self.context
@@ -314,7 +305,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             .with_label_values(&[peer_hostname, "transactions", error.name()])
             .inc();
         self.misbehavior_store
-            .record_faulty_block_header(peer, author, error);
+            .record_faulty_block_header(peer, peer, error);
     }
 
     fn extract_additional_block_headers_from_bundle(
@@ -572,7 +563,24 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         }
     }
 
-    fn select_quorum_certifier_refs(&self, votes: Vec<BlockRef>) -> (Vec<BlockRef>, Stake, Stake) {
+    /// Selects a minimal set of vote refs — one per author, only votes for
+    /// the digest of the locally stored commit at `index` — whose stake
+    /// reaches quorum. Returns None if the commit is not stored locally or
+    /// the matching votes do not reach quorum.
+    fn read_quorum_certifier_refs(
+        &self,
+        index: CommitIndex,
+    ) -> ConsensusResult<Option<Vec<BlockRef>>> {
+        let Some(commit) = self
+            .store
+            .scan_commits((index..=index).into())?
+            .into_iter()
+            .next()
+        else {
+            debug!("Commit {index} with votes is not in the local store, skipping");
+            return Ok(None);
+        };
+        let votes = self.store.read_commit_votes(index, commit.digest())?;
         let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         let mut seen_authors = BTreeSet::new();
         let mut certifier_refs = Vec::new();
@@ -583,14 +591,16 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             let reached_quorum = stake_aggregator.add(vote.author, &self.context.committee);
             certifier_refs.push(vote);
             if reached_quorum {
-                break;
+                return Ok(Some(certifier_refs));
             }
         }
-        (
-            certifier_refs,
+        debug!(
+            "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
+            index,
             stake_aggregator.stake(),
-            stake_aggregator.threshold(&self.context.committee),
-        )
+            stake_aggregator.threshold(&self.context.committee)
+        );
+        Ok(None)
     }
 
     /// Finds the highest commit index in the commit range up to search_up_to
@@ -619,10 +629,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 return Ok(None);
             }
 
-            let votes = self.store.read_commit_votes(index_with_votes)?;
-            let (certifier_refs, certifier_stake, certifier_threshold) =
-                self.select_quorum_certifier_refs(votes);
-            if self.context.committee.reached_quorum(certifier_stake) {
+            if let Some(certifier_refs) = self.read_quorum_certifier_refs(index_with_votes)? {
                 self.context
                     .metrics
                     .node_metrics
@@ -631,10 +638,6 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .inc_by((search_up_to - index_with_votes) as u64);
                 return Ok(Some((index_with_votes, certifier_refs)));
             } else {
-                debug!(
-                    "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
-                    index_with_votes, certifier_stake, certifier_threshold
-                );
                 self.context
                     .metrics
                     .node_metrics
@@ -673,10 +676,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 return Ok(None);
             }
 
-            let votes = self.store.read_commit_votes(index_with_votes)?;
-            let (certifier_refs, certifier_stake, certifier_threshold) =
-                self.select_quorum_certifier_refs(votes);
-            if self.context.committee.reached_quorum(certifier_stake) {
+            if let Some(certifier_refs) = self.read_quorum_certifier_refs(index_with_votes)? {
                 self.context
                     .metrics
                     .node_metrics
@@ -685,10 +685,6 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .inc_by((index_with_votes - current_search_from) as u64);
                 return Ok(Some((index_with_votes, certifier_refs)));
             } else {
-                debug!(
-                    "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
-                    index_with_votes, certifier_stake, certifier_threshold
-                );
                 self.context
                     .metrics
                     .node_metrics
@@ -1060,11 +1056,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // For commit sync, the fetch size is larger. For periodic/live synchronizer,
         // the fetch size is smaller. Instead of rejecting the request, we truncate
         // the size to allow an easy update of this parameter in the future.
-        let max_fetch_size = if commit_sync_handle {
-            self.context.parameters.max_headers_per_commit_sync_fetch
-        } else {
-            self.context.parameters.max_headers_per_regular_sync_fetch
-        };
+        let max_fetch_size = self
+            .context
+            .parameters
+            .max_headers_per_fetch(commit_sync_handle);
 
         if block_refs.len() > max_fetch_size {
             warn!(
@@ -1194,11 +1189,21 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
     // can be different, bigger for fast sync and smaller for regular.
     async fn handle_fetch_commits(
         &self,
-        _peer: AuthorityIndex,
+        peer: AuthorityIndex,
         commit_range: CommitRange,
         commit_sync_type: CommitSyncType,
     ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlockHeader>)> {
         fail_point_async!("consensus-rpc-response");
+
+        // The range is peer-controlled; an inverted range would underflow the
+        // arithmetic below.
+        if commit_range.start() > commit_range.end() {
+            return Err(ConsensusError::InvalidCommitRange {
+                peer,
+                start: commit_range.start(),
+                end: commit_range.end(),
+            });
+        }
 
         // TODO: This gate can be removed once consensus_fast_commit_sync is enabled on
         // all networks. Fast commit sync type is controlled by the client, so
@@ -1776,7 +1781,7 @@ mod tests {
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
-        commit::{CertifiedCommits, CommitRange},
+        commit::{CertifiedCommits, CommitDigest, CommitRange, CommitRef},
         commit_observer::CommitObserver,
         commit_syncer::CommitSyncType,
         commit_vote_monitor::CommitVoteMonitor,
@@ -3662,6 +3667,18 @@ mod tests {
             .set_timestamp_ms((rounds as u64 + 2) * 1000)
             .build();
         new_block_headers.push(VerifiedBlockHeader::new_for_test(equivocation));
+        // Votes for a fabricated digest sort before votes for any real digest
+        // and must not crowd real votes out of the served certifier set.
+        let poisoned_votes = commit_refs
+            .iter()
+            .map(|commit_ref| CommitRef::new(commit_ref.index, CommitDigest::MIN))
+            .collect::<Vec<_>>();
+        let poisoned_equivocation = TestBlockHeader::new(rounds + 1, 2)
+            .set_commit_votes(poisoned_votes)
+            .set_ancestors(refs_to_headers_from_prev_round.clone())
+            .set_timestamp_ms((rounds as u64 + 2) * 1000 + 1)
+            .build();
+        new_block_headers.push(VerifiedBlockHeader::new_for_test(poisoned_equivocation));
         all_block_headers.push(new_block_headers[..validators].to_vec());
         core_dispatcher
             .add_block_headers(new_block_headers.clone(), DataSource::Test)
@@ -3705,6 +3722,14 @@ mod tests {
             .collect::<BTreeSet<_>>();
         assert_eq!(result.1.len(), certifier_authors.len());
         assert!(result.1.len() <= context.committee.size());
+        let end_commit_ref = result.0.last().unwrap().reference();
+        assert!(
+            result
+                .1
+                .iter()
+                .all(|header| header.commit_votes().contains(&end_commit_ref)),
+            "Served certifiers must vote for the digest of the served end commit"
+        );
         assert_eq!(
             result.0.len() as u32,
             rounds - 2,

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -4,7 +4,7 @@
 
 use std::{
     cmp::max,
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     pin::Pin,
     sync::Arc,
     time::Duration,
@@ -16,7 +16,7 @@ use dashmap::DashSet;
 use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
-use starfish_config::AuthorityIndex;
+use starfish_config::{AuthorityIndex, Stake};
 use tokio::sync::{Mutex, broadcast, mpsc::Sender};
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, error, info, warn};
@@ -55,6 +55,18 @@ use crate::{
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
 const MAX_FILTER_SIZE: u32 = 100000;
+// BCS encodes sequence lengths as ULEB128 values. Ten bytes covers any usize
+// length on supported 64-bit targets.
+const MAX_BCS_LENGTH_PREFIX_BYTES: usize = 10;
+
+fn serialized_transactions_size_limit(context: &Context) -> usize {
+    (context.protocol_config.max_transactions_in_block_bytes() as usize)
+        .saturating_add(
+            (context.protocol_config.max_num_transactions_in_block() as usize)
+                .saturating_mul(MAX_BCS_LENGTH_PREFIX_BYTES),
+        )
+        .saturating_add(MAX_BCS_LENGTH_PREFIX_BYTES)
+}
 
 struct FilterForHeaders {
     header_digests: DashSet<BlockHeaderDigest>,
@@ -214,6 +226,26 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             return Err(e);
         }
 
+        let max_serialized_transactions_size = serialized_transactions_size_limit(&self.context);
+        if serialized_transactions.len() > max_serialized_transactions_size {
+            let e = ConsensusError::SerializedTransactionsTooLarge {
+                size: serialized_transactions.len(),
+                limit: max_serialized_transactions_size,
+            };
+            self.record_invalid_transactions(peer, peer_hostname, signed_block_header.author(), &e);
+            return Err(e);
+        }
+
+        let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
+            .map_err(ConsensusError::MalformedTransactions)
+            .inspect_err(|e| {
+                self.record_invalid_transactions(
+                    peer,
+                    peer_hostname,
+                    signed_block_header.author(),
+                    e,
+                );
+            })?;
         let (transaction_commitment, our_shard, proof_for_shard) =
             TransactionsCommitment::compute_merkle_root_shard_and_proof(
                 &serialized_transactions,
@@ -221,20 +253,28 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 encoder,
             )?;
         if signed_block_header.transactions_commitment() != transaction_commitment {
-            return Err(ConsensusError::TransactionCommitmentFailure {
+            let e = ConsensusError::TransactionCommitmentFailure {
                 round: signed_block_header.round(),
                 author: signed_block_header.author(),
                 peer,
-            });
+            };
+            self.record_invalid_transactions(peer, peer_hostname, signed_block_header.author(), &e);
+            return Err(e);
         }
 
         let verified_block_header =
             VerifiedBlockHeader::new_verified(signed_block_header, serialized_block_header);
-        let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
-            .map_err(ConsensusError::MalformedTransactions)?;
 
         self.block_verifier
-            .check_and_verify_transactions(&transactions)?;
+            .check_and_verify_transactions(&transactions)
+            .inspect_err(|e| {
+                self.record_invalid_transactions(
+                    peer,
+                    peer_hostname,
+                    verified_block_header.author(),
+                    e,
+                );
+            })?;
 
         let verified_transactions = VerifiedTransactions::new(
             transactions,
@@ -258,6 +298,23 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             None
         };
         Ok((verified_block, shard_for_core))
+    }
+
+    fn record_invalid_transactions(
+        &self,
+        peer: AuthorityIndex,
+        peer_hostname: &str,
+        author: AuthorityIndex,
+        error: &ConsensusError,
+    ) {
+        self.context
+            .metrics
+            .node_metrics
+            .bundles_with_invalid_parts
+            .with_label_values(&[peer_hostname, "transactions", error.name()])
+            .inc();
+        self.misbehavior_store
+            .record_faulty_block_header(peer, author, error);
     }
 
     fn extract_additional_block_headers_from_bundle(
@@ -515,6 +572,27 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         }
     }
 
+    fn select_quorum_certifier_refs(&self, votes: Vec<BlockRef>) -> (Vec<BlockRef>, Stake, Stake) {
+        let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        let mut seen_authors = BTreeSet::new();
+        let mut certifier_refs = Vec::new();
+        for vote in votes {
+            if !seen_authors.insert(vote.author) {
+                continue;
+            }
+            let reached_quorum = stake_aggregator.add(vote.author, &self.context.committee);
+            certifier_refs.push(vote);
+            if reached_quorum {
+                break;
+            }
+        }
+        (
+            certifier_refs,
+            stake_aggregator.stake(),
+            stake_aggregator.threshold(&self.context.committee),
+        )
+    }
+
     /// Finds the highest commit index in the commit range up to search_up_to
     /// that can be certified with available votes. Returns the highest
     /// certifiable commit index and the block refs (votes) that certify it,
@@ -542,24 +620,20 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             }
 
             let votes = self.store.read_commit_votes(index_with_votes)?;
-            let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
-            for v in &votes {
-                stake_aggregator.add(v.author, &self.context.committee);
-            }
-            if stake_aggregator.reached_threshold(&self.context.committee) {
+            let (certifier_refs, certifier_stake, certifier_threshold) =
+                self.select_quorum_certifier_refs(votes);
+            if self.context.committee.reached_quorum(certifier_stake) {
                 self.context
                     .metrics
                     .node_metrics
                     .commit_sync_fetch_commits_handler_uncertified_skipped
                     .with_label_values(&[commit_sync_type.as_str()])
                     .inc_by((search_up_to - index_with_votes) as u64);
-                return Ok(Some((index_with_votes, votes)));
+                return Ok(Some((index_with_votes, certifier_refs)));
             } else {
                 debug!(
                     "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
-                    index_with_votes,
-                    stake_aggregator.stake(),
-                    stake_aggregator.threshold(&self.context.committee)
+                    index_with_votes, certifier_stake, certifier_threshold
                 );
                 self.context
                     .metrics
@@ -600,24 +674,20 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             }
 
             let votes = self.store.read_commit_votes(index_with_votes)?;
-            let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
-            for v in &votes {
-                stake_aggregator.add(v.author, &self.context.committee);
-            }
-            if stake_aggregator.reached_threshold(&self.context.committee) {
+            let (certifier_refs, certifier_stake, certifier_threshold) =
+                self.select_quorum_certifier_refs(votes);
+            if self.context.committee.reached_quorum(certifier_stake) {
                 self.context
                     .metrics
                     .node_metrics
                     .commit_sync_fetch_commits_handler_uncertified_skipped
                     .with_label_values(&[commit_sync_type.as_str()])
                     .inc_by((index_with_votes - current_search_from) as u64);
-                return Ok(Some((index_with_votes, votes)));
+                return Ok(Some((index_with_votes, certifier_refs)));
             } else {
                 debug!(
                     "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
-                    index_with_votes,
-                    stake_aggregator.stake(),
-                    stake_aggregator.threshold(&self.context.committee)
+                    index_with_votes, certifier_stake, certifier_threshold
                 );
                 self.context
                     .metrics
@@ -973,13 +1043,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
     ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
 
-        // Some quick validation of the requested block refs
-        ConsensusError::quick_validation_requested_block_refs(
-            &block_refs,
-            peer,
-            &self.context.committee,
-        )?;
-
         if !highest_accepted_rounds.is_empty()
             && highest_accepted_rounds.len() != self.context.committee.size()
         {
@@ -1012,6 +1075,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             );
             block_refs.truncate(max_fetch_size);
         }
+
+        ConsensusError::quick_validation_requested_block_refs(
+            &block_refs,
+            peer,
+            &self.context.committee,
+        )?;
 
         // Get requested block headers from store.
         let serialized_headers = if commit_sync_handle {
@@ -1698,11 +1767,12 @@ mod tests {
         CommitConsumer, Round, Transaction, TransactionClient,
         authority_service::{
             AuthorityService, BroadcastedBlockStream, MAX_FILTER_SIZE, SubscriptionCounter,
+            serialized_transactions_size_limit,
         },
         block_header::{
-            BlockHeaderAPI, BlockRef, GENESIS_ROUND, SignedBlockHeader, TestBlockHeader,
-            TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard,
-            VerifiedTransactions,
+            BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
+            TestBlockHeader, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
+            VerifiedOwnShard, VerifiedTransactions,
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
@@ -1719,7 +1789,7 @@ mod tests {
         error::{ConsensusError, ConsensusResult},
         header_synchronizer::HeaderSynchronizer,
         leader_schedule::LeaderSchedule,
-        misbehavior_store::MisbehaviorStore,
+        misbehavior_store::{MisbehaviorCounts, MisbehaviorStore},
         network::{
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
@@ -1933,6 +2003,7 @@ mod tests {
             Arc::new(MisbehaviorStore::new(&context)),
         );
 
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
@@ -1943,7 +2014,7 @@ mod tests {
             rx_block_broadcast,
             dag_state,
             store,
-            Arc::new(MisbehaviorStore::new(&context)),
+            misbehavior_store.clone(),
             tx_message_sender,
             cordial_knowledge,
         ));
@@ -1978,6 +2049,42 @@ mod tests {
         } else {
             panic!("Expected TransactionCommitmentFailure error, got {result:?}",);
         }
+
+        let counts = misbehavior_store.snapshot_totals();
+        let MisbehaviorCounts::V1(counts) = &counts[0];
+        assert_eq!(counts.faulty_blocks_unprovable, 1);
+
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
+        );
+        let mut bundle_parts = SerializedBlockBundleParts::try_from(input_block).unwrap();
+        let mut block_parts = SerializedHeaderAndTransactions::try_from(SerializedBlock {
+            serialized_block: bundle_parts.serialized_block,
+        })
+        .unwrap();
+        let serialized_limit = serialized_transactions_size_limit(&context);
+        block_parts.serialized_transactions = Bytes::from(vec![0; serialized_limit + 1]);
+        bundle_parts.serialized_block = SerializedBlock::try_from(block_parts)
+            .unwrap()
+            .serialized_block;
+        let oversized_bundle = SerializedBlockBundle::try_from(bundle_parts).unwrap();
+
+        let result = authority_service
+            .handle_subscribed_block_bundle(
+                context.committee.to_authority_index(0).unwrap(),
+                oversized_bundle,
+                &mut encoder,
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConsensusError::SerializedTransactionsTooLarge { size, limit })
+                if size == limit + 1
+        ));
+
+        let counts = misbehavior_store.snapshot_totals();
+        let MisbehaviorCounts::V1(counts) = &counts[0];
+        assert_eq!(counts.faulty_blocks_unprovable, 2);
     }
 
     #[rstest]
@@ -3207,8 +3314,14 @@ mod tests {
             .collect();
 
         let peer = context.committee.to_authority_index(1).unwrap();
+        let mut oversized_request = block_refs_to_request.clone();
+        oversized_request.push(BlockRef::new(
+            rounds + 1,
+            AuthorityIndex::new_for_test(validators as u8),
+            BlockHeaderDigest::MIN,
+        ));
         let truncated_headers = authority_service
-            .handle_fetch_headers(peer, block_refs_to_request.clone(), vec![])
+            .handle_fetch_headers(peer, oversized_request, vec![])
             .await
             .expect("Should return a valid vector of serialized block headers");
 
@@ -3543,7 +3656,13 @@ mod tests {
             let verified_block_header = VerifiedBlockHeader::new_for_test(test_block_header);
             new_block_headers.push(verified_block_header);
         }
-        all_block_headers.push(new_block_headers.clone());
+        let equivocation = TestBlockHeader::new(rounds + 1, 1)
+            .set_commit_votes(commit_refs.clone())
+            .set_ancestors(refs_to_headers_from_prev_round.clone())
+            .set_timestamp_ms((rounds as u64 + 2) * 1000)
+            .build();
+        new_block_headers.push(VerifiedBlockHeader::new_for_test(equivocation));
+        all_block_headers.push(new_block_headers[..validators].to_vec());
         core_dispatcher
             .add_block_headers(new_block_headers.clone(), DataSource::Test)
             .await
@@ -3579,6 +3698,13 @@ mod tests {
             .await
             .unwrap();
 
+        let certifier_authors = result
+            .1
+            .iter()
+            .map(|header| header.author())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(result.1.len(), certifier_authors.len());
+        assert!(result.1.len() <= context.committee.size());
         assert_eq!(
             result.0.len() as u32,
             rounds - 2,

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    CommitIndex, Round, Transaction, VerifiedBlockHeader,
+    CommitIndex, Round, VerifiedBlockHeader,
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, ShardWithProof,
         ShardWithProofAPI, ShardWithProofV1, SignedBlockHeader, TransactionsCommitment,
@@ -55,22 +55,6 @@ use crate::{
 pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
 const MAX_FILTER_SIZE: u32 = 100000;
-// BCS encodes sequence lengths as ULEB128 values. Ten bytes covers any usize
-// length on supported 64-bit targets.
-const MAX_BCS_LENGTH_PREFIX_BYTES: usize = 10;
-
-fn serialized_transactions_size_limit(context: &Context) -> usize {
-    let max_bytes = context.protocol_config.max_transactions_in_block_bytes() as usize;
-    let max_count = context.protocol_config.max_num_transactions_in_block() as usize;
-    // A zero protocol limit disables the corresponding check in the block
-    // verifier; without both bounds no finite serialized size is implied.
-    if max_bytes == 0 || max_count == 0 {
-        return usize::MAX;
-    }
-    max_bytes
-        .saturating_add(max_count.saturating_mul(MAX_BCS_LENGTH_PREFIX_BYTES))
-        .saturating_add(MAX_BCS_LENGTH_PREFIX_BYTES)
-}
 
 struct FilterForHeaders {
     header_digests: DashSet<BlockHeaderDigest>,
@@ -230,18 +214,9 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             return Err(e);
         }
 
-        let max_serialized_transactions_size = serialized_transactions_size_limit(&self.context);
-        if serialized_transactions.len() > max_serialized_transactions_size {
-            let e = ConsensusError::SerializedTransactionsTooLarge {
-                size: serialized_transactions.len(),
-                limit: max_serialized_transactions_size,
-            };
-            self.record_invalid_transactions(peer, peer_hostname, &e);
-            return Err(e);
-        }
-
-        let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
-            .map_err(ConsensusError::MalformedTransactions)
+        let transactions = self
+            .block_verifier
+            .check_and_parse_transactions(&serialized_transactions)
             .inspect_err(|e| self.record_invalid_transactions(peer, peer_hostname, e))?;
         let (transaction_commitment, our_shard, proof_for_shard) =
             TransactionsCommitment::compute_merkle_root_shard_and_proof(
@@ -1772,7 +1747,6 @@ mod tests {
         CommitConsumer, Round, Transaction, TransactionClient,
         authority_service::{
             AuthorityService, BroadcastedBlockStream, MAX_FILTER_SIZE, SubscriptionCounter,
-            serialized_transactions_size_limit,
         },
         block_header::{
             BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
@@ -2067,24 +2041,22 @@ mod tests {
             serialized_block: bundle_parts.serialized_block,
         })
         .unwrap();
-        let serialized_limit = serialized_transactions_size_limit(&context);
-        block_parts.serialized_transactions = Bytes::from(vec![0; serialized_limit + 1]);
+        block_parts.serialized_transactions = Bytes::from(vec![0xFF; 8]);
         bundle_parts.serialized_block = SerializedBlock::try_from(block_parts)
             .unwrap()
             .serialized_block;
-        let oversized_bundle = SerializedBlockBundle::try_from(bundle_parts).unwrap();
+        let malformed_bundle = SerializedBlockBundle::try_from(bundle_parts).unwrap();
 
         let result = authority_service
             .handle_subscribed_block_bundle(
                 context.committee.to_authority_index(0).unwrap(),
-                oversized_bundle,
+                malformed_bundle,
                 &mut encoder,
             )
             .await;
         assert!(matches!(
             result,
-            Err(ConsensusError::SerializedTransactionsTooLarge { size, limit })
-                if size == limit + 1
+            Err(ConsensusError::MalformedTransactions(_))
         ));
 
         let counts = misbehavior_store.snapshot_totals();

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -43,6 +43,58 @@ pub(crate) const GENESIS_ROUND: Round = 0;
 /// Block proposal as epoch UNIX timestamp in milliseconds.
 pub type BlockTimestampMs = u64;
 
+/// BCS-serialized size of a [`BlockRef`]: `round` (u32, 4) + `author`
+/// (`AuthorityIndex`, 1) + `digest` (32). Pinned by
+/// `max_signed_block_header_bytes_bounds_maximal_header`.
+pub(crate) const SERIALIZED_BLOCK_REF_BYTES: usize = 37;
+
+/// ULEB128 byte length of `value`, matching how BCS frames sequence and
+/// variant lengths.
+pub(crate) const fn uleb128_len(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
+
+/// Upper bound on the BCS-serialized size of a [`SignedBlockHeader`] for a
+/// committee of `committee_size` authorities.
+///
+/// `BlockHeaderV2` is the largest header variant; its size is dominated by two
+/// committee-sized vectors. Layout:
+/// - 55 fixed bytes: `epoch` (8) + `round` (4) + `author` (1) + `timestamp_ms`
+///   (8) + overlap indices (1 + 1) + `transactions_commitment` (32).
+/// - `references`: at most `3 * committee_size` [`BlockRef`]s (37 bytes each)
+///   plus the sequence-length prefix.
+/// - `commit_votes`: at most `committee_size` `CommitVote`s (36 bytes each:
+///   index (4) + digest (32)) plus the sequence-length prefix.
+/// - 34 bytes for `Option<StrongVote>`: `Some` tag (1) + `leader_authority` (1)
+///   + `AuthoritySet` bitmask (32).
+///
+/// The [`SignedBlockHeader`] wrapper adds the `BlockHeader` enum tag (1), the
+/// signature length prefix (1), and the 64-byte signature.
+pub(crate) fn max_signed_block_header_bytes(committee_size: usize) -> usize {
+    const FIXED_HEADER_BYTES: usize = 55;
+    const STRONG_VOTE_BYTES: usize = 34;
+    const COMMIT_VOTE_BYTES: usize = 36;
+    // BlockHeader enum tag (1) + signature length prefix (1) + signature (64).
+    const SIGNATURE_FRAME_BYTES: usize = 1 + 1 + 64;
+
+    let max_refs = committee_size.saturating_mul(3);
+    let references =
+        uleb128_len(max_refs).saturating_add(max_refs.saturating_mul(SERIALIZED_BLOCK_REF_BYTES));
+    let commit_votes = uleb128_len(committee_size)
+        .saturating_add(committee_size.saturating_mul(COMMIT_VOTE_BYTES));
+
+    FIXED_HEADER_BYTES
+        .saturating_add(references)
+        .saturating_add(commit_votes)
+        .saturating_add(STRONG_VOTE_BYTES)
+        .saturating_add(SIGNATURE_FRAME_BYTES)
+}
+
 /// IOTA transaction is considered as serialised bytes inside consensus
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default, Debug)]
 pub struct Transaction {
@@ -1649,11 +1701,37 @@ mod tests {
     use crate::{
         BlockHeaderAPI,
         block_header::{
-            BlockHeaderDigest, SignedBlockHeader, TestBlockHeader, genesis_block_headers,
+            BlockHeader, BlockHeaderDigest, BlockHeaderV2, BlockRef, SignedBlockHeader, StrongVote,
+            TestBlockHeader, genesis_block_headers, max_signed_block_header_bytes,
         },
+        commit::{CommitDigest, CommitRef},
         context::Context,
         error::ConsensusError,
     };
+
+    /// Pins the `BlockHeaderV2` wire layout that
+    /// `max_signed_block_header_bytes` is derived from: a header carrying
+    /// the maximal `3 * committee_size` references, one commit vote per
+    /// authority, and a strong vote must serialize to exactly the computed
+    /// bound. Fails if the BCS framing or any of `BlockRef` / `CommitVote`
+    /// / `StrongVote` / `SignedBlockHeader` layout changes.
+    #[tokio::test]
+    async fn max_signed_block_header_bytes_bounds_maximal_header() {
+        let (context, key_pairs) = Context::new_for_test(4);
+        let n = context.committee.size();
+
+        let header = BlockHeader::V2(BlockHeaderV2 {
+            references: vec![BlockRef::MAX; 3 * n],
+            commit_votes: vec![CommitRef::new(u32::MAX, CommitDigest::MIN); n],
+            strong_vote: Some(StrongVote::default()),
+            ..Default::default()
+        });
+        let signed =
+            SignedBlockHeader::new(header, &key_pairs[0].1).expect("signing should succeed");
+        let serialized = bcs::to_bytes(&signed).expect("serialization should succeed");
+
+        assert_eq!(serialized.len(), max_signed_block_header_bytes(n));
+    }
 
     #[tokio::test]
     async fn test_sign_and_verify() {

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -387,8 +387,8 @@ pub(crate) mod test {
     /// to exactly one ULEB128 length prefix per sequence plus the raw bytes,
     /// and fit within the limit. Fails if the BCS framing or the
     /// `Transaction` layout changes.
-    #[test]
-    fn serialized_transactions_size_limit_bounds_maximal_valid_batch() {
+    #[tokio::test]
+    async fn serialized_transactions_size_limit_bounds_maximal_valid_batch() {
         fn uleb128_len(mut value: usize) -> usize {
             let mut len = 1;
             while value >= 0x80 {
@@ -417,8 +417,8 @@ pub(crate) mod test {
         assert!(serialized.len() <= serialized_transactions_size_limit(&context));
     }
 
-    #[test]
-    fn check_and_parse_transactions_rejects_oversized_payload() {
+    #[tokio::test]
+    async fn check_and_parse_transactions_rejects_oversized_payload() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let size_limit = serialized_transactions_size_limit(&context);

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -22,6 +22,15 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
     /// This is called before examining a block's causal history.
     fn verify(&self, block: &SignedBlockHeader) -> ConsensusResult<()>;
 
+    /// Bounds and parses a serialized transaction payload. Call this before
+    /// any expensive processing of the payload; failures cannot be attributed
+    /// to the block author until the payload is bound to the header's
+    /// transactions commitment, so they are sender faults.
+    fn check_and_parse_transactions(
+        &self,
+        serialized_transactions: &[u8],
+    ) -> ConsensusResult<Vec<Transaction>>;
+
     fn check_and_verify_transactions(&self, transactions: &[Transaction]) -> ConsensusResult<()>;
 }
 
@@ -296,6 +305,20 @@ impl BlockVerifier for SignedBlockVerifier {
         Ok(())
     }
 
+    fn check_and_parse_transactions(
+        &self,
+        serialized_transactions: &[u8],
+    ) -> ConsensusResult<Vec<Transaction>> {
+        let limit = serialized_transactions_size_limit(&self.context);
+        if serialized_transactions.len() > limit {
+            return Err(ConsensusError::SerializedTransactionsTooLarge {
+                size: serialized_transactions.len(),
+                limit,
+            });
+        }
+        bcs::from_bytes(serialized_transactions).map_err(ConsensusError::MalformedTransactions)
+    }
+
     fn check_and_verify_transactions(&self, transactions: &[Transaction]) -> ConsensusResult<()> {
         let batch: Vec<_> = transactions.iter().map(|t| t.data()).collect();
         self.check_transactions(&batch)?;
@@ -305,6 +328,27 @@ impl BlockVerifier for SignedBlockVerifier {
     }
 }
 
+// BCS encodes sequence lengths as ULEB128 values. Ten bytes covers any usize
+// length on supported 64-bit targets.
+const MAX_BCS_LENGTH_PREFIX_BYTES: usize = 10;
+
+/// Upper bound on the BCS-serialized size of any transaction batch that
+/// passes `check_transactions`: the maximum payload bytes plus a length
+/// prefix per transaction and one for the enclosing sequence.
+pub(crate) fn serialized_transactions_size_limit(context: &Context) -> usize {
+    let max_bytes = context.protocol_config.max_transactions_in_block_bytes() as usize;
+    let max_count = context.protocol_config.max_num_transactions_in_block() as usize;
+    // A zero protocol limit disables the corresponding check in
+    // `check_transactions`; without both bounds no finite serialized size is
+    // implied.
+    if max_bytes == 0 || max_count == 0 {
+        return usize::MAX;
+    }
+    max_bytes
+        .saturating_add(max_count.saturating_mul(MAX_BCS_LENGTH_PREFIX_BYTES))
+        .saturating_add(MAX_BCS_LENGTH_PREFIX_BYTES)
+}
+
 #[cfg(test)]
 pub(crate) struct NoopBlockVerifier;
 
@@ -312,6 +356,13 @@ pub(crate) struct NoopBlockVerifier;
 impl BlockVerifier for NoopBlockVerifier {
     fn verify(&self, _block: &SignedBlockHeader) -> ConsensusResult<()> {
         Ok(())
+    }
+
+    fn check_and_parse_transactions(
+        &self,
+        serialized_transactions: &[u8],
+    ) -> ConsensusResult<Vec<Transaction>> {
+        bcs::from_bytes(serialized_transactions).map_err(ConsensusError::MalformedTransactions)
     }
 
     fn check_and_verify_transactions(&self, _transactions: &[Transaction]) -> ConsensusResult<()> {
@@ -330,6 +381,56 @@ pub(crate) mod test {
         context::Context,
         transaction::{TransactionVerifier, ValidationError},
     };
+
+    /// Pins the wire layout `serialized_transactions_size_limit` is derived
+    /// from: a maximal batch accepted by `check_transactions` must serialize
+    /// to exactly one ULEB128 length prefix per sequence plus the raw bytes,
+    /// and fit within the limit. Fails if the BCS framing or the
+    /// `Transaction` layout changes.
+    #[test]
+    fn serialized_transactions_size_limit_bounds_maximal_valid_batch() {
+        fn uleb128_len(mut value: usize) -> usize {
+            let mut len = 1;
+            while value >= 0x80 {
+                value >>= 7;
+                len += 1;
+            }
+            len
+        }
+
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let max_bytes = context.protocol_config.max_transactions_in_block_bytes() as usize;
+        let max_count = context.protocol_config.max_num_transactions_in_block() as usize;
+        let tx_size = max_bytes / max_count;
+        let transactions: Vec<Transaction> = (0..max_count)
+            .map(|_| Transaction::new(vec![0; tx_size]))
+            .collect();
+
+        let verifier = SignedBlockVerifier::new(context.clone(), Arc::new(TxnSizeVerifier {}));
+        let batch: Vec<_> = transactions.iter().map(|t| t.data()).collect();
+        verifier.check_transactions(&batch).unwrap();
+
+        let serialized = bcs::to_bytes(&transactions).unwrap();
+        let expected = uleb128_len(max_count) + max_count * (uleb128_len(tx_size) + tx_size);
+        assert_eq!(serialized.len(), expected);
+        assert!(serialized.len() <= serialized_transactions_size_limit(&context));
+    }
+
+    #[test]
+    fn check_and_parse_transactions_rejects_oversized_payload() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let size_limit = serialized_transactions_size_limit(&context);
+        let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
+
+        let result = verifier.check_and_parse_transactions(&vec![0u8; size_limit + 1]);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::SerializedTransactionsTooLarge { size, limit })
+                if size == size_limit + 1 && limit == size_limit
+        ));
+    }
 
     pub(crate) struct TxnSizeVerifier {}
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -20,8 +20,8 @@ use tracing::debug;
 
 use crate::{
     block_header::{
-        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlockHeader,
-        VerifiedTransactions,
+        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, SERIALIZED_BLOCK_REF_BYTES, Slot,
+        VerifiedBlockHeader, VerifiedTransactions, uleb128_len,
     },
     context::Context,
     leader_scoring::ReputationScores,
@@ -42,6 +42,43 @@ pub(crate) const WAVE_LENGTH: Round = 3;
 /// The consensus protocol operates in 'waves'. Each wave is composed of a
 /// leader round, at least one voting round, and one certifying round.
 pub(crate) type WaveNumber = u32;
+
+/// Upper bound on the BCS-serialized size of a [`Commit`] for a committee of
+/// `committee_size` authorities and a GC depth of `gc_depth` rounds.
+///
+/// `CommitV3` is the largest variant. Its two variable-length vectors span the
+/// committed sub-DAG, which garbage collection bounds to `gc_depth *
+/// committee_size` blocks (at most one block per authority per uncollected
+/// round); `committed_transactions` carries at most one [`TransactionRef`] per
+/// such block, and `reputation_scores_desc` at most one entry per authority.
+///
+/// Returns [`usize::MAX`] when `gc_depth` or `committee_size` is zero (GC
+/// disabled implies no finite sub-DAG bound), matching the convention that a
+/// zero limit disables the corresponding check.
+pub(crate) fn max_commit_bytes(committee_size: usize, gc_depth: usize) -> usize {
+    if gc_depth == 0 || committee_size == 0 {
+        return usize::MAX;
+    }
+    // `TransactionRef` is round (4) + author (1) + transactions_commitment (32).
+    const SERIALIZED_TRANSACTION_REF_BYTES: usize = 37;
+    // enum tag (1) + index (4) + previous_digest (32) + timestamp_ms (8) +
+    // leader BlockRef (37) + is_optimistic (1).
+    const FIXED_COMMIT_BYTES: usize = 1 + 4 + 32 + 8 + SERIALIZED_BLOCK_REF_BYTES + 1;
+
+    let max_subdag_blocks = gc_depth.saturating_mul(committee_size);
+    let block_headers = uleb128_len(max_subdag_blocks)
+        .saturating_add(max_subdag_blocks.saturating_mul(SERIALIZED_BLOCK_REF_BYTES));
+    let committed_transactions = uleb128_len(max_subdag_blocks)
+        .saturating_add(max_subdag_blocks.saturating_mul(SERIALIZED_TRANSACTION_REF_BYTES));
+    // reputation_scores_desc: Vec<(AuthorityIndex (1), u64 (8))>.
+    let reputation_scores =
+        uleb128_len(committee_size).saturating_add(committee_size.saturating_mul(1 + 8));
+
+    FIXED_COMMIT_BYTES
+        .saturating_add(block_headers)
+        .saturating_add(committed_transactions)
+        .saturating_add(reputation_scores)
+}
 
 /// [`Commit`] summarizes [`CommittedSubDag`] for storage and network
 /// communications.
@@ -1192,15 +1229,46 @@ impl Debug for CommitRange {
 mod tests {
     use std::sync::Arc;
 
+    use starfish_config::AuthorityIndex;
+
     use crate::{
         BlockHeaderAPI, BlockTimestampMs, CommitDigest, VerifiedBlockHeader,
-        block_header::{TestBlockHeader, VerifiedBlock},
-        commit::{CommitRange, TrustedCommit, WAVE_LENGTH, load_pending_subdag_from_store},
+        block_header::{BlockRef, TestBlockHeader, VerifiedBlock},
+        commit::{
+            Commit, CommitRange, CommitV3, TrustedCommit, WAVE_LENGTH,
+            load_pending_subdag_from_store, max_commit_bytes,
+        },
         context::Context,
         encoder::create_encoder,
         storage::{Store, WriteBatch, mem_store::MemStore},
-        transaction_ref::convert_block_refs_to_generic_transaction_refs,
+        transaction_ref::{TransactionRef, convert_block_refs_to_generic_transaction_refs},
     };
+
+    /// Pins the `CommitV3` wire layout that `max_commit_bytes` is derived from:
+    /// a commit whose sub-DAG vectors are filled to the GC bound
+    /// (`gc_depth * committee_size`) with one reputation score per authority
+    /// must serialize to exactly the computed bound. Also checks that a zero GC
+    /// depth or committee size disables the bound.
+    #[tokio::test]
+    async fn max_commit_bytes_bounds_maximal_commit() {
+        let n = 4usize;
+        let gc_depth = 5usize;
+        let max_subdag_blocks = gc_depth * n;
+
+        let commit = Commit::V3(CommitV3 {
+            block_headers: vec![BlockRef::MAX; max_subdag_blocks],
+            committed_transactions: vec![TransactionRef::default(); max_subdag_blocks],
+            reputation_scores_desc: vec![(AuthorityIndex::MAX, u64::MAX); n],
+            ..Default::default()
+        });
+        let serialized = bcs::to_bytes(&commit).expect("serialization should succeed");
+
+        assert_eq!(serialized.len(), max_commit_bytes(n, gc_depth));
+
+        // A zero GC depth (GC disabled) or empty committee disables the bound.
+        assert_eq!(max_commit_bytes(n, 0), usize::MAX);
+        assert_eq!(max_commit_bytes(0, gc_depth), usize::MAX);
+    }
 
     #[tokio::test]
     async fn test_new_committed_subdag_from_commit() {

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -52,7 +52,7 @@ use crate::{
     block_header::{
         BlockHeaderAPI, SignedBlockHeader, TransactionsCommitment, VerifiedTransactions,
     },
-    block_verifier::BlockVerifier,
+    block_verifier::{BlockVerifier, serialized_transactions_size_limit},
     commit::{Commit, CommitAPI as _, CommitDigest, CommitRange, CommitRef, TrustedCommit},
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -380,6 +380,7 @@ pub(crate) fn verify_transactions_with_headers(
 ) -> ConsensusResult<BTreeMap<GenericTransactionRef, VerifiedTransactions>> {
     let mut verified_transactions_map = BTreeMap::new();
     let mut encoder = create_encoder(&context);
+    let size_limit = serialized_transactions_size_limit(&context);
     for (committed_transactions_ref, inner_serialized_transactions) in serialized_transactions {
         let block_ref = match committed_transactions_ref {
             GenericTransactionRef::BlockRef(br) => br,
@@ -391,6 +392,13 @@ pub(crate) fn verify_transactions_with_headers(
                 });
             }
         };
+        // Bound the peer-supplied payload before erasure-encoding it.
+        if inner_serialized_transactions.len() > size_limit {
+            return Err(ConsensusError::SerializedTransactionsTooLarge {
+                size: inner_serialized_transactions.len(),
+                limit: size_limit,
+            });
+        }
         // Step 1: Get the block header and verify that the transactions commitment
         // matches. This ensures the transactions we received are exactly
         // the ones that were included in the block when it was created.
@@ -442,6 +450,7 @@ pub(crate) fn verify_transactions_with_transactions_refs(
 ) -> ConsensusResult<BTreeMap<GenericTransactionRef, VerifiedTransactions>> {
     let mut verified_transactions_map = BTreeMap::new();
     let mut encoder = create_encoder(context);
+    let size_limit = serialized_transactions_size_limit(context);
     for (committed_transactions_ref, inner_serialized_transactions) in serialized_transactions {
         let transaction_ref = match committed_transactions_ref {
             GenericTransactionRef::TransactionRef(tx_ref) => tx_ref,
@@ -453,6 +462,13 @@ pub(crate) fn verify_transactions_with_transactions_refs(
                 });
             }
         };
+        // Bound the peer-supplied payload before erasure-encoding it.
+        if inner_serialized_transactions.len() > size_limit {
+            return Err(ConsensusError::SerializedTransactionsTooLarge {
+                size: inner_serialized_transactions.len(),
+                limit: size_limit,
+            });
+        }
         // Step 1: Verify that the transaction commitment matches.
         if transaction_ref.transactions_commitment
             != TransactionsCommitment::compute_transactions_commitment(
@@ -896,6 +912,31 @@ mod tests {
         assert_eq!(actual, expected_variant);
         assert_eq!(fast_commit_sync, fast_commit_sync_on);
         assert_eq!(starfish_speed, starfish_speed_on);
+    }
+
+    #[test]
+    fn verify_transactions_rejects_oversized_payload_before_encoding() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let peer = AuthorityIndex::new_for_test(1);
+        let size_limit = serialized_transactions_size_limit(&context);
+        let transaction_ref = TransactionRef {
+            round: 1,
+            author: AuthorityIndex::new_for_test(0),
+            transactions_commitment: TransactionsCommitment::MIN,
+        };
+        let serialized_transactions = BTreeMap::from([(
+            GenericTransactionRef::TransactionRef(transaction_ref),
+            Bytes::from(vec![0u8; size_limit + 1]),
+        )]);
+
+        let result =
+            verify_transactions_with_transactions_refs(&context, peer, serialized_transactions);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::SerializedTransactionsTooLarge { size, limit })
+                if size == size_limit + 1 && limit == size_limit
+        ));
     }
 
     #[test]

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -914,8 +914,8 @@ mod tests {
         assert_eq!(starfish_speed, starfish_speed_on);
     }
 
-    #[test]
-    fn verify_transactions_rejects_oversized_payload_before_encoding() {
+    #[tokio::test]
+    async fn verify_transactions_rejects_oversized_payload_before_encoding() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let peer = AuthorityIndex::new_for_test(1);
@@ -939,8 +939,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn verify_commits_rejects_excessive_vote_headers_before_parsing() {
+    #[tokio::test]
+    async fn verify_commits_rejects_excessive_vote_headers_before_parsing() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let peer = AuthorityIndex::new_for_test(1);

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -64,7 +64,7 @@ use crate::{
     misbehavior_store::MisbehaviorStore,
     network::NetworkClient,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
-    transaction_ref::{GenericTransactionRef, TransactionRef},
+    transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI, TransactionRef},
 };
 
 /// Allowed multiplicity of commit vote headers per authority in a
@@ -250,6 +250,39 @@ pub(crate) fn check_commit_version_matches_flags(
     Ok(())
 }
 
+/// Validates every `AuthorityIndex` carried by a fetched commit against the
+/// committee, so malformed indices are rejected at ingress with peer
+/// attribution instead of panicking later when commit content is indexed
+/// into per-authority state.
+fn verify_commit_authority_indices(
+    context: &Context,
+    peer: AuthorityIndex,
+    commit: &Commit,
+) -> ConsensusResult<()> {
+    let committee = &context.committee;
+    let check = |index: AuthorityIndex| -> ConsensusResult<()> {
+        if !committee.is_valid_index(index) {
+            return Err(ConsensusError::InvalidAuthorityIndexRequested {
+                index,
+                max: committee.size(),
+                peer,
+            });
+        }
+        Ok(())
+    };
+    check(commit.leader().author)?;
+    for block_ref in commit.block_headers() {
+        check(block_ref.author)?;
+    }
+    for transaction_ref in commit.committed_transactions() {
+        check(transaction_ref.author())?;
+    }
+    for (index, _) in commit.reputation_scores() {
+        check(*index)?;
+    }
+    Ok(())
+}
+
 /// Free-function form of `Inner::verify_commits`, taking only the inputs the
 /// verification actually uses (`Context` and `BlockVerifier`). Lets tests
 /// exercise the full deserialize-and-verify path without constructing a full
@@ -295,6 +328,7 @@ pub(crate) fn verify_commits(
         let commit: Commit =
             bcs::from_bytes(serialized).map_err(ConsensusError::MalformedCommit)?;
         check_commit_version_matches_flags(&commit, &context.protocol_config)?;
+        verify_commit_authority_indices(context, peer, &commit)?;
         let digest = TrustedCommit::compute_digest(serialized);
         if commits.is_empty() {
             // start is inclusive, so first commit must be at the start index.
@@ -850,6 +884,7 @@ pub(crate) fn requeue_partial_range(
 mod tests {
     use super::*;
     use crate::{
+        block_header::BlockHeaderDigest,
         block_verifier::NoopBlockVerifier,
         commit::{CommitV1, CommitV2, CommitV3},
     };
@@ -912,6 +947,53 @@ mod tests {
         assert_eq!(actual, expected_variant);
         assert_eq!(fast_commit_sync, fast_commit_sync_on);
         assert_eq!(starfish_speed, starfish_speed_on);
+    }
+
+    #[tokio::test]
+    async fn verify_commits_rejects_out_of_range_authority_index() {
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(false);
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(false);
+        let context = Arc::new(context);
+        let misbehavior_store = MisbehaviorStore::new(&context);
+        let peer = AuthorityIndex::new_for_test(1);
+        let invalid_author = AuthorityIndex::new_for_test(4);
+        let leader = BlockRef::new(1, invalid_author, BlockHeaderDigest::MIN);
+        let commit = Commit::new(
+            &context,
+            1,
+            CommitDigest::MIN,
+            0,
+            leader,
+            vec![leader],
+            vec![],
+            vec![],
+            false,
+        );
+        let serialized = commit.serialize().unwrap();
+
+        let result = verify_commits(
+            &context,
+            &NoopBlockVerifier,
+            &misbehavior_store,
+            peer,
+            CommitRange::new(1..=1),
+            vec![serialized],
+            vec![],
+            10,
+        );
+        assert!(matches!(
+            result,
+            Err(ConsensusError::InvalidAuthorityIndexRequested {
+                index,
+                max,
+                peer: error_peer,
+            }) if index == invalid_author && max == 4 && error_peer == peer
+        ));
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -529,7 +529,7 @@ where
     const TIMEOUT: Duration = Duration::from_millis(500);
     // Max per-request timeout will be base timeout times a multiplier.
     // At the extreme, this means there will be 120s timeout to fetch
-    // max_blocks_per_fetch blocks.
+    // max_headers_per_commit_sync_fetch headers.
     const MAX_TIMEOUT_MULTIPLIER: u32 = 12;
     // timeout * max number of targets should be reasonably small, so the
     // system can adjust to slow network or large data sizes quickly.

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -66,6 +66,13 @@ use crate::{
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
+
+/// Allowed multiplicity of commit vote headers per authority in a
+/// fetch-commits response.
+// TODO: Reduce to 1 once all networks serve certifier votes deduplicated by
+// author, so a response never needs more than one header per authority.
+const MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY: usize = 2;
+
 pub(crate) enum CommitSyncType {
     Fast,
     Regular,
@@ -266,7 +273,14 @@ pub(crate) fn verify_commits(
         });
     }
 
-    let max_vote_headers = context.committee.size();
+    // One vote header per authority certifies a commit, but servers that do
+    // not dedup votes by author may legitimately serve a few more (e.g. an
+    // author re-including its vote in a block after crash recovery), so allow
+    // some multiplicity while still bounding signature verification work.
+    let max_vote_headers = context
+        .committee
+        .size()
+        .saturating_mul(MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY);
     if serialized_vote_blocks_headers.len() > max_vote_headers {
         return Err(ConsensusError::TooManyCommitVoteHeaders {
             peer,
@@ -890,6 +904,7 @@ mod tests {
         let context = Arc::new(context);
         let peer = AuthorityIndex::new_for_test(1);
         let misbehavior_store = MisbehaviorStore::new(&context);
+        let limit = context.committee.size() * MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY;
         let result = verify_commits(
             &context,
             &NoopBlockVerifier,
@@ -897,7 +912,7 @@ mod tests {
             peer,
             CommitRange::new(1..=1),
             vec![],
-            vec![Bytes::new(); context.committee.size() + 1],
+            vec![Bytes::new(); limit + 1],
             10,
         );
 
@@ -905,9 +920,9 @@ mod tests {
             result,
             Err(ConsensusError::TooManyCommitVoteHeaders {
                 peer: error_peer,
-                count: 5,
-                limit: 4,
-            }) if error_peer == peer
+                count,
+                limit: error_limit,
+            }) if error_peer == peer && count == limit + 1 && error_limit == limit
         ));
     }
 }

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -266,6 +266,15 @@ pub(crate) fn verify_commits(
         });
     }
 
+    let max_vote_headers = context.committee.size();
+    if serialized_vote_blocks_headers.len() > max_vote_headers {
+        return Err(ConsensusError::TooManyCommitVoteHeaders {
+            peer,
+            count: serialized_vote_blocks_headers.len(),
+            limit: max_vote_headers,
+        });
+    }
+
     // Parse and verify commits.
     let mut commits = Vec::new();
     for serialized in &serialized_commits {
@@ -873,5 +882,32 @@ mod tests {
         assert_eq!(actual, expected_variant);
         assert_eq!(fast_commit_sync, fast_commit_sync_on);
         assert_eq!(starfish_speed, starfish_speed_on);
+    }
+
+    #[test]
+    fn verify_commits_rejects_excessive_vote_headers_before_parsing() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let peer = AuthorityIndex::new_for_test(1);
+        let misbehavior_store = MisbehaviorStore::new(&context);
+        let result = verify_commits(
+            &context,
+            &NoopBlockVerifier,
+            &misbehavior_store,
+            peer,
+            CommitRange::new(1..=1),
+            vec![],
+            vec![Bytes::new(); context.committee.size() + 1],
+            10,
+        );
+
+        assert!(matches!(
+            result,
+            Err(ConsensusError::TooManyCommitVoteHeaders {
+                peer: error_peer,
+                count: 5,
+                limit: 4,
+            }) if error_peer == peer
+        ));
     }
 }

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -249,6 +249,13 @@ pub(crate) enum ConsensusError {
         limit: usize,
     },
 
+    #[error("Invalid commit range from peer {peer}: start {start} > end {end}")]
+    InvalidCommitRange {
+        peer: AuthorityIndex,
+        start: CommitIndex,
+        end: CommitIndex,
+    },
+
     #[error("Received unexpected block header from peer {peer}: {requested:?} vs {received:?}")]
     UnexpectedBlockHeaderForCommit {
         peer: AuthorityIndex,

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -45,6 +45,9 @@ pub(crate) enum ConsensusError {
     #[error("Block contains too many transaction bytes: {size} > {limit}")]
     TooManyTransactionBytes { size: usize, limit: usize },
 
+    #[error("Serialized block transactions are too large: {size} > {limit}")]
+    SerializedTransactionsTooLarge { size: usize, limit: usize },
+
     #[error("Unexpected block authority {0} from peer {1}")]
     UnexpectedAuthority(AuthorityIndex, AuthorityIndex),
 
@@ -237,6 +240,13 @@ pub(crate) enum ConsensusError {
         stake: Stake,
         peer: AuthorityIndex,
         commit: Box<Commit>,
+    },
+
+    #[error("Received too many commit vote headers from peer {peer}: {count} > {limit}")]
+    TooManyCommitVoteHeaders {
+        peer: AuthorityIndex,
+        count: usize,
+        limit: usize,
     },
 
     #[error("Received unexpected block header from peer {peer}: {requested:?} vs {received:?}")]

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -482,7 +482,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                             // task will take care syncing whatever is leftover.
                             let missing_block_refs = missing_block_refs
                                 .into_iter()
-                                .take(self.context.parameters.max_headers_per_regular_sync_fetch)
+                                .take(self.context.parameters.max_headers_per_header_sync_fetch)
                                 .collect();
 
                             let blocks_guard = self.inflight_block_headers_map.lock_headers(missing_block_refs, peer_index, SyncMethod::Live);
@@ -706,12 +706,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             .scope_processing_time
             .with_label_values(&["Synchronizer::process_fetched_blocks"])
             .start_timer();
-        if serialized_headers.len() > context.parameters.max_headers_per_regular_sync_fetch {
+        if serialized_headers.len() > context.parameters.max_headers_per_header_sync_fetch {
             debug!(
                 "Truncating fetched headers from peer {} to max allowed {} blocks",
-                peer_index, context.parameters.max_headers_per_regular_sync_fetch
+                peer_index, context.parameters.max_headers_per_header_sync_fetch
             );
-            serialized_headers.truncate(context.parameters.max_headers_per_regular_sync_fetch);
+            serialized_headers.truncate(context.parameters.max_headers_per_header_sync_fetch);
         }
 
         // Verify all the fetched block headers
@@ -1330,7 +1330,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 let limited_block_refs = block_refs
                     .iter()
                     .copied()
-                    .take(context.parameters.max_headers_per_regular_sync_fetch)
+                    .take(context.parameters.max_headers_per_header_sync_fetch)
                     .collect();
                 (peer, limited_block_refs, "periodic_known")
             })
@@ -1349,7 +1349,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                         let limited_block_refs = block_refs
                             .iter()
                             .copied()
-                            .take(context.parameters.max_headers_per_regular_sync_fetch)
+                            .take(context.parameters.max_headers_per_header_sync_fetch)
                             .collect();
                         (peer, limited_block_refs, "periodic_known")
                     })
@@ -1395,7 +1395,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         all_missing_block_headers_refs.shuffle(&mut rng);
 
         let mut block_headers_chunks = all_missing_block_headers_refs
-            .chunks(context.parameters.max_headers_per_regular_sync_fetch);
+            .chunks(context.parameters.max_headers_per_header_sync_fetch);
 
         for peer in random_peers {
             if let Some(chunk) = block_headers_chunks.next() {
@@ -2463,14 +2463,14 @@ mod tests {
         let stub_block_author_1 = stub_block_headers
             .iter()
             .filter(|(block, _)| block.author == AuthorityIndex::new_for_test(1))
-            .take(context.parameters.max_headers_per_regular_sync_fetch)
+            .take(context.parameters.max_headers_per_header_sync_fetch)
             .map(|(_, block)| block.clone())
             .collect::<Vec<_>>();
 
         let stub_block_author_2 = stub_block_headers
             .iter()
             .filter(|(block, _)| block.author == AuthorityIndex::new_for_test(2))
-            .take(context.parameters.max_headers_per_regular_sync_fetch)
+            .take(context.parameters.max_headers_per_header_sync_fetch)
             .map(|(_, block)| block.clone())
             .collect::<Vec<_>>();
 
@@ -2478,7 +2478,7 @@ mod tests {
         // blocks
         let stub_block_author_3 = stub_block_headers
             .iter()
-            .take(context.parameters.max_headers_per_regular_sync_fetch)
+            .take(context.parameters.max_headers_per_header_sync_fetch)
             .map(|(_, block)| block.clone())
             .collect::<Vec<_>>();
 
@@ -2574,7 +2574,7 @@ mod tests {
         let sync_missing_block_round_threshold = context.parameters.commit_sync_batch_size;
         let stub_headers = (sync_missing_block_round_threshold * 2
             ..sync_missing_block_round_threshold * 2
-                + context.parameters.max_headers_per_regular_sync_fetch as u32)
+                + context.parameters.max_headers_per_header_sync_fetch as u32)
             .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
             .collect::<Vec<_>>();
         let missing_blocks_refs = stub_headers
@@ -2590,7 +2590,7 @@ mod tests {
         // authority = 0, so we are skipped anyway.
         let mut expected_headers = stub_headers
             .iter()
-            .take(context.parameters.max_headers_per_regular_sync_fetch)
+            .take(context.parameters.max_headers_per_header_sync_fetch)
             .cloned()
             .collect::<Vec<_>>();
         network_client
@@ -3103,7 +3103,7 @@ mod tests {
                             .unwrap()
                             .contains(&peer)
                     })
-                    .take(context.parameters.max_headers_per_regular_sync_fetch)
+                    .take(context.parameters.max_headers_per_header_sync_fetch)
                     .cloned()
                     .collect::<Vec<_>>();
                 (peer, verified_block_headers)
@@ -3137,8 +3137,7 @@ mod tests {
         // 4) Stub responses for fetches from additional random peers (1 and 4 in tests)
         network_client
             .stub_fetch_headers_response(
-                all_verified_block_headers
-                    [0..context.parameters.max_headers_per_regular_sync_fetch]
+                all_verified_block_headers[0..context.parameters.max_headers_per_header_sync_fetch]
                     .to_vec(),
                 AuthorityIndex::new_for_test(1),
                 None,
@@ -3147,8 +3146,8 @@ mod tests {
 
         network_client
             .stub_fetch_headers_response(
-                all_verified_block_headers[context.parameters.max_headers_per_regular_sync_fetch
-                    ..2 * context.parameters.max_headers_per_regular_sync_fetch]
+                all_verified_block_headers[context.parameters.max_headers_per_header_sync_fetch
+                    ..2 * context.parameters.max_headers_per_header_sync_fetch]
                     .to_vec(),
                 AuthorityIndex::new_for_test(4),
                 None,
@@ -3187,7 +3186,7 @@ mod tests {
         let (_guard1, bytes1, peer1) = &results[1];
         assert_eq!(*peer1, AuthorityIndex::new_for_test(1));
         let expected1 = all_verified_block_headers
-            [0..context.parameters.max_headers_per_regular_sync_fetch]
+            [0..context.parameters.max_headers_per_header_sync_fetch]
             .iter()
             .map(|vb| vb.serialized().clone())
             .collect::<Vec<_>>();
@@ -3197,8 +3196,8 @@ mod tests {
         let (_guard4, bytes4, peer4) = &results[2];
         assert_eq!(*peer4, AuthorityIndex::new_for_test(4));
         let expected4 =
-            all_verified_block_headers[context.parameters.max_headers_per_regular_sync_fetch
-                ..2 * context.parameters.max_headers_per_regular_sync_fetch]
+            all_verified_block_headers[context.parameters.max_headers_per_header_sync_fetch
+                ..2 * context.parameters.max_headers_per_header_sync_fetch]
                 .iter()
                 .map(|vb| vb.serialized().clone())
                 .collect::<Vec<_>>();

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -257,10 +257,13 @@ fn classify_block_header_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::UnexpectedAuthority(..)
         | ConsensusError::InvalidAuthorityIndex { .. }
         | ConsensusError::MalformedHeader(_)
+        | ConsensusError::MalformedTransactions(_)
         | ConsensusError::MalformedSignature(_)
         | ConsensusError::SignatureVerificationFailure(_)
         | ConsensusError::SerializationFailure(_)
-        | ConsensusError::DeserializationFailure(_) => FaultType::Unprovable,
+        | ConsensusError::DeserializationFailure(_)
+        | ConsensusError::SerializedTransactionsTooLarge { .. }
+        | ConsensusError::TransactionCommitmentFailure { .. } => FaultType::Unprovable,
 
         // Signed block header verification — provably the author's fault
         ConsensusError::TooManyAncestors(..)

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -68,7 +68,7 @@ pub(crate) enum TransactionFetchMode {
     /// referenced by commits in a batch
     FastCommitSync,
     /// Truncate to the maximum of max_transactions_per_commit_sync_fetch and
-    /// max_transactions_per_regular_sync_fetch- used by regular commit sync
+    /// max_transactions_per_transaction_sync_fetch- used by regular commit sync
     /// and transactions synchronizer
     TransactionSync,
 }

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -57,6 +57,21 @@ const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 // the responses.
 const MAX_TOTAL_FETCHED_BYTES: usize = 128 * 1024 * 1024;
 
+fn validate_header_response_count(
+    peer: AuthorityIndex,
+    requested: usize,
+    received: usize,
+) -> ConsensusResult<()> {
+    if received > requested {
+        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
+            authority: peer,
+            requested,
+            received_headers: received,
+        });
+    }
+    Ok(())
+}
+
 // Implements Tonic RPC client for Consensus.
 pub(crate) struct TonicClient {
     context: Arc<Context>,
@@ -257,10 +272,15 @@ impl NetworkClient for TonicClient {
             .into_inner();
         let mut blocks = vec![];
         let mut total_fetched_bytes = 0;
+        let max_headers = authorities.len();
         loop {
             match stream.message().await {
                 Ok(Some(response)) => {
                     let vec_serialized_block_headers = response.vec_serialized_block_header;
+                    let received_headers = blocks
+                        .len()
+                        .saturating_add(vec_serialized_block_headers.len());
+                    validate_header_response_count(peer, max_headers, received_headers)?;
                     for b in &vec_serialized_block_headers {
                         total_fetched_bytes += b.len();
                     }
@@ -646,9 +666,24 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
         let inner = request.into_inner();
+        let highest_accepted_rounds = inner.highest_accepted_rounds;
+        let max_fetch_size = if highest_accepted_rounds.is_empty() {
+            self.context.parameters.max_headers_per_commit_sync_fetch
+        } else {
+            self.context.parameters.max_headers_per_regular_sync_fetch
+        };
+        if inner.block_refs.len() > max_fetch_size {
+            warn!(
+                "Truncated fetch headers request from {} to {} blocks for peer {}",
+                inner.block_refs.len(),
+                max_fetch_size,
+                peer_index
+            );
+        }
         let block_refs = inner
             .block_refs
             .into_iter()
+            .take(max_fetch_size)
             .filter_map(|serialized| match bcs::from_bytes(&serialized) {
                 Ok(r) => Some(r),
                 Err(e) => {
@@ -657,7 +692,6 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
                 }
             })
             .collect();
-        let highest_accepted_rounds = inner.highest_accepted_rounds;
         let blocks = self
             .service
             .handle_fetch_headers(peer_index, block_refs, highest_accepted_rounds)
@@ -1442,4 +1476,23 @@ fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
         chunks.push(chunk);
     }
     chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_more_latest_headers_than_requested() {
+        let peer = AuthorityIndex::new_for_test(1);
+        let result = validate_header_response_count(peer, 1, 2);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
+                authority,
+                requested: 1,
+                received_headers: 2,
+            }) if authority == peer
+        ));
+    }
 }

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -57,21 +57,6 @@ const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 // the responses.
 const MAX_TOTAL_FETCHED_BYTES: usize = 128 * 1024 * 1024;
 
-fn validate_header_response_count(
-    peer: AuthorityIndex,
-    requested: usize,
-    received: usize,
-) -> ConsensusResult<()> {
-    if received > requested {
-        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
-            authority: peer,
-            requested,
-            received_headers: received,
-        });
-    }
-    Ok(())
-}
-
 // Implements Tonic RPC client for Consensus.
 pub(crate) struct TonicClient {
     context: Arc<Context>,
@@ -280,7 +265,13 @@ impl NetworkClient for TonicClient {
                     let received_headers = headers
                         .len()
                         .saturating_add(vec_serialized_block_headers.len());
-                    validate_header_response_count(peer, max_headers, received_headers)?;
+                    if received_headers > max_headers {
+                        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
+                            authority: peer,
+                            requested: max_headers,
+                            received_headers,
+                        });
+                    }
                     for b in &vec_serialized_block_headers {
                         total_fetched_bytes += b.len();
                     }
@@ -667,11 +658,10 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         };
         let inner = request.into_inner();
         let highest_accepted_rounds = inner.highest_accepted_rounds;
-        let max_fetch_size = if highest_accepted_rounds.is_empty() {
-            self.context.parameters.max_headers_per_commit_sync_fetch
-        } else {
-            self.context.parameters.max_headers_per_regular_sync_fetch
-        };
+        let max_fetch_size = self
+            .context
+            .parameters
+            .max_headers_per_fetch(highest_accepted_rounds.is_empty());
         if inner.block_refs.len() > max_fetch_size {
             warn!(
                 "Truncated fetch headers request from {} to {} blocks for peer {}",
@@ -1476,23 +1466,4 @@ fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
         chunks.push(chunk);
     }
     chunks
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn reject_more_latest_headers_than_requested() {
-        let peer = AuthorityIndex::new_for_test(1);
-        let result = validate_header_response_count(peer, 1, 2);
-        assert!(matches!(
-            result,
-            Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
-                authority,
-                requested: 1,
-                received_headers: 2,
-            }) if authority == peer
-        ));
-    }
 }

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -37,8 +37,9 @@ use super::{
 };
 use crate::{
     CommitIndex, Round,
-    block_header::BlockRef,
-    commit::CommitRange,
+    block_header::{BlockRef, max_signed_block_header_bytes},
+    block_verifier::serialized_transactions_size_limit,
+    commit::{CommitRange, max_commit_bytes},
     commit_syncer::CommitSyncType,
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -53,9 +54,56 @@ use crate::{
 // TODO: put max RPC response size in protocol config.
 const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 
-// Maximum total bytes fetched in a single fetch_blocks() call, after combining
-// the responses.
-const MAX_TOTAL_FETCHED_BYTES: usize = 128 * 1024 * 1024;
+// Upper bound on the total bytes a peer may stream in response to a fetch,
+// terminating the stream once exceeded. Each bound mirrors the matching
+// server-side per-fetch cap, so an honest peer's response always fits while a
+// flooding peer is cut off. Sizing tracks the cap, not the requested count.
+
+/// Header-fetch budget: the per-fetch header count cap times the maximum
+/// serialized header size for this committee. `commit_sync` selects the same
+/// cap the server applies in `ConsensusService::fetch_block_headers`.
+fn max_fetch_block_headers_response_bytes(context: &Context, commit_sync: bool) -> usize {
+    context
+        .parameters
+        .max_headers_per_fetch(commit_sync)
+        .saturating_mul(max_signed_block_header_bytes(context.committee.size()))
+}
+
+/// Transaction-fetch budget: the per-fetch transaction count cap times the
+/// maximum serialized per-block transaction payload. The larger of the two
+/// sync caps is used, matching `TransactionFetchMode::TransactionSync`.
+fn max_fetch_transactions_response_bytes(context: &Context) -> usize {
+    let max_transactions = context
+        .parameters
+        .max_transactions_per_commit_sync_fetch
+        .max(
+            context
+                .parameters
+                .max_transactions_per_transaction_sync_fetch,
+        );
+    max_transactions.saturating_mul(serialized_transactions_size_limit(context))
+}
+
+/// Combined fetch-commits-and-transactions budget: serialized commits, the
+/// certifier headers served alongside them, and the transactions referenced by
+/// those commits.
+fn max_fetch_commits_and_transactions_response_bytes(context: &Context) -> usize {
+    let committee_size = context.committee.size();
+    let gc_depth = context.protocol_config.gc_depth() as usize;
+    let commits = (context.parameters.fast_commit_sync_batch_size as usize)
+        .saturating_mul(max_commit_bytes(committee_size, gc_depth));
+    let certifier_headers = context
+        .parameters
+        .max_headers_per_header_sync_fetch
+        .saturating_mul(max_signed_block_header_bytes(committee_size));
+    let transactions = context
+        .parameters
+        .max_transactions_per_commit_sync_fetch
+        .saturating_mul(serialized_transactions_size_limit(context));
+    commits
+        .saturating_add(certifier_headers)
+        .saturating_add(transactions)
+}
 
 // Implements Tonic RPC client for Consensus.
 pub(crate) struct TonicClient {
@@ -141,6 +189,10 @@ impl NetworkClient for TonicClient {
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>> {
         let mut client = self.get_client(peer, timeout).await?;
+        let max_allowed_bytes = max_fetch_block_headers_response_bytes(
+            &self.context,
+            highest_accepted_rounds.is_empty(),
+        );
         let mut request = Request::new(FetchBlockHeadersRequest {
             block_refs: block_refs
                 .iter()
@@ -175,10 +227,10 @@ impl NetworkClient for TonicClient {
                         total_fetched_bytes += b.len();
                     }
                     vec_serialized_block_header.extend(response.vec_serialized_block_header);
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                    if total_fetched_bytes > max_allowed_bytes {
                         info!(
-                            "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                            "fetch_block_headers() fetched bytes exceeded limit: {} > {}, terminating stream.",
+                            total_fetched_bytes, max_allowed_bytes,
                         );
                         break;
                     }
@@ -258,6 +310,8 @@ impl NetworkClient for TonicClient {
         let mut headers = vec![];
         let mut total_fetched_bytes = 0;
         let max_headers = authorities.len();
+        let max_allowed_bytes = max_headers
+            .saturating_mul(max_signed_block_header_bytes(self.context.committee.size()));
         loop {
             match stream.message().await {
                 Ok(Some(response)) => {
@@ -276,10 +330,10 @@ impl NetworkClient for TonicClient {
                         total_fetched_bytes += b.len();
                     }
                     headers.extend(vec_serialized_block_headers);
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                    if total_fetched_bytes > max_allowed_bytes {
                         info!(
-                            "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                            "fetch_latest_block_headers() fetched bytes exceeded limit: {} > {}, terminating stream.",
+                            total_fetched_bytes, max_allowed_bytes,
                         );
                         break;
                     }
@@ -351,6 +405,7 @@ impl NetworkClient for TonicClient {
             })?
             .into_inner();
 
+        let max_allowed_bytes = max_fetch_transactions_response_bytes(&self.context);
         let mut total_fetched_bytes = 0;
         let mut vec_serialized_transactions = vec![];
         loop {
@@ -359,10 +414,10 @@ impl NetworkClient for TonicClient {
                     for b in &response.vec_serialized_transactions {
                         total_fetched_bytes += b.len();
                     }
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                    if total_fetched_bytes > max_allowed_bytes {
                         info!(
                             "fetch_transactions() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                            total_fetched_bytes, max_allowed_bytes,
                         );
                         break;
                     }
@@ -423,6 +478,7 @@ impl NetworkClient for TonicClient {
         let mut commits = Vec::new();
         let mut certifier_block_headers = Vec::new();
         let mut transactions = Vec::new();
+        let max_allowed_bytes = max_fetch_commits_and_transactions_response_bytes(&self.context);
         let mut total_fetched_bytes = 0;
 
         loop {
@@ -445,10 +501,10 @@ impl NetworkClient for TonicClient {
                     }
                     transactions.extend(response.transactions);
 
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                    if total_fetched_bytes > max_allowed_bytes {
                         info!(
                             "fetch_commits_and_transactions() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                            total_fetched_bytes, max_allowed_bytes,
                         );
                         break;
                     }
@@ -1466,4 +1522,48 @@ fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
         chunks.push(chunk);
     }
     chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{max_fetch_block_headers_response_bytes, max_fetch_transactions_response_bytes};
+    use crate::{
+        block_header::max_signed_block_header_bytes,
+        block_verifier::serialized_transactions_size_limit, context::Context,
+    };
+
+    /// The per-fetch response budgets track the matching server-side count cap:
+    /// the value is the cap times the maximum per-item size, depends only on the
+    /// cap and committee, and never on how many items the caller requested.
+    #[tokio::test]
+    async fn fetch_response_budgets_track_server_caps() {
+        let (mut context, _keys) = Context::new_for_test(4);
+        context.parameters.max_headers_per_commit_sync_fetch = 7;
+        context.parameters.max_headers_per_header_sync_fetch = 11;
+        context.parameters.max_transactions_per_commit_sync_fetch = 5;
+        context
+            .parameters
+            .max_transactions_per_transaction_sync_fetch = 9;
+        let committee_size = context.committee.size();
+        let context = Arc::new(context);
+
+        let header_bytes = max_signed_block_header_bytes(committee_size);
+        // Commit sync selects the commit-sync header cap.
+        assert_eq!(
+            max_fetch_block_headers_response_bytes(&context, true),
+            7 * header_bytes
+        );
+        // Header sync selects the header-sync cap.
+        assert_eq!(
+            max_fetch_block_headers_response_bytes(&context, false),
+            11 * header_bytes
+        );
+        // Transaction budget uses the larger of the two transaction caps.
+        assert_eq!(
+            max_fetch_transactions_response_bytes(&context),
+            9 * serialized_transactions_size_limit(&context)
+        );
+    }
 }

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -270,21 +270,21 @@ impl NetworkClient for TonicClient {
                 }
             })?
             .into_inner();
-        let mut blocks = vec![];
+        let mut headers = vec![];
         let mut total_fetched_bytes = 0;
         let max_headers = authorities.len();
         loop {
             match stream.message().await {
                 Ok(Some(response)) => {
                     let vec_serialized_block_headers = response.vec_serialized_block_header;
-                    let received_headers = blocks
+                    let received_headers = headers
                         .len()
                         .saturating_add(vec_serialized_block_headers.len());
                     validate_header_response_count(peer, max_headers, received_headers)?;
                     for b in &vec_serialized_block_headers {
                         total_fetched_bytes += b.len();
                     }
-                    blocks.extend(vec_serialized_block_headers);
+                    headers.extend(vec_serialized_block_headers);
                     if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
                         info!(
                             "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
@@ -297,7 +297,7 @@ impl NetworkClient for TonicClient {
                     break;
                 }
                 Err(e) => {
-                    if blocks.is_empty() {
+                    if headers.is_empty() {
                         if e.code() == tonic::Code::DeadlineExceeded {
                             return Err(ConsensusError::NetworkRequestTimeout(format!(
                                 "fetch_blocks failed mid-stream: {e:?}"
@@ -313,7 +313,7 @@ impl NetworkClient for TonicClient {
                 }
             }
         }
-        Ok(blocks)
+        Ok(headers)
     }
 
     async fn fetch_transactions(

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -453,13 +453,17 @@ impl Store for MemStore {
         Ok(commits)
     }
 
-    fn read_commit_votes(&self, commit_index: CommitIndex) -> ConsensusResult<Vec<BlockRef>> {
+    fn read_commit_votes(
+        &self,
+        commit_index: CommitIndex,
+        commit_digest: CommitDigest,
+    ) -> ConsensusResult<Vec<BlockRef>> {
         let inner = self.inner.read();
         let votes = inner
             .commit_votes
             .range((
-                Included((commit_index, CommitDigest::MIN, BlockRef::MIN)),
-                Included((commit_index, CommitDigest::MAX, BlockRef::MAX)),
+                Included((commit_index, commit_digest, BlockRef::MIN)),
+                Included((commit_index, commit_digest, BlockRef::MAX)),
             ))
             .map(|(_, _, block_ref)| *block_ref)
             .collect();

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -17,7 +17,7 @@ use starfish_config::AuthorityIndex;
 use crate::{
     CommitIndex,
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions},
-    commit::{CommitInfo, CommitRange, CommitRef, TrustedCommit},
+    commit::{CommitDigest, CommitInfo, CommitRange, CommitRef, TrustedCommit},
     context::Context,
     error::ConsensusResult,
     misbehavior_store::MisbehaviorCounts,
@@ -156,8 +156,15 @@ pub(crate) trait Store: Send + Sync {
     /// Reads all commits from start (inclusive) until end (inclusive).
     fn scan_commits(&self, range: CommitRange) -> ConsensusResult<Vec<TrustedCommit>>;
 
-    /// Reads all blocks voting on a particular commit.
-    fn read_commit_votes(&self, commit_index: CommitIndex) -> ConsensusResult<Vec<BlockRef>>;
+    /// Reads all blocks voting on a particular commit, identified by both
+    /// index and digest. Votes for other digests at the same index (possible
+    /// with Byzantine voters, since vote digests are not validated against
+    /// stored commits) are excluded.
+    fn read_commit_votes(
+        &self,
+        commit_index: CommitIndex,
+        commit_digest: CommitDigest,
+    ) -> ConsensusResult<Vec<BlockRef>>;
 
     /// Finds the highest commit index that has at least one vote, up to (and
     /// including) the given index. Returns None if no votes exist for any

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -696,11 +696,15 @@ impl Store for RocksDBStore {
         Ok(commits)
     }
 
-    fn read_commit_votes(&self, commit_index: CommitIndex) -> ConsensusResult<Vec<BlockRef>> {
+    fn read_commit_votes(
+        &self,
+        commit_index: CommitIndex,
+        commit_digest: CommitDigest,
+    ) -> ConsensusResult<Vec<BlockRef>> {
         let mut votes = Vec::new();
         for vote in self.commit_votes.safe_range_iter((
-            Included((commit_index, CommitDigest::MIN, BlockRef::MIN)),
-            Included((commit_index, CommitDigest::MAX, BlockRef::MAX)),
+            Included((commit_index, commit_digest, BlockRef::MIN)),
+            Included((commit_index, commit_digest, BlockRef::MAX)),
         )) {
             let ((_, _, block_ref), _) = vote?;
             votes.push(block_ref);

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -755,7 +755,9 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 .lock_transactions_and_active_request(
                     authority_block_refs.clone(),
                     authority,
-                    context.parameters.max_transactions_per_regular_sync_fetch,
+                    context
+                        .parameters
+                        .max_transactions_per_transaction_sync_fetch,
                     sync_method,
                     active_requests.clone(),
                 )
@@ -2100,7 +2102,9 @@ mod tests {
             let guard = map.lock_transactions_and_active_request(
                 missing_transactions_refs.clone(),
                 authority,
-                context.parameters.max_transactions_per_regular_sync_fetch,
+                context
+                    .parameters
+                    .max_transactions_per_transaction_sync_fetch,
                 sync_method,
                 active_requests.clone(),
             );
@@ -2123,7 +2127,9 @@ mod tests {
             let guard = map.lock_transactions_and_active_request(
                 missing_transactions_refs.clone(),
                 authority,
-                context.parameters.max_transactions_per_regular_sync_fetch,
+                context
+                    .parameters
+                    .max_transactions_per_transaction_sync_fetch,
                 sync_method,
                 active_requests.clone(),
             );
@@ -2138,7 +2144,9 @@ mod tests {
         let guard = map.lock_transactions_and_active_request(
             missing_transactions_refs.clone(),
             AuthorityIndex::new_for_test(MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION as u8),
-            context.parameters.max_transactions_per_regular_sync_fetch,
+            context
+                .parameters
+                .max_transactions_per_transaction_sync_fetch,
             sync_method,
             active_requests,
         );


### PR DESCRIPTION
# Description of change

Replaces the fixed per-call fetched-bytes cap on the consensus fetch paths with per-endpoint budgets computed from each fetch's count parameters and the maximum serialized size of the items it returns, so the client-side stream-termination limit scales with committee size and the configured per-fetch caps instead of a single hard-coded constant.

Adds two size estimators, each pinned by a test against the BCS wire layout: `max_signed_block_header_bytes(committee_size)` and `max_commit_bytes(committee_size, gc_depth)`. The per-fetch budgets in `tonic_network.rs` combine these with the per-fetch count parameters (`max_headers_per_fetch`, `max_transactions_per_*_sync_fetch`) and the transaction-payload limit.

Builds on #11858 and reuses its `max_headers_per_fetch` selector and `serialized_transactions_size_limit`; the base will retarget to `develop` once #11858 merges.

## Links to any relevant issues

Relates to #11857

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes