### PR TITLE
upstream(core): Run consensus startup async

### DIFF
--- a/crates/iota-core/src/consensus_manager/mod.rs
+++ b/crates/iota-core/src/consensus_manager/mod.rs
@@ -12,13 +12,13 @@ use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use fastcrypto::traits::KeyPair as _;
 use iota_config::{ConsensusConfig, NodeConfig};
-use iota_metrics::{RegistryID, RegistryService};
+use iota_metrics::RegistryService;
 use iota_protocol_config::ProtocolVersion;
 use iota_types::{committee::EpochId, error::IotaResult, messages_consensus::ConsensusTransaction};
 use prometheus::{IntGauge, Registry, register_int_gauge_with_registry};
-use starfish_core::ConsensusAuthority;
+use starfish_core::CommitConsumerMonitor;
 use tokio::{
-    sync::{Mutex, MutexGuard},
+    sync::{Mutex, MutexGuard, broadcast},
     time::{sleep, timeout},
 };
 use tracing::info;
@@ -54,7 +54,7 @@ pub trait ConsensusManagerTrait {
 
     async fn is_running(&self) -> bool;
 
-    fn replay_waiter(&self) -> Option<ReplayWaiter>;
+    fn replay_waiter(&self) -> ReplayWaiter;
 }
 
 /// Used by IOTA validator to start consensus protocol for each epoch.
@@ -122,7 +122,7 @@ impl ConsensusManagerTrait for ConsensusManager {
         self.starfish_manager.is_running().await
     }
 
-    fn replay_waiter(&self) -> Option<ReplayWaiter> {
+    fn replay_waiter(&self) -> ReplayWaiter {
         self.starfish_manager.replay_waiter()
     }
 }
@@ -184,18 +184,38 @@ impl ConsensusClient for UpdatableConsensusClient {
     }
 }
 
-#[derive(Clone)]
+/// Waits for consensus to finish replaying at consensus handler.
 pub struct ReplayWaiter {
-    authority: Arc<(ConsensusAuthority, RegistryID)>,
+    consumer_monitor_receiver: broadcast::Receiver<Arc<CommitConsumerMonitor>>,
 }
 
 impl ReplayWaiter {
-    pub(crate) fn new(authority: Arc<(ConsensusAuthority, RegistryID)>) -> Self {
-        Self { authority }
+    pub(crate) fn new(
+        consumer_monitor_receiver: broadcast::Receiver<Arc<CommitConsumerMonitor>>,
+    ) -> Self {
+        Self {
+            consumer_monitor_receiver,
+        }
     }
 
-    pub(crate) async fn wait_for_replay(&self) {
-        self.authority.0.replay_complete().await;
+    pub(crate) async fn wait_for_replay(mut self) {
+        loop {
+            info!("Waiting for consensus to start replaying ...");
+            let Ok(monitor) = self.consumer_monitor_receiver.recv().await else {
+                continue;
+            };
+            info!("Waiting for consensus handler to finish replaying ...");
+            monitor.replay_complete().await;
+            break;
+        }
+    }
+}
+
+impl Clone for ReplayWaiter {
+    fn clone(&self) -> Self {
+        Self {
+            consumer_monitor_receiver: self.consumer_monitor_receiver.resubscribe(),
+        }
     }
 }
 

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -18,7 +18,7 @@ use starfish_config::{Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use starfish_core::{
     Clock, CommitConsumer, CommitConsumerMonitor, CommitIndex, ConsensusAuthority,
 };
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, broadcast};
 use tracing::info;
 
 use crate::{
@@ -49,6 +49,7 @@ pub struct StarfishManager {
     client: Arc<LazyStarfishClient>,
     consensus_handler: Mutex<Option<StarfishConsensusHandler>>,
     consumer_monitor: ArcSwapOption<CommitConsumerMonitor>,
+    consumer_monitor_sender: broadcast::Sender<Arc<CommitConsumerMonitor>>,
 }
 
 impl StarfishManager {
@@ -63,6 +64,7 @@ impl StarfishManager {
         metrics: Arc<ConsensusManagerMetrics>,
         client: Arc<LazyStarfishClient>,
     ) -> Self {
+        let (consumer_monitor_sender, _) = broadcast::channel(1);
         Self {
             protocol_keypair: ProtocolKeyPair::new(protocol_keypair),
             network_keypair: NetworkKeyPair::new(network_keypair),
@@ -75,6 +77,7 @@ impl StarfishManager {
             consensus_handler: Mutex::new(None),
             boot_counter: Mutex::new(0),
             consumer_monitor: ArcSwapOption::empty(),
+            consumer_monitor_sender,
         }
     }
 
@@ -158,6 +161,17 @@ impl ConsensusManagerTrait for StarfishManager {
         let consumer = CommitConsumer::new(commit_sender, starting_commit);
         let monitor = consumer.monitor();
 
+        // Spin up the new starfish consensus handler to listen for committed sub dags,
+        // before starting authority.
+        let handler = StarfishConsensusHandler::new(
+            last_processed_commit,
+            consensus_handler,
+            commit_receiver,
+            monitor.clone(),
+        );
+        let mut consensus_handler = self.consensus_handler.lock().await;
+        *consensus_handler = Some(handler);
+
         // If there is a previous consumer monitor, it indicates that the consensus
         // engine has been restarted, due to an epoch change. However, that on its
         // own doesn't tell us much whether it participated on an active epoch or an old
@@ -208,21 +222,13 @@ impl ConsensusManagerTrait for StarfishManager {
         let registry_id = self.registry_service.add(registry.clone());
 
         let registered_authority = Arc::new((authority, registry_id));
-        self.authority.swap(Some(registered_authority.clone()));
+        self.authority.swap(Some(registered_authority));
 
         // Initialize the client to send transactions to this Starfish instance.
         self.client.set(client);
 
-        // spin up the new starfish consensus handler to listen for committed sub dags
-        let handler = StarfishConsensusHandler::new(
-            last_processed_commit,
-            consensus_handler,
-            commit_receiver,
-            monitor,
-        );
-
-        let mut consensus_handler = self.consensus_handler.lock().await;
-        *consensus_handler = Some(handler);
+        // Send the consumer monitor to the replay waiter.
+        let _ = self.consumer_monitor_sender.send(monitor);
     }
 
     async fn shutdown(&self) {
@@ -258,8 +264,8 @@ impl ConsensusManagerTrait for StarfishManager {
         Running::False != *self.running.lock().await
     }
 
-    fn replay_waiter(&self) -> Option<ReplayWaiter> {
-        let authority = self.authority.load_full()?;
-        Some(ReplayWaiter::new(authority))
+    fn replay_waiter(&self) -> ReplayWaiter {
+        let consumer_monitor_receiver = self.consumer_monitor_sender.subscribe();
+        ReplayWaiter::new(consumer_monitor_receiver)
     }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -160,7 +160,7 @@ pub mod metrics;
 pub struct ValidatorComponents {
     validator_server_handle: SpawnOnce,
     validator_overload_monitor_handle: Option<JoinHandle<()>>,
-    consensus_manager: ConsensusManager,
+    consensus_manager: Arc<ConsensusManager>,
     consensus_store_pruner: ConsensusStorePruner,
     consensus_adapter: Arc<ConsensusAdapter>,
     // Keeping the handle to the checkpoint service tasks to shut them down during reconfiguration.
@@ -1167,13 +1167,13 @@ impl IotaNode {
             client.clone(),
             checkpoint_store.clone(),
         ));
-        let consensus_manager = ConsensusManager::new(
+        let consensus_manager = Arc::new(ConsensusManager::new(
             &config,
             consensus_config,
             registry_service,
             &validator_registry,
             client,
-        );
+        ));
 
         // This only gets started up once, not on every epoch. (Make call to remove
         // every epoch.)
@@ -1244,7 +1244,7 @@ impl IotaNode {
         epoch_store: Arc<AuthorityPerEpochStore>,
         state_sync_handle: state_sync::Handle,
         randomness_handle: randomness::Handle,
-        consensus_manager: ConsensusManager,
+        consensus_manager: Arc<ConsensusManager>,
         consensus_store_pruner: ConsensusStorePruner,
         global_state_hasher: Weak<GlobalStateHasher>,
         backpressure_manager: Arc<BackpressureManager>,
@@ -1294,25 +1294,39 @@ impl IotaNode {
             backpressure_manager,
         );
 
-        info!("Starting consensus manager");
+        info!("Starting consensus manager asynchronously");
 
-        consensus_manager
-            .start(
-                config,
+        // Spawn consensus startup asynchronously to avoid blocking other components
+        tokio::spawn({
+            let config = config.clone();
+            let epoch_store = epoch_store.clone();
+            let iota_tx_validator = IotaTxValidator::new(
                 epoch_store.clone(),
-                consensus_handler_initializer,
-                IotaTxValidator::new(
-                    epoch_store.clone(),
-                    checkpoint_service.clone(),
-                    state.transaction_manager().clone(),
-                    iota_tx_validator_metrics.clone(),
-                ),
-            )
-            .await;
-        let consensus_replay_waiter = consensus_manager.replay_waiter();
+                checkpoint_service.clone(),
+                state.transaction_manager().clone(),
+                iota_tx_validator_metrics.clone(),
+            );
+            let consensus_manager = consensus_manager.clone();
+            async move {
+                consensus_manager
+                    .start(
+                        &config,
+                        epoch_store,
+                        consensus_handler_initializer,
+                        iota_tx_validator,
+                    )
+                    .await;
+            }
+        });
+        let replay_waiter = consensus_manager.replay_waiter();
 
         info!("Spawning checkpoint service");
-        let checkpoint_service_tasks = checkpoint_service.spawn(consensus_replay_waiter).await;
+        let replay_waiter = if std::env::var("DISABLE_REPLAY_WAITER").is_ok() {
+            None
+        } else {
+            Some(replay_waiter)
+        };
+        let checkpoint_service_tasks = checkpoint_service.spawn(replay_waiter).await;
 
         Ok(ValidatorComponents {
             validator_server_handle,

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -15,7 +15,7 @@ use starfish_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, Pro
 use tracing::{info, warn};
 
 use crate::{
-    CommitConsumer, CommitConsumerMonitor,
+    CommitConsumer,
     authority_service::AuthorityService,
     block_manager::BlockManager,
     block_verifier::SignedBlockVerifier,
@@ -46,7 +46,6 @@ pub struct ConsensusAuthority {
     transaction_client: Arc<TransactionClient>,
     header_synchronizer: Arc<HeaderSynchronizerHandle>,
     transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
-    commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     shard_reconstructor: Arc<ShardReconstructorHandle>,
     cordial_knowledge: Arc<CordialKnowledgeHandle>,
     regular_commit_syncer_handle: CommitSyncerHandle,
@@ -362,7 +361,6 @@ impl ConsensusAuthority {
             shard_reconstructor,
             cordial_knowledge,
             transactions_synchronizer,
-            commit_consumer_monitor,
             regular_commit_syncer_handle,
             fast_commit_syncer_handle,
             leader_timeout_handle,
@@ -468,10 +466,6 @@ impl ConsensusAuthority {
         self.transaction_client.clone()
     }
 
-    pub async fn replay_complete(&self) {
-        self.commit_consumer_monitor.replay_complete().await;
-    }
-
     #[cfg(test)]
     pub(crate) fn context(&self) -> &Arc<Context> {
         &self.context
@@ -534,7 +528,7 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::{
-        CommittedSubDag, block_header::GENESIS_ROUND, commit::CommitIndex,
+        CommitConsumerMonitor, CommittedSubDag, block_header::GENESIS_ROUND, commit::CommitIndex,
         transaction::NoopTransactionVerifier,
     };
 

--- a/crates/starfish/core/src/commit_consumer.rs
+++ b/crates/starfish/core/src/commit_consumer.rs
@@ -87,7 +87,7 @@ impl CommitConsumerMonitor {
         *commit = highest_observed_commit_at_startup;
     }
 
-    pub(crate) async fn replay_complete(&self) {
+    pub async fn replay_complete(&self) {
         let highest_observed_commit_at_startup = self.highest_observed_commit_at_startup();
         let mut rx = self.highest_handled_commit.subscribe();
         loop {


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.51.5, v1.52.3)
- Port commit:
  - [MystenLabs/sui@2d263494](https://github.com/MystenLabs/sui/commit/2d263494413100fa9f088ed52a17d6074da17136)
- Description:

Spawns consensus startup asynchronously so it no longer blocks the other
node components during validator bring-up. The consensus handler is now
created before the authority starts (so it is listening for committed
sub-dags first), and the replay-waiting mechanism is rewired from holding
an `Arc<ConsensusAuthority>` to receiving the `CommitConsumerMonitor` over
a broadcast channel. A `DISABLE_REPLAY_WAITER` env var is added as an
escape hatch.

Built on top of https://github.com/iotaledger/iota/pull/11850 which is required to prevent OOM on recovery.
## Links to any relevant issues

Part of #11885

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes