### PR TITLE
fix(docker): ignore nested `target/` dirs in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 *~
 *.swp
 **/.terraform/
-target/
+**/target/
 **/*Dockerfile
 **/*Dockerfile.cache
 *.md


### PR DESCRIPTION
# Description of change

The `target/` pattern in `.dockerignore` only matched the root dir; nested `target/` dirs (such as in `docs/examples/rust`, `external-crates/move`, `examples/custom-indexer`) were sent in the build context and copied into builder stages. This PR uses `**/target/` to exclude them at any depth.

## Links to any relevant issues

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes