### PR TITLE
fix(starfish): bound peer-controlled resources on the consensus gRPC server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13251,6 +13251,7 @@ dependencies = [
  "rand 0.8.6",
  "rs_merkle",
  "serde",
+ "serde_yaml",
  "tracing",
 ]
 

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -127,6 +127,21 @@ impl ConsensusManagerTrait for StarfishManager {
             .find(|(_, a)| a.protocol_key == own_protocol_key)
             .expect("Own authority should be among the consensus authorities!");
 
+        // Opt into the protective consensus gRPC resource limits via an
+        // environment variable, for gradual rollout on a subset of validators
+        // without changing the default (inert) behaviour.
+        let parameters = {
+            let mut p = parameters;
+            if matches!(
+                std::env::var("CONSENSUS_GRPC_PROTECTIVE_LIMITS").as_deref(),
+                Ok("1") | Ok("true")
+            ) {
+                info!("Applying protective consensus gRPC limits for validator {own_index}");
+                p.tonic.apply_protective();
+            }
+            p
+        };
+
         // Allow DAG visualizer port to be set via environment variable.
         // The port is used as-is (no offset) — in Docker each validator has its
         // own container so port collisions aren't a concern.

--- a/crates/iota-network-stack/src/grpc_timeout.rs
+++ b/crates/iota-network-stack/src/grpc_timeout.rs
@@ -24,13 +24,26 @@ const GRPC_TIMEOUT_HEADER: &str = "grpc-timeout";
 pub struct GrpcTimeout<S> {
     inner: S,
     server_timeout: Option<Duration>,
+    /// Request URI paths exempt from `server_timeout` — for long-lived
+    /// server-streaming RPCs that must not be aborted by a fallback deadline.
+    /// An explicit client `grpc-timeout` is still honored for these paths.
+    timeout_exempt_paths: &'static [&'static str],
 }
 
 impl<S> GrpcTimeout<S> {
     pub fn new(inner: S, server_timeout: Option<Duration>) -> Self {
+        Self::new_with_exempt_paths(inner, server_timeout, &[])
+    }
+
+    pub fn new_with_exempt_paths(
+        inner: S,
+        server_timeout: Option<Duration>,
+        timeout_exempt_paths: &'static [&'static str],
+    ) -> Self {
         Self {
             inner,
             server_timeout,
+            timeout_exempt_paths,
         }
     }
 }
@@ -53,8 +66,16 @@ where
             None
         });
 
+        // Exempt configured paths (long-lived server-streaming RPCs) from the
+        // server-side fallback timeout; an explicit client deadline still applies.
+        let server_timeout = if self.timeout_exempt_paths.contains(&req.uri().path()) {
+            None
+        } else {
+            self.server_timeout
+        };
+
         // Use the shorter of the two durations, if either are set
-        let timeout_duration = match (client_timeout, self.server_timeout) {
+        let timeout_duration = match (client_timeout, server_timeout) {
             (None, None) => None,
             (Some(dur), None) => Some(dur),
             (None, Some(dur)) => Some(dur),
@@ -282,5 +303,49 @@ mod tests {
     fn test_invalid_digits() {
         // gRPC spec states TimeoutValue will be at most 8 digits
         setup_map_try_parse(Some("oneH")).unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn server_timeout_skips_exempt_paths() {
+        use std::{convert::Infallible, future, future::Pending};
+
+        // A service whose responses never become ready, so the only way a call
+        // resolves is via the timeout branch.
+        #[derive(Clone)]
+        struct NeverReady;
+        impl Service<Request<()>> for NeverReady {
+            type Response = Response<Body>;
+            type Error = Infallible;
+            type Future = Pending<Result<Response<Body>, Infallible>>;
+
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, _req: Request<()>) -> Self::Future {
+                future::pending()
+            }
+        }
+
+        const EXEMPT: &[&str] = &["/pkg.Svc/Stream"];
+        let timeout = Duration::from_millis(50);
+
+        // Non-exempt path: the server-side fallback timeout fires.
+        let mut svc = GrpcTimeout::new_with_exempt_paths(NeverReady, Some(timeout), EXEMPT);
+        let fut = svc.call(Request::builder().uri("/pkg.Svc/Unary").body(()).unwrap());
+        assert!(
+            fut.await.is_ok(),
+            "non-exempt request should be completed by the fallback timeout"
+        );
+
+        // Exempt path: no fallback timeout, so the request is never aborted.
+        let mut svc = GrpcTimeout::new_with_exempt_paths(NeverReady, Some(timeout), EXEMPT);
+        let fut = svc.call(Request::builder().uri("/pkg.Svc/Stream").body(()).unwrap());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(150), fut)
+                .await
+                .is_err(),
+            "exempt path must not be aborted by the server timeout"
+        );
     }
 }

--- a/crates/starfish/config/Cargo.toml
+++ b/crates/starfish/config/Cargo.toml
@@ -24,3 +24,4 @@ iota-sdk-types.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+serde_yaml.workspace = true

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -401,6 +401,33 @@ pub struct TonicParameters {
     /// If unspecified, this will default to 1GiB.
     #[serde(default = "TonicParameters::default_message_size_limit")]
     pub message_size_limit: usize,
+
+    /// Maximum number of concurrent HTTP/2 streams a peer may open on a single
+    /// connection. Bounds per-connection request fan-out.
+    ///
+    /// `0` (the default) disables the limit, leaving the transport default.
+    #[serde(default)]
+    pub max_concurrent_streams: u32,
+
+    /// Server-side fallback deadline for requests that omit a `grpc-timeout`
+    /// header. The long-lived block-subscription stream is always exempt.
+    ///
+    /// A zero duration (the default) disables the fallback deadline.
+    #[serde(default)]
+    pub request_timeout: Duration,
+
+    /// Hard size limit for inbound (decoded) requests. Consensus requests are
+    /// small (ref lists); large payloads belong to responses, bounded by
+    /// `message_size_limit`. A smaller inbound bound shrinks the memory a
+    /// single in-flight request can pin before its handler runs.
+    ///
+    /// `0` (the default) falls back to `message_size_limit`.
+    #[serde(default)]
+    pub max_inbound_message_size: usize,
+
+    /// Per-peer, per-RPC admission caps for the inbound consensus server.
+    #[serde(default)]
+    pub admission: AdmissionParameters,
 }
 
 impl TonicParameters {
@@ -419,6 +446,25 @@ impl TonicParameters {
     fn default_message_size_limit() -> usize {
         64 << 20
     }
+
+    /// Overrides only the inbound resource bounds with the protective preset
+    /// (sized for ~100-validator committees), preserving any
+    /// operator-configured transport settings (keepalive, buffers,
+    /// `message_size_limit`). `default()` stays inert, so the bounds never
+    /// change behaviour unless explicitly enabled.
+    pub fn apply_protective(&mut self) {
+        self.max_concurrent_streams = 64;
+        self.request_timeout = Duration::from_secs(120);
+        self.max_inbound_message_size = 1 << 20;
+        self.admission = AdmissionParameters::protective();
+    }
+
+    /// The inert defaults with the protective bounds applied.
+    pub fn protective() -> Self {
+        let mut params = Self::default();
+        params.apply_protective();
+        params
+    }
 }
 
 impl Default for TonicParameters {
@@ -428,6 +474,57 @@ impl Default for TonicParameters {
             connection_buffer_size: TonicParameters::default_connection_buffer_size(),
             excessive_message_size: TonicParameters::default_excessive_message_size(),
             message_size_limit: TonicParameters::default_message_size_limit(),
+            max_concurrent_streams: 0,
+            request_timeout: Duration::ZERO,
+            max_inbound_message_size: 0,
+            admission: AdmissionParameters::default(),
+        }
+    }
+}
+
+/// Per-peer, per-RPC concurrency caps for the inbound consensus gRPC server.
+///
+/// Each cap bounds how many concurrent requests of one RPC group a single
+/// committee peer (keyed on its authenticated authority index) may have in
+/// flight; a peer cannot consume another peer's budget. These are local,
+/// non-protocol parameters — heterogeneous values across authorities are safe,
+/// so they can be rolled out and tuned per node.
+///
+/// `0` (the default for every cap) disables admission for that group, leaving
+/// the mechanism inert until an operator opts in. Recommended values for the
+/// opt-in protective preset, sized for ~100-validator committees and the local
+/// synchronizer fan-out toward one server: subscriptions 2, header fetches 32,
+/// transaction fetches 16, commit fetches `commit_sync_parallel_fetches` (8).
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct AdmissionParameters {
+    /// Max concurrent block-subscription streams per peer.
+    #[serde(default)]
+    pub max_subscriptions_per_peer: u32,
+
+    /// Max concurrent header fetches per peer
+    /// (`fetch_block_headers` + `fetch_latest_block_headers`).
+    #[serde(default)]
+    pub max_header_fetches_per_peer: u32,
+
+    /// Max concurrent transaction fetches per peer (`fetch_transactions`).
+    #[serde(default)]
+    pub max_transaction_fetches_per_peer: u32,
+
+    /// Max concurrent commit fetches per peer
+    /// (`fetch_commits` + `fetch_commits_and_transactions`).
+    #[serde(default)]
+    pub max_commit_fetches_per_peer: u32,
+}
+
+impl AdmissionParameters {
+    /// Opt-in preset sized for ~100-validator committees and the local
+    /// synchronizer fan-out toward one server.
+    pub fn protective() -> Self {
+        Self {
+            max_subscriptions_per_peer: 2,
+            max_header_fetches_per_peer: 32,
+            max_transaction_fetches_per_peer: 16,
+            max_commit_fetches_per_peer: Parameters::default_commit_sync_parallel_fetches() as u32,
         }
     }
 }

--- a/crates/starfish/config/tests/parameters_test.rs
+++ b/crates/starfish/config/tests/parameters_test.rs
@@ -8,3 +8,93 @@ fn parameters_snapshot_matches() {
     let parameters = starfish_config::Parameters::default();
     insta::assert_yaml_snapshot!("parameters", parameters)
 }
+
+#[test]
+fn protective_preset_enables_bounds_and_default_stays_inert() {
+    let protective = starfish_config::TonicParameters::protective();
+    assert_eq!(protective.max_concurrent_streams, 64);
+    assert_eq!(
+        protective.request_timeout,
+        std::time::Duration::from_secs(120)
+    );
+    assert_eq!(protective.max_inbound_message_size, 1 << 20);
+    assert_eq!(protective.admission.max_subscriptions_per_peer, 2);
+    assert_eq!(protective.admission.max_header_fetches_per_peer, 32);
+    assert_eq!(protective.admission.max_transaction_fetches_per_peer, 16);
+    assert!(protective.admission.max_commit_fetches_per_peer > 0);
+
+    // The default must stay inert so behaviour is unchanged unless opted in.
+    let inert = starfish_config::TonicParameters::default();
+    assert_eq!(inert.max_concurrent_streams, 0);
+    assert!(inert.request_timeout.is_zero());
+    assert_eq!(inert.max_inbound_message_size, 0);
+    assert_eq!(inert.admission.max_header_fetches_per_peer, 0);
+}
+
+#[test]
+fn apply_protective_preserves_operator_transport_fields() {
+    // Operator-customised transport settings that must survive opting in.
+    let mut tonic = starfish_config::TonicParameters {
+        keepalive_interval: std::time::Duration::from_secs(11),
+        connection_buffer_size: 9 << 20,
+        excessive_message_size: 5 << 20,
+        message_size_limit: 7 << 20,
+        ..Default::default()
+    };
+
+    tonic.apply_protective();
+
+    // Protective bounds applied.
+    assert_eq!(tonic.max_concurrent_streams, 64);
+    assert_eq!(tonic.max_inbound_message_size, 1 << 20);
+    assert_eq!(tonic.admission.max_header_fetches_per_peer, 32);
+    // Operator transport settings preserved (not reset to defaults).
+    assert_eq!(tonic.keepalive_interval, std::time::Duration::from_secs(11));
+    assert_eq!(tonic.connection_buffer_size, 9 << 20);
+    assert_eq!(tonic.excessive_message_size, 5 << 20);
+    assert_eq!(tonic.message_size_limit, 7 << 20);
+}
+
+#[test]
+fn partial_tonic_config_falls_back_to_defaults() {
+    let parameters: starfish_config::Parameters = serde_yaml::from_str(
+        r#"
+tonic:
+  keepalive_interval:
+    secs: 5
+    nanos: 0
+  admission: {}
+"#,
+    )
+    .unwrap();
+    let defaults = starfish_config::Parameters::default();
+
+    assert_eq!(
+        parameters.tonic.max_concurrent_streams,
+        defaults.tonic.max_concurrent_streams
+    );
+    assert_eq!(
+        parameters.tonic.request_timeout,
+        defaults.tonic.request_timeout
+    );
+    assert_eq!(
+        parameters.tonic.max_inbound_message_size,
+        defaults.tonic.max_inbound_message_size
+    );
+    assert_eq!(
+        parameters.tonic.admission.max_subscriptions_per_peer,
+        defaults.tonic.admission.max_subscriptions_per_peer
+    );
+    assert_eq!(
+        parameters.tonic.admission.max_header_fetches_per_peer,
+        defaults.tonic.admission.max_header_fetches_per_peer
+    );
+    assert_eq!(
+        parameters.tonic.admission.max_transaction_fetches_per_peer,
+        defaults.tonic.admission.max_transaction_fetches_per_peer
+    );
+    assert_eq!(
+        parameters.tonic.admission.max_commit_fetches_per_peer,
+        defaults.tonic.admission.max_commit_fetches_per_peer
+    );
+}

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -35,6 +35,16 @@ tonic:
   connection_buffer_size: 33554432
   excessive_message_size: 16777216
   message_size_limit: 67108864
+  max_concurrent_streams: 0
+  request_timeout:
+    secs: 0
+    nanos: 0
+  max_inbound_message_size: 0
+  admission:
+    max_subscriptions_per_peer: 0
+    max_header_fetches_per_peer: 0
+    max_transaction_fetches_per_peer: 0
+    max_commit_fetches_per_peer: 0
 fast_commit_sync_batch_size: 1000
 commit_sync_gap_threshold: 1000
 enable_fast_commit_syncer: true

--- a/crates/starfish/core/src/network/admission.rs
+++ b/crates/starfish/core/src/network/admission.rs
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-peer, per-RPC admission control for the inbound consensus gRPC server.
+//!
+//! Each RPC group has an independent concurrency budget per committee peer,
+//! keyed on the peer's authenticated authority index. A misbehaving peer can
+//! only exhaust its own budget, never another peer's. Caps are local, opt-in
+//! parameters; a cap of `0` disables the group, leaving the mechanism inert.
+
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context as TaskContext, Poll},
+};
+
+use futures::Stream;
+use prometheus::IntGauge;
+use starfish_config::AuthorityIndex;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::context::Context;
+
+/// Inbound consensus RPCs grouped by cost and access pattern. Each group has an
+/// independent per-peer concurrency budget.
+#[derive(Clone, Copy)]
+pub(crate) enum RpcGroup {
+    Subscribe,
+    HeaderFetch,
+    TransactionFetch,
+    CommitFetch,
+}
+
+impl RpcGroup {
+    /// Stable label for metrics.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            RpcGroup::Subscribe => "subscribe",
+            RpcGroup::HeaderFetch => "header_fetch",
+            RpcGroup::TransactionFetch => "transaction_fetch",
+            RpcGroup::CommitFetch => "commit_fetch",
+        }
+    }
+}
+
+/// Outcome of an admission attempt.
+pub(crate) enum Admission {
+    /// The group is disabled (cap 0); proceed without holding a permit.
+    Unlimited,
+    /// A slot was available; hold the permit for the request's (or stream's)
+    /// lifetime and drop it to release the slot.
+    Permit(OwnedSemaphorePermit),
+    /// The peer is at its cap for this group; the request must be rejected.
+    Rejected,
+}
+
+/// Per-(peer, RPC group) admission control for the inbound consensus server.
+///
+/// Each enabled group holds one semaphore per committee peer, sized to that
+/// group's per-peer cap. A `None` row means the group is disabled.
+pub(crate) struct PerPeerAdmission {
+    subscribe: Option<Box<[Arc<Semaphore>]>>,
+    header: Option<Box<[Arc<Semaphore>]>>,
+    transaction: Option<Box<[Arc<Semaphore>]>>,
+    commit: Option<Box<[Arc<Semaphore>]>>,
+}
+
+impl PerPeerAdmission {
+    pub(crate) fn new(context: &Context) -> Self {
+        let admission = &context.parameters.tonic.admission;
+        let size = context.committee.size();
+        Self {
+            subscribe: Self::row(size, admission.max_subscriptions_per_peer),
+            header: Self::row(size, admission.max_header_fetches_per_peer),
+            transaction: Self::row(size, admission.max_transaction_fetches_per_peer),
+            commit: Self::row(size, admission.max_commit_fetches_per_peer),
+        }
+    }
+
+    /// One semaphore per peer for an enabled group, or `None` when `cap == 0`.
+    fn row(size: usize, cap: u32) -> Option<Box<[Arc<Semaphore>]>> {
+        (cap > 0).then(|| {
+            (0..size)
+                .map(|_| Arc::new(Semaphore::new(cap as usize)))
+                .collect()
+        })
+    }
+
+    fn group(&self, group: RpcGroup) -> &Option<Box<[Arc<Semaphore>]>> {
+        match group {
+            RpcGroup::Subscribe => &self.subscribe,
+            RpcGroup::HeaderFetch => &self.header,
+            RpcGroup::TransactionFetch => &self.transaction,
+            RpcGroup::CommitFetch => &self.commit,
+        }
+    }
+
+    /// Tries to admit one request from `peer` in `group`.
+    pub(crate) fn try_acquire(&self, group: RpcGroup, peer: AuthorityIndex) -> Admission {
+        let Some(row) = self.group(group) else {
+            return Admission::Unlimited;
+        };
+        // An authenticated committee peer's index is always in range; stay
+        // defensive rather than panicking on any unexpected index.
+        let Some(semaphore) = row.get(peer.value()) else {
+            return Admission::Unlimited;
+        };
+        match semaphore.clone().try_acquire_owned() {
+            Ok(permit) => Admission::Permit(permit),
+            Err(_) => Admission::Rejected,
+        }
+    }
+}
+
+/// RAII guard for an admitted request: holds the per-peer permit and keeps the
+/// per-group in-use gauge incremented for the request's (or stream's) lifetime.
+/// Dropping it releases the slot and decrements the gauge.
+pub(crate) struct AdmissionGuard {
+    _permit: OwnedSemaphorePermit,
+    in_use: IntGauge,
+}
+
+impl AdmissionGuard {
+    pub(crate) fn new(permit: OwnedSemaphorePermit, in_use: IntGauge) -> Self {
+        in_use.inc();
+        Self {
+            _permit: permit,
+            in_use,
+        }
+    }
+}
+
+impl Drop for AdmissionGuard {
+    fn drop(&mut self) {
+        self.in_use.dec();
+    }
+}
+
+/// Wraps a response stream so it owns an admission guard for the stream's
+/// entire lifetime; the guard is released when the stream is dropped (client
+/// disconnect, server shutdown, or stream end).
+pub(crate) struct PermitGuardedStream<St> {
+    inner: St,
+    _guard: Option<AdmissionGuard>,
+}
+
+impl<St> PermitGuardedStream<St> {
+    pub(crate) fn new(inner: St, guard: Option<AdmissionGuard>) -> Self {
+        Self {
+            inner,
+            _guard: guard,
+        }
+    }
+}
+
+impl<St: Stream + Unpin> Stream for PermitGuardedStream<St> {
+    type Item = St::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().inner).poll_next(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(i: u8) -> AuthorityIndex {
+        AuthorityIndex::from(i)
+    }
+
+    fn expect_permit(outcome: Admission) -> OwnedSemaphorePermit {
+        match outcome {
+            Admission::Permit(permit) => permit,
+            _ => panic!("expected a permit"),
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_group_is_unlimited() {
+        let admission = PerPeerAdmission {
+            subscribe: PerPeerAdmission::row(4, 0),
+            header: PerPeerAdmission::row(4, 0),
+            transaction: PerPeerAdmission::row(4, 0),
+            commit: PerPeerAdmission::row(4, 0),
+        };
+        for _ in 0..1000 {
+            assert!(matches!(
+                admission.try_acquire(RpcGroup::HeaderFetch, peer(0)),
+                Admission::Unlimited
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn enforces_cap_and_releases_on_drop() {
+        let admission = PerPeerAdmission {
+            subscribe: None,
+            header: PerPeerAdmission::row(4, 2),
+            transaction: None,
+            commit: None,
+        };
+        let p0 = expect_permit(admission.try_acquire(RpcGroup::HeaderFetch, peer(1)));
+        let p1 = expect_permit(admission.try_acquire(RpcGroup::HeaderFetch, peer(1)));
+        // A third concurrent request from the same peer exceeds the cap.
+        assert!(matches!(
+            admission.try_acquire(RpcGroup::HeaderFetch, peer(1)),
+            Admission::Rejected
+        ));
+        // Releasing one permit frees exactly one slot.
+        drop(p0);
+        let p2 = expect_permit(admission.try_acquire(RpcGroup::HeaderFetch, peer(1)));
+        drop((p1, p2));
+    }
+
+    #[tokio::test]
+    async fn peers_are_isolated() {
+        let admission = PerPeerAdmission {
+            subscribe: None,
+            header: PerPeerAdmission::row(4, 1),
+            transaction: None,
+            commit: None,
+        };
+        let held = expect_permit(admission.try_acquire(RpcGroup::HeaderFetch, peer(0)));
+        // Peer 0 is saturated...
+        assert!(matches!(
+            admission.try_acquire(RpcGroup::HeaderFetch, peer(0)),
+            Admission::Rejected
+        ));
+        // ...but peer 1 has its own independent budget.
+        let _other = expect_permit(admission.try_acquire(RpcGroup::HeaderFetch, peer(1)));
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn permit_guarded_stream_holds_until_dropped() {
+        let admission = PerPeerAdmission {
+            subscribe: PerPeerAdmission::row(4, 1),
+            header: None,
+            transaction: None,
+            commit: None,
+        };
+        let gauge = IntGauge::new("test_subscribe_in_use", "test").unwrap();
+        let permit = expect_permit(admission.try_acquire(RpcGroup::Subscribe, peer(2)));
+        let guarded = PermitGuardedStream::new(
+            futures::stream::empty::<i32>(),
+            Some(AdmissionGuard::new(permit, gauge.clone())),
+        );
+        // While the stream lives, the peer's single subscribe slot is taken and
+        // the in-use gauge reflects it.
+        assert_eq!(gauge.get(), 1);
+        assert!(matches!(
+            admission.try_acquire(RpcGroup::Subscribe, peer(2)),
+            Admission::Rejected
+        ));
+        // Dropping the stream releases the permit and decrements the gauge.
+        drop(guarded);
+        assert_eq!(gauge.get(), 0);
+        assert!(matches!(
+            admission.try_acquire(RpcGroup::Subscribe, peer(2)),
+            Admission::Permit(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn in_use_gauge_tracks_held_guards() {
+        let admission = PerPeerAdmission {
+            subscribe: None,
+            header: PerPeerAdmission::row(4, 2),
+            transaction: None,
+            commit: None,
+        };
+        let gauge = IntGauge::new("test_header_in_use", "test").unwrap();
+        let g0 = AdmissionGuard::new(
+            expect_permit(admission.try_acquire(RpcGroup::HeaderFetch, peer(0))),
+            gauge.clone(),
+        );
+        let g1 = AdmissionGuard::new(
+            expect_permit(admission.try_acquire(RpcGroup::HeaderFetch, peer(1))),
+            gauge.clone(),
+        );
+        assert_eq!(gauge.get(), 2);
+        drop(g0);
+        assert_eq!(gauge.get(), 1);
+        drop(g1);
+        assert_eq!(gauge.get(), 0);
+    }
+}

--- a/crates/starfish/core/src/network/metrics.rs
+++ b/crates/starfish/core/src/network/metrics.rs
@@ -17,6 +17,12 @@ pub(crate) struct NetworkMetrics {
     pub(crate) outbound: Arc<NetworkRouteMetrics>,
     #[cfg_attr(msim, allow(dead_code))]
     pub(crate) tcp_connection_metrics: Arc<TcpConnectionMetrics>,
+    /// Inbound requests rejected by per-peer admission control, by RPC group.
+    pub(crate) admission_rejected: IntCounterVec,
+    /// Inbound requests currently in flight under admission control, by RPC
+    /// group (summed across peers). Shows live concurrency vs the per-peer
+    /// caps.
+    pub(crate) admission_in_use: IntGaugeVec,
 }
 
 impl NetworkMetrics {
@@ -32,6 +38,20 @@ impl NetworkMetrics {
             inbound: Arc::new(NetworkRouteMetrics::new("inbound", registry)),
             outbound: Arc::new(NetworkRouteMetrics::new("outbound", registry)),
             tcp_connection_metrics: Arc::new(TcpConnectionMetrics::new(registry)),
+            admission_rejected: register_int_counter_vec_with_registry!(
+                "inbound_admission_rejected",
+                "Inbound consensus requests rejected by per-peer admission control, by RPC group",
+                &["group"],
+                registry
+            )
+            .unwrap(),
+            admission_in_use: register_int_gauge_vec_with_registry!(
+                "inbound_admission_in_use",
+                "Inbound consensus requests currently in flight under admission control, by RPC group",
+                &["group"],
+                registry
+            )
+            .unwrap(),
         }
     }
 }

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -43,6 +43,7 @@ mod tonic_gen {
     include!(concat!(env!("OUT_DIR"), "/consensus.ConsensusService.rs"));
 }
 
+mod admission;
 pub(crate) mod metrics;
 mod metrics_layer;
 #[cfg(all(test, not(msim)))]

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -22,13 +22,14 @@ use iota_network_stack::{
 use iota_tls::AllowPublicKeys;
 use parking_lot::RwLock;
 use starfish_config::{AuthorityIndex, NetworkKeyPair, NetworkPublicKey};
-use tokio_stream::{Iter, iter};
+use tokio_stream::iter;
 use tonic::{Request, Response, Streaming, codec::CompressionEncoding};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, TraceLayer};
 use tracing::{debug, error, info, trace, warn};
 
 use super::{
     BlockBundleStream, NetworkClient, NetworkService, SerializedBlockBundle, TransactionFetchMode,
+    admission::{Admission, AdmissionGuard, PerPeerAdmission, PermitGuardedStream, RpcGroup},
     metrics_layer::{MetricsCallbackMaker, MetricsResponseCallback, SizedRequest, SizedResponse},
     tonic_gen::{
         consensus_service_client::ConsensusServiceClient,
@@ -588,11 +589,52 @@ impl ChannelPool {
 struct TonicServiceProxy<S: NetworkService> {
     context: Arc<Context>,
     service: Arc<S>,
+    admission: PerPeerAdmission,
 }
 
 impl<S: NetworkService> TonicServiceProxy<S> {
     fn new(context: Arc<Context>, service: Arc<S>) -> Self {
-        Self { context, service }
+        let admission = PerPeerAdmission::new(&context);
+        Self {
+            context,
+            service,
+            admission,
+        }
+    }
+
+    /// Admits one request from `peer` in `group`, returning a permit to hold
+    /// for the request's (or stream's) lifetime, or `None` when the group's
+    /// limit is disabled. A rejected request increments the admission
+    /// metric and returns `ResourceExhausted` so the peer backs off.
+    fn admit(
+        &self,
+        group: RpcGroup,
+        peer: AuthorityIndex,
+    ) -> Result<Option<AdmissionGuard>, tonic::Status> {
+        match self.admission.try_acquire(group, peer) {
+            Admission::Unlimited => Ok(None),
+            Admission::Permit(permit) => {
+                let in_use = self
+                    .context
+                    .metrics
+                    .network_metrics
+                    .admission_in_use
+                    .with_label_values(&[group.as_str()]);
+                Ok(Some(AdmissionGuard::new(permit, in_use)))
+            }
+            Admission::Rejected => {
+                self.context
+                    .metrics
+                    .network_metrics
+                    .admission_rejected
+                    .with_label_values(&[group.as_str()])
+                    .inc();
+                Err(tonic::Status::resource_exhausted(format!(
+                    "per-peer {} limit reached",
+                    group.as_str()
+                )))
+            }
+        }
     }
 }
 
@@ -612,6 +654,9 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         else {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
+        // Acquire before reading the request stream so a peer cannot stack
+        // half-open subscriptions; the permit is held for the stream's lifetime.
+        let permit = self.admit(RpcGroup::Subscribe, peer_index)?;
         let mut request_stream = request.into_inner();
         let first_request = match request_stream.next().await {
             Some(Ok(r)) => r,
@@ -639,11 +684,13 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         let rate_limited_stream =
             tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_block_delay / 2)
                 .boxed();
-        Ok(Response::new(rate_limited_stream))
+        Ok(Response::new(
+            PermitGuardedStream::new(rate_limited_stream, permit).boxed(),
+        ))
     }
 
     type FetchBlockHeadersStream =
-        Iter<std::vec::IntoIter<Result<FetchBlockHeadersResponse, tonic::Status>>>;
+        Pin<Box<dyn Stream<Item = Result<FetchBlockHeadersResponse, tonic::Status>> + Send>>;
 
     async fn fetch_block_headers(
         &self,
@@ -656,6 +703,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         else {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
+        let permit = self.admit(RpcGroup::HeaderFetch, peer_index)?;
         let inner = request.into_inner();
         let highest_accepted_rounds = inner.highest_accepted_rounds;
         let max_fetch_size = self
@@ -697,7 +745,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
                 })
                 .collect::<Vec<_>>()
                 .into_iter();
-        let stream = iter(responses);
+        let stream = PermitGuardedStream::new(iter(responses), permit).boxed();
         Ok(Response::new(stream))
     }
 
@@ -712,6 +760,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         else {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
+        let _permit = self.admit(RpcGroup::CommitFetch, peer_index)?;
         let request = request.into_inner();
         let (commits, certifier_block_headers) = self
             .service
@@ -736,8 +785,9 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         }))
     }
 
-    type FetchCommitsAndTransactionsStream =
-        Iter<std::vec::IntoIter<Result<FetchCommitsAndTransactionsResponse, tonic::Status>>>;
+    type FetchCommitsAndTransactionsStream = Pin<
+        Box<dyn Stream<Item = Result<FetchCommitsAndTransactionsResponse, tonic::Status>> + Send>,
+    >;
 
     async fn fetch_commits_and_transactions(
         &self,
@@ -750,6 +800,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         else {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
+        let permit = self.admit(RpcGroup::CommitFetch, peer_index)?;
         let request = request.into_inner();
         let (serialized_commits, serialized_headers, serialized_transactions) = self
             .service
@@ -792,12 +843,12 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             }));
         }
 
-        let stream = iter(responses);
+        let stream = PermitGuardedStream::new(iter(responses), permit).boxed();
         Ok(Response::new(stream))
     }
 
     type FetchLatestBlockHeadersStream =
-        Iter<std::vec::IntoIter<Result<FetchLatestBlockHeadersResponse, tonic::Status>>>;
+        Pin<Box<dyn Stream<Item = Result<FetchLatestBlockHeadersResponse, tonic::Status>> + Send>>;
 
     async fn fetch_latest_block_headers(
         &self,
@@ -810,6 +861,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         else {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
+        let permit = self.admit(RpcGroup::HeaderFetch, peer_index)?;
         let inner = request.into_inner();
 
         // Convert the authority indexes and validate them
@@ -842,7 +894,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
                 })
                 .collect::<Vec<_>>()
                 .into_iter();
-        let stream = iter(responses);
+        let stream = PermitGuardedStream::new(iter(responses), permit).boxed();
         Ok(Response::new(stream))
     }
 
@@ -859,7 +911,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
     }
 
     type FetchTransactionsStream =
-        Iter<std::vec::IntoIter<Result<FetchTransactionsResponse, tonic::Status>>>;
+        Pin<Box<dyn Stream<Item = Result<FetchTransactionsResponse, tonic::Status>> + Send>>;
 
     async fn fetch_transactions(
         &self,
@@ -872,6 +924,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         else {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
+        let permit = self.admit(RpcGroup::TransactionFetch, peer_index)?;
 
         let request = request.into_inner();
         let committed_transactions_refs: Vec<GenericTransactionRef> = request
@@ -920,7 +973,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
                 })
                 .collect::<Vec<_>>()
                 .into_iter();
-        let stream = iter(responses);
+        let stream = PermitGuardedStream::new(iter(responses), permit).boxed();
         Ok(Response::new(stream))
     }
 }
@@ -943,6 +996,11 @@ where
     server: Option<ServerHandle>,
     _marker: std::marker::PhantomData<S>,
 }
+
+/// Long-lived server-streaming RPCs exempt from the server-side fallback
+/// request timeout: they carry no client `grpc-timeout`, so a deadline would
+/// abort an otherwise healthy subscription. Bounded RPCs are not listed.
+const TIMEOUT_EXEMPT_PATHS: &[&str] = &["/consensus.ConsensusService/SubscribeBlockBundles"];
 
 impl<S: NetworkService> TonicManager<S> {
     pub(crate) fn new(context: Arc<Context>, network_keypair: NetworkKeyPair) -> Self {
@@ -1005,11 +1063,30 @@ impl<S: NetworkService> TonicManager<S> {
                     .make_span_with(DefaultMakeSpan::new().level(tracing::Level::TRACE))
                     .on_failure(DefaultOnFailure::new().level(tracing::Level::DEBUG)),
             )
-            .layer_fn(|service| iota_network_stack::grpc_timeout::GrpcTimeout::new(service, None));
+            .layer_fn({
+                // A zero `request_timeout` disables the server-side fallback deadline.
+                let server_timeout =
+                    (!config.request_timeout.is_zero()).then_some(config.request_timeout);
+                move |service| {
+                    iota_network_stack::grpc_timeout::GrpcTimeout::new_with_exempt_paths(
+                        service,
+                        server_timeout,
+                        TIMEOUT_EXEMPT_PATHS,
+                    )
+                }
+            });
 
+        // Inbound (decoded) requests are small; bound them tighter than the
+        // (large) response encoding limit when configured. `0` falls back to
+        // `message_size_limit`.
+        let max_decoding_message_size = if config.max_inbound_message_size == 0 {
+            config.message_size_limit
+        } else {
+            config.max_inbound_message_size
+        };
         let consensus_service_server = ConsensusServiceServer::new(service)
             .max_encoding_message_size(config.message_size_limit)
-            .max_decoding_message_size(config.message_size_limit)
+            .max_decoding_message_size(max_decoding_message_size)
             .send_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Zstd);
 
@@ -1070,6 +1147,9 @@ impl<S: NetworkService> TonicManager<S> {
             .tcp_nodelay(true)
             .initial_connection_window_size(64 << 20)
             .initial_stream_window_size(32 << 20)
+            .max_concurrent_streams(
+                (config.max_concurrent_streams > 0).then_some(config.max_concurrent_streams),
+            )
             .http2_keepalive_interval(Some(config.keepalive_interval))
             .http2_keepalive_timeout(Some(config.keepalive_interval))
             .accept_http1(false);

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -19472,6 +19472,194 @@
           ],
           "title": "Outbound Response Size Per Request",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "default": false,
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 812
+          },
+          "id": 408,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by(group, host) (consensus_inbound_admission_in_use)",
+              "legendFormat": "{{group}} @ {{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Consensus Admission In-Use (concurrency)",
+          "type": "timeseries",
+          "description": "Inbound consensus requests currently in flight under per-peer admission control, by RPC group. Shows live concurrency vs the configured per-peer caps."
+        },
+        {
+          "datasource": {
+            "default": false,
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 812
+          },
+          "id": 409,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(consensus_inbound_admission_rejected[2m])",
+              "legendFormat": "{{group}} @ {{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Consensus Admission Rejections Rate",
+          "type": "timeseries",
+          "description": "Rate of inbound consensus requests rejected by per-peer admission control (ResourceExhausted), by RPC group. Should be ~0 under honest load."
         }
       ],
       "title": "Inbound / Outbound Network Metrics",


### PR DESCRIPTION
# Description of change

The Starfish consensus gRPC server applied no per-peer resource bounds: a single mTLS-authenticated committee member could open unbounded requests/streams and consume a disproportionate share of an honest node's serving resources, up to memory/availability exhaustion.

This adds **per-(peer, RPC group) admission control** keyed on the authenticated `authority_index`, so a peer can only exhaust its own budget — never another peer's (Byzantine self-containment). Each group has an independent per-peer concurrency cap, held for the whole request, including the response stream:

- block-subscription (`subscribe_block_bundles`)
- header fetches (`fetch_block_headers` + `fetch_latest_block_headers`)
- transaction fetches (`fetch_transactions`)
- commit fetches (`fetch_commits` + `fetch_commits_and_transactions`)

Over-limit requests are rejected with `ResourceExhausted`. This replaces the previous global concurrency limit, which had no per-peer fairness. The server also gains an inbound (decoded) request-size limit, a server-side request timeout (the long-lived subscription stream stays exempt), and a per-connection stream cap.

**Inert by default, opt-in via environment variable.** Every limit defaults to `0`/off, so default config is unchanged behaviour and the binary ships network-wide unchanged. A validator opts into the protective preset by setting:

```
CONSENSUS_GRPC_PROTECTIVE_LIMITS=1
```

read inline when consensus parameters are built. This allows gradual rollout on a subset of validators and later promotion to the default. These are local operational parameters (no protocol version / feature flag); heterogeneous values across validators are safe and cannot affect consensus safety.

Protective preset: `max_concurrent_streams=64`, `request_timeout=120s`, `max_inbound_message_size=1 MiB`; per-peer admission caps `subscriptions=2`, `header=32`, `transaction=16`, `commit=commit_sync_parallel_fetches`.

**Observability:** `consensus_inbound_admission_rejected{group}` (rejections) and `consensus_inbound_admission_in_use{group}` (live concurrency), charted in the starfish dashboard's "Inbound / Outbound Network Metrics" row.

## Links to any relevant issues

Fixes iotaledger/iota-private#439

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Add opt-in per-peer admission controls for the consensus gRPC server, inert by default. Set `CONSENSUS_GRPC_PROTECTIVE_LIMITS=1` to enable the protective preset on a node. 
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
