### PR TITLE
fix(iota-indexer): scope the watermark and the cursor pruning check to only the tables provided filter reads

### DIFF
--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1574,8 +1574,10 @@ impl IndexerReader {
         &self,
         filter: Option<&TransactionFilterKind>,
     ) -> IndexerResult<&'static [CommitterTables]> {
+        use CommitterTables::*;
+
         let Some(filter) = filter else {
-            return Ok(&[CommitterTables::Transactions]);
+            return Ok(&[Transactions]);
         };
         let tables: &'static [CommitterTables] = match filter {
             TransactionFilterKind::V1(TransactionFilter::MoveFunction {
@@ -1586,56 +1588,53 @@ impl IndexerReader {
                 function,
                 ..
             }) => match (module, function) {
-                (Some(_), Some(_)) => &[CommitterTables::TxCallsFun],
-                (Some(_), None) => &[CommitterTables::TxCallsMod],
+                (Some(_), Some(_)) => &[TxCallsFun, TxDigests],
+                (Some(_), None) => &[TxCallsMod, TxDigests],
                 (None, Some(_)) => {
                     return Err(IndexerError::InvalidArgument(
                         "Function cannot be present without Module.".into(),
                     ));
                 }
-                (None, None) => &[CommitterTables::TxCallsPkg],
+                (None, None) => &[TxCallsPkg, TxDigests],
             },
             TransactionFilterKind::V1(TransactionFilter::InputObject(_))
             | TransactionFilterKind::V2(TransactionFilterV2::InputObject(_)) => {
-                &[CommitterTables::TxInputObjects]
+                &[TxInputObjects, TxDigests]
             }
             TransactionFilterKind::V1(TransactionFilter::ChangedObject(_))
             | TransactionFilterKind::V2(TransactionFilterV2::ChangedObject(_)) => {
-                &[CommitterTables::TxChangedObjects]
+                &[TxChangedObjects, TxDigests]
             }
             TransactionFilterKind::V2(TransactionFilterV2::WrappedOrDeletedObject(_)) => {
-                &[CommitterTables::TxWrappedOrDeletedObjects]
+                &[TxWrappedOrDeletedObjects, TxDigests]
             }
             TransactionFilterKind::V1(TransactionFilter::FromAddress(_))
             | TransactionFilterKind::V2(TransactionFilterV2::FromAddress(_)) => {
-                &[CommitterTables::TxSenders]
+                &[TxSenders, TxDigests]
             }
             TransactionFilterKind::V1(TransactionFilter::ToAddress(_))
             | TransactionFilterKind::V2(TransactionFilterV2::ToAddress(_)) => {
-                &[CommitterTables::TxRecipients]
+                &[TxRecipients, TxDigests]
             }
             TransactionFilterKind::V1(TransactionFilter::FromAndToAddress { .. })
             | TransactionFilterKind::V2(TransactionFilterV2::FromAndToAddress { .. }) => {
-                &[CommitterTables::TxSenders, CommitterTables::TxRecipients]
+                &[TxSenders, TxRecipients, TxDigests]
             }
             TransactionFilterKind::V1(TransactionFilter::TransactionKind(_))
             | TransactionFilterKind::V2(TransactionFilterV2::TransactionKind(_))
             | TransactionFilterKind::V1(TransactionFilter::TransactionKindIn(_))
             | TransactionFilterKind::V2(TransactionFilterV2::TransactionKindIn(_)) => {
-                &[CommitterTables::TxKinds]
+                &[TxKinds, TxDigests]
             }
             // Served by dedicated fallback paths
             TransactionFilterKind::V1(TransactionFilter::Checkpoint(_))
-            | TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(_)) => &[
-                CommitterTables::Transactions,
-                CommitterTables::PrunerCpWatermark,
-            ],
+            | TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(_)) => {
+                &[Transactions, PrunerCpWatermark, TxDigests]
+            }
             TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { .. })
-            | TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { .. }) => &[
-                CommitterTables::TxSenders,
-                CommitterTables::TxRecipients,
-                CommitterTables::Transactions,
-            ],
+            | TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { .. }) => {
+                &[TxSenders, TxRecipients, TxDigests]
+            }
             // Unsupported V2-only filters error out in the query match.
             TransactionFilterKind::V2(_) => {
                 return Err(IndexerError::InvalidArgument(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1323,22 +1323,12 @@ impl IndexerReader {
                 .await;
         };
 
-        // All transaction-related tables that could be used by any filter
-        let tx_tables = [
-            CommitterTables::Transactions,
-            CommitterTables::TxCallsFun,
-            CommitterTables::TxCallsMod,
-            CommitterTables::TxCallsPkg,
-            CommitterTables::TxInputObjects,
-            CommitterTables::TxChangedObjects,
-            CommitterTables::TxWrappedOrDeletedObjects,
-            CommitterTables::TxSenders,
-            CommitterTables::TxRecipients,
-            CommitterTables::TxKinds,
-        ];
+        // scope the watermark and the cursor pruning check to only the tables this
+        // filter reads.
+        let tx_tables = self.tx_tables_for_filter(filter.as_ref())?;
         let min_available_tx = self
             .watermark_cache
-            .get_lowest_available_tx_for_tables(&tx_tables)
+            .get_lowest_available_tx_for_tables(tx_tables)
             .unwrap_or(0);
 
         let cursor_tx_seq = if let Some(cursor) = cursor {
@@ -1346,7 +1336,7 @@ impl IndexerReader {
                 .db()
                 .resolve_cursor_tx_digest_to_seq_num(cursor)
                 .await?;
-            self.ensure_data_not_pruned_for_tx(tx_seq, &tx_tables)?;
+            self.ensure_data_not_pruned_for_tx(tx_seq, tx_tables)?;
             Some(tx_seq)
         } else {
             None
@@ -1571,6 +1561,89 @@ impl IndexerReader {
             Some(is_descending),
         )
         .await
+    }
+
+    /// Returns the minimal set of tables read by [`TransactionFilterKind`],
+    /// used to scope both the `min_available_tx` watermark and the cursor
+    /// pruning check.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the filter is not supported.
+    fn tx_tables_for_filter(
+        &self,
+        filter: Option<&TransactionFilterKind>,
+    ) -> IndexerResult<&'static [CommitterTables]> {
+        let Some(filter) = filter else {
+            return Ok(&[CommitterTables::Transactions]);
+        };
+        let tables: &'static [CommitterTables] = match filter {
+            TransactionFilterKind::V1(TransactionFilter::MoveFunction {
+                module, function, ..
+            })
+            | TransactionFilterKind::V2(TransactionFilterV2::MoveFunction {
+                module,
+                function,
+                ..
+            }) => match (module, function) {
+                (Some(_), Some(_)) => &[CommitterTables::TxCallsFun],
+                (Some(_), None) => &[CommitterTables::TxCallsMod],
+                (None, Some(_)) => {
+                    return Err(IndexerError::InvalidArgument(
+                        "Function cannot be present without Module.".into(),
+                    ));
+                }
+                (None, None) => &[CommitterTables::TxCallsPkg],
+            },
+            TransactionFilterKind::V1(TransactionFilter::InputObject(_))
+            | TransactionFilterKind::V2(TransactionFilterV2::InputObject(_)) => {
+                &[CommitterTables::TxInputObjects]
+            }
+            TransactionFilterKind::V1(TransactionFilter::ChangedObject(_))
+            | TransactionFilterKind::V2(TransactionFilterV2::ChangedObject(_)) => {
+                &[CommitterTables::TxChangedObjects]
+            }
+            TransactionFilterKind::V2(TransactionFilterV2::WrappedOrDeletedObject(_)) => {
+                &[CommitterTables::TxWrappedOrDeletedObjects]
+            }
+            TransactionFilterKind::V1(TransactionFilter::FromAddress(_))
+            | TransactionFilterKind::V2(TransactionFilterV2::FromAddress(_)) => {
+                &[CommitterTables::TxSenders]
+            }
+            TransactionFilterKind::V1(TransactionFilter::ToAddress(_))
+            | TransactionFilterKind::V2(TransactionFilterV2::ToAddress(_)) => {
+                &[CommitterTables::TxRecipients]
+            }
+            TransactionFilterKind::V1(TransactionFilter::FromAndToAddress { .. })
+            | TransactionFilterKind::V2(TransactionFilterV2::FromAndToAddress { .. }) => {
+                &[CommitterTables::TxSenders, CommitterTables::TxRecipients]
+            }
+            TransactionFilterKind::V1(TransactionFilter::TransactionKind(_))
+            | TransactionFilterKind::V2(TransactionFilterV2::TransactionKind(_))
+            | TransactionFilterKind::V1(TransactionFilter::TransactionKindIn(_))
+            | TransactionFilterKind::V2(TransactionFilterV2::TransactionKindIn(_)) => {
+                &[CommitterTables::TxKinds]
+            }
+            // Served by dedicated fallback paths
+            TransactionFilterKind::V1(TransactionFilter::Checkpoint(_))
+            | TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(_)) => &[
+                CommitterTables::Transactions,
+                CommitterTables::PrunerCpWatermark,
+            ],
+            TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { .. })
+            | TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { .. }) => &[
+                CommitterTables::TxSenders,
+                CommitterTables::TxRecipients,
+                CommitterTables::Transactions,
+            ],
+            // Unsupported V2-only filters error out in the query match.
+            TransactionFilterKind::V2(_) => {
+                return Err(IndexerError::InvalidArgument(
+                    "transaction filter is not supported".into(),
+                ));
+            }
+        };
+        Ok(tables)
     }
 
     async fn multi_get_transaction_block_response_in_blocking_task_impl(


### PR DESCRIPTION
# Description of change

This PR fixes a bug in the iota-indexer where filtered queries were incorrectly dropping valid rows and failing to trigger the KV-store fallback because they calculate the `min_available_tx` watermark using a global set of tables, causing the filter to be unnecessarily restricted by the most heavily pruned table.

## Links to any relevant issues

fixes #11963

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Ran the `iota-indexer` JSON-RPC locally against mainnet, with both the Postgres database and the KV fallback store pointed at mainnet.
- Re-ran the `queryTransactionBlocks` request FromAddress filter on the address previously failed to paginate.
- Confirmed:
  - `min_available_tx` is now scoped to `tx_senders`, which is unpruned, so it resolves to `0`. The emitted SQL no longer carries the inflated lower bound; it reads `tx_sequence_number >= 0`.
  - Pagination walks the full history correctly across pages (descending cursor advancing `< 321263599`, then `< 3618188`, down to the final page), with no rows silently dropped.
  - Transaction content for pruned ranges is served from the fallback store via `multi_get_transaction_block_response_by_sequence_numbers_with_fallback`.
  - The final page returns 13 rows (fewer than the limit of 51), correctly terminating pagination.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.

### Release Notes

- [x] Indexer: Fixed resolution of the pruning threshold in the JSON-RPC filtered queries.