### PR TITLE
upstream: Porting core-protocol related upstream changes in range mainnet-1.51.5 to mainnet-1.52.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5758,6 +5758,7 @@ dependencies = [
  "object_store 0.13.1",
  "once_cell",
  "parking_lot 0.12.3",
+ "pin-project-lite",
  "pprof",
  "pretty_assertions",
  "prometheus-filtered",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,6 +3566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6849,7 +6859,7 @@ dependencies = [
  "prometheus-filtered",
  "scopeguard",
  "simple-server-timing-header",
- "sysinfo 0.33.1",
+ "sysinfo 0.39.5",
  "tap",
  "thiserror 1.0.64",
  "tokio",
@@ -10216,12 +10226,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
 ]
 
 [[package]]
@@ -10232,6 +10269,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -13626,20 +13674,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "rayon",
- "windows 0.57.0",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
@@ -13650,6 +13684,21 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows 0.61.3",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -14741,6 +14790,7 @@ dependencies = [
  "iota-macros",
  "iota-metrics",
  "msim",
+ "num_cpus",
  "once_cell",
  "ouroboros 0.18.4",
  "prometheus-filtered",
@@ -14748,6 +14798,7 @@ dependencies = [
  "rocksdb",
  "rstest",
  "serde",
+ "sysinfo 0.39.5",
  "tap",
  "tempfile",
  "tokio",
@@ -15328,25 +15379,27 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -15356,6 +15409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -15369,27 +15431,28 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -15400,18 +15463,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -15419,17 +15482,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15470,12 +15522,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15488,12 +15541,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15594,6 +15665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,6 +348,7 @@ static_assertions = "1.1.0"
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 syn = { version = "1.0.104", features = ["full", "derive", "extra-traits"] }
+sysinfo = "0.39"
 tabled = { version = "0.12" }
 tap = "1.0.1"
 tempfile = "3.20.0"

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -38,6 +38,7 @@ num_cpus.workspace = true
 object_store.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
+pin-project-lite.workspace = true
 quinn-proto = "0.11.15"
 rand.workspace = true
 rayon = "1.5.3"

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5919,7 +5919,7 @@ impl RandomnessRoundReceiver {
             tokio::select! {
                 maybe_recv = self.randomness_rx.recv() => {
                     if let Some((epoch, round, bytes)) = maybe_recv {
-                        self.handle_new_randomness(epoch, round, bytes);
+                        self.handle_new_randomness(epoch, round, bytes).await;
                     } else {
                         break;
                     }
@@ -5931,7 +5931,9 @@ impl RandomnessRoundReceiver {
     }
 
     #[instrument(level = "debug", skip_all, fields(?epoch, ?round))]
-    fn handle_new_randomness(&self, epoch: EpochId, round: RandomnessRound, bytes: Vec<u8>) {
+    async fn handle_new_randomness(&self, epoch: EpochId, round: RandomnessRound, bytes: Vec<u8>) {
+        fail_point_async!("randomness-delay");
+
         let epoch_store = self.authority_state.load_epoch_store_one_call_per_task();
         if epoch_store.epoch() != epoch {
             warn!(

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -65,7 +65,8 @@ use iota_types::{
     storage::{BackingPackageStore, InputKey},
     transaction::{
         CertifiedTransaction, InputObjectKind, SenderSignedData, Transaction, TransactionDataAPI,
-        TransactionKey, VerifiedCertificate, VerifiedSignedTransaction, VerifiedTransaction,
+        TransactionKey, TxValidityCheckContext, VerifiedCertificate, VerifiedSignedTransaction,
+        VerifiedTransaction,
     },
 };
 use itertools::izip;
@@ -1424,6 +1425,13 @@ impl AuthorityPerEpochStore {
 
     pub fn epoch(&self) -> EpochId {
         self.committee.epoch
+    }
+
+    pub fn tx_validity_check_context(&self) -> TxValidityCheckContext<'_> {
+        TxValidityCheckContext {
+            config: &self.protocol_config,
+            epoch: self.epoch(),
+        }
     }
 
     pub fn get_state_hash_for_checkpoint(

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -65,7 +65,7 @@ pub async fn certify_transaction(
     // Make the initial request
     let epoch_store = authority.load_epoch_store_one_call_per_task();
     // TODO: Move this check to a more appropriate place.
-    transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+    transaction.validity_check(&epoch_store.tx_validity_check_context())?;
     let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     let response = authority

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -185,16 +185,39 @@ impl<'a> TestAuthorityBuilder<'a> {
     }
 
     pub async fn build(self) -> Arc<AuthorityState> {
-        let mut local_network_config_builder =
-            iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
-                .with_accounts(self.accounts)
-                .with_reference_gas_price(self.reference_gas_price.unwrap_or(500));
-        if let Some(protocol_config) = &self.protocol_config {
-            local_network_config_builder =
-                local_network_config_builder.with_protocol_version(protocol_config.version);
-        }
+        let protocol_config = self.protocol_config.clone();
 
-        let local_network_config = local_network_config_builder.build();
+        // Genesis must build the system framework at the binary format version it was
+        // compiled with. A test override that lowers `move_binary_format_version`
+        // must not apply while genesis verifies the system packages.
+        // Build genesis with the framework's binary format version
+        // restored, then apply the unmodified override below for transaction
+        // execution.
+        let local_network_config = {
+            let _genesis_guard = protocol_config.clone().map(|mut config| {
+                let framework_binary_format_version =
+                    ProtocolConfig::get_for_version(config.version, Chain::Unknown)
+                        .move_binary_format_version();
+                config.set_move_binary_format_version_for_testing(framework_binary_format_version);
+                ProtocolConfig::apply_overrides_for_testing(move |_, _| config.clone())
+            });
+
+            let mut local_network_config_builder =
+                iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                    .with_accounts(self.accounts)
+                    .with_reference_gas_price(self.reference_gas_price.unwrap_or(500));
+            if let Some(protocol_config) = &self.protocol_config {
+                local_network_config_builder =
+                    local_network_config_builder.with_protocol_version(protocol_config.version);
+            }
+            local_network_config_builder.build()
+        };
+
+        // `_guard` must be declared here so it is not dropped before
+        // `AuthorityPerEpochStore::new` is called
+        let _guard = protocol_config
+            .map(|config| ProtocolConfig::apply_overrides_for_testing(move |_, _| config.clone()));
+
         let genesis = &self.genesis.unwrap_or(&local_network_config.genesis);
         let genesis_committee = genesis.committee().unwrap();
         let storage_dir = self
@@ -250,11 +273,6 @@ impl<'a> TestAuthorityBuilder<'a> {
         let name: AuthorityName = secret.public().into();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
         let signature_verifier_metrics = SignatureVerifierMetrics::new(&registry);
-        // `_guard` must be declared here so it is not dropped before
-        // `AuthorityPerEpochStore::new` is called
-        let _guard = self
-            .protocol_config
-            .map(|config| ProtocolConfig::apply_overrides_for_testing(move |_, _| config.clone()));
         let epoch_flags = EpochFlag::default_flags_for_new_epoch(&config);
         let epoch_start_configuration = EpochStartConfiguration::new(
             genesis.iota_system_object().into_epoch_start_state(),

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -90,7 +90,7 @@ impl ValidatorService {
             .into()
         );
 
-        transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+        transaction.validity_check(&epoch_store.tx_validity_check_context())?;
 
         // When authority is overloaded and decide to reject this tx, we still lock the
         // object and ask the client to retry in the future. This is because
@@ -451,7 +451,7 @@ impl ValidatorService {
         );
 
         let certificate = request.into_inner();
-        certificate.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+        certificate.validity_check(&epoch_store.tx_validity_check_context())?;
 
         let span = error_span!("submit_certificate", tx_digest = ?certificate.digest());
         self.handle_certificates(
@@ -496,7 +496,7 @@ impl ValidatorService {
         let request = request.into_inner();
         request
             .certificate
-            .validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+            .validity_check(&epoch_store.tx_validity_check_context())?;
 
         let span = error_span!("handle_certificate_v1", tx_digest = ?request.certificate.digest());
         self.handle_certificates(
@@ -646,9 +646,8 @@ impl ValidatorService {
         let mut total_size_bytes = 0;
         for certificate in &certificates {
             // We need to check this first because we haven't verified the cert signature.
-            total_size_bytes += certificate
-                .validity_check(epoch_store.protocol_config(), epoch_store.epoch())?
-                as u64;
+            total_size_bytes +=
+                certificate.validity_check(&epoch_store.tx_validity_check_context())? as u64;
         }
 
         self.metrics

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -179,9 +179,7 @@ impl ValidatorService {
         }
 
         // Validate transaction.
-        if let Err(e) =
-            transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())
-        {
+        if let Err(e) = transaction.validity_check(&epoch_store.tx_validity_check_context()) {
             let weight = normalize(&e);
             return (TxStatusUpdate::Rejected { error: e }, weight);
         }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1081,8 +1081,13 @@ impl CheckpointBuilder {
             last_height = Some(height);
             last_timestamp = Some(current_timestamp);
             debug!(
-                checkpoint_commit_height = height,
-                "Making checkpoint at commit height"
+                checkpoint_commit_height_from = grouped_pending_checkpoints
+                    .first()
+                    .unwrap()
+                    .details()
+                    .checkpoint_height,
+                checkpoint_commit_height_to = last_height,
+                "Making checkpoint with commit height range"
             );
 
             match self
@@ -1139,6 +1144,10 @@ impl CheckpointBuilder {
         let mut all_roots = HashSet::new();
         for pending_checkpoint in pendings.into_iter() {
             let pending = pending_checkpoint.into_v1();
+            debug!(
+                checkpoint_commit_height = pending.details.checkpoint_height,
+                "Resolving checkpoint transactions for pending checkpoint.",
+            );
             let (root_digests, txn_in_checkpoint) = self
                 .resolve_checkpoint_transactions(pending.roots, &mut effects_in_current_checkpoint)
                 .await?;
@@ -1459,6 +1468,7 @@ impl CheckpointBuilder {
             Self::load_last_built_checkpoint_summary(&self.epoch_store, &self.store)?;
         let last_checkpoint_seq = last_checkpoint.as_ref().map(|(seq, _)| *seq);
         debug!(
+            checkpoint_commit_height = details.checkpoint_height,
             next_checkpoint_seq = last_checkpoint_seq.unwrap_or_default() + 1,
             checkpoint_timestamp = details.timestamp_ms,
             "Creating checkpoint(s) for {} transactions",

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -10,9 +10,12 @@ mod metrics;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs::File,
+    future::Future,
     io::Write,
     path::Path,
+    pin::Pin,
     sync::{Arc, Weak},
+    task::{Context, Poll},
     time::{Duration, SystemTime},
 };
 
@@ -49,6 +52,7 @@ use iota_types::{
 use itertools::Itertools;
 use nonempty::NonEmpty;
 use parking_lot::Mutex;
+use pin_project_lite::pin_project;
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -1131,29 +1135,17 @@ impl CheckpointBuilder {
         let _scope = monitored_scope("CheckpointBuilder::make_checkpoint");
         let last_details = pendings.last().unwrap().details().clone();
 
-        // Keeps track of the effects that are already included in the current
-        // checkpoint. This is used when there are multiple pending checkpoints
-        // to create a single checkpoint because in such scenarios, dependencies
-        // of a transaction may in earlier created checkpoints, or in earlier
-        // pending checkpoints.
-        let mut effects_in_current_checkpoint = BTreeSet::new();
-
         // Stores the transactions that should be included in the checkpoint.
         // Transactions will be recorded in the checkpoint in this order.
-        let mut sorted_tx_effects_included_in_checkpoint = Vec::new();
-        let mut all_roots = HashSet::new();
-        for pending_checkpoint in pendings.into_iter() {
-            let pending = pending_checkpoint.into_v1();
-            debug!(
-                checkpoint_commit_height = pending.details.checkpoint_height,
-                "Resolving checkpoint transactions for pending checkpoint.",
-            );
-            let (root_digests, txn_in_checkpoint) = self
-                .resolve_checkpoint_transactions(pending.roots, &mut effects_in_current_checkpoint)
-                .await?;
-            sorted_tx_effects_included_in_checkpoint.extend(txn_in_checkpoint);
-            all_roots.extend(root_digests);
-        }
+        let highest_executed_sequence = self
+            .store
+            .get_highest_executed_checkpoint_seq_number()
+            .expect("db error")
+            .unwrap_or(0);
+
+        let (poll_count, result) = poll_count(self.resolve_checkpoint_transactions(pendings)).await;
+        let (sorted_tx_effects_included_in_checkpoint, all_roots) = result?;
+
         let new_checkpoints = self
             .create_checkpoints(
                 sorted_tx_effects_included_in_checkpoint,
@@ -1162,97 +1154,126 @@ impl CheckpointBuilder {
             )
             .await?;
         let highest_sequence = *new_checkpoints.last().0.sequence_number();
+        if highest_sequence <= highest_executed_sequence && poll_count > 1 {
+            debug_fatal!(
+                "resolve_checkpoint_transactions should be instantaneous when executed checkpoint is ahead of checkpoint builder"
+            );
+        }
+
         self.write_checkpoints(last_details.checkpoint_height, new_checkpoints)
             .await?;
         Ok(highest_sequence)
     }
 
-    // Given the root transactions of a pending checkpoint, resolve the transactions
-    // should be included in the checkpoint, and return them in the order they
-    // should be included in the checkpoint. `effects_in_current_checkpoint`
-    // tracks the transactions that already exist in the current checkpoint.
+    // Given the root transactions of the pending checkpoints, resolve the
+    // transactions that should be included in the checkpoint, and return them in
+    // the order they should be included in the checkpoint, together with all the
+    // resolved roots.
     #[instrument(level = "debug", skip_all)]
     async fn resolve_checkpoint_transactions(
         &self,
-        roots: Vec<TransactionKey>,
-        effects_in_current_checkpoint: &mut BTreeSet<TransactionDigest>,
-    ) -> IotaResult<(Vec<TransactionDigest>, Vec<TransactionEffects>)> {
+        pending_checkpoints: Vec<PendingCheckpoint>,
+    ) -> IotaResult<(Vec<TransactionEffects>, HashSet<TransactionDigest>)> {
         let _scope = monitored_scope("CheckpointBuilder::resolve_checkpoint_transactions");
 
-        self.metrics
-            .checkpoint_roots_count
-            .inc_by(roots.len() as u64);
+        // Keeps track of the effects that are already included in the current
+        // checkpoint. This is used when there are multiple pending checkpoints
+        // to create a single checkpoint because in such scenarios, dependencies
+        // of a transaction may in earlier created checkpoints, or in earlier
+        // pending checkpoints.
+        let mut effects_in_current_checkpoint = BTreeSet::new();
 
-        let root_digests = self
-            .epoch_store
-            .notify_read_executed_digests(&roots)
-            .in_monitored_scope("CheckpointNotifyDigests")
-            .await?;
-        let root_effects = self
-            .effects_store
-            .try_notify_read_executed_effects(&root_digests)
-            .in_monitored_scope("CheckpointNotifyRead")
-            .await?;
+        let mut tx_effects = Vec::new();
+        let mut tx_roots = HashSet::new();
 
-        let consensus_commit_prologue = {
-            // If the roots contains consensus commit prologue transaction, we want to
-            // extract it, and put it to the front of the checkpoint.
+        for pending_checkpoint in pending_checkpoints.into_iter() {
+            let pending = pending_checkpoint.into_v1();
+            debug!(
+                checkpoint_commit_height = pending.details.checkpoint_height,
+                roots = ?pending.roots,
+                "Resolving checkpoint transactions for pending checkpoint.",
+            );
 
-            let consensus_commit_prologue = self
-                .extract_consensus_commit_prologue(&root_digests, &root_effects)
+            let roots = &pending.roots;
+
+            self.metrics
+                .checkpoint_roots_count
+                .inc_by(roots.len() as u64);
+
+            let root_digests = self
+                .epoch_store
+                .notify_read_executed_digests(roots)
+                .in_monitored_scope("CheckpointNotifyDigests")
+                .await?;
+            let root_effects = self
+                .effects_store
+                .try_notify_read_executed_effects(&root_digests)
+                .in_monitored_scope("CheckpointNotifyRead")
                 .await?;
 
-            // Get the un-included dependencies of the consensus commit prologue. We should
-            // expect no other dependencies that haven't been included in any
-            // previous checkpoints.
-            if let Some((ccp_digest, ccp_effects)) = &consensus_commit_prologue {
-                let unsorted_ccp = self.complete_checkpoint_effects(
-                    vec![ccp_effects.clone()],
-                    effects_in_current_checkpoint,
-                )?;
+            let consensus_commit_prologue = {
+                // If the roots contains consensus commit prologue transaction, we want to
+                // extract it, and put it to the front of the checkpoint.
 
-                // No other dependencies of this consensus commit prologue that haven't been
-                // included in any previous checkpoint.
-                if unsorted_ccp.len() != 1 {
-                    fatal!(
-                        "Expected 1 consensus commit prologue, got {:?}",
-                        unsorted_ccp
-                            .iter()
-                            .map(|e| e.transaction_digest())
-                            .collect::<Vec<_>>()
-                    );
+                let consensus_commit_prologue = self
+                    .extract_consensus_commit_prologue(&root_digests, &root_effects)
+                    .await?;
+
+                // Get the un-included dependencies of the consensus commit prologue. We should
+                // expect no other dependencies that haven't been included in
+                // any previous checkpoints.
+                if let Some((ccp_digest, ccp_effects)) = &consensus_commit_prologue {
+                    let unsorted_ccp = self.complete_checkpoint_effects(
+                        vec![ccp_effects.clone()],
+                        &mut effects_in_current_checkpoint,
+                    )?;
+
+                    // No other dependencies of this consensus commit prologue that haven't been
+                    // included in any previous checkpoint.
+                    if unsorted_ccp.len() != 1 {
+                        fatal!(
+                            "Expected 1 consensus commit prologue, got {:?}",
+                            unsorted_ccp
+                                .iter()
+                                .map(|e| e.transaction_digest())
+                                .collect::<Vec<_>>()
+                        );
+                    }
+                    assert_eq!(unsorted_ccp.len(), 1);
+                    assert_eq!(unsorted_ccp[0].transaction_digest(), ccp_digest);
                 }
-                assert_eq!(unsorted_ccp.len(), 1);
-                assert_eq!(unsorted_ccp[0].transaction_digest(), ccp_digest);
+                consensus_commit_prologue
+            };
+
+            let unsorted =
+                self.complete_checkpoint_effects(root_effects, &mut effects_in_current_checkpoint)?;
+
+            let _scope = monitored_scope("CheckpointBuilder::causal_sort");
+            let mut sorted: Vec<TransactionEffects> = Vec::with_capacity(unsorted.len() + 1);
+            if let Some((_ccp_digest, ccp_effects)) = consensus_commit_prologue {
+                #[cfg(debug_assertions)]
+                {
+                    // When consensus_commit_prologue is extracted, it should not be included in the
+                    // `unsorted`.
+                    for tx in unsorted.iter() {
+                        assert!(tx.transaction_digest() != &_ccp_digest);
+                    }
+                }
+                sorted.push(ccp_effects);
             }
-            consensus_commit_prologue
-        };
+            sorted.extend(CausalOrder::causal_sort(unsorted));
 
-        let unsorted =
-            self.complete_checkpoint_effects(root_effects, effects_in_current_checkpoint)?;
-
-        let _scope = monitored_scope("CheckpointBuilder::causal_sort");
-        let mut sorted: Vec<TransactionEffects> = Vec::with_capacity(unsorted.len() + 1);
-        if let Some((_ccp_digest, ccp_effects)) = consensus_commit_prologue {
-            #[cfg(debug_assertions)]
+            #[cfg(msim)]
             {
-                // When consensus_commit_prologue is extracted, it should not be included in the
-                // `unsorted`.
-                for tx in unsorted.iter() {
-                    assert!(tx.transaction_digest() != &_ccp_digest);
-                }
+                // Check consensus commit prologue invariants in sim test.
+                self.expensive_consensus_commit_prologue_invariants_check(&root_digests, &sorted);
             }
-            sorted.push(ccp_effects);
-        }
-        sorted.extend(CausalOrder::causal_sort(unsorted));
 
-        #[cfg(msim)]
-        {
-            // Check consensus commit prologue invariants in sim test.
-            self.expensive_consensus_commit_prologue_invariants_check(&root_digests, &sorted);
+            tx_effects.extend(sorted);
+            tx_roots.extend(root_digests);
         }
 
-        Ok((root_digests, sorted))
+        Ok((tx_effects, tx_roots))
     }
 
     // This function is used to extract the consensus commit prologue digest and
@@ -2712,6 +2733,41 @@ impl CheckpointServiceNotify for CheckpointServiceNoop {
     fn notify_checkpoint(&self) -> IotaResult {
         Ok(())
     }
+}
+
+pin_project! {
+    pub struct PollCounter<Fut> {
+        #[pin]
+        future: Fut,
+        count: usize,
+    }
+}
+
+impl<Fut> PollCounter<Fut> {
+    pub fn new(future: Fut) -> Self {
+        Self { future, count: 0 }
+    }
+
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+impl<Fut: Future> Future for PollCounter<Fut> {
+    type Output = (usize, Fut::Output);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        *this.count += 1;
+        match this.future.poll(cx) {
+            Poll::Ready(output) => Poll::Ready((*this.count, output)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn poll_count<Fut>(future: Fut) -> PollCounter<Fut> {
+    PollCounter::new(future)
 }
 
 #[cfg(test)]

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -21,7 +21,7 @@ use futures::{
     pin_mut,
     stream::FuturesUnordered,
 };
-use iota_metrics::{GaugeGuard, GaugeGuardFutureExt, LATENCY_SEC_BUCKETS, spawn_monitored_task};
+use iota_metrics::{GaugeGuard, InflightGuardFutureExt, LATENCY_SEC_BUCKETS, spawn_monitored_task};
 use iota_simulator::anemo::PeerId;
 use iota_types::{
     base_types::{AuthorityName, TransactionDigest},
@@ -848,7 +848,7 @@ impl ConsensusAdapter {
             let _permit: SemaphorePermit = self
                 .submit_semaphore
                 .acquire()
-                .count_in_flight(&self.metrics.sequencing_in_flight_semaphore_wait)
+                .count_in_flight(self.metrics.sequencing_in_flight_semaphore_wait.clone())
                 .await
                 .expect("Consensus adapter does not close semaphore");
             let _in_flight_submission_guard =

--- a/crates/iota-core/src/consensus_manager/mod.rs
+++ b/crates/iota-core/src/consensus_manager/mod.rs
@@ -12,13 +12,13 @@ use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use fastcrypto::traits::KeyPair as _;
 use iota_config::{ConsensusConfig, NodeConfig};
-use iota_metrics::{RegistryID, RegistryService};
+use iota_metrics::RegistryService;
 use iota_protocol_config::ProtocolVersion;
 use iota_types::{committee::EpochId, error::IotaResult, messages_consensus::ConsensusTransaction};
 use prometheus_filtered::{IntGauge, Registry, register_int_gauge_with_registry};
-use starfish_core::ConsensusAuthority;
+use starfish_core::CommitConsumerMonitor;
 use tokio::{
-    sync::{Mutex, MutexGuard},
+    sync::{Mutex, MutexGuard, broadcast},
     time::{sleep, timeout},
 };
 use tracing::info;
@@ -54,7 +54,7 @@ pub trait ConsensusManagerTrait {
 
     async fn is_running(&self) -> bool;
 
-    fn replay_waiter(&self) -> Option<ReplayWaiter>;
+    fn replay_waiter(&self) -> ReplayWaiter;
 }
 
 /// Used by IOTA validator to start consensus protocol for each epoch.
@@ -122,7 +122,7 @@ impl ConsensusManagerTrait for ConsensusManager {
         self.starfish_manager.is_running().await
     }
 
-    fn replay_waiter(&self) -> Option<ReplayWaiter> {
+    fn replay_waiter(&self) -> ReplayWaiter {
         self.starfish_manager.replay_waiter()
     }
 }
@@ -184,18 +184,38 @@ impl ConsensusClient for UpdatableConsensusClient {
     }
 }
 
-#[derive(Clone)]
+/// Waits for consensus to finish replaying at consensus handler.
 pub struct ReplayWaiter {
-    authority: Arc<(ConsensusAuthority, RegistryID)>,
+    consumer_monitor_receiver: broadcast::Receiver<Arc<CommitConsumerMonitor>>,
 }
 
 impl ReplayWaiter {
-    pub(crate) fn new(authority: Arc<(ConsensusAuthority, RegistryID)>) -> Self {
-        Self { authority }
+    pub(crate) fn new(
+        consumer_monitor_receiver: broadcast::Receiver<Arc<CommitConsumerMonitor>>,
+    ) -> Self {
+        Self {
+            consumer_monitor_receiver,
+        }
     }
 
-    pub(crate) async fn wait_for_replay(&self) {
-        self.authority.0.replay_complete().await;
+    pub(crate) async fn wait_for_replay(mut self) {
+        loop {
+            info!("Waiting for consensus to start replaying ...");
+            let Ok(monitor) = self.consumer_monitor_receiver.recv().await else {
+                continue;
+            };
+            info!("Waiting for consensus handler to finish replaying ...");
+            monitor.replay_complete().await;
+            break;
+        }
+    }
+}
+
+impl Clone for ReplayWaiter {
+    fn clone(&self) -> Self {
+        Self {
+            consumer_monitor_receiver: self.consumer_monitor_receiver.resubscribe(),
+        }
     }
 }
 

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -18,7 +18,7 @@ use starfish_config::{Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use starfish_core::{
     Clock, CommitConsumer, CommitConsumerMonitor, CommitIndex, ConsensusAuthority,
 };
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, broadcast};
 use tracing::info;
 
 use crate::{
@@ -49,6 +49,7 @@ pub struct StarfishManager {
     client: Arc<LazyStarfishClient>,
     consensus_handler: Mutex<Option<StarfishConsensusHandler>>,
     consumer_monitor: ArcSwapOption<CommitConsumerMonitor>,
+    consumer_monitor_sender: broadcast::Sender<Arc<CommitConsumerMonitor>>,
 }
 
 impl StarfishManager {
@@ -63,6 +64,7 @@ impl StarfishManager {
         metrics: Arc<ConsensusManagerMetrics>,
         client: Arc<LazyStarfishClient>,
     ) -> Self {
+        let (consumer_monitor_sender, _) = broadcast::channel(1);
         Self {
             protocol_keypair: ProtocolKeyPair::new(protocol_keypair),
             network_keypair: NetworkKeyPair::new(network_keypair),
@@ -75,6 +77,7 @@ impl StarfishManager {
             consensus_handler: Mutex::new(None),
             boot_counter: Mutex::new(0),
             consumer_monitor: ArcSwapOption::empty(),
+            consumer_monitor_sender,
         }
     }
 
@@ -211,7 +214,7 @@ impl ConsensusManagerTrait for StarfishManager {
             last_processed_commit,
             consensus_handler,
             commit_receiver,
-            monitor,
+            monitor.clone(),
         );
 
         {
@@ -243,6 +246,9 @@ impl ConsensusManagerTrait for StarfishManager {
 
         // Initialize the client to send transactions to this Starfish instance.
         self.client.set(client);
+
+        // Send the consumer monitor to the replay waiter.
+        let _ = self.consumer_monitor_sender.send(monitor);
     }
 
     async fn shutdown(&self) {
@@ -278,8 +284,8 @@ impl ConsensusManagerTrait for StarfishManager {
         Running::False != *self.running.lock().await
     }
 
-    fn replay_waiter(&self) -> Option<ReplayWaiter> {
-        let authority = self.authority.load_full()?;
-        Some(ReplayWaiter::new(authority))
+    fn replay_waiter(&self) -> ReplayWaiter {
+        let consumer_monitor_receiver = self.consumer_monitor_sender.subscribe();
+        ReplayWaiter::new(consumer_monitor_receiver)
     }
 }

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -32,7 +32,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 use typed_store::{
     DBMapUtils, TypedStoreError,
-    rocks::{DBMap, MetricConf},
+    rocks::{
+        DBMap, DBMapTableConfigMap, MetricConf, bulk_ingestion_options,
+        bulk_ingestion_write_options,
+    },
     traits::Map,
 };
 
@@ -398,12 +401,13 @@ impl IndexStoreTables {
     fn open_with_options<P: Into<PathBuf>>(
         path: P,
         options: typed_store::rocksdb::Options,
+        table_options: Option<DBMapTableConfigMap>,
     ) -> Self {
         IndexStoreTables::open_tables_read_write(
             path.into(),
             MetricConf::new("grpc-index"),
             Some(options),
-            None,
+            table_options,
         )
     }
 
@@ -430,6 +434,7 @@ impl IndexStoreTables {
         &mut self,
         authority_store: &AuthorityStore,
         checkpoint_store: &CheckpointStore,
+        batch_size_limit: usize,
     ) -> Result<(), StorageError> {
         info!("Initializing gRPC indexes");
 
@@ -465,6 +470,7 @@ impl IndexStoreTables {
         let make_live_object_indexer = GrpcParLiveObjectSetIndexer {
             tables: self,
             coin_index: &coin_index,
+            batch_size_limit,
         };
 
         crate::par_index_live_object_set::par_index_live_object_set(
@@ -513,7 +519,9 @@ impl IndexStoreTables {
             self.index_epoch(&checkpoint_data, &mut batch)?;
             self.index_transactions(&checkpoint_data, &mut batch)?;
 
-            batch.write().map_err(StorageError::from)
+            batch
+                .write_opt(&bulk_ingestion_write_options())
+                .map_err(StorageError::from)
         })?;
 
         info!(
@@ -933,22 +941,44 @@ impl GrpcIndexesStore {
             // If the index tables are uninitialized or on an older version then we need to
             // populate them
             if tables.needs_to_do_initialization(checkpoint_store) {
+                let batch_size_limit;
                 let mut tables = {
                     drop(tables);
                     typed_store::rocks::safe_drop_db(path.clone(), Duration::from_secs(30))
                         .await
                         .expect("unable to destroy old gRPC index db");
 
-                    // Open the empty DB with `unordered_write`s enabled in order to get a ~3x
-                    // speedup when indexing
-                    let mut options = typed_store::rocksdb::Options::default();
-                    options.set_unordered_write(true);
-                    IndexStoreTables::open_with_options(&path, options)
+                    // Open the empty DB with tuned bulk ingestion options to
+                    // speed up the initial indexing. The DB is reopened with default options
+                    // afterwards.
+                    let bulk_options = bulk_ingestion_options();
+                    batch_size_limit = bulk_options.batch_size_limit;
+
+                    // Apply the per-column-family bulk options to every table.
+                    let mut table_config = BTreeMap::new();
+                    for table_name in IndexStoreTables::describe_tables().into_keys() {
+                        table_config.insert(table_name, bulk_options.column_family_options.clone());
+                    }
+
+                    IndexStoreTables::open_with_options(
+                        &path,
+                        bulk_options.db_options,
+                        Some(DBMapTableConfigMap::new(table_config)),
+                    )
                 };
 
                 tables
-                    .init(&authority_store, checkpoint_store)
+                    .init(&authority_store, checkpoint_store, batch_size_limit)
                     .expect("unable to initialize gRPC index");
+
+                // Flush all data to disk before dropping tables. This is critical because
+                // WAL is disabled for the bulk writes during initialization. Flushing any
+                // table flushes every column family of the shared underlying database, so
+                // one call covers all tables.
+                tables
+                    .meta
+                    .flush_all()
+                    .expect("gRPC index DB should be flushable after bulk ingestion");
 
                 let weak_db = Arc::downgrade(&tables.meta.db);
                 drop(tables);
@@ -965,7 +995,22 @@ impl GrpcIndexesStore {
                 }
 
                 // Reopen the DB with default options (eg without `unordered_write`s enabled)
-                IndexStoreTables::open(&path)
+                let reopened_tables = IndexStoreTables::open(&path);
+
+                // Sanity check: verify the database version was persisted correctly, i.e.
+                // the WAL-disabled bulk writes were flushed before the reopen.
+                let stored_version = reopened_tables
+                    .meta
+                    .get(&())
+                    .expect("reopened gRPC index DB should expose readable metadata")
+                    .expect("metadata should have been written before flush and reopen");
+                assert_eq!(
+                    stored_version.version, CURRENT_DB_VERSION,
+                    "database version mismatch after flush and reopen: expected {}, found {}",
+                    CURRENT_DB_VERSION, stored_version.version
+                );
+
+                reopened_tables
             } else {
                 tables
             }
@@ -1261,12 +1306,14 @@ fn try_create_package_version_info(
 struct GrpcParLiveObjectSetIndexer<'a> {
     tables: &'a IndexStoreTables,
     coin_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfo>>,
+    batch_size_limit: usize,
 }
 
 struct GrpcLiveObjectIndexer<'a> {
     tables: &'a IndexStoreTables,
     batch: typed_store::rocks::DBBatch,
     coin_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfo>>,
+    batch_size_limit: usize,
 }
 
 impl<'a> ParMakeLiveObjectIndexer for GrpcParLiveObjectSetIndexer<'a> {
@@ -1277,6 +1324,7 @@ impl<'a> ParMakeLiveObjectIndexer for GrpcParLiveObjectSetIndexer<'a> {
             tables: self.tables,
             batch: self.tables.owner.batch(),
             coin_index: self.coin_index,
+            batch_size_limit: self.batch_size_limit,
         }
     }
 }
@@ -1325,17 +1373,18 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
             );
         }
 
-        // If the batch size grows to greater that 128MB then write out to the DB so
-        // that the data we need to hold in memory doesn't grown unbounded.
-        if self.batch.size_in_bytes() >= 1 << 27 {
-            std::mem::replace(&mut self.batch, self.tables.owner.batch()).write()?;
+        // If the batch size grows beyond the limit then write out to the DB so
+        // that the data we need to hold in memory doesn't grow unbounded.
+        if self.batch.size_in_bytes() >= self.batch_size_limit {
+            std::mem::replace(&mut self.batch, self.tables.owner.batch())
+                .write_opt(&bulk_ingestion_write_options())?;
         }
 
         Ok(())
     }
 
     fn finish(self) -> Result<(), StorageError> {
-        self.batch.write()?;
+        self.batch.write_opt(&bulk_ingestion_write_options())?;
         Ok(())
     }
 }

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -173,9 +173,7 @@ pub async fn validate_and_resolve_conflicts(
         }
 
         // Check #2: Structural validity.
-        if let Err(e) =
-            transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())
-        {
+        if let Err(e) = transaction.validity_check(&epoch_store.tx_validity_check_context()) {
             warn!(
                 ?digest,
                 error = ?e,

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -41,7 +41,7 @@ pub async fn send_and_confirm_transaction(
 ) -> Result<(CertifiedTransaction, SignedTransactionEffects), IotaError> {
     // Make the initial request
     let epoch_store = authority.load_epoch_store_one_call_per_task();
-    transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+    transaction.validity_check(&epoch_store.tx_validity_check_context())?;
     let transaction = epoch_store.verify_transaction(transaction)?;
     let response = authority
         .handle_transaction(&epoch_store, transaction.clone())

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -698,7 +698,7 @@ where
         // inputs or `MoveAuthenticator`
         request
             .transaction
-            .validity_check(epoch_store.protocol_config(), epoch_store.epoch())
+            .validity_check(&epoch_store.tx_validity_check_context())
             .map_err(QuorumDriverError::InvalidTransaction)?;
         let transaction = epoch_store
             .verify_transaction(request.transaction.clone())

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -690,7 +690,7 @@ where
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.transaction.digest()))]
     pub async fn execute_transaction_impl(
         &self,
-        epoch_store: &AuthorityPerEpochStore,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
     ) -> Result<(VerifiedTransaction, QuorumDriverResponse), QuorumDriverError> {
@@ -731,7 +731,12 @@ where
         });
 
         let ticket = self
-            .submit(transaction.clone(), request, client_addr)
+            .submit(
+                epoch_store.clone(),
+                transaction.clone(),
+                request,
+                client_addr,
+            )
             .await
             .map_err(|e| {
                 warn!(?tx_digest, "QuorumDriverInternalError: {e:?}");
@@ -767,6 +772,7 @@ where
     #[instrument(name = "tx_orchestrator_submit", level = "trace", skip_all)]
     async fn submit(
         &self,
+        epoch_store: Arc<AuthorityPerEpochStore>,
         transaction: VerifiedTransaction,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
@@ -794,7 +800,8 @@ where
         let qd = self.clone_quorum_driver();
         Ok(async move {
             let digests = [tx_digest];
-            let effects_await = cache_reader.try_notify_read_executed_effects(&digests);
+            let effects_await = epoch_store
+                .within_alive_epoch(cache_reader.try_notify_read_executed_effects(&digests));
             // let-and-return necessary to satisfy borrow checker.
             let res = match select(ticket, effects_await.boxed()).await {
                 Either::Left((quorum_driver_response, _)) => Ok(quorum_driver_response),

--- a/crates/iota-metrics/Cargo.toml
+++ b/crates/iota-metrics/Cargo.toml
@@ -23,7 +23,7 @@ once_cell.workspace = true
 parking_lot.workspace = true
 scopeguard.workspace = true
 simple-server-timing-header = "0.1.1"
-sysinfo = "^0.33"
+sysinfo.workspace = true
 tap.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net"] }

--- a/crates/iota-metrics/src/guards.rs
+++ b/crates/iota-metrics/src/guards.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use prometheus_filtered::{IntGauge, IntGaugeVec};
+use prometheus_filtered::IntGauge;
 
 /// Increments gauge when acquired, decrements when guard drops
 pub struct GaugeGuard<'a>(&'a IntGauge);
@@ -30,103 +30,60 @@ impl Drop for GaugeGuard<'_> {
     }
 }
 
-/// Increments an `IntGaugeVec` for a set of label values when acquired,
-/// decrements the same labeled gauge when the guard drops.
-pub struct IntGaugeVecGuard<'a> {
-    gauge: &'a IntGaugeVec,
-    labels: Vec<String>,
-}
+/// Difference vs `GaugeGuard`: stores the gauge by value to avoid borrowing
+/// issues. Increments the gauge when acquired, decrements when the guard drops.
+pub struct InflightGuard(IntGauge);
 
-impl<'a> IntGaugeVecGuard<'a> {
-    /// Acquires the labeled gauge by incrementing it and retaining the label
-    /// values so the matching gauge can be decremented on drop.
-    pub fn acquire(gauge: &'a IntGaugeVec, labels: &[&str]) -> Self {
-        gauge.with_label_values(labels).inc();
-        let labels: Vec<String> = labels.iter().map(|s| s.to_string()).collect();
-        Self { gauge, labels }
+impl InflightGuard {
+    /// Acquires an `IntGauge` by incrementing its value and taking ownership of
+    /// the gauge so it can be decremented on drop.
+    pub fn acquire(g: IntGauge) -> Self {
+        g.inc();
+        Self(g)
     }
 }
 
-impl Drop for IntGaugeVecGuard<'_> {
-    /// Decrements the labeled gauge when the guard is dropped.
+impl Drop for InflightGuard {
+    /// Decrements the value of the `IntGauge` when the guard is dropped.
     fn drop(&mut self) {
-        self.gauge
-            .with_label_values(&self.labels.iter().map(|s| s.as_str()).collect::<Vec<_>>())
-            .dec();
+        self.0.dec();
     }
 }
 
-pub trait GaugeGuardFutureExt: Future + Sized {
+pub trait InflightGuardFutureExt: Future + Sized {
     /// Count number of in flight futures running
-    fn count_in_flight(self, g: &IntGauge) -> GaugeGuardFuture<'_, Self>;
-
-    /// Count number of in flight futures running, tracked on a labeled gauge.
-    fn count_in_flight_with_labels<'a>(
-        self,
-        g: &'a IntGaugeVec,
-        labels: &[&str],
-    ) -> IntGaugeVecGuardFuture<'a, Self>;
+    fn count_in_flight(self, g: IntGauge) -> InflightGuardFuture<Self>;
 }
 
-impl<F: Future> GaugeGuardFutureExt for F {
+impl<F: Future> InflightGuardFutureExt for F {
     /// Count number of in flight futures running.
-    fn count_in_flight(self, g: &IntGauge) -> GaugeGuardFuture<'_, Self> {
-        GaugeGuardFuture {
+    fn count_in_flight(self, g: IntGauge) -> InflightGuardFuture<Self> {
+        InflightGuardFuture {
             f: Box::pin(self),
-            _guard: GaugeGuard::acquire(g),
-        }
-    }
-
-    /// Count number of in flight futures running, tracked on a labeled gauge.
-    fn count_in_flight_with_labels<'a>(
-        self,
-        g: &'a IntGaugeVec,
-        labels: &[&str],
-    ) -> IntGaugeVecGuardFuture<'a, Self> {
-        IntGaugeVecGuardFuture {
-            f: Box::pin(self),
-            _guard: IntGaugeVecGuard::acquire(g, labels),
+            _guard: InflightGuard::acquire(g),
         }
     }
 }
 
-/// A struct that wraps a future (`f`) with a `GaugeGuard`. The
-/// `GaugeGuardFuture` is used to manage the lifecycle of a future while
-/// ensuring the associated `GaugeGuard` properly tracks the resource usage
+/// A struct that wraps a future (`f`) with an `InflightGuard`. The
+/// `InflightGuardFuture` is used to manage the lifecycle of a future while
+/// ensuring the associated `InflightGuard` properly tracks the resource usage
 /// during the future's execution. The guard increments the gauge
-/// when the future starts and decrements it when the `GaugeGuardFuture` is
+/// when the future starts and decrements it when the `InflightGuardFuture` is
 /// dropped.
-pub struct GaugeGuardFuture<'a, F: Sized> {
+pub struct InflightGuardFuture<F: Sized> {
     f: Pin<Box<F>>,
-    _guard: GaugeGuard<'a>,
+    _guard: InflightGuard,
 }
 
-impl<F: Future> Future for GaugeGuardFuture<'_, F> {
+impl<F: Future> Future for InflightGuardFuture<F> {
     type Output = F::Output;
 
     /// Polls the wrapped future (`f`) to determine its readiness. This function
     /// forwards the poll operation to the inner future, allowing the
-    /// `GaugeGuardFuture` to manage the polling lifecycle.
+    /// `InflightGuardFuture` to manage the polling lifecycle.
     /// Returns `Poll::Pending` if the future is not ready or `Poll::Ready` with
     /// the future's result if complete.
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.f.as_mut().poll(cx)
-    }
-}
-
-/// A struct that wraps a future (`f`) with an `IntGaugeVecGuard`. The labeled
-/// gauge is incremented when the future starts and decremented when the
-/// `IntGaugeVecGuardFuture` is dropped.
-pub struct IntGaugeVecGuardFuture<'a, F: Sized> {
-    f: Pin<Box<F>>,
-    _guard: IntGaugeVecGuard<'a>,
-}
-
-impl<F: Future> Future for IntGaugeVecGuardFuture<'_, F> {
-    type Output = F::Output;
-
-    /// Polls the wrapped future (`f`) to determine its readiness, forwarding
-    /// the poll to the inner future.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.f.as_mut().poll(cx)
     }

--- a/crates/iota-metrics/src/guards.rs
+++ b/crates/iota-metrics/src/guards.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use prometheus_filtered::IntGauge;
+use prometheus_filtered::{IntGauge, IntGaugeVec};
 
 /// Increments gauge when acquired, decrements when guard drops
 pub struct GaugeGuard<'a>(&'a IntGauge);
@@ -30,9 +30,42 @@ impl Drop for GaugeGuard<'_> {
     }
 }
 
+/// Increments an `IntGaugeVec` for a set of label values when acquired,
+/// decrements the same labeled gauge when the guard drops.
+pub struct IntGaugeVecGuard<'a> {
+    gauge: &'a IntGaugeVec,
+    labels: Vec<String>,
+}
+
+impl<'a> IntGaugeVecGuard<'a> {
+    /// Acquires the labeled gauge by incrementing it and retaining the label
+    /// values so the matching gauge can be decremented on drop.
+    pub fn acquire(gauge: &'a IntGaugeVec, labels: &[&str]) -> Self {
+        gauge.with_label_values(labels).inc();
+        let labels: Vec<String> = labels.iter().map(|s| s.to_string()).collect();
+        Self { gauge, labels }
+    }
+}
+
+impl Drop for IntGaugeVecGuard<'_> {
+    /// Decrements the labeled gauge when the guard is dropped.
+    fn drop(&mut self) {
+        self.gauge
+            .with_label_values(&self.labels.iter().map(|s| s.as_str()).collect::<Vec<_>>())
+            .dec();
+    }
+}
+
 pub trait GaugeGuardFutureExt: Future + Sized {
     /// Count number of in flight futures running
     fn count_in_flight(self, g: &IntGauge) -> GaugeGuardFuture<'_, Self>;
+
+    /// Count number of in flight futures running, tracked on a labeled gauge.
+    fn count_in_flight_with_labels<'a>(
+        self,
+        g: &'a IntGaugeVec,
+        labels: &[&str],
+    ) -> IntGaugeVecGuardFuture<'a, Self>;
 }
 
 impl<F: Future> GaugeGuardFutureExt for F {
@@ -41,6 +74,18 @@ impl<F: Future> GaugeGuardFutureExt for F {
         GaugeGuardFuture {
             f: Box::pin(self),
             _guard: GaugeGuard::acquire(g),
+        }
+    }
+
+    /// Count number of in flight futures running, tracked on a labeled gauge.
+    fn count_in_flight_with_labels<'a>(
+        self,
+        g: &'a IntGaugeVec,
+        labels: &[&str],
+    ) -> IntGaugeVecGuardFuture<'a, Self> {
+        IntGaugeVecGuardFuture {
+            f: Box::pin(self),
+            _guard: IntGaugeVecGuard::acquire(g, labels),
         }
     }
 }
@@ -64,6 +109,24 @@ impl<F: Future> Future for GaugeGuardFuture<'_, F> {
     /// `GaugeGuardFuture` to manage the polling lifecycle.
     /// Returns `Poll::Pending` if the future is not ready or `Poll::Ready` with
     /// the future's result if complete.
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.f.as_mut().poll(cx)
+    }
+}
+
+/// A struct that wraps a future (`f`) with an `IntGaugeVecGuard`. The labeled
+/// gauge is incremented when the future starts and decremented when the
+/// `IntGaugeVecGuardFuture` is dropped.
+pub struct IntGaugeVecGuardFuture<'a, F: Sized> {
+    f: Pin<Box<F>>,
+    _guard: IntGaugeVecGuard<'a>,
+}
+
+impl<F: Future> Future for IntGaugeVecGuardFuture<'_, F> {
+    type Output = F::Output;
+
+    /// Polls the wrapped future (`f`) to determine its readiness, forwarding
+    /// the poll to the inner future.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.f.as_mut().poll(cx)
     }

--- a/crates/iota-metrics/src/hardware_metrics.rs
+++ b/crates/iota-metrics/src/hardware_metrics.rs
@@ -173,7 +173,7 @@ impl HardwareMetrics {
         Self::uint_gauge(
             "cpu_core_count",
             "CPU core count (and labels: model,vendor_id,arch)",
-            system.physical_core_count().unwrap_or_default() as u64,
+            System::physical_core_count().unwrap_or_default() as u64,
             &[
                 Some(Self::label("model", Self::cpu_model(system))),
                 Some(Self::label("vendor_id", Self::cpu_vendor_id(system))),

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -171,7 +171,7 @@ pub struct ValidatorComponents {
     /// via a `Weak` reference; this handle exists purely for ownership clarity.
     soft_lock_sweep_handle: JoinHandle<()>,
     overload_notifier_handle: Option<JoinHandle<()>>,
-    consensus_manager: ConsensusManager,
+    consensus_manager: Arc<ConsensusManager>,
     consensus_store_pruner: ConsensusStorePruner,
     consensus_adapter: Arc<ConsensusAdapter>,
     soft_locks: Arc<PreConsensusSoftLocks>,
@@ -1224,13 +1224,13 @@ impl IotaNode {
             client.clone(),
             checkpoint_store.clone(),
         ));
-        let consensus_manager = ConsensusManager::new(
+        let consensus_manager = Arc::new(ConsensusManager::new(
             &config,
             consensus_config,
             registry_service,
             &validator_registry,
             client,
-        );
+        ));
 
         // This only gets started up once, not on every epoch. (Make call to remove
         // every epoch.)
@@ -1350,7 +1350,7 @@ impl IotaNode {
         epoch_store: Arc<AuthorityPerEpochStore>,
         state_sync_handle: state_sync::Handle,
         randomness_handle: randomness::Handle,
-        consensus_manager: ConsensusManager,
+        consensus_manager: Arc<ConsensusManager>,
         consensus_store_pruner: ConsensusStorePruner,
         global_state_hasher: Weak<GlobalStateHasher>,
         backpressure_manager: Arc<BackpressureManager>,
@@ -1410,25 +1410,39 @@ impl IotaNode {
             backpressure_manager,
         );
 
-        info!("Starting consensus manager");
+        info!("Starting consensus manager asynchronously");
 
-        consensus_manager
-            .start(
-                config,
+        // Spawn consensus startup asynchronously to avoid blocking other components
+        tokio::spawn({
+            let config = config.clone();
+            let epoch_store = epoch_store.clone();
+            let iota_tx_validator = IotaTxValidator::new(
                 epoch_store.clone(),
-                consensus_handler_initializer,
-                IotaTxValidator::new(
-                    epoch_store.clone(),
-                    checkpoint_service.clone(),
-                    state.transaction_manager().clone(),
-                    iota_tx_validator_metrics.clone(),
-                ),
-            )
-            .await;
-        let consensus_replay_waiter = consensus_manager.replay_waiter();
+                checkpoint_service.clone(),
+                state.transaction_manager().clone(),
+                iota_tx_validator_metrics.clone(),
+            );
+            let consensus_manager = consensus_manager.clone();
+            async move {
+                consensus_manager
+                    .start(
+                        &config,
+                        epoch_store,
+                        consensus_handler_initializer,
+                        iota_tx_validator,
+                    )
+                    .await;
+            }
+        });
+        let replay_waiter = consensus_manager.replay_waiter();
 
         info!("Spawning checkpoint service");
-        let checkpoint_service_tasks = checkpoint_service.spawn(consensus_replay_waiter).await;
+        let replay_waiter = if std::env::var("DISABLE_REPLAY_WAITER").is_ok() {
+            None
+        } else {
+            Some(replay_waiter)
+        };
+        let checkpoint_service_tasks = checkpoint_service.spawn(replay_waiter).await;
 
         let overload_notifier_handle = Self::start_overload_notifier(
             config,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1805,6 +1805,11 @@ impl TransactionDataAPI for TransactionData {
     }
 }
 
+pub struct TxValidityCheckContext<'a> {
+    pub config: &'a ProtocolConfig,
+    pub epoch: EpochId,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SenderSignedData(SizeOneVec<SenderSignedTransaction>);
 
@@ -2003,14 +2008,10 @@ impl SenderSignedData {
     /// Validate untrusted user transaction, including its size, input count,
     /// command count, etc.
     /// Returns the certificate serialised bytes size.
-    pub fn validity_check(
-        &self,
-        config: &ProtocolConfig,
-        epoch: EpochId,
-    ) -> Result<usize, IotaError> {
+    pub fn validity_check(&self, context: &TxValidityCheckContext<'_>) -> Result<usize, IotaError> {
         // Check that the features used by the user signatures are enabled on the
         // network.
-        self.check_user_signature_protocol_compatibility(config)?;
+        self.check_user_signature_protocol_compatibility(context.config)?;
 
         // CRITICAL!!
         // Users cannot send system transactions.
@@ -2027,7 +2028,7 @@ impl SenderSignedData {
         // Checks to see if the transaction has expired
         if match &tx_data.expiration() {
             TransactionExpiration::None => false,
-            TransactionExpiration::Epoch(exp_poch) => *exp_poch < epoch,
+            TransactionExpiration::Epoch(exp_poch) => *exp_poch < context.epoch,
             _ => unimplemented!(
                 "a new TransactionExpiration enum variant was added and needs to be handled"
             ),
@@ -2037,7 +2038,7 @@ impl SenderSignedData {
 
         // Enforce overall transaction size limit.
         let tx_size = self.serialized_size()?;
-        let max_tx_size_bytes = config.max_tx_size_bytes();
+        let max_tx_size_bytes = context.config.max_tx_size_bytes();
         fp_ensure!(
             tx_size as u64 <= max_tx_size_bytes,
             IotaError::UserInput {
@@ -2051,10 +2052,10 @@ impl SenderSignedData {
         );
 
         tx_data
-            .validity_check(config)
+            .validity_check(context.config)
             .map_err(Into::<IotaError>::into)?;
 
-        self.move_authenticators_validity_check(config)?;
+        self.move_authenticators_validity_check(context.config)?;
 
         Ok(tx_size)
     }

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -15,7 +15,7 @@ use starfish_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, Pro
 use tracing::{info, warn};
 
 use crate::{
-    CommitConsumer, CommitConsumerMonitor,
+    CommitConsumer,
     authority_service::AuthorityService,
     block_manager::BlockManager,
     block_verifier::SignedBlockVerifier,
@@ -46,7 +46,6 @@ pub struct ConsensusAuthority {
     transaction_client: Arc<TransactionClient>,
     header_synchronizer: Arc<HeaderSynchronizerHandle>,
     transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
-    commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     shard_reconstructor: Arc<ShardReconstructorHandle>,
     cordial_knowledge: Arc<CordialKnowledgeHandle>,
     regular_commit_syncer_handle: CommitSyncerHandle,
@@ -365,7 +364,6 @@ impl ConsensusAuthority {
             shard_reconstructor,
             cordial_knowledge,
             transactions_synchronizer,
-            commit_consumer_monitor,
             regular_commit_syncer_handle,
             fast_commit_syncer_handle,
             leader_timeout_handle,
@@ -471,10 +469,6 @@ impl ConsensusAuthority {
         self.transaction_client.clone()
     }
 
-    pub async fn replay_complete(&self) {
-        self.commit_consumer_monitor.replay_complete().await;
-    }
-
     #[cfg(test)]
     pub(crate) fn context(&self) -> &Arc<Context> {
         &self.context
@@ -537,7 +531,7 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::{
-        CommittedSubDag, block_header::GENESIS_ROUND, commit::CommitIndex,
+        CommitConsumerMonitor, CommittedSubDag, block_header::GENESIS_ROUND, commit::CommitIndex,
         transaction::NoopTransactionVerifier,
     };
 

--- a/crates/starfish/core/src/commit_consumer.rs
+++ b/crates/starfish/core/src/commit_consumer.rs
@@ -115,7 +115,7 @@ impl CommitConsumerMonitor {
         }
     }
 
-    pub(crate) async fn replay_complete(&self) {
+    pub async fn replay_complete(&self) {
         let highest_observed_commit_at_startup = self.highest_observed_commit_at_startup();
         let mut rx = self.highest_handled_commit.subscribe();
         loop {

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -17,11 +17,13 @@ eyre.workspace = true
 fastcrypto.workspace = true
 fdlimit = "0.2.1"
 hdrhistogram = "7.5.1"
+num_cpus.workspace = true
 once_cell.workspace = true
 ouroboros = "0.18"
 rand.workspace = true
 rocksdb = { version = "0.24.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf", "bindgen-runtime"] }
 serde.workspace = true
+sysinfo.workspace = true
 tap.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing.workspace = true

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -311,14 +311,63 @@ impl Database {
         }
     }
 
+    /// Flush the memtable of a single column family to SST files on disk.
+    pub(crate) fn flush_cf(&self, cf: &ColumnFamily) -> Result<(), TypedStoreError> {
+        match &self.storage {
+            Storage::Rocks(rocks) => {
+                let cf_name = cf.name();
+                if let Some(handle) = rocks.underlying.cf_handle(cf_name) {
+                    rocks.underlying.flush_cf(&handle).map_err(|e| {
+                        TypedStoreError::RocksDB(format!(
+                            "Failed to flush column family {cf_name}: {e}"
+                        ))
+                    })?;
+                }
+                Ok(())
+            }
+            // InMemory databases don't need flushing.
+            Storage::InMemory(_) => Ok(()),
+        }
+    }
+
+    /// Iterate all column families and flush the memtables of every column
+    /// family to SST files on disk.
+    pub fn flush_all(&self) -> Result<(), TypedStoreError> {
+        match &self.storage {
+            Storage::Rocks(rocks) => {
+                for cf_name in &rocks.cf_names {
+                    if let Some(cf) = rocks.underlying.cf_handle(cf_name) {
+                        rocks.underlying.flush_cf(&cf).map_err(|e| {
+                            TypedStoreError::RocksDB(format!(
+                                "Failed to flush column family {cf_name}: {e}"
+                            ))
+                        })?;
+                    }
+                }
+                Ok(())
+            }
+            // InMemory databases don't need flushing.
+            Storage::InMemory(_) => Ok(()),
+        }
+    }
+
     pub fn write(&self, batch: StorageWriteBatch) -> Result<(), TypedStoreError> {
+        self.write_opt(batch, &rocksdb::WriteOptions::default())
+    }
+
+    pub fn write_opt(
+        &self,
+        batch: StorageWriteBatch,
+        write_options: &rocksdb::WriteOptions,
+    ) -> Result<(), TypedStoreError> {
         fail_point!("batch-write-before");
         let ret = match (&self.storage, batch) {
             (Storage::Rocks(rocks), StorageWriteBatch::Rocks(batch)) => rocks
                 .underlying
-                .write(batch)
+                .write_opt(batch, write_options)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), StorageWriteBatch::InMemory(batch)) => {
+                // InMemory doesn't support write options.
                 db.write(batch);
                 Ok(())
             }
@@ -525,6 +574,17 @@ impl<K, V> DBMap<K, V> {
             &self.db_metrics,
             &self.write_sample_interval,
         )
+    }
+
+    /// Flush the memtable of this table's column family to SST files on disk.
+    pub fn flush(&self) -> Result<(), TypedStoreError> {
+        self.db.flush_cf(&self.column_family)
+    }
+
+    /// Iterate all column families and flush the memtables of every column
+    /// family to SST files on disk.
+    pub fn flush_all(&self) -> Result<(), TypedStoreError> {
+        self.db.flush_all()
     }
 
     pub fn compact_range<J: Serialize>(&self, start: &J, end: &J) -> Result<(), TypedStoreError> {
@@ -908,6 +968,13 @@ impl DBBatch {
     /// Consume the batch and write its operations to the database
     #[instrument(level = "trace", skip_all, err)]
     pub fn write(self) -> Result<(), TypedStoreError> {
+        self.write_opt(&rocksdb::WriteOptions::default())
+    }
+
+    /// Consume the batch and write its operations to the database with custom
+    /// write options
+    #[instrument(level = "trace", skip_all, err)]
+    pub fn write_opt(self, write_options: &rocksdb::WriteOptions) -> Result<(), TypedStoreError> {
         let db_name = self.database.db_name();
         let timer = self
             .db_metrics
@@ -922,7 +989,7 @@ impl DBBatch {
         } else {
             None
         };
-        self.database.write(self.batch)?;
+        self.database.write_opt(self.batch, write_options)?;
         self.db_metrics
             .op_metrics
             .rocksdb_batch_commit_bytes

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -27,7 +27,8 @@ use typed_store_error::TypedStoreError;
 pub use crate::{
     database::{DBBatch, DBMap, MetricConf},
     rocks::options::{
-        DBMapTableConfigMap, DBOptions, ReadWriteOptions, default_db_options, list_tables,
+        BulkIngestionOptions, DBMapTableConfigMap, DBOptions, ReadWriteOptions,
+        bulk_ingestion_options, bulk_ingestion_write_options, default_db_options, list_tables,
         read_size_from_env,
     },
 };
@@ -52,6 +53,8 @@ mod tests;
 #[derive(Debug)]
 pub(crate) struct RocksDB {
     pub(crate) underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
+    /// Names of all column families opened on this database.
+    pub(crate) cf_names: Vec<String>,
 }
 
 impl Drop for RocksDB {
@@ -125,6 +128,7 @@ pub fn open_cf_opts<P: AsRef<Path>>(
         let mut options = db_options.unwrap_or_else(|| default_db_options().options);
         options.create_if_missing(true);
         options.create_missing_column_families(true);
+        let cf_names: Vec<String> = cfs.iter().map(|(name, _)| name.clone()).collect();
         let rocksdb = {
             rocksdb::DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
                 &options,
@@ -137,6 +141,7 @@ pub fn open_cf_opts<P: AsRef<Path>>(
         Ok(Arc::new(Database::new(
             Storage::Rocks(RocksDB {
                 underlying: rocksdb,
+                cf_names,
             }),
             metric_conf,
         )))
@@ -200,9 +205,11 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
                 .map_err(typed_store_err_from_rocks_err)?;
             db
         };
+        let cf_names: Vec<String> = opt_cfs.keys().map(|name| name.to_string()).collect();
         Ok(Arc::new(Database::new(
             Storage::Rocks(RocksDB {
                 underlying: rocksdb,
+                cf_names,
             }),
             metric_conf,
         )))

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -5,8 +5,9 @@
 use std::{collections::BTreeMap, env};
 
 use rocksdb::{BlockBasedOptions, Cache, ReadOptions};
+use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 use tap::TapFallible;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 // Write buffer size per RocksDB instance can be set via the env var below.
 // If the env var is not set, use the default value in MiB.
@@ -56,6 +57,127 @@ impl ReadWriteOptions {
 pub struct DBOptions {
     pub options: rocksdb::Options,
     pub rw_options: ReadWriteOptions,
+}
+
+/// Write options tuned for one-shot bulk ingestion into a freshly created
+/// store.
+pub fn bulk_ingestion_write_options() -> rocksdb::WriteOptions {
+    let mut opts = rocksdb::WriteOptions::default();
+    opts.disable_wal(true);
+    opts
+}
+
+/// RocksDB options tuned for one-shot bulk ingestion into a freshly created
+/// store, e.g. initial index building, inserting the genesis snapshot, or
+/// restoring a formal snapshot.
+pub struct BulkIngestionOptions {
+    pub db_options: rocksdb::Options,
+    pub column_family_options: DBOptions,
+    pub batch_size_limit: usize,
+}
+
+pub fn bulk_ingestion_options() -> BulkIngestionOptions {
+    let total_memory_bytes = available_memory_bytes();
+    let num_cpus = num_cpus::get();
+
+    let mut db_options = rocksdb::Options::default();
+
+    // `unordered_write` gives a large speedup for bulk writes; relaxed write
+    // ordering is acceptable because the store is rebuilt from scratch on
+    // failure.
+    db_options.set_unordered_write(true);
+
+    // Allow CPU-intensive flushing to use all cores.
+    db_options.set_max_background_jobs(num_cpus as i32);
+
+    // Upper bound on memtable memory across all column families: 80% of RAM.
+    // Large memtables give flushing threads enough buffer to keep up with the
+    // writers so the CPUs stay busy.
+    let db_write_buffer_size = (total_memory_bytes as f64 * 0.8) as usize;
+    db_options.set_db_write_buffer_size(db_write_buffer_size);
+
+    // Per-column-family options: Create options with compactions disabled and large
+    // write buffers. Each CF can use up to 25% of system RAM, but total is
+    // still limited by set_db_write_buffer_size configured above.
+    let mut column_family_options = default_db_options();
+    column_family_options
+        .options
+        .set_disable_auto_compactions(true);
+
+    // Disable the write backpressure that kicks in as L0 files build up: `-1`
+    // turns off the compaction and slowdown triggers, and the stop trigger is
+    // pushed out of reach. These are per-column-family options, so they must be
+    // set here rather than on `db_options` to reach the index CFs. Compaction
+    // itself is disabled above, so no L0 files are ever compacted away.
+    column_family_options
+        .options
+        .set_level_zero_file_num_compaction_trigger(-1);
+    column_family_options
+        .options
+        .set_level_zero_slowdown_writes_trigger(-1);
+    column_family_options
+        .options
+        .set_level_zero_stop_writes_trigger(i32::MAX);
+
+    let cf_memory_budget = (total_memory_bytes as f64 * 0.25) as usize;
+    const MIN_BUFFER_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
+    // More CPUs means more parallel flushing capacity, so target more buffers,
+    // but never shrink a buffer below the minimum.
+    let target_buffer_count = num_cpus.max(2);
+    let buffer_size = (cf_memory_budget / target_buffer_count).max(MIN_BUFFER_SIZE);
+    let buffer_count = (cf_memory_budget / buffer_size).clamp(2, target_buffer_count) as i32;
+    column_family_options
+        .options
+        .set_write_buffer_size(buffer_size);
+    column_family_options
+        .options
+        .set_max_write_buffer_number(buffer_count);
+
+    // Calculate batch size limit: default to half the buffer size or 128MB,
+    // whichever is smaller
+    let batch_size_limit = (buffer_size / 2).min(1 << 27);
+
+    debug!(
+        total_memory_bytes,
+        num_cpus,
+        db_write_buffer_size,
+        buffer_size,
+        buffer_count,
+        batch_size_limit,
+        "configured bulk ingestion options"
+    );
+
+    BulkIngestionOptions {
+        db_options,
+        column_family_options,
+        batch_size_limit,
+    }
+}
+
+/// Available memory in bytes, honoring cgroup limits in containerized
+/// environments and falling back to total system memory.
+fn available_memory_bytes() -> u64 {
+    // `RefreshKind::nothing().with_memory(..)` avoids collecting other, slower
+    // stats.
+    let mut sys = System::new_with_specifics(
+        RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
+    );
+    sys.refresh_memory();
+
+    if let Some(cgroup_limits) = sys.cgroup_limits() {
+        // `total_memory` is 0 when there is no cgroup limit.
+        if cgroup_limits.total_memory > 0 {
+            debug!(
+                limit = cgroup_limits.total_memory,
+                "using cgroup memory limit"
+            );
+            return cgroup_limits.total_memory;
+        }
+    }
+
+    let total = sys.total_memory();
+    debug!(total, "using total system memory");
+    total
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
# Description of change

This PR contains a batch of core-protocol related upstream changes. The changes have been individually reviewed before squash-merging. None of them modify protocol parameters, so a new protocol version is not necessary.

## Links to any relevant issues

List of included PRs:
- #11887 
- #11916 
- #11925
- #11969
- #11928 
- #11990 
- #12021 
- #12051 
- #12001

Closes #11885

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)


