### PR TITLE
feat(graphql): wire archival fallback config and reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6266,6 +6266,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -43,6 +43,7 @@ toml.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+url.workspace = true
 uuid.workspace = true
 
 # internal dependencies

--- a/crates/iota-graphql-rpc/src/commands.rs
+++ b/crates/iota-graphql-rpc/src/commands.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use clap::*;
 
-use crate::config::{ConnectionConfig, Ide, TxExecFullNodeConfig};
+use crate::config::{ConnectionConfig, HistoricFallbackOptions, Ide, TxExecFullNodeConfig};
 
 #[derive(Parser)]
 #[command(name = "iota-graphql-rpc", about = "IOTA GraphQL RPC", author)]
@@ -28,6 +28,9 @@ pub enum Command {
 
         #[command(flatten)]
         connection: ConnectionConfig,
+
+        #[command(flatten)]
+        historic_fallback: Box<HistoricFallbackOptions>,
 
         /// Path to TOML file containing configuration for service.
         #[arg(short, long)]

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -8,6 +8,7 @@ use async_graphql::*;
 use iota_graphql_config::GraphQLConfig;
 use iota_names::config::IotaNamesConfig;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::functional_group::FunctionalGroup;
 
@@ -23,6 +24,7 @@ pub struct ServerConfig {
     pub internal_features: InternalFeatureConfig,
     pub tx_exec_full_node: TxExecFullNodeConfig,
     pub ide: Ide,
+    pub historic_fallback: HistoricFallbackOptions,
 }
 
 /// Configuration for connections for the RPC, passed in as command-line
@@ -64,6 +66,59 @@ pub struct ConnectionConfig {
         env = "MAX_AVAILABLE_RANGE",
     )]
     pub max_available_range: u64,
+}
+
+/// CLI options that control the archival fallback used when Postgres data has
+/// been pruned.
+#[GraphQLConfig]
+#[derive(clap::Args, Debug, Clone)]
+pub struct HistoricFallbackOptions {
+    #[arg(
+        long,
+        help = "Experimental: REST KV store URL for historic fallback. Depends on the iota-rest-kv API which is still being finalized."
+    )]
+    pub fallback_kv_url: Option<Url>,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_MULTI_FETCH_BATCH_SIZE,
+        env = "FALLBACK_KV_MULTI_FETCH_BATCH_SIZE",
+        help = "Experimental: Maximum number of keys per batch request to fallback KV store."
+    )]
+    pub fallback_kv_multi_fetch_batch_size: usize,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_CONCURRENT_FETCHES,
+        env = "FALLBACK_KV_CONCURRENT_FETCHES",
+        help = "Experimental: Maximum number of concurrent batch requests to fallback KV store."
+    )]
+    pub fallback_kv_concurrent_fetches: usize,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_CACHE_SIZE,
+        env = "FALLBACK_KV_CACHE_SIZE",
+        help = "Experimental: Cache size for historic fallback."
+    )]
+    pub fallback_kv_cache_size: u64,
+}
+
+impl HistoricFallbackOptions {
+    pub const DEFAULT_MULTI_FETCH_BATCH_SIZE: usize = 100;
+    pub const DEFAULT_CONCURRENT_FETCHES: usize = 10;
+    pub const DEFAULT_CACHE_SIZE: u64 = 100_000;
+}
+
+impl Default for HistoricFallbackOptions {
+    fn default() -> Self {
+        Self {
+            fallback_kv_url: None,
+            fallback_kv_multi_fetch_batch_size: Self::DEFAULT_MULTI_FETCH_BATCH_SIZE,
+            fallback_kv_concurrent_fetches: Self::DEFAULT_CONCURRENT_FETCHES,
+            fallback_kv_cache_size: Self::DEFAULT_CACHE_SIZE,
+        }
+    }
 }
 
 /// Configuration on features supported by the GraphQL service, passed in a

--- a/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use iota_indexer::{
     apis::GovernanceReadApi,
     db::ConnectionPoolConfig,
+    historical_fallback::HistoricalFallbackReader,
     metrics::IndexerMetrics,
     pruning::watermark_task::{WatermarkCache, WatermarkTask},
     read::IndexerReader,
@@ -17,9 +18,11 @@ use iota_types::{
     governance::StakedIota as NativeStakedIota,
     iota_system_state::iota_system_state_summary::IotaSystemStateSummary as NativeIotaSystemStateSummary,
 };
+use prometheus::Registry;
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
-use crate::error::Error;
+use crate::{config::HistoricFallbackOptions, error::Error};
 
 pub(crate) struct PgManager {
     pub inner: IndexerReader,
@@ -31,13 +34,17 @@ impl PgManager {
     }
 
     /// Create a new underlying reader, which is used by this type as well as
-    /// other data providers.
+    /// other data providers. If `historic_fallback` carries a URL, an archival
+    /// fallback reader is attached so reads can be served from the REST KV
+    /// store if Postgres data is pruned.
     pub(crate) fn reader_with_config(
         db_url: impl Into<String>,
         pool_size: u32,
         timeout_ms: u64,
         indexer_metrics: IndexerMetrics,
         cancellation_token: CancellationToken,
+        historic_fallback: &HistoricFallbackOptions,
+        registry: &Registry,
     ) -> Result<IndexerReader, Error> {
         let mut config = ConnectionPoolConfig::default();
         config.set_pool_size(pool_size);
@@ -56,7 +63,35 @@ impl PgManager {
         watermark_task.start(cancellation_token);
 
         // Create reader with watermark cache
-        Ok(IndexerReader::new(connection_pool, watermark_cache))
+        let mut reader = IndexerReader::new(connection_pool, watermark_cache);
+
+        if let HistoricFallbackOptions {
+            fallback_kv_url: Some(url),
+            fallback_kv_multi_fetch_batch_size,
+            fallback_kv_concurrent_fetches,
+            fallback_kv_cache_size,
+        } = historic_fallback
+        {
+            let fallback = HistoricalFallbackReader::new(
+                url.as_str(),
+                *fallback_kv_cache_size,
+                reader.package_resolver().clone(),
+                *fallback_kv_multi_fetch_batch_size,
+                *fallback_kv_concurrent_fetches,
+                registry,
+            )
+            .map_err(|e| {
+                Error::Internal(format!(
+                    "Failed to construct historical fallback reader: {e}"
+                ))
+            })?;
+            info!("HistoricalFallbackReader initialized with URL: {url}");
+            reader.with_fallback_reader(fallback);
+        } else {
+            info!("No config for HistoricalFallbackReader provided, skipping...");
+        }
+
+        Ok(reader)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/main.rs
+++ b/crates/iota-graphql-rpc/src/main.rs
@@ -53,6 +53,7 @@ async fn main() {
         Command::StartServer {
             ide,
             connection,
+            historic_fallback,
             config,
             tx_exec_full_node,
         } => {
@@ -69,6 +70,7 @@ async fn main() {
                 service: service_config,
                 ide,
                 tx_exec_full_node,
+                historic_fallback: *historic_fallback,
                 ..ServerConfig::default()
             };
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -447,8 +447,10 @@ impl ServerBuilder {
             config.service.limits.request_timeout_ms.into(),
             indexer_metrics.clone(),
             cancellation_token,
+            &config.historic_fallback,
+            &registry,
         )
-        .map_err(|e| Error::ServerInit(format!("Failed to create pg connection pool: {e}")))?;
+        .map_err(|e| Error::ServerInit(format!("Failed to initialize indexer reader: {e}")))?;
 
         if !config.connection.skip_migration_consistency_check {
             // Compatibility check
@@ -794,7 +796,7 @@ pub mod tests {
 
     use super::*;
     use crate::{
-        config::{ConnectionConfig, Limits, ServiceConfig, Version},
+        config::{ConnectionConfig, HistoricFallbackOptions, Limits, ServiceConfig, Version},
         context_data::db_data_provider::PgManager,
         extensions::{query_limits_checker::QueryLimitsChecker, timeout::Timeout},
         test_infra::cluster::Cluster,
@@ -810,12 +812,15 @@ pub mod tests {
         let connection_config = connection_config.unwrap_or_default();
         let service_config = service_config.unwrap_or_default();
 
+        let registry = prometheus::Registry::new();
         let reader = PgManager::reader_with_config(
             connection_config.db_url.clone(),
             connection_config.db_pool_size,
             service_config.limits.request_timeout_ms.into(),
-            IndexerMetrics::new(&prometheus::Registry::new()),
+            IndexerMetrics::new(&registry),
             CancellationToken::new(),
+            &HistoricFallbackOptions::default(),
+            &registry,
         )
         .expect("failed to create pg connection pool");
 

--- a/crates/iota-indexer/src/historical_fallback/mod.rs
+++ b/crates/iota-indexer/src/historical_fallback/mod.rs
@@ -12,3 +12,5 @@ pub(crate) mod client;
 pub(crate) mod convert;
 pub(crate) mod metrics;
 pub(crate) mod reader;
+
+pub use reader::HistoricalFallbackReader;

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -61,7 +61,7 @@ pub type OutputObjects = Vec<Object>;
 /// when the indexer is unable to fetch data from the database, which is
 /// especially useful when pruning is enabled.
 #[derive(Clone)]
-pub(crate) struct HistoricalFallbackReader {
+pub struct HistoricalFallbackReader {
     /// Client responsible for fetching data from the historical fallback
     /// storage through REST API interface.
     client: HttpRestKVClient,

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -199,7 +199,7 @@ impl IndexerReader {
     ///
     /// In case the IndexerReader fails to retrieve data, the fallback reader
     /// will be used to retrieve the data.
-    pub(crate) fn with_fallback_reader(&mut self, fallback: HistoricalFallbackReader) {
+    pub fn with_fallback_reader(&mut self, fallback: HistoricalFallbackReader) {
         self.fallback = Some(fallback);
     }
 


### PR DESCRIPTION
# Description of change

Add CLI/env options to configure KV client in graphql, analogous to how it is configured in iota-indexer.

Constructed client is attached to the Indexer Reader, to be used for actual fallback that will be introduced in subsequent PRs.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11932

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

  - [x] GraphQL: new optional CLI flags `--fallback-kv-url`, `--fallback-kv-multi-fetch-batch-size`, `--fallback-kv-concurrent-fetches`, `--fallback-kv-cache-size` for the archival fallback. Setting `--fallback-kv-url` enables fallback to KV store for data pruned from postgres DB.

