### PR TITLE
fix(starfish): do not feature gate `dag_visualizer_port` config parameter

### DIFF
--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -7158,7 +7158,7 @@ async fn test_pcool_deferred_tx_not_dropped_next_round_but_executed() {
             vec![],
             gas_object.object_ref(),
             vec![
-                CallArg::Shared(SharedObjectRef::new(
+                CallArg::Shared(SharedObjectReference::new(
                     shared_objects[0].id(),
                     OBJECT_START_VERSION,
                     true,

--- a/crates/starfish/config/Cargo.toml
+++ b/crates/starfish/config/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 
-[features]
-dag-visualizer = []
-
 [lints]
 workspace = true
 

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -154,8 +154,8 @@ pub struct Parameters {
 
     /// Port for the DAG visualizer gRPC server (localhost only).
     /// When set, starts a debugging server for real-time DAG visualization.
+    /// Only has an effect when the `dag-visualizer` feature is compiled in.
     /// Disabled by default (None).
-    #[cfg(feature = "dag-visualizer")]
     #[serde(default)]
     pub dag_visualizer_port: Option<u16>,
 }
@@ -369,7 +369,6 @@ impl Default for Parameters {
             enable_fast_commit_syncer: Parameters::default_enable_fast_commit_syncer(),
             enable_starfish_speed_adaptive_acknowledgments:
                 Parameters::default_enable_starfish_speed_adaptive_acknowledgments(),
-            #[cfg(feature = "dag-visualizer")]
             dag_visualizer_port: None,
         }
     }

--- a/crates/starfish/core/Cargo.toml
+++ b/crates/starfish/core/Cargo.toml
@@ -70,7 +70,7 @@ tokio = { workspace = true, features = ["test-util"] }
 telemetry-subscribers.workspace = true
 
 [features]
-dag-visualizer = ["dep:dag-visualizer-proto", "starfish-config/dag-visualizer"]
+dag-visualizer = ["dep:dag-visualizer-proto"]
 
 [build-dependencies]
 tonic-build.workspace = true


### PR DESCRIPTION
# Description of change

This fixes the difference between the CI and the output of `update_all_snapshots.sh`.
We do not feature gate the `dag_visualizer_port` config parameter. The config parameter is just not used if the feature is not enabled.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes