### PR TITLE
fix(starfish): bound far-future block rounds to cap suspender memory

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -84,6 +84,12 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_dag_state_cached_rounds")]
     pub dag_state_cached_rounds: u32,
 
+    /// Rounds a peer-disseminated block may lead the locally accepted frontier,
+    /// in addition to `dag_state_cached_rounds`, before it is dropped as too
+    /// far ahead to connect.
+    #[serde(default = "Parameters::default_peer_round_ahead_margin")]
+    pub peer_round_ahead_margin: u32,
+
     // Number of authorities commit syncer fetches in parallel.
     // Both commits in a range and blocks referenced by the commits are fetched per authority.
     #[serde(default = "Parameters::default_commit_sync_parallel_fetches")]
@@ -191,6 +197,15 @@ impl Parameters {
         (self.block_rate_window.as_millis() as u64 / interval_ms).max(1)
     }
 
+    /// Highest round a peer-disseminated block may have, relative to the
+    /// accepted `frontier`, to still be close enough to connect; blocks above
+    /// this are too far ahead and dropped.
+    pub fn peer_disseminated_round_ceiling(&self, frontier: u32) -> u32 {
+        frontier
+            .saturating_add(self.dag_state_cached_rounds)
+            .saturating_add(self.peer_round_ahead_margin)
+    }
+
     /// Maximum number of block headers served per fetch request, depending on
     /// whether the request comes from commit sync or the header synchronizer.
     pub fn max_headers_per_fetch(&self, commit_sync: bool) -> usize {
@@ -256,6 +271,10 @@ impl Parameters {
         } else {
             500
         }
+    }
+
+    pub(crate) fn default_peer_round_ahead_margin() -> u32 {
+        1000
     }
 
     pub(crate) fn default_commit_sync_parallel_fetches() -> usize {
@@ -338,6 +357,7 @@ impl Default for Parameters {
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),
             dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),
+            peer_round_ahead_margin: Parameters::default_peer_round_ahead_margin(),
             commit_sync_parallel_fetches: Parameters::default_commit_sync_parallel_fetches(),
             commit_sync_batch_size: Parameters::default_commit_sync_batch_size(),
             commit_sync_batches_ahead: Parameters::default_commit_sync_batches_ahead(),

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -84,9 +84,9 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_dag_state_cached_rounds")]
     pub dag_state_cached_rounds: u32,
 
-    /// Rounds a peer-disseminated block may lead the locally accepted frontier,
-    /// in addition to `dag_state_cached_rounds`, before it is dropped as too
-    /// far ahead to connect.
+    /// Rounds a header from a far-future-bounded source may lead the locally
+    /// accepted frontier, in addition to `dag_state_cached_rounds`, before it
+    /// is dropped as too far ahead to connect.
     #[serde(default = "Parameters::default_peer_round_ahead_margin")]
     pub peer_round_ahead_margin: u32,
 
@@ -197,10 +197,10 @@ impl Parameters {
         (self.block_rate_window.as_millis() as u64 / interval_ms).max(1)
     }
 
-    /// Highest round a peer-disseminated block may have, relative to the
-    /// accepted `frontier`, to still be close enough to connect; blocks above
-    /// this are too far ahead and dropped.
-    pub fn peer_disseminated_round_ceiling(&self, frontier: u32) -> u32 {
+    /// Highest round a header from a far-future-bounded source may have,
+    /// relative to the accepted `frontier`, to still be close enough to
+    /// connect; headers above this are too far ahead and dropped.
+    pub fn far_future_round_ceiling(&self, frontier: u32) -> u32 {
         frontier
             .saturating_add(self.dag_state_cached_rounds)
             .saturating_add(self.peer_round_ahead_margin)

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -22,6 +22,7 @@ sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0
 dag_state_cached_rounds: 500
+peer_round_ahead_margin: 1000
 commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100
 commit_sync_batches_ahead: 32

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -787,30 +787,42 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
         self.commit_vote_monitor.observe_block(&verified_block);
 
-        // 5. Drop a far-future primary block before shard/transaction
-        // processing, so it cannot grow the shard reconstructor or DagState
-        // shard state.
-        let far_future_ceiling = self.dag_state.read().peer_disseminated_round_ceiling();
-        if block_ref.round > far_future_ceiling {
-            self.context
-                .metrics
-                .node_metrics
-                .dropped_far_future_blocks_total
-                .with_label_values(&["block_bundle"])
-                .inc();
+        // 5. Bound the far-future parts of the bundle, reusing the block-manager
+        // helper as the synchronizer does. Additional headers above the connect
+        // ceiling are dropped; a far-future primary block is dropped here too, so
+        // it is neither processed for shards (the reconstructor bypasses the
+        // block manager) nor forwarded to the core.
+        additional_block_headers = crate::block_manager::drop_far_future(
+            &self.context,
+            &self.dag_state,
+            additional_block_headers,
+            DataSource::BlockBundleStream,
+            |header| header.round(),
+        );
+        let verified_blocks = crate::block_manager::drop_far_future(
+            &self.context,
+            &self.dag_state,
+            vec![verified_block],
+            DataSource::BlockStreaming,
+            |block| block.round(),
+        );
+        let primary_block_far_future = verified_blocks.is_empty();
+        if primary_block_far_future {
             debug!(
-                "Dropping far-future streamed block {block_ref} from peer {peer}; round {} exceeds ceiling {far_future_ceiling}",
+                "Dropped far-future streamed block {block_ref} from peer {peer}; round {} exceeds the connect ceiling",
                 block_ref.round
             );
-            return Ok(());
         }
 
-        // 6. Collect shards from a bundle and check their proofs.
-
-        let serialized_shards =
-            std::mem::take(&mut serialized_block_bundle_parts.serialized_shards);
-        let verified_shards =
-            self.extract_shards_from_bundle(peer, peer_hostname, serialized_shards, block_ref)?;
+        // 6. Collect shards from a bundle and check their proofs. Skipped for a
+        // far-future primary block so its shards never reach the reconstructor.
+        let verified_shards = if primary_block_far_future {
+            Vec::new()
+        } else {
+            let serialized_shards =
+                std::mem::take(&mut serialized_block_bundle_parts.serialized_shards);
+            self.extract_shards_from_bundle(peer, peer_hostname, serialized_shards, block_ref)?
+        };
 
         // 7. Reject blocks when local commit index is lagging too far from quorum
         //    commit index.
@@ -831,18 +843,21 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         self.add_digests_to_filter(peer_hostname, &mut additional_block_headers, block_ref)
             .await;
 
-        // 9. Prepare transaction messages for shard reconstructor and send them
-        let transaction_messages = TransactionMessage::create_transaction_messages(
-            &verified_block,
-            &verified_shards,
-            peer.value(),
-        );
-        if let Err(e) = self
-            .transaction_message_sender
-            .send(transaction_messages)
-            .await
-        {
-            warn!("Failed to send transaction messages to shard reconstructor: {e}");
+        // 9. Prepare transaction messages for shard reconstructor and send them.
+        // Skipped for a far-future primary block (no shards were collected).
+        if !primary_block_far_future {
+            let transaction_messages = TransactionMessage::create_transaction_messages(
+                &verified_blocks[0],
+                &verified_shards,
+                peer.value(),
+            );
+            if let Err(e) = self
+                .transaction_message_sender
+                .send(transaction_messages)
+                .await
+            {
+                warn!("Failed to send transaction messages to shard reconstructor: {e}");
+            }
         }
 
         // 10. Add additional headers from bundle to dag, receive missing ancestors for
@@ -863,21 +878,24 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&["headers"])
             .observe(missing_ancestors.len() as f64);
 
-        // 11. Add the block to dag, add its missing ancestors to the set
-        let (missing_block_ancestors, missing_block_committed_transactions) = self
-            .core_dispatcher
-            .add_blocks(vec![verified_block], DataSource::BlockStreaming)
-            .await
-            .map_err(|_| ConsensusError::Shutdown)?;
-        self.context
-            .metrics
-            .node_metrics
-            .missing_ancestors_from_streaming
-            .with_label_values(&["block"])
-            .observe(missing_block_ancestors.len() as f64);
+        // 11. Add the block to dag, add its missing ancestors to the set. A
+        // far-future block was dropped above and is not forwarded to the core.
+        if !primary_block_far_future {
+            let (missing_block_ancestors, missing_block_committed_transactions) = self
+                .core_dispatcher
+                .add_blocks(verified_blocks, DataSource::BlockStreaming)
+                .await
+                .map_err(|_| ConsensusError::Shutdown)?;
+            self.context
+                .metrics
+                .node_metrics
+                .missing_ancestors_from_streaming
+                .with_label_values(&["block"])
+                .observe(missing_block_ancestors.len() as f64);
 
-        missing_ancestors.extend(missing_block_ancestors);
-        missing_committed_txns.extend(missing_block_committed_transactions);
+            missing_ancestors.extend(missing_block_ancestors);
+            missing_committed_txns.extend(missing_block_committed_transactions);
+        }
 
         for missing_block_ref in missing_ancestors.iter() {
             self.context
@@ -888,8 +906,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // 12. Add our shard from the received block and its proof to the dag_state
-        // only if it contains transactions
-        if let Some(shard_for_core) = shard_for_core {
+        // only if it contains transactions and the block is not far-future.
+        if let Some(shard_for_core) = shard_for_core.filter(|_| !primary_block_far_future) {
             let serialized_shard_for_core: Bytes = match shard_for_core {
                 // For backward compatibility, we still support ShardWithProofV1 during the
                 // epoch during which nodes are upgraded to a new software version. Because of
@@ -1960,10 +1978,9 @@ mod tests {
         assert_eq!(blocks[0], input_block);
     }
 
-    /// A signed far-future bundle is dropped after verification and commit-vote
-    /// observation but before shard/transaction processing: nothing is sent to
-    /// the shard reconstructor and nothing reaches core, so it cannot grow
-    /// shard/transaction state.
+    /// A signed far-future bundle is dropped at ingress: the block is counted,
+    /// not forwarded to the core, and not sent to the shard reconstructor, so
+    /// it cannot grow shard/transaction state.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_drops_far_future(
@@ -2019,7 +2036,7 @@ mod tests {
         let mut encoder = create_encoder(&context);
 
         // One round past the acceptance ceiling (frontier is genesis round 0).
-        let far_round = context.parameters.peer_disseminated_round_ceiling(0) + 1;
+        let far_round = context.parameters.far_future_round_ceiling(0) + 1;
         let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new_with_commitment(far_round, 0, &context, &mut encoder).build(),
         );
@@ -2034,19 +2051,26 @@ mod tests {
             .await
             .unwrap();
 
-        // Dropped: counted, not forwarded to core, and nothing sent to the
-        // shard reconstructor.
+        // The far-future block is dropped at ingress: counted, not forwarded to
+        // the core, and not sent to the shard reconstructor.
+        assert!(
+            tx_message_receiver.try_recv().is_err(),
+            "far-future bundle must not feed the shard reconstructor"
+        );
+        assert!(
+            core_dispatcher.get_blocks().is_empty(),
+            "far-future block must not be forwarded to the core"
+        );
         assert_eq!(
             context
                 .metrics
                 .node_metrics
-                .dropped_far_future_blocks_total
-                .with_label_values(&["block_bundle"])
+                .dropped_far_future_headers_total
+                .with_label_values(&[DataSource::BlockStreaming.as_str()])
                 .get(),
-            1
+            1,
+            "the dropped far-future block is counted"
         );
-        assert!(core_dispatcher.get_blocks().is_empty());
-        assert!(tx_message_receiver.try_recv().is_err());
     }
 
     #[rstest]

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -787,11 +787,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
         self.commit_vote_monitor.observe_block(&verified_block);
 
-        // 5. Drop a far-future primary block here — after signature/header
-        // verification and vote observation, but before shard extraction,
-        // transaction messages, digest filtering, and add_shards — so it cannot
-        // grow the shard reconstructor or DagState shard state. BlockManager
-        // applies the same bound again as defense in depth.
+        // 5. Drop a far-future primary block before shard/transaction
+        // processing, so it cannot grow the shard reconstructor or DagState
+        // shard state.
         let far_future_ceiling = self
             .context
             .parameters

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -790,10 +790,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // 5. Drop a far-future primary block before shard/transaction
         // processing, so it cannot grow the shard reconstructor or DagState
         // shard state.
-        let far_future_ceiling = self
-            .context
-            .parameters
-            .peer_disseminated_round_ceiling(self.dag_state.read().highest_accepted_round());
+        let far_future_ceiling = self.dag_state.read().peer_disseminated_round_ceiling();
         if block_ref.round > far_future_ceiling {
             self.context
                 .metrics

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -778,21 +778,46 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             block_ref,
         )?;
 
-        // 4. Collect shards from a bundle and check their proofs.
+        // 4. Observe headers and the block for the commit votes. When local commit is
+        // lagging too much, commit sync loop will trigger fetching. Done before the
+        // far-future check below so quorum-commit tracking keeps progressing even
+        // for bundles we drop.
+        for block_header in additional_block_headers.iter() {
+            self.commit_vote_monitor.observe_block(block_header);
+        }
+        self.commit_vote_monitor.observe_block(&verified_block);
+
+        // 5. Drop a far-future primary block here — after signature/header
+        // verification and vote observation, but before shard extraction,
+        // transaction messages, digest filtering, and add_shards — so it cannot
+        // grow the shard reconstructor or DagState shard state. BlockManager
+        // applies the same bound again as defense in depth.
+        let far_future_ceiling = self
+            .context
+            .parameters
+            .peer_disseminated_round_ceiling(self.dag_state.read().highest_accepted_round());
+        if block_ref.round > far_future_ceiling {
+            self.context
+                .metrics
+                .node_metrics
+                .dropped_far_future_blocks_total
+                .with_label_values(&["block_bundle"])
+                .inc();
+            debug!(
+                "Dropping far-future streamed block {block_ref} from peer {peer}; round {} exceeds ceiling {far_future_ceiling}",
+                block_ref.round
+            );
+            return Ok(());
+        }
+
+        // 6. Collect shards from a bundle and check their proofs.
 
         let serialized_shards =
             std::mem::take(&mut serialized_block_bundle_parts.serialized_shards);
         let verified_shards =
             self.extract_shards_from_bundle(peer, peer_hostname, serialized_shards, block_ref)?;
 
-        // 5. Observe headers and the block for the commit votes. When local commit is
-        // lagging too much, commit sync loop will trigger fetching.
-        for block_header in additional_block_headers.iter() {
-            self.commit_vote_monitor.observe_block(block_header);
-        }
-        self.commit_vote_monitor.observe_block(&verified_block);
-
-        // 6. Reject blocks when local commit index is lagging too far from quorum
+        // 7. Reject blocks when local commit index is lagging too far from quorum
         //    commit index.
         //
         // IMPORTANT: this must be done after observing votes from the block, otherwise
@@ -806,12 +831,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname])
             .inc();
 
-        // 7. Add digests to filter. Exclude from the vector those that are already
+        // 8. Add digests to filter. Exclude from the vector those that are already
         //    inserted
         self.add_digests_to_filter(peer_hostname, &mut additional_block_headers, block_ref)
             .await;
 
-        // 8. Prepare transaction messages for shard reconstructor and send them
+        // 9. Prepare transaction messages for shard reconstructor and send them
         let transaction_messages = TransactionMessage::create_transaction_messages(
             &verified_block,
             &verified_shards,
@@ -825,7 +850,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             warn!("Failed to send transaction messages to shard reconstructor: {e}");
         }
 
-        // 9. Add additional headers from bundle to dag, receive missing ancestors for
+        // 10. Add additional headers from bundle to dag, receive missing ancestors for
         // them. Normally, there should be no missing ancestors, as the headers are
         // sent in order of increasing rounds.
         let (mut missing_ancestors, mut missing_committed_txns) = self
@@ -843,7 +868,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&["headers"])
             .observe(missing_ancestors.len() as f64);
 
-        // 10. Add the block to dag, add its missing ancestors to the set
+        // 11. Add the block to dag, add its missing ancestors to the set
         let (missing_block_ancestors, missing_block_committed_transactions) = self
             .core_dispatcher
             .add_blocks(vec![verified_block], DataSource::BlockStreaming)
@@ -867,7 +892,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .observe(block_ref.round as f64 - missing_block_ref.round as f64);
         }
 
-        // 11. Add our shard from the received block and its proof to the dag_state
+        // 12. Add our shard from the received block and its proof to the dag_state
         // only if it contains transactions
         if let Some(shard_for_core) = shard_for_core {
             let serialized_shard_for_core: Bytes = match shard_for_core {
@@ -898,7 +923,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .map_err(|_| ConsensusError::Shutdown)?;
         }
 
-        // 12. Report useful info for cordial and connection knowledge
+        // 13. Report useful info for cordial and connection knowledge
         let block_round = block_ref.round;
         self.cordial_knowledge.report_useful_authors(
             peer,
@@ -908,7 +933,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             block_round,
         )?;
 
-        // 13. schedule the fetching of missing ancestors (if any) from this peer
+        // 14. schedule the fetching of missing ancestors (if any) from this peer
         if !missing_ancestors.is_empty() {
             if let Err(err) = self
                 .synchronizer
@@ -919,7 +944,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             }
         }
 
-        // 14. schedule the fetching of missing committed transactions (if any)
+        // 15. schedule the fetching of missing committed transactions (if any)
         if !missing_committed_txns.is_empty() {
             if let Err(err) = self
                 .transactions_synchronizer
@@ -1938,6 +1963,95 @@ mod tests {
         let blocks = core_dispatcher.get_blocks();
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0], input_block);
+    }
+
+    /// A signed far-future bundle is dropped after verification and commit-vote
+    /// observation but before shard/transaction processing: nothing is sent to
+    /// the shard reconstructor and nothing reaches core, so it cannot grow
+    /// shard/transaction state.
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_subscribed_block_bundle_drops_far_future(
+        #[values(false, true)] consensus_fast_commit_sync: bool,
+    ) {
+        let (mut context, _keys) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
+        let (tx_message_sender, mut tx_message_receiver) = mpsc::channel(100);
+        let network_client = Arc::new(FakeNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+        );
+        let header_synchronizer = HeaderSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            false,
+            None,
+            Arc::new(MisbehaviorStore::new(&context)),
+        );
+        let authority_service = Arc::new(AuthorityService::new(
+            context.clone(),
+            block_verifier,
+            commit_vote_monitor,
+            header_synchronizer,
+            transactions_synchronizer,
+            core_dispatcher.clone(),
+            rx_block_broadcast,
+            dag_state,
+            store,
+            Arc::new(MisbehaviorStore::new(&context)),
+            tx_message_sender,
+            cordial_knowledge,
+        ));
+        let mut encoder = create_encoder(&context);
+
+        // One round past the acceptance ceiling (frontier is genesis round 0).
+        let far_round = context.parameters.peer_disseminated_round_ceiling(0) + 1;
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(far_round, 0, &context, &mut encoder).build(),
+        );
+        let bundle = SerializedBlockBundle::try_from(input_block).unwrap();
+
+        authority_service
+            .handle_subscribed_block_bundle(
+                context.committee.to_authority_index(0).unwrap(),
+                bundle,
+                &mut encoder,
+            )
+            .await
+            .unwrap();
+
+        // Dropped: counted, not forwarded to core, and nothing sent to the
+        // shard reconstructor.
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_far_future_blocks_total
+                .with_label_values(&["block_bundle"])
+                .get(),
+            1
+        );
+        assert!(core_dispatcher.get_blocks().is_empty());
+        assert!(tx_message_receiver.try_recv().is_err());
     }
 
     #[rstest]

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -87,6 +87,39 @@ pub(crate) struct BlockManager {
     last_gc_floor_applied: Round,
 }
 
+/// Drops headers/blocks whose round is too far above the accepted frontier to
+/// ever connect, bounding the round horizon retained in the suspender. Sources
+/// not subject to the bound (`DataSource::is_subject_to_far_future_bound`) pass
+/// through unchanged. Each drop is counted in
+/// `dropped_far_future_headers_total` under the source label.
+pub(crate) fn drop_far_future<T>(
+    context: &Context,
+    dag_state: &RwLock<DagState>,
+    items: Vec<T>,
+    source: DataSource,
+    round_of: impl Fn(&T) -> Round,
+) -> Vec<T> {
+    if !source.is_subject_to_far_future_bound() {
+        return items;
+    }
+    let ceiling = dag_state.read().far_future_round_ceiling();
+    let total = items.len();
+    let kept: Vec<T> = items
+        .into_iter()
+        .filter(|item| round_of(item) <= ceiling)
+        .collect();
+    let dropped = (total - kept.len()) as u64;
+    if dropped > 0 {
+        context
+            .metrics
+            .node_metrics
+            .dropped_far_future_headers_total
+            .with_label_values(&[source.as_str()])
+            .inc_by(dropped);
+    }
+    kept
+}
+
 impl BlockManager {
     pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
         Self {
@@ -168,36 +201,6 @@ impl BlockManager {
         unsuspended_headers
     }
 
-    /// Drops peer-disseminated blocks/headers whose round is too far above the
-    /// accepted frontier to ever connect, bounding the round horizon retained
-    /// in the suspender. Non-peer-disseminated sources pass through unchanged.
-    fn drop_far_future<T>(
-        &self,
-        items: Vec<T>,
-        source: DataSource,
-        round_of: impl Fn(&T) -> Round,
-    ) -> Vec<T> {
-        if !source.is_peer_disseminated() {
-            return items;
-        }
-        let ceiling = self.dag_state.read().peer_disseminated_round_ceiling();
-        let total = items.len();
-        let kept: Vec<T> = items
-            .into_iter()
-            .filter(|item| round_of(item) <= ceiling)
-            .collect();
-        let dropped = (total - kept.len()) as u64;
-        if dropped > 0 {
-            self.context
-                .metrics
-                .node_metrics
-                .dropped_far_future_blocks_total
-                .with_label_values(&["block_manager"])
-                .inc_by(dropped);
-        }
-        kept
-    }
-
     /// Does all the same things as try_accept_block_headers and additionally
     /// saves blocks with transaction data into recent_blocks in DagState
     #[tracing::instrument(skip_all)]
@@ -208,7 +211,9 @@ impl BlockManager {
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_blocks");
         let gc_unsuspended = self.maybe_evict_below_gc_floor();
-        let blocks = self.drop_far_future(blocks, source, |b| b.round());
+        let blocks = drop_far_future(&self.context, &self.dag_state, blocks, source, |b| {
+            b.round()
+        });
 
         let block_headers: Vec<_> = blocks
             .iter()
@@ -253,7 +258,10 @@ impl BlockManager {
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers");
         let gc_unsuspended = self.maybe_evict_below_gc_floor();
-        let block_headers = self.drop_far_future(block_headers, source, |h| h.round());
+        let block_headers =
+            drop_far_future(&self.context, &self.dag_state, block_headers, source, |h| {
+                h.round()
+            });
 
         // Headers are added through synchronizer, commit syncer and cordial
         // dissemination.
@@ -1294,11 +1302,11 @@ mod tests {
         );
     }
 
-    /// A peer-disseminated header whose round is far above the accepted
-    /// frontier is dropped before entering the suspender, so a Byzantine peer
-    /// streaming far-future rounds cannot grow the suspender without bound.
+    /// A header from a far-future-bounded source whose round is far above the
+    /// accepted frontier is dropped before entering the suspender, so a
+    /// Byzantine peer streaming far-future rounds cannot grow it without bound.
     #[tokio::test]
-    async fn drops_far_future_peer_disseminated_headers() {
+    async fn drops_far_future_headers() {
         use gc_eviction_helpers::*;
 
         let (context, _) = Context::new_for_test(4);
@@ -1308,17 +1316,22 @@ mod tests {
         let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
 
         // Frontier starts at genesis round 0, so the acceptance ceiling is
-        // `dag_state_cached_rounds + peer_round_ahead_margin`; one round past it
-        // is dropped.
-        let far_round = context.parameters.peer_disseminated_round_ceiling(0) + 1;
-        let far_header = header(far_round, 1, vec![block_ref(far_round - 1, 0)]);
+        // `dag_state_cached_rounds + peer_round_ahead_margin`; rounds past it
+        // are dropped. Feed several at once so the metric counts each dropped
+        // header, not one per call (e.g. one per bundle).
+        let far_round = context.parameters.far_future_round_ceiling(0) + 1;
+        let far_headers = vec![
+            header(far_round, 1, vec![block_ref(far_round - 1, 0)]),
+            header(far_round + 1, 2, vec![block_ref(far_round, 0)]),
+            header(far_round + 2, 3, vec![block_ref(far_round + 1, 0)]),
+        ];
 
         let (accepted, missing) =
-            block_manager.try_accept_block_headers(vec![far_header], DataSource::BlockBundleStream);
+            block_manager.try_accept_block_headers(far_headers, DataSource::BlockBundleStream);
 
         assert!(
             accepted.is_empty(),
-            "far-future header must not be accepted"
+            "far-future headers must not be accepted"
         );
         assert!(
             missing.is_empty(),
@@ -1329,16 +1342,17 @@ mod tests {
         assert_eq!(
             dag_state.read().highest_accepted_round(),
             0,
-            "dropped header must not advance the frontier"
+            "dropped headers must not advance the frontier"
         );
         assert_eq!(
             context
                 .metrics
                 .node_metrics
-                .dropped_far_future_blocks_total
-                .with_label_values(&["block_manager"])
+                .dropped_far_future_headers_total
+                .with_label_values(&[DataSource::BlockBundleStream.as_str()])
                 .get(),
-            1
+            3,
+            "every dropped header is counted, not one per call"
         );
     }
 
@@ -1355,7 +1369,7 @@ mod tests {
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
 
-        let far_round = context.parameters.peer_disseminated_round_ceiling(0) + 1;
+        let far_round = context.parameters.far_future_round_ceiling(0) + 1;
         let far_header = header(far_round, 1, vec![block_ref(far_round - 1, 0)]);
         let far_ref = far_header.reference();
 
@@ -1371,22 +1385,22 @@ mod tests {
             context
                 .metrics
                 .node_metrics
-                .dropped_far_future_blocks_total
-                .with_label_values(&["block_manager"])
+                .dropped_far_future_headers_total
+                .with_label_values(&[DataSource::CommitSyncer.as_str()])
                 .get(),
             0
         );
     }
 
     /// A header exactly at the ceiling is retained, one round past it is
-    /// dropped, and the bound applies to every peer-disseminated header source.
+    /// dropped, and the bound applies to every far-future-bounded source.
     #[tokio::test]
     async fn far_future_bound_ceiling_and_sources() {
         use gc_eviction_helpers::*;
 
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
-        let ceiling = context.parameters.peer_disseminated_round_ceiling(0);
+        let ceiling = context.parameters.far_future_round_ceiling(0);
 
         // Exactly at the ceiling: within bounds, so suspended rather than dropped.
         {
@@ -1404,7 +1418,7 @@ mod tests {
             );
         }
 
-        // One round past the ceiling: dropped for every peer-disseminated source.
+        // One round past the ceiling: dropped for every far-future-bounded source.
         for source in [
             DataSource::BlockBundleStream,
             DataSource::HeaderSynchronizer,
@@ -1427,7 +1441,7 @@ mod tests {
     /// block far above the accepted frontier is dropped before its header or
     /// transactions can enter the suspender.
     #[tokio::test]
-    async fn drops_far_future_peer_disseminated_blocks() {
+    async fn drops_far_future_blocks() {
         use gc_eviction_helpers::*;
 
         let (context, _) = Context::new_for_test(4);
@@ -1436,7 +1450,7 @@ mod tests {
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
 
-        let far_round = context.parameters.peer_disseminated_round_ceiling(0) + 1;
+        let far_round = context.parameters.far_future_round_ceiling(0) + 1;
         let h = header(far_round, 1, vec![block_ref(far_round - 1, 0)]);
         let txs = crate::block_header::VerifiedTransactions::new_for_test(
             &h,
@@ -1463,8 +1477,8 @@ mod tests {
             context
                 .metrics
                 .node_metrics
-                .dropped_far_future_blocks_total
-                .with_label_values(&["block_manager"])
+                .dropped_far_future_headers_total
+                .with_label_values(&[DataSource::BlockStreaming.as_str()])
                 .get(),
             1
         );

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -180,11 +180,7 @@ impl BlockManager {
         if !source.is_peer_disseminated() {
             return items;
         }
-        let frontier = self.dag_state.read().highest_accepted_round();
-        let ceiling = self
-            .context
-            .parameters
-            .peer_disseminated_round_ceiling(frontier);
+        let ceiling = self.dag_state.read().peer_disseminated_round_ceiling();
         let total = items.len();
         let kept: Vec<T> = items
             .into_iter()

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -168,6 +168,42 @@ impl BlockManager {
         unsuspended_headers
     }
 
+    /// Drops peer-disseminated blocks/headers whose round is too far above the
+    /// accepted frontier to connect, bounding the round horizon retained in the
+    /// suspender. Certified/local sources (commit sync, recovery, own block)
+    /// are exempt: a node that legitimately trails further catches up through
+    /// commit sync, which bypasses this path.
+    fn drop_far_future<T>(
+        &self,
+        items: Vec<T>,
+        source: DataSource,
+        round_of: impl Fn(&T) -> Round,
+    ) -> Vec<T> {
+        if !source.is_peer_disseminated() {
+            return items;
+        }
+        let frontier = self.dag_state.read().highest_accepted_round();
+        let ceiling = self
+            .context
+            .parameters
+            .peer_disseminated_round_ceiling(frontier);
+        let total = items.len();
+        let kept: Vec<T> = items
+            .into_iter()
+            .filter(|item| round_of(item) <= ceiling)
+            .collect();
+        let dropped = (total - kept.len()) as u64;
+        if dropped > 0 {
+            self.context
+                .metrics
+                .node_metrics
+                .dropped_far_future_blocks_total
+                .with_label_values(&["block_manager"])
+                .inc_by(dropped);
+        }
+        kept
+    }
+
     /// Does all the same things as try_accept_block_headers and additionally
     /// saves blocks with transaction data into recent_blocks in DagState
     #[tracing::instrument(skip_all)]
@@ -178,6 +214,7 @@ impl BlockManager {
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_blocks");
         let gc_unsuspended = self.maybe_evict_below_gc_floor();
+        let blocks = self.drop_far_future(blocks, source, |b| b.round());
 
         let block_headers: Vec<_> = blocks
             .iter()
@@ -222,6 +259,7 @@ impl BlockManager {
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers");
         let gc_unsuspended = self.maybe_evict_below_gc_floor();
+        let block_headers = self.drop_far_future(block_headers, source, |h| h.round());
 
         // Headers are added through synchronizer, commit syncer and cordial
         // dissemination.
@@ -1260,6 +1298,135 @@ mod tests {
             block_manager.blocks_to_fetch().is_empty(),
             "old ancestor below gc_floor should not be queued for fetching"
         );
+    }
+
+    /// A peer-disseminated header whose round is far above the accepted
+    /// frontier is dropped before entering the suspender, so a Byzantine peer
+    /// streaming far-future rounds cannot grow the suspender without bound.
+    #[tokio::test]
+    async fn drops_far_future_peer_disseminated_headers() {
+        use gc_eviction_helpers::*;
+
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
+
+        // Frontier starts at genesis round 0, so the acceptance ceiling is
+        // `dag_state_cached_rounds + peer_round_ahead_margin`; one round past it
+        // is dropped.
+        let far_round = context.parameters.peer_disseminated_round_ceiling(0) + 1;
+        let far_header = header(far_round, 1, vec![block_ref(far_round - 1, 0)]);
+
+        let (accepted, missing) =
+            block_manager.try_accept_block_headers(vec![far_header], DataSource::BlockBundleStream);
+
+        assert!(
+            accepted.is_empty(),
+            "far-future header must not be accepted"
+        );
+        assert!(
+            missing.is_empty(),
+            "far-future ancestors must not be queued to fetch"
+        );
+        assert!(block_manager.suspended_blocks_refs().is_empty());
+        assert!(block_manager.blocks_to_fetch_refs().is_empty());
+        assert_eq!(
+            dag_state.read().highest_accepted_round(),
+            0,
+            "dropped header must not advance the frontier"
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_far_future_blocks_total
+                .with_label_values(&["block_manager"])
+                .get(),
+            1
+        );
+    }
+
+    /// The future-round bound exempts certified/local sources: a far-ahead
+    /// header from the commit syncer (which catches a node up past the bound)
+    /// is still suspended as before, not dropped.
+    #[tokio::test]
+    async fn far_future_bound_exempts_commit_sync() {
+        use gc_eviction_helpers::*;
+
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let mut block_manager = BlockManager::new(context.clone(), dag_state);
+
+        let far_round = context.parameters.peer_disseminated_round_ceiling(0) + 1;
+        let far_header = header(far_round, 1, vec![block_ref(far_round - 1, 0)]);
+        let far_ref = far_header.reference();
+
+        let (accepted, _missing) =
+            block_manager.try_accept_block_headers(vec![far_header], DataSource::CommitSyncer);
+
+        assert!(accepted.is_empty());
+        assert!(
+            block_manager.suspended_blocks_refs().contains(&far_ref),
+            "commit-sync headers must not be subject to the future-round bound"
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_far_future_blocks_total
+                .with_label_values(&["block_manager"])
+                .get(),
+            0
+        );
+    }
+
+    /// A header exactly at the ceiling is retained, one round past it is
+    /// dropped, and the bound applies to every peer-disseminated header source.
+    #[tokio::test]
+    async fn far_future_bound_ceiling_and_sources() {
+        use gc_eviction_helpers::*;
+
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let ceiling = context.parameters.peer_disseminated_round_ceiling(0);
+
+        // Exactly at the ceiling: within bounds, so suspended rather than dropped.
+        {
+            let store = Arc::new(MemStore::new());
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            let mut block_manager = BlockManager::new(context.clone(), dag_state);
+            let at_ceiling = header(ceiling, 1, vec![block_ref(ceiling - 1, 0)]);
+            let at_ceiling_ref = at_ceiling.reference();
+            block_manager.try_accept_block_headers(vec![at_ceiling], DataSource::BlockBundleStream);
+            assert!(
+                block_manager
+                    .suspended_blocks_refs()
+                    .contains(&at_ceiling_ref),
+                "a header exactly at the ceiling must be retained, not dropped"
+            );
+        }
+
+        // One round past the ceiling: dropped for every peer-disseminated source.
+        for source in [
+            DataSource::BlockBundleStream,
+            DataSource::HeaderSynchronizer,
+        ] {
+            let store = Arc::new(MemStore::new());
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            let mut block_manager = BlockManager::new(context.clone(), dag_state);
+            let far = header(ceiling + 1, 1, vec![block_ref(ceiling, 0)]);
+            let (accepted, missing) = block_manager.try_accept_block_headers(vec![far], source);
+            assert!(accepted.is_empty() && missing.is_empty());
+            assert!(
+                block_manager.suspended_blocks_refs().is_empty(),
+                "{} far-future header must be dropped",
+                source.as_str()
+            );
+        }
     }
 
     /// A full block whose own round is at or below the GC floor must not be

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -169,10 +169,8 @@ impl BlockManager {
     }
 
     /// Drops peer-disseminated blocks/headers whose round is too far above the
-    /// accepted frontier to connect, bounding the round horizon retained in the
-    /// suspender. Certified/local sources (commit sync, recovery, own block)
-    /// are exempt: a node that legitimately trails further catches up through
-    /// commit sync, which bypasses this path.
+    /// accepted frontier to ever connect, bounding the round horizon retained
+    /// in the suspender. Non-peer-disseminated sources pass through unchanged.
     fn drop_far_future<T>(
         &self,
         items: Vec<T>,
@@ -1427,6 +1425,53 @@ mod tests {
                 source.as_str()
             );
         }
+    }
+
+    /// The future-round bound also covers the full-block path: a peer-streamed
+    /// block far above the accepted frontier is dropped before its header or
+    /// transactions can enter the suspender.
+    #[tokio::test]
+    async fn drops_far_future_peer_disseminated_blocks() {
+        use gc_eviction_helpers::*;
+
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
+
+        let far_round = context.parameters.peer_disseminated_round_ceiling(0) + 1;
+        let h = header(far_round, 1, vec![block_ref(far_round - 1, 0)]);
+        let txs = crate::block_header::VerifiedTransactions::new_for_test(
+            &h,
+            vec![crate::block_header::Transaction::new(vec![1u8; 16])],
+        );
+        let block = crate::block_header::VerifiedBlock::new(h, txs);
+
+        let (accepted, missing) =
+            block_manager.try_accept_blocks(vec![block], DataSource::BlockStreaming);
+
+        assert!(accepted.is_empty(), "far-future block must not be accepted");
+        assert!(
+            missing.is_empty(),
+            "far-future ancestors must not be queued to fetch"
+        );
+        assert!(block_manager.suspended_blocks_refs().is_empty());
+        assert_eq!(block_manager.suspended_transactions.len(), 0);
+        assert_eq!(
+            dag_state.read().highest_accepted_round(),
+            0,
+            "dropped block must not advance the frontier"
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_far_future_blocks_total
+                .with_label_values(&["block_manager"])
+                .get(),
+            1
+        );
     }
 
     /// A full block whose own round is at or below the GC floor must not be

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -945,7 +945,10 @@ mod tests {
         for (index, _) in committee.authorities() {
             let parameters = Parameters {
                 db_path: temp_dirs[index.value()].path().to_path_buf(),
-                dag_state_cached_rounds: 5,
+                // Retain enough recent rounds to serve voting-block headers to
+                // lagging peers during catch-up; stabilizes the A/B convergence
+                // asserted below.
+                dag_state_cached_rounds: COMMIT_GAP_THRESHOLD / 2,
                 commit_sync_parallel_fetches: 2,
                 commit_sync_batch_size: 10,
                 commit_sync_gap_threshold: COMMIT_GAP_THRESHOLD,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -95,6 +95,26 @@ pub(crate) enum DataSource {
 }
 
 impl DataSource {
+    /// Whether the data was pushed or served by a peer, as opposed to
+    /// certified/local sources (commit sync, recovery, own block) whose rounds
+    /// are already bounded. Only peer-disseminated blocks are subject to the
+    /// future-round acceptance bound.
+    pub(crate) fn is_peer_disseminated(&self) -> bool {
+        match self {
+            DataSource::BlockStreaming
+            | DataSource::BlockBundleStream
+            | DataSource::HeaderSynchronizer => true,
+            DataSource::TransactionSynchronizer
+            | DataSource::ShardReconstructor
+            | DataSource::Recover
+            | DataSource::OwnBlock
+            | DataSource::CommitSyncer
+            | DataSource::FastCommitSyncer => false,
+            #[cfg(test)]
+            DataSource::Test => false,
+        }
+    }
+
     /// Returns the string label used for metrics reporting.
     /// This ensures consistency with existing metrics that may be monitored.
     pub(crate) fn as_str(&self) -> &'static str {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -95,10 +95,8 @@ pub(crate) enum DataSource {
 }
 
 impl DataSource {
-    /// Whether the data was pushed or served by a peer, as opposed to
-    /// certified/local sources (commit sync, recovery, own block) whose rounds
-    /// are already bounded. Only peer-disseminated blocks are subject to the
-    /// future-round acceptance bound.
+    /// Whether the data was pushed or served by a peer, as opposed to certified
+    /// or locally produced sources.
     pub(crate) fn is_peer_disseminated(&self) -> bool {
         match self {
             DataSource::BlockStreaming

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -95,9 +95,10 @@ pub(crate) enum DataSource {
 }
 
 impl DataSource {
-    /// Whether the data was pushed or served by a peer, as opposed to certified
-    /// or locally produced sources.
-    pub(crate) fn is_peer_disseminated(&self) -> bool {
+    /// Whether headers from this source are subject to the far-future round
+    /// bound — the live header-ingress paths, as opposed to certified catch-up,
+    /// locally produced, or transaction/shard sources.
+    pub(crate) fn is_subject_to_far_future_bound(&self) -> bool {
         match self {
             DataSource::BlockStreaming
             | DataSource::BlockBundleStream
@@ -1993,12 +1994,12 @@ impl DagState {
         self.highest_accepted_round
     }
 
-    /// Highest round a peer-disseminated block may have, given the current
-    /// accepted frontier, to still be close enough to ever connect.
-    pub(crate) fn peer_disseminated_round_ceiling(&self) -> Round {
+    /// Highest round a header from a far-future-bounded source may have, given
+    /// the current accepted frontier, to still be close enough to ever connect.
+    pub(crate) fn far_future_round_ceiling(&self) -> Round {
         self.context
             .parameters
-            .peer_disseminated_round_ceiling(self.highest_accepted_round())
+            .far_future_round_ceiling(self.highest_accepted_round())
     }
 
     /// Highest round where a block is committed, which is last commit's leader

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1993,6 +1993,14 @@ impl DagState {
         self.highest_accepted_round
     }
 
+    /// Highest round a peer-disseminated block may have, given the current
+    /// accepted frontier, to still be close enough to ever connect.
+    pub(crate) fn peer_disseminated_round_ceiling(&self) -> Round {
+        self.context
+            .parameters
+            .peer_disseminated_round_ceiling(self.highest_accepted_round())
+    }
+
     /// Highest round where a block is committed, which is last commit's leader
     /// round.
     pub(crate) fn last_commit_round(&self) -> Round {

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -717,7 +717,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         }
 
         // Verify all the fetched block headers
-        let mut block_headers = Handle::current()
+        let block_headers = Handle::current()
             .spawn_blocking({
                 let block_verifier = block_verifier.clone();
                 let verified_cache = verified_cache.clone();
@@ -768,21 +768,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 .join(", "),
         );
 
-        // Drop headers too far above the accepted frontier to ever connect. A
-        // peer may volunteer validly-signed headers we never requested, so this
-        // path bounds the response itself rather than trusting the requested set.
-        let ceiling = dag_state.read().peer_disseminated_round_ceiling();
-        let before_drop = block_headers.len();
-        block_headers.retain(|header| header.round() <= ceiling);
-        let dropped = (before_drop - block_headers.len()) as u64;
-        if dropped > 0 {
-            context
-                .metrics
-                .node_metrics
-                .dropped_far_future_blocks_total
-                .with_label_values(&["header_synchronizer"])
-                .inc_by(dropped);
-        }
+        // A peer may volunteer validly-signed headers we never requested, so
+        // bound the response here; the block manager applies the same bound
+        // downstream when these headers are accepted.
+        let block_headers = crate::block_manager::drop_far_future(
+            &context,
+            &dag_state,
+            block_headers,
+            DataSource::HeaderSynchronizer,
+            |header| header.round(),
+        );
 
         // Now send them to core for processing. Ignore the returned missing blocks as
         // we don't want this mechanism to keep feedback looping on fetching
@@ -3402,7 +3397,7 @@ mod tests {
 
         // Frontier is genesis round 0; a header one past the ceiling can never
         // connect and must be dropped, while an in-window header is forwarded.
-        let ceiling = context.parameters.peer_disseminated_round_ceiling(0);
+        let ceiling = context.parameters.far_future_round_ceiling(0);
         let in_window = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(60, 0).build());
         let far_future =
             VerifiedBlockHeader::new_for_test(TestBlockHeader::new(ceiling + 1, 1).build());
@@ -3456,8 +3451,8 @@ mod tests {
             context
                 .metrics
                 .node_metrics
-                .dropped_far_future_blocks_total
-                .with_label_values(&["header_synchronizer"])
+                .dropped_far_future_headers_total
+                .with_label_values(&[DataSource::HeaderSynchronizer.as_str()])
                 .get(),
             1
         );

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -771,9 +771,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         // Drop headers too far above the accepted frontier to ever connect. A
         // peer may volunteer validly-signed headers we never requested, so this
         // path bounds the response itself rather than trusting the requested set.
-        let ceiling = context
-            .parameters
-            .peer_disseminated_round_ceiling(dag_state.read().highest_accepted_round());
+        let ceiling = dag_state.read().peer_disseminated_round_ceiling();
         let before_drop = block_headers.len();
         block_headers.retain(|header| header.round() <= ceiling);
         let dropped = (before_drop - block_headers.len()) as u64;

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -768,8 +768,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 .join(", "),
         );
 
-        // Drop headers too far above the accepted frontier to ever connect;
-        // the block manager applies the same bound as defense in depth.
+        // Drop headers too far above the accepted frontier to ever connect. A
+        // peer may volunteer validly-signed headers we never requested, so this
+        // path bounds the response itself rather than trusting the requested set.
         let ceiling = context
             .parameters
             .peer_disseminated_round_ceiling(dag_state.read().highest_accepted_round());

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -647,6 +647,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                                 peer_index,
                                 blocks_guard,
                                 core_dispatcher.clone(),
+                                dag_state.clone(),
                                 block_verifier.clone(),
                                 verified_cache.clone(),
                                 commit_vote_monitor.clone(),
@@ -688,6 +689,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         peer_index: AuthorityIndex,
         requested_blocks_guard: BlocksGuard,
         core_dispatcher: Arc<D>,
+        dag_state: Arc<RwLock<DagState>>,
         block_verifier: Arc<V>,
         verified_cache: Arc<Mutex<LruCache<BlockHeaderDigest, ()>>>,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
@@ -715,7 +717,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         }
 
         // Verify all the fetched block headers
-        let block_headers = Handle::current()
+        let mut block_headers = Handle::current()
             .spawn_blocking({
                 let block_verifier = block_verifier.clone();
                 let verified_cache = verified_cache.clone();
@@ -765,6 +767,23 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 .map(|b| b.reference().to_string())
                 .join(", "),
         );
+
+        // Drop headers too far above the accepted frontier to ever connect;
+        // the block manager applies the same bound as defense in depth.
+        let ceiling = context
+            .parameters
+            .peer_disseminated_round_ceiling(dag_state.read().highest_accepted_round());
+        let before_drop = block_headers.len();
+        block_headers.retain(|header| header.round() <= ceiling);
+        let dropped = (before_drop - block_headers.len()) as u64;
+        if dropped > 0 {
+            context
+                .metrics
+                .node_metrics
+                .dropped_far_future_blocks_total
+                .with_label_values(&["header_synchronizer"])
+                .inc_by(dropped);
+        }
 
         // Now send them to core for processing. Ignore the returned missing blocks as
         // we don't want this mechanism to keep feedback looping on fetching
@@ -1197,7 +1216,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                     inflight_block_headers_map.clone(),
                     network_client,
                     missing_blocks_refs,
-                    dag_state,
+                    dag_state.clone(),
                 )
                 .await;
                 context
@@ -1220,6 +1239,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                         peer,
                         blocks_guard,
                         core_dispatcher.clone(),
+                        dag_state.clone(),
                         block_verifier.clone(),
                         verified_cache.clone(),
                         commit_vote_monitor.clone(),
@@ -3285,6 +3305,7 @@ mod tests {
             peer_index,
             blocks_guard, // The guard is consumed here
             core_dispatcher.clone(),
+            dag_state.clone(),
             block_verifier.clone(),
             verified_cache.clone(),
             commit_vote_monitor.clone(),
@@ -3327,6 +3348,7 @@ mod tests {
             peer_index,
             blocks_guard_second,
             core_dispatcher.clone(),
+            dag_state.clone(),
             block_verifier,
             verified_cache.clone(),
             commit_vote_monitor,
@@ -3357,6 +3379,88 @@ mod tests {
             "Expected {} entries in the LruCache, but got {}",
             expected_block_refs.len(),
             cache_size
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_fetched_drops_far_future() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (commands_sender, _commands_receiver) =
+            monitored_mpsc::channel("consensus_synchronizer_commands", 1000);
+        let network_client = Arc::new(MockNetworkClient::default());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+        );
+
+        // Frontier is genesis round 0; a header one past the ceiling can never
+        // connect and must be dropped, while an in-window header is forwarded.
+        let ceiling = context.parameters.peer_disseminated_round_ceiling(0);
+        let in_window = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(60, 0).build());
+        let far_future =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(ceiling + 1, 1).build());
+        let serialized = vec![
+            in_window.serialized().clone(),
+            far_future.serialized().clone(),
+        ];
+        let refs = [in_window.reference(), far_future.reference()]
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+
+        let peer_index = AuthorityIndex::new_for_test(2);
+        let inflight_blocks_map = InflightBlockHeadersMap::new();
+        let blocks_guard = inflight_blocks_map
+            .lock_headers(refs, peer_index, SyncMethod::Live)
+            .expect("Failed to lock blocks");
+        let verified_cache = Arc::new(parking_lot::Mutex::new(lru::LruCache::new(
+            NonZero::new(1000).unwrap(),
+        )));
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+
+        let result = HeaderSynchronizer::<
+            MockNetworkClient,
+            NoopBlockVerifier,
+            MockCoreThreadDispatcher,
+        >::process_fetched_headers_from_authority(
+            serialized,
+            peer_index,
+            blocks_guard,
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier,
+            verified_cache,
+            commit_vote_monitor,
+            transactions_synchronizer,
+            context.clone(),
+            commands_sender,
+            "live",
+            misbehavior_store,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        // Only the in-window header reaches core; the far-future one is dropped.
+        let added = core_dispatcher.get_and_drain_block_headers().await;
+        assert_eq!(
+            added.iter().map(|b| b.reference()).collect::<Vec<_>>(),
+            vec![in_window.reference()],
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_far_future_blocks_total
+                .with_label_values(&["header_synchronizer"])
+                .get(),
+            1
         );
     }
 }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -240,6 +240,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_manager_gc_unsuspended_total: IntCounter,
     pub(crate) block_manager_gc_evicted_suspended_transactions_total: IntCounter,
     pub(crate) block_manager_gc_evicted_old_headers_total: IntCounter,
+    pub(crate) dropped_far_future_blocks_total: IntCounterVec,
     pub(crate) threshold_clock_round: IntGauge,
     pub(crate) subscriber_connection_attempts: IntCounterVec,
     pub(crate) subscribed_to: IntGaugeVec,
@@ -994,6 +995,12 @@ impl NodeMetrics {
             block_manager_gc_evicted_old_headers_total: register_int_counter_with_registry!(
                 "block_manager_gc_evicted_old_headers_total",
                 "Total number of incoming block headers dropped because their round is at or below the GC floor",
+                registry,
+            ).unwrap(),
+            dropped_far_future_blocks_total: register_int_counter_vec_with_registry!(
+                "dropped_far_future_blocks_total",
+                "Number of peer-disseminated blocks dropped because their round is too far above the accepted frontier to ever connect, by enforcement point",
+                &["source"],
                 registry,
             ).unwrap(),
             threshold_clock_round: register_int_gauge_with_registry!(

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -240,7 +240,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_manager_gc_unsuspended_total: IntCounter,
     pub(crate) block_manager_gc_evicted_suspended_transactions_total: IntCounter,
     pub(crate) block_manager_gc_evicted_old_headers_total: IntCounter,
-    pub(crate) dropped_far_future_blocks_total: IntCounterVec,
+    pub(crate) dropped_far_future_headers_total: IntCounterVec,
     pub(crate) threshold_clock_round: IntGauge,
     pub(crate) subscriber_connection_attempts: IntCounterVec,
     pub(crate) subscribed_to: IntGaugeVec,
@@ -997,9 +997,9 @@ impl NodeMetrics {
                 "Total number of incoming block headers dropped because their round is at or below the GC floor",
                 registry,
             ).unwrap(),
-            dropped_far_future_blocks_total: register_int_counter_vec_with_registry!(
-                "dropped_far_future_blocks_total",
-                "Number of peer-disseminated blocks dropped because their round is too far above the accepted frontier to ever connect, by enforcement point",
+            dropped_far_future_headers_total: register_int_counter_vec_with_registry!(
+                "dropped_far_future_headers_total",
+                "Number of block headers dropped because their round is too far above the accepted frontier to ever connect, by source",
                 &["source"],
                 registry,
             ).unwrap(),

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -15070,7 +15070,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Rate of peer-disseminated blocks/headers dropped because their round is too far above the accepted frontier to ever connect, by enforcement point (block_bundle, header_synchronizer, block_manager). Near-zero in honest operation; sustained drops indicate a peer streaming far-future rounds.",
+          "description": "Rate of block headers dropped because their round is too far above the accepted frontier to ever connect, by source. Near-zero in honest operation; sustained drops indicate a peer streaming far-future rounds.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -15150,7 +15150,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum by(source) (rate(consensus_dropped_far_future_blocks_total[2m]))",
+              "expr": "sum by(source) (rate(consensus_dropped_far_future_headers_total[2m]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -15160,7 +15160,7 @@
               "useBackend": false
             }
           ],
-          "title": "Far-future blocks dropped by source",
+          "title": "Far-future headers dropped by source",
           "type": "timeseries"
         }
       ],

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -10751,7 +10751,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 435
+            "y": 443
           },
           "id": 300,
           "options": {
@@ -15063,6 +15063,104 @@
             }
           ],
           "title": "GC evicted old incoming headers (rate)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate of peer-disseminated blocks/headers dropped because their round is too far above the accepted frontier to ever connect, by enforcement point (block_bundle, header_synchronizer, block_manager). Near-zero in honest operation; sustained drops indicate a peer streaming far-future rounds.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 624
+          },
+          "id": 407,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "sum by(source) (rate(consensus_dropped_far_future_blocks_total[2m]))",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Far-future blocks dropped by source",
           "type": "timeseries"
         }
       ],


### PR DESCRIPTION
# Description of change

## Intuition

A Byzantine validator can self-author blocks at far-future rounds (`local + 1e6`, `+1`, …), each citing 2f+1 *fabricated* round-(R-1) ancestor refs. They pass `verify` — which only bounds ancestor rounds *relative* to the block's own round and has no absolute upper bound — but can never connect, so they accumulate per-block state without bound (suspender entries, shard-reconstructor transactions, DagState shards). GC is keyed off `gc_round_for_last_commit`, a *low* watermark, so it never reclaims rounds *above* the frontier. The fix drops a peer-disseminated block once its round is implausibly far above the node's accepted frontier; a node that legitimately trails that far catches up via commit sync, the proper catch-up path.

## What it does

Drop peer-disseminated blocks/headers whose round exceeds
`highest_accepted_round + dag_state_cached_rounds + peer_round_ahead_margin`, enforced at each peer ingress path and again in the block manager, all sharing one formula (`Parameters::peer_disseminated_round_ceiling`) and one metric (`dropped_far_future_blocks_total`, labeled by `source`):

- **`handle_subscribed_block_bundle`** (streamed bundles) — `source="block_bundle"`. Placed after signature/header verification and commit-vote observation, but *before* shard extraction, transaction messages, digest filtering, and `add_shards`. Required here because the streaming path populates `ShardReconstructor::processed_transactions` and `DagState` shard state *before* `BlockManager` ever sees the block. This ingress point checks only the bundle's *primary* block; far-future *additional* headers carried in the same bundle are forwarded to core and bounded by the `BlockManager` layer below.
- **`process_fetched_headers_from_authority`** (header synchronizer) — `source="header_synchronizer"`. The fetch path has no other round bound: `verify_block_headers` accepts any validly-signed header a peer returns (not just the refs we requested), and the only other limit is a header *count* truncate. Placed after verification and vote observation, before headers are forwarded to core — rejecting a round earlier than the block manager would.
- **`BlockManager` accept path** (`drop_far_future` in `try_accept_block_headers` / `try_accept_blocks`, gated on `DataSource::is_peer_disseminated()`) — `source="block_manager"`. Bounds the suspender (`suspended_headers` / `missing_ancestors` / `headers_to_fetch` / `suspended_transactions`). It is the *sole* far-future bound for additional headers carried in a bundle (the bundle ingress checks only the primary block), so this counter legitimately counts those drops; the two dedicated ingress points cover everything else, so any count beyond additional-header drops flags an otherwise-unguarded peer path.

Certified/local sources (`CommitSyncer`, `FastCommitSyncer`, `Recover`, `OwnBlock`) and the transaction/shard synchronizers are exempt — commit sync is the catch-up path and bypasses these ingress paths.

## Why this horizon

- **Anchor = local frontier.** `highest_accepted_round` is Byzantine-unforgeable: a far-future block is never *accepted*, only suspended/dropped, so it cannot inflate the frontier. The quorum-committed round is only a *lower* bound on where the network is (a 2/3 set with a laggard can drag it down), so it is unsafe as an *upper* reject bound.
- **`peer_round_ahead_margin` (new local parameter, default 1000), above `cached_rounds`.** A reconnecting or restarted node re-pushes roughly `dag_state_cached_rounds` of cached history plus its own freshly produced blocks; the horizon must sit above the cache window so those honest catch-up blocks are not rejected. The default is generous enough that the bound never fires in honest operation — no cache-stress test overrides or msim defaults had to change.
- **It is a local consensus parameter, not protocol state.** Divergent values across nodes do not affect safety — they only change how aggressively each node drops blocks that could never connect — so an operator can tune the horizon without a protocol upgrade. Centralized in `peer_disseminated_round_ceiling` with saturating arithmetic so it cannot overflow.
- **This bounds the round *horizon*, not memory.** Actual memory still scales with committee size, ancestors per header, per-slot equivocations (audit M5), and payload bytes — out of scope here.

## Testing

- `BlockManager`: drop of a far-future header, the exact-ceiling boundary (retained at ceiling, dropped at +1), per-disseminated-source coverage (`BlockBundleStream` + `HeaderSynchronizer`), and certified-source exemption (`CommitSyncer` suspended, not dropped).
- `AuthorityService`: end-to-end signed far-future bundle dropped after verification — counted under `source="block_bundle"`, never forwarded to core, nothing sent to the shard reconstructor (both fast-sync variants).
- `HeaderSynchronizer`: a far-future fetched header is dropped (counted under `source="header_synchronizer"`) while an in-window header is forwarded to core.
- `Parameters` default snapshot updated for the new field.
- Full `starfish-core` / `starfish-config` lib suites pass; clippy clean.

## Links to any relevant issues

Fixes #11919

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
