### PR TITLE
fix(iota-core): deferred transactions get dropped next round as conflicting in pcool

### DIFF
--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -24,7 +24,9 @@
 //!    its locks, skips re-validation); not dropped. See issue #11649.
 //! 4. `validity_check()` — drop with error.
 //! 5. Three-tier lock conflict check (local HashMap → quarantine → DB) — drop
-//!    with error. Cheap; performed before expensive checks.
+//!    with error, except a lock held by the same transaction (a deferred tx's
+//!    own prior-round lock), which is exempt. Cheap; performed before expensive
+//!    checks.
 //! 6. `handle_transaction_validation_checks()` — drop with error. Only reached
 //!    when all locks are free.
 //! 7. All passed — acquire locks in the local tracking map, keep transaction.
@@ -209,6 +211,20 @@ pub async fn validate_and_resolve_conflicts(
             if let Some(locked_by) =
                 find_existing_lock(obj_ref, &current_commit_locks, epoch_store)?
             {
+                // A lock held by this same transaction is its own lock from a
+                // prior round: it acquired owned-object locks, was then deferred,
+                // and is reloaded this round. A self-held lock is NOT a conflict
+                // - without this guard, the transaction will be dropped with
+                // `ObjectLockConflict` and never executed. Issue #11649 mirrors
+                // this guard for the already-executed branch in Check #1.
+                //
+                // Note that same-commit duplicates cannot slip through here since
+                // Check #0 already dedups by digest, so a same-digest lock here
+                // is always this transaction's own prior-round lock.
+                if locked_by == digest {
+                    continue;
+                }
+
                 debug!(
                     ?digest,
                     ?obj_ref,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -7071,3 +7071,167 @@ async fn test_single_authority_reconfigure() {
     state.reconfigure_for_testing().await;
     assert_eq!(state.epoch_store_for_testing().epoch(), 1);
 }
+
+/// Regression test: a deferred transaction must be executed in a later round,
+/// not dropped.
+///
+/// A transaction acquires its owned-object locks when
+/// `validate_and_resolve_conflicts` first processes it in some round; if the
+/// transaction is deferred in that round, it is then reloaded and re-validated
+/// by the same function in a next round. The lock-conflict check used to treat
+/// the transaction's *own* prior-round lock as a conflict and drop it
+/// immediately in the next round, effectively breaking the core logic of the
+/// deferral machinery: a deferred transaction should eventually be executed or
+/// cancelled.
+///
+/// Deferral has more than one trigger (shared-object congestion, randomness not
+/// yet available); this test uses congestion as the lever because it is the
+/// simplest to force deterministically. Two transactions touch the same shared
+/// object in one commit; with a per-commit limit of one transaction per shared
+/// object and zero overshoot, the first executes and the second is deferred,
+/// then must execute in the next round instead of being dropped.
+///
+/// Driving the consensus handler commit-by-commit places both transactions in
+/// the same commit deterministically, independent of the simulator seed.
+#[sim_test]
+async fn test_pcool_deferred_tx_not_dropped_next_round_but_executed() {
+    telemetry_subscribers::init_for_testing();
+
+    let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
+
+    // One shared object both transactions contend on, plus a distinct gas coin
+    // each so the only contention is the shared object (congestion), not the gas.
+    let shared_objects = create_shared_objects(1);
+    let gas_objects = create_gas_objects(2, sender);
+
+    // Enable the P-COOL flow (where the bug lived) and force congestion-driven
+    // deferral: count each transaction as one unit of cost, allow only one unit
+    // per shared object per commit, and forbid any overshoot, so the second
+    // transaction touching the shared object in the same commit is deferred.
+    // Allow one deferral round so the deferred transaction has a next round to
+    // execute in, rather than being cancelled.
+    let mut protocol_config =
+        ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    protocol_config.set_enable_pcool_flow_for_testing(true);
+    protocol_config.set_per_object_congestion_control_mode_for_testing(
+        PerObjectCongestionControlMode::TotalTxCount,
+    );
+    protocol_config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(1);
+    protocol_config.set_max_congestion_limit_overshoot_per_commit_for_testing(0);
+    protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(1);
+
+    let authority = TestAuthorityBuilder::new()
+        .with_reference_gas_price(1000)
+        .with_protocol_config(protocol_config)
+        .build()
+        .await;
+    let mut genesis_objects = gas_objects.clone();
+    genesis_objects.extend(shared_objects.clone());
+    authority.insert_genesis_objects(&genesis_objects).await;
+
+    // Build two `UserTransactionV1` transactions touching the same shared object,
+    // each paid by a distinct gas coin. The move call is never executed (the
+    // consensus handler only schedules here), so a placeholder `set_value` call
+    // is enough to declare the shared-object input for congestion accounting.
+    let epoch_store = authority.epoch_store_for_testing();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    let make_user_tx = |gas_object: &Object| {
+        let data = TransactionData::new_move_call(
+            sender,
+            ObjectId::FRAMEWORK,
+            Identifier::from_static("object_basics"),
+            Identifier::from_static("set_value"),
+            vec![],
+            gas_object.object_ref(),
+            vec![
+                CallArg::Shared(SharedObjectRef::new(
+                    shared_objects[0].id(),
+                    OBJECT_START_VERSION,
+                    true,
+                )),
+                CallArg::Pure(16u64.to_le_bytes().to_vec()),
+            ],
+            rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
+            rgp,
+        )
+        .unwrap();
+        let tx = to_sender_signed_transaction(data, &keypair);
+        epoch_store.verify_transaction(tx).unwrap()
+    };
+    let tx1 = make_user_tx(&gas_objects[0]);
+    let tx2 = make_user_tx(&gas_objects[1]);
+    let tx1_digest = *tx1.digest();
+    let tx2_digest = *tx2.digest();
+
+    let seq = |tx: VerifiedTransaction| {
+        SequencedConsensusTransaction::new_test(ConsensusTransaction {
+            kind: ConsensusTransactionKind::UserTransactionV1(Box::new(tx.into())),
+            tracking_id: Default::default(),
+        })
+    };
+    let process = |txns: Vec<SequencedConsensusTransaction>| {
+        let authority = &authority;
+        async move {
+            authority
+                .epoch_store_for_testing()
+                .process_consensus_transactions_for_tests(
+                    txns,
+                    &Arc::new(CheckpointServiceNoop {}),
+                    authority.get_object_cache_reader().as_ref(),
+                    authority.get_transaction_cache_reader().as_ref(),
+                    &authority.metrics,
+                    true,
+                    authority,
+                )
+                .await
+                .unwrap()
+                .iter()
+                .map(|tx| *tx.digest())
+                .collect::<Vec<_>>()
+        }
+    };
+
+    // Round r: both transactions are sequenced in one commit.
+    // `validate_and_resolve_conflicts` sets owned-object (gas) locks for BOTH
+    // before congestion scheduling defers the second one.
+    let scheduled_r = process(vec![seq(tx1), seq(tx2)]).await;
+    assert_eq!(
+        scheduled_r,
+        vec![tx1_digest],
+        "only the first transaction executes in round r; the second is deferred"
+    );
+    assert_eq!(
+        authority
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .len(),
+        1,
+        "the second transaction must be deferred, not dropped"
+    );
+
+    // Round r+1: no new transactions. The deferred transaction is reloaded and
+    // re-validated, where it finds its OWN gas-coin lock from round r. With the
+    // self-exemption it survives and executes; without it, it is dropped as
+    // `ObjectLockConflict` and never executes.
+    let scheduled_r1 = process(vec![]).await;
+    assert_eq!(
+        scheduled_r1,
+        vec![tx2_digest],
+        "the deferred transaction must be executed in the next round, not dropped"
+    );
+    assert!(
+        authority
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .is_empty(),
+        "no transaction should remain deferred"
+    );
+    assert_eq!(
+        authority
+            .metrics
+            .consensus_handler_validation_dropped_transactions
+            .get(),
+        0,
+        "no transaction should be dropped during post-consensus validation"
+    );
+}

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -1309,7 +1309,9 @@ async fn double_spend_loser_excluded_from_checkpoint_roots() {
 // two places (via `find_existing_lock`):
 //   * Check #1 (already-executed branch): same digest = OK; different digest =
 //     `fatal!`.
-//   * Check #4 (conflict drop): any hit = drop with `ObjectLockConflict`.
+//   * Check #4 (conflict drop): a hit from a different digest = drop with
+//     `ObjectLockConflict`; a hit from the same digest (a deferred tx's own
+//     prior-round lock) is exempt and the tx is retained.
 //
 // The earlier tests cover Tier 1 (`current_commit_locks` HashMap within the
 // same commit). The tests below close the matrix by seeding Tier 2 (consensus
@@ -1541,6 +1543,65 @@ async fn run_same_digest_lock_retains_already_executed(tier: LockTier) {
             .try_is_tx_already_executed(&tx_digest)
             .unwrap()
     );
+}
+
+/// Body for the deferred-transaction self-lock case: a transaction that already
+/// holds its OWN lock in the given tier (from a prior consensus round in which
+/// it acquired owned-object locks and was then deferred for shared-object
+/// congestion) must NOT be dropped when it is reloaded and re-validated.
+/// Without the self-exemption in Check #4 it would conflict with its own lock,
+/// drop as `ObjectLockConflict`, and never execute.
+///
+/// Unlike the already-executed case (Check #1), the transaction is NOT executed
+/// here, so it flows through the full validation pass (Check #2-#5) and must
+/// survive end-to-end and re-acquire its locks.
+///
+/// Dedup by digest already runs upstream in Check #0, so a same-digest lock
+/// seen in Check #4 can only be this transaction's own prior-round lock (a
+/// deferred tx), never a same-commit duplicate.
+async fn run_self_lock_retains_deferred_tx(tier: LockTier) {
+    let setup = setup_lock_tier().await;
+
+    let tx = setup.make_tx();
+    let tx_digest = *tx.digest();
+
+    // Seed the tx's own lock into the tier, as round r would before deferral.
+    setup.seed_lock(tier, &tx);
+
+    let mut transactions = vec![make_user_tx_v1_verified(tx)];
+    let (dropped, locks) = post_consensus_validation::validate_and_resolve_conflicts(
+        &setup.authority,
+        &setup.epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        dropped.is_empty(),
+        "deferred tx must not self-conflict on its own prior-round lock"
+    );
+    assert_eq!(transactions.len(), 1, "deferred tx must be retained");
+    assert_eq!(
+        locks.get(&setup.object_ref),
+        Some(&tx_digest),
+        "deferred tx must re-acquire its own object lock"
+    );
+    assert_eq!(
+        locks.get(&setup.gas_ref),
+        Some(&tx_digest),
+        "deferred tx must re-acquire its own gas lock"
+    );
+}
+
+#[tokio::test]
+async fn tier2_quarantine_self_lock_retains_deferred_tx() {
+    run_self_lock_retains_deferred_tx(LockTier::Quarantine).await;
+}
+
+#[tokio::test]
+async fn tier3_persistent_self_lock_retains_deferred_tx() {
+    run_self_lock_retains_deferred_tx(LockTier::Persistent).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description of change

Under the P-COOL flow, a transaction acquires its owned-object locks in `validate_and_resolve_conflicts` when it is first processed there. If it is then deferred (shared-object congestion, or randomness not yet available), it is reloaded and re-validated in a later round. The lock-conflict check treated the transaction's own prior-round lock as a conflict and dropped it rather than rolling it to the next round, so deferred transactions were never executed. This bug effectively broke the core logic of the deferral machinery: a deferred transaction should eventually be executed or cancelled.

This PR provides the fix: skip the conflict when the existing lock is held by the same transaction. A same-digest lock can only be the transaction's own lock from an earlier round: `Check #0` in `validate_and_resolve_conflicts` already deduplicates by digest, so two different copies never reach this point (`Check #4`) in the same commit, and distinct transactions have distinct digests.

P-COOL has not been enabled on any network, so this is not live - no protocol feature flag needed. The bug must be fixed before P-COOL is turned on, since with `max_deferral_rounds >= 1`, it breaks the deferral path.

## Links to any relevant issues

## How the change has been tested

Added new tests (red without the fix):
  
- `post_consensus_validation_tests.rs`: deferred transacion holding its own lock in the quarantine / persistent-DB tier survives and re-acquires its locks.
  - ```shell
    cargo nextest run -p iota-core self_lock_retains_deferred_tx
    ```
- `authority_tests.rs`: drives the consensus handler over two commits with congestion-forced deferral; the deferred transaction executes in the next round instead of being dropped.
  - ```shell
    cargo simtest -p iota-core test_pcool_deferred_tx_not_dropped_next_round_but_executed
    ```

<!----->

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes