### PR TITLE
chore: remove unused swap space step from llvm-cov workflow

### DIFF
--- a/.github/workflows/cargo_llvm_cov.yml
+++ b/.github/workflows/cargo_llvm_cov.yml
@@ -50,11 +50,6 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch-or-commit || github.ref }}
 
-      - name: Set Swap Space
-        uses: actionhippie/swap-space@0cffa893f224708cfb6b011690d8ba819d69c10f # v1.1.0
-        with:
-          size: 256G
-
       - name: Install llvm-tools
         run: |
           TOOLCHAIN=$(rustup show active-toolchain | grep -Eo '\S+' | head -n 1)


### PR DESCRIPTION
## Summary

The `Code Coverage (llvm-cov)` workflow was failing at the **Set Swap Space** step ([run 27660370970](https://github.com/iotaledger/iota/actions/runs/27660370970/workflow)): the `actionhippie/swap-space` action tried to allocate 256G of swap, which didn't fit on the runner's disk. The swap was never actually used by the job, so the step was pure overhead — and a hard failure when the allocation couldn't be satisfied.

This PR removes the step:

```yaml
- name: Set Swap Space
  uses: actionhippie/swap-space@0cffa893f224708cfb6b011690d8ba819d69c10f # v1.1.0
  with:
    size: 256G
```

## Verification

Dispatched the workflow on this branch and it completed successfully end-to-end — all 17 steps green (~55 min):

🔗 **https://github.com/iotaledger/iota/actions/runs/27669992059**

Checkout now flows straight into *Install llvm-tools* with no swap-space step in between, and both coverage passes (nextest + simtest), report generation, and the Coveralls upload all succeeded — confirming the swap was unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXV8UZjfrUwBmEdPGX79pP)_