### PR TITLE
fix(docs): update framework reference anchors to new docgen format

### DIFF
--- a/docs/content/developer/iota-101/access-time.mdx
+++ b/docs/content/developer/iota-101/access-time.mdx
@@ -14,14 +14,14 @@ import questions from '/json/developer/iota-101/access-time.json';
 When you need to access network-based time for your transactions on IOTA, you have several options:
 
 - **Near Real-Time Measurement**: Use the immutable reference of time provided by the [`Clock`](../../developer/references/framework/iota/clock.mdx) module in Move. This value updates with every network checkpoint.
-- **Epoch Start Time**: Use the [`epoch_timestamp_ms`](../../developer/references/framework/iota/tx_context.mdx#function-epoch_timestamp_ms) function to capture the precise moment the current epoch started.
+- **Epoch Start Time**: Use the [`epoch_timestamp_ms`](../../developer/references/framework/iota/tx_context.mdx#iota_tx_context_epoch_timestamp_ms) function to capture the precise moment the current epoch started.
 
 ## Using the `iota::clock::Clock` Module
 
 To access a prompt timestamp, you can pass a read-only reference of [`iota::clock::Clock`](../../developer/references/framework/iota/clock.mdx) as an entry function parameter in your transactions.
 An instance of `Clock` is provided at the address `0x6`, and no new instances can be created.
 
-Use the [`timestamp_ms`](../../developer/references/framework/iota/clock.mdx#function-timestamp_ms) function from the `iota::clock` module to extract a Unix timestamp in milliseconds.
+Use the [`timestamp_ms`](../../developer/references/framework/iota/clock.mdx#iota_clock_timestamp_ms) function from the `iota::clock` module to extract a Unix timestamp in milliseconds.
 
 ```move file=<rootDir>/crates/iota-framework/packages/iota-framework/sources/clock.move#L29-L33
 ```
@@ -70,7 +70,7 @@ Here's a basic test that creates a `Clock`, increments it, and then checks its v
 ## Using Epoch Timestamps
 
 If you don't need a near real-time measurement,
-you can use the [`epoch_timestamp_ms`](../../developer/references/framework/iota/tx_context.mdx#function-epoch_timestamp_ms) function 
+you can use the [`epoch_timestamp_ms`](../../developer/references/framework/iota/tx_context.mdx#iota_tx_context_epoch_timestamp_ms) function 
 from the [`iota::tx_context`](../../developer/references/framework/iota/tx_context.mdx) module to access the timestamp for the start of the
 current epoch. This function works for all transactions, including those that do not go through consensus:
 

--- a/docs/content/developer/iota-101/create-coin/create-coin.mdx
+++ b/docs/content/developer/iota-101/create-coin/create-coin.mdx
@@ -29,7 +29,7 @@ You can send further transactions directly to `iota::coin::Coin` using the `Trea
 ## Extending the Coin Module
 
 To extend the coin module, add a `mint` function.
-This function utilizes the [`mint`](../../references/framework/iota/coin.mdx#function-mint) method from the `Coin` module
+This function utilizes the [`mint`](../../references/framework/iota/coin.mdx#iota_coin_mint) method from the `Coin` module
 to create a coin and transfer it to a specified address.
 
 ## IOTA CLI
@@ -63,7 +63,7 @@ If you need to restrict specific addresses from accessing your coin, consider im
 ## Creating a Regulated Coin
 
 To deny specific addresses from holding your coin,
-use the [`create_regulated_currency`](../../references/framework/iota/coin.mdx#function-create_regulated_currency_v1) function instead of [`create_currency`](../../references/framework/iota/coin.mdx#function-create_currency).
+use the [`create_regulated_currency`](../../references/framework/iota/coin.mdx#iota_coin_create_regulated_currency_v1) function instead of [`create_currency`](../../references/framework/iota/coin.mdx#iota_coin_create_currency).
 
 Internally, `create_regulated_currency` calls `create_currency` to create the coin
 and also produces a [`DenyCap`](../../references/framework/iota/coin.mdx#struct-denycapv1) object.
@@ -78,8 +78,8 @@ The `coin::create_currency` function ensures the uniqueness of the `TreasuryCap`
 
 You can mint and burn tokens using functions similar to those for coins, both requiring the `TreasuryCap`:
 
-- [`token::mint`](../../references/framework/iota/token.mdx#function-mint) — Mint a token.
-- [`token::burn`](../../references/framework/iota/token.mdx#function-burn) — Burn a token.
+- [`token::mint`](../../references/framework/iota/token.mdx#iota_token_mint) — Mint a token.
+- [`token::burn`](../../references/framework/iota/token.mdx#iota_token_burn) — Burn a token.
 
 For complete details on working with tokens, refer to the [Closed-Loop Token](../../standards/closed-loop-token.mdx) standard.
 

--- a/docs/content/developer/iota-101/create-coin/loyalty.mdx
+++ b/docs/content/developer/iota-101/create-coin/loyalty.mdx
@@ -37,7 +37,7 @@ These characteristics ensure the `LOYALTY` type has a single instance.
 
 The module's [`init` function](../move-overview/init.mdx) uses the `LOYALTY` OTW to create the token.
 Remember that all `init` functions run only once at the package publish event.
-The initializer function calls [`create_currency`](../../references/framework/iota/coin.mdx#function-create_currency)
+The initializer function calls [`create_currency`](../../references/framework/iota/coin.mdx#iota_coin_create_currency)
 using the `LOYALTY` type defined earlier.
 It also sets up a policy by sending both the [policy capability](../../references/framework/iota/token.mdx#struct-tokenpolicycap) 
 and the [treasury capability](../../references/framework/iota/coin.mdx#struct-treasurycap) to the address associated with the publish event.
@@ -50,8 +50,8 @@ The holder of these transferable capabilities can mint new `LOYALTY` tokens and 
 
 The `reward_user` function allows the holder of the `TreasuryCap` 
 to mint new loyalty tokens and send them to specified addresses.
-It uses the [`token::mint`](../../references/framework/iota/token.mdx#function-mint) function
-to create the tokens and [`token::transfer`](../../references/framework/iota/token.mdx#function-transfer) to deliver them to the intended recipients.
+It uses the [`token::mint`](../../references/framework/iota/token.mdx#iota_token_mint) function
+to create the tokens and [`token::transfer`](../../references/framework/iota/token.mdx#iota_token_transfer) to deliver them to the intended recipients.
 
 ```move file=<rootDir>/examples/move/token/sources/loyalty.move#L71-L81
 ```
@@ -60,7 +60,7 @@ to create the tokens and [`token::transfer`](../../references/framework/iota/tok
 
 Finally, the module includes a `buy_a_gift` function to handle the redemption of `LOYALTY` tokens for `Gift` items.
 This function ensures that the gift's price matches the number of loyalty tokens spent.
-It uses the [`token::spend`](../../references/framework/iota/token.mdx#function-spend) function to manage the treasury bookkeeping.
+It uses the [`token::spend`](../../references/framework/iota/token.mdx#iota_token_spend) function to manage the treasury bookkeeping.
 
 ```move file=<rootDir>/examples/move/token/sources/loyalty.move#L85-L100
 ```

--- a/docs/content/developer/iota-101/create-coin/migrate-to-coin-manager.mdx
+++ b/docs/content/developer/iota-101/create-coin/migrate-to-coin-manager.mdx
@@ -210,7 +210,7 @@ fun init(witness: MY_COIN_MANAGER, ctx: &mut TxContext) {
 
 ```
 
-However, since you are migrating from a `Coin`, you will use another constructor for `CoinManager`: [`CoinManager::new_with_immutable_metadata(cap,meta,ctx)`](../../references/framework/iota/coin_manager.mdx#function-new_with_immutable_metadata) if the metadata is already frozen, and [`CoinManager::new(cap,meta,ctx)`](../../references/framework/iota/coin_manager.mdx#function-new) if the metadata is mutable.
+However, since you are migrating from a `Coin`, you will use another constructor for `CoinManager`: [`CoinManager::new_with_immutable_metadata(cap,meta,ctx)`](../../references/framework/iota/coin_manager.mdx#iota_coin_manager_new_with_immutable_metadata) if the metadata is already frozen, and [`CoinManager::new(cap,meta,ctx)`](../../references/framework/iota/coin_manager.mdx#iota_coin_manager_new) if the metadata is mutable.
 
 In that case, `init` would have to take two extra parameters: the [`Coin`'s `CoinMetadata`](../../references/framework/iota/coin.mdx#struct-coinmetadata) object and the [`TreasuryCap`](../../references/framework/iota/coin.mdx#struct-treasurycap) object. IOTA's Move only allows `TxContext` and an optional Witness. There is no means to pass in the extra argument.
 

--- a/docs/content/developer/iota-101/create-coin/regulated.mdx
+++ b/docs/content/developer/iota-101/create-coin/regulated.mdx
@@ -13,11 +13,11 @@ Regulated coins on IOTA allow you to control access by restricting certain addre
 which is crucial for assets like stablecoins.
 These coins are similar to standard IOTA coins but provide additional control through a deny list.
 
-The IOTA [Coin](../../standards/coin.mdx) standard offers the [`create_regulated_currency`](../../references/framework/iota/coin.mdx#function-create_regulated_currency_v1) function
+The IOTA [Coin](../../standards/coin.mdx) standard offers the [`create_regulated_currency`](../../references/framework/iota/coin.mdx#iota_coin_create_regulated_currency_v1) function
 to create such coins.
 This function not only creates the coin but also generates a [`DenyCap`](../../references/framework/iota/coin.mdx#struct-denycapv1) object,
 \enabling you to manage a deny list via a [`DenyList`](../../references/framework/iota/deny_list.mdx) object.
-The process is akin to using [`create_currency`](../../references/framework/iota/coin.mdx#function-create_currency),
+The process is akin to using [`create_currency`](../../references/framework/iota/coin.mdx#iota_coin_create_currency),
 with the added step of handling the `DenyCap` object.
 
 ```move title="regcoin.move"

--- a/docs/content/developer/iota-101/move-overview/one-time-witness.mdx
+++ b/docs/content/developer/iota-101/move-overview/one-time-witness.mdx
@@ -19,7 +19,7 @@ A One-Time Witness (OTW) is a unique type in Move, specifically designed to ensu
 The only instance of this type is automatically passed to the module’s `init` function during the package’s publication, ensuring it cannot be created or instantiated elsewhere.
 
 To verify if a type can be used as a OTW,
-you can pass an instance of it to [`iota::types::is_one_time_witness`](../../references/framework/iota/types.mdx#function-is_one_time_witness).
+you can pass an instance of it to [`iota::types::is_one_time_witness`](../../references/framework/iota/types.mdx#iota_types_is_one_time_witness).
 
 
 

--- a/docs/content/developer/iota-101/move-overview/package-upgrades/custom-policies.mdx
+++ b/docs/content/developer/iota-101/move-overview/package-upgrades/custom-policies.mdx
@@ -446,7 +446,7 @@ Array [
 </details>
 
 
-You should use the IOTA Client CLI to call [`iota::package::make_immutable`](../../../references/framework/iota/package.mdx#function-make_immutable) on the
+You should use the IOTA Client CLI to call [`iota::package::make_immutable`](../../../references/framework/iota/package.mdx#iota_package_make_immutable) on the
 `UpgradeCap` to make the policy immutable.
 
 ```bash

--- a/docs/content/developer/iota-101/move-overview/package-upgrades/introduction.mdx
+++ b/docs/content/developer/iota-101/move-overview/package-upgrades/introduction.mdx
@@ -46,7 +46,7 @@ relying on a single key to manage upgrades can introduce significant security ri
 ## Making Packages Truly Immutable
 
 To eliminate the risks associated with single-key control, you can make your package _immutable_ after it is published.
-You can do this with the [`iota::package::make_immutable`](../../../references/framework/iota/package.mdx#function-make_immutable) function,
+You can do this with the [`iota::package::make_immutable`](../../../references/framework/iota/package.mdx#iota_package_make_immutable) function,
 which destroys the `UpgradeCap` associated with the package, preventing any future upgrades.
 However, making a package immutable also means that you lose the ability to fix bugs or introduce new features,
 so it should be done with caution.

--- a/docs/content/developer/iota-101/move-overview/package-upgrades/upgrade.mdx
+++ b/docs/content/developer/iota-101/move-overview/package-upgrades/upgrade.mdx
@@ -354,7 +354,7 @@ Use the `iota client upgrade` command to perform the package upgrade. Provide va
 
 Developers working with Move can define custom upgrade policies using available types and functions.
 For instance, you might want to prevent upgrades, regardless of the package owner.
-The [`make_immutable` function](../../../../developer/references/framework/iota/package.mdx#function-make_immutable) allows you 
+The [`make_immutable` function](../../../../developer/references/framework/iota/package.mdx#iota_package_make_immutable) allows you 
 to enforce this behavior.
 For more complex policies, you can leverage types like [`UpgradeTicket`](../../../../developer/references/framework/iota/package.mdx#struct-upgradeticket) and [`UpgradeReceipt`](../../../../developer/references/framework/iota/package.mdx#struct-upgradereceipt).
 

--- a/docs/content/developer/iota-101/move-overview/strings.mdx
+++ b/docs/content/developer/iota-101/move-overview/strings.mdx
@@ -51,11 +51,11 @@ To create a new UTF-8 `String` instance, you can use the `string::utf8` method.
 
 The UTF-8 `String` type provides several methods to work with strings. The most common operations include:
 
-* [`append`](../../references/framework/std/string.mdx#function-append).
-* [`append_utf8`](../../references/framework/std/string.mdx#function-append_utf8).
-* [`substring`](../../references/framework/std/string.mdx#function-sub_string).
-* [`length`](../../references/framework/std/string.mdx#function-length).
-* [`is_empty`](../../references/framework/std/string.mdx#function-is_empty).
+* [`append`](../../references/framework/std/string.mdx#std_string_append).
+* [`append_utf8`](../../references/framework/std/string.mdx#std_string_append_utf8).
+* [`substring`](../../references/framework/std/string.mdx#std_string_sub_string).
+* [`length`](../../references/framework/std/string.mdx#std_string_length).
+* [`is_empty`](../../references/framework/std/string.mdx#std_string_is_empty).
 
 Additionally, for custom string operations, the `as_bytes()` method can be used to access the underlying byte vector.
 
@@ -64,7 +64,7 @@ Additionally, for custom string operations, the `as_bytes()` method can be used 
 
 ### Safe UTF-8 Operations
 
-The default `utf8` method may abort if the bytes passed into it are not valid UTF-8. If you're unsure whether the bytes are valid, you should use the [`try_utf8`](../../references/framework/std/string.mdx#function-try_utf8) method instead. It returns an [`Option<String>`](../../references/framework/std/option.mdx#struct-option), which contains no value if the bytes are not valid UTF-8, and a `String` otherwise.
+The default `utf8` method may abort if the bytes passed into it are not valid UTF-8. If you're unsure whether the bytes are valid, you should use the [`try_utf8`](../../references/framework/std/string.mdx#std_string_try_utf8) method instead. It returns an [`Option<String>`](../../references/framework/std/option.mdx#struct-option), which contains no value if the bytes are not valid UTF-8, and a `String` otherwise.
 
 :::tip Try
 

--- a/docs/content/developer/iota-101/objects/dynamic-fields/dynamic-fields.mdx
+++ b/docs/content/developer/iota-101/objects/dynamic-fields/dynamic-fields.mdx
@@ -146,7 +146,7 @@ public fun mutate_child_via_parent(parent: &mut Parent) {
 
 In this example, `mutate_child` directly modifies a `Child` object, while `mutate_child_via_parent` accesses
 and modifies a `Child` object that has been added as a dynamic field in a `Parent` object
-using the [`borrow_mut`](../../../../developer/references/framework/iota/dynamic_field.mdx#function-borrow_mut) function.
+using the [`borrow_mut`](../../../../developer/references/framework/iota/dynamic_field.mdx#iota_dynamic_field_borrow_mut) function.
 
 :::tip
 
@@ -182,7 +182,7 @@ The [`iota::dynamic_object_field`](../../../../developer/references/framework/io
 :::
 
 Once removed, the value can be used like any other value. 
-For instance, you can [`delete`](../../../../developer/references/framework/iota/object.mdx#function-delete)
+For instance, you can [`delete`](../../../../developer/references/framework/iota/object.mdx#iota_object_delete)
 or [`transfer`](../../../../developer/references/framework/iota/transfer.mdx) a removed object:
 
 ```move

--- a/docs/content/developer/iota-101/objects/dynamic-fields/tables-bags.mdx
+++ b/docs/content/developer/iota-101/objects/dynamic-fields/tables-bags.mdx
@@ -34,7 +34,7 @@ public fun new<K: copy + drop + store, V: store>(
 
 A [`Table<K, V>`](../../../../developer/references/framework/iota/table.mdx) is a homogeneous map where all keys
 (`K`) and values (`V`) share the same type.
-These tables are created using [`iota::table::new`](../../../../developer/references/framework/iota/table.mdx#function-new),
+These tables are created using [`iota::table::new`](../../../../developer/references/framework/iota/table.mdx#iota_table_new),
 which requires a mutable transaction context (`&mut TxContext`).
 Because `Table` itself is an object, it can be transferred, shared, or wrapped like any other object.
 

--- a/docs/content/developer/iota-101/objects/object-ownership/address-owned.mdx
+++ b/docs/content/developer/iota-101/objects/object-ownership/address-owned.mdx
@@ -27,8 +27,8 @@ public fun transfer<T: key>(obj: T, recipient: address)
 public fun public_transfer<T: key + store>(obj: T, recipient: address)
 ```
 
-- Use [`iota::transfer::transfer`](../../../../developer/references/framework/iota/transfer.mdx#function-transfer) when defining a [custom transfer policy](../transfers/custom-rules.mdx) for the object.
-- Use [`iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#function-public_transfer) if the object has the `store` capability and you do not need a custom policy.
+- Use [`iota::transfer::transfer`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_transfer) when defining a [custom transfer policy](../transfers/custom-rules.mdx) for the object.
+- Use [`iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_transfer) if the object has the `store` capability and you do not need a custom policy.
 
 After creating an address-owned object, its ownership can change over time by transferring it,
 adding it as a dynamic object field, or making it immutable.

--- a/docs/content/developer/iota-101/objects/object-ownership/immutable.mdx
+++ b/docs/content/developer/iota-101/objects/object-ownership/immutable.mdx
@@ -18,7 +18,7 @@ Once an object is made immutable, it has no owner, making it accessible to anyon
 ### Using `public_freeze_object`
 
 To make an object immutable,
-use the [`transfer::public_freeze_object`](../../../../developer/references/framework/iota/transfer.mdx#function-public_freeze_object) function:
+use the [`transfer::public_freeze_object`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_freeze_object) function:
 
 ```move
 public native fun public_freeze_object<T: key>(obj: T);
@@ -48,12 +48,12 @@ Once frozen, the object is no longer owned by anyone and can never be altered.
 
 ### Using `public_freeze_object`
 
-The [`public_freeze_object`](../../../../developer/references/framework/iota/transfer.mdx#function-public_freeze_object) function requires the object
+The [`public_freeze_object`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_freeze_object) function requires the object
 to be passed by value.
 This ensures that after the function is called, no one can mutate the object,
 which would contradict its immutable status.
 
-Alternatively, you can create an immutable object directly upon its creation using the [`transfer::public_freeze_object`](../../../../developer/references/framework/iota/transfer.mdx#function-public_freeze_object) function:
+Alternatively, you can create an immutable object directly upon its creation using the [`transfer::public_freeze_object`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_freeze_object) function:
 
 ```move
 public fun create_immutable(red: u8, green: u8, blue: u8, ctx: &mut TxContext) {

--- a/docs/content/developer/iota-101/objects/object-ownership/object-ownership.mdx
+++ b/docs/content/developer/iota-101/objects/object-ownership/object-ownership.mdx
@@ -33,7 +33,7 @@ Immutable objects are especially useful when you need to ensure that the data re
 ## Shared Objects
 
 [Shared objects](shared.mdx) are made accessible to everyone on the network through the
-[`0x2::transfer::share_object`](../../../../developer/references/framework/iota/transfer.mdx#function-share_object) function.
+[`0x2::transfer::share_object`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_share_object) function.
 Unlike address-owned objects, shared objects are not restricted to a single owner and can be read or modified by any entity on the network.
 
 ## Wrapped Objects

--- a/docs/content/developer/iota-101/objects/object-ownership/shared.mdx
+++ b/docs/content/developer/iota-101/objects/object-ownership/shared.mdx
@@ -9,7 +9,7 @@ import Quiz from '@site/src/components/Quiz';
 import questions from '/json/developer/iota-101/objects/object-ownership/shared.json';
 
 A shared object is an object that is made accessible to everyone on the IOTA network using the 
-[`iota::transfer::share_object`](../../../../developer/references/framework/iota/transfer.mdx#function-share_object) function.
+[`iota::transfer::share_object`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_share_object) function.
 Unlike owned objects, which are restricted to a specific address, shared objects can be accessed by anyone.
 This extended accessibility can be advantageous for certain applications,
 but it also requires careful consideration of security, especially when sensitive operations are involved.

--- a/docs/content/developer/iota-101/objects/object-ownership/wrapped.mdx
+++ b/docs/content/developer/iota-101/objects/object-ownership/wrapped.mdx
@@ -139,7 +139,7 @@ public fun request_swap(
 
 In this function, the `Object` is passed by value, fully consuming it and wrapping it into a `SwapRequest`.
 The wrapper object is then sent to the service operator.
-The example also uses [`coin::into_balance`](../../../../developer/references/framework/iota/coin.mdx#function-into_balance)
+The example also uses [`coin::into_balance`](../../../../developer/references/framework/iota/coin.mdx#iota_coin_into_balance)
 to wrap the fee's [`Coin`](../../../../developer/references/framework/iota/coin.mdx) into a
 [`Balance`](../../../../developer/references/framework/iota/balance.mdx).
 
@@ -247,7 +247,7 @@ and passes a `sword` by value to wrap it into the `warrior`.
 
 Since `Sword` is an object type without `drop` ability,
 the warrior can't drop that sword if he's already equipped another.
-If you call [`option::fill`](../../../../developer/references/framework/std/option.mdx#function-fill) without checking and taking out the existing sword,
+If you call [`option::fill`](../../../../developer/references/framework/std/option.mdx#std_option_fill) without checking and taking out the existing sword,
 an error will occur.
 Therefore, `equip_sword` should start by checking whether there is already a sword equipped. If so, remove it out and send it back to the sender, in this case, the player's inventory.
 

--- a/docs/content/developer/iota-101/objects/shared-object-example.mdx
+++ b/docs/content/developer/iota-101/objects/shared-object-example.mdx
@@ -40,7 +40,7 @@ https://github.com/iotaledger/iota/blob/0494dad2b1d64c054795bac75342597e2eda1e9a
 
 This function deposits IOTA coins into `SharedCoins` by adding them to the `coins` array of `SharedCoins`.  
 Before using this function, ensure that some IOTA coins have been transferred to the address/object ID of the `SharedCoins` object.
-For the `coin` parameter, provide the address/object ID of the IOTA coin you transferred to `SharedCoins`. For further details, refer to [Receiving](../../../developer/references/framework/iota/transfer.mdx#struct-receiving) and [public_receive](../../../developer/references/framework/iota/transfer.mdx#function-public_receive).
+For the `coin` parameter, provide the address/object ID of the IOTA coin you transferred to `SharedCoins`. For further details, refer to [Receiving](../../../developer/references/framework/iota/transfer.mdx#struct-receiving) and [public_receive](../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_receive).
 
 ```move reference
 https://github.com/iotaledger/iota/blob/0494dad2b1d64c054795bac75342597e2eda1e9a/examples/move/transfer-to-shared-object/sources/shared_coins.move#L31-L38
@@ -48,7 +48,7 @@ https://github.com/iotaledger/iota/blob/0494dad2b1d64c054795bac75342597e2eda1e9a
 
 ### [`transfer_coin`](https://github.com/iotaledger/iota/blob/0494dad2b1d64c054795bac75342597e2eda1e9a/examples/move/transfer-to-shared-object/sources/shared_coins.move#L41-L48)
 
-This function transfers an IOTA coin to the specified `recipient` address. It removes the coin object from the `coins` array and utilizes the [`public_transfer`](../../../developer/references/framework/iota/transfer.mdx#function-public_transfer) function to complete the transfer.
+This function transfers an IOTA coin to the specified `recipient` address. It removes the coin object from the `coins` array and utilizes the [`public_transfer`](../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_transfer) function to complete the transfer.
 
 ```move reference
 https://github.com/iotaledger/iota/blob/0494dad2b1d64c054795bac75342597e2eda1e9a/examples/move/transfer-to-shared-object/sources/shared_coins.move#L41-L48

--- a/docs/content/developer/iota-101/objects/transfers/custom-rules.mdx
+++ b/docs/content/developer/iota-101/objects/transfers/custom-rules.mdx
@@ -12,14 +12,14 @@ Every IOTA object must have the `key` ability.
 The `store` ability, on the other hand, is optional and provides more flexibility for how objects are managed and transferred.
 Objects with the `store` ability:
 
-- Can be transferred by anyone using the[ `iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#function-public_transfer) function.
+- Can be transferred by anyone using the[ `iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_transfer) function.
 - Can be wrapped in other objects.
 
 However, when creating custom transfer rules,
 it's crucial to note that if an IOTA object `O` does not have the `store` ability,
 the `iota::transfer::public_transfer` function cannot be used to transfer it.
 Instead, the Move module defining `O` exclusively controls how such objects are transferred,
-typically using the [`iota::transfer::transfer`](../../../../developer/references/framework/iota/transfer.mdx#function-transfer) function.
+typically using the [`iota::transfer::transfer`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_transfer) function.
 This allows the module to implement custom transfer functions for `O`,
 which can enforce specific conditions (such as requiring a fee) before a transfer is allowed.
 
@@ -84,7 +84,7 @@ Now, the module provides two custom transfer rules for any object `O`:
 * One that allows transfer of locked objects only to the address `0xCAFE`.
  
 Because `O` lacks the `store` ability,
-these custom rules are the only ways to transfer `O`—the [`iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#function-public_transfer) function cannot be used.
+these custom rules are the only ways to transfer `O`—the [`iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_transfer) function cannot be used.
 
 By defining custom transfer rules, you maintain precise control over how and when your objects can be transferred,
 ensuring that your specific business logic is enforced during these operations.

--- a/docs/content/developer/iota-101/objects/transfers/transfer-to-object.mdx
+++ b/docs/content/developer/iota-101/objects/transfers/transfer-to-object.mdx
@@ -124,7 +124,7 @@ module iota::transfer {
 ### Key Concepts
 
 - **Receiving Argument:** Each `Receiving` argument in a PTB refers to an object of type `T` and is represented by [`iota::transfer::Receiving<T>`](../../../../developer/references/framework/iota/transfer.mdx#struct-receiving).
-- **Receiving an Object:** To receive the object, call the [`iota::transfer::receive`](../../../../developer/references/framework/iota/transfer.mdx#function-receive) function with a mutable reference to the parent object's `UID`. The module defining the parent object controls access and sets any restrictions on receiving the child object.
+- **Receiving an Object:** To receive the object, call the [`iota::transfer::receive`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_receive) function with a mutable reference to the parent object's `UID`. The module defining the parent object controls access and sets any restrictions on receiving the child object.
 - **Ownership Verification:** The system dynamically checks and enforces that the `UID` of the parent object actually owns the object referenced by the `Receiving` parameter.
 
 Because [`iota::transfer::Receiving`](../../../../developer/references/framework/iota/transfer.mdx#struct-receiving) has only the `drop` ability,
@@ -138,8 +138,8 @@ Similar to custom transfer policies, IOTA allows the definition of custom receiv
 
 ### Receiving Rules Based on Object Abilities
 
-- **Module-Specific Reception:** You can use the [`iota::transfer::receive`](../../../../developer/references/framework/iota/transfer.mdx#function-receive)  function only on objects defined in the same module where the `receive` call is made, similar to the [`iota::transfer::transfer`](../../../../developer/references/framework/iota/transfer.mdx#function-transfer)  function.
-- **Public Reception:** For objects that also have the `store` ability, anyone can use the [`iota::transfer::public_receive`](../../../../developer/references/framework/iota/transfer.mdx#function-public_receive)  function to receive them, akin to the [`iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#function-public_transfer) function.
+- **Module-Specific Reception:** You can use the [`iota::transfer::receive`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_receive)  function only on objects defined in the same module where the `receive` call is made, similar to the [`iota::transfer::transfer`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_transfer)  function.
+- **Public Reception:** For objects that also have the `store` ability, anyone can use the [`iota::transfer::public_receive`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_receive)  function to receive them, akin to the [`iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_transfer) function.
 
 This leads to the following matrix of permissions for receiving objects:
 
@@ -206,8 +206,8 @@ If you want to allow receiving sent objects from shared objects defined in a mod
 Otherwise, anyone could receive sent objects.
 
 Because the `receive_object` function is generic over the object being received, it can only receive objects that have both `key` and `store` abilities.
-`receive_object` must also use the [`iota::transfer::public_receive`](../../../../developer/references/framework/iota/transfer.mdx#function-public_receive)
-function to receive the object and not [`iota::transfer::receive`](../../../../developer/references/framework/iota/transfer.mdx#function-receive)
+`receive_object` must also use the [`iota::transfer::public_receive`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_receive)
+function to receive the object and not [`iota::transfer::receive`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_receive)
 because you can only use `receive` on objects defined in the current module.
 
 In this example, a shared object (`SharedObject`) holds a counter that anyone can increment,

--- a/docs/content/developer/iota-101/objects/transfers/transfers.mdx
+++ b/docs/content/developer/iota-101/objects/transfers/transfers.mdx
@@ -10,7 +10,7 @@ transferring them from one owner to another.
 IOTA allows you to define [custom transfer rules](custom-rules.mdx) for objects,
 specifying the conditions that must be satisfied for a transfer to be valid.
 However, note that objects with the `store` ability cannot have custom transfer rules,
-as this ability allows for unrestricted transfers using [`iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#function-public_transfer)
+as this ability allows for unrestricted transfers using [`iota::transfer::public_transfer`](../../../../developer/references/framework/iota/transfer.mdx#iota_transfer_public_transfer)
 or the `TransferObjects` transaction command.
 
 ## Transfer to Object

--- a/docs/content/developer/iota-101/objects/uid-id.mdx
+++ b/docs/content/developer/iota-101/objects/uid-id.mdx
@@ -30,7 +30,7 @@ public struct ID has store, drop {
 - IOTA Verifier will not allow using a UID that wasn't created in the same function. That prevents
   UIDs from being pre-generated and reused after the object was unpacked.
 
-You can create a new UID with the [`object::new(ctx)` function](../../../developer/references/framework/iota/object.mdx#function-new). It takes a mutable reference to TxContext,
+You can create a new UID with the [`object::new(ctx)` function](../../../developer/references/framework/iota/object.mdx#iota_object_new). It takes a mutable reference to TxContext,
 and returns a new UID.
 
 ```move
@@ -45,8 +45,8 @@ in this chapter.
 
 ## UID Lifecycle
 
-The `UID` type is created with the [`object::new(ctx)` function](../../../developer/references/framework/iota/object.mdx#function-new), and it is destroyed with the
-[`object::delete(uid)` function](../../../developer/references/framework/iota/object.mdx#function-delete). The `object::delete` consumes the UID _by value_, and it is
+The `UID` type is created with the [`object::new(ctx)` function](../../../developer/references/framework/iota/object.mdx#iota_object_new), and it is destroyed with the
+[`object::delete(uid)` function](../../../developer/references/framework/iota/object.mdx#iota_object_delete). The `object::delete` consumes the UID _by value_, and it is
 impossible to delete it unless the value was unpacked from an Object.
 
 ```move

--- a/docs/content/developer/iota-101/objects/versioning.mdx
+++ b/docs/content/developer/iota-101/objects/versioning.mdx
@@ -166,7 +166,7 @@ In contrast, a wrapped object's version remains unchanged.
 When you add a new dynamic field to a parent object,
 it creates a `Field` object that links the field name and value to the parent.
 Unlike other newly created objects,
-the ID for this `Field` instance is not generated using [`iota::object::new`](../../../developer/references/framework/iota/object.mdx#function-new).
+the ID for this `Field` instance is not generated using [`iota::object::new`](../../../developer/references/framework/iota/object.mdx#iota_object_new).
 Instead, it's computed as a hash of the parent object ID along with the field name’s type and value,
 allowing you to look up the `Field` via its parent and name.
 

--- a/docs/content/developer/iota-101/transactions/ptb/programmable-transaction-blocks.mdx
+++ b/docs/content/developer/iota-101/transactions/ptb/programmable-transaction-blocks.mdx
@@ -179,7 +179,7 @@ When borrowing arguments:
 
 #### Special Considerations
 
-- **Object Inputs**: For `ObjectArg::Receiving` inputs, the object type `T` is wrapped as [`iota::transfer::Receiving<T>`](../../../references/framework/iota/transfer.mdx#struct-receiving). You need to call [`iota::transfer::receive`](../../../references/framework/iota/transfer.mdx#function-receive) to prove ownership.
+- **Object Inputs**: For `ObjectArg::Receiving` inputs, the object type `T` is wrapped as [`iota::transfer::Receiving<T>`](../../../references/framework/iota/transfer.mdx#struct-receiving). You need to call [`iota::transfer::receive`](../../../references/framework/iota/transfer.mdx#iota_transfer_receive) to prove ownership.
 - **Gas Coin**: You can only use the gas coin by-value with the [`TransferObjects`](#transferobjects) command. This ensures that any remaining gas can be returned to it.
   - **Shared Objects**: Shared objects have restrictions to ensure they remain shared or are deleted by the end of the transaction. They cannot be unshared or wrapped.
    A shared object:

--- a/docs/content/developer/iota-101/using-events.mdx
+++ b/docs/content/developer/iota-101/using-events.mdx
@@ -54,7 +54,7 @@ First, import the `event` module in your Move code:
 use iota::event;
 ```
 
-Then, within your function, you can emit an event using the [`emit`](../../developer/references/framework/iota/event.mdx#function-emit) function. For example:
+Then, within your function, you can emit an event using the [`emit`](../../developer/references/framework/iota/event.mdx#iota_event_emit) function. For example:
 
 ```move file=<rootDir>/examples/trading/contracts/escrow/sources/lock.move#L42-L63
 ```

--- a/docs/content/developer/iota-move-ctf/challenge_5.mdx
+++ b/docs/content/developer/iota-move-ctf/challenge_5.mdx
@@ -23,13 +23,13 @@ Package: 0xa0fb6be5ee8585e7d512e73739657319dbfe3cb58817c062d0fd67335193fbd5
 ```
 
 :::tip
-The pizzaiolo uses [bcs::to_bytes](../references/framework/iota/bcs.mdx#function-to_bytes) to make sure the ingredients are in order. Make sure you understand how to use this function to pass the test.
+The pizzaiolo uses [bcs::to_bytes](../references/framework/iota/bcs.mdx#iota_bcs_to_bytes) to make sure the ingredients are in order. Make sure you understand how to use this function to pass the test.
 :::
 
 
 ## Related Articles
 Now that your are familiar with the basics of Move, this challenge will introduce a function from the iota-framework which you should be familiar with.
-After taking a look at the challenge's usage of [bcs::to_bytes](../references/framework/iota/bcs.mdx#function-to_bytes), we recommend you to take a look at the IOTA Framework documentation to understand how to use it in further challenges.
+After taking a look at the challenge's usage of [bcs::to_bytes](../references/framework/iota/bcs.mdx#iota_bcs_to_bytes), we recommend you to take a look at the IOTA Framework documentation to understand how to use it in further challenges.
 
 - [IOTA Framework](../references/framework/iota/bcs.mdx){/* TODO: Link to /iota instead */}
 

--- a/docs/content/developer/move/how-tos/account-abstraction/security/inputs-cryptographic-protection.mdx
+++ b/docs/content/developer/move/how-tos/account-abstraction/security/inputs-cryptographic-protection.mdx
@@ -17,7 +17,7 @@ This how-to explains the importance of cryptographically protecting all authenti
 
 ## The Vulnerability
 
-The content of a transaction can be cryptographically verified using the transaction digest (see [Function digest](../../../../references/framework/iota/tx_context.mdx#function-digest)). However, when this digest is created, the authenticator inputs are not included. 
+The content of a transaction can be cryptographically verified using the transaction digest (see [Function digest](../../../../references/framework/iota/tx_context.mdx#iota_tx_context_digest)). However, when this digest is created, the authenticator inputs are not included. 
 When implementing custom authenticator functions that accept additional input parameters (beyond just verifying the transaction), it's critical to include **all inputs** in the cryptographic verification. If an authenticator only verifies the transaction digest but doesn't cryptographically bind other input parameters (such as shared objects or raw values) to the signature, an attacker can swap those inputs after the signature was created.
 
 ## Attack Scenario

--- a/docs/content/developer/references/cli/ptb.mdx
+++ b/docs/content/developer/references/cli/ptb.mdx
@@ -194,7 +194,7 @@ To call a specific function from a specific package, you can use the following c
 
 ### Publish
 
-Publishing a package is one of the most important commands you need when working with IOTA. While the CLI has a standalone `publish` command, PTBs also support publishing and upgrading packages. One main difference is that with `iota client ptb`, you must explicitly transfer the `UpgradeCap` object that is returned when creating a package, or destroy it with a call to [`make_immutable`](../../iota-101/move-overview/package-upgrades/introduction.mdx). Here is an example on how to publish a Move project (from within its folder, that's why the path is ".") on chain using the `iota client ptb` command. It makes a call to the [`iota::tx_context::sender`](../framework/iota/tx_context.mdx#function-sender) to acquire the sender and assigns the result of that call to the `sender` variable, and then calls the publish command. The result of `publish` is bounded to `upgrade_cap` variable, and then this object is transferred to the sender. 
+Publishing a package is one of the most important commands you need when working with IOTA. While the CLI has a standalone `publish` command, PTBs also support publishing and upgrading packages. One main difference is that with `iota client ptb`, you must explicitly transfer the `UpgradeCap` object that is returned when creating a package, or destroy it with a call to [`make_immutable`](../../iota-101/move-overview/package-upgrades/introduction.mdx). Here is an example on how to publish a Move project (from within its folder, that's why the path is ".") on chain using the `iota client ptb` command. It makes a call to the [`iota::tx_context::sender`](../framework/iota/tx_context.mdx#iota_tx_context_sender) to acquire the sender and assigns the result of that call to the `sender` variable, and then calls the publish command. The result of `publish` is bounded to `upgrade_cap` variable, and then this object is transferred to the sender. 
 
 ```bash
 iota client ptb \
@@ -409,7 +409,7 @@ iota client ptb \
 
 :::note 
 
-Functions that return a reference, such as [`std::option::borrow`](../framework/std/option.mdx#function-borrow), cannot be used in a PTB call but only in a smart contract.
+Functions that return a reference, such as [`std::option::borrow`](../framework/std/option.mdx#std_option_borrow), cannot be used in a PTB call but only in a smart contract.
 
 :::
 

--- a/docs/content/developer/standards/closed-loop-token/tutorial.mdx
+++ b/docs/content/developer/standards/closed-loop-token/tutorial.mdx
@@ -7,7 +7,7 @@ A municipality aims to promote energy efficiency among households by distributin
 
 Let's dive right into it. We can start by minting a new token. Tokens are similar to [coins](../coin.mdx) in IOTA, but if you have read the prior articles, you already know that they can have their own [rules](rules.mdx) and [policies](token-policy.mdx).
 
-Since they share similarities with coins, we can start by creating an [`init` function](../../iota-101/move-overview/init.mdx) with an [OTW](../../iota-101/move-overview/one-time-witness.mdx) for our module and create a coin with a name, symbol, and description using [`coin::create_currency`](../../../developer/references/framework/iota/coin.mdx#function-create_currency):
+Since they share similarities with coins, we can start by creating an [`init` function](../../iota-101/move-overview/init.mdx) with an [OTW](../../iota-101/move-overview/one-time-witness.mdx) for our module and create a coin with a name, symbol, and description using [`coin::create_currency`](../../../developer/references/framework/iota/coin.mdx#iota_coin_create_currency):
 
 ```move file=<rootDir>/docs/examples/move/clt-tutorial/sources/clt_tutorial.move#L24-L33
 ```
@@ -42,7 +42,7 @@ This is relatively easy; we create a `gift_voucher` function that will mint the 
 ```move file=<rootDir>/docs/examples/move/clt-tutorial/sources/clt_tutorial.move#L65-L75
 ```
 
-As you can see, the [`token::transfer`](../../../developer/references/framework/iota/token.mdx#function-transfer) function returns an [`ActionRequest`](../../../developer/references/framework/iota/token.mdx#struct-actionrequest). This object can not be dropped, so without passing it to another function that destroys it, the contract wouldn't work.
+As you can see, the [`token::transfer`](../../../developer/references/framework/iota/token.mdx#iota_token_transfer) function returns an [`ActionRequest`](../../../developer/references/framework/iota/token.mdx#struct-actionrequest). This object can not be dropped, so without passing it to another function that destroys it, the contract wouldn't work.
 This means we have to confirm the transfer for which we have [multiple options](./action-request.mdx#approving-actions).
 
 In this case, as the caller of the `gift_voucher` function is the municipality, we can approve the action directly using our treasury capability, as shown in the last line of the `gift_voucher` function.
@@ -88,10 +88,10 @@ Next, add a function to add addresses to the rule configuration:
 ```move file=<rootDir>/docs/examples/move/clt-tutorial/sources/rules.move#L61-L75
 ```
 
-First, we check if the token policy already has a rule configuration. If not, we create a new one with [`token::add_rule_config`](../../../developer/references/framework/iota/token.mdx#function-add_rule_config)
+First, we check if the token policy already has a rule configuration. If not, we create a new one with [`token::add_rule_config`](../../../developer/references/framework/iota/token.mdx#iota_token_add_rule_config)
 passing the rule witness, the token policy and its capability, and a new [bag](../../../developer/references/framework/iota/bag.mdx) in which we want to store the addresses.
 
-Then we can get the mutable config with our `config_mut` helper function, which is just a wrapper of [`token::rule_config_mut.`](../../../developer/references/framework/iota/token.mdx#function-rule_config_mut).
+Then we can get the mutable config with our `config_mut` helper function, which is just a wrapper of [`token::rule_config_mut.`](../../../developer/references/framework/iota/token.mdx#iota_token_rule_config_mut).
 And as a last step, we add the address to our bag.
 
 :::note Bonus Task
@@ -143,7 +143,7 @@ And now we are back to our `buy_led_bulb` function. We can now verify/stamp the 
 ```
 
 In this tutorial we are returning the action request. We could also approve it right away. 
-So, in this case, we have to call the [`token_policy::confirm_request`](../../../developer/references/framework/iota/token.mdx#function-confirm_request) function in a [PTB](../../iota-101/transactions/ptb/programmable-transaction-blocks-overview.mdx) afterward, which will check the request for the approval stamp and make our TX succeed.
+So, in this case, we have to call the [`token_policy::confirm_request`](../../../developer/references/framework/iota/token.mdx#iota_token_confirm_request) function in a [PTB](../../iota-101/transactions/ptb/programmable-transaction-blocks-overview.mdx) afterward, which will check the request for the approval stamp and make our TX succeed.
 
 Now the shop owns the voucher, and the household just got a new energy-efficient LED bulb.
 

--- a/docs/content/developer/stardust/migration-process.mdx
+++ b/docs/content/developer/stardust/migration-process.mdx
@@ -100,7 +100,7 @@ the `owner` of `B` to the address of `A` (the Alias ID), which is equivalent to 
 the same as if `B` would have been transferred (using either of `iota::transfer::{transfer,public_transfer}`) to the
 address of `A` (the Alias ID). The migrated alias `A` can then _receive_ `B` using the
 `stardust::address_unlock_condition::unlock_alias_address_owned_basic` function, which is essentially a wrapper around
-[`iota::transfer::receive`](../../developer/references/framework/iota/transfer.mdx#function-receive). There are
+[`iota::transfer::receive`](../../developer/references/framework/iota/transfer.mdx#iota_transfer_receive). There are
 equivalent unlock functions for the other possible variants of object ownership.
 
 ## Basic Outputs

--- a/docs/content/developer/stardust/move-models.mdx
+++ b/docs/content/developer/stardust/move-models.mdx
@@ -169,9 +169,9 @@ that were owned by the `Alias Address` in Stardust are now owned by the `Alias` 
 functionality in the new move framework](../iota-101/objects/transfers/transfer-to-object.mdx#receiving-objects) that
  allows one to receive assets on the an `ObjectID` that is an `AliasID`. The following functions let an `Alias` receive
  other Stardust containers:
-  - [`unlock_alias_address_owned_basic`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_alias_address_owned_basic)
-  - [`unlock_alias_address_owned_alias`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_alias_address_owned_alias)
-  - [`unlock_alias_address_owned_nft`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_alias_address_owned_nft)
+  - [`unlock_alias_address_owned_basic`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_alias_address_owned_basic)
+  - [`unlock_alias_address_owned_alias`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_alias_address_owned_alias)
+  - [`unlock_alias_address_owned_nft`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_alias_address_owned_nft)
 
 ### Non-Fungible Tokens (NFTs)
 
@@ -181,9 +181,9 @@ that were owned by the `Nft Address` in Stardust are now owned by the `Nft` obje
 functionality in the new move framework](../iota-101/objects/transfers/transfer-to-object.mdx#receiving-objects) that
  allows one to receive assets on the an `ObjectID` that is an `NftID`. The following functions let an `Nft` receive
     other Stardust containers:
-    - [`unlock_nft_address_owned_basic`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_nft_address_owned_basic)
-    - [`unlock_nft_address_owned_alias`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_nft_address_owned_alias)
-    - [`unlock_nft_address_owned_nft`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_nft_address_owned_nft)
+    - [`unlock_nft_address_owned_basic`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_nft_address_owned_basic)
+    - [`unlock_nft_address_owned_alias`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_nft_address_owned_alias)
+    - [`unlock_nft_address_owned_nft`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_nft_address_owned_nft)
 
 ## Unlock Conditions
 
@@ -226,14 +226,14 @@ However, there are outputs in Stardust with such unlock conditions that are stil
 therefore makes sure that the storage deposit amount is returned to the original sender as a `Coin<IOTA>` object during the claiming process.
 
 The move model [`StorageDepositReturnUnlockCondition`](../references/framework/stardust/storage_deposit_return_unlock_condition.mdx#struct-storagedepositreturnunlockcondition)
-is added to the containers during the migration process where applicable. The [`unlock()`](../references/framework/stardust/storage_deposit_return_unlock_condition.mdx#function-unlock)
+is added to the containers during the migration process where applicable. The [`unlock()`](../references/framework/stardust/storage_deposit_return_unlock_condition.mdx#stardust_storage_deposit_return_unlock_condition_unlock)
 function is called when assets are extracted from the container, which will return the storage deposit to the sender.
 
 ### Timelock Unlock Condition
 
 A [stardust timelock](https://github.com/iotaledger/tips/blob/main/tips/TIP-0018/tip-0018.md#timelock-unlock-condition)
 locks funds until a certain time has passed. It is modeled in move via the [`TimelockUnlockCondition`](../references/framework/stardust/timelock_unlock_condition.mdx#struct-timelockunlockcondition)
-that is added to the containers during the migration process where applicable. The [`unlock()`](../references/framework/stardust/timelock_unlock_condition.mdx#function-unlock)
+that is added to the containers during the migration process where applicable. The [`unlock()`](../references/framework/stardust/timelock_unlock_condition.mdx#stardust_timelock_unlock_condition_unlock)
 function is called when assets are extracted from the container, which checks if the timelock has expired and if so, unlocks the container.
 
 :::info
@@ -255,7 +255,7 @@ in Stardust allows one to create a conditional transfer: if the recipient doesn'
 ownership is transferred back to the sender.
 
 In move, the expiration unlock condition is modeled via the [`ExpirationUnlockCondition`](../references/framework/stardust/expiration_unlock_condition.mdx#struct-expirationunlockcondition).
-The [`unlock()`](../references/framework/stardust/expiration_unlock_condition.mdx#function-unlock) function is called when assets are extracted from the container,
+The [`unlock()`](../references/framework/stardust/expiration_unlock_condition.mdx#stardust_expiration_unlock_condition_unlock) function is called when assets are extracted from the container,
 which checks if the expiration time has passed and if so, transfers the ownership back to the sender.
 
 :::info
@@ -353,7 +353,7 @@ The indexer API can also be queried for all objects owned by an address.
 
 There are two ways to interact with `BasicOutputs` in move:
 
-1. Call the [`extract_assets()`](../references/framework/stardust/basic_output#function-extract_assets) function on
+1. Call the [`extract_assets()`](../references/framework/stardust/basic_output#stardust_basic_output_extract_assets) function on
   the object, which checks the unlock conditions, returns the assets stored in them and deletes the container. The function signature
   of the `extract_assets()` function is:
   ```move
@@ -366,8 +366,8 @@ There are two ways to interact with `BasicOutputs` in move:
 2. Receive them on an `ObjectID` address. The [Receiving Objects](../iota-101/objects/transfers/transfer-to-object.mdx#receiving-objects)
   guide explains how to receive assets on an object. In the Stardust models the following two functions are used to receive `BasicOutputs`
   that were locked in the legacy network to `Alias` or `Nft` addresses:
-   - [`unlock_alias_address_owned_basic()`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_alias_address_owned_basic)
-   - [`unlock_nft_address_owned_basic()`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_nft_address_owned_basic)
+   - [`unlock_alias_address_owned_basic()`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_alias_address_owned_basic)
+   - [`unlock_nft_address_owned_basic()`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_nft_address_owned_basic)
 
    Once a `BasicOutput` was received on an `ObjectID` address, the `extract_assets()` function can be called on it to claim it.
 
@@ -434,10 +434,10 @@ The actual `Alias` asset that can be extracted from the `AliasOutput` container 
  - The `AliasId` is preserved as the `ObjectID` of the `Alias` object in move.
  - This `Alias` object owns all other containers or `Coins` that were owned by the `Alias Address` in Stardust. One can
    receive them via the following functions:
-    -  [`unlock_alias_address_owned_basic()`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_alias_address_owned_basic)
-    -  [`unlock_alias_address_owned_alias()`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_alias_address_owned_alias)
-    -  [`unlock_alias_address_owned_nft()`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_alias_address_owned_nft)
-    - For coins, use [transfer::public_receive()](../references/framework/iota/transfer#function-public_receive).
+    -  [`unlock_alias_address_owned_basic()`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_alias_address_owned_basic)
+    -  [`unlock_alias_address_owned_alias()`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_alias_address_owned_alias)
+    -  [`unlock_alias_address_owned_nft()`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_alias_address_owned_nft)
+    - For coins, use [transfer::public_receive()](../references/framework/iota/transfer#iota_transfer_public_receive).
 
 The `extract_assets()` function of the `AliasOutput` container looks the following:
 ```move
@@ -515,15 +515,15 @@ The actual Non-Fungible Token is represented in move as the following:
  - The `NftID` is preserved as the `ObjectID` of the `Nft` object in move.
  - This `Nft` object owns all other containers or `Coins` that were owned by the `Nft Address` in Stardust. One can
    receive them via the following functions:
-    -  [`unlock_nft_address_owned_basic()`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_nft_address_owned_basic)
-    -  [`unlock_nft_address_owned_alias()`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_nft_address_owned_alias)
-    -  [`unlock_nft_address_owned_nft()`](../references/framework/stardust/address_unlock_condition.mdx#function-unlock_nft_address_owned_nft)
-    - For coins, use [transfer::public_receive()](../references/framework/iota/transfer.mdx#function-public_receive).
+    -  [`unlock_nft_address_owned_basic()`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_nft_address_owned_basic)
+    -  [`unlock_nft_address_owned_alias()`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_nft_address_owned_alias)
+    -  [`unlock_nft_address_owned_nft()`](../references/framework/stardust/address_unlock_condition.mdx#stardust_address_unlock_condition_unlock_nft_address_owned_nft)
+    - For coins, use [transfer::public_receive()](../references/framework/iota/transfer.mdx#iota_transfer_public_receive).
  - The immutable metadata field has been standardized as [`Irc27Metadata`](../references/framework/stardust/irc27.mdx#struct-irc27metadata),
   which is a move struct that holds the metadata of the NFT. It is parsed from the Stardust output metadata during the migration process.
   If the metadata in Stardust does not follow the IRC-27 standard, or fields are missing, the migration script uses default values.
 
-The [`extract_assets()`](../references/framework/stardust/nft_output.mdx#function-extract_assets) function of the `NftOutput` container looks the following:
+The [`extract_assets()`](../references/framework/stardust/nft_output.mdx#stardust_nft_output_extract_assets) function of the `NftOutput` container looks the following:
 ```move
 public fun extract_assets<T>(output: nft_output::NftOutput<T>, ctx: &mut tx_context::TxContext): (balance::Balance<T>, bag::Bag, nft::Nft) { ... }
 ```

--- a/docs/content/developer/tutorials/simple-token-transfer.mdx
+++ b/docs/content/developer/tutorials/simple-token-transfer.mdx
@@ -76,10 +76,10 @@ cd ~/.iota/iota_config/
 #### [`init`](https://github.com/iota-community/token-transfer-tutorial/blob/ea71112c1156d1885567353fee0a03e09308e293/sources/token_transfer.move#L9-L13)
 
 - Executes at the time of publication of the package.
-- Takes `MY_TOKEN` as a witness and the transaction context ([ctx](https://docs.iota.org/developer/references/framework/iota/tx_context#0x2_tx_context_sender)).
-- Uses the [`coin::create_currency`](https://docs.iota.org/developer/references/framework/iota/coin#0x2_coin_create_currency) function to create the token by specifying the name, symbol, and decimal precision of the token.
-- The [`coin::create_currency`](https://docs.iota.org/developer/references/framework/iota/coin#0x2_coin_create_currency) function returns a TreasuryCap, which allows the owner to mint and transfer the token, and the metadata of the token.
-- Transfers the metadata to the owner of the contract using [`transfer::public_freeze_object(metadata)`](https://docs.iota.org/developer/references/framework/iota/transfer#0x2_transfer_public_freeze_object) and [`transfer::public_transfer(treasury, ctx.sender())`](https://docs.iota.org/developer/references/framework/iota/transfer#function-public_transfer).
+- Takes `MY_TOKEN` as a witness and the transaction context ([ctx](https://docs.iota.org/developer/references/framework/iota/tx_context#iota_tx_context_sender)).
+- Uses the [`coin::create_currency`](https://docs.iota.org/developer/references/framework/iota/coin#iota_coin_create_currency) function to create the token by specifying the name, symbol, and decimal precision of the token.
+- The [`coin::create_currency`](https://docs.iota.org/developer/references/framework/iota/coin#iota_coin_create_currency) function returns a TreasuryCap, which allows the owner to mint and transfer the token, and the metadata of the token.
+- Transfers the metadata to the owner of the contract using [`transfer::public_freeze_object(metadata)`](https://docs.iota.org/developer/references/framework/iota/transfer#iota_transfer_public_freeze_object) and [`transfer::public_transfer(treasury, ctx.sender())`](https://docs.iota.org/developer/references/framework/iota/transfer#iota_transfer_public_transfer).
 
 ```move reference
 https://github.com/iota-community/token-transfer-tutorial/blob/ea71112c1156d1885567353fee0a03e09308e293/sources/token_transfer.move#L9-L13
@@ -101,7 +101,7 @@ https://github.com/iota-community/token-transfer-tutorial/blob/ea71112c1156d1885
 
 - Transfers the token from the caller address to the recipient address.
 - Requires the correct token object address that is owned by the caller.
-- The function first uses the [`coin::split`](/developer/references/framework/iota/coin#function-split) function to split the specified amount from the token and then uses [`transfer::public_transfer`](https://docs.iota.org/developer/references/framework/iota/transfer#function-public_transfer) to transfer the split tokens to the recipient.
+- The function first uses the [`coin::split`](/developer/references/framework/iota/coin#iota_coin_split) function to split the specified amount from the token and then uses [`transfer::public_transfer`](https://docs.iota.org/developer/references/framework/iota/transfer#iota_transfer_public_transfer) to transfer the split tokens to the recipient.
 
 ```move reference
 https://github.com/iota-community/token-transfer-tutorial/blob/ea71112c1156d1885567353fee0a03e09308e293/sources/token_transfer.move#L25-L33
@@ -111,7 +111,7 @@ https://github.com/iota-community/token-transfer-tutorial/blob/ea71112c1156d1885
 
 - Returns the balance of the token for the specified owner.
 - Requires passing the token address to retrieve the balance.
-- Uses [`coin::balance`](https://docs.iota.org/developer/references/framework/iota/coin#function-balance) to query the balance and returns the value held by the coin object.
+- Uses [`coin::balance`](https://docs.iota.org/developer/references/framework/iota/coin#iota_coin_balance) to query the balance and returns the value held by the coin object.
 
 ```move reference
 https://github.com/iota-community/token-transfer-tutorial/blob/ea71112c1156d1885567353fee0a03e09308e293/sources/token_transfer.move#L34-L37

--- a/docs/content/operator/validator-node/cli-validator-command.mdx
+++ b/docs/content/operator/validator-node/cli-validator-command.mdx
@@ -174,7 +174,7 @@ At this point, you are a validator candidate and can start to accept self-stakin
 
 **If you haven't already, start a fullnode now to catch up with the network. When you officially join the committee but are not fully up-to-date, you cannot make meaningful contributions to the network and may be subject to peer reporting, hence face the risk of reduced staking rewards for you and your delegators.**
 
-Add stake to a validator's staking pool: https://docs.iota.org/developer/references/framework/iota_system/iota_system#function-request_add_stake
+Add stake to a validator's staking pool: https://docs.iota.org/developer/references/framework/iota_system/iota_system#iota_system_iota_system_request_add_stake
 
 Once you collect enough staking amount, run:
 


### PR DESCRIPTION
# Description of change

The Docusaurus docs build (`docusaurus / Lint, Build, and Test` and `wiki-preview`) is failing on `develop` — and therefore on every open PR — with `Docusaurus found broken anchors!`. The build sets `onBrokenAnchors: "throw"`, so a single dangling anchor fails it.

**Root cause:** #11537 ("feat(docs): group framework functions by visibility") reworked the Move documentation generator. As its description notes, it *"dropped the redundant `Function` heading prefix"* and switched function cross-reference anchors from `#function-<name>` to `#<package>_<module>_<name>` (emitted as explicit `<Link id="iota_coin_create_currency">` targets). The generated framework reference pages are fetched from the published docs tarball at build time, so once the regenerated docs were published, the ~33 hand-written pages still linking to the old `#function-*` anchors started failing the build. This is unrelated to any single feature PR — it breaks the docs build for everyone.

**Fix:** rewrite every stale framework function anchor to the new scheme, e.g.:

```
framework/iota/tx_context.mdx#function-epoch_timestamp_ms
  -> framework/iota/tx_context.mdx#iota_tx_context_epoch_timestamp_ms
framework/std/string.mdx#function-append
  -> framework/std/string.mdx#std_string_append
```

94 anchors across 33 pages. Also fixes 4 stale `#0x2_*` anchors in the simple-token-transfer tutorial (an even older format; these were written as absolute `https://docs.iota.org` URLs, so Docusaurus never anchor-checked them, but they were genuinely broken).

`#struct-<name>` anchors are intentionally **left unchanged** — they still resolve via the heading slug (`### struct \`TreasuryCap\`` → `struct-treasurycap`) and are not broken.

## Links to any relevant issues

Surfaced by CI on #11906; introduced by the docgen rework in #11537.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Specifically, I reproduced Docusaurus' anchor resolution locally against the current published framework reference docs (the mainnet docs tarball that the build downloads), computing each page's full anchor set from both explicit element ids and github-slugger heading slugs:

- Every one of the 94 rewritten anchors was verified to exist as a `<Link id="…">` target in the generated docs.
- A build-equivalent sweep of **all 240 internal framework anchor links** in `docs/content` reports **0 broken** after the change (and 0 stale external links remaining).

Final validation is the `docusaurus` build in CI.

### Release Notes

Documentation-only change (cross-reference anchors in `docs/content`). No protocol, node, indexer, JSON-RPC, GraphQL, CLI, Rust SDK, or gRPC behaviour changes, so no release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Q3qstfEEkghiQa28vJmLL

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q3qstfEEkghiQa28vJmLL)_