### PR TITLE
feat(starfish-core): derive fetch response byte limits from per-fetch caps

### DIFF
--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -43,6 +43,58 @@ pub(crate) const GENESIS_ROUND: Round = 0;
 /// Block proposal as epoch UNIX timestamp in milliseconds.
 pub type BlockTimestampMs = u64;
 
+/// BCS-serialized size of a [`BlockRef`]: `round` (u32, 4) + `author`
+/// (`AuthorityIndex`, 1) + `digest` (32). Pinned by
+/// `max_signed_block_header_bytes_bounds_maximal_header`.
+pub(crate) const SERIALIZED_BLOCK_REF_BYTES: usize = 37;
+
+/// ULEB128 byte length of `value`, matching how BCS frames sequence and
+/// variant lengths.
+pub(crate) const fn uleb128_len(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
+
+/// Upper bound on the BCS-serialized size of a [`SignedBlockHeader`] for a
+/// committee of `committee_size` authorities.
+///
+/// `BlockHeaderV2` is the largest header variant; its size is dominated by two
+/// committee-sized vectors. Layout:
+/// - 55 fixed bytes: `epoch` (8) + `round` (4) + `author` (1) + `timestamp_ms`
+///   (8) + overlap indices (1 + 1) + `transactions_commitment` (32).
+/// - `references`: at most `3 * committee_size` [`BlockRef`]s (37 bytes each)
+///   plus the sequence-length prefix.
+/// - `commit_votes`: at most `committee_size` `CommitVote`s (36 bytes each:
+///   index (4) + digest (32)) plus the sequence-length prefix.
+/// - 34 bytes for `Option<StrongVote>`: `Some` tag (1) + `leader_authority` (1)
+///   + `AuthoritySet` bitmask (32).
+///
+/// The [`SignedBlockHeader`] wrapper adds the `BlockHeader` enum tag (1), the
+/// signature length prefix (1), and the 64-byte signature.
+pub(crate) fn max_signed_block_header_bytes(committee_size: usize) -> usize {
+    const FIXED_HEADER_BYTES: usize = 55;
+    const STRONG_VOTE_BYTES: usize = 34;
+    const COMMIT_VOTE_BYTES: usize = 36;
+    // BlockHeader enum tag (1) + signature length prefix (1) + signature (64).
+    const SIGNATURE_FRAME_BYTES: usize = 1 + 1 + 64;
+
+    let max_refs = committee_size.saturating_mul(3);
+    let references =
+        uleb128_len(max_refs).saturating_add(max_refs.saturating_mul(SERIALIZED_BLOCK_REF_BYTES));
+    let commit_votes = uleb128_len(committee_size)
+        .saturating_add(committee_size.saturating_mul(COMMIT_VOTE_BYTES));
+
+    FIXED_HEADER_BYTES
+        .saturating_add(references)
+        .saturating_add(commit_votes)
+        .saturating_add(STRONG_VOTE_BYTES)
+        .saturating_add(SIGNATURE_FRAME_BYTES)
+}
+
 /// IOTA transaction is considered as serialised bytes inside consensus
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default, Debug)]
 pub struct Transaction {
@@ -1649,11 +1701,37 @@ mod tests {
     use crate::{
         BlockHeaderAPI,
         block_header::{
-            BlockHeaderDigest, SignedBlockHeader, TestBlockHeader, genesis_block_headers,
+            BlockHeader, BlockHeaderDigest, BlockHeaderV2, BlockRef, SignedBlockHeader, StrongVote,
+            TestBlockHeader, genesis_block_headers, max_signed_block_header_bytes,
         },
+        commit::{CommitDigest, CommitRef},
         context::Context,
         error::ConsensusError,
     };
+
+    /// Pins the `BlockHeaderV2` wire layout that
+    /// `max_signed_block_header_bytes` is derived from: a header carrying
+    /// the maximal `3 * committee_size` references, one commit vote per
+    /// authority, and a strong vote must serialize to exactly the computed
+    /// bound. Fails if the BCS framing or any of `BlockRef` / `CommitVote`
+    /// / `StrongVote` / `SignedBlockHeader` layout changes.
+    #[tokio::test]
+    async fn max_signed_block_header_bytes_bounds_maximal_header() {
+        let (context, key_pairs) = Context::new_for_test(4);
+        let n = context.committee.size();
+
+        let header = BlockHeader::V2(BlockHeaderV2 {
+            references: vec![BlockRef::MAX; 3 * n],
+            commit_votes: vec![CommitRef::new(u32::MAX, CommitDigest::MIN); n],
+            strong_vote: Some(StrongVote::default()),
+            ..Default::default()
+        });
+        let signed =
+            SignedBlockHeader::new(header, &key_pairs[0].1).expect("signing should succeed");
+        let serialized = bcs::to_bytes(&signed).expect("serialization should succeed");
+
+        assert_eq!(serialized.len(), max_signed_block_header_bytes(n));
+    }
 
     #[tokio::test]
     async fn test_sign_and_verify() {

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -20,8 +20,8 @@ use tracing::debug;
 
 use crate::{
     block_header::{
-        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlockHeader,
-        VerifiedTransactions,
+        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, SERIALIZED_BLOCK_REF_BYTES, Slot,
+        VerifiedBlockHeader, VerifiedTransactions, uleb128_len,
     },
     context::Context,
     leader_scoring::ReputationScores,
@@ -42,6 +42,43 @@ pub(crate) const WAVE_LENGTH: Round = 3;
 /// The consensus protocol operates in 'waves'. Each wave is composed of a
 /// leader round, at least one voting round, and one certifying round.
 pub(crate) type WaveNumber = u32;
+
+/// Upper bound on the BCS-serialized size of a [`Commit`] for a committee of
+/// `committee_size` authorities and a GC depth of `gc_depth` rounds.
+///
+/// `CommitV3` is the largest variant. Its two variable-length vectors span the
+/// committed sub-DAG, which garbage collection bounds to `gc_depth *
+/// committee_size` blocks (at most one block per authority per uncollected
+/// round); `committed_transactions` carries at most one [`TransactionRef`] per
+/// such block, and `reputation_scores_desc` at most one entry per authority.
+///
+/// Returns [`usize::MAX`] when `gc_depth` or `committee_size` is zero (GC
+/// disabled implies no finite sub-DAG bound), matching the convention that a
+/// zero limit disables the corresponding check.
+pub(crate) fn max_commit_bytes(committee_size: usize, gc_depth: usize) -> usize {
+    if gc_depth == 0 || committee_size == 0 {
+        return usize::MAX;
+    }
+    // `TransactionRef` is round (4) + author (1) + transactions_commitment (32).
+    const SERIALIZED_TRANSACTION_REF_BYTES: usize = 37;
+    // enum tag (1) + index (4) + previous_digest (32) + timestamp_ms (8) +
+    // leader BlockRef (37) + is_optimistic (1).
+    const FIXED_COMMIT_BYTES: usize = 1 + 4 + 32 + 8 + SERIALIZED_BLOCK_REF_BYTES + 1;
+
+    let max_subdag_blocks = gc_depth.saturating_mul(committee_size);
+    let block_headers = uleb128_len(max_subdag_blocks)
+        .saturating_add(max_subdag_blocks.saturating_mul(SERIALIZED_BLOCK_REF_BYTES));
+    let committed_transactions = uleb128_len(max_subdag_blocks)
+        .saturating_add(max_subdag_blocks.saturating_mul(SERIALIZED_TRANSACTION_REF_BYTES));
+    // reputation_scores_desc: Vec<(AuthorityIndex (1), u64 (8))>.
+    let reputation_scores =
+        uleb128_len(committee_size).saturating_add(committee_size.saturating_mul(1 + 8));
+
+    FIXED_COMMIT_BYTES
+        .saturating_add(block_headers)
+        .saturating_add(committed_transactions)
+        .saturating_add(reputation_scores)
+}
 
 /// [`Commit`] summarizes [`CommittedSubDag`] for storage and network
 /// communications.
@@ -1192,15 +1229,46 @@ impl Debug for CommitRange {
 mod tests {
     use std::sync::Arc;
 
+    use starfish_config::AuthorityIndex;
+
     use crate::{
         BlockHeaderAPI, BlockTimestampMs, CommitDigest, VerifiedBlockHeader,
-        block_header::{TestBlockHeader, VerifiedBlock},
-        commit::{CommitRange, TrustedCommit, WAVE_LENGTH, load_pending_subdag_from_store},
+        block_header::{BlockRef, TestBlockHeader, VerifiedBlock},
+        commit::{
+            Commit, CommitRange, CommitV3, TrustedCommit, WAVE_LENGTH,
+            load_pending_subdag_from_store, max_commit_bytes,
+        },
         context::Context,
         encoder::create_encoder,
         storage::{Store, WriteBatch, mem_store::MemStore},
-        transaction_ref::convert_block_refs_to_generic_transaction_refs,
+        transaction_ref::{TransactionRef, convert_block_refs_to_generic_transaction_refs},
     };
+
+    /// Pins the `CommitV3` wire layout that `max_commit_bytes` is derived from:
+    /// a commit whose sub-DAG vectors are filled to the GC bound
+    /// (`gc_depth * committee_size`) with one reputation score per authority
+    /// must serialize to exactly the computed bound. Also checks that a zero GC
+    /// depth or committee size disables the bound.
+    #[tokio::test]
+    async fn max_commit_bytes_bounds_maximal_commit() {
+        let n = 4usize;
+        let gc_depth = 5usize;
+        let max_subdag_blocks = gc_depth * n;
+
+        let commit = Commit::V3(CommitV3 {
+            block_headers: vec![BlockRef::MAX; max_subdag_blocks],
+            committed_transactions: vec![TransactionRef::default(); max_subdag_blocks],
+            reputation_scores_desc: vec![(AuthorityIndex::MAX, u64::MAX); n],
+            ..Default::default()
+        });
+        let serialized = bcs::to_bytes(&commit).expect("serialization should succeed");
+
+        assert_eq!(serialized.len(), max_commit_bytes(n, gc_depth));
+
+        // A zero GC depth (GC disabled) or empty committee disables the bound.
+        assert_eq!(max_commit_bytes(n, 0), usize::MAX);
+        assert_eq!(max_commit_bytes(0, gc_depth), usize::MAX);
+    }
 
     #[tokio::test]
     async fn test_new_committed_subdag_from_commit() {

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -574,7 +574,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // 2. Verify the response contains block headers that can certify the last
         //    returned commit, and the returned commits are chained by digest,
         // so earlier commits are certified as well.
-        let batch_size = inner.sync_type.commit_sync_batch_size(&inner.context) as usize;
+        let max_commits = inner.sync_type.max_commits_per_response(&inner.context);
         let (commits, voting_block_headers) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
@@ -584,7 +584,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         commit_range,
                         serialized_commits,
                         serialized_proof_for_last_commit,
-                        2 * batch_size,
+                        max_commits,
                     )
                 }
             })

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -71,7 +71,7 @@ use crate::{
 /// fetch-commits response.
 // TODO: Reduce to 1 once all networks serve certifier votes deduplicated by
 // author, so a response never needs more than one header per authority.
-const MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY: usize = 2;
+pub(crate) const MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY: usize = 2;
 
 pub(crate) enum CommitSyncType {
     Fast,
@@ -83,6 +83,19 @@ impl CommitSyncType {
         match self {
             CommitSyncType::Fast => context.parameters.fast_commit_sync_batch_size,
             CommitSyncType::Regular => context.parameters.commit_sync_batch_size,
+        }
+    }
+
+    /// Maximum number of commits a peer may return in a single fetch response.
+    /// This is the bound `verify_commits` enforces and the same bound the
+    /// streaming fetch loop applies before buffering. Fast sync extends past
+    /// the requested range end to reach a  certifiable commit, so it accepts up
+    /// to twice the batch size; regular sync stays within one batch.
+    pub(crate) fn max_commits_per_response(&self, context: &Context) -> usize {
+        let batch_size = self.commit_sync_batch_size(context) as usize;
+        match self {
+            CommitSyncType::Fast => 2 * batch_size,
+            CommitSyncType::Regular => batch_size,
         }
     }
 

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -546,7 +546,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         //    returned commit,
         // and the returned commits are chained by digest, so earlier commits are
         // certified as well.
-        let batch_size = inner.sync_type.commit_sync_batch_size(&inner.context) as usize;
+        let max_commits = inner.sync_type.max_commits_per_response(&inner.context);
         let (commits, _) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
@@ -556,7 +556,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         commit_range,
                         serialized_commits,
                         serialized_voting_block_headers,
-                        batch_size,
+                        max_commits,
                     )
                 }
             })

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -249,6 +249,20 @@ pub(crate) enum ConsensusError {
         limit: usize,
     },
 
+    #[error("Peer {peer} sent a commit that is too large: {size} > {limit}")]
+    SerializedCommitTooLarge {
+        peer: AuthorityIndex,
+        size: usize,
+        limit: usize,
+    },
+
+    #[error("Peer {peer} sent a block header that is too large: {size} > {limit}")]
+    SerializedBlockHeaderTooLarge {
+        peer: AuthorityIndex,
+        size: usize,
+        limit: usize,
+    },
+
     #[error("Invalid commit range from peer {peer}: start {start} > end {end}")]
     InvalidCommitRange {
         peer: AuthorityIndex,

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -37,8 +37,9 @@ use super::{
 };
 use crate::{
     CommitIndex, Round,
-    block_header::BlockRef,
-    commit::CommitRange,
+    block_header::{BlockRef, max_signed_block_header_bytes},
+    block_verifier::serialized_transactions_size_limit,
+    commit::{CommitRange, max_commit_bytes},
     commit_syncer::CommitSyncType,
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -53,9 +54,56 @@ use crate::{
 // TODO: put max RPC response size in protocol config.
 const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 
-// Maximum total bytes fetched in a single fetch_blocks() call, after combining
-// the responses.
-const MAX_TOTAL_FETCHED_BYTES: usize = 128 * 1024 * 1024;
+// Upper bound on the total bytes a peer may stream in response to a fetch,
+// terminating the stream once exceeded. Each bound mirrors the matching
+// server-side per-fetch cap, so an honest peer's response always fits while a
+// flooding peer is cut off. Sizing tracks the cap, not the requested count.
+
+/// Header-fetch budget: the per-fetch header count cap times the maximum
+/// serialized header size for this committee. `commit_sync` selects the same
+/// cap the server applies in `ConsensusService::fetch_block_headers`.
+fn max_fetch_block_headers_response_bytes(context: &Context, commit_sync: bool) -> usize {
+    context
+        .parameters
+        .max_headers_per_fetch(commit_sync)
+        .saturating_mul(max_signed_block_header_bytes(context.committee.size()))
+}
+
+/// Transaction-fetch budget: the per-fetch transaction count cap times the
+/// maximum serialized per-block transaction payload. The larger of the two
+/// sync caps is used, matching `TransactionFetchMode::TransactionSync`.
+fn max_fetch_transactions_response_bytes(context: &Context) -> usize {
+    let max_transactions = context
+        .parameters
+        .max_transactions_per_commit_sync_fetch
+        .max(
+            context
+                .parameters
+                .max_transactions_per_transaction_sync_fetch,
+        );
+    max_transactions.saturating_mul(serialized_transactions_size_limit(context))
+}
+
+/// Combined fetch-commits-and-transactions budget: serialized commits, the
+/// certifier headers served alongside them, and the transactions referenced by
+/// those commits.
+fn max_fetch_commits_and_transactions_response_bytes(context: &Context) -> usize {
+    let committee_size = context.committee.size();
+    let gc_depth = context.protocol_config.gc_depth() as usize;
+    let commits = (context.parameters.fast_commit_sync_batch_size as usize)
+        .saturating_mul(max_commit_bytes(committee_size, gc_depth));
+    let certifier_headers = context
+        .parameters
+        .max_headers_per_header_sync_fetch
+        .saturating_mul(max_signed_block_header_bytes(committee_size));
+    let transactions = context
+        .parameters
+        .max_transactions_per_commit_sync_fetch
+        .saturating_mul(serialized_transactions_size_limit(context));
+    commits
+        .saturating_add(certifier_headers)
+        .saturating_add(transactions)
+}
 
 // Implements Tonic RPC client for Consensus.
 pub(crate) struct TonicClient {
@@ -141,6 +189,10 @@ impl NetworkClient for TonicClient {
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>> {
         let mut client = self.get_client(peer, timeout).await?;
+        let max_allowed_bytes = max_fetch_block_headers_response_bytes(
+            &self.context,
+            highest_accepted_rounds.is_empty(),
+        );
         let mut request = Request::new(FetchBlockHeadersRequest {
             block_refs: block_refs
                 .iter()
@@ -175,10 +227,10 @@ impl NetworkClient for TonicClient {
                         total_fetched_bytes += b.len();
                     }
                     vec_serialized_block_header.extend(response.vec_serialized_block_header);
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                    if total_fetched_bytes > max_allowed_bytes {
                         info!(
-                            "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                            "fetch_block_headers() fetched bytes exceeded limit: {} > {}, terminating stream.",
+                            total_fetched_bytes, max_allowed_bytes,
                         );
                         break;
                     }
@@ -258,6 +310,8 @@ impl NetworkClient for TonicClient {
         let mut headers = vec![];
         let mut total_fetched_bytes = 0;
         let max_headers = authorities.len();
+        let max_allowed_bytes = max_headers
+            .saturating_mul(max_signed_block_header_bytes(self.context.committee.size()));
         loop {
             match stream.message().await {
                 Ok(Some(response)) => {
@@ -276,10 +330,10 @@ impl NetworkClient for TonicClient {
                         total_fetched_bytes += b.len();
                     }
                     headers.extend(vec_serialized_block_headers);
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                    if total_fetched_bytes > max_allowed_bytes {
                         info!(
-                            "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                            "fetch_latest_block_headers() fetched bytes exceeded limit: {} > {}, terminating stream.",
+                            total_fetched_bytes, max_allowed_bytes,
                         );
                         break;
                     }
@@ -351,6 +405,7 @@ impl NetworkClient for TonicClient {
             })?
             .into_inner();
 
+        let max_allowed_bytes = max_fetch_transactions_response_bytes(&self.context);
         let mut total_fetched_bytes = 0;
         let mut vec_serialized_transactions = vec![];
         loop {
@@ -359,10 +414,10 @@ impl NetworkClient for TonicClient {
                     for b in &response.vec_serialized_transactions {
                         total_fetched_bytes += b.len();
                     }
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                    if total_fetched_bytes > max_allowed_bytes {
                         info!(
                             "fetch_transactions() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                            total_fetched_bytes, max_allowed_bytes,
                         );
                         break;
                     }
@@ -423,6 +478,7 @@ impl NetworkClient for TonicClient {
         let mut commits = Vec::new();
         let mut certifier_block_headers = Vec::new();
         let mut transactions = Vec::new();
+        let max_allowed_bytes = max_fetch_commits_and_transactions_response_bytes(&self.context);
         let mut total_fetched_bytes = 0;
 
         loop {
@@ -445,10 +501,10 @@ impl NetworkClient for TonicClient {
                     }
                     transactions.extend(response.transactions);
 
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                    if total_fetched_bytes > max_allowed_bytes {
                         info!(
                             "fetch_commits_and_transactions() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                            total_fetched_bytes, max_allowed_bytes,
                         );
                         break;
                     }
@@ -1466,4 +1522,48 @@ fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
         chunks.push(chunk);
     }
     chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{max_fetch_block_headers_response_bytes, max_fetch_transactions_response_bytes};
+    use crate::{
+        block_header::max_signed_block_header_bytes,
+        block_verifier::serialized_transactions_size_limit, context::Context,
+    };
+
+    /// The per-fetch response budgets track the matching server-side count cap:
+    /// the value is the cap times the maximum per-item size, depends only on the
+    /// cap and committee, and never on how many items the caller requested.
+    #[tokio::test]
+    async fn fetch_response_budgets_track_server_caps() {
+        let (mut context, _keys) = Context::new_for_test(4);
+        context.parameters.max_headers_per_commit_sync_fetch = 7;
+        context.parameters.max_headers_per_header_sync_fetch = 11;
+        context.parameters.max_transactions_per_commit_sync_fetch = 5;
+        context
+            .parameters
+            .max_transactions_per_transaction_sync_fetch = 9;
+        let committee_size = context.committee.size();
+        let context = Arc::new(context);
+
+        let header_bytes = max_signed_block_header_bytes(committee_size);
+        // Commit sync selects the commit-sync header cap.
+        assert_eq!(
+            max_fetch_block_headers_response_bytes(&context, true),
+            7 * header_bytes
+        );
+        // Header sync selects the header-sync cap.
+        assert_eq!(
+            max_fetch_block_headers_response_bytes(&context, false),
+            11 * header_bytes
+        );
+        // Transaction budget uses the larger of the two transaction caps.
+        assert_eq!(
+            max_fetch_transactions_response_bytes(&context),
+            9 * serialized_transactions_size_limit(&context)
+        );
+    }
 }

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -40,7 +40,7 @@ use crate::{
     block_header::{BlockRef, max_signed_block_header_bytes},
     block_verifier::serialized_transactions_size_limit,
     commit::{CommitRange, max_commit_bytes},
-    commit_syncer::CommitSyncType,
+    commit_syncer::{CommitSyncType, MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY},
     context::Context,
     error::{ConsensusError, ConsensusResult},
     network::{
@@ -82,27 +82,6 @@ fn max_fetch_transactions_response_bytes(context: &Context) -> usize {
                 .max_transactions_per_transaction_sync_fetch,
         );
     max_transactions.saturating_mul(serialized_transactions_size_limit(context))
-}
-
-/// Combined fetch-commits-and-transactions budget: serialized commits, the
-/// certifier headers served alongside them, and the transactions referenced by
-/// those commits.
-fn max_fetch_commits_and_transactions_response_bytes(context: &Context) -> usize {
-    let committee_size = context.committee.size();
-    let gc_depth = context.protocol_config.gc_depth() as usize;
-    let commits = (context.parameters.fast_commit_sync_batch_size as usize)
-        .saturating_mul(max_commit_bytes(committee_size, gc_depth));
-    let certifier_headers = context
-        .parameters
-        .max_headers_per_header_sync_fetch
-        .saturating_mul(max_signed_block_header_bytes(committee_size));
-    let transactions = context
-        .parameters
-        .max_transactions_per_commit_sync_fetch
-        .saturating_mul(serialized_transactions_size_limit(context));
-    commits
-        .saturating_add(certifier_headers)
-        .saturating_add(transactions)
 }
 
 // Implements Tonic RPC client for Consensus.
@@ -474,33 +453,104 @@ impl NetworkClient for TonicClient {
             })?
             .into_inner();
 
-        // First chunk contains commits and certifier headers
+        // First chunk contains commits and certifier headers.
+        //
+        // Bound the response per element and per category while streaming, since
+        // `verify_commits` only runs on the fully-received buffers and so cannot
+        // protect them from a malicious server. Commits and certifier headers
+        // carry the same count caps `verify_commits` applies
+        // (`2 * fast_commit_sync_batch_size` and two headers per authority).
+        // Transactions have no count cap on the fast path — the server returns
+        // every transaction the committed range references — so only their
+        // per-element size is enforced here; their count is validated against
+        // the commits downstream, and the coarse total below bounds the buffer.
+        let committee_size = self.context.committee.size();
+        let gc_depth = self.context.protocol_config.gc_depth() as usize;
+        let max_commits = CommitSyncType::Fast.max_commits_per_response(&self.context);
+        let max_certifier_headers =
+            committee_size.saturating_mul(MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY);
+        let max_commit_size = max_commit_bytes(committee_size, gc_depth);
+        let max_header_size = max_signed_block_header_bytes(committee_size);
+        let max_transaction_size = serialized_transactions_size_limit(&self.context);
+        // Coarse total backstop for the buffer. The commit and certifier-header
+        // terms reuse the per-category caps above so the total never trips
+        // before them; the transaction term uses the commit-sync fetch cap as a
+        // coarse allowance, since the fast path has no transaction count cap.
+        let max_allowed_bytes = max_commits
+            .saturating_mul(max_commit_size)
+            .saturating_add(max_certifier_headers.saturating_mul(max_header_size))
+            .saturating_add(
+                self.context
+                    .parameters
+                    .max_transactions_per_commit_sync_fetch
+                    .saturating_mul(max_transaction_size),
+            );
+
         let mut commits = Vec::new();
         let mut certifier_block_headers = Vec::new();
         let mut transactions = Vec::new();
-        let max_allowed_bytes = max_fetch_commits_and_transactions_response_bytes(&self.context);
         let mut total_fetched_bytes = 0;
 
         loop {
             match stream.message().await {
                 Ok(Some(response)) => {
-                    // Accumulate commits and headers (typically in first chunk)
+                    // Commits (typically in the first chunk): count cap + per-element size.
+                    if commits.len() + response.commits.len() > max_commits {
+                        return Err(ConsensusError::TooManyCommitsFromPeer {
+                            peer,
+                            count: (commits.len() + response.commits.len()) as CommitIndex,
+                            limit: max_commits as CommitIndex,
+                        });
+                    }
                     for c in &response.commits {
+                        if c.len() > max_commit_size {
+                            return Err(ConsensusError::SerializedCommitTooLarge {
+                                peer,
+                                size: c.len(),
+                                limit: max_commit_size,
+                            });
+                        }
                         total_fetched_bytes += c.len();
                     }
                     commits.extend(response.commits);
 
+                    // Certifier headers: count cap + per-element size.
+                    if certifier_block_headers.len() + response.certifier_block_headers.len()
+                        > max_certifier_headers
+                    {
+                        return Err(ConsensusError::TooManyCommitVoteHeaders {
+                            peer,
+                            count: certifier_block_headers.len()
+                                + response.certifier_block_headers.len(),
+                            limit: max_certifier_headers,
+                        });
+                    }
                     for h in &response.certifier_block_headers {
+                        if h.len() > max_header_size {
+                            return Err(ConsensusError::SerializedBlockHeaderTooLarge {
+                                peer,
+                                size: h.len(),
+                                limit: max_header_size,
+                            });
+                        }
                         total_fetched_bytes += h.len();
                     }
                     certifier_block_headers.extend(response.certifier_block_headers);
 
-                    // Accumulate transactions (streamed in subsequent chunks)
+                    // Transactions (streamed in subsequent chunks): per-element size only.
                     for t in &response.transactions {
+                        if t.len() > max_transaction_size {
+                            return Err(ConsensusError::SerializedTransactionsTooLarge {
+                                size: t.len(),
+                                limit: max_transaction_size,
+                            });
+                        }
                         total_fetched_bytes += t.len();
                     }
                     transactions.extend(response.transactions);
 
+                    // Coarse total backstop bounding the transaction buffer, which
+                    // has no precise count cap on the fast path.
                     if total_fetched_bytes > max_allowed_bytes {
                         info!(
                             "fetch_commits_and_transactions() fetched bytes exceeded limit: {} > {}, terminating stream.",
@@ -1535,8 +1585,9 @@ mod tests {
     };
 
     /// The per-fetch response budgets track the matching server-side count cap:
-    /// the value is the cap times the maximum per-item size, depends only on the
-    /// cap and committee, and never on how many items the caller requested.
+    /// the value is the cap times the maximum per-item size, depends only on
+    /// the cap and committee, and never on how many items the caller
+    /// requested.
     #[tokio::test]
     async fn fetch_response_budgets_track_server_caps() {
         let (mut context, _keys) = Context::new_for_test(4);


### PR DESCRIPTION
# Description of change

Replaces the fixed per-call fetched-bytes cap on the consensus fetch paths with per-endpoint budgets computed from each fetch's count parameters and the maximum serialized size of the items it returns, so the client-side stream-termination limit scales with committee size and the configured per-fetch caps instead of a single hard-coded constant.

Adds two size estimators, each pinned by a test against the BCS wire layout: `max_signed_block_header_bytes(committee_size)` and `max_commit_bytes(committee_size, gc_depth)`. The per-fetch budgets in `tonic_network.rs` combine these with the per-fetch count parameters (`max_headers_per_fetch`, `max_transactions_per_*_sync_fetch`) and the transaction-payload limit.

Builds on the parameters and limits introduced in #11858 (now merged), reusing its `max_headers_per_fetch` selector and `serialized_transactions_size_limit`.

## Links to any relevant issues

Relates to #11857

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes