### PR TITLE
fix(starfish-core): await CommitObserver::new in core_thread test

### DIFF
--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -909,7 +909,8 @@ pub(crate) mod tests {
             dag_state.clone(),
             store.clone(),
             leader_schedule.clone(),
-        );
+        )
+        .await;
 
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         let mut block_receiver = signal_receivers.block_broadcast_receiver();


### PR DESCRIPTION
# Description of change

`CommitObserver::new` was made `async` in #11850, but the call site in the
`test_last_known_sync_wakes_threshold_clock_round` test (added in #11640) was
not updated to `.await` the call. As a result the `starfish-core` test build
fails to compile on `develop`.

This adds the missing `.await`, matching the sibling call site in the same file.

## Links to any relevant issues

N/A

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check -p starfish-core --tests` now compiles cleanly.
