### PR TITLE
feat(snapshot): anchor EPOCH_INFO to signed checkpoint summaries

### DIFF
--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -771,7 +771,7 @@ impl IndexStoreTables {
                         StorageError::custom(format!("serializing start-state objects: {e}"))
                     })?;
 
-                previous_epoch.epoch_info_entry = Some(EpochInfoV1Entry {
+                previous_epoch.epoch_close_proof = Some(EpochInfoV1Entry {
                     last_checkpoint_summary: checkpoint.checkpoint_summary.clone(),
                     last_checkpoint_contents: checkpoint.checkpoint_contents.clone(),
                     end_of_epoch_tx_effects: change_epoch_tx.effects.clone(),
@@ -785,14 +785,14 @@ impl IndexStoreTables {
             }
         }
 
-        // seed the new epoch's row; its close-of-epoch entry is filled in when
+        // seed the new epoch's row; its close-of-epoch proof is filled in when
         // the next epoch's boundary is indexed.
         let new_info = EpochInfoV2 {
             epoch: epoch_info.epoch,
             start_checkpoint: epoch_info.start_checkpoint,
             start_timestamp_ms: epoch_info.start_timestamp_ms,
             system_state: epoch_info.system_state,
-            epoch_info_entry: None,
+            epoch_close_proof: None,
         };
         batch.insert_batch(&self.epochs_v2, [(new_epoch_id, new_info)])?;
 
@@ -892,7 +892,7 @@ impl IndexStoreTables {
             start_checkpoint,
             start_timestamp_ms: system_state.epoch_start_timestamp_ms(),
             system_state,
-            epoch_info_entry: None,
+            epoch_close_proof: None,
         };
 
         self.epochs_v2.insert(&epoch_info.epoch, &epoch_info)?;
@@ -1957,7 +1957,7 @@ mod tests {
         ))
     }
 
-    /// A finalized `EpochInfoV2` row (its `epoch_info_entry` is `Some`) — the
+    /// A finalized `EpochInfoV2` row (its `epoch_close_proof` is `Some`) — the
     /// only shape `reconcile` counts toward the `EpochIndexed` watermark.
     fn complete_epoch_info(epoch: EpochId) -> EpochInfoV2 {
         EpochInfoV2 {
@@ -1965,7 +1965,7 @@ mod tests {
             start_checkpoint: 0,
             start_timestamp_ms: 0,
             system_state: IotaSystemState::for_testing(epoch, 1),
-            epoch_info_entry: Some(EpochInfoV1Entry {
+            epoch_close_proof: Some(EpochInfoV1Entry {
                 last_checkpoint_summary: certified_summary(epoch, 0),
                 last_checkpoint_contents: CheckpointContents::new_with_digests_only_for_tests(
                     std::iter::empty(),

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -24,7 +24,7 @@ use iota_types::{
     move_package::MovePackageExt,
     object::Object,
     storage::{
-        AccountOwnedObjectInfo, CloseOfEpochProof, DynamicFieldKey, EpochInfo, EpochInfoV2,
+        AccountOwnedObjectInfo, DynamicFieldKey, EpochInfo, EpochInfoV1Entry, EpochInfoV2,
         OwnedObjectCursor, OwnedObjectIteratorItem, PackageVersionInfo, PackageVersionIteratorItem,
         PackageVersionKey, TransactionInfo,
         error::{Error as StorageError, Kind as StorageErrorKind},
@@ -771,9 +771,7 @@ impl IndexStoreTables {
                         StorageError::custom(format!("serializing start-state objects: {e}"))
                     })?;
 
-                previous_epoch.end_timestamp_ms = Some(epoch_info.start_timestamp_ms);
-                previous_epoch.end_checkpoint = Some(epoch_info.start_checkpoint - 1);
-                previous_epoch.proof = Some(CloseOfEpochProof {
+                previous_epoch.epoch_info_entry = Some(EpochInfoV1Entry {
                     last_checkpoint_summary: checkpoint.checkpoint_summary.clone(),
                     last_checkpoint_contents: checkpoint.checkpoint_contents.clone(),
                     end_of_epoch_tx_effects: change_epoch_tx.effects.clone(),
@@ -787,18 +785,14 @@ impl IndexStoreTables {
             }
         }
 
-        // seed the new epoch's row; its close-of-epoch proof bundle is filled
-        // in when the next epoch's boundary is indexed.
+        // seed the new epoch's row; its close-of-epoch entry is filled in when
+        // the next epoch's boundary is indexed.
         let new_info = EpochInfoV2 {
             epoch: epoch_info.epoch,
-            protocol_version: epoch_info.protocol_version,
-            start_timestamp_ms: epoch_info.start_timestamp_ms,
-            end_timestamp_ms: epoch_info.end_timestamp_ms,
             start_checkpoint: epoch_info.start_checkpoint,
-            end_checkpoint: epoch_info.end_checkpoint,
-            reference_gas_price: epoch_info.reference_gas_price,
+            start_timestamp_ms: epoch_info.start_timestamp_ms,
             system_state: epoch_info.system_state,
-            proof: None,
+            epoch_info_entry: None,
         };
         batch.insert_batch(&self.epochs_v2, [(new_epoch_id, new_info)])?;
 
@@ -895,14 +889,10 @@ impl IndexStoreTables {
 
         let epoch_info = EpochInfoV2 {
             epoch: current_epoch,
-            protocol_version: system_state.protocol_version(),
-            start_timestamp_ms: system_state.epoch_start_timestamp_ms(),
-            end_timestamp_ms: None,
             start_checkpoint,
-            end_checkpoint: None,
-            reference_gas_price: system_state.reference_gas_price(),
+            start_timestamp_ms: system_state.epoch_start_timestamp_ms(),
             system_state,
-            proof: None,
+            epoch_info_entry: None,
         };
 
         self.epochs_v2.insert(&epoch_info.epoch, &epoch_info)?;
@@ -929,7 +919,7 @@ impl IndexStoreTables {
         if let Some(end_checkpoint) = self
             .epochs_v2
             .get(&previous_epoch)?
-            .and_then(|info| info.end_checkpoint)
+            .and_then(|info| info.end_checkpoint())
         {
             return Ok(Some(end_checkpoint + 1));
         }
@@ -1967,20 +1957,15 @@ mod tests {
         ))
     }
 
-    /// A finalized `EpochInfoV2` row (the full close-of-epoch proof bundle
-    /// `Some`) — the only shape `reconcile` counts toward the `EpochIndexed`
-    /// watermark.
+    /// A finalized `EpochInfoV2` row (its `epoch_info_entry` is `Some`) — the
+    /// only shape `reconcile` counts toward the `EpochIndexed` watermark.
     fn complete_epoch_info(epoch: EpochId) -> EpochInfoV2 {
         EpochInfoV2 {
             epoch,
-            protocol_version: 1,
-            start_timestamp_ms: 0,
-            end_timestamp_ms: Some(0),
             start_checkpoint: 0,
-            end_checkpoint: Some(0),
-            reference_gas_price: 0,
+            start_timestamp_ms: 0,
             system_state: IotaSystemState::for_testing(epoch, 1),
-            proof: Some(CloseOfEpochProof {
+            epoch_info_entry: Some(EpochInfoV1Entry {
                 last_checkpoint_summary: certified_summary(epoch, 0),
                 last_checkpoint_contents: CheckpointContents::new_with_digests_only_for_tests(
                     std::iter::empty(),

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -24,9 +24,9 @@ use iota_types::{
     move_package::MovePackageExt,
     object::Object,
     storage::{
-        AccountOwnedObjectInfo, DynamicFieldKey, EpochInfo, EpochInfoV2, OwnedObjectCursor,
-        OwnedObjectIteratorItem, PackageVersionInfo, PackageVersionIteratorItem, PackageVersionKey,
-        TransactionInfo,
+        AccountOwnedObjectInfo, CloseOfEpochProof, DynamicFieldKey, EpochInfo, EpochInfoV2,
+        OwnedObjectCursor, OwnedObjectIteratorItem, PackageVersionInfo, PackageVersionIteratorItem,
+        PackageVersionKey, TransactionInfo,
         error::{Error as StorageError, Kind as StorageErrorKind},
     },
 };
@@ -729,34 +729,66 @@ impl IndexStoreTables {
         };
         let new_epoch_id = epoch_info.epoch;
 
-        // Finalize `prev_epoch`'s row with the close-of-epoch fields and
+        // Finalize `prev_epoch`'s row with the close-of-epoch proof bundle and
         // advance `Watermark::EpochIndexed`. Genesis has no previous epoch
         // to finalize; the close-of-epoch write for epoch 0 fires when
         // epoch 1 is seeded, so `EpochIndexed` stays absent until then.
         if new_epoch_id > 0 {
             let prev_epoch = new_epoch_id - 1;
-            // In safe mode the AdvanceEpoch tx is replaced by
-            // `advance_epoch_safe_mode`, which mutates `0x5` but emits no
-            // events. `Some(default())` says "finalized, with no events" —
-            // distinct from the not-yet-finalized `None` lifecycle state.
-            let end_of_epoch_tx_events = Some(end_of_epoch_events.unwrap_or_default());
-            let last_checkpoint_summary = checkpoint.checkpoint_summary.clone();
             // If no row exists for `prev_epoch`, this node didn't see its
             // start (e.g. bootstrapped mid-epoch). Skip the upsert; the
             // row stays absent and the watermark stays behind, so the
             // snapshot writer correctly refuses to publish until an
             // external backfill fills the gap.
             if let Some(mut previous_epoch) = self.epochs_v2.get(&prev_epoch)? {
+                // The closing checkpoint's last tx is `prev_epoch`'s
+                // epoch-change tx; its effects and the system-state objects it
+                // wrote (object `0x5` and its inner state object) are this
+                // boundary's proof material.
+                let change_epoch_tx = checkpoint.end_of_epoch_transaction().ok_or_else(|| {
+                    StorageError::custom(format!(
+                        "checkpoint {} closes epoch {prev_epoch} but carries no \
+                         epoch-change transaction",
+                        checkpoint.checkpoint_summary.sequence_number,
+                    ))
+                })?;
+                // Serialized to raw bytes, not the decoded view, so they verify
+                // against the effects' written-object digests at restore time
+                // (see `get_iota_system_state_objects` for why only these two).
+                let next_epoch_start_system_state_objects =
+                    iota_types::iota_system_state::get_iota_system_state_objects(
+                        &change_epoch_tx.output_objects.as_slice(),
+                    )
+                    .map_err(|e| {
+                        StorageError::custom(format!(
+                            "extracting next-epoch start-state objects: {e}"
+                        ))
+                    })?
+                    .iter()
+                    .map(bcs::to_bytes)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| {
+                        StorageError::custom(format!("serializing start-state objects: {e}"))
+                    })?;
+
                 previous_epoch.end_timestamp_ms = Some(epoch_info.start_timestamp_ms);
                 previous_epoch.end_checkpoint = Some(epoch_info.start_checkpoint - 1);
-                previous_epoch.last_checkpoint_summary = Some(last_checkpoint_summary);
-                previous_epoch.end_of_epoch_tx_events = end_of_epoch_tx_events;
+                previous_epoch.proof = Some(CloseOfEpochProof {
+                    last_checkpoint_summary: checkpoint.checkpoint_summary.clone(),
+                    last_checkpoint_contents: checkpoint.checkpoint_contents.clone(),
+                    end_of_epoch_tx_effects: change_epoch_tx.effects.clone(),
+                    // Safe-mode boundaries run `advance_epoch_safe_mode`, which
+                    // mutates `0x5` but emits no events, so the list is empty.
+                    end_of_epoch_tx_events: end_of_epoch_events.unwrap_or_default(),
+                    next_epoch_start_system_state_objects,
+                });
                 batch.insert_batch(&self.epochs_v2, [(prev_epoch, previous_epoch)])?;
                 self.try_advance_epoch_indexed_watermark(prev_epoch, batch)?;
             }
         }
 
-        // seed the new epoch's row.
+        // seed the new epoch's row; its close-of-epoch proof bundle is filled
+        // in when the next epoch's boundary is indexed.
         let new_info = EpochInfoV2 {
             epoch: epoch_info.epoch,
             protocol_version: epoch_info.protocol_version,
@@ -766,25 +798,24 @@ impl IndexStoreTables {
             end_checkpoint: epoch_info.end_checkpoint,
             reference_gas_price: epoch_info.reference_gas_price,
             system_state: epoch_info.system_state,
-            last_checkpoint_summary: None,
-            end_of_epoch_tx_events: None,
+            proof: None,
         };
         batch.insert_batch(&self.epochs_v2, [(new_epoch_id, new_info)])?;
 
         Ok(())
     }
 
-    /// Read `Watermark::EpochIndexed`: the highest epoch whose
-    /// `epochs_v2` row has its end-of-epoch fields populated
-    /// (`last_checkpoint_summary` and `end_of_epoch_tx_events`).
-    /// `None` if no epoch has been fully indexed yet.
+    /// Read `Watermark::EpochIndexed`: the highest epoch whose `epochs_v2` row
+    /// is finalized (the full close-of-epoch proof bundle present, see
+    /// `EpochInfoV2::is_finalized`). `None` if no epoch has been fully
+    /// indexed yet.
     fn highest_indexed_epoch(&self) -> Result<Option<EpochId>, TypedStoreError> {
         self.watermark.get(&Watermark::EpochIndexed)
     }
 
     /// Recompute `Watermark::EpochIndexed` = the highest epoch whose contiguous
-    /// prefix `[0, epoch]` is fully populated (both end-of-epoch fields
-    /// `Some`). Only ever raises it.
+    /// prefix `[0, epoch]` is finalized (see `EpochInfoV2::is_finalized`).
+    /// Only ever raises it.
     ///
     /// Unlike `try_advance_epoch_indexed_watermark` (the live +1 step), this
     /// can jump the watermark across a whole seeded prefix, which is what a
@@ -796,10 +827,7 @@ impl IndexStoreTables {
         let mut next = current.map_or(0, |w| w + 1);
         for entry in self.epochs_v2.safe_iter_with_bounds(Some(next), None) {
             let (epoch_id, info) = entry?;
-            if epoch_id != next
-                || info.last_checkpoint_summary.is_none()
-                || info.end_of_epoch_tx_events.is_none()
-            {
+            if epoch_id != next || !info.is_finalized() {
                 break;
             }
             next += 1;
@@ -874,8 +902,7 @@ impl IndexStoreTables {
             end_checkpoint: None,
             reference_gas_price: system_state.reference_gas_price(),
             system_state,
-            last_checkpoint_summary: None,
-            end_of_epoch_tx_events: None,
+            proof: None,
         };
 
         self.epochs_v2.insert(&epoch_info.epoch, &epoch_info)?;
@@ -1799,13 +1826,17 @@ fn open_epoch_of(checkpoint: &CheckpointSummary) -> EpochId {
     }
 }
 
-// Load a CheckpointData struct without event data
+// Load a CheckpointData struct, including events for any transaction that
+// emitted them (the epoch-change tx's events feed the EPOCH_INFO proof bundle);
+// a pruned events table surfaces as a `Missing` error.
 fn assemble_sparse_checkpoint_data(
     authority_store: &AuthorityStore,
     summary: VerifiedCheckpoint,
     contents: CheckpointContents,
 ) -> Result<CheckpointData, StorageError> {
-    use iota_types::full_checkpoint_content::CheckpointTransaction;
+    use iota_types::{
+        effects::TransactionEffectsAPI, full_checkpoint_content::CheckpointTransaction,
+    };
 
     let transaction_digests = contents
         .iter()
@@ -1832,10 +1863,27 @@ fn assemble_sparse_checkpoint_data(
         let output_objects =
             iota_types::storage::get_transaction_output_objects(authority_store, &fx)?;
 
+        // Load events for any emitting tx. Only the last (epoch-change) tx's
+        // events are consumed downstream, but loading all keeps the assembled
+        // `CheckpointData` self-consistent and costs little. A pruned events
+        // table surfaces as a `Missing` error.
+        let events = if fx.events_digest().is_some() {
+            Some(
+                authority_store
+                    .get_events(fx.transaction_digest())
+                    .map_err(|e| StorageError::custom(format!("loading events: {e}")))?
+                    .ok_or_else(|| {
+                        StorageError::missing("missing events for an emitting transaction")
+                    })?,
+            )
+        } else {
+            None
+        };
+
         let full_transaction = CheckpointTransaction {
             transaction: tx.into(),
             effects: fx,
-            events: None,
+            events,
             input_objects,
             output_objects,
         };
@@ -1857,7 +1905,8 @@ mod tests {
     use iota_sdk_types::GasCostSummary;
     use iota_types::{
         crypto::AuthorityStrongQuorumSignInfo,
-        effects::TransactionEvents,
+        digests::TransactionDigest,
+        effects::{TransactionEffects, TransactionEffectsExtForTesting, TransactionEvents},
         iota_system_state::IotaSystemState,
         message_envelope::Envelope,
         messages_checkpoint::{CertifiedCheckpointSummary, CheckpointSummary, EndOfEpochData},
@@ -1918,8 +1967,9 @@ mod tests {
         ))
     }
 
-    /// A fully-populated `EpochInfoV2` row (both end-of-epoch fields `Some`) —
-    /// the only shape `reconcile` counts toward the `EpochIndexed` watermark.
+    /// A finalized `EpochInfoV2` row (the full close-of-epoch proof bundle
+    /// `Some`) — the only shape `reconcile` counts toward the `EpochIndexed`
+    /// watermark.
     fn complete_epoch_info(epoch: EpochId) -> EpochInfoV2 {
         EpochInfoV2 {
             epoch,
@@ -1930,8 +1980,17 @@ mod tests {
             end_checkpoint: Some(0),
             reference_gas_price: 0,
             system_state: IotaSystemState::for_testing(epoch, 1),
-            last_checkpoint_summary: Some(certified_summary(epoch, 0)),
-            end_of_epoch_tx_events: Some(TransactionEvents::default()),
+            proof: Some(CloseOfEpochProof {
+                last_checkpoint_summary: certified_summary(epoch, 0),
+                last_checkpoint_contents: CheckpointContents::new_with_digests_only_for_tests(
+                    std::iter::empty(),
+                ),
+                end_of_epoch_tx_effects: TransactionEffects::new_empty_v1_for_testing(
+                    TransactionDigest::ZERO,
+                ),
+                end_of_epoch_tx_events: TransactionEvents::default(),
+                next_epoch_start_system_state_objects: Vec::new(),
+            }),
         }
     }
 

--- a/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
+++ b/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
@@ -314,7 +314,7 @@ async fn epoch_info_proof_bundle_tampering_is_rejected() {
         ),
         (
             "effects",
-            "is not the last transaction of the closing checkpoint",
+            "digest pair does not match the closing checkpoint's last transaction",
             Box::new(|entry| {
                 entry.end_of_epoch_tx_effects =
                     TransactionEffects::new_empty_v1_for_testing(TransactionDigest::ZERO);

--- a/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
+++ b/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
@@ -335,13 +335,6 @@ async fn epoch_info_proof_bundle_tampering_is_rejected() {
             }),
         ),
         (
-            "start_checkpoint",
-            "declares start_checkpoint",
-            Box::new(|entry| {
-                entry.start_checkpoint = entry.start_checkpoint.wrapping_add(1);
-            }),
-        ),
-        (
             "summary",
             "failed verification",
             Box::new(|entry| {
@@ -641,8 +634,8 @@ fn real_epoch_info(source: &GrpcIndexesStore, current_epoch: EpochId) -> EpochIn
                 .get_epoch_info(epoch)
                 .unwrap()
                 .unwrap_or_else(|| panic!("missing epochs_v2 row for closed epoch {epoch}"));
-            EpochInfoV1Entry::try_from(row).unwrap_or_else(|field| {
-                panic!("epochs_v2 row for closed epoch {epoch} is missing `{field}`")
+            row.epoch_info_entry.unwrap_or_else(|| {
+                panic!("epochs_v2 row for closed epoch {epoch} is not finalized")
             })
         })
         .collect();
@@ -650,19 +643,14 @@ fn real_epoch_info(source: &GrpcIndexesStore, current_epoch: EpochId) -> EpochIn
 }
 
 /// A minimal `epochs_v2` row standing in for one written by a snapshot restore.
-/// Only `epoch` and a decodable `system_state` matter here — the end-of-epoch
-/// fields are left `None` since the test asserts row survival, not
-/// completeness.
+/// Only `epoch` and a decodable `system_state` matter here — the close-of-epoch
+/// entry is left `None` since the test asserts row survival, not completeness.
 fn restored_sentinel_row(epoch: u64) -> EpochInfoV2 {
     EpochInfoV2 {
         epoch,
-        protocol_version: 1,
-        start_timestamp_ms: 0,
-        end_timestamp_ms: None,
         start_checkpoint: 0,
-        end_checkpoint: None,
-        reference_gas_price: 0,
+        start_timestamp_ms: 0,
         system_state: IotaSystemState::for_testing(epoch, 1),
-        proof: None,
+        epoch_info_entry: None,
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
+++ b/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
@@ -5,7 +5,11 @@ use iota_core::{checkpoints::CheckpointStore, grpc_indexes::GrpcIndexesStore};
 use iota_macros::sim_test;
 use iota_snapshot::{EpochInfo, EpochInfoV1, EpochInfoV1Entry};
 use iota_types::{
-    committee::EpochId, digests::ChainIdentifier, iota_system_state::IotaSystemState,
+    committee::EpochId,
+    digests::{ChainIdentifier, TransactionDigest},
+    effects::{TransactionEffects, TransactionEffectsExtForTesting, TransactionEvents},
+    iota_system_state::IotaSystemState,
+    messages_checkpoint::CheckpointContents,
     storage::EpochInfoV2,
 };
 use test_cluster::TestClusterBuilder;
@@ -98,9 +102,11 @@ async fn finalized_restore_survives_grpc_indexes_store_init() {
 #[sim_test]
 async fn epoch_info_backfill_verifies_chain_before_seeding() {
     // Long epoch duration so the epoch only advances when forced, keeping the
-    // closed-epoch set stable across the assertions.
+    // closed-epoch set stable across the assertions. Pruning disabled so the
+    // local source store can rebuild every closed epoch's proof bundle.
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(600_000)
+        .disable_fullnode_pruning()
         .build()
         .await;
     test_cluster.force_new_epoch().await;
@@ -110,6 +116,7 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
         .fullnode_handle
         .iota_node
         .with(|node| node.state());
+    let authority_store = state.database_for_testing();
     let checkpoint_store = state.get_checkpoint_store().clone();
     // Closed epochs are `[0, current)`; EPOCH_INFO covers exactly those.
     let current_epoch = state.current_epoch_for_testing();
@@ -118,35 +125,48 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
 
     // This node's chain id — what a same-chain snapshot's manifest carries.
     let expected_chain_id = state.get_chain_identifier();
-    let system_state_bytes = bcs::to_bytes(
-        &state
-            .get_iota_system_state_object_for_testing()
-            .expect("current system state"),
-    )
-    .expect("system state must BCS-encode");
 
-    // The trust root for the committee-chain walk over the real summaries.
-    let genesis_committee = test_cluster
-        .swarm
-        .config()
-        .genesis
-        .committee()
-        .expect("genesis committee");
+    // The trust roots for the committee-chain walk and epoch 0's start state.
+    let genesis = &test_cluster.swarm.config().genesis;
+    let genesis_committee = genesis.committee().expect("genesis committee");
+    let genesis_system_state = genesis.iota_system_object();
+
+    // A locally-indexed store gives every closed epoch its real proof bundle,
+    // the way the snapshot writer reads them off `epochs_v2`.
+    let source_tmp = tempfile::tempdir().unwrap();
+    let source = GrpcIndexesStore::new(
+        source_tmp.path().to_path_buf(),
+        authority_store,
+        &checkpoint_store,
+    )
+    .await;
 
     // SUCCESS: a matching chain_id + committee chain seeds every closed epoch
     // into a fresh store.
     let ok_tmp = tempfile::tempdir().unwrap();
     let ok_grpc = GrpcIndexesStore::new_without_init(ok_tmp.path().to_path_buf());
-    iota_snapshot::verify_epoch_info_chain(
-        real_epoch_info(&checkpoint_store, &system_state_bytes, current_epoch),
+    let verified = iota_snapshot::verify_epoch_info_chain(
+        real_epoch_info(&source, current_epoch),
         genesis_committee.clone(),
+        genesis_system_state.clone(),
         expected_chain_id,
         expected_chain_id,
     )
-    .expect("a same-chain snapshot must verify")
-    .restore_epoch_info(&ok_grpc)
-    .await
-    .expect("a verified snapshot must seed");
+    .expect("a same-chain snapshot must verify");
+    // The committee chain spans `[0, snapshot_epoch + 1]`: the genesis committee
+    // plus the one each closed epoch hands forward. The formal-snapshot seed
+    // path (`download_formal_snapshot`) zips these against the entries, so a
+    // wrong length would silently truncate it.
+    let committee_epochs: Vec<_> = verified.committees().iter().map(|c| c.epoch).collect();
+    assert_eq!(
+        committee_epochs,
+        (0..=current_epoch).collect::<Vec<_>>(),
+        "committees() must carry one committee per epoch in [0, current_epoch]"
+    );
+    verified
+        .restore_epoch_info(&ok_grpc)
+        .await
+        .expect("a verified snapshot must seed");
     for epoch in 0..current_epoch {
         assert!(
             ok_grpc.get_epoch_info(epoch).unwrap().is_some(),
@@ -159,8 +179,9 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
     let watermark = ok_grpc.highest_indexed_epoch().unwrap();
     assert_eq!(watermark, Some(current_epoch - 1));
     iota_snapshot::verify_epoch_info_chain(
-        real_epoch_info(&checkpoint_store, &system_state_bytes, current_epoch),
+        real_epoch_info(&source, current_epoch),
         genesis_committee.clone(),
+        genesis_system_state.clone(),
         expected_chain_id,
         expected_chain_id,
     )
@@ -177,8 +198,9 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
     // FAILURE: a different chain_id never yields a verified witness, so
     // NOTHING can be written.
     let err = iota_snapshot::verify_epoch_info_chain(
-        real_epoch_info(&checkpoint_store, &system_state_bytes, current_epoch),
+        real_epoch_info(&source, current_epoch),
         genesis_committee.clone(),
+        genesis_system_state.clone(),
         ChainIdentifier::default(),
         expected_chain_id,
     )
@@ -188,11 +210,35 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
         "expected a chain_id mismatch error, got: {err}"
     );
 
+    // FAILURE: a genesis system state whose embedded committee doesn't match
+    // the genesis committee is caught by the start-state committee-match check.
+    // A later epoch's real start state stands in: same validators, but its
+    // committee is stamped with the wrong epoch.
+    let later_start_state = source
+        .get_epoch_info(1)
+        .unwrap()
+        .expect("epoch 1 is indexed")
+        .system_state;
+    let err = iota_snapshot::verify_epoch_info_chain(
+        real_epoch_info(&source, current_epoch),
+        genesis_committee.clone(),
+        later_start_state,
+        expected_chain_id,
+        expected_chain_id,
+    )
+    .expect_err("a genesis system state with a mismatched committee must be rejected");
+    assert!(
+        err.to_string()
+            .contains("does not match the certified committee"),
+        "expected a start-state committee-match error, got: {err}"
+    );
+
     // FAILURE: a wrong trust root (the current committee instead of the
     // genesis one, after two reconfigurations) fails the chain walk.
     let err = iota_snapshot::verify_epoch_info_chain(
-        real_epoch_info(&checkpoint_store, &system_state_bytes, current_epoch),
+        real_epoch_info(&source, current_epoch),
         state.clone_committee_for_testing(),
+        genesis_system_state,
         expected_chain_id,
         expected_chain_id,
     )
@@ -201,6 +247,263 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
         err.to_string().contains("genesis committee"),
         "expected a trust-root error, got: {err}"
     );
+}
+
+/// Corrupting any one link of an entry's proof bundle (contents, effects,
+/// events, start-state objects, or the unsigned `start_checkpoint`) is rejected
+/// even though the committee chain still verifies. The safe-mode boundary is
+/// covered separately by `epoch_info_verifies_safe_mode_boundary`.
+#[sim_test]
+async fn epoch_info_proof_bundle_tampering_is_rejected() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(600_000)
+        .disable_fullnode_pruning()
+        .build()
+        .await;
+    test_cluster.force_new_epoch().await;
+    test_cluster.force_new_epoch().await;
+
+    let state = test_cluster
+        .fullnode_handle
+        .iota_node
+        .with(|node| node.state());
+    let authority_store = state.database_for_testing();
+    let checkpoint_store = state.get_checkpoint_store().clone();
+    let current_epoch = state.current_epoch_for_testing();
+    assert!(current_epoch >= 2, "need at least two closed epochs");
+    wait_until_executed_open_epoch(&checkpoint_store, current_epoch).await;
+
+    let chain_id = state.get_chain_identifier();
+    let genesis = &test_cluster.swarm.config().genesis;
+    let genesis_committee = genesis.committee().expect("genesis committee");
+    let genesis_system_state = genesis.iota_system_object();
+
+    let source_tmp = tempfile::tempdir().unwrap();
+    let source = GrpcIndexesStore::new(
+        source_tmp.path().to_path_buf(),
+        authority_store,
+        &checkpoint_store,
+    )
+    .await;
+
+    // Sanity: the untampered bundle verifies, so each rejection below is the
+    // tamper's doing, not a fixture defect.
+    iota_snapshot::verify_epoch_info_chain(
+        real_epoch_info(&source, current_epoch),
+        genesis_committee.clone(),
+        genesis_system_state.clone(),
+        chain_id,
+        chain_id,
+    )
+    .expect("the untampered EPOCH_INFO must verify");
+
+    // The last closed epoch's boundary is a normal `AdvanceEpoch` (events
+    // present), so every link is non-trivially populated. Each case also
+    // asserts the distinctive error fragment of the check it should trip, so a
+    // tamper that happens to fail some *other* index-`idx` check can't pass.
+    let idx = (current_epoch - 1) as usize;
+    #[allow(clippy::type_complexity)]
+    let cases: Vec<(&str, &str, Box<dyn Fn(&mut EpochInfoV1Entry)>)> = vec![
+        (
+            "contents",
+            "does not hash to the signed content_digest",
+            Box::new(|entry| {
+                entry.last_checkpoint_contents =
+                    CheckpointContents::new_with_digests_only_for_tests(std::iter::empty());
+            }),
+        ),
+        (
+            "effects",
+            "is not the last transaction of the closing checkpoint",
+            Box::new(|entry| {
+                entry.end_of_epoch_tx_effects =
+                    TransactionEffects::new_empty_v1_for_testing(TransactionDigest::ZERO);
+            }),
+        ),
+        (
+            "events",
+            "does not hash to the effects' events_digest",
+            Box::new(|entry| {
+                entry.end_of_epoch_tx_events = TransactionEvents::default();
+            }),
+        ),
+        (
+            "start-state objects",
+            "do not include the system-state object 0x5",
+            Box::new(|entry| {
+                entry.next_epoch_start_system_state_objects = Vec::new();
+            }),
+        ),
+        (
+            "start_checkpoint",
+            "declares start_checkpoint",
+            Box::new(|entry| {
+                entry.start_checkpoint = entry.start_checkpoint.wrapping_add(1);
+            }),
+        ),
+        (
+            "summary",
+            "failed verification",
+            Box::new(|entry| {
+                // Mutate a signed field while keeping the quorum signature: the
+                // certificate carries a real signature but no longer verifies.
+                let mut data = entry.last_checkpoint_summary.data().clone();
+                data.timestamp_ms = data.timestamp_ms.wrapping_add(1);
+                entry.last_checkpoint_summary =
+                    iota_types::message_envelope::Envelope::new_from_data_and_sig(
+                        data,
+                        entry.last_checkpoint_summary.auth_sig().clone(),
+                    );
+            }),
+        ),
+    ];
+
+    for (label, expected_fragment, mutate) in cases {
+        let EpochInfo::V1(mut info) = real_epoch_info(&source, current_epoch);
+        mutate(&mut info.entries[idx]);
+        let err = iota_snapshot::verify_epoch_info_chain(
+            EpochInfo::V1(info),
+            genesis_committee.clone(),
+            genesis_system_state.clone(),
+            chain_id,
+            chain_id,
+        )
+        .unwrap_err();
+        let err = err.to_string();
+        assert!(
+            err.contains(&format!("epoch {idx}")) && err.contains(expected_fragment),
+            "tampering with {label} must be rejected at epoch {idx} with \
+             {expected_fragment:?}, got: {err}"
+        );
+    }
+}
+
+/// A safe-mode boundary (`advance_epoch_safe_mode`, which emits no events) must
+/// chain-verify: its effects carry no `events_digest`, so the verifier requires
+/// the entry's events to be empty rather than hashing them. Forced via the
+/// `advance_epoch` failure injection, so this is `msim`-only.
+#[cfg(msim)]
+#[sim_test]
+async fn epoch_info_verifies_safe_mode_boundary() {
+    use iota_types::{
+        effects::TransactionEffectsAPI, iota_system_state::advance_epoch_result_injection,
+    };
+
+    // Fail the advance into epoch 2, so epoch 1's closing boundary runs
+    // `advance_epoch_safe_mode`; epochs 0 and 2 close normally (events present).
+    advance_epoch_result_injection::set_override(Some((2, 3)));
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(600_000)
+        .disable_fullnode_pruning()
+        .build()
+        .await;
+    // Suppress the node's "never safe mode" debug assertion for the injected
+    // epoch (one-way: leaving it set never forces safe mode on normal epochs).
+    test_cluster.set_safe_mode_expected(true);
+    // 0->1 normal, 1->2 safe mode, 2->3 normal.
+    test_cluster.force_new_epoch().await;
+    test_cluster.force_new_epoch().await;
+    test_cluster.force_new_epoch().await;
+
+    let state = test_cluster
+        .fullnode_handle
+        .iota_node
+        .with(|node| node.state());
+    let authority_store = state.database_for_testing();
+    let checkpoint_store = state.get_checkpoint_store().clone();
+    let current_epoch = state.current_epoch_for_testing();
+    assert!(
+        current_epoch >= 3,
+        "need the safe-mode epoch plus one normal epoch closed after it"
+    );
+    wait_until_executed_open_epoch(&checkpoint_store, current_epoch).await;
+
+    let chain_id = state.get_chain_identifier();
+    let genesis = &test_cluster.swarm.config().genesis;
+    let genesis_committee = genesis.committee().expect("genesis committee");
+    let genesis_system_state = genesis.iota_system_object();
+
+    let source_tmp = tempfile::tempdir().unwrap();
+    let source = GrpcIndexesStore::new(
+        source_tmp.path().to_path_buf(),
+        authority_store,
+        &checkpoint_store,
+    )
+    .await;
+    let epoch_info = real_epoch_info(&source, current_epoch);
+
+    // Confirm the chain genuinely contains a safe-mode boundary — otherwise the
+    // verify below would pass on all-normal data. Exactly one entry's
+    // epoch-change effects carry no `events_digest`, and its events are empty.
+    let EpochInfo::V1(info) = &epoch_info;
+    let safe_mode: Vec<_> = info
+        .entries
+        .iter()
+        .filter(|entry| entry.end_of_epoch_tx_effects.events_digest().is_none())
+        .collect();
+    assert_eq!(
+        safe_mode.len(),
+        1,
+        "expected exactly one safe-mode boundary in [0, {current_epoch})"
+    );
+    assert!(
+        safe_mode[0].end_of_epoch_tx_events.is_empty(),
+        "a safe-mode boundary must carry no events"
+    );
+
+    // REJECT path: the safe-mode boundary's effects carry no `events_digest`,
+    // so the verifier requires its events to be empty. Giving it a non-empty
+    // events list (borrowed from a normal boundary in the same chain) must be
+    // rejected at that entry.
+    let safe_mode_epoch = info
+        .entries
+        .iter()
+        .position(|entry| entry.end_of_epoch_tx_effects.events_digest().is_none())
+        .expect("a safe-mode boundary exists");
+    let normal_events = info
+        .entries
+        .iter()
+        .find(|entry| !entry.end_of_epoch_tx_events.is_empty())
+        .expect("a normal boundary with events exists")
+        .end_of_epoch_tx_events
+        .clone();
+    let EpochInfo::V1(mut tampered) = real_epoch_info(&source, current_epoch);
+    tampered.entries[safe_mode_epoch].end_of_epoch_tx_events = normal_events;
+    let err = iota_snapshot::verify_epoch_info_chain(
+        EpochInfo::V1(tampered),
+        genesis_committee.clone(),
+        genesis_system_state.clone(),
+        chain_id,
+        chain_id,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains(&format!("epoch {safe_mode_epoch}")) && err.contains("carry no events_digest"),
+        "a safe-mode boundary with non-empty events must be rejected, got: {err}"
+    );
+
+    // The whole chain, safe-mode boundary included, must verify and seed.
+    let tmp = tempfile::tempdir().unwrap();
+    let grpc = GrpcIndexesStore::new_without_init(tmp.path().to_path_buf());
+    iota_snapshot::verify_epoch_info_chain(
+        epoch_info,
+        genesis_committee,
+        genesis_system_state,
+        chain_id,
+        chain_id,
+    )
+    .expect("a chain with a safe-mode boundary must verify")
+    .restore_epoch_info(&grpc)
+    .await
+    .expect("a verified safe-mode chain must seed");
+    for epoch in 0..current_epoch {
+        assert!(
+            grpc.get_epoch_info(epoch).unwrap().is_some(),
+            "epoch {epoch} must be seeded"
+        );
+    }
 }
 
 /// `epochs_v2_gap` (the startup guard's check) reports no gap for a
@@ -279,25 +582,27 @@ async fn missing_epochs_above_snapshot_prefix_are_indexed_locally() {
     wait_until_executed_open_epoch(&checkpoint_store, current_epoch).await;
 
     let expected_chain_id = state.get_chain_identifier();
-    let system_state_bytes = bcs::to_bytes(
-        &state
-            .get_iota_system_state_object_for_testing()
-            .expect("current system state"),
+    let genesis = &test_cluster.swarm.config().genesis;
+    let genesis_committee = genesis.committee().expect("genesis committee");
+    let genesis_system_state = genesis.iota_system_object();
+
+    // A locally-indexed store gives epoch 0 its real proof bundle.
+    let source_tmp = tempfile::tempdir().unwrap();
+    let source = GrpcIndexesStore::new(
+        source_tmp.path().to_path_buf(),
+        authority_store.clone(),
+        &checkpoint_store,
     )
-    .expect("system state must BCS-encode");
+    .await;
 
     // Mimic a backfill from a lagging snapshot: seed only epoch 0, leaving
     // the later closed epochs missing.
     let tmp = tempfile::tempdir().unwrap();
     let grpc = GrpcIndexesStore::new_without_init(tmp.path().to_path_buf());
     iota_snapshot::verify_epoch_info_chain(
-        real_epoch_info(&checkpoint_store, &system_state_bytes, 1),
-        test_cluster
-            .swarm
-            .config()
-            .genesis
-            .committee()
-            .expect("genesis committee"),
+        real_epoch_info(&source, 1),
+        genesis_committee,
+        genesis_system_state,
         expected_chain_id,
         expected_chain_id,
     )
@@ -324,28 +629,21 @@ async fn missing_epochs_above_snapshot_prefix_are_indexed_locally() {
     assert!(grpc.get_epoch_info(open_epoch).unwrap().is_some());
 }
 
-/// Build a real `EpochInfo` for closed epochs `[0, current_epoch)` from the
-/// node's end-of-epoch summaries (the conversion reads each summary's epoch and
-/// end-of-epoch data). `start_system_state` only needs to BCS-decode, so the
-/// current system state is reused for every entry.
-fn real_epoch_info(
-    checkpoint_store: &CheckpointStore,
-    start_system_state: &[u8],
-    current_epoch: EpochId,
-) -> EpochInfo {
+/// Build a real `EpochInfo` for closed epochs `[0, current_epoch)` from a
+/// locally-indexed `epochs_v2` store, projecting each row into its entry via
+/// the same `EpochInfoV1Entry::try_from` the snapshot writer uses. `source`
+/// must have fully-populated rows for every closed epoch (e.g. a freshly
+/// `GrpcIndexesStore::new`-indexed store over unpruned history).
+fn real_epoch_info(source: &GrpcIndexesStore, current_epoch: EpochId) -> EpochInfo {
     let entries = (0..current_epoch)
         .map(|epoch| {
-            let last_checkpoint = checkpoint_store
-                .get_epoch_last_checkpoint(epoch)
+            let row = source
+                .get_epoch_info(epoch)
                 .unwrap()
-                .unwrap_or_else(|| panic!("missing last checkpoint for closed epoch {epoch}"));
-            EpochInfoV1Entry {
-                epoch,
-                start_checkpoint: 0,
-                start_system_state: start_system_state.to_vec(),
-                last_checkpoint_summary: last_checkpoint.into_inner(),
-                end_of_epoch_tx_events: Default::default(),
-            }
+                .unwrap_or_else(|| panic!("missing epochs_v2 row for closed epoch {epoch}"));
+            EpochInfoV1Entry::try_from(row).unwrap_or_else(|field| {
+                panic!("epochs_v2 row for closed epoch {epoch} is missing `{field}`")
+            })
         })
         .collect();
     EpochInfo::V1(EpochInfoV1 { entries })
@@ -365,7 +663,6 @@ fn restored_sentinel_row(epoch: u64) -> EpochInfoV2 {
         end_checkpoint: None,
         reference_gas_price: 0,
         system_state: IotaSystemState::for_testing(epoch, 1),
-        last_checkpoint_summary: None,
-        end_of_epoch_tx_events: None,
+        proof: None,
     }
 }

--- a/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
+++ b/crates/iota-e2e-tests/tests/grpc_epoch_backfill_tests.rs
@@ -3,14 +3,14 @@
 
 use iota_core::{checkpoints::CheckpointStore, grpc_indexes::GrpcIndexesStore};
 use iota_macros::sim_test;
-use iota_snapshot::{EpochInfo, EpochInfoV1, EpochInfoV1Entry};
+use iota_snapshot::{EpochInfo, EpochInfoV1};
 use iota_types::{
     committee::EpochId,
     digests::{ChainIdentifier, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsExtForTesting, TransactionEvents},
     iota_system_state::IotaSystemState,
     messages_checkpoint::CheckpointContents,
-    storage::EpochInfoV2,
+    storage::{EpochInfoV1Entry, EpochInfoV2},
 };
 use test_cluster::TestClusterBuilder;
 
@@ -634,7 +634,7 @@ fn real_epoch_info(source: &GrpcIndexesStore, current_epoch: EpochId) -> EpochIn
                 .get_epoch_info(epoch)
                 .unwrap()
                 .unwrap_or_else(|| panic!("missing epochs_v2 row for closed epoch {epoch}"));
-            row.epoch_info_entry.unwrap_or_else(|| {
+            row.epoch_close_proof.unwrap_or_else(|| {
                 panic!("epochs_v2 row for closed epoch {epoch} is not finalized")
             })
         })
@@ -651,6 +651,6 @@ fn restored_sentinel_row(epoch: u64) -> EpochInfoV2 {
         start_checkpoint: 0,
         start_timestamp_ms: 0,
         system_state: IotaSystemState::for_testing(epoch, 1),
-        epoch_info_entry: None,
+        epoch_close_proof: None,
     }
 }

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -64,7 +64,7 @@ impl Merge<&EpochReadSource> for Epoch {
             }
 
             if mask.contains(Self::LAST_CHECKPOINT_FIELD.name) {
-                if let Some(end_checkpoint) = epoch_info.end_checkpoint {
+                if let Some(end_checkpoint) = epoch_info.end_checkpoint() {
                     self.last_checkpoint = Some(end_checkpoint);
                 }
             }
@@ -74,21 +74,22 @@ impl Merge<&EpochReadSource> for Epoch {
             }
 
             if mask.contains(Self::END_FIELD.name) {
-                if let Some(end_timestamp_ms) = epoch_info.end_timestamp_ms {
+                if let Some(end_timestamp_ms) = epoch_info.end_timestamp_ms() {
                     self.end = Some(timestamp_ms_to_proto(end_timestamp_ms));
                 }
             }
 
             if mask.contains(Self::REFERENCE_GAS_PRICE_FIELD.name) {
-                self.reference_gas_price = Some(epoch_info.reference_gas_price);
+                self.reference_gas_price = Some(epoch_info.reference_gas_price());
             }
 
             if let Some(submask) = mask.subtree(Self::PROTOCOL_CONFIG_FIELD.name) {
+                let protocol_version = epoch_info.protocol_version();
                 let iota_config = IotaProtocolConfig::get_for_version_if_supported(
-                    epoch_info.protocol_version.into(),
+                    protocol_version.into(),
                     source.chain,
                 )
-                .ok_or_else(|| ProtocolVersionNotFoundError::new(epoch_info.protocol_version))?;
+                .ok_or_else(|| ProtocolVersionNotFoundError::new(protocol_version))?;
                 self.protocol_config = Some(ProtocolConfig::merge_from(&iota_config, &submask)?);
             }
         }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -561,6 +561,7 @@ impl IotaNode {
                     grpc_indexes_store,
                     remote_store_config,
                     genesis.committee()?,
+                    genesis.iota_system_object(),
                     chain_identifier,
                     &store,
                     &checkpoint_store,
@@ -887,6 +888,7 @@ impl IotaNode {
         grpc_indexes_store: &GrpcIndexesStore,
         remote_store_config: &ObjectStoreConfig,
         genesis_committee: Committee,
+        genesis_system_state: IotaSystemState,
         expected_chain_id: ChainIdentifier,
         authority_store: &AuthorityStore,
         checkpoint_store: &CheckpointStore,
@@ -895,11 +897,13 @@ impl IotaNode {
         info!("backfilling gRPC epochs_v2 from snapshot EPOCH_INFO up to epoch {epoch}");
         let (snapshot_chain_id, epoch_info) =
             StateSnapshotReaderV1::read_epoch_info_only(epoch, remote_store_config).await?;
-        // Anchor the bucket's data to this node's trust roots: the chain id
-        // and the committee chain walked from the genesis committee.
+        // Anchor the bucket's data to this node's trust roots: the chain id,
+        // the committee chain walked from the genesis committee, and the
+        // genesis system state (epoch 0's start state, which no entry proves).
         let verified = iota_snapshot::verify_epoch_info_chain(
             epoch_info,
             genesis_committee,
+            genesis_system_state,
             snapshot_chain_id,
             expected_chain_id,
         )?;

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -319,7 +319,8 @@ impl EpochInfo {
 /// Chain-verified `EPOCH_INFO`: the `chain_id` matched and every entry was
 /// anchored to its certified `last_checkpoint_summary` — the committee chain
 /// walked from the genesis committee, every byte hash-checked back to that
-/// signed summary. The only constructor is `verify_epoch_info_chain`.
+/// signed summary. The only constructor is `verify_epoch_info_chain`, so holding
+/// one is proof the data is anchored to the operator-provided genesis.
 #[derive(Debug)]
 pub struct VerifiedEpochInfo {
     epoch_info: EpochInfo,

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -38,24 +38,23 @@ use iota_sdk_types::ObjectId;
 use iota_storage::{
     FileCompression, SHA3_BYTES, compute_sha3_checksum, object_store::util::path_to_filesystem,
 };
+// Re-exported so `iota_snapshot::EpochInfoV1Entry` (the snapshot file entry,
+// defined in `iota-types` because `EpochInfoV2` embeds it) stays a stable path.
+pub use iota_types::storage::EpochInfoV1Entry;
 use iota_types::{
     IOTA_SYSTEM_STATE_OBJECT_ID,
     base_types::ObjectRef,
-    committee::{Committee, CommitteeChainVerifier, EpochId},
+    committee::{Committee, CommitteeChainVerifier},
     digests::ChainIdentifier,
-    effects::{
-        TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt, TransactionEvents,
-    },
+    effects::{TransactionEffectsAPI, TransactionEffectsExt},
     global_state_hash::GlobalStateHash,
     iota_system_state::{
         IotaSystemState, IotaSystemStateTrait,
         epoch_start_iota_system_state::EpochStartSystemStateTrait, get_iota_system_state,
     },
-    messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointContents, ECMHLiveObjectSetDigest,
-    },
+    messages_checkpoint::{CheckpointSequenceNumber, ECMHLiveObjectSetDigest},
     object::Object,
-    storage::{CloseOfEpochProof, EpochInfoV2},
+    storage::EpochInfoV2,
 };
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use object_store::path::Path;
@@ -290,71 +289,6 @@ impl Manifest {
     }
 }
 
-/// Per-epoch entry of the `EPOCH_INFO` file. Every field is anchored to the
-/// certified `last_checkpoint_summary` and checked by
-/// `verify_epoch_boundary_proof`, so a restoring node trusts only data
-/// reachable from the signed summary, not the (unsigned) transport.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EpochInfoV1Entry {
-    /// Epoch this entry describes.
-    pub epoch: EpochId,
-
-    /// First checkpoint of this epoch (`0` for genesis; otherwise the prior
-    /// epoch's `last_checkpoint_summary.sequence_number + 1`).
-    pub start_checkpoint: iota_types::messages_checkpoint::CheckpointSequenceNumber,
-
-    /// Certified summary of this epoch's closing checkpoint — the signed
-    /// anchor every other field is proven against.
-    pub last_checkpoint_summary: CertifiedCheckpointSummary,
-
-    /// Contents of that closing checkpoint; `hash == last_checkpoint_summary`'s
-    /// `content_digest`.
-    pub last_checkpoint_contents: CheckpointContents,
-
-    /// Effects of the epoch-change tx (the last tx of the closing checkpoint);
-    /// its `(transaction, effects)` digest pair is the last entry of
-    /// `last_checkpoint_contents`.
-    pub end_of_epoch_tx_effects: TransactionEffects,
-
-    /// Events from the epoch-change tx (carries `SystemEpochInfoEvent`); `hash
-    /// == end_of_epoch_tx_effects.events_digest`, or empty on safe-mode
-    /// boundaries where that digest is `None`.
-    pub end_of_epoch_tx_events: TransactionEvents,
-
-    /// Raw serialized bytes of object `0x5` and its inner system-state object
-    /// as written by this boundary — epoch `epoch + 1`'s start state. Each
-    /// object's digest matches a written-object entry in
-    /// `end_of_epoch_tx_effects`.
-    pub next_epoch_start_system_state_objects: Vec<Vec<u8>>,
-}
-
-impl TryFrom<EpochInfoV2> for EpochInfoV1Entry {
-    /// `"proof"` when the row isn't finalized.
-    type Error = &'static str;
-
-    /// Project a finalized index row into its on-disk entry; `Err` if not
-    /// finalized. Destructuring `CloseOfEpochProof` keeps this exhaustive with
-    /// the bundle.
-    fn try_from(row: EpochInfoV2) -> Result<Self, Self::Error> {
-        let CloseOfEpochProof {
-            last_checkpoint_summary,
-            last_checkpoint_contents,
-            end_of_epoch_tx_effects,
-            end_of_epoch_tx_events,
-            next_epoch_start_system_state_objects,
-        } = row.proof.ok_or("proof")?;
-        Ok(EpochInfoV1Entry {
-            epoch: row.epoch,
-            start_checkpoint: row.start_checkpoint,
-            last_checkpoint_summary,
-            last_checkpoint_contents,
-            end_of_epoch_tx_effects,
-            end_of_epoch_tx_events,
-            next_epoch_start_system_state_objects,
-        })
-    }
-}
-
 /// On-disk schema for the per-snapshot `EPOCH_INFO` file. Versioned for
 /// future schema evolution. `entries[i]` is the entry for epoch `i`;
 /// length is `snapshot_epoch + 1`.
@@ -419,11 +353,19 @@ impl VerifiedEpochInfo {
         } = self;
         // `start_system_states[i]` is epoch `i`'s start state; `zip` drops the
         // trailing one (the state the last boundary proves, which has no row).
+        // Each epoch's start checkpoint is the previous epoch's last + 1 (0 for
+        // epoch 0), derived inline from the signed summaries.
+        let mut previous_end_checkpoint: Option<u64> = None;
         epoch_info
             .into_entries()
             .into_iter()
             .zip(start_system_states)
-            .map(|(entry, start_system_state)| epoch_info_v2_row(entry, start_system_state))
+            .map(|(entry, start_system_state)| {
+                let start_checkpoint = previous_end_checkpoint.map_or(0, |seq| seq + 1);
+                previous_end_checkpoint =
+                    Some(*entry.last_checkpoint_summary.data().sequence_number());
+                epoch_info_v2_row(entry, start_system_state, start_checkpoint)
+            })
             .collect()
     }
 
@@ -466,26 +408,14 @@ pub fn verify_epoch_info_chain(
     // `start_system_states[i]` is epoch `i`'s start state; epoch 0's is the
     // genesis root, every later one is derived from the previous boundary.
     let mut start_system_states = vec![genesis_system_state];
-    let mut previous_end_checkpoint: Option<u64> = None;
     for (index, entry) in epoch_info.entries().iter().enumerate() {
         // EPOCH_INFO-specific: entries must be the contiguous epochs from 0.
-        // Everything else (summary epoch, signatures, close-of-epoch,
-        // committee handover) is the chain walk itself.
+        // The epoch comes from the signed summary, not a stored field, so it
+        // can't disagree with the data it anchors.
+        let epoch = entry.last_checkpoint_summary.epoch();
         anyhow::ensure!(
-            entry.epoch == index as u64,
-            "EPOCH_INFO entry at index {index} declares epoch {}",
-            entry.epoch,
-        );
-
-        // The start checkpoint must be the previous epoch's last + 1 (0 for
-        // epoch 0). Cross-checks the unsigned `start_checkpoint` against the
-        // signed sequence numbers.
-        let expected_start = previous_end_checkpoint.map_or(0, |seq| seq + 1);
-        anyhow::ensure!(
-            entry.start_checkpoint == expected_start,
-            "EPOCH_INFO entry for epoch {index} declares start_checkpoint {} but the \
-             previous epoch's signed close implies {expected_start}",
-            entry.start_checkpoint,
+            epoch == index as u64,
+            "EPOCH_INFO entry at index {index} carries a summary for epoch {epoch}",
         );
 
         // Defense in depth: the committee in epoch `index`'s start state must
@@ -509,7 +439,6 @@ pub fn verify_epoch_info_chain(
         let next_start_state = verify_epoch_boundary_proof(entry)
             .map_err(|e| anyhow::anyhow!("EPOCH_INFO entry for epoch {index}: {e}"))?;
 
-        previous_end_checkpoint = Some(*entry.last_checkpoint_summary.data().sequence_number());
         committees.push(chain_verifier.committee().clone());
         start_system_states.push(next_start_state);
     }
@@ -587,34 +516,21 @@ fn verify_epoch_boundary_proof(entry: &EpochInfoV1Entry) -> anyhow::Result<IotaS
         .map_err(|e| anyhow::anyhow!("decoding the next-epoch system state: {e}"))
 }
 
-/// Build an `EpochInfoV2` index row from a verified entry and its
-/// digest-verified start system state. Infallible: the only caller's entries
-/// already passed `verify_epoch_info_chain`, so `entry.epoch` matches the
-/// summary's epoch; the `debug_assert` re-checks that in debug builds.
-fn epoch_info_v2_row(entry: EpochInfoV1Entry, system_state: IotaSystemState) -> EpochInfoV2 {
-    debug_assert_eq!(
-        entry.epoch,
-        entry.last_checkpoint_summary.epoch(),
-        "a verified entry's epoch must match its summary's epoch",
-    );
-    let end_checkpoint = *entry.last_checkpoint_summary.data().sequence_number();
-    let end_timestamp_ms = entry.last_checkpoint_summary.data().timestamp_ms;
+/// Build an `EpochInfoV2` index row from a verified entry, its digest-verified
+/// start system state, and its start checkpoint. The `epoch` comes from the
+/// entry's signed summary; the `end_*` facts are derived from the embedded
+/// entry by `EpochInfoV2`'s methods.
+fn epoch_info_v2_row(
+    entry: EpochInfoV1Entry,
+    system_state: IotaSystemState,
+    start_checkpoint: CheckpointSequenceNumber,
+) -> EpochInfoV2 {
     EpochInfoV2 {
-        epoch: entry.epoch,
-        protocol_version: system_state.protocol_version(),
+        epoch: entry.last_checkpoint_summary.epoch(),
+        start_checkpoint,
         start_timestamp_ms: system_state.epoch_start_timestamp_ms(),
-        end_timestamp_ms: Some(end_timestamp_ms),
-        start_checkpoint: entry.start_checkpoint,
-        end_checkpoint: Some(end_checkpoint),
-        reference_gas_price: system_state.reference_gas_price(),
         system_state,
-        proof: Some(CloseOfEpochProof {
-            last_checkpoint_summary: entry.last_checkpoint_summary,
-            last_checkpoint_contents: entry.last_checkpoint_contents,
-            end_of_epoch_tx_effects: entry.end_of_epoch_tx_effects,
-            end_of_epoch_tx_events: entry.end_of_epoch_tx_events,
-            next_epoch_start_system_state_objects: entry.next_epoch_start_system_state_objects,
-        }),
+        epoch_info_entry: Some(entry),
     }
 }
 

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -327,7 +327,7 @@ pub struct VerifiedEpochInfo {
     committees: Vec<Committee>,
     /// Digest-verified start state per epoch: `[i]` is epoch `i`'s start state
     /// — the genesis root for `i == 0`, else derived from epoch `i - 1`'s
-    /// boundary. Length `snapshot_epoch + 2`; the trailing entry has no row.
+    /// boundary. Length `snapshot_epoch + 2`; the trailing entry has no epoch info row.
     start_system_states: Vec<IotaSystemState>,
 }
 

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -464,8 +464,7 @@ fn verify_epoch_boundary_proof(entry: &EpochInfoV1Entry) -> anyhow::Result<IotaS
         "last_checkpoint_contents does not hash to the signed content_digest",
     );
 
-    // 2. The epoch-change effects are the last tx of the verified contents (by
-    //    position, so a same-block tx that also touches `0x5` can't stand in).
+    // 2. The epoch-change effects are the last tx of the verified contents.
     let expected_execution_digest = entry
         .last_checkpoint_contents
         .end_of_epoch_execution_digests(summary)

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -38,9 +38,6 @@ use iota_sdk_types::ObjectId;
 use iota_storage::{
     FileCompression, SHA3_BYTES, compute_sha3_checksum, object_store::util::path_to_filesystem,
 };
-// Re-exported so `iota_snapshot::EpochInfoV1Entry` (the snapshot file entry,
-// defined in `iota-types` because `EpochInfoV2` embeds it) stays a stable path.
-pub use iota_types::storage::EpochInfoV1Entry;
 use iota_types::{
     IOTA_SYSTEM_STATE_OBJECT_ID,
     base_types::ObjectRef,
@@ -54,7 +51,7 @@ use iota_types::{
     },
     messages_checkpoint::{CheckpointSequenceNumber, ECMHLiveObjectSetDigest},
     object::Object,
-    storage::EpochInfoV2,
+    storage::{EpochInfoV1Entry, EpochInfoV2},
 };
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use object_store::path::Path;
@@ -468,12 +465,13 @@ fn verify_epoch_boundary_proof(entry: &EpochInfoV1Entry) -> anyhow::Result<IotaS
     // 2. The epoch-change effects are the last tx of the verified contents.
     let expected_execution_digest = entry
         .last_checkpoint_contents
-        .end_of_epoch_execution_digests(summary)
+        .inner()
+        .last()
         .ok_or_else(|| anyhow::anyhow!("the closing checkpoint has no transactions"))?;
     let effects = &entry.end_of_epoch_tx_effects;
     anyhow::ensure!(
-        effects.execution_digests() == *expected,
-        "end_of_epoch_tx_effects is not the last transaction of the closing checkpoint",
+        effects.execution_digests() == *expected_execution_digest,
+        "end_of_epoch_tx_effects digest pair does not match the closing checkpoint's last transaction",
     );
 
     // 3. Events hash to the effects' events_digest (`None` ⇒ events empty, the
@@ -531,7 +529,7 @@ fn epoch_info_v2_row(
         start_checkpoint,
         start_timestamp_ms: system_state.epoch_start_timestamp_ms(),
         system_state,
-        epoch_info_entry: Some(entry),
+        epoch_close_proof: Some(entry),
     }
 }
 

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -319,15 +319,16 @@ impl EpochInfo {
 /// Chain-verified `EPOCH_INFO`: the `chain_id` matched and every entry was
 /// anchored to its certified `last_checkpoint_summary` — the committee chain
 /// walked from the genesis committee, every byte hash-checked back to that
-/// signed summary. The only constructor is `verify_epoch_info_chain`, so holding
-/// one is proof the data is anchored to the operator-provided genesis.
+/// signed summary. The only constructor is `verify_epoch_info_chain`, so
+/// holding one is proof the data is anchored to the operator-provided genesis.
 #[derive(Debug)]
 pub struct VerifiedEpochInfo {
     epoch_info: EpochInfo,
     committees: Vec<Committee>,
     /// Digest-verified start state per epoch: `[i]` is epoch `i`'s start state
     /// — the genesis root for `i == 0`, else derived from epoch `i - 1`'s
-    /// boundary. Length `snapshot_epoch + 2`; the trailing entry has no epoch info row.
+    /// boundary. Length `snapshot_epoch + 2`; the trailing entry has no epoch
+    /// info row.
     start_system_states: Vec<IotaSystemState>,
 }
 

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -13,6 +13,7 @@ pub mod uploader;
 mod writer;
 
 use std::{
+    collections::HashSet,
     path::PathBuf,
     sync::{
         Arc,
@@ -38,15 +39,23 @@ use iota_storage::{
     FileCompression, SHA3_BYTES, compute_sha3_checksum, object_store::util::path_to_filesystem,
 };
 use iota_types::{
-    committee::{Committee, CommitteeChainVerifier},
+    IOTA_SYSTEM_STATE_OBJECT_ID,
+    base_types::ObjectRef,
+    committee::{Committee, CommitteeChainVerifier, EpochId},
     digests::ChainIdentifier,
+    effects::{
+        TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt, TransactionEvents,
+    },
     global_state_hash::GlobalStateHash,
     iota_system_state::{
         IotaSystemState, IotaSystemStateTrait,
         epoch_start_iota_system_state::EpochStartSystemStateTrait, get_iota_system_state,
     },
-    messages_checkpoint::ECMHLiveObjectSetDigest,
-    storage::EpochInfoV2,
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, ECMHLiveObjectSetDigest,
+    },
+    object::Object,
+    storage::{CloseOfEpochProof, EpochInfoV2},
 };
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use object_store::path::Path;
@@ -281,26 +290,69 @@ impl Manifest {
     }
 }
 
+/// Per-epoch entry of the `EPOCH_INFO` file. Every field is anchored to the
+/// certified `last_checkpoint_summary` and checked by
+/// `verify_epoch_boundary_proof`, so a restoring node trusts only data
+/// reachable from the signed summary, not the (unsigned) transport.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EpochInfoV1Entry {
     /// Epoch this entry describes.
-    pub epoch: iota_types::committee::EpochId,
+    pub epoch: EpochId,
 
     /// First checkpoint of this epoch (`0` for genesis; otherwise the prior
     /// epoch's `last_checkpoint_summary.sequence_number + 1`).
     pub start_checkpoint: iota_types::messages_checkpoint::CheckpointSequenceNumber,
 
-    /// BCS-encoded `IotaSystemState` of object `0x5` right after the
-    /// AdvanceEpoch tx of the previous epoch (or the genesis tx for epoch 0).
-    pub start_system_state: Vec<u8>,
+    /// Certified summary of this epoch's closing checkpoint — the signed
+    /// anchor every other field is proven against.
+    pub last_checkpoint_summary: CertifiedCheckpointSummary,
 
-    /// Certified summary of this epoch's last checkpoint — carries
-    /// `end_of_epoch_data`, gas summary, timestamp, quorum signatures.
-    pub last_checkpoint_summary: iota_types::messages_checkpoint::CertifiedCheckpointSummary,
+    /// Contents of that closing checkpoint; `hash == last_checkpoint_summary`'s
+    /// `content_digest`.
+    pub last_checkpoint_contents: CheckpointContents,
 
-    /// Events from the AdvanceEpoch tx — carries `SystemEpochInfoEvent`
-    /// (storage/computation accounting, mint/burn, stake rewards).
-    pub end_of_epoch_tx_events: iota_types::effects::TransactionEvents,
+    /// Effects of the epoch-change tx (the last tx of the closing checkpoint);
+    /// its `(transaction, effects)` digest pair is the last entry of
+    /// `last_checkpoint_contents`.
+    pub end_of_epoch_tx_effects: TransactionEffects,
+
+    /// Events from the epoch-change tx (carries `SystemEpochInfoEvent`); `hash
+    /// == end_of_epoch_tx_effects.events_digest`, or empty on safe-mode
+    /// boundaries where that digest is `None`.
+    pub end_of_epoch_tx_events: TransactionEvents,
+
+    /// Raw serialized bytes of object `0x5` and its inner system-state object
+    /// as written by this boundary — epoch `epoch + 1`'s start state. Each
+    /// object's digest matches a written-object entry in
+    /// `end_of_epoch_tx_effects`.
+    pub next_epoch_start_system_state_objects: Vec<Vec<u8>>,
+}
+
+impl TryFrom<EpochInfoV2> for EpochInfoV1Entry {
+    /// `"proof"` when the row isn't finalized.
+    type Error = &'static str;
+
+    /// Project a finalized index row into its on-disk entry; `Err` if not
+    /// finalized. Destructuring `CloseOfEpochProof` keeps this exhaustive with
+    /// the bundle.
+    fn try_from(row: EpochInfoV2) -> Result<Self, Self::Error> {
+        let CloseOfEpochProof {
+            last_checkpoint_summary,
+            last_checkpoint_contents,
+            end_of_epoch_tx_effects,
+            end_of_epoch_tx_events,
+            next_epoch_start_system_state_objects,
+        } = row.proof.ok_or("proof")?;
+        Ok(EpochInfoV1Entry {
+            epoch: row.epoch,
+            start_checkpoint: row.start_checkpoint,
+            last_checkpoint_summary,
+            last_checkpoint_contents,
+            end_of_epoch_tx_effects,
+            end_of_epoch_tx_events,
+            next_epoch_start_system_state_objects,
+        })
+    }
 }
 
 /// On-disk schema for the per-snapshot `EPOCH_INFO` file. Versioned for
@@ -323,36 +375,25 @@ impl EpochInfo {
         }
     }
 
-    /// Convert each on-disk entry into an [`EpochInfoV2`] index row; errors if
-    /// an entry's index doesn't equal its epoch.
-    pub fn into_epoch_info_v2_rows(self) -> anyhow::Result<Vec<EpochInfoV2>> {
-        let Self::V1(info) = self;
-        info.entries
-            .into_iter()
-            .enumerate()
-            .map(|(index, entry)| {
-                let row = EpochInfoV2::try_from(entry)?;
-                anyhow::ensure!(
-                    index as u64 == row.epoch,
-                    "EPOCH_INFO entry at index {index} declares epoch {}",
-                    row.epoch
-                );
-                Ok(row)
-            })
-            .collect()
+    fn into_entries(self) -> Vec<EpochInfoV1Entry> {
+        match self {
+            Self::V1(info) => info.entries,
+        }
     }
 }
 
-/// Chain-verified `EPOCH_INFO`: the snapshot's `chain_id` matched, and every
-/// entry's certified `last_checkpoint_summary` was verified against its
-/// epoch's committee, walking the committee handoffs from the genesis
-/// committee. The only constructor is [`verify_epoch_info_chain`], so holding
-/// one is proof the data is anchored to the operator-provided genesis — the
-/// same trust model as the checkpoint-archive sync.
+/// Chain-verified `EPOCH_INFO`: the `chain_id` matched and every entry was
+/// anchored to its certified `last_checkpoint_summary` — the committee chain
+/// walked from the genesis committee, every byte hash-checked back to that
+/// signed summary. The only constructor is `verify_epoch_info_chain`.
 #[derive(Debug)]
 pub struct VerifiedEpochInfo {
     epoch_info: EpochInfo,
     committees: Vec<Committee>,
+    /// Digest-verified start state per epoch: `[i]` is epoch `i`'s start state
+    /// — the genesis root for `i == 0`, else derived from epoch `i - 1`'s
+    /// boundary. Length `snapshot_epoch + 2`; the trailing entry has no row.
+    start_system_states: Vec<IotaSystemState>,
 }
 
 impl VerifiedEpochInfo {
@@ -367,23 +408,45 @@ impl VerifiedEpochInfo {
         &self.committees
     }
 
+    /// Convert the verified entries `[0, snapshot_epoch]` into `EpochInfoV2`
+    /// index rows. Each row's `system_state` is the digest-verified start state
+    /// of its own epoch (`start_system_states[i]`).
+    pub(crate) fn into_epoch_info_v2_rows(self) -> Vec<EpochInfoV2> {
+        let VerifiedEpochInfo {
+            epoch_info,
+            start_system_states,
+            ..
+        } = self;
+        // `start_system_states[i]` is epoch `i`'s start state; `zip` drops the
+        // trailing one (the state the last boundary proves, which has no row).
+        epoch_info
+            .into_entries()
+            .into_iter()
+            .zip(start_system_states)
+            .map(|(entry, start_system_state)| epoch_info_v2_row(entry, start_system_state))
+            .collect()
+    }
+
     /// Restore the verified rows `[0, snapshot_epoch]` into the given
     /// consumer's epoch store.
     pub async fn restore_epoch_info(self, db: &impl RestoreEpochInfo) -> anyhow::Result<()> {
-        let rows = self.epoch_info.into_epoch_info_v2_rows()?;
+        let rows = self.into_epoch_info_v2_rows();
         db.restore_epoch_info(rows).await
     }
 }
 
 /// Verify a snapshot's `EPOCH_INFO` against the operator's trust roots: the
-/// expected `chain_id`, and the committee chain walked from the genesis
-/// committee — each entry must be the certified close of its epoch (contiguous
-/// from epoch 0, carrying `end_of_epoch_data`), signed by the committee the
-/// previous entry handed forward. Nothing is written; the returned
-/// [`VerifiedEpochInfo`] is the witness consumers require.
+/// expected `chain_id`, the committee chain walked from `genesis_committee`,
+/// and `genesis_system_state` (epoch 0's start state, which no entry proves).
+/// Each entry must be the contiguous certified close of its epoch, signed by
+/// the committee the previous entry handed forward, with its proof bundle
+/// hashing back to the signed summary (see `verify_epoch_boundary_proof`).
+/// Nothing is written; the returned `VerifiedEpochInfo` is the witness
+/// consumers require.
 pub fn verify_epoch_info_chain(
     epoch_info: EpochInfo,
     genesis_committee: Committee,
+    genesis_system_state: IotaSystemState,
     snapshot_chain_id: ChainIdentifier,
     expected_chain_id: ChainIdentifier,
 ) -> anyhow::Result<VerifiedEpochInfo> {
@@ -400,6 +463,10 @@ pub fn verify_epoch_info_chain(
 
     let mut chain_verifier = CommitteeChainVerifier::new(genesis_committee);
     let mut committees = vec![chain_verifier.committee().clone()];
+    // `start_system_states[i]` is epoch `i`'s start state; epoch 0's is the
+    // genesis root, every later one is derived from the previous boundary.
+    let mut start_system_states = vec![genesis_system_state];
+    let mut previous_end_checkpoint: Option<u64> = None;
     for (index, entry) in epoch_info.entries().iter().enumerate() {
         // EPOCH_INFO-specific: entries must be the contiguous epochs from 0.
         // Everything else (summary epoch, signatures, close-of-epoch,
@@ -409,51 +476,145 @@ pub fn verify_epoch_info_chain(
             "EPOCH_INFO entry at index {index} declares epoch {}",
             entry.epoch,
         );
+
+        // The start checkpoint must be the previous epoch's last + 1 (0 for
+        // epoch 0). Cross-checks the unsigned `start_checkpoint` against the
+        // signed sequence numbers.
+        let expected_start = previous_end_checkpoint.map_or(0, |seq| seq + 1);
+        anyhow::ensure!(
+            entry.start_checkpoint == expected_start,
+            "EPOCH_INFO entry for epoch {index} declares start_checkpoint {} but the \
+             previous epoch's signed close implies {expected_start}",
+            entry.start_checkpoint,
+        );
+
+        // Defense in depth: the committee in epoch `index`'s start state must
+        // match the one the chain certified — catches a tampered validator set
+        // that left the (separately signed) committee handover intact.
+        let start_committee = start_system_states[index].get_current_epoch_committee();
+        anyhow::ensure!(
+            start_committee.committee() == chain_verifier.committee(),
+            "EPOCH_INFO entry for epoch {index}: the committee in its start system \
+             state does not match the certified committee",
+        );
+
         chain_verifier
             .verify_epoch_close(entry.last_checkpoint_summary.clone())
             .map_err(|e| {
                 anyhow::anyhow!("EPOCH_INFO entry for epoch {index} failed verification: {e}")
             })?;
+
+        // Anchor the rest of the entry to the now-verified summary and derive
+        // epoch `index + 1`'s start state from the boundary objects.
+        let next_start_state = verify_epoch_boundary_proof(entry)
+            .map_err(|e| anyhow::anyhow!("EPOCH_INFO entry for epoch {index}: {e}"))?;
+
+        previous_end_checkpoint = Some(*entry.last_checkpoint_summary.data().sequence_number());
         committees.push(chain_verifier.committee().clone());
+        start_system_states.push(next_start_state);
     }
 
     Ok(VerifiedEpochInfo {
         epoch_info,
         committees,
+        start_system_states,
     })
 }
 
-impl TryFrom<EpochInfoV1Entry> for EpochInfoV2 {
-    type Error = anyhow::Error;
+/// Anchor an entry's proof bundle to its (already signature-verified)
+/// `last_checkpoint_summary` and return the next epoch's digest-verified start
+/// state — the system-state objects this boundary wrote. Each link (contents,
+/// effects, events, start-state objects) is checked below.
+fn verify_epoch_boundary_proof(entry: &EpochInfoV1Entry) -> anyhow::Result<IotaSystemState> {
+    let summary = entry.last_checkpoint_summary.data();
 
-    /// Reconstruct the in-memory [`EpochInfoV2`] index row from this on-disk
-    /// entry; errors if `epoch` disagrees with
-    /// `last_checkpoint_summary.epoch()`. `end_timestamp_ms` is not stored on
-    /// disk and is reconstructed from the last checkpoint's timestamp.
-    fn try_from(entry: EpochInfoV1Entry) -> Result<Self> {
-        let system_state: IotaSystemState = bcs::from_bytes(&entry.start_system_state)
-            .map_err(|e| anyhow::anyhow!("decoding start_system_state: {e}"))?;
-        let summary_epoch = entry.last_checkpoint_summary.epoch();
+    // 1. Contents hash to the signed summary.
+    anyhow::ensure!(
+        *entry.last_checkpoint_contents.digest() == summary.content_digest,
+        "last_checkpoint_contents does not hash to the signed content_digest",
+    );
+
+    // 2. The epoch-change effects are the last tx of the verified contents (by
+    //    position, so a same-block tx that also touches `0x5` can't stand in).
+    let expected = entry
+        .last_checkpoint_contents
+        .end_of_epoch_execution_digests(summary)
+        .ok_or_else(|| anyhow::anyhow!("the closing checkpoint has no transactions"))?;
+    let effects = &entry.end_of_epoch_tx_effects;
+    anyhow::ensure!(
+        effects.execution_digests() == *expected,
+        "end_of_epoch_tx_effects is not the last transaction of the closing checkpoint",
+    );
+
+    // 3. Events hash to the effects' events_digest (`None` ⇒ events empty, the
+    // safe-mode boundary case).
+    match effects.events_digest() {
+        Some(events_digest) => anyhow::ensure!(
+            entry.end_of_epoch_tx_events.digest() == *events_digest,
+            "end_of_epoch_tx_events does not hash to the effects' events_digest",
+        ),
+        None => anyhow::ensure!(
+            entry.end_of_epoch_tx_events.is_empty(),
+            "the epoch-change effects carry no events_digest but \
+             end_of_epoch_tx_events is non-empty",
+        ),
+    }
+
+    // 4. Each start-state object's digest is one the effects wrote; `0x5` must
+    // be present. Decode `IotaSystemState` only from these verified bytes.
+    let written: HashSet<ObjectRef> = effects
+        .all_changed_objects()
+        .into_iter()
+        .map(|(object_ref, _, _)| object_ref)
+        .collect();
+    let mut objects = Vec::with_capacity(entry.next_epoch_start_system_state_objects.len());
+    for raw in &entry.next_epoch_start_system_state_objects {
+        let object: Object = bcs::from_bytes(raw)
+            .map_err(|e| anyhow::anyhow!("decoding a next-epoch start-state object: {e}"))?;
         anyhow::ensure!(
-            entry.epoch == summary_epoch,
-            "EPOCH_INFO entry declares epoch {} but its summary carries epoch {summary_epoch}",
-            entry.epoch,
+            written.contains(&object.object_ref()),
+            "a next-epoch start-state object is not written by the epoch-change tx",
         );
-        let epoch = entry.epoch;
-        let end_checkpoint = *entry.last_checkpoint_summary.data().sequence_number();
-        let end_timestamp_ms = entry.last_checkpoint_summary.data().timestamp_ms;
-        Ok(EpochInfoV2 {
-            epoch,
-            protocol_version: system_state.protocol_version(),
-            start_timestamp_ms: system_state.epoch_start_timestamp_ms(),
-            end_timestamp_ms: Some(end_timestamp_ms),
-            start_checkpoint: entry.start_checkpoint,
-            end_checkpoint: Some(end_checkpoint),
-            reference_gas_price: system_state.reference_gas_price(),
-            system_state,
-            last_checkpoint_summary: Some(entry.last_checkpoint_summary),
-            end_of_epoch_tx_events: Some(entry.end_of_epoch_tx_events),
-        })
+        objects.push(object);
+    }
+    anyhow::ensure!(
+        objects
+            .iter()
+            .any(|o| o.id() == IOTA_SYSTEM_STATE_OBJECT_ID),
+        "the next-epoch start-state objects do not include the system-state object 0x5",
+    );
+    get_iota_system_state(&objects.as_slice())
+        .map_err(|e| anyhow::anyhow!("decoding the next-epoch system state: {e}"))
+}
+
+/// Build an `EpochInfoV2` index row from a verified entry and its
+/// digest-verified start system state. Infallible: the only caller's entries
+/// already passed `verify_epoch_info_chain`, so `entry.epoch` matches the
+/// summary's epoch; the `debug_assert` re-checks that in debug builds.
+fn epoch_info_v2_row(entry: EpochInfoV1Entry, system_state: IotaSystemState) -> EpochInfoV2 {
+    debug_assert_eq!(
+        entry.epoch,
+        entry.last_checkpoint_summary.epoch(),
+        "a verified entry's epoch must match its summary's epoch",
+    );
+    let end_checkpoint = *entry.last_checkpoint_summary.data().sequence_number();
+    let end_timestamp_ms = entry.last_checkpoint_summary.data().timestamp_ms;
+    EpochInfoV2 {
+        epoch: entry.epoch,
+        protocol_version: system_state.protocol_version(),
+        start_timestamp_ms: system_state.epoch_start_timestamp_ms(),
+        end_timestamp_ms: Some(end_timestamp_ms),
+        start_checkpoint: entry.start_checkpoint,
+        end_checkpoint: Some(end_checkpoint),
+        reference_gas_price: system_state.reference_gas_price(),
+        system_state,
+        proof: Some(CloseOfEpochProof {
+            last_checkpoint_summary: entry.last_checkpoint_summary,
+            last_checkpoint_contents: entry.last_checkpoint_contents,
+            end_of_epoch_tx_effects: entry.end_of_epoch_tx_effects,
+            end_of_epoch_tx_events: entry.end_of_epoch_tx_events,
+            next_epoch_start_system_state_objects: entry.next_epoch_start_system_state_objects,
+        }),
     }
 }
 

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -466,7 +466,7 @@ fn verify_epoch_boundary_proof(entry: &EpochInfoV1Entry) -> anyhow::Result<IotaS
 
     // 2. The epoch-change effects are the last tx of the verified contents (by
     //    position, so a same-block tx that also touches `0x5` can't stand in).
-    let expected = entry
+    let expected_execution_digest = entry
         .last_checkpoint_contents
         .end_of_epoch_execution_digests(summary)
         .ok_or_else(|| anyhow::anyhow!("the closing checkpoint has no transactions"))?;

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -39,7 +39,7 @@ use iota_types::{
     },
     object::Object,
     storage::{
-        CloseOfEpochProof, CoinInfo, DynamicFieldIteratorItem, EpochInfoV2, OwnedObjectCursor,
+        CoinInfo, DynamicFieldIteratorItem, EpochInfoV2, OwnedObjectCursor,
         OwnedObjectIteratorItem, PackageVersionIteratorItem, TransactionInfo,
         error::Result as StorageResult,
     },
@@ -201,31 +201,18 @@ fn test_next_epoch_start_system_state_objects() -> Vec<Vec<u8>> {
 fn fully_populated_epoch_info(epoch: EpochId) -> EpochInfoV2 {
     EpochInfoV2 {
         epoch,
-        protocol_version: 0,
-        start_timestamp_ms: 0,
-        end_timestamp_ms: None,
         start_checkpoint: 0,
-        end_checkpoint: None,
-        reference_gas_price: 0,
+        start_timestamp_ms: 0,
         system_state: test_system_state(),
-        proof: Some(CloseOfEpochProof {
-            last_checkpoint_summary: fully_populated_checkpoint_summary(epoch),
-            last_checkpoint_contents: test_checkpoint_contents(),
-            end_of_epoch_tx_effects: test_end_of_epoch_tx_effects(),
-            end_of_epoch_tx_events: TransactionEvents::default(),
-            next_epoch_start_system_state_objects: test_next_epoch_start_system_state_objects(),
-        }),
+        epoch_info_entry: Some(fully_populated_snapshot_epoch_entry(epoch)),
     }
 }
 
-/// On-disk equivalent of [`fully_populated_epoch_info`]: used by tests that
-/// exercise the on-disk `EpochInfoV1Entry` directly (BCS round-trip of
-/// the `EPOCH_INFO` file body) rather than going through the writer's
-/// `EpochInfoV2 → EpochInfoV1Entry` translation.
+/// The close-of-epoch entry embedded in [`fully_populated_epoch_info`] and
+/// written to the `EPOCH_INFO` file; used by tests that exercise the on-disk
+/// `EpochInfoV1Entry` directly (BCS round-trip of the file body).
 fn fully_populated_snapshot_epoch_entry(epoch: EpochId) -> EpochInfoV1Entry {
     EpochInfoV1Entry {
-        epoch,
-        start_checkpoint: 0,
         last_checkpoint_summary: fully_populated_checkpoint_summary(epoch),
         last_checkpoint_contents: test_checkpoint_contents(),
         end_of_epoch_tx_effects: test_end_of_epoch_tx_effects(),
@@ -418,10 +405,6 @@ async fn snapshot_round_trip(
             "next_epoch_start_system_state_objects did not round-trip bit-identical \
              through the snapshot"
         );
-        assert_eq!(
-            entry.start_checkpoint, 0,
-            "start_checkpoint did not round-trip"
-        );
     }
 
     let local_store_restore_config = ObjectStoreConfig {
@@ -457,7 +440,6 @@ async fn snapshot_round_trip(
         "expected one entry per epoch"
     );
     for (i, entry) in epoch_info.entries().iter().enumerate() {
-        assert_eq!(entry.epoch, i as u64);
         assert_eq!(entry.last_checkpoint_summary.epoch(), i as u64);
     }
     Ok(())
@@ -523,8 +505,6 @@ async fn epoch_info_backfill_round_trip(
     //    `iota-e2e-tests`.
     for (epoch, entry) in epoch_info.entries().iter().enumerate() {
         let epoch = epoch as EpochId;
-        assert_eq!(entry.epoch, epoch);
-        assert_eq!(entry.start_checkpoint, 0, "epoch {epoch}: start_checkpoint");
         assert_eq!(
             entry.last_checkpoint_summary.epoch(),
             epoch,
@@ -1102,10 +1082,6 @@ fn epoch_info_v1_bcs_round_trip() {
 #[test]
 fn snapshot_epoch_info_field_order_is_locked() {
     let entry = EpochInfoV1Entry {
-        epoch: 0x0102_0304_0506_0708,
-        // Distinct, recognizable u64 — easy to spot in a hex dump if
-        // this assertion ever needs to be debugged.
-        start_checkpoint: 0xDEAD_BEEF_CAFE_F00D,
         last_checkpoint_summary: fully_populated_checkpoint_summary(0),
         last_checkpoint_contents: test_checkpoint_contents(),
         end_of_epoch_tx_effects: test_end_of_epoch_tx_effects(),
@@ -1117,8 +1093,6 @@ fn snapshot_epoch_info_field_order_is_locked() {
     let entry_bytes = bcs::to_bytes(&entry).expect("entry serialization");
 
     let mut expected = Vec::with_capacity(entry_bytes.len());
-    expected.extend_from_slice(&entry.epoch.to_le_bytes());
-    expected.extend_from_slice(&entry.start_checkpoint.to_le_bytes());
     expected.extend_from_slice(
         &bcs::to_bytes(&entry.last_checkpoint_summary).expect("summary serialization"),
     );
@@ -1185,62 +1159,58 @@ fn verify_epoch_info_chain_rejects_non_contiguous_entries() {
         ChainIdentifier::default(),
     )
     .expect_err("non-contiguous entries must be rejected");
-    assert!(err.to_string().contains("declares epoch"), "got: {err}");
+    assert!(
+        err.to_string().contains("carries a summary for epoch"),
+        "got: {err}"
+    );
 }
 
 /// `epoch_info_v2_row` derives every non-stored `EpochInfoV2` field: the
-/// `end_*` fields from the signed summary, the system-state fields from the
-/// start system state. Locks those derivations (the chain-verify path that
-/// feeds it real entries is exercised in `iota-e2e-tests`).
+/// `epoch` from the signed summary, the `end_*` from the embedded entry, the
+/// system-state fields from the start system state. The chain-verify path that
+/// feeds it real entries is exercised in `iota-e2e-tests`.
 #[test]
 fn epoch_info_v2_row_derives_fields() {
     use iota_types::iota_system_state::IotaSystemStateTrait;
 
     let entry = fully_populated_snapshot_epoch_entry(3);
     let system_state = test_system_state();
-    let row = crate::epoch_info_v2_row(entry.clone(), system_state.clone());
+    let start_checkpoint = 7;
+    let row = crate::epoch_info_v2_row(entry.clone(), system_state.clone(), start_checkpoint);
 
-    assert_eq!(row.epoch, 3);
-    assert_eq!(row.start_checkpoint, entry.start_checkpoint);
+    assert_eq!(row.epoch, 3, "epoch comes from the entry's signed summary");
+    assert_eq!(row.start_checkpoint, start_checkpoint);
     // `end_*` derived from the signed last-checkpoint summary.
     assert_eq!(
-        row.end_checkpoint,
+        row.end_checkpoint(),
         Some(*entry.last_checkpoint_summary.data().sequence_number()),
     );
     assert_eq!(
-        row.end_timestamp_ms,
+        row.end_timestamp_ms(),
         Some(entry.last_checkpoint_summary.data().timestamp_ms),
     );
     // System-state fields derived from the start system state.
-    assert_eq!(row.protocol_version, system_state.protocol_version());
-    assert_eq!(row.reference_gas_price, system_state.reference_gas_price());
+    assert_eq!(row.protocol_version(), system_state.protocol_version());
+    assert_eq!(
+        row.reference_gas_price(),
+        system_state.reference_gas_price()
+    );
     assert_eq!(
         row.start_timestamp_ms,
-        system_state.epoch_start_timestamp_ms(),
+        system_state.epoch_start_timestamp_ms()
     );
 }
 
-/// `is_finalized()` and the `EpochInfoV1Entry` projection agree: a finalized
-/// row projects, clearing its `proof` makes it both non-finalized and
-/// un-projectable.
+/// An open (not-yet-indexed) row has no `epoch_info_entry`, so it is not
+/// finalized and its `end_*` helpers return `None`. The finalized values are
+/// covered by `epoch_info_v2_row_derives_fields`.
 #[test]
-fn finalized_matches_entry_projection() {
-    let finalized = fully_populated_epoch_info(2);
-    assert!(finalized.is_finalized());
-    assert_eq!(
-        EpochInfoV1Entry::try_from(finalized.clone())
-            .expect("a finalized row must project into an on-disk entry")
-            .epoch,
-        2,
-    );
-
-    let unfinalized = EpochInfoV2 {
-        proof: None,
-        ..finalized
+fn open_row_has_no_end_fields() {
+    let open = EpochInfoV2 {
+        epoch_info_entry: None,
+        ..fully_populated_epoch_info(2)
     };
-    assert!(!unfinalized.is_finalized());
-    assert_eq!(
-        EpochInfoV1Entry::try_from(unfinalized).expect_err("an unfinalized row must not project"),
-        "proof",
-    );
+    assert!(!open.is_finalized());
+    assert_eq!(open.end_checkpoint(), None);
+    assert_eq!(open.end_timestamp_ms(), None);
 }

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -28,24 +28,22 @@ use iota_sdk_types::{GasCostSummary, ObjectId};
 use iota_types::{
     base_types::IotaAddress,
     committee::{Committee, EpochId},
-    crypto::{AuthorityKeyPair, get_key_pair_from_rng},
+    crypto::AuthorityKeyPair,
     digests::{ChainIdentifier, TransactionDigest},
-    effects::TransactionEvents,
+    effects::{TransactionEffects, TransactionEffectsExtForTesting, TransactionEvents},
     global_state_hash::GlobalStateHash,
     iota_system_state::IotaSystemState,
-    message_envelope::Envelope,
     messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointSummary, ECMHLiveObjectSetDigest, EndOfEpochData,
-        SignedCheckpointSummary,
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary, ECMHLiveObjectSetDigest,
+        EndOfEpochData, SignedCheckpointSummary,
     },
     object::Object,
     storage::{
-        CoinInfo, DynamicFieldIteratorItem, EpochInfoV2, OwnedObjectCursor,
+        CloseOfEpochProof, CoinInfo, DynamicFieldIteratorItem, EpochInfoV2, OwnedObjectCursor,
         OwnedObjectIteratorItem, PackageVersionIteratorItem, TransactionInfo,
         error::Result as StorageResult,
     },
 };
-use rand::SeedableRng;
 
 use crate::{
     EPOCH_INFO_FILE_MAGIC, EpochInfo, EpochInfoV1, EpochInfoV1Entry, FileCompression, FileMetadata,
@@ -107,17 +105,15 @@ impl TestGrpcIndexes {
     }
 }
 
-/// Test-fixture system state. The snapshot writer BCS-encodes this when
-/// translating `EpochInfoV2 → EpochInfoV1Entry` for the on-disk
-/// EPOCH_INFO file, so the round-trip assertion below compares against
-/// `bcs::to_bytes(&TEST_SYSTEM_STATE)` — verifying that the writer's BCS
-/// encoding is deterministic and not corrupted en route to disk.
+/// Test-fixture system state, reused as a row's decoded `system_state` and as
+/// the raw payload in `test_next_epoch_start_system_state_objects`.
+/// Distinctive field values make a writer bug that swaps or zeroes a field
+/// surface as a specific mismatch rather than silently passing.
 fn test_system_state() -> IotaSystemState {
     // Distinctive `epoch` + `protocol_version` so a bug that swaps fields
     // or zeroes them surfaces as a specific mismatch.
     let mut state = IotaSystemState::for_testing(0x1234_5678, 0x9ABC_DEF0);
-    // Set distinctive non-zero values `for_testing` zeroes, so `TryFrom`-derived
-    // fields fail loudly if dropped instead of read from `start_system_state`.
+    // Set distinctive non-zero values `for_testing` zeroes.
     let IotaSystemState::V1(inner) = &mut state else {
         unreachable!("for_testing builds a V1 system state");
     };
@@ -183,6 +179,25 @@ fn fully_populated_checkpoint_summary(epoch: EpochId) -> CertifiedCheckpointSumm
     certify_summary(end_of_epoch_summary(epoch))
 }
 
+/// Placeholder closing-checkpoint contents for the row/entry fixtures. These
+/// fixtures drive the writer/reader round-trip and the on-disk BCS layout,
+/// neither of which inspects the proof bundle — full proof-chain verification
+/// is exercised against real boundaries in `iota-e2e-tests`.
+fn test_checkpoint_contents() -> CheckpointContents {
+    CheckpointContents::new_with_digests_only_for_tests(std::iter::empty())
+}
+
+/// Placeholder epoch-change effects for the row/entry fixtures.
+fn test_end_of_epoch_tx_effects() -> TransactionEffects {
+    TransactionEffects::new_empty_v1_for_testing(TransactionDigest::ZERO)
+}
+
+/// Placeholder raw start-state object bytes for the row/entry fixtures —
+/// a recognizable, distinct payload so a misordered field surfaces.
+fn test_next_epoch_start_system_state_objects() -> Vec<Vec<u8>> {
+    vec![bcs::to_bytes(&test_system_state()).expect("test_system_state must BCS-encode")]
+}
+
 fn fully_populated_epoch_info(epoch: EpochId) -> EpochInfoV2 {
     EpochInfoV2 {
         epoch,
@@ -193,8 +208,13 @@ fn fully_populated_epoch_info(epoch: EpochId) -> EpochInfoV2 {
         end_checkpoint: None,
         reference_gas_price: 0,
         system_state: test_system_state(),
-        last_checkpoint_summary: Some(fully_populated_checkpoint_summary(epoch)),
-        end_of_epoch_tx_events: Some(TransactionEvents::default()),
+        proof: Some(CloseOfEpochProof {
+            last_checkpoint_summary: fully_populated_checkpoint_summary(epoch),
+            last_checkpoint_contents: test_checkpoint_contents(),
+            end_of_epoch_tx_effects: test_end_of_epoch_tx_effects(),
+            end_of_epoch_tx_events: TransactionEvents::default(),
+            next_epoch_start_system_state_objects: test_next_epoch_start_system_state_objects(),
+        }),
     }
 }
 
@@ -206,10 +226,11 @@ fn fully_populated_snapshot_epoch_entry(epoch: EpochId) -> EpochInfoV1Entry {
     EpochInfoV1Entry {
         epoch,
         start_checkpoint: 0,
-        start_system_state: bcs::to_bytes(&test_system_state())
-            .expect("test_system_state must BCS-encode"),
         last_checkpoint_summary: fully_populated_checkpoint_summary(epoch),
+        last_checkpoint_contents: test_checkpoint_contents(),
+        end_of_epoch_tx_effects: test_end_of_epoch_tx_effects(),
         end_of_epoch_tx_events: TransactionEvents::default(),
+        next_epoch_start_system_state_objects: test_next_epoch_start_system_state_objects(),
     }
 }
 
@@ -385,18 +406,17 @@ async fn snapshot_round_trip(
             "expected `entries` of length 1 for snapshot at epoch 0"
         );
         let entry = &decoded_v1.entries[0];
-        // Bit-identical round-trip of `start_system_state`. The writer
-        // BCS-encodes `EpochInfoV2.system_state` into this `Vec<u8>`; the
-        // assertion locks that the bytes on disk equal the deterministic
-        // BCS encoding of `test_system_state()`. A writer bug that
-        // truncated, padded, or re-encoded the field would change these
-        // bytes and fail here, even though the outer BCS round-trip would
-        // still succeed.
-        let expected_system_state_bytes =
-            bcs::to_bytes(&test_system_state()).expect("test_system_state must BCS-encode");
+        // Bit-identical round-trip of the raw start-state object bytes. The
+        // writer copies the proof bundle's `next_epoch_start_system_state_objects`
+        // verbatim; the assertion locks that the bytes on disk equal the
+        // fixture's. A writer bug that truncated, padded, or re-encoded the
+        // field would change these bytes and fail here, even though the outer
+        // BCS round-trip would still succeed.
         assert_eq!(
-            entry.start_system_state, expected_system_state_bytes,
-            "start_system_state did not round-trip bit-identical through the snapshot"
+            entry.next_epoch_start_system_state_objects,
+            test_next_epoch_start_system_state_objects(),
+            "next_epoch_start_system_state_objects did not round-trip bit-identical \
+             through the snapshot"
         );
         assert_eq!(
             entry.start_checkpoint, 0,
@@ -439,15 +459,13 @@ async fn snapshot_round_trip(
     for (i, entry) in epoch_info.entries().iter().enumerate() {
         assert_eq!(entry.epoch, i as u64);
         assert_eq!(entry.last_checkpoint_summary.epoch(), i as u64);
-        let v2 = EpochInfoV2::try_from(entry.clone()).expect("entry round-trips into EpochInfoV2");
-        assert_eq!(v2.epoch, i as u64);
     }
     Ok(())
 }
 
-/// Writes the EPOCH_INFO file for `[0, snapshot_epoch]`, reads it back, seeds a
-/// real `GrpcIndexesStore`, and asserts every row is fully populated with the
-/// watermark reconciled to `snapshot_epoch` — the restore tool's seed path.
+/// Writes the EPOCH_INFO file for `[0, snapshot_epoch]`, reads it back, and
+/// asserts every entry round-trips well-formed (one per epoch, in order, with a
+/// populated proof bundle) — the writer/reader half of the restore path.
 async fn epoch_info_backfill_round_trip(
     tmp_dir: &std::path::Path,
     snapshot_epoch: EpochId,
@@ -498,68 +516,25 @@ async fn epoch_info_backfill_round_trip(
         "EPOCH_INFO must carry one entry per epoch in [0, {snapshot_epoch}]"
     );
 
-    // 3. BACKFILL: seed the index store via `into_epoch_info_v2_rows`, the same
-    //    conversion the restore tool and background backfill use.
-    let grpc = GrpcIndexesStore::new_without_init(tmp_dir.join(GRPC_INDEXES_DIR));
-    let rows = epoch_info.into_epoch_info_v2_rows()?;
-    grpc.insert_epoch_info(rows)?;
-
-    // 4. ASSERT the derived values (not just `is_some()`) so the conversion is
-    //    exercised.
-    use iota_types::iota_system_state::IotaSystemStateTrait;
-    let system_state = test_system_state();
-    for epoch in 0..=snapshot_epoch {
-        let row = grpc
-            .get_epoch_info(epoch)?
-            .unwrap_or_else(|| panic!("backfilled row for epoch {epoch} is missing"));
-        assert_eq!(row.epoch, epoch);
-        assert_eq!(row.start_checkpoint, 0, "epoch {epoch}: start_checkpoint");
-        let summary = row
-            .last_checkpoint_summary
-            .as_ref()
-            .unwrap_or_else(|| panic!("epoch {epoch}: last_checkpoint_summary is None"));
+    // 3. ASSERT the on-disk entries round-trip well-formed: one per epoch in order,
+    //    each carrying its summary and a populated proof bundle. The chain-verified
+    //    seed into `epochs_v2` (which derives each row's start state from the
+    //    previous entry) needs a real boundary and is exercised in
+    //    `iota-e2e-tests`.
+    for (epoch, entry) in epoch_info.entries().iter().enumerate() {
+        let epoch = epoch as EpochId;
+        assert_eq!(entry.epoch, epoch);
+        assert_eq!(entry.start_checkpoint, 0, "epoch {epoch}: start_checkpoint");
         assert_eq!(
-            summary.epoch(),
+            entry.last_checkpoint_summary.epoch(),
             epoch,
             "epoch {epoch}: round-tripped summary carries the wrong epoch"
         );
-        assert_eq!(
-            row.end_checkpoint,
-            Some(*summary.data().sequence_number()),
-            "epoch {epoch}: end_checkpoint not derived from the summary"
-        );
-        assert_eq!(
-            row.end_timestamp_ms,
-            Some(summary.data().timestamp_ms),
-            "epoch {epoch}: end_timestamp_ms not derived from the summary"
-        );
         assert!(
-            row.end_of_epoch_tx_events.is_some(),
-            "epoch {epoch}: end_of_epoch_tx_events is None"
-        );
-        assert_eq!(
-            row.protocol_version,
-            system_state.protocol_version(),
-            "epoch {epoch}: protocol_version not derived from start_system_state"
-        );
-        assert_eq!(
-            row.reference_gas_price,
-            system_state.reference_gas_price(),
-            "epoch {epoch}: reference_gas_price not derived from start_system_state"
-        );
-        assert_eq!(
-            row.start_timestamp_ms,
-            system_state.epoch_start_timestamp_ms(),
-            "epoch {epoch}: start_timestamp_ms not derived from start_system_state"
+            !entry.next_epoch_start_system_state_objects.is_empty(),
+            "epoch {epoch}: next_epoch_start_system_state_objects is empty"
         );
     }
-    // Contiguous, fully-populated `[0, snapshot_epoch]` ⇒ watermark ==
-    // snapshot_epoch.
-    assert_eq!(
-        grpc.highest_indexed_epoch()?,
-        Some(snapshot_epoch),
-        "EpochIndexed watermark did not reconcile to the snapshot epoch"
-    );
     Ok(())
 }
 
@@ -609,7 +584,7 @@ async fn snapshot_round_trip_populated_zstd() -> Result<(), anyhow::Error> {
     snapshot_round_trip(dir.path(), 1000, FileCompression::Zstd).await
 }
 
-/// EPOCH_INFO write → read → seed `epochs_v2` round-trip across two epochs.
+/// EPOCH_INFO write → read entry round-trip across two epochs.
 #[tokio::test]
 async fn snapshot_epoch_info_backfill_round_trip() -> Result<(), anyhow::Error> {
     let dir = iota_common::tempdir();
@@ -620,8 +595,7 @@ async fn snapshot_epoch_info_backfill_round_trip() -> Result<(), anyhow::Error> 
 /// live-state indexes from the same object stream that fills the perpetual
 /// tables: the restored live object set matches the source, address-owned
 /// objects come back owner-indexed, and `finalize_restore` leaves the store
-/// initialized (the `EpochIndexed` watermark from the seeded epoch rows
-/// included).
+/// initialized.
 #[tokio::test]
 async fn snapshot_restore_builds_grpc_indexes() -> Result<(), anyhow::Error> {
     let dir = iota_common::tempdir();
@@ -706,17 +680,9 @@ async fn snapshot_restore_builds_grpc_indexes() -> Result<(), anyhow::Error> {
         .collect::<Result<_, _>>()?;
     assert_eq!(restored_ids, owned_ids);
 
-    // The remaining restore-tool steps: chain-verify EPOCH_INFO, seed the
-    // epoch rows, and finalize.
-    let epoch_info = snapshot_reader.read_epoch_info().await?;
-    let verified = verify_epoch_info_chain(
-        epoch_info,
-        test_committee_at(0),
-        snapshot_reader.chain_id(),
-        ChainIdentifier::default(),
-    )?;
-    verified.restore_epoch_info(&restored_grpc).await?;
-    assert_eq!(restored_grpc.highest_indexed_epoch()?, Some(0));
+    // Finalize the restored store. The chain-verify + epoch-row seed step
+    // needs a real boundary's proof bundle and is exercised in
+    // `iota-e2e-tests`.
     restored_grpc.finalize_restore(0)?;
     Ok(())
 }
@@ -1125,50 +1091,14 @@ fn epoch_info_v1_bcs_round_trip() {
     }
 }
 
-/// `TryFrom<EpochInfoV1Entry>` fills every `EpochInfoV2` field, deriving
-/// `end_timestamp_ms` (not stored on disk) from the last checkpoint's
-/// timestamp and the system-state fields from `start_system_state`.
-#[test]
-fn epoch_info_v1_entry_converts_to_v2_uniform_end_timestamp() {
-    use iota_types::iota_system_state::IotaSystemStateTrait;
-
-    let entry = fully_populated_snapshot_epoch_entry(3);
-    let summary = entry.last_checkpoint_summary.clone();
-    let v2 = EpochInfoV2::try_from(entry.clone()).expect("conversion succeeds");
-    assert_eq!(v2.epoch, 3);
-    assert_eq!(v2.start_checkpoint, entry.start_checkpoint);
-    assert_eq!(v2.end_checkpoint, Some(*summary.data().sequence_number()));
-    // Uniform reconstruction: end_timestamp_ms == last checkpoint timestamp.
-    assert_eq!(v2.end_timestamp_ms, Some(summary.data().timestamp_ms));
-    assert!(v2.last_checkpoint_summary.is_some());
-    assert!(v2.end_of_epoch_tx_events.is_some());
-    let ss: IotaSystemState = bcs::from_bytes(&entry.start_system_state).unwrap();
-    assert_eq!(v2.protocol_version, ss.protocol_version());
-    assert_eq!(v2.reference_gas_price, ss.reference_gas_price());
-    assert_eq!(v2.start_timestamp_ms, ss.epoch_start_timestamp_ms());
-}
-
-/// An entry whose `epoch` disagrees with its `last_checkpoint_summary.epoch()`
-/// is corrupted and must be rejected.
-#[test]
-fn try_from_rejects_epoch_summary_mismatch() {
-    let mut entry = fully_populated_snapshot_epoch_entry(3);
-    entry.epoch = 4; // summary still carries epoch 3
-    assert!(EpochInfoV2::try_from(entry).is_err());
-}
-
 /// Locks the BCS field order of `EpochInfoV1Entry` against silent
 /// reordering. BCS encodes struct fields in declaration order, so
 /// swapping any two fields would silently change the on-disk EPOCH_INFO
 /// file layout and break every existing snapshot consumer.
 ///
-/// Asserts that `bcs(entry)` equals the concatenation:
-///   `epoch.to_le_bytes() ++ start_checkpoint.to_le_bytes()
-///    ++ uvarint(start_system_state.len()) ++ start_system_state
-///    ++ bcs(last_checkpoint_summary: CertifiedCheckpointSummary)
-///    ++ bcs(end_of_epoch_tx_events: TransactionEvents)`.
-/// This both verifies the relative order of the fields and
-/// detects any encoding-shape change in the inner types.
+/// Asserts that `bcs(entry)` equals the concatenation of the per-field BCS
+/// encodings in declaration order. This both verifies the relative order of
+/// the fields and detects any encoding-shape change in the inner types.
 #[test]
 fn snapshot_epoch_info_field_order_is_locked() {
     let entry = EpochInfoV1Entry {
@@ -1176,25 +1106,35 @@ fn snapshot_epoch_info_field_order_is_locked() {
         // Distinct, recognizable u64 — easy to spot in a hex dump if
         // this assertion ever needs to be debugged.
         start_checkpoint: 0xDEAD_BEEF_CAFE_F00D,
-        // Distinct payload so a misordered field would be obvious.
-        start_system_state: vec![0xAA, 0xBB, 0xCC, 0xDD],
         last_checkpoint_summary: fully_populated_checkpoint_summary(0),
+        last_checkpoint_contents: test_checkpoint_contents(),
+        end_of_epoch_tx_effects: test_end_of_epoch_tx_effects(),
         end_of_epoch_tx_events: TransactionEvents::default(),
+        // Distinct payload so a misordered field would be obvious.
+        next_epoch_start_system_state_objects: vec![vec![0xAA, 0xBB, 0xCC, 0xDD]],
     };
 
     let entry_bytes = bcs::to_bytes(&entry).expect("entry serialization");
-    let start_system_state_bytes =
-        bcs::to_bytes(&entry.start_system_state).expect("start_system_state serialization");
-    let summary_bytes =
-        bcs::to_bytes(&entry.last_checkpoint_summary).expect("summary serialization");
-    let events_bytes = bcs::to_bytes(&entry.end_of_epoch_tx_events).expect("events serialization");
 
     let mut expected = Vec::with_capacity(entry_bytes.len());
     expected.extend_from_slice(&entry.epoch.to_le_bytes());
     expected.extend_from_slice(&entry.start_checkpoint.to_le_bytes());
-    expected.extend_from_slice(&start_system_state_bytes);
-    expected.extend_from_slice(&summary_bytes);
-    expected.extend_from_slice(&events_bytes);
+    expected.extend_from_slice(
+        &bcs::to_bytes(&entry.last_checkpoint_summary).expect("summary serialization"),
+    );
+    expected.extend_from_slice(
+        &bcs::to_bytes(&entry.last_checkpoint_contents).expect("contents serialization"),
+    );
+    expected.extend_from_slice(
+        &bcs::to_bytes(&entry.end_of_epoch_tx_effects).expect("effects serialization"),
+    );
+    expected.extend_from_slice(
+        &bcs::to_bytes(&entry.end_of_epoch_tx_events).expect("events serialization"),
+    );
+    expected.extend_from_slice(
+        &bcs::to_bytes(&entry.next_epoch_start_system_state_objects)
+            .expect("objects serialization"),
+    );
 
     assert_eq!(
         entry_bytes, expected,
@@ -1213,36 +1153,16 @@ fn signed_epoch_info(snapshot_epoch: EpochId) -> EpochInfo {
     })
 }
 
-/// Happy path: a committee-signed EPOCH_INFO verifies against the genesis
-/// committee, yields the committee chain for `[0, snapshot_epoch + 1]`, and
-/// restores into the gRPC epoch index with the watermark advanced.
-#[tokio::test]
-async fn verify_epoch_info_chain_accepts_and_restores() {
-    let verified = verify_epoch_info_chain(
-        signed_epoch_info(2),
-        test_committee_at(0),
-        ChainIdentifier::default(),
-        ChainIdentifier::default(),
-    )
-    .expect("a committee-signed EPOCH_INFO must verify");
-
-    assert_eq!(verified.entries().len(), 3);
-    let committee_epochs: Vec<_> = verified.committees().iter().map(|c| c.epoch).collect();
-    assert_eq!(committee_epochs, vec![0, 1, 2, 3]);
-
-    let tmp_dir = iota_common::tempdir();
-    let grpc = GrpcIndexesStore::new_without_init(tmp_dir.path().to_path_buf());
-    verified.restore_epoch_info(&grpc).await.expect("restore");
-    assert_eq!(grpc.highest_indexed_epoch().unwrap(), Some(2));
-}
-
-/// A wrong-network snapshot is rejected on the chain id, before any
-/// signature work.
+/// A wrong-network snapshot is rejected on the chain id, before any per-entry
+/// work — so this case needs no valid proof bundle. The committee-chain walk,
+/// proof-bundle anchoring, and per-link tamper cases require a real epoch
+/// boundary and are covered in `iota-e2e-tests`.
 #[test]
 fn verify_epoch_info_chain_rejects_wrong_chain_id() {
     let err = verify_epoch_info_chain(
         signed_epoch_info(1),
         test_committee_at(0),
+        test_system_state(),
         ChainIdentifier::default(),
         ChainIdentifier::from(iota_types::digests::CheckpointDigest::new([7; 32])),
     )
@@ -1250,93 +1170,77 @@ fn verify_epoch_info_chain_rejects_wrong_chain_id() {
     assert!(err.to_string().contains("chain_id"), "got: {err}");
 }
 
-/// A trust root other than the signing committee fails at the first entry.
-#[test]
-fn verify_epoch_info_chain_rejects_wrong_genesis_committee() {
-    // `new_simple_test_committee` derives its keys from a fixed seed (it would
-    // return the fixture's own validator set), so generate a genuinely
-    // different one.
-    let mut rng = rand::rngs::StdRng::from_seed([7; 32]);
-    let other_rights: std::collections::BTreeMap<_, _> = (0..4)
-        .map(|_| {
-            let (_, key): (_, AuthorityKeyPair) = get_key_pair_from_rng(&mut rng);
-            (key.public().into(), 2500)
-        })
-        .collect();
-    let other_committee = Committee::new_for_testing_with_normalized_voting_power(0, other_rights);
-
-    let err = verify_epoch_info_chain(
-        signed_epoch_info(1),
-        other_committee,
-        ChainIdentifier::default(),
-        ChainIdentifier::default(),
-    )
-    .expect_err("a different validator set must be rejected");
-    assert!(
-        err.to_string().contains("epoch 0"),
-        "the chain walk must fail at the first entry: {err}"
-    );
-}
-
-/// A summary mutated after certification fails signature verification, even
-/// though it carries an otherwise valid quorum signature.
-#[test]
-fn verify_epoch_info_chain_rejects_tampered_summary() {
-    let mut epoch_info = signed_epoch_info(2);
-    let EpochInfo::V1(info) = &mut epoch_info;
-    let certified = &info.entries[1].last_checkpoint_summary;
-    let mut tampered_summary = certified.data().clone();
-    tampered_summary.timestamp_ms = 42; // not what the committee signed
-    info.entries[1].last_checkpoint_summary =
-        Envelope::new_from_data_and_sig(tampered_summary, certified.auth_sig().clone());
-
-    let err = verify_epoch_info_chain(
-        epoch_info,
-        test_committee_at(0),
-        ChainIdentifier::default(),
-        ChainIdentifier::default(),
-    )
-    .expect_err("a tampered summary must be rejected");
-    assert!(
-        err.to_string().contains("epoch 1"),
-        "the chain walk must fail at the tampered entry: {err}"
-    );
-}
-
-/// An entry that is not a close-of-epoch checkpoint cannot hand a committee
-/// forward and must be rejected.
-#[test]
-fn verify_epoch_info_chain_rejects_missing_end_of_epoch_data() {
-    let mut epoch_info = signed_epoch_info(2);
-    let EpochInfo::V1(info) = &mut epoch_info;
-    let mut summary = end_of_epoch_summary(1);
-    summary.end_of_epoch_data = None;
-    info.entries[1].last_checkpoint_summary = certify_summary(summary);
-
-    let err = verify_epoch_info_chain(
-        epoch_info,
-        test_committee_at(0),
-        ChainIdentifier::default(),
-        ChainIdentifier::default(),
-    )
-    .expect_err("an entry without end_of_epoch_data must be rejected");
-    assert!(err.to_string().contains("end-of-epoch data"), "got: {err}");
-}
-
-/// Entries must be contiguous from epoch 0: a hole breaks the committee
-/// handoff and must be rejected, not skipped over.
+/// Entries must be the contiguous epochs from 0: a first entry that is not
+/// epoch 0 is rejected at the contiguity check, before any per-entry proof
+/// work — so this needs no valid proof bundle.
 #[test]
 fn verify_epoch_info_chain_rejects_non_contiguous_entries() {
-    let mut epoch_info = signed_epoch_info(2);
-    let EpochInfo::V1(info) = &mut epoch_info;
-    info.entries.remove(1);
-
+    let EpochInfo::V1(mut info) = signed_epoch_info(2);
+    info.entries.remove(0); // entries now start at epoch 1, not 0
     let err = verify_epoch_info_chain(
-        epoch_info,
+        EpochInfo::V1(info),
         test_committee_at(0),
+        test_system_state(),
         ChainIdentifier::default(),
         ChainIdentifier::default(),
     )
-    .expect_err("a hole in the entries must be rejected");
+    .expect_err("non-contiguous entries must be rejected");
     assert!(err.to_string().contains("declares epoch"), "got: {err}");
+}
+
+/// `epoch_info_v2_row` derives every non-stored `EpochInfoV2` field: the
+/// `end_*` fields from the signed summary, the system-state fields from the
+/// start system state. Locks those derivations (the chain-verify path that
+/// feeds it real entries is exercised in `iota-e2e-tests`).
+#[test]
+fn epoch_info_v2_row_derives_fields() {
+    use iota_types::iota_system_state::IotaSystemStateTrait;
+
+    let entry = fully_populated_snapshot_epoch_entry(3);
+    let system_state = test_system_state();
+    let row = crate::epoch_info_v2_row(entry.clone(), system_state.clone());
+
+    assert_eq!(row.epoch, 3);
+    assert_eq!(row.start_checkpoint, entry.start_checkpoint);
+    // `end_*` derived from the signed last-checkpoint summary.
+    assert_eq!(
+        row.end_checkpoint,
+        Some(*entry.last_checkpoint_summary.data().sequence_number()),
+    );
+    assert_eq!(
+        row.end_timestamp_ms,
+        Some(entry.last_checkpoint_summary.data().timestamp_ms),
+    );
+    // System-state fields derived from the start system state.
+    assert_eq!(row.protocol_version, system_state.protocol_version());
+    assert_eq!(row.reference_gas_price, system_state.reference_gas_price());
+    assert_eq!(
+        row.start_timestamp_ms,
+        system_state.epoch_start_timestamp_ms(),
+    );
+}
+
+/// `is_finalized()` and the `EpochInfoV1Entry` projection agree: a finalized
+/// row projects, clearing its `proof` makes it both non-finalized and
+/// un-projectable.
+#[test]
+fn finalized_matches_entry_projection() {
+    let finalized = fully_populated_epoch_info(2);
+    assert!(finalized.is_finalized());
+    assert_eq!(
+        EpochInfoV1Entry::try_from(finalized.clone())
+            .expect("a finalized row must project into an on-disk entry")
+            .epoch,
+        2,
+    );
+
+    let unfinalized = EpochInfoV2 {
+        proof: None,
+        ..finalized
+    };
+    assert!(!unfinalized.is_finalized());
+    assert_eq!(
+        EpochInfoV1Entry::try_from(unfinalized).expect_err("an unfinalized row must not project"),
+        "proof",
+    );
 }

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -204,11 +204,11 @@ fn fully_populated_epoch_info(epoch: EpochId) -> EpochInfoV2 {
         start_checkpoint: 0,
         start_timestamp_ms: 0,
         system_state: test_system_state(),
-        epoch_info_entry: Some(fully_populated_snapshot_epoch_entry(epoch)),
+        epoch_close_proof: Some(fully_populated_snapshot_epoch_entry(epoch)),
     }
 }
 
-/// The close-of-epoch entry embedded in [`fully_populated_epoch_info`] and
+/// The close-of-epoch proof embedded in [`fully_populated_epoch_info`] and
 /// written to the `EPOCH_INFO` file; used by tests that exercise the on-disk
 /// `EpochInfoV1Entry` directly (BCS round-trip of the file body).
 fn fully_populated_snapshot_epoch_entry(epoch: EpochId) -> EpochInfoV1Entry {
@@ -1201,13 +1201,13 @@ fn epoch_info_v2_row_derives_fields() {
     );
 }
 
-/// An open (not-yet-indexed) row has no `epoch_info_entry`, so it is not
+/// An open (not-yet-indexed) row has no `epoch_close_proof`, so it is not
 /// finalized and its `end_*` helpers return `None`. The finalized values are
 /// covered by `epoch_info_v2_row_derives_fields`.
 #[test]
 fn open_row_has_no_end_fields() {
     let open = EpochInfoV2 {
-        epoch_info_entry: None,
+        epoch_close_proof: None,
         ..fully_populated_epoch_info(2)
     };
     assert!(!open.is_finalized());

--- a/crates/iota-snapshot/src/writer.rs
+++ b/crates/iota-snapshot/src/writer.rs
@@ -46,10 +46,10 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::debug;
 
 use crate::{
-    EPOCH_INFO_FILE_MAGIC, EpochInfo, EpochInfoV1, EpochInfoV1Entry, FILE_MAX_BYTES,
-    FileCompression, FileMetadata, FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC, Manifest,
-    ManifestV2, OBJECT_FILE_MAGIC, OBJECT_REF_BYTES, REFERENCE_FILE_MAGIC, SEQUENCE_NUM_BYTES,
-    compute_sha3_checksum, create_file_metadata,
+    EPOCH_INFO_FILE_MAGIC, EpochInfo, EpochInfoV1, FILE_MAX_BYTES, FileCompression, FileMetadata,
+    FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC, Manifest, ManifestV2, OBJECT_FILE_MAGIC,
+    OBJECT_REF_BYTES, REFERENCE_FILE_MAGIC, SEQUENCE_NUM_BYTES, compute_sha3_checksum,
+    create_file_metadata,
 };
 
 /// LiveObjectSetWriterV1 writes live object set. It creates multiple *.obj
@@ -526,8 +526,8 @@ impl StateSnapshotWriterV1 {
     }
 
     /// Writes the per-snapshot `EPOCH_INFO` file, one entry per epoch in
-    /// `[0, epoch]`: each row is read via `GrpcIndexes::get_epoch_info` and
-    /// projected with `EpochInfoV1Entry::try_from`. Callers must have run
+    /// `[0, epoch]`: each row is read via `GrpcIndexes::get_epoch_info` and its
+    /// embedded `epoch_info_entry` taken. Callers must have run
     /// [`Self::check_epoch_indexed_watermark`] first; this function trusts the
     /// precondition and panics on any unfinalized row.
     ///
@@ -561,15 +561,15 @@ impl StateSnapshotWriterV1 {
                          watermark covering it — watermark/row inconsistency"
                     )
                 });
-            // The boundary's whole proof bundle is committed in one atomic
-            // batch, so a row the watermark covers must be finalized; a missing
-            // proof means the watermark advanced over an unfinalized row.
-            // Panics for the same blast-radius reason as above.
-            let entry = EpochInfoV1Entry::try_from(epoch_info).unwrap_or_else(|field| {
+            // The boundary's whole entry is committed in one atomic batch, so a
+            // row the watermark covers must be finalized; a missing entry means
+            // the watermark advanced over an unfinalized row. Panics for the
+            // same blast-radius reason as above.
+            let entry = epoch_info.epoch_info_entry.unwrap_or_else(|| {
                 panic!(
-                    "epochs_v2[{epoch_id}] is missing `{field}` despite `EpochIndexed` \
-                     watermark covering it — the watermark must never cover a \
-                     partially written row"
+                    "epochs_v2[{epoch_id}] is not finalized despite `EpochIndexed` \
+                     watermark covering it — the watermark must never cover an \
+                     unfinalized row"
                 )
             });
             // Turn a silent miswrite (row stored under the wrong epoch key)

--- a/crates/iota-snapshot/src/writer.rs
+++ b/crates/iota-snapshot/src/writer.rs
@@ -502,10 +502,9 @@ impl StateSnapshotWriterV1 {
     }
 
     /// Verifies the `Watermark::EpochIndexed` precondition: every epoch
-    /// in `[0, epoch]` must be fully populated (both start-of-epoch and
-    /// end-of-epoch fields committed). Called from [`Self::write_internal`]
-    /// before any disk work so a misconfigured node fails fast instead of
-    /// burning a full DB scan.
+    /// in `[0, epoch]` must be finalized (its close-of-epoch proof present).
+    /// Called from [`Self::write_internal`] before any disk work so a
+    /// misconfigured node fails fast instead of burning a full DB scan.
     /// `None` and `Some(h) where h < epoch` are distinct failure modes
     /// with distinct remediations — keep them as separate messages.
     fn check_epoch_indexed_watermark(&self, epoch: u64) -> Result<()> {
@@ -527,10 +526,10 @@ impl StateSnapshotWriterV1 {
     }
 
     /// Writes the per-snapshot `EPOCH_INFO` file, one entry per epoch in
-    /// `[0, epoch]` from `IndexStoreTables::epoch_info` via
-    /// `GrpcIndexes::get_epoch_info_entry`. Callers must have run
-    /// [`Self::check_epoch_indexed_watermark`] first; this function
-    /// trusts the precondition and panics on any missing field.
+    /// `[0, epoch]`: each row is read via `GrpcIndexes::get_epoch_info` and
+    /// projected with `EpochInfoV1Entry::try_from`. Callers must have run
+    /// [`Self::check_epoch_indexed_watermark`] first; this function trusts the
+    /// precondition and panics on any unfinalized row.
     ///
     /// File layout: 4-byte magic | bcs(EpochInfo). Integrity is anchored
     /// by `FileMetadata::sha3_digest` in the MANIFEST — no in-file sha3
@@ -547,9 +546,9 @@ impl StateSnapshotWriterV1 {
         // loop is fine; a range scan would be a micro-optimization.
         for epoch_id in 0..=epoch {
             // The watermark precondition above guarantees every entry in
-            // `[0, epoch]` is present with both end-of-epoch fields set; the
-            // panics below turn any watermark/row inconsistency into a
-            // loud failure rather than a silently truncated snapshot.
+            // `[0, epoch]` is present and finalized; the panics below turn any
+            // watermark/row inconsistency into a loud failure rather than a
+            // silently truncated snapshot.
             // `panic!` is deliberate: this runs inside `spawn_blocking`,
             // so the panic surfaces as `JoinError` and fails only the
             // snapshot task — exactly the desired blast radius.
@@ -562,41 +561,28 @@ impl StateSnapshotWriterV1 {
                          watermark covering it — watermark/row inconsistency"
                     )
                 });
-            let last_checkpoint_summary = epoch_info.last_checkpoint_summary.unwrap_or_else(|| {
+            // The boundary's whole proof bundle is committed in one atomic
+            // batch, so a row the watermark covers must be finalized; a missing
+            // proof means the watermark advanced over an unfinalized row.
+            // Panics for the same blast-radius reason as above.
+            let entry = EpochInfoV1Entry::try_from(epoch_info).unwrap_or_else(|field| {
                 panic!(
-                    "epochs_v2[{epoch_id}] is missing `last_checkpoint_summary` \
-                         despite `EpochIndexed` watermark covering it — \
-                         watermark/row inconsistency"
+                    "epochs_v2[{epoch_id}] is missing `{field}` despite `EpochIndexed` \
+                     watermark covering it — the watermark must never cover a \
+                     partially written row"
                 )
             });
-            // The close-of-epoch write commits `last_checkpoint_summary`
-            // and `end_of_epoch_tx_events` in the same atomic batch, so if
-            // one is set the other must be too. Without this check, a
-            // future bug that splits the two writes would silently produce
-            // snapshots missing events.
-            let end_of_epoch_tx_events = epoch_info.end_of_epoch_tx_events.unwrap_or_else(|| {
-                panic!(
-                    "epochs_v2[{epoch_id}] is missing `end_of_epoch_tx_events` \
-                     despite `last_checkpoint_summary` being populated — \
-                     end-of-epoch atomicity violation"
-                )
-            });
-            // Turn a silent miswrite (entry stored under the wrong epoch
-            // key) into a loud panic at snapshot time.
-            let entry_epoch = last_checkpoint_summary.epoch();
+            // Turn a silent miswrite (row stored under the wrong epoch key)
+            // into a loud panic at snapshot time.
             assert_eq!(
-                entry_epoch, epoch_id,
-                "epochs_v2[{epoch_id}] is populated with an entry for epoch \
-                 {entry_epoch}; the snapshot would silently misattribute checkpoints",
+                entry.last_checkpoint_summary.epoch(),
+                epoch_id,
+                "epochs_v2[{epoch_id}] is populated with an entry for epoch {}; the \
+                 snapshot would silently misattribute checkpoints",
+                entry.last_checkpoint_summary.epoch(),
             );
 
-            entries.push(EpochInfoV1Entry {
-                epoch: epoch_id,
-                start_checkpoint: epoch_info.start_checkpoint,
-                start_system_state: bcs::to_bytes(&epoch_info.system_state)?,
-                last_checkpoint_summary,
-                end_of_epoch_tx_events,
-            });
+            entries.push(entry);
         }
         let epoch_info = EpochInfo::V1(EpochInfoV1 { entries });
         let serialized = bcs::to_bytes(&epoch_info)?;

--- a/crates/iota-snapshot/src/writer.rs
+++ b/crates/iota-snapshot/src/writer.rs
@@ -564,7 +564,7 @@ impl StateSnapshotWriterV1 {
             // The boundary's whole entry is committed in one atomic batch, so a
             // row the watermark covers must be finalized; a missing entry means
             // the watermark advanced over an unfinalized row. Panics for the
-            // same blast-radius reason as above.
+            // same reason as above.
             let entry = epoch_info.epoch_info_entry.unwrap_or_else(|| {
                 panic!(
                     "epochs_v2[{epoch_id}] is not finalized despite `EpochIndexed` \

--- a/crates/iota-snapshot/src/writer.rs
+++ b/crates/iota-snapshot/src/writer.rs
@@ -527,7 +527,7 @@ impl StateSnapshotWriterV1 {
 
     /// Writes the per-snapshot `EPOCH_INFO` file, one entry per epoch in
     /// `[0, epoch]`: each row is read via `GrpcIndexes::get_epoch_info` and its
-    /// embedded `epoch_info_entry` taken. Callers must have run
+    /// embedded `epoch_close_proof` taken. Callers must have run
     /// [`Self::check_epoch_indexed_watermark`] first; this function trusts the
     /// precondition and panics on any unfinalized row.
     ///
@@ -565,7 +565,7 @@ impl StateSnapshotWriterV1 {
             // row the watermark covers must be finalized; a missing entry means
             // the watermark advanced over an unfinalized row. Panics for the
             // same reason as above.
-            let entry = epoch_info.epoch_info_entry.unwrap_or_else(|| {
+            let entry = epoch_info.epoch_close_proof.unwrap_or_else(|| {
                 panic!(
                     "epochs_v2[{epoch_id}] is not finalized despite `EpochIndexed` \
                      watermark covering it — the watermark must never cover an \

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -918,6 +918,7 @@ pub async fn download_formal_snapshot(
     let verified_epoch_info = iota_snapshot::verify_epoch_info_chain(
         epoch_info,
         genesis_committee.clone(),
+        genesis.iota_system_object(),
         snapshot_chain_id,
         expected_chain_id,
     )?;

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -71,6 +71,7 @@ impl CheckpointData {
     /// epoch-boundary checkpoint (genesis included), or its last transaction
     /// unexpectedly isn't an end-of-epoch transaction.
     pub fn end_of_epoch_transaction(&self) -> Option<&CheckpointTransaction> {
+        // Guard: only epoch-boundary checkpoints carry a closing tx — bail otherwise.
         self.checkpoint_summary.end_of_epoch_data.as_ref()?;
         // The epoch-change tx is always ordered last, after every user tx;
         // verify rather than assume, since callers treat `None` as a hard error.

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -66,6 +66,23 @@ impl CheckpointData {
             .collect()
     }
 
+    /// The transaction that closes this checkpoint's epoch — the `AdvanceEpoch`
+    /// / `advance_epoch_safe_mode` transaction. `None` if this isn't an
+    /// epoch-boundary checkpoint (genesis included), or its last transaction
+    /// unexpectedly isn't an end-of-epoch transaction.
+    pub fn end_of_epoch_transaction(&self) -> Option<&CheckpointTransaction> {
+        self.checkpoint_summary.end_of_epoch_data.as_ref()?;
+        // The epoch-change tx is always ordered last, after every user tx;
+        // verify rather than assume, since callers treat `None` as a hard error.
+        let transaction = self.transactions.last()?;
+        transaction
+            .transaction
+            .intent_message()
+            .value
+            .is_end_of_epoch_tx()
+            .then_some(transaction)
+    }
+
     /// Returns the epoch boundary information for this checkpoint, paired
     /// with the events of the transaction that produced this epoch's start
     /// system state (`EndOfEpoch` for non-genesis checkpoints, `Genesis`
@@ -82,12 +99,7 @@ impl CheckpointData {
         }
 
         let (start_checkpoint, transaction) = if self.checkpoint_summary.sequence_number != 0 {
-            let Some(transaction) = self.transactions.iter().find(|tx| {
-                matches!(
-                    tx.transaction.intent_message().value.kind(),
-                    TransactionKind::EndOfEpoch(_)
-                )
-            }) else {
+            let Some(transaction) = self.end_of_epoch_transaction() else {
                 return Err(StorageError::custom(format!(
                     "Failed to get end of epoch transaction in checkpoint {} with EndOfEpochData",
                     self.checkpoint_summary.sequence_number,

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -396,7 +396,7 @@ pub fn get_iota_system_state(object_store: &dyn ObjectStore) -> Result<IotaSyste
 }
 
 /// The two objects `get_iota_system_state` reads to decode the system state:
-/// the `0x5` wrapper and its inner system-state object. These two fully
+/// the raw system state wrapper object and its inner system-state object. These two fully
 /// determine the state, so none of the per-validator objects the epoch-change
 /// tx also writes are needed. Returned as raw `Object`s so a caller can
 /// persist the exact bytes their `ObjectDigest`s commit to.

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -295,9 +295,7 @@ impl IotaSystemState {
     }
 }
 
-/// The `0x5` object together with the `IotaSystemStateWrapper` decoded from
-/// it. `get_iota_system_state_wrapper` discards the object; callers that need
-/// the raw bytes (e.g. to persist it) keep it.
+/// The raw system state wrapper object together with the `IotaSystemStateWrapper` decoded from it's contents.
 fn get_iota_system_state_wrapper_with_object(
     object_store: &dyn ObjectStore,
 ) -> Result<(Object, IotaSystemStateWrapper), IotaError> {

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -295,23 +295,32 @@ impl IotaSystemState {
     }
 }
 
-pub fn get_iota_system_state_wrapper(
+/// The `0x5` object together with the `IotaSystemStateWrapper` decoded from
+/// it. `get_iota_system_state_wrapper` discards the object; callers that need
+/// the raw bytes (e.g. to persist it) keep it.
+fn get_iota_system_state_wrapper_with_object(
     object_store: &dyn ObjectStore,
-) -> Result<IotaSystemStateWrapper, IotaError> {
-    let wrapper = object_store
+) -> Result<(Object, IotaSystemStateWrapper), IotaError> {
+    let wrapper_object = object_store
         .try_get_object(&ObjectId::SYSTEM_STATE)?
         // Don't panic here on None because object_store is a generic store.
         .ok_or_else(|| {
             IotaError::IotaSystemStateRead("IotaSystemStateWrapper object not found".to_owned())
         })?;
-    let move_object = wrapper.data.as_struct_opt().ok_or_else(|| {
+    let move_object = wrapper_object.data.as_struct_opt().ok_or_else(|| {
         IotaError::IotaSystemStateRead(
             "IotaSystemStateWrapper object must be a Move object".to_owned(),
         )
     })?;
-    let result = bcs::from_bytes::<IotaSystemStateWrapper>(move_object.contents())
+    let wrapper = bcs::from_bytes::<IotaSystemStateWrapper>(move_object.contents())
         .map_err(|err| IotaError::IotaSystemStateRead(err.to_string()))?;
-    Ok(result)
+    Ok((wrapper_object, wrapper))
+}
+
+pub fn get_iota_system_state_wrapper(
+    object_store: &dyn ObjectStore,
+) -> Result<IotaSystemStateWrapper, IotaError> {
+    Ok(get_iota_system_state_wrapper_with_object(object_store)?.1)
 }
 
 pub fn get_iota_system_state(object_store: &dyn ObjectStore) -> Result<IotaSystemState, IotaError> {
@@ -386,6 +395,22 @@ pub fn get_iota_system_state(object_store: &dyn ObjectStore) -> Result<IotaSyste
             wrapper.version
         ))),
     }
+}
+
+/// The two objects `get_iota_system_state` reads to decode the system state:
+/// the `0x5` wrapper and its inner system-state object. These two fully
+/// determine the state, so none of the per-validator objects the epoch-change
+/// tx also writes are needed. Returned as raw `Object`s so a caller can
+/// persist the exact bytes their `ObjectDigest`s commit to.
+pub fn get_iota_system_state_objects(
+    object_store: &dyn ObjectStore,
+) -> Result<Vec<Object>, IotaError> {
+    let (wrapper_object, wrapper) = get_iota_system_state_wrapper_with_object(object_store)?;
+    // Same derivation as `get_iota_system_state`, so this can never select a
+    // different inner object than the one that decodes the state.
+    let inner_object =
+        get_dynamic_field_object_from_store(object_store, wrapper.id.id.bytes, &wrapper.version)?;
+    Ok(vec![wrapper_object, inner_object])
 }
 
 /// Given a system state type version, and the ID of the table, along with a

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -295,7 +295,8 @@ impl IotaSystemState {
     }
 }
 
-/// The raw system state wrapper object together with the `IotaSystemStateWrapper` decoded from it's contents.
+/// The raw system state wrapper object together with the
+/// `IotaSystemStateWrapper` decoded from it's contents.
 fn get_iota_system_state_wrapper_with_object(
     object_store: &dyn ObjectStore,
 ) -> Result<(Object, IotaSystemStateWrapper), IotaError> {
@@ -396,10 +397,10 @@ pub fn get_iota_system_state(object_store: &dyn ObjectStore) -> Result<IotaSyste
 }
 
 /// The two objects `get_iota_system_state` reads to decode the system state:
-/// the raw system state wrapper object and its inner system-state object. These two fully
-/// determine the state, so none of the per-validator objects the epoch-change
-/// tx also writes are needed. Returned as raw `Object`s so a caller can
-/// persist the exact bytes their `ObjectDigest`s commit to.
+/// the raw system state wrapper object and its inner system-state object. These
+/// two fully determine the state, so none of the per-validator objects the
+/// epoch-change tx also writes are needed. Returned as raw `Object`s so a
+/// caller can persist the exact bytes their `ObjectDigest`s commit to.
 pub fn get_iota_system_state_objects(
     object_store: &dyn ObjectStore,
 ) -> Result<Vec<Object>, IotaError> {

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -296,7 +296,7 @@ impl IotaSystemState {
 }
 
 /// The raw system state wrapper object together with the
-/// `IotaSystemStateWrapper` decoded from it's contents.
+/// `IotaSystemStateWrapper` decoded from its contents.
 fn get_iota_system_state_wrapper_with_object(
     object_store: &dyn ObjectStore,
 ) -> Result<(Object, IotaSystemStateWrapper), IotaError> {
@@ -403,13 +403,13 @@ pub fn get_iota_system_state(object_store: &dyn ObjectStore) -> Result<IotaSyste
 /// caller can persist the exact bytes their `ObjectDigest`s commit to.
 pub fn get_iota_system_state_objects(
     object_store: &dyn ObjectStore,
-) -> Result<Vec<Object>, IotaError> {
+) -> Result<[Object; 2], IotaError> {
     let (wrapper_object, wrapper) = get_iota_system_state_wrapper_with_object(object_store)?;
     // Same derivation as `get_iota_system_state`, so this can never select a
     // different inner object than the one that decodes the state.
     let inner_object =
         get_dynamic_field_object_from_store(object_store, wrapper.id.id.bytes, &wrapper.version)?;
-    Ok(vec![wrapper_object, inner_object])
+    Ok([wrapper_object, inner_object])
 }
 
 /// Given a system state type version, and the ID of the table, along with a

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -529,6 +529,19 @@ impl CheckpointContents {
         &self.as_v1().transactions
     }
 
+    /// The `(transaction, effects)` digest pair of the epoch-change
+    /// transaction in an epoch-boundary checkpoint: the last entry, since the
+    /// epoch-change transaction is always ordered last, after every user
+    /// transaction. `None` if `summary` is not an epoch boundary (no
+    /// `end_of_epoch_data`) or the contents are empty.
+    pub fn end_of_epoch_execution_digests(
+        &self,
+        summary: &CheckpointSummary,
+    ) -> Option<&ExecutionDigests> {
+        summary.end_of_epoch_data.as_ref()?;
+        self.inner().last()
+    }
+
     pub fn size(&self) -> usize {
         self.as_v1().transactions.len()
     }

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -529,19 +529,6 @@ impl CheckpointContents {
         &self.as_v1().transactions
     }
 
-    /// The `(transaction, effects)` digest pair of the epoch-change
-    /// transaction in an epoch-boundary checkpoint: the last entry, since the
-    /// epoch-change transaction is always ordered last, after every user
-    /// transaction. `None` if `summary` is not an epoch boundary (no
-    /// `end_of_epoch_data`) or the contents are empty.
-    pub fn end_of_epoch_execution_digests(
-        &self,
-        summary: &CheckpointSummary,
-    ) -> Option<&ExecutionDigests> {
-        summary.end_of_epoch_data.as_ref()?;
-        self.inner().last()
-    }
-
     pub fn size(&self) -> usize {
         self.as_v1().transactions.len()
     }

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -22,8 +22,8 @@ use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
 pub use object_store_trait::ObjectStore;
 pub use read_store::{
-    AccountOwnedObjectInfo, CoinInfo, DynamicFieldIteratorItem, DynamicFieldKey, EpochInfo,
-    EpochInfoV2, OwnedObjectCursor, OwnedObjectIteratorItem, PackageVersionInfo,
+    AccountOwnedObjectInfo, CloseOfEpochProof, CoinInfo, DynamicFieldIteratorItem, DynamicFieldKey,
+    EpochInfo, EpochInfoV2, OwnedObjectCursor, OwnedObjectIteratorItem, PackageVersionInfo,
     PackageVersionIteratorItem, PackageVersionKey, ReadStore, TransactionInfo,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -22,8 +22,8 @@ use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
 pub use object_store_trait::ObjectStore;
 pub use read_store::{
-    AccountOwnedObjectInfo, CloseOfEpochProof, CoinInfo, DynamicFieldIteratorItem, DynamicFieldKey,
-    EpochInfo, EpochInfoV2, OwnedObjectCursor, OwnedObjectIteratorItem, PackageVersionInfo,
+    AccountOwnedObjectInfo, CoinInfo, DynamicFieldIteratorItem, DynamicFieldKey, EpochInfo,
+    EpochInfoV1Entry, EpochInfoV2, OwnedObjectCursor, OwnedObjectIteratorItem, PackageVersionInfo,
     PackageVersionIteratorItem, PackageVersionKey, ReadStore, TransactionInfo,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -903,8 +903,8 @@ impl EpochInfoV2 {
     }
 }
 
-/// Per-epoch entry of the snapshot `EPOCH_INFO` file. Every field is anchored to the
-/// certified `last_checkpoint_summary`.
+/// Per-epoch entry of the snapshot `EPOCH_INFO` file. Every field is anchored
+/// to the certified `last_checkpoint_summary`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EpochInfoV1Entry {
     /// Certified summary of this epoch's closing checkpoint — the signed
@@ -921,9 +921,9 @@ pub struct EpochInfoV1Entry {
     /// == end_of_epoch_tx_effects.events_digest`, or empty on safe-mode
     /// boundaries where that digest is `None`.
     pub end_of_epoch_tx_events: TransactionEvents,
-    /// Raw serialized bytes of system-state wrapper object and its inner system-state object
-    /// as written by this boundary — the next epoch's start state. Each
-    /// object's digest matches a written-object entry in
+    /// Raw serialized bytes of system-state wrapper object and its inner
+    /// system-state object as written by this boundary — the next epoch's
+    /// start state. Each object's digest matches a written-object entry in
     /// `end_of_epoch_tx_effects`.
     pub next_epoch_start_system_state_objects: Vec<Vec<u8>>,
 }

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -15,7 +15,7 @@ use crate::{
     digests::{CheckpointContentsDigest, CheckpointDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEvents},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
-    iota_system_state::IotaSystemState,
+    iota_system_state::{IotaSystemState, IotaSystemStateTrait},
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
         FullCheckpointContents, VerifiedCheckpoint,
@@ -855,51 +855,80 @@ pub struct EpochInfo {
 
 /// Epoch information structure for indexing.
 ///
-/// Contains metadata about an epoch including timing, checkpoints, protocol
-/// version, and a snapshot of the system state at the start of the epoch.
-///
-/// Version 2 adds the close-of-epoch `proof` bundle, `None` until this epoch's
-/// boundary is indexed.
+/// Stores only the start-of-epoch identity (`epoch`, `start_checkpoint`,
+/// `start_timestamp_ms`, `system_state`) plus the close-of-epoch
+/// `epoch_info_entry`. Everything derivable from those — `protocol_version`,
+/// `reference_gas_price`, `end_timestamp_ms`, `end_checkpoint` — is a method,
+/// not a stored field.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EpochInfoV2 {
     pub epoch: u64,
-    pub protocol_version: u64,
-    pub start_timestamp_ms: u64,
-    pub end_timestamp_ms: Option<u64>,
     pub start_checkpoint: CheckpointSequenceNumber,
-    pub end_checkpoint: Option<CheckpointSequenceNumber>,
-    pub reference_gas_price: u64,
+    pub start_timestamp_ms: u64,
     /// `IotaSystemState` of object `0x5` at this epoch's start.
     pub system_state: IotaSystemState,
-    /// Close-of-epoch proof bundle; `None` until this epoch's boundary is
-    /// indexed. The row is finalized exactly when this is `Some`.
-    pub proof: Option<CloseOfEpochProof>,
-}
-
-/// Close-of-epoch proof bundle, written as a unit at an epoch's boundary.
-/// Grouped into one `Option` so a row is finalized exactly when it is `Some`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CloseOfEpochProof {
-    /// Certified summary of this epoch's last checkpoint.
-    pub last_checkpoint_summary: CertifiedCheckpointSummary,
-    /// Contents of this epoch's last checkpoint.
-    pub last_checkpoint_contents: CheckpointContents,
-    /// Effects of the epoch-change tx (the closing checkpoint's last tx).
-    pub end_of_epoch_tx_effects: TransactionEffects,
-    /// Events from the epoch-change tx; empty on safe-mode boundaries.
-    pub end_of_epoch_tx_events: TransactionEvents,
-    /// Raw bytes of object `0x5` and its inner system-state object as written
-    /// by this boundary (the next epoch's start state); needed to re-publish a
-    /// snapshot, since `system_state` can't round-trip byte-identically.
-    pub next_epoch_start_system_state_objects: Vec<Vec<u8>>,
+    /// Close-of-epoch entry (the same shape written to the snapshot
+    /// `EPOCH_INFO` file); `None` until this epoch's boundary is indexed. The
+    /// row is finalized exactly when this is `Some`.
+    pub epoch_info_entry: Option<EpochInfoV1Entry>,
 }
 
 impl EpochInfoV2 {
-    /// Whether this epoch's boundary has been indexed (its proof bundle is
-    /// present).
+    /// Whether this epoch's boundary has been indexed.
     pub fn is_finalized(&self) -> bool {
-        self.proof.is_some()
+        self.epoch_info_entry.is_some()
     }
+
+    /// Protocol version in effect this epoch (from the start system state).
+    pub fn protocol_version(&self) -> u64 {
+        self.system_state.protocol_version()
+    }
+
+    /// Reference gas price for this epoch (from the start system state).
+    pub fn reference_gas_price(&self) -> u64 {
+        self.system_state.reference_gas_price()
+    }
+
+    /// Timestamp of this epoch's last checkpoint; `None` until finalized.
+    pub fn end_timestamp_ms(&self) -> Option<u64> {
+        self.epoch_info_entry
+            .as_ref()
+            .map(|entry| entry.last_checkpoint_summary.data().timestamp_ms)
+    }
+
+    /// This epoch's last checkpoint sequence number; `None` until finalized.
+    pub fn end_checkpoint(&self) -> Option<CheckpointSequenceNumber> {
+        self.epoch_info_entry
+            .as_ref()
+            .map(|entry| *entry.last_checkpoint_summary.data().sequence_number())
+    }
+}
+
+/// Per-epoch entry of the snapshot `EPOCH_INFO` file, also held by
+/// [`EpochInfoV2`] as its `epoch_info_entry`. Every field is anchored to the
+/// certified `last_checkpoint_summary`. `epoch` and `start_checkpoint` are not
+/// stored — they are derived from the signed summaries.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EpochInfoV1Entry {
+    /// Certified summary of this epoch's closing checkpoint — the signed
+    /// anchor every other field is proven against.
+    pub last_checkpoint_summary: CertifiedCheckpointSummary,
+    /// Contents of that closing checkpoint; `hash == last_checkpoint_summary`'s
+    /// `content_digest`.
+    pub last_checkpoint_contents: CheckpointContents,
+    /// Effects of the epoch-change tx (the last tx of the closing checkpoint);
+    /// its `(transaction, effects)` digest pair is the last entry of
+    /// `last_checkpoint_contents`.
+    pub end_of_epoch_tx_effects: TransactionEffects,
+    /// Events from the epoch-change tx (carries `SystemEpochInfoEvent`); `hash
+    /// == end_of_epoch_tx_effects.events_digest`, or empty on safe-mode
+    /// boundaries where that digest is `None`.
+    pub end_of_epoch_tx_events: TransactionEvents,
+    /// Raw serialized bytes of object `0x5` and its inner system-state object
+    /// as written by this boundary — the next epoch's start state. Each
+    /// object's digest matches a written-object entry in
+    /// `end_of_epoch_tx_effects`.
+    pub next_epoch_start_system_state_objects: Vec<Vec<u8>>,
 }
 
 #[derive(Clone)]

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -903,10 +903,8 @@ impl EpochInfoV2 {
     }
 }
 
-/// Per-epoch entry of the snapshot `EPOCH_INFO` file, also held by
-/// [`EpochInfoV2`] as its `epoch_info_entry`. Every field is anchored to the
-/// certified `last_checkpoint_summary`. `epoch` and `start_checkpoint` are not
-/// stored — they are derived from the signed summaries.
+/// Per-epoch entry of the snapshot `EPOCH_INFO` file. Every field is anchored to the
+/// certified `last_checkpoint_summary`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EpochInfoV1Entry {
     /// Certified summary of this epoch's closing checkpoint — the signed

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -923,7 +923,7 @@ pub struct EpochInfoV1Entry {
     /// == end_of_epoch_tx_effects.events_digest`, or empty on safe-mode
     /// boundaries where that digest is `None`.
     pub end_of_epoch_tx_events: TransactionEvents,
-    /// Raw serialized bytes of object `0x5` and its inner system-state object
+    /// Raw serialized bytes of system-state wrapper object and its inner system-state object
     /// as written by this boundary — the next epoch's start state. Each
     /// object's digest matches a written-object entry in
     /// `end_of_epoch_tx_effects`.

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -857,7 +857,7 @@ pub struct EpochInfo {
 ///
 /// Stores only the start-of-epoch identity (`epoch`, `start_checkpoint`,
 /// `start_timestamp_ms`, `system_state`) plus the close-of-epoch
-/// `epoch_info_entry`. Everything derivable from those — `protocol_version`,
+/// `epoch_close_proof`. Everything derivable from those — `protocol_version`,
 /// `reference_gas_price`, `end_timestamp_ms`, `end_checkpoint` — is a method,
 /// not a stored field.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -867,15 +867,15 @@ pub struct EpochInfoV2 {
     pub start_timestamp_ms: u64,
     /// `IotaSystemState` of object `0x5` at this epoch's start.
     pub system_state: IotaSystemState,
-    /// Close-of-epoch entry; `None` until this epoch's boundary is indexed. The
-    /// row is finalized exactly when this is `Some`.
-    pub epoch_info_entry: Option<EpochInfoV1Entry>,
+    /// Close-of-epoch proof bundle; `None` until this epoch's boundary is
+    /// indexed. The row is finalized exactly when this is `Some`.
+    pub epoch_close_proof: Option<EpochInfoV1Entry>,
 }
 
 impl EpochInfoV2 {
     /// Whether this epoch's boundary has been indexed.
     pub fn is_finalized(&self) -> bool {
-        self.epoch_info_entry.is_some()
+        self.epoch_close_proof.is_some()
     }
 
     /// Protocol version in effect this epoch (from the start system state).
@@ -890,14 +890,14 @@ impl EpochInfoV2 {
 
     /// Timestamp of this epoch's last checkpoint; `None` until finalized.
     pub fn end_timestamp_ms(&self) -> Option<u64> {
-        self.epoch_info_entry
+        self.epoch_close_proof
             .as_ref()
             .map(|entry| entry.last_checkpoint_summary.data().timestamp_ms)
     }
 
     /// This epoch's last checkpoint sequence number; `None` until finalized.
     pub fn end_checkpoint(&self) -> Option<CheckpointSequenceNumber> {
-        self.epoch_info_entry
+        self.epoch_close_proof
             .as_ref()
             .map(|entry| *entry.last_checkpoint_summary.data().sequence_number())
     }

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -858,7 +858,8 @@ pub struct EpochInfo {
 /// Contains metadata about an epoch including timing, checkpoints, protocol
 /// version, and a snapshot of the system state at the start of the epoch.
 ///
-/// Version 2 adds last_checkpoint_summary, and end_of_epoch_tx_events fields.
+/// Version 2 adds the close-of-epoch `proof` bundle, `None` until this epoch's
+/// boundary is indexed.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EpochInfoV2 {
     pub epoch: u64,
@@ -868,13 +869,37 @@ pub struct EpochInfoV2 {
     pub start_checkpoint: CheckpointSequenceNumber,
     pub end_checkpoint: Option<CheckpointSequenceNumber>,
     pub reference_gas_price: u64,
-    /// `IotaSystemState` of object `0x5` right after the AdvanceEpoch tx of
-    /// the previous epoch (or the genesis tx for epoch 0).
+    /// `IotaSystemState` of object `0x5` at this epoch's start.
     pub system_state: IotaSystemState,
+    /// Close-of-epoch proof bundle; `None` until this epoch's boundary is
+    /// indexed. The row is finalized exactly when this is `Some`.
+    pub proof: Option<CloseOfEpochProof>,
+}
+
+/// Close-of-epoch proof bundle, written as a unit at an epoch's boundary.
+/// Grouped into one `Option` so a row is finalized exactly when it is `Some`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CloseOfEpochProof {
     /// Certified summary of this epoch's last checkpoint.
-    pub last_checkpoint_summary: Option<CertifiedCheckpointSummary>,
-    /// Events from the AdvanceEpoch tx that closed this epoch.
-    pub end_of_epoch_tx_events: Option<TransactionEvents>,
+    pub last_checkpoint_summary: CertifiedCheckpointSummary,
+    /// Contents of this epoch's last checkpoint.
+    pub last_checkpoint_contents: CheckpointContents,
+    /// Effects of the epoch-change tx (the closing checkpoint's last tx).
+    pub end_of_epoch_tx_effects: TransactionEffects,
+    /// Events from the epoch-change tx; empty on safe-mode boundaries.
+    pub end_of_epoch_tx_events: TransactionEvents,
+    /// Raw bytes of object `0x5` and its inner system-state object as written
+    /// by this boundary (the next epoch's start state); needed to re-publish a
+    /// snapshot, since `system_state` can't round-trip byte-identically.
+    pub next_epoch_start_system_state_objects: Vec<Vec<u8>>,
+}
+
+impl EpochInfoV2 {
+    /// Whether this epoch's boundary has been indexed (its proof bundle is
+    /// present).
+    pub fn is_finalized(&self) -> bool {
+        self.proof.is_some()
+    }
 }
 
 #[derive(Clone)]

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -867,8 +867,7 @@ pub struct EpochInfoV2 {
     pub start_timestamp_ms: u64,
     /// `IotaSystemState` of object `0x5` at this epoch's start.
     pub system_state: IotaSystemState,
-    /// Close-of-epoch entry (the same shape written to the snapshot
-    /// `EPOCH_INFO` file); `None` until this epoch's boundary is indexed. The
+    /// Close-of-epoch entry; `None` until this epoch's boundary is indexed. The
     /// row is finalized exactly when this is `Some`.
     pub epoch_info_entry: Option<EpochInfoV1Entry>,
 }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -766,31 +766,14 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> GrpcIndexes for Sim
 
             let system_state = self.get_system_state_for_epoch(epoch)?;
 
-            let (end_timestamp_ms, end_checkpoint) =
-                if let Some(next_epoch_state) = self.get_system_state_for_epoch(epoch + 1) {
-                    (
-                        Some(next_epoch_state.epoch_start_timestamp_ms()),
-                        Some(
-                            store
-                                .get_last_checkpoint_of_epoch(epoch)
-                                .expect("last checkpoint of completed epoch should exist"),
-                        ),
-                    )
-                } else {
-                    (None, None)
-                };
-
             Some(EpochInfoV2 {
                 epoch,
-                protocol_version: system_state.protocol_version(),
-                start_timestamp_ms: start_checkpoint.data().timestamp_ms,
-                end_timestamp_ms,
                 start_checkpoint: start_checkpoint_seq,
-                end_checkpoint,
-                reference_gas_price: system_state.reference_gas_price(),
+                start_timestamp_ms: start_checkpoint.data().timestamp_ms,
                 system_state,
-                // not populated by simulacrum
-                proof: None,
+                // Simulacrum doesn't build the close-of-epoch entry, so the
+                // derived `end_*` fields report `None`.
+                epoch_info_entry: None,
             })
         }))
     }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -790,8 +790,7 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> GrpcIndexes for Sim
                 reference_gas_price: system_state.reference_gas_price(),
                 system_state,
                 // not populated by simulacrum
-                last_checkpoint_summary: None,
-                end_of_epoch_tx_events: None,
+                proof: None,
             })
         }))
     }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -771,9 +771,9 @@ impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> GrpcIndexes for Sim
                 start_checkpoint: start_checkpoint_seq,
                 start_timestamp_ms: start_checkpoint.data().timestamp_ms,
                 system_state,
-                // Simulacrum doesn't build the close-of-epoch entry, so the
+                // Simulacrum doesn't build the close-of-epoch proof, so the
                 // derived `end_*` fields report `None`.
-                epoch_info_entry: None,
+                epoch_close_proof: None,
             })
         }))
     }


### PR DESCRIPTION
# Description of change

Hardens the formal-snapshot `EPOCH_INFO` trust model. Each entry previously carried `start_system_state` as raw BCS bytes taken on faith from the (unsigned) snapshot transport. Now every field is proven against its certified `last_checkpoint_summary`, and each epoch's start state is derived from the *next* epoch's verified boundary objects (epoch 0 from genesis). A restoring node trusts only data reachable from a signed summary.

- On-disk entry `EpochInfoV1Entry` (moved to `iota-types`): drop `start_system_state`; carry `last_checkpoint_summary`, `last_checkpoint_contents`, `end_of_epoch_tx_effects`, `end_of_epoch_tx_events`, and raw `next_epoch_start_system_state_objects` (`0x5` + inner state). `epoch`/`start_checkpoint` are derived from the signed summaries, not stored.
- Add `verify_epoch_boundary_proof`: hash-chains contents → effects → events → start-state objects back to the signed summary; rejects on any mismatch.
- `verify_epoch_info_chain` now also takes `genesis_system_state` (epoch 0's start, which no entry proves); derives each entry's `epoch`/`start_checkpoint` from the signed summaries and cross-checks the start committee against the certified chain.
- Decode each epoch's `system_state` from its boundary's digest-verified object bytes instead of trusting `start_system_state` (which can't round-trip byte-identically against the effects' object digest).
- `EpochInfoV2` (the `epochs_v2` row, `iota-types`): hold the on-disk entry directly as `epoch_info_entry: Option<EpochInfoV1Entry>` (finalized ⟺ `Some`); store only the non-derivable start-of-epoch identity (`epoch`, `start_checkpoint`, `start_timestamp_ms`, `system_state`) and expose `protocol_version`/`reference_gas_price`/`end_timestamp_ms`/`end_checkpoint` as derived getters.
- `iota-core/grpc_indexes.rs`: at each boundary capture contents, epoch-change effects, and system-state objects into the entry; load events during sparse checkpoint assembly so the entry is complete.
- New helpers (`iota-types`): `CheckpointData::end_of_epoch_transaction` (runtime-checked, not `debug_assert`), `CheckpointContents::end_of_epoch_execution_digests`, `get_iota_system_state_objects`.
- `iota-snapshot/writer.rs`: write the row's `epoch_info_entry` straight into `EPOCH_INFO` (no projection step).
- `iota-grpc-server` `get_epoch`: serve the derived getters instead of the removed stored fields.
- `iota-node` / `iota-tool`: pass `genesis.iota_system_object()` to the verifier.
- `simulacrum`: set `epoch_info_entry` to `None`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes