### PR TITLE
chore: bump iota-rust-sdk rev to 36bffd6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "bech32 0.11.1",
  "bip32",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7508,7 +7508,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7562,7 +7562,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,9 +400,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "b24fbed6856580569d4fd374ed2aae0f07a461f1" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "36bffd625e1b1d38307eb9e49bd2cb7dd988bb11" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "b24fbed6856580569d4fd374ed2aae0f07a461f1" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "36bffd625e1b1d38307eb9e49bd2cb7dd988bb11" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -441,8 +441,8 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b24fbed6856580569d4fd374ed2aae0f07a461f1", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b24fbed6856580569d4fd374ed2aae0f07a461f1", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "36bffd625e1b1d38307eb9e49bd2cb7dd988bb11", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "36bffd625e1b1d38307eb9e49bd2cb7dd988bb11", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 iota-grpc-client = { workspace = true, optional = true }
 iota-grpc-types = { workspace = true, optional = true }
 iota-sdk-crypto = { workspace = true, optional = true }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b24fbed6856580569d4fd374ed2aae0f07a461f1", optional = true }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b24fbed6856580569d4fd374ed2aae0f07a461f1", default-features = false, optional = true }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "36bffd625e1b1d38307eb9e49bd2cb7dd988bb11", optional = true }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "36bffd625e1b1d38307eb9e49bd2cb7dd988bb11", default-features = false, optional = true }
 iota-sdk-types = { workspace = true, optional = true }
 
 [features]

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3453,7 +3453,6 @@ dependencies = [
  "iota-protocol-config",
  "iota-sdk",
  "iota-sdk-types",
- "iota-types",
  "move-package",
  "move-symbol-pool",
  "thiserror 1.0.69",
@@ -3543,7 +3542,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "ed25519-dalek",
  "iota-sdk-types",
@@ -3558,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b24fbed6856580569d4fd374ed2aae0f07a461f1#b24fbed6856580569d4fd374ed2aae0f07a461f1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=36bffd625e1b1d38307eb9e49bd2cb7dd988bb11#36bffd625e1b1d38307eb9e49bd2cb7dd988bb11"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b24fbed6856580569d4fd374ed2aae0f07a461f1" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "36bffd625e1b1d38307eb9e49bd2cb7dd988bb11" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b24fbed6856580569d4fd374ed2aae0f07a461f1" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "36bffd625e1b1d38307eb9e49bd2cb7dd988bb11" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
# Description of change

Bump the pinned `iota-rust-sdk` git dependency from `b24fbed6` to `36bffd62` across all workspace manifests and lockfiles (`Cargo.toml`, `crates/iota-rust-sdk`, `examples/tic-tac-toe/cli`, `docs/examples/rust`).

This range removes the deprecated zkLogin variants from the SDK signature types (iotaledger/iota-rust-sdk#1195). The node keeps its **own** deprecated zkLogin stubs (e.g. `SignatureScheme::ZkLoginAuthenticatorDeprecated`, `GenericSignature::ZkLoginAuthenticatorDeprecated`) for serialization compatibility and never referenced the SDK's removed variants, so no source changes were required.

The `docs/examples/rust` lockfile additionally drops a stale `iota-types` entry from `iota-package-management`, bringing it back in sync with its manifest (the main `Cargo.lock` was already in sync).

## Links to any relevant issues

- iotaledger/iota-rust-sdk#1195

## How the change has been tested

Dependency revision bump with no source changes. Verified locally that `cargo check --workspace --all-targets` compiles cleanly against the new SDK rev; full linting, formatting, and the unit/integration/e2e test suites run in CI.

No user-facing or behavioral changes, so there are no changelog entries for this PR.

[run-ci]