### PR TITLE
feat(iota-rust-sdk): add `iota-rust-sdk` re-exports

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,7 @@
 /crates/iota-replay/ @iotaledger/node
 /crates/iota-rest-kv/ @iotaledger/infrastructure
 /crates/iota-rpc-loadgen/ @iotaledger/infrastructure
+/crates/iota-rust-sdk/ @iotaledger/dev-tools
 /crates/iota-sdk/ @iotaledger/dev-tools
 /crates/iota-simulator/ @iotaledger/core-protocol
 /crates/iota-single-node-benchmark/ @iotaledger/node

--- a/.github/crates-filters.yml
+++ b/.github/crates-filters.yml
@@ -132,6 +132,8 @@ iota-rest-kv:
   - "crates/iota-rest-kv/**"
 iota-rpc-loadgen:
   - "crates/iota-rpc-loadgen/**"
+iota-rust-sdk:
+  - "crates/iota-rust-sdk/**"
 iota-sdk:
   - "crates/iota-sdk/**"
 iota-simulator:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,8 +1786,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -3892,7 +3898,7 @@ dependencies = [
  "ark-serialize",
  "auto_ops",
  "base64ct",
- "bech32",
+ "bech32 0.9.1",
  "bincode",
  "blake2",
  "blst",
@@ -7389,6 +7395,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-rust-sdk"
+version = "1.26.0-alpha"
+dependencies = [
+ "iota-sdk-crypto",
+ "iota-sdk-graphql-client",
+ "iota-sdk-grpc-client",
+ "iota-sdk-grpc-types",
+ "iota-sdk-transaction-builder",
+ "iota-sdk-types",
+]
+
+[[package]]
 name = "iota-sdk"
 version = "1.26.0-alpha"
 dependencies = [
@@ -7432,17 +7450,59 @@ name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
 source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4e685468c6e589f2701f4ffd64699f60c430f6da#4e685468c6e589f2701f4ffd64699f60c430f6da"
 dependencies = [
+ "bech32 0.11.1",
  "bip32",
  "bip39",
+ "blst",
  "ed25519-dalek",
  "iota-sdk-types",
  "k256",
  "p256",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
+ "roaring",
  "sha2 0.10.9",
  "signature 2.2.0",
  "slip10_ed25519",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "iota-sdk-graphql-client"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4e685468c6e589f2701f4ffd64699f60c430f6da#4e685468c6e589f2701f4ffd64699f60c430f6da"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "chrono",
+ "cynic",
+ "derive_more 2.1.1",
+ "futures",
+ "getrandom 0.2.15",
+ "iota-sdk-graphql-client-build",
+ "iota-sdk-transaction-builder",
+ "iota-sdk-types",
+ "js-sys",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "variadics_please",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "iota-sdk-graphql-client-build"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=4e685468c6e589f2701f4ffd64699f60c430f6da#4e685468c6e589f2701f4ffd64699f60c430f6da"
+dependencies = [
+ "cynic-codegen",
 ]
 
 [[package]]
@@ -7688,7 +7748,7 @@ dependencies = [
 name = "iota-stardust-types"
 version = "1.26.0-alpha"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "bitflags 2.10.0",
  "derive_more 1.0.0",
  "getset",
@@ -11339,7 +11399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -11373,7 +11433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14604,7 +14664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.6",
  "static_assertions",
 ]
 
@@ -15206,7 +15266,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ members = [
   "crates/iota-replay",
   "crates/iota-rest-kv",
   "crates/iota-rpc-loadgen",
+  "crates/iota-rust-sdk",
   "crates/iota-sdk",
   "crates/iota-simulator",
   "crates/iota-single-node-benchmark",

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -53,7 +53,7 @@ iota-move-build.workspace = true
 iota-move-natives-latest = { path = "../../iota-execution/latest/iota-move-natives" }
 iota-protocol-config.workspace = true
 # iota-sdk-crypto is only used when compiling the test-outputs feature
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "4e685468c6e589f2701f4ffd64699f60c430f6da", optional = true, features = ["ed25519", "mnemonic"] }
+iota-sdk-crypto = { workspace = true, features = ["ed25519", "mnemonic"], default-features = true, optional = true }
 iota-sdk-types.workspace = true
 iota-stardust-types = { path = "../iota-stardust-types", features = ["irc_27", "irc_30", "std"] }
 iota-types.workspace = true

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "iota-rust-sdk"
+version.workspace = true
+authors = ["IOTA Foundation <info@iota.org>"]
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+iota-grpc-client = { workspace = true, optional = true }
+iota-grpc-types = { workspace = true, optional = true }
+iota-sdk-crypto = { workspace = true, optional = true }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "4e685468c6e589f2701f4ffd64699f60c430f6da", optional = true }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "4e685468c6e589f2701f4ffd64699f60c430f6da", default-features = false, optional = true }
+iota-sdk-types = { workspace = true, optional = true }
+
+[features]
+default = [
+  "bech32",
+  "crypto",
+  "ed25519",
+  "graphql",
+  "hash",
+  "mnemonic",
+  "passkey",
+  "pem",
+  "rand",
+  "secp256k1",
+  "secp256r1",
+  "serde",
+  "txn-builder",
+  "types",
+]
+# Crypto
+crypto = ["dep:iota-sdk-crypto"]
+ed25519 = ["crypto", "iota-sdk-crypto/ed25519"]
+secp256r1 = ["crypto", "iota-sdk-crypto/secp256r1"]
+passkey = ["crypto", "iota-sdk-crypto/passkey"]
+secp256k1 = ["crypto", "iota-sdk-crypto/secp256k1"]
+pem = ["crypto", "iota-sdk-crypto/pem"]
+bls12381 = ["crypto", "iota-sdk-crypto/bls12381"]
+bech32 = ["crypto", "iota-sdk-crypto/bech32"]
+mnemonic = ["crypto", "iota-sdk-crypto/mnemonic"]
+# GraphQL
+graphql = ["dep:iota-sdk-graphql-client"]
+# gRPC
+grpc = ["dep:iota-grpc-client", "dep:iota-grpc-types"]
+# Transaction Builder
+txn-builder = ["dep:iota-sdk-transaction-builder"]
+# Types
+types = ["dep:iota-sdk-types"]
+serde = ["types", "iota-sdk-types/serde"]
+rand = ["types", "iota-sdk-types/rand"]
+hash = ["types", "iota-sdk-types/hash"]
+proptest = ["types", "iota-sdk-types/proptest"]

--- a/crates/iota-rust-sdk/src/lib.rs
+++ b/crates/iota-rust-sdk/src/lib.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Re-exports of the [`iota-rust-sdk`](https://github.com/iotaledger/iota-rust-sdk)
+//! crates pinned by this repository.
+//!
+//! Depend on this crate (instead of declaring your own `iota-rust-sdk` git
+//! dependency) to use those crates version-matched to the revision this
+//! repository pins. The module layout and feature flags mirror the upstream
+//! `iota-sdk` meta-crate.
+//!
+//! To actually get version unification, reach these crates only through this
+//! crate's re-exports; adding a separate `iota-rust-sdk` git dependency at a
+//! different revision reintroduces incompatible duplicate types.
+
+#[cfg(feature = "grpc")]
+pub use iota_grpc_client as grpc_client;
+#[cfg(feature = "grpc")]
+pub use iota_grpc_types as grpc_types;
+#[cfg(feature = "crypto")]
+pub use iota_sdk_crypto as crypto;
+#[cfg(feature = "graphql")]
+pub use iota_sdk_graphql_client as graphql_client;
+#[cfg(feature = "txn-builder")]
+pub use iota_sdk_transaction_builder as transaction_builder;
+#[cfg(feature = "types")]
+pub use iota_sdk_types as types;

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true
-tonic-prost = "0.14"
+tonic-prost.workspace = true
 tonic-rustls = "0.3.0"
 tower.workspace = true
 tower-http.workspace = true

--- a/scripts/cargo_sort/cargo_sort.py
+++ b/scripts/cargo_sort/cargo_sort.py
@@ -1702,6 +1702,7 @@ Examples:
     internal_crates_dict["iota-grpc-client"] = None
     internal_crates_dict["iota-grpc-types"] = None
     internal_crates_dict["iota-sdk-crypto"] = None
+    internal_crates_dict["iota-sdk-graphql-client"] = None
     internal_crates_dict["iota-sdk-grpc-client"] = None
     internal_crates_dict["iota-sdk-grpc-types"] = None
     internal_crates_dict["iota-sdk-transaction-builder"] = None

--- a/scripts/update_sdk_types_rev.sh
+++ b/scripts/update_sdk_types_rev.sh
@@ -56,13 +56,15 @@ update_rev() {
     sed_inplace "/${crate}/s/rev = \"[^\"]*\"/rev = \"$NEW_REV\"/" "$file"
 }
 
-# Update both iota-sdk-types and iota-sdk-crypto in the given Cargo.toml.
+# Update every pinned iota-rust-sdk crate in the given Cargo.toml.
 update_file() {
     local file="$1"
     update_rev iota-sdk-types "$file"
     update_rev iota-sdk-crypto "$file"
     update_rev iota-sdk-grpc-types "$file"
     update_rev iota-sdk-grpc-client "$file"
+    update_rev iota-sdk-graphql-client "$file"
+    update_rev iota-sdk-transaction-builder "$file"
 }
 
 echo "New rev: $NEW_REV"
@@ -70,6 +72,7 @@ echo "Updating Cargo.toml files..."
 
 update_file Cargo.toml
 update_file crates/iota-genesis-builder/Cargo.toml
+update_file crates/iota-rust-sdk/Cargo.toml
 update_file examples/tic-tac-toe/cli/Cargo.toml
 update_file docs/examples/rust/Cargo.toml
 


### PR DESCRIPTION
# Description of change

Re-export the `iota-rust-sdk` crates this repo pins (`iota-sdk-types`, `iota-sdk-crypto`, the gRPC client/types, the GraphQL client, and the transaction builder) from `iota-sdk`, behind feature flags that mirror the upstream `iota-rust-sdk` meta-crate.

A downstream repo that links against this repo and `iota-rust-sdk` directly risks ending up with two incompatible copies of e.g. `iota-sdk-types`. Cargo only unifies deps resolving to the same git rev, so a rev mismatch yields two distinct `ObjectId` types that won't interoperate.

By re-exporting, consumers can reach these types through `iota_rust_sdk::*` and drop their own `iota-rust-sdk` git dependency entirely, getting exactly the rev `iota-rust-sdk` pins. No more manual rev-matching.

##  Details
  
- Features mirror upstream (crypto/ed25519/…, types/serde/rand/…, grpc, graphql, txn-builder) so consumers can enable any underlying feature through iota-sdk alone.
- default keeps the build light: types + crypto on; grpc/graphql/txn-builder/bls12381/proptest are opt-in (the first three pull extra git deps).
- transaction_builder re-exports iota-rust-sdk's iota-sdk-transaction-builder, distinct from the local iota-transaction-builder the client uses internally.
- types is the one divergence from upstream: iota-sdk-types stays non-optional (the client uses it internally), so the feature gates only the re-export.

  ▎ Note for consumers: to actually get version-matching, reach these crates only via iota_rust_sdk::* — don't also add a direct iota-rust-sdk git dependency.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes