### PR TITLE
fix(json-rpc-api): restore wire format of version in tryGetPastObject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6589,6 +6589,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.6",
  "reqwest",
+ "serde_json",
  "telemetry-subscribers",
  "test-cluster",
  "tokio",

--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -193,7 +193,7 @@ async fn construct_object_response(
         ObjectRead::Deleted(object_ref) => Ok(IotaObjectResponse::new_with_error(
             IotaObjectResponseError::Deleted {
                 object_id: object_ref.object_id,
-                version: object_ref.version,
+                version: object_ref.version.into(),
                 digest: object_ref.digest,
             },
         )),

--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -12,6 +12,7 @@ use iota_json_rpc_types::{
     Checkpoint, CheckpointId, CheckpointPage, IotaEvent, IotaGetPastObjectRequest, IotaObjectData,
     IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseError, IotaPastObjectResponse,
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ProtocolConfigResponse,
+    iota_primitives::SequenceNumberU64,
 };
 use iota_open_rpc::Module;
 use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
@@ -101,7 +102,7 @@ impl ReadApi {
             ObjectRead::Deleted(object_ref) => Ok(IotaObjectResponse::new_with_error(
                 IotaObjectResponseError::Deleted {
                     object_id: object_ref.object_id,
-                    version: object_ref.version,
+                    version: object_ref.version.into(),
                     digest: object_ref.digest,
                 },
             )),
@@ -141,9 +142,9 @@ impl ReadApi {
                 ))
             }
 
-            PastObjectRead::VersionNotFound(object_id, version) => {
-                Ok(IotaPastObjectResponse::VersionNotFound(object_id, version))
-            }
+            PastObjectRead::VersionNotFound(object_id, version) => Ok(
+                IotaPastObjectResponse::VersionNotFound(object_id, version.into()),
+            ),
 
             PastObjectRead::VersionTooHigh {
                 object_id,
@@ -151,8 +152,8 @@ impl ReadApi {
                 latest_version,
             } => Ok(IotaPastObjectResponse::VersionTooHigh {
                 object_id,
-                asked_version,
-                latest_version,
+                asked_version: asked_version.into(),
+                latest_version: latest_version.into(),
             }),
         }
     }
@@ -317,12 +318,12 @@ impl ReadApiServer for ReadApi {
     async fn try_get_past_object(
         &self,
         object_id: ObjectId,
-        version: SequenceNumber,
+        version: SequenceNumberU64,
         options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<IotaPastObjectResponse> {
         let past_object_read = self
             .inner
-            .get_past_object_read_with_fallback(object_id, version, false)
+            .get_past_object_read_with_fallback(object_id, version.into(), false)
             .await?;
 
         self.past_object_read_to_response(options, past_object_read)

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -1490,7 +1490,7 @@ fn try_get_past_object_object_not_exists() {
         let version = SequenceNumber::default();
 
         let result = client
-            .try_get_past_object(object_id, version, None)
+            .try_get_past_object(object_id, version.into(), None)
             .await
             .expect("rpc call should succeed");
 
@@ -1527,7 +1527,7 @@ fn try_get_past_object_version_found() {
         wait_for_objects_history(tx_digest, store, client).await;
 
         let result = client
-            .try_get_past_object(gas_ref.object_id, gas_ref.version, None)
+            .try_get_past_object(gas_ref.object_id, gas_ref.version.into(), None)
             .await
             .expect("rpc call should succeed");
 
@@ -1571,13 +1571,13 @@ fn try_get_past_object_version_not_found() {
         let missing_version = gas_ref.version.previous().unwrap();
 
         let result = client
-            .try_get_past_object(gas_ref.object_id, missing_version, None)
+            .try_get_past_object(gas_ref.object_id, missing_version.into(), None)
             .await
             .expect("rpc call should succeed");
 
         assert_eq!(
             result,
-            IotaPastObjectResponse::VersionNotFound(gas_ref.object_id, missing_version),
+            IotaPastObjectResponse::VersionNotFound(gas_ref.object_id, missing_version.into()),
             "mismatch in VersionNotFound response"
         );
     });
@@ -1611,7 +1611,7 @@ fn try_get_past_object_version_too_high() {
         let asked_version = latest_version.next().unwrap();
 
         let result = client
-            .try_get_past_object(gas_ref.object_id, asked_version, None)
+            .try_get_past_object(gas_ref.object_id, asked_version.into(), None)
             .await
             .expect("rpc call should succeed");
 
@@ -1619,8 +1619,8 @@ fn try_get_past_object_version_too_high() {
             result,
             IotaPastObjectResponse::VersionTooHigh {
                 object_id: gas_ref.object_id,
-                asked_version,
-                latest_version,
+                asked_version: asked_version.into(),
+                latest_version: latest_version.into(),
             },
             "mismatch in VersionTooHigh response"
         );
@@ -1671,7 +1671,7 @@ fn try_get_past_object_object_deleted() {
 
         // Retrieve the deleted object at that version
         let result = client
-            .try_get_past_object(nft_object_id, deleted_version, None)
+            .try_get_past_object(nft_object_id, deleted_version.into(), None)
             .await
             .expect("rpc call should succeed");
 
@@ -1687,7 +1687,11 @@ fn try_get_past_object_object_deleted() {
 
         // Try fetching the object before the deleted version.
         let result = client
-            .try_get_past_object(nft_object_id, deleted_version.previous().unwrap(), None)
+            .try_get_past_object(
+                nft_object_id,
+                deleted_version.previous().unwrap().into(),
+                None,
+            )
             .await
             .expect("rpc call should succeed");
 
@@ -1798,12 +1802,12 @@ fn try_multi_get_past_objects() {
             .expect("rpc call should succeed");
 
         let past_object_response_1 = client
-            .try_get_past_object(gas_ref_1.object_id, gas_ref_1.version, None)
+            .try_get_past_object(gas_ref_1.object_id, gas_ref_1.version.into(), None)
             .await
             .expect("rpc call should succeed");
 
         let past_object_response_2 = client
-            .try_get_past_object(gas_ref_2.object_id, gas_ref_2.version, None)
+            .try_get_past_object(gas_ref_2.object_id, gas_ref_2.version.into(), None)
             .await
             .expect("rpc call should succeed");
 

--- a/crates/iota-json-rpc-api/src/read.rs
+++ b/crates/iota-json-rpc-api/src/read.rs
@@ -7,10 +7,7 @@ use iota_json_rpc_types::{
     IotaObjectDataOptions, IotaObjectResponse, IotaPastObjectResponse,
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, Page,
     ProtocolConfigResponse,
-    iota_primitives::{
-        Base58 as Base58Schema, ObjectId as ObjectIdSchema,
-        SequenceNumberU64 as SequenceNumberU64Schema,
-    },
+    iota_primitives::{Base58 as Base58Schema, ObjectId as ObjectIdSchema, SequenceNumberU64},
 };
 use iota_open_rpc_macros::open_rpc;
 use iota_sdk_types::ObjectId;
@@ -99,8 +96,7 @@ pub trait ReadApi {
         #[schemars(with = "ObjectIdSchema")]
         object_id: ObjectId,
         /// the version of the queried object. If None, default to the latest known version
-        #[schemars(with = "SequenceNumberU64Schema")]
-        version: SequenceNumber,
+        version: SequenceNumberU64,
         /// options for specifying the content to be returned
         options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<IotaPastObjectResponse>;

--- a/crates/iota-json-rpc-tests/Cargo.toml
+++ b/crates/iota-json-rpc-tests/Cargo.toml
@@ -21,6 +21,7 @@ jsonrpsee.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 reqwest.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
 tracing.workspace = true
 

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -25,6 +25,7 @@ use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType,
     transaction::CallArg,
 };
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
 use rand::{SeedableRng, rngs::StdRng};
 use test_cluster::{TestCluster, TestClusterBuilder};
 
@@ -1764,4 +1765,32 @@ async fn display_transaction_block_with_empty_balance_changes() {
     assert!(rpc_transaction.balance_changes.as_ref().unwrap().is_empty());
 
     let _ = rpc_transaction.to_string();
+}
+
+#[sim_test]
+async fn try_get_past_object_valid_params() {
+    let cluster = TestClusterBuilder::new().build().await;
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "iota_tryGetPastObject",
+        "params": [ObjectId::ZERO.to_string(), 7, null],
+    });
+
+    let response: serde_json::Value = reqwest::Client::new()
+        .post(cluster.rpc_url())
+        .json(&request)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response["error"]["code"].as_i64(),
+        Some(INVALID_PARAMS_CODE as i64),
+        "{response}",
+    );
 }

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -251,7 +251,7 @@ async fn try_get_past_object_with_options(options: IotaObjectDataOptions) {
     let rpc_past_obj = http_client
         .try_get_past_object(
             object_data.object_id,
-            object_data.version,
+            object_data.version.into(),
             Some(options.clone()),
         )
         .await
@@ -286,7 +286,11 @@ async fn try_get_past_object_with_options(options: IotaObjectDataOptions) {
     } = transaction.mutated_objects().next().unwrap();
 
     let rpc_past_obj = http_client
-        .try_get_past_object(mutated_obj_id, mutated_obj_version, Some(options.clone()))
+        .try_get_past_object(
+            mutated_obj_id,
+            mutated_obj_version.into(),
+            Some(options.clone()),
+        )
         .await
         .unwrap();
 
@@ -1442,7 +1446,7 @@ async fn try_get_past_object_not_exists() {
     let http_client = cluster.rpc_client();
 
     let rpc_past_obj = http_client
-        .try_get_past_object(ObjectId::ZERO, SequenceNumber::from_u64(1), None)
+        .try_get_past_object(ObjectId::ZERO, SequenceNumber::from_u64(1).into(), None)
         .await
         .unwrap();
 
@@ -1464,12 +1468,12 @@ async fn try_get_past_object_version_too_high() {
         let object_id = object.object_id().unwrap();
 
         let rpc_past_obj = http_client
-            .try_get_past_object(object_id, seq_num, None)
+            .try_get_past_object(object_id, seq_num.into(), None)
             .await
             .unwrap();
 
         assert!(
-            matches!(rpc_past_obj, IotaPastObjectResponse::VersionTooHigh{object_id: obj_id, asked_version, latest_version} if obj_id == object_id && asked_version == seq_num && latest_version == 1)
+            matches!(rpc_past_obj, IotaPastObjectResponse::VersionTooHigh{object_id: obj_id, asked_version, latest_version} if obj_id == object_id && SequenceNumber::from(asked_version) == seq_num && SequenceNumber::from(latest_version) == 1)
         );
     }
 }
@@ -1523,12 +1527,12 @@ async fn try_get_past_object_version_not_found() {
             .unwrap()
         {
             let rpc_past_obj = http_client
-                .try_get_past_object(mutated_obj_id, seq_num, None)
+                .try_get_past_object(mutated_obj_id, seq_num.into(), None)
                 .await
                 .unwrap();
 
             assert!(
-                matches!(rpc_past_obj, IotaPastObjectResponse::VersionNotFound(obj_id, seq_number) if obj_id == mutated_obj_id && seq_number == seq_num)
+                matches!(rpc_past_obj, IotaPastObjectResponse::VersionNotFound(obj_id, seq_number) if obj_id == mutated_obj_id && SequenceNumber::from(seq_number) == seq_num)
             );
 
             at_least_one_version_not_found = true;
@@ -1633,7 +1637,7 @@ async fn try_get_past_object_deleted() {
 
     let seq_num = SequenceNumber::from_u64(4);
     let rpc_past_obj = http_client
-        .try_get_past_object(created_object_id, seq_num, None)
+        .try_get_past_object(created_object_id, seq_num.into(), None)
         .await
         .unwrap();
 

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -40,8 +40,8 @@ use crate::{
     iota_primitives::{
         Base58 as Base58Schema, Base64 as Base64Schema, Identifier as IdentifierSchema,
         IotaAddress as IotaAddressSchema, ObjectId as ObjectIdSchema,
-        SequenceNumberString as SequenceNumberStringSchema,
-        SequenceNumberU64 as SequenceNumberU64Schema, StructTag as StructTagSchema,
+        SequenceNumberString as SequenceNumberStringSchema, SequenceNumberU64,
+        StructTag as StructTagSchema,
     },
 };
 
@@ -86,7 +86,7 @@ impl IotaObjectResponse {
             ObjectRead::Deleted(object_ref) => Ok(IotaObjectResponse::new_with_error(
                 IotaObjectResponseError::Deleted {
                     object_id: object_ref.object_id,
-                    version: object_ref.version,
+                    version: object_ref.version.into(),
                     digest: object_ref.digest,
                 },
             )),
@@ -608,7 +608,7 @@ impl TryInto<Object> for IotaObjectData {
             Some(IotaRawData::MoveObject(o)) => ObjectData::Struct({
                 MoveObject::new_from_execution(
                     o.type_().clone(),
-                    o.version,
+                    o.version.into(),
                     o.bcs_bytes,
                     &protocol_config,
                 )?
@@ -656,9 +656,7 @@ pub struct ObjectRefSchema {
     #[schemars(with = "ObjectIdSchema")]
     pub object_id: ObjectId,
     /// Object version.
-    #[serde_as(as = "SequenceNumberU64Schema")]
-    #[schemars(with = "SequenceNumberU64Schema")]
-    pub version: SequenceNumber,
+    pub version: SequenceNumberU64,
     /// Base64 string representing the object digest
     #[serde_as(as = "Base58Schema")]
     #[schemars(with = "Base58Schema")]
@@ -689,7 +687,7 @@ impl From<ObjectRef> for ObjectRefSchema {
     fn from(oref: ObjectRef) -> Self {
         Self {
             object_id: oref.object_id,
-            version: oref.version,
+            version: oref.version.into(),
             digest: oref.digest,
         }
     }
@@ -697,7 +695,7 @@ impl From<ObjectRef> for ObjectRefSchema {
 
 impl From<ObjectRefSchema> for ObjectRef {
     fn from(oref: ObjectRefSchema) -> Self {
-        ObjectRef::new(oref.object_id, oref.version, oref.digest)
+        ObjectRef::new(oref.object_id, oref.version.into(), oref.digest)
     }
 }
 
@@ -987,9 +985,7 @@ pub struct IotaRawMoveObject {
     #[schemars(with = "StructTagSchema")]
     #[serde_as(as = "StructTagSchema")]
     pub type_: StructTag,
-    #[serde_as(as = "SequenceNumberU64Schema")]
-    #[schemars(with = "SequenceNumberU64Schema")]
-    pub version: SequenceNumber,
+    pub version: SequenceNumberU64,
     #[serde_as(as = "Base64")]
     #[schemars(with = "Base64Schema")]
     pub bcs_bytes: Vec<u8>,
@@ -999,7 +995,7 @@ impl From<MoveObject> for IotaRawMoveObject {
     fn from(o: MoveObject) -> Self {
         Self {
             type_: o.struct_tag().clone(),
-            version: o.version(),
+            version: o.version().into(),
             bcs_bytes: o.into_contents(),
         }
     }
@@ -1012,7 +1008,7 @@ impl IotaMoveObject for IotaRawMoveObject {
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
             type_: object.struct_tag().clone(),
-            version: object.version(),
+            version: object.version().into(),
             bcs_bytes: object.into_contents(),
         })
     }
@@ -1091,16 +1087,14 @@ pub struct IotaUpgradeInfo {
     #[schemars(with = "ObjectIdSchema")]
     pub upgraded_id: ObjectId,
     /// The version of the package at `upgraded_id`.
-    #[serde_as(as = "SequenceNumberU64Schema")]
-    #[schemars(with = "SequenceNumberU64Schema")]
-    pub upgraded_version: SequenceNumber,
+    pub upgraded_version: SequenceNumberU64,
 }
 
 impl From<UpgradeInfo> for IotaUpgradeInfo {
     fn from(info: UpgradeInfo) -> Self {
         Self {
             upgraded_id: info.upgraded_id,
-            upgraded_version: info.upgraded_version,
+            upgraded_version: info.upgraded_version.into(),
         }
     }
 }
@@ -1109,7 +1103,7 @@ impl From<IotaUpgradeInfo> for UpgradeInfo {
     fn from(info: IotaUpgradeInfo) -> Self {
         Self {
             upgraded_id: info.upgraded_id,
-            upgraded_version: info.upgraded_version,
+            upgraded_version: info.upgraded_version.into(),
         }
     }
 }
@@ -1121,9 +1115,7 @@ pub struct IotaRawMovePackage {
     #[serde_as(as = "ObjectIdSchema")]
     #[schemars(with = "ObjectIdSchema")]
     pub id: ObjectId,
-    #[serde_as(as = "SequenceNumberU64Schema")]
-    #[schemars(with = "SequenceNumberU64Schema")]
-    pub version: SequenceNumber,
+    pub version: SequenceNumberU64,
     #[schemars(with = "BTreeMap<String, Base64Schema>")]
     #[serde_as(as = "BTreeMap<_, Base64>")]
     pub module_map: BTreeMap<String, Vec<u8>>,
@@ -1138,7 +1130,7 @@ impl From<MovePackage> for IotaRawMovePackage {
     fn from(p: MovePackage) -> Self {
         Self {
             id: p.id(),
-            version: p.version(),
+            version: p.version().into(),
             module_map: p
                 .modules
                 .into_iter()
@@ -1161,7 +1153,7 @@ impl IotaRawMovePackage {
     ) -> Result<MovePackage, ExecutionError> {
         Ok(MovePackage::new(
             self.id,
-            self.version,
+            self.version.into(),
             self.module_map
                 .iter()
                 .map(|(k, v)| (Identifier::new_unchecked(k), v.clone()))
@@ -1201,21 +1193,15 @@ pub enum IotaPastObjectResponse {
         #[serde_as(as = "ObjectIdSchema")]
         #[schemars(with = "ObjectIdSchema")]
         ObjectId,
-        #[serde_as(as = "SequenceNumberU64Schema")]
-        #[schemars(with = "SequenceNumberU64Schema")]
-        SequenceNumber,
+        SequenceNumberU64,
     ),
     /// The asked object version is higher than the latest
     VersionTooHigh {
         #[serde_as(as = "ObjectIdSchema")]
         #[schemars(with = "ObjectIdSchema")]
         object_id: ObjectId,
-        #[serde_as(as = "SequenceNumberU64Schema")]
-        #[schemars(with = "SequenceNumberU64Schema")]
-        asked_version: SequenceNumber,
-        #[serde_as(as = "SequenceNumberU64Schema")]
-        #[schemars(with = "SequenceNumberU64Schema")]
-        latest_version: SequenceNumber,
+        asked_version: SequenceNumberU64,
+        latest_version: SequenceNumberU64,
     },
 }
 
@@ -1231,7 +1217,7 @@ impl IotaPastObjectResponse {
             Self::VersionFound(o) => Ok(o),
             Self::VersionNotFound(id, seq_num) => Err(UserInputError::ObjectNotFound {
                 object_id: *id,
-                version: Some(*seq_num),
+                version: Some((*seq_num).into()),
             }),
             Self::VersionTooHigh {
                 object_id,
@@ -1239,8 +1225,8 @@ impl IotaPastObjectResponse {
                 latest_version,
             } => Err(UserInputError::ObjectSequenceNumberTooHigh {
                 object_id: *object_id,
-                asked_version: *asked_version,
-                latest_version: *latest_version,
+                asked_version: (*asked_version).into(),
+                latest_version: (*latest_version).into(),
             }),
         }
     }
@@ -1256,7 +1242,7 @@ impl IotaPastObjectResponse {
             Self::VersionFound(o) => Ok(o),
             Self::VersionNotFound(object_id, version) => Err(UserInputError::ObjectNotFound {
                 object_id,
-                version: Some(version),
+                version: Some(version.into()),
             }),
             Self::VersionTooHigh {
                 object_id,
@@ -1264,8 +1250,8 @@ impl IotaPastObjectResponse {
                 latest_version,
             } => Err(UserInputError::ObjectSequenceNumberTooHigh {
                 object_id,
-                asked_version,
-                latest_version,
+                asked_version: asked_version.into(),
+                latest_version: latest_version.into(),
             }),
         }
     }

--- a/crates/iota-json-rpc-types/src/iota_object_response_error.rs
+++ b/crates/iota-json-rpc-types/src/iota_object_response_error.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk_types::ObjectId;
-use iota_types::{base_types::SequenceNumber, digests::ObjectDigest};
+use iota_types::digests::ObjectDigest;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -10,8 +10,7 @@ use strum::{AsRefStr, IntoStaticStr};
 use thiserror::Error;
 
 use crate::iota_primitives::{
-    Base58 as Base58Schema, ObjectId as ObjectIdSchema,
-    SequenceNumberU64 as SequenceNumberU64Schema,
+    Base58 as Base58Schema, ObjectId as ObjectIdSchema, SequenceNumberU64,
 };
 
 #[serde_as]
@@ -50,9 +49,7 @@ pub enum IotaObjectResponseError {
         #[schemars(with = "ObjectIdSchema")]
         object_id: ObjectId,
         /// Object version.
-        #[serde_as(as = "SequenceNumberU64Schema")]
-        #[schemars(with = "SequenceNumberU64Schema")]
-        version: SequenceNumber,
+        version: SequenceNumberU64,
         /// Base64 string representing the object digest
         #[serde_as(as = "Base58Schema")]
         #[schemars(with = "Base58Schema")]

--- a/crates/iota-json-rpc-types/src/iota_owner.rs
+++ b/crates/iota-json-rpc-types/src/iota_owner.rs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk_types::{ObjectId, Owner};
-use iota_types::base_types::{IotaAddress, SequenceNumber};
+use iota_types::base_types::IotaAddress;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeAs, SerializeAs, serde_as};
 
-use crate::iota_primitives::{
-    IotaAddress as IotaAddressSchema, SequenceNumberU64 as SequenceNumberU64Schema,
-};
+use crate::iota_primitives::{IotaAddress as IotaAddressSchema, SequenceNumberU64};
 
 /// Enum of different types of ownership for an object.
 ///
@@ -40,9 +38,7 @@ pub enum OwnerSchema {
     /// Object is shared, can be used by any address, and is mutable.
     Shared {
         /// The version at which the object became shared
-        #[serde_as(as = "SequenceNumberU64Schema")]
-        #[schemars(with = "SequenceNumberU64Schema")]
-        initial_shared_version: SequenceNumber,
+        initial_shared_version: SequenceNumberU64,
     },
     /// Object is immutable, and hence ownership doesn't matter.
     Immutable,
@@ -94,7 +90,7 @@ impl From<Owner> for OwnerSchema {
             Owner::Address(address) => OwnerSchema::AddressOwner(address),
             Owner::Object(object_id) => OwnerSchema::ObjectOwner(*object_id.as_address()),
             Owner::Shared(initial_shared_version) => OwnerSchema::Shared {
-                initial_shared_version,
+                initial_shared_version: initial_shared_version.into(),
             },
             Owner::Immutable => OwnerSchema::Immutable,
             _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
@@ -109,7 +105,7 @@ impl From<OwnerSchema> for Owner {
             OwnerSchema::ObjectOwner(address) => Owner::Object(ObjectId::from(address)),
             OwnerSchema::Shared {
                 initial_shared_version,
-            } => Owner::Shared(initial_shared_version),
+            } => Owner::Shared(initial_shared_version.into()),
             OwnerSchema::Immutable => Owner::Immutable,
         }
     }

--- a/crates/iota-json-rpc-types/src/iota_primitives.rs
+++ b/crates/iota-json-rpc-types/src/iota_primitives.rs
@@ -170,10 +170,50 @@ impl<'de> DeserializeAs<'de, iota_types::base_types::SequenceNumber> for Sequenc
     }
 }
 
-/// A schema type that defines the JSON representation of the
-/// [`SequenceNumber`] type as a u64
-/// integer and uses the default serialization.
-pub struct SequenceNumberU64;
+/// JSON representation of a [`SequenceNumber`] as a u64 integer.
+///
+/// This serializes to a number as opposed to the SDK type that serializes
+/// as a string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SequenceNumberU64(SequenceNumber);
+
+impl From<SequenceNumber> for SequenceNumberU64 {
+    fn from(value: SequenceNumber) -> Self {
+        Self(value)
+    }
+}
+
+impl From<SequenceNumberU64> for SequenceNumber {
+    fn from(value: SequenceNumberU64) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Display for SequenceNumberU64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Serialize for SequenceNumberU64 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.as_u64().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SequenceNumberU64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self(SequenceNumber::from_u64(u64::deserialize(
+            deserializer,
+        )?)))
+    }
+}
 
 impl JsonSchema for SequenceNumberU64 {
     fn schema_name() -> String {
@@ -195,24 +235,6 @@ impl JsonSchema for SequenceNumberU64 {
             ..Default::default()
         }
         .into()
-    }
-}
-
-impl SerializeAs<SequenceNumber> for SequenceNumberU64 {
-    fn serialize_as<S>(value: &SequenceNumber, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        value.as_u64().serialize(serializer)
-    }
-}
-
-impl<'de> DeserializeAs<'de, SequenceNumber> for SequenceNumberU64 {
-    fn deserialize_as<D>(deserializer: D) -> Result<SequenceNumber, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(SequenceNumber::from_u64(u64::deserialize(deserializer)?))
     }
 }
 

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -60,8 +60,8 @@ use crate::{
     iota_primitives::{
         Base58 as Base58Schema, Base64 as Base64Schema, GenericSignature as GenericSignatureSchema,
         IotaAddress as IotaAddressSchema, ObjectId as ObjectIdSchema,
-        SequenceNumberString as SequenceNumberStringSchema,
-        SequenceNumberU64 as SequenceNumberU64Schema, TypeTag as TypeTagSchema,
+        SequenceNumberString as SequenceNumberStringSchema, SequenceNumberU64,
+        TypeTag as TypeTagSchema,
     },
     object_changes::ObjectChange,
 };
@@ -1883,9 +1883,9 @@ pub struct IotaConsensusCommitPrologueV1 {
 pub enum IotaConsensusDeterminedVersionAssignments {
     // Cancelled transaction version assignment.
     CancelledTransactions(
-        #[serde_as(as = "Vec<(Base58Schema, Vec<(ObjectIdSchema, SequenceNumberU64Schema)>)>")]
-        #[schemars(with = "Vec<(Base58Schema, Vec<(ObjectIdSchema, SequenceNumberU64Schema)>)>")]
-        Vec<(TransactionDigest, Vec<(ObjectId, SequenceNumber)>)>,
+        #[serde_as(as = "Vec<(Base58Schema, Vec<(ObjectIdSchema, serde_with::Same)>)>")]
+        #[schemars(with = "Vec<(Base58Schema, Vec<(ObjectIdSchema, SequenceNumberU64)>)>")]
+        Vec<(TransactionDigest, Vec<(ObjectId, SequenceNumberU64)>)>,
     ),
 }
 
@@ -1905,7 +1905,7 @@ impl From<ConsensusDeterminedVersionAssignments> for IotaConsensusDeterminedVers
                             cancelled
                                 .version_assignments
                                 .into_iter()
-                                .map(|va| (va.object_id, va.version))
+                                .map(|va| (va.object_id, va.version.into()))
                                 .collect(),
                         )
                     })
@@ -1933,7 +1933,7 @@ impl From<IotaConsensusDeterminedVersionAssignments> for ConsensusDeterminedVers
                                 .into_iter()
                                 .map(|(object_id, version)| VersionAssignment {
                                     object_id,
-                                    version,
+                                    version: version.into(),
                                 })
                                 .collect(),
                         })

--- a/crates/iota-json-rpc-types/src/lib.rs
+++ b/crates/iota-json-rpc-types/src/lib.rs
@@ -19,8 +19,8 @@ pub use iota_object::*;
 pub use iota_object_response_error::*;
 pub use iota_owner::*;
 use iota_primitives::{
-    Base58 as Base58Schema, Base64 as Base64Schema, ObjectId as ObjectIdSchema,
-    SequenceNumberU64 as SequenceNumberU64Schema, TypeTag as TypeTagSchema,
+    Base58 as Base58Schema, Base64 as Base64Schema, ObjectId as ObjectIdSchema, SequenceNumberU64,
+    TypeTag as TypeTagSchema,
 };
 pub use iota_protocol::*;
 use iota_sdk_types::{ObjectId, TypeTag};
@@ -194,9 +194,7 @@ pub struct IotaDynamicFieldInfo {
     #[serde_as(as = "ObjectIdSchema")]
     #[schemars(with = "ObjectIdSchema")]
     pub object_id: ObjectId,
-    #[serde_as(as = "SequenceNumberU64Schema")]
-    #[schemars(with = "SequenceNumberU64Schema")]
-    pub version: iota_types::base_types::SequenceNumber,
+    pub version: SequenceNumberU64,
     #[serde_as(as = "Base58Schema")]
     #[schemars(with = "Base58Schema")]
     pub digest: iota_types::digests::ObjectDigest,
@@ -220,7 +218,7 @@ impl From<DynamicFieldInfo> for IotaDynamicFieldInfo {
             type_,
             object_type,
             object_id,
-            version,
+            version: version.into(),
             digest,
         }
     }
@@ -244,7 +242,7 @@ impl From<IotaDynamicFieldInfo> for DynamicFieldInfo {
             type_,
             object_type,
             object_id,
-            version,
+            version: version.into(),
             digest,
         }
     }

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -20,7 +20,7 @@ use iota_json_rpc_types::{
     IotaObjectData, IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseError,
     IotaPastObjectResponse, IotaTransactionBlock, IotaTransactionBlockEffects,
     IotaTransactionBlockEvents, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
-    ObjectChange, ProtocolConfigResponse,
+    ObjectChange, ProtocolConfigResponse, iota_primitives::SequenceNumberU64,
 };
 use iota_metrics::{add_server_timing, spawn_monitored_task};
 use iota_open_rpc::Module;
@@ -538,7 +538,7 @@ impl ReadApiServer for ReadApi {
                 ObjectRead::Deleted(object_ref) => Ok(IotaObjectResponse::new_with_error(
                     IotaObjectResponseError::Deleted {
                         object_id: object_ref.object_id,
-                        version: object_ref.version,
+                        version: object_ref.version.into(),
                         digest: object_ref.digest,
                     },
                 )),
@@ -601,10 +601,11 @@ impl ReadApiServer for ReadApi {
     async fn try_get_past_object(
         &self,
         object_id: ObjectId,
-        version: SequenceNumber,
+        version: SequenceNumberU64,
         options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<IotaPastObjectResponse> {
         async move {
+            let version: SequenceNumber = version.into();
             let state = self.state.clone();
             let past_read = spawn_monitored_task!(async move {
             state.get_past_object_read(&object_id, version)
@@ -640,7 +641,7 @@ impl ReadApiServer for ReadApi {
                     Ok(IotaPastObjectResponse::ObjectDeleted(oref))
                 }
                 PastObjectRead::VersionNotFound(id, seq_num) => {
-                    Ok(IotaPastObjectResponse::VersionNotFound(id, seq_num))
+                    Ok(IotaPastObjectResponse::VersionNotFound(id, seq_num.into()))
                 }
                 PastObjectRead::VersionTooHigh {
                     object_id,
@@ -648,8 +649,8 @@ impl ReadApiServer for ReadApi {
                     latest_version,
                 } => Ok(IotaPastObjectResponse::VersionTooHigh {
                     object_id,
-                    asked_version,
-                    latest_version,
+                    asked_version: asked_version.into(),
+                    latest_version: latest_version.into(),
                 }),
             }
         }
@@ -672,7 +673,7 @@ impl ReadApiServer for ReadApi {
             .unwrap_or_default();
         self.try_get_past_object(
             object_id,
-            version,
+            version.into(),
             Some(IotaObjectDataOptions::bcs_lossless()),
         )
         .await
@@ -690,7 +691,7 @@ impl ReadApiServer for ReadApi {
                 for past_object in past_objects {
                     futures.push(self.try_get_past_object(
                         past_object.object_id,
-                        past_object.version,
+                        past_object.version.into(),
                         options.clone(),
                     ));
                 }

--- a/crates/iota-replay/src/data_fetcher.rs
+++ b/crates/iota-replay/src/data_fetcher.rs
@@ -663,7 +663,10 @@ fn convert_past_obj_response(resp: IotaPastObjectResponse) -> Result<Object, Rep
             Err(ReplayEngineError::ObjectNotExist { id })
         }
         IotaPastObjectResponse::VersionNotFound(id, version) => {
-            Err(ReplayEngineError::ObjectVersionNotFound { id, version })
+            Err(ReplayEngineError::ObjectVersionNotFound {
+                id,
+                version: version.into(),
+            })
         }
         IotaPastObjectResponse::VersionTooHigh {
             object_id,
@@ -671,8 +674,8 @@ fn convert_past_obj_response(resp: IotaPastObjectResponse) -> Result<Object, Rep
             latest_version,
         } => Err(ReplayEngineError::ObjectVersionTooHigh {
             id: object_id,
-            asked_version,
-            latest_version,
+            asked_version: asked_version.into(),
+            latest_version: latest_version.into(),
         }),
     }
 }

--- a/crates/iota-replay/src/types.rs
+++ b/crates/iota-replay/src/types.rs
@@ -222,7 +222,7 @@ impl From<IotaObjectResponseError> for ReplayEngineError {
                 version,
             } => ReplayEngineError::ObjectDeleted {
                 id: object_id,
-                version,
+                version: version.into(),
                 digest,
             },
             _ => ReplayEngineError::IotaObjectResponseError { err },

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -235,7 +235,7 @@ impl ReadApi {
         Ok(self
             .api
             .http
-            .try_get_past_object(object_id, version, Some(options))
+            .try_get_past_object(object_id, version.into(), Some(options))
             .await?)
     }
 

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -470,7 +470,7 @@ impl<'a> PTBBuilder<'a> {
 
         MovePackage::new(
             package.id,
-            package.version,
+            package.version.into(),
             package
                 .module_map
                 .into_iter()


### PR DESCRIPTION
# Description of change

This patch follows #11851 and restores the wire format for the `version` param in the `tryGetPastObject` method. We missed that, as the SDK change did not have any effect on the schema. 

The fix is to elevate the `SequenceNumberU64` into a proper newtype of the SDK type, and implement `From`  to completely replace the SDK type in `iota-json-rpc-{api,types}` whenever a numeric sequence number is expected. 

The previous pattern was to use `serde_as` (complemented by `schemars`) annotation to force the proper wire format, but this was not acceptable in the `ReadApi` trait method. 

## Links to any relevant issues

Fixes #11914

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

